### PR TITLE
Add two test cases for Web Site Projects

### DIFF
--- a/build/tests.dev17.vsconfig
+++ b/build/tests.dev17.vsconfig
@@ -101,6 +101,9 @@
     "Microsoft.Component.ClickOnce",
     "Microsoft.VisualStudio.Component.VisualStudioData",
     "Microsoft.Net.Component.4.6.1.SDK",
-    "Microsoft.Net.Component.4.7.2.SDK"
+    "Microsoft.Net.Component.4.7.2.SDK",
+    "Microsoft.Net.Component.4.8.1.SDK",
+    "Microsoft.Net.Component.4.8.1.TargetingPack",
+    "Microsoft.VisualStudio.ComponentGroup.AdditionalWebProjectTemplates"
   ]
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -3,10 +3,13 @@
 
 using System;
 using System.Diagnostics;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using EnvDTE;
 using Microsoft.Test.Apex.VisualStudio.Solution;
+using NuGet.StaFact;
+using NuGet.Test.Utility;
 using Test.Utility;
 using Xunit;
 using Xunit.Abstractions;
@@ -508,6 +511,76 @@ namespace NuGet.Tests.Apex
                 Timeout,
                 Interval,
                 $"{file.FullName} still existed after {Timeout}.");
+        }
+
+        [NuGetWpfTheory]
+        [MemberData(nameof(GetWebSiteTemplates))]
+        public void InstallPackageToWebSiteFromUI(ProjectTemplate projectTemplate, string projectName, ProjectTargetFramework targetFramework, string packageName, string packageVersion)
+        {
+            // Arrange
+            EnsureVisualStudioHost();
+            var dte = VisualStudio.Dte;
+            var solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution();
+
+            var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, targetFramework, projectName);
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            // Act
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, XunitLogger);
+            var nugetTestService = GetNuGetTestService();
+            var uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI(packageName, packageVersion);
+
+            // Assert
+            CommonUtility.AssertPackageInPackagesConfig(VisualStudio, project, packageName, packageVersion, XunitLogger);
+        }
+
+        public static IEnumerable<object[]> GetWebSiteTemplates()
+        {
+            yield return new object[] { ProjectTemplate.WebSiteEmpty, "WebSiteEmpty", ProjectTargetFramework.V48, "log4net", "2.0.13" };
+            yield return new object[] { ProjectTemplate.WebSite, "WebSite", ProjectTargetFramework.V48, "Log4Net.Async", "2.0.3" };
+            yield return new object[] { ProjectTemplate.WebSiteWCF, "WebSiteWCF", ProjectTargetFramework.V48, "log4net.Ext.Json", "2.0.9.1" };
+            yield return new object[] { ProjectTemplate.WebSiteDynamicDataEntityFramework, "WebSiteEntity", ProjectTargetFramework.V48, "log4net", "2.0.13" };
+            yield return new object[] { ProjectTemplate.WebSiteDynamicDataLinqToSql, "WebSiteLinq", ProjectTargetFramework.V45, "Log4Net.Async", "2.0.3" };
+        }
+
+        [NuGetWpfTheory]
+        [MemberData(nameof(UpdateWebSiteTemplates))]
+        public void UpdateWebSitePackageFromUI(ProjectTemplate projectTemplate, string projectName, ProjectTargetFramework targetFramework, string packageName, string installVersion, string updateVersion)
+        {
+            // Arrange
+            EnsureVisualStudioHost();
+            var dte = VisualStudio.Dte;
+            var solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution();
+
+            var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, targetFramework, projectName);
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            // Act
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, XunitLogger);
+            var nugetTestService = GetNuGetTestService();
+            var uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI(packageName, installVersion);
+
+            // Act
+            VisualStudio.ClearWindows();
+            uiwindow.UpdatePackageFromUI(packageName, updateVersion);
+
+            // Assert
+            CommonUtility.AssertPackageInPackagesConfig(VisualStudio, project, packageName, updateVersion, XunitLogger);
+        }
+
+        public static IEnumerable<object[]> UpdateWebSiteTemplates()
+        {
+            yield return new object[] { ProjectTemplate.WebSiteEmpty, "WebSiteEmpty", ProjectTargetFramework.V48, "log4net", "2.0.13", "2.0.15" };
+            yield return new object[] { ProjectTemplate.WebSite, "WebSite", ProjectTargetFramework.V48, "Log4Net.Async", "2.0.3", "2.0.4" };
+            yield return new object[] { ProjectTemplate.WebSiteWCF, "WebSiteWCF", ProjectTargetFramework.V48, "log4net.Ext.Json", "2.0.9.1", "2.0.10.1" };
+            yield return new object[] { ProjectTemplate.WebSiteDynamicDataEntityFramework, "WebSiteEntity", ProjectTargetFramework.V48, "log4net", "2.0.13", "2.0.15" };
+            yield return new object[] { ProjectTemplate.WebSiteDynamicDataLinqToSql, "WebSiteLinq", ProjectTargetFramework.V45, "Log4Net.Async", "2.0.3", "2.0.4" };
         }
     }
 }


### PR DESCRIPTION
## Description
**Add two test cases：**
1.InstallPackageToWebSiteFromUI: Install particular package to C# ASP Web Site Project from PM UI.
2.UpdateWebSitePackageFromUI: Update package for C# ASP Web Site Project in PM UI.

- Updated the "...\build\tests.dev17.vsconfig" to install Web Site Projects for testing.
- We created a bulk of C# ASP Web Site Projects with Theory.
- The test cases were added into the end of the ...\NuGet.Tests.Apex\NuGetEndToEndTests\NuGetUITestCase.cs file.

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes


- **Tests**
- [x] Automated tests added
1.InstallPackageToWebSiteFromUI
2.UpdateWebSitePackageFromUI