### PR TITLE
Display WarningsAsErrors when a warning is elevated to an error

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
@@ -160,6 +160,7 @@ namespace NuGet.Commands
                 {
                     // If the project wide AllWarningsAsErrors is true and the message has a valid code or
                     // Project wide WarningsAsErrors contains the message code then upgrade to error.
+                    message.Message = "(WarningsAsErrors) " + message.Message;
                     message.Level = LogLevel.Error;
                 }
             }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
@@ -285,7 +285,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 errors.Count().Should().Be(1);
                 errors.First().Code.Should().Be(NuGetLogCode.NU3005);
-                errors.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource));
+                errors.First().Message.Should().Be("(WarningsAsErrors) " + SigningTestUtility.AddSignatureLogPrefix(NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource));
                 errors.First().LibraryId.Should().Be(packageX.Id);
 
                 warnings.Count().Should().Be(0);

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
@@ -281,7 +281,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(1);
-                result.Errors.Should().Contain(string.Format(NU3005, SigningTestUtility.AddSignatureLogPrefix(NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource)));
+                result.Errors.Should().Contain(string.Format(NU3005, "(WarningsAsErrors) " + SigningTestUtility.AddSignatureLogPrefix(NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource)));
 
                 errors.Count().Should().Be(1);
                 errors.First().Code.Should().Be(NuGetLogCode.NU3005);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/CollectorLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/CollectorLoggerTests.cs
@@ -393,7 +393,7 @@ namespace NuGet.Commands.Test
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Once(), NuGetLogCode.NU1601);
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Warning", Times.Once(), NuGetLogCode.NU1500);
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "(WarningsAsErrors) Warning", Times.Once(), NuGetLogCode.NU1500);
         }
 
 
@@ -426,7 +426,7 @@ namespace NuGet.Commands.Test
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Never());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Warning", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "(WarningsAsErrors) Warning", Times.Once());
         }
 
         [Fact]
@@ -460,7 +460,7 @@ namespace NuGet.Commands.Test
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Never());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Warning", Times.Exactly(3));
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "(WarningsAsErrors) Warning", Times.Exactly(3));
         }
 
         [Fact]
@@ -1038,7 +1038,7 @@ namespace NuGet.Commands.Test
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Verbose, "Verbose", Times.Once());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Never());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Warning", Times.Once(), NuGetLogCode.NU1107);
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "(WarningsAsErrors) Warning", Times.Once(), NuGetLogCode.NU1107);
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/8803

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Prepend `(WarningsAsErrors) ` when a warning is elevated to an error.

For example:

**Before**

```text
D:\src\test\hasWarning\hasWarning.csproj : error NU1605: Detected package downgrade: NuGet.Frameworks from 6.3.0 to 6.2.0. Reference the package directly from the project to select a different version.
D:\src\test\hasWarning\hasWarning.csproj : error NU1605:  hasWarning -> NuGet.Protocol 6.3.0 -> NuGet.Packaging 6.3.0 -> NuGet.Configuration 6.3.0 -> NuGet.Common 6.3.0 -> NuGet.Frameworks (>= 6.3.0)
D:\src\test\hasWarning\hasWarning.csproj : error NU1605:  hasWarning -> NuGet.Frameworks (>= 6.2.0)
```

**After**
```text
D:\src\test\hasWarning\hasWarning.csproj : error NU1605: (WarningsAsErrors) Detected package downgrade: NuGet.Frameworks from 6.3.0 to 6.2.0. Reference the package directly from the project to select a different version.
D:\src\test\hasWarning\hasWarning.csproj : error NU1605:  hasWarning -> NuGet.Protocol 6.3.0 -> NuGet.Packaging 6.3.0 -> NuGet.Configuration 6.3.0 -> NuGet.Common 6.3.0 -> NuGet.Frameworks (>= 6.3.0)
D:\src\test\hasWarning\hasWarning.csproj : error NU1605:  hasWarning -> NuGet.Frameworks (>= 6.2.0)
```

This gives knowledgable customers a sufficient hint that `NoWarn="NU1605"` would give them a work around. Otherwise, it's very difficult for customers to know that 1. their project is treating the warning (possibly all warnings) as errors, and 2. that a specific "error" code is really a warning that was elevated.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
