### PR TITLE
Honour DOTNET_CLI_UI_LANGUAGE envvar in NuGet.Commandline.XPlat.exe

### DIFF
--- a/scripts/nuget-debug-helpers.ps1
+++ b/scripts/nuget-debug-helpers.ps1
@@ -79,6 +79,8 @@ Function Add-NuGetToCLI {
     }
     $sdk_path = $sdkLocation
 
+    $locFolders = @('cs', 'de', 'es', 'fr', 'it', 'ja', 'ko', 'pl', 'pt-BR', 'ru', 'tr', 'zh-Hans', 'zh-Hant')
+
     $nugetXplatArtifactsPath = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'NuGet.CommandLine.XPlat', 'bin', $Configuration, $NETCoreApp)
     $nugetBuildTasks = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'NuGet.Build.Tasks', 'bin', $Configuration, $NETCoreApp, 'NuGet.Build.Tasks.dll')
     $nugetBuildTasksConsole = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts', 'NuGet.Build.Tasks.Console', 'bin', $Configuration, $NETCoreApp, 'NuGet.Build.Tasks.Console.dll')
@@ -142,10 +144,21 @@ Function Add-NuGetToCLI {
 
     ## Copy the xplat artifacts
 
-    Get-ChildItem $nugetXplatArtifactsPath -Filter NuGet*.dll |
+    Write-Debug "Artifacts: $nugetXplatArtifactsPath"
+    Get-ChildItem -Recurse $nugetXplatArtifactsPath -Filter NuGet*.dll |
         Foreach-Object {
-            $new_position = "$($sdk_path)\$($_.BaseName )$($_.Extension )"
+            $currDir = $_.Directory.BaseName
+            Write-Debug "Parent $currDir" 
+            if ($locFolders -contains $currDir)
+            {
+                $new_position = "$($sdk_path)\$($currDir)\$($_.BaseName )$($_.Extension )"
+            }
+            else
+            {
+                $new_position = "$($sdk_path)\$($_.BaseName )$($_.Extension )"
+            }
 
+            Write-Debug "Moving $($_.FullName) to - $($new_position)"
             Write-Host "Moving to - $($new_position)"
             Copy-Item $_.FullName $new_position
         }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -63,8 +63,9 @@ namespace NuGet.CommandLine.XPlat
             }
             else
             {
-                UILanguageOverride.Setup();
+                UILanguageOverride.Setup(log);
             }
+            log.LogDebug(string.Format(CultureInfo.CurrentCulture, Strings.Debug_CurrentUICulture, CultureInfo.DefaultThreadCurrentUICulture));
 
             var app = InitializeApp(args, log);
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -61,6 +61,10 @@ namespace NuGet.CommandLine.XPlat
             {
                 CultureUtility.DisableLocalization();
             }
+            else
+            {
+                UILanguageOverride.Setup();
+            }
 
             var app = InitializeApp(args, log);
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -367,7 +367,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid culture in {0} environment variable. Value read is &apos;{1}&apos;.
+        ///   Looks up a localized string similar to Invalid culture identifier in {0} environment variable. Value read is &apos;{1}&apos;.
         /// </summary>
         internal static string Error_InvalidCultureInfo {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -241,6 +241,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to DefaultThreadCurrentUICulture value: {0}.
+        /// </summary>
+        internal static string Debug_CurrentUICulture {
+            get {
+                return ResourceManager.GetString("Debug_CurrentUICulture", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Deletes a package from the server..
         /// </summary>
         internal static string Delete_Description {
@@ -354,6 +363,15 @@ namespace NuGet.CommandLine.XPlat {
         internal static string Error_AssetsFileNotFound {
             get {
                 return ResourceManager.GetString("Error_AssetsFileNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid culture in {0} environment variable. Value read is &apos;{1}&apos;.
+        /// </summary>
+        internal static string Error_InvalidCultureInfo {
+            get {
+                return ResourceManager.GetString("Error_InvalidCultureInfo", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -753,4 +753,12 @@ The search is a case-insensitive string comparison using the supplied value, whi
 Non-HTTPS access will be removed in a future version. Consider migrating to 'HTTPS' sources.</value>
     <comment>0 - The command name. Ex. Push/Delete. 1 - list of server uris</comment>
   </data>
+  <data name="Debug_CurrentUICulture" xml:space="preserve">
+    <value>DefaultThreadCurrentUICulture value: {0}</value>
+    <comment>0 - Value of CultureInfo.DefaultThreadCurrentUICulture</comment>
+  </data>
+  <data name="Error_InvalidCultureInfo" xml:space="preserve">
+    <value>Invalid culture in {0} environment variable. Value read is '{1}'</value>
+    <comment>0 - Environment variable name, 1 - value set in environment variable</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -758,7 +758,7 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
     <comment>0 - Value of CultureInfo.DefaultThreadCurrentUICulture</comment>
   </data>
   <data name="Error_InvalidCultureInfo" xml:space="preserve">
-    <value>Invalid culture in {0} environment variable. Value read is '{1}'</value>
+    <value>Invalid culture identifier in {0} environment variable. Value read is '{1}'</value>
     <comment>0 - Environment variable name, 1 - value set in environment variable</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/UILanguageOverride.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/UILanguageOverride.cs
@@ -1,0 +1,84 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+
+namespace NuGet.CommandLine.XPlat
+{
+    /// <summary>
+    /// Copied from https://github.com/dotnet/sdk/blob/49d9b4148c4f65fd3f691186a4533375c3a83c97/src/Cli/dotnet/UILanguageOverride.cs#L9
+    /// </summary>
+    internal static class UILanguageOverride
+    {
+        private const string DOTNET_CLI_UI_LANGUAGE = nameof(DOTNET_CLI_UI_LANGUAGE);
+        private const string VSLANG = nameof(VSLANG);
+        private const string PreferredUILang = nameof(PreferredUILang);
+
+        public static void Setup()
+        {
+            CultureInfo language = GetOverriddenUILanguage();
+            if (language != null)
+            {
+                ApplyOverrideToCurrentProcess(language);
+                FlowOverrideToChildProcesses(language);
+            }
+        }
+
+        private static void ApplyOverrideToCurrentProcess(CultureInfo language)
+        {
+            CultureInfo.DefaultThreadCurrentUICulture = language;
+        }
+
+        private static void FlowOverrideToChildProcesses(CultureInfo language)
+        {
+            // Do not override any environment variables that are already set as we do not want to clobber a more granular setting with our global setting.
+            SetIfNotAlreadySet(DOTNET_CLI_UI_LANGUAGE, language.Name);
+            SetIfNotAlreadySet(VSLANG, language.LCID); // for tools following VS guidelines to just work in CLI
+            SetIfNotAlreadySet(PreferredUILang, language.Name); // for C#/VB targets that pass $(PreferredUILang) to compiler
+        }
+
+        private static CultureInfo GetOverriddenUILanguage()
+        {
+            // DOTNET_CLI_UI_LANGUAGE=<culture name> is the main way for users to customize the CLI's UI language.
+            string dotnetCliLanguage = Environment.GetEnvironmentVariable(DOTNET_CLI_UI_LANGUAGE);
+            if (dotnetCliLanguage != null)
+            {
+                try
+                {
+                    return new CultureInfo(dotnetCliLanguage);
+                }
+                catch (CultureNotFoundException) { }
+            }
+
+            // VSLANG=<lcid> is set by VS and we respect that as well so that we will respect the VS 
+            // language preference if we're invoked by VS. 
+            string vsLang = Environment.GetEnvironmentVariable(VSLANG);
+            if (vsLang != null && int.TryParse(vsLang, out int vsLcid))
+            {
+                try
+                {
+                    return new CultureInfo(vsLcid);
+                }
+                catch (ArgumentOutOfRangeException) { }
+                catch (CultureNotFoundException) { }
+            }
+
+            return null;
+        }
+
+        private static void SetIfNotAlreadySet(string environmentVariableName, string value)
+        {
+            string currentValue = Environment.GetEnvironmentVariable(environmentVariableName);
+            if (currentValue == null)
+            {
+                Environment.SetEnvironmentVariable(environmentVariableName, value);
+            }
+        }
+
+        private static void SetIfNotAlreadySet(string environmentVariableName, int value)
+        {
+            SetIfNotAlreadySet(environmentVariableName, value.ToString());
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11326

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- Adds `UILanguageOverride` class from dotnet.exe CLI to get the value of DOTNET_CLI_UI_LANGUAGE and propagate it to child process
- Use class above in `NuGet.CommandLine.XPlat\Program.cs` to initialize language.
- Modifies debug helper scripts to support localized builds of NuGet.CommandLine.XPlat


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: Manual test, it's almost impossible to do localized unit tests.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A: No product changes.


### Validation

Validated with comparing output with different values of `DOTNET_CLI_UI_LANGUAGE`

- Before: Windows 11 in Spanish with .NET 7
- After: Windows 11 in Spanish with patched .NET 7

#### `dotnet list package` in French (Canada)

|    Before     |     After     |
|---------------|---------------|
| ![list-package-before](https://user-images.githubusercontent.com/1192347/191890269-6e8c520f-144e-4181-a8fa-988734e873f2.png) | ![list-package-after](https://user-images.githubusercontent.com/1192347/191890136-3a2bd60b-58ba-43d5-b6e6-374eff0d2a1b.png) |

#### `dotnet nuget` in German (Germany)

|    Before     |     After     |
|---------------|---------------|
| ![nuget-before](https://user-images.githubusercontent.com/1192347/191890815-6b77315a-c55f-41b0-a28d-995b7f5415f6.png) | ![nuget-after](https://user-images.githubusercontent.com/1192347/191890898-b79264c2-6354-4501-8890-0cf13b97aa1f.png)


#### `dotnet restore` and `dotnet pack` in Chinese (simplified)

This PR has no effect in restore and pack output because both operations run via MSBuild. See issue for more info https://github.com/dotnet/msbuild/issues/1596

|    Before     |     After     |
|---------------|---------------|
| ![pack-and-restore-before](https://user-images.githubusercontent.com/1192347/191891957-3519731e-dbb9-4e77-8b21-69c208b4b226.png) | ![pack-and-restore-after](https://user-images.githubusercontent.com/1192347/191891815-d85438d0-6178-48f7-b6cd-91e678b4a444.png) |


#### `dotnet nuget locals` in an invalid input language in DOTNET_CLI_UI_LANGUAGE

Ran `dotnet nuget locals` with a invalid CultureInfo. dotnet.exe shows an error message, defaulted in the OS language.

|    Before     |     After     |
|---------------|---------------|
| ![invalid-ui-lang-before](https://user-images.githubusercontent.com/1192347/193144115-9d0ee353-405b-4b0f-af3a-acab176017e0.png) | ![invalid-ui-lang-after](https://user-images.githubusercontent.com/1192347/193143817-fa4eb7ce-5775-4466-b3b0-6d8da9d05a69.png) |


##### `dotnet nuget locals` with an empty value in DOTNET_CLI_LANGUAGE

No error is shown, since an empty string is considered an [invariant culture](https://learn.microsoft.com/dotnet/api/system.globalization.cultureinfo?view=net-6.0#invariant-neutral-and-specific-cultures).

![empty-cultureinfo-after](https://user-images.githubusercontent.com/1192347/193168973-c80cc38b-f426-41a8-919c-1b4a839ae725.png)

#### `dotnet nuget locals` with an invalid value in VSLANG envvar

dotnet now shows an error message.

![image](https://user-images.githubusercontent.com/1192347/193186595-3d1e13cf-91aa-4acf-bea0-dd3fcfe1ad22.png)
