### PR TITLE
Improve OptProf pipeline job run names

### DIFF
--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -1,6 +1,7 @@
 # NuGet OptProf profiling pipeline
 
 trigger: none # Prevents this pipeline from triggering on check-ins
+name: $(Resources.Pipeline.ComponentBuildUnderTest.SourceBranch)_$(Resources.Pipeline.ComponentBuildUnderTest.SourceCommit)
 
 resources:
   pipelines:

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -65,12 +65,12 @@ stages:
     - powershell: "Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize"
       displayName: 'Print Environment Variables'
     - powershell: |
-        $branch = $(Resources.Pipeline.ComponentBuildUnderTest.SourceBranch)
+        $branch = "$(Resources.Pipeline.ComponentBuildUnderTest.SourceBranch)"
         $refsHead = "refs/head/"
         if ($branch.StartsWith($refsHead)) {
           $branch = $branch.SubString($refsHead.Length)
         }
-        $commit = $(Resources.Pipeline.ComponentBuildUnderTest.SourceCommit)
+        $commit = "$(Resources.Pipeline.ComponentBuildUnderTest.SourceCommit)"
 
         $BuildName = "${branch}_${commit}"
         Write-Host "Settings build name = $BuildName"

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -66,10 +66,11 @@ stages:
       displayName: 'Print Environment Variables'
     - powershell: |
         $branch = "$(Resources.Pipeline.ComponentBuildUnderTest.SourceBranch)"
-        $refsHead = "refs/head/"
+        $refsHead = "refs/heads/"
         if ($branch.StartsWith($refsHead)) {
           $branch = $branch.SubString($refsHead.Length)
         }
+        $branch = $branch.Replace('/', '_')
         $commit = "$(Resources.Pipeline.ComponentBuildUnderTest.SourceCommit)"
 
         $BuildName = "${branch}_${commit}"

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -1,7 +1,6 @@
 # NuGet OptProf profiling pipeline
 
 trigger: none # Prevents this pipeline from triggering on check-ins
-name: $(Resources.Pipeline.ComponentBuildUnderTest.SourceBranch)_$(Resources.Pipeline.ComponentBuildUnderTest.SourceCommit)
 
 resources:
   pipelines:
@@ -65,6 +64,18 @@ stages:
     preTestMachineConfigurationStepList:
     - powershell: "Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize"
       displayName: 'Print Environment Variables'
+    - powershell: |
+        $branch = $(Resources.Pipeline.ComponentBuildUnderTest.SourceBranch)
+        $refsHead = "refs/head/"
+        if ($branch.StartsWith($refsHead)) {
+          $branch = $branch.SubString($refsHead.Length)
+        }
+        $commit = $(Resources.Pipeline.ComponentBuildUnderTest.SourceCommit)
+
+        $BuildName = "${branch}_${commit}"
+        Write-Host "Settings build name = $BuildName"
+        Write-Host "##vso[build.updatebuildnumber]$BuildName"
+      displayName: 'Set Build Name'
     - download: ComponentBuildUnderTest
       artifact: BuildInfo
       displayName: 'Download buildinfo.json'


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1875

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

When looking at the list of pipeline runs, it's difficult (impossible) to tell which branch or commit the OptProf job was for. This change makes the build name include the branch and commit, so we can tell when it's run for the dev branch, or release branches.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
