### PR TITLE
Disable BuildIntegratedLockFileIsCreatedOnBuild as it's a flaky test

### DIFF
--- a/test/EndToEnd/tests/BuildIntegratedTest.ps1
+++ b/test/EndToEnd/tests/BuildIntegratedTest.ps1
@@ -111,6 +111,7 @@ function Test-BuildIntegratedUninstallNonExistantPackage {
 }
 
 function Test-BuildIntegratedLockFileIsCreatedOnBuild {
+    [SkipTest('https://github.com/NuGet/Home/issues/12104')]
     # Arrange
     $project = New-BuildIntegratedProj UAPApp
     Install-Package NuGet.Versioning -ProjectName $project.Name -version 1.0.7

--- a/test/EndToEnd/tests/BuildIntegratedTest.ps1
+++ b/test/EndToEnd/tests/BuildIntegratedTest.ps1
@@ -112,6 +112,7 @@ function Test-BuildIntegratedUninstallNonExistantPackage {
 
 function Test-BuildIntegratedLockFileIsCreatedOnBuild {
     [SkipTest('https://github.com/NuGet/Home/issues/12104')]
+    param($context)
     # Arrange
     $project = New-BuildIntegratedProj UAPApp
     Install-Package NuGet.Versioning -ProjectName $project.Name -version 1.0.7


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1879
 
Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Given that https://github.com/NuGet/NuGet.Client/pull/4821 is still in draft mode, and this is blocking merges due to failures, I think we should disable this test until https://github.com/NuGet/Home/issues/12104 is fixed. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
