### PR TITLE
Ensure IsVsOfflineFeed is calculated correctly on 64-bit machines

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
@@ -146,7 +146,7 @@ namespace NuGet.VisualStudio.Telemetry
         /// </summary>
         public static bool IsVsOfflineFeed(PackageSource source)
         {
-            return IsVsOfflineFeed(source, ExpectedVsOfflinePackagesPath.Value);
+            return IsVsOfflineFeed(source, ExpectedVsOfflinePackagesPathX86.Value) || IsVsOfflineFeed(source, ExpectedVsOfflinePackagesPath.Value);
         }
 
         internal static bool IsVsOfflineFeed(PackageSource source, string expectedVsOfflinePackagesPath)
@@ -167,6 +167,16 @@ namespace NuGet.VisualStudio.Telemetry
 
         private static readonly Lazy<string> ExpectedVsOfflinePackagesPath = new Lazy<string>(() =>
         {
+            return ComputeVSOfflineFeedPath(Environment.SpecialFolder.ProgramFiles);
+        });
+
+        private static readonly Lazy<string> ExpectedVsOfflinePackagesPathX86 = new Lazy<string>(() =>
+        {
+            return ComputeVSOfflineFeedPath(Environment.SpecialFolder.ProgramFilesX86);
+        });
+
+        private static string ComputeVSOfflineFeedPath(Environment.SpecialFolder folderPath)
+        {
             if (!RuntimeEnvironmentHelper.IsWindows)
             {
                 return null;
@@ -174,7 +184,7 @@ namespace NuGet.VisualStudio.Telemetry
 
             try
             {
-                var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+                var programFiles = Environment.GetFolderPath(folderPath);
                 return Path.Combine(programFiles, "Microsoft SDKs", "NuGetPackages");
             }
             catch
@@ -182,7 +192,7 @@ namespace NuGet.VisualStudio.Telemetry
                 // Ignore this check if we fail for any reason to generate the path.
                 return null;
             }
-        });
+        }
 
         /// <summary>
         /// Converts a collection of timings to a json array formatted string.

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/TelemetryUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/TelemetryUtilityTests.cs
@@ -125,7 +125,7 @@ namespace NuGet.VisualStudio.Common.Test.Telemetry
             Assert.Equal(expected, actual);
         }
 
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/10926")]
+        [Fact]
         public void IsVsOfflineFeed_WhenSourceIsNull_Throws()
         {
             var exception = Assert.Throws<ArgumentNullException>(() => TelemetryUtility.IsVsOfflineFeed(source: null));
@@ -133,7 +133,7 @@ namespace NuGet.VisualStudio.Common.Test.Telemetry
             Assert.Equal("source", exception.ParamName);
         }
 
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/10926")]
+        [Fact]
         public void IsVsOfflineFeed_WhenSourceIsNotLocal_ReturnsFalse()
         {
             var source = new PackageSource("https://nuget.test");
@@ -171,6 +171,16 @@ namespace NuGet.VisualStudio.Common.Test.Telemetry
             var source = new PackageSource(packageSourcePath);
             var expectedVsOfflinePackagesPath = vsOfflinePackagesPath;
             bool actualResult = TelemetryUtility.IsVsOfflineFeed(source, expectedVsOfflinePackagesPath);
+
+            Assert.True(actualResult);
+        }
+
+        [Theory]
+        [InlineData(@"C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\")]
+        [InlineData(@"C:\Program Files\Microsoft SDKs\NuGetPackages\")]
+        public void IsVSOfflineFeed_WithValidOfflineFeed_ReturnsTrue(string expectedOfflineFeed)
+        {
+            bool actualResult = TelemetryUtility.IsVsOfflineFeed(new PackageSource(expectedOfflineFeed));
 
             Assert.True(actualResult);
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12110
Fixes: https://github.com/NuGet/Home/issues/10926

Regression? Last working version:
Yes, 5.11, before VS became 64-bit.

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Getting the program files path will vary based on the process bitness, https://learn.microsoft.com/en-us/dotnet/api/system.environment.specialfolder?view=net-6.0#fields. 

We explicitly check both paths.

I have also uncommented a few tests that aren't broken anymore.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
