### PR TITLE
Change VsTargetChannel to int.d17.3

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -27,6 +27,7 @@
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <VsTargetBranch>main</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
+    <VsTargetChannelForTests>int.d$(VsTargetMajorVersion).3</VsTargetChannelForTests>
 
     <!-- NuGet SDK VS package Semantic Version -->
     <NuGetSdkVsSemanticVersion>$(VsTargetMajorVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</NuGetSdkVsSemanticVersion>
@@ -85,6 +86,9 @@
   </Target>
   <Target Name="GetVsTargetChannel">
     <Message Text="$(VsTargetChannel)" Importance="High"/>
+  </Target>
+  <Target Name="GetVsTargetChannelForTests">
+    <Message Text="$(VsTargetChannelForTests)" Importance="High"/>
   </Target>
   <Target Name="GetCliBranchForTesting">
       <Message Text="$(CliBranchForTesting)" Importance="High"/>

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -82,7 +82,7 @@ stages:
       displayName: 'Download buildinfo.json'
     - powershell: |
         try {
-          Write-Host "Set VSBranch variable"
+          Write-Host "Set VSBranch, VsTargetChannel &  VsTargetMajorVersion variables"
           $buildInfoJsonFilePath = "$(Pipeline.Workspace)\ComponentBuildUnderTest\BuildInfo\buildinfo.json"
 
           Write-Host "buildinfo.json drop URI:  $buildInfoJsonFilePath"
@@ -105,10 +105,18 @@ stages:
 
           Write-Host "Target Visual Studio branch: $VSBranch"
           Set-AzurePipelinesVariable 'VSBranch' $VSBranch
+
+          $VsTargetChannel = $buildInfoJson.VsTargetChannel
+          Write-Host "Visual Studio target channel: $VsTargetChannel"
+          Set-AzurePipelinesVariable 'VsTargetChannel' $VsTargetChannel
+
+          $VsTargetMajorVersion = $buildInfoJson.VsTargetMajorVersion
+          Write-Host "Visual Studio major version: $VsTargetMajorVersion"
+          Set-AzurePipelinesVariable 'VsTargetMajorVersion' $VsTargetMajorVersion
         }
         catch {
           Write-Host $_
-          Write-Error "Failed to set VSBranch pipeline variable"
+          Write-Error "Failed to set VSBranch, VsTargetChannel &  VsTargetMajorVersion pipeline variables"
           throw
         }
       displayName: 'Set VSBranch variable'
@@ -131,15 +139,23 @@ stages:
         }
       displayName: 'Set RunSettingsURI variable'
       name: SetRunSettingsURI
-    - download: ComponentBuildUnderTest
-      artifact: MicroBuildOutputs
-      patterns: '**\BootstrapperInfo.json'
-      displayName: Download Bootstrapper Information
+    - task: MicroBuildBuildVSBootstrapper@2
+      displayName: 'Build a Visual Studio bootstrapper'
+      inputs:
+        channelName: "$(VsTargetChannel)"
+        vsMajorVersion: "$(VsTargetMajorVersion)"
+        manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
+        outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish BootstrapperInfo.json as a pipeline artifact'
+      inputs:
+        publishLocation: $(Pipeline.Workspace)\MicroBuild\Output
+      condition: succeeded()    
     - task: PowerShell@2
       displayName: Set 'VisualStudio.InstallationUnderTest.BootstrapperURL'
       inputs:
         filePath: $(DartLab.Path)\Scripts\VisualStudio\Bootstrapper\Get-BootstrapperURL.ps1
-        arguments: -BootstrapperInfoJsonURI '$(Pipeline.Workspace)\ComponentBuildUnderTest\MicroBuildOutputs\BootstrapperInfo.json' -VSBranch '$(VSBranch)' -OutVariableName 'VisualStudio.InstallationUnderTest.BootstrapperURL'
+        arguments: -BootstrapperInfoJsonURI '$(Pipeline.Workspace)\MicroBuild\Output\MicroBuildOutputs\BootstrapperInfo.json' -VSBranch '$(VSBranch)' -OutVariableName 'VisualStudio.InstallationUnderTest.BootstrapperURL'
     # Remove this step hook and it's task if you don't want LKG support
     prePublishOptimizationInputsDropStepList:
     # Set parameter for PreviousOptimizationInputsDropName 

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -149,13 +149,12 @@ stages:
     - task: PublishPipelineArtifact@1
       displayName: 'Publish BootstrapperInfo.json as a pipeline artifact'
       inputs:
-        publishLocation: $(Pipeline.Workspace)\MicroBuild\Output
-      condition: succeeded()    
+        publishLocation: $(Pipeline.Workspace)\MicroBuild\Output          
     - task: PowerShell@2
       displayName: Set 'VisualStudio.InstallationUnderTest.BootstrapperURL'
       inputs:
         filePath: $(DartLab.Path)\Scripts\VisualStudio\Bootstrapper\Get-BootstrapperURL.ps1
-        arguments: -BootstrapperInfoJsonURI '$(Pipeline.Workspace)\MicroBuild\Output\MicroBuildOutputs\BootstrapperInfo.json' -VSBranch '$(VSBranch)' -OutVariableName 'VisualStudio.InstallationUnderTest.BootstrapperURL'
+        arguments: -BootstrapperInfoJsonURI '$(Pipeline.Workspace)\MicroBuild\Output\BootstrapperInfo.json' -VSBranch '$(VSBranch)' -OutVariableName 'VisualStudio.InstallationUnderTest.BootstrapperURL'
     # Remove this step hook and it's task if you don't want LKG support
     prePublishOptimizationInputsDropStepList:
     # Set parameter for PreviousOptimizationInputsDropName 

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -300,7 +300,7 @@ steps:
 - task: MicroBuildBuildVSBootstrapper@2
   displayName: 'Build a Visual Studio bootstrapper'
   inputs:
-    channelName: "$(VsTargetChannel)"
+    channelName: "$(VsTargetChannelForTests)"
     vsMajorVersion: "$(VsTargetMajorVersion)"
     manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
     outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
@@ -315,7 +315,7 @@ steps:
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: PowerShell@1
-  displayName: "Set Bootstrapper URL variable"
+  displayName: "Set Bootstrapper URL variable for tests"
   name: "vsbootstrapper"
   inputs:
     scriptType: "inlineScript"

--- a/eng/pipelines/templates/Initialize_Build.yml
+++ b/eng/pipelines/templates/Initialize_Build.yml
@@ -30,9 +30,12 @@ steps:
           $targetChannel = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetChannel
           $targetChannel = $targetChannel.Trim()
         }
+        $targetChannelForTests = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetChannelForTests
+        $targetChannelForTests = $targetChannelForTests.Trim()
         $targetMajorVersion = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetMajorVersion
         $targetMajorVersion = $targetMajorVersion.Trim()
         Write-Host "##vso[task.setvariable variable=VsTargetChannel;isOutput=true]$targetChannel"
+        Write-Host "##vso[task.setvariable variable=VsTargetChannelForTests;isOutput=true]$targetChannelForTests"
         Write-Host "##vso[task.setvariable variable=VsTargetMajorVersion;isOutput=true]$targetMajorVersion"
         Write-Host "##vso[build.updatebuildnumber]$FullBuildNumber"
         Write-Host "##vso[task.setvariable variable=BuildNumber;isOutput=true]$(BuildRevision)"

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -92,6 +92,7 @@ stages:
       BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
       FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
       VsTargetChannel: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
+      VsTargetChannelForTests: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannelForTests']]
       VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
       SDKVersionForBuild: $[stageDependencies.Initialize.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
       BuildRTM: "false"
@@ -113,6 +114,7 @@ stages:
       BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
       FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
       VsTargetChannel: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
+      VsTargetChannelForTests: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannelForTests']]
       VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
       SDKVersionForBuild: $[stageDependencies.Initialize.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
       BuildRTM: "true"

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -173,6 +173,8 @@ else
     $newBuildCounter = $BuildNumber
     $VsTargetBranch = & dotnet msbuild $RepositoryPath\build\config.props /v:m /nologo /t:GetVsTargetBranch
     $NuGetSdkVsVersion = & dotnet msbuild $RepositoryPath\build\config.props /v:m /nologo /t:GetNuGetSdkVsSemanticVersion
+    $VsTargetChannel = & dotnet msbuild $RepositoryPath\build\config.props /v:m /nologo /t:GetVsTargetChannel
+    $VsTargetMajorVersion = & dotnet msbuild $RepositoryPath\build\config.props /v:m /nologo /t:GetVsTargetMajorVersion
     Write-Host "VS target branch: $VsTargetBranch"
     $jsonRepresentation = @{
         BuildNumber = $newBuildCounter
@@ -181,6 +183,8 @@ else
         LocalizationRepositoryBranch = $NuGetLocalizationRepoBranch
         LocalizationRepositoryCommitHash = $LocalizationRepoCommitHash
         VsTargetBranch = $VsTargetBranch.Trim()
+        VsTargetChannel = $VstargetChannel.Trim()
+        VsTargetMajorVersion = $VsTargetMajorVersion.Trim()
         NuGetSdkVsVersion = $NuGetSdkVsVersion.Trim()
     }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fix: https://github.com/NuGet/Home/issues/12104

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

NuGet Client end to end tests are failing on VS 2022 17.4 because of [VS2022 always in build, never finish](https://developercommunity.visualstudio.com/t/VS2022-always-in-build-never-finish-/10119082) which is marked as duplicate of [another issue](https://developercommunity.visualstudio.com/t/VS2022-hangs-during-build/1587726). We are able to reproduce `Build must be stopped before the solution can be closed` locally and on CI while running tests on the preview versions of 17.4. Hence in this PR, I propose to change the `VSTargetChannel` to `int.d.17.3` so that tests are executed on 17.3 for PR/official builds and it still targets `main` for NuGet code insertion into VS.

This change is temporary and created https://github.com/NuGet/Client.Engineering/issues/1881 to revert this PR once the tests are passing on 17.4 preview versions.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A