### PR TITLE
Migrates existing source-gen commands to System.CommandLine

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/CommandParsers.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/CommandParsers.cs
@@ -15,7 +15,12 @@ namespace NuGet.CommandLine.XPlat.Commands
     {
         public static void Register(Command app, Func<ILogger> getLogger)
         {
+            AddVerbParser.Register(app, getLogger);
+            DisableVerbParser.Register(app, getLogger);
+            EnableVerbParser.Register(app, getLogger);
             ListVerbParser.Register(app, getLogger);
+            RemoveVerbParser.Register(app, getLogger);
+            UpdateVerbParser.Register(app, getLogger);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/Commands.xml
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/Commands.xml
@@ -2,6 +2,57 @@
 <!-- Copyright (c) .NET Foundation. All rights reserved.
      Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. -->
 <Commands>
+  <Verb Name="add">
+    <Noun Name="source" Version="3.1.200"
+       Description="adds a new package source to your NuGet configuration files." >
+      <Argument Name="Source" LongName="PackageSourcePath" Help="SourcesCommandSourceDescription" />
+      <SingleValueOption Name="name" Shortcut="n" Help="SourcesCommandNameDescription"/>
+      <SingleValueOption Name="username" Shortcut="u" Help="SourcesCommandUsernameDescription"/>
+      <SingleValueOption Name="password" Shortcut="p" Help="SourcesCommandPasswordDescription"/>
+      <SwitchOption Name="store-Password-In-Clear-Text" Help="SourcesCommandStorePasswordInClearTextDescription"/>
+      <SingleValueOption Name="valid-Authentication-Types" Help="SourcesCommandValidAuthenticationTypesDescription" />
+      <SingleValueOption Name="configfile" Help="Option_ConfigFile" />
+      <Example Title="Add `nuget.org` as a source:" Command="dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org" />
+      <Example Title="Add `c:\packages` as a local source:" Command="dotnet nuget add source c:\packages" />
+      <Example Title="Add a source that needs authentication:" Command="dotnet nuget add source https://contoso.com/litware -n myTeam -u myUsername -p myPassword --store-password-in-clear-text" />
+      <Example Title="Add a source that needs authentication (then go install credential provider):" Command="dotnet nuget add source https://pkgs.dev.azure.com/contoso/litware/_packaging/litware-deps/nuget/v3/index.json -n myTeam" />
+      <SeeAlso Title="Package source sections in NuGet.config files" Url="/nuget/reference/nuget-config-file#package-source-sections" />
+      <SeeAlso Title="sources command (nuget.exe)" Url="/nuget/reference/cli-reference/cli-ref-sources" />
+    </Noun>
+    <Noun Name="client-cert" Version="3.1.200"
+       Description="adds a new client certificate to your NuGet configuration files.">
+      <SingleValueOption Name="package-source" Shortcut="s" Help="Option_PackageSource"/>
+      <SingleValueOption Name="path" Help="Option_Path"/>
+      <SingleValueOption Name="password" Help="Option_Password"/>
+      <SwitchOption Name="store-password-in-clear-text" Help="Option_StorePasswordInClearText"/>
+      <SingleValueOption Name="store-location" Help="Option_StoreLocation"/>
+      <SingleValueOption Name="store-name" Help="Option_StoreName"/>
+      <SingleValueOption Name="find-by" Help="Option_FindBy"/>
+      <SingleValueOption Name="find-value" Help="Option_FindValue"/>
+      <SwitchOption Name="force" Shortcut="f" Help="Option_Force"/>
+      <SingleValueOption Name="configfile" Help="Option_ConfigFile" />
+    </Noun>
+  </Verb>
+  <Verb Name="disable">
+    <Noun Name="source" Version="3.1.200"
+       Description="disables an existing source in your NuGet configuration files." >
+      <Argument Name="name" Help="SourcesCommandNameDescription" />
+      <SingleValueOption Name="configfile" Help="Option_ConfigFile"/>
+      <Example Title="Disable a source with name of `mySource`:" Command="dotnet nuget disable source mySource" />
+      <SeeAlso Title="Package source sections in NuGet.config files" Url="/nuget/reference/nuget-config-file#package-source-sections" />
+      <SeeAlso Title="sources command (nuget.exe)" Url="/nuget/reference/cli-reference/cli-ref-sources" />
+    </Noun>
+  </Verb>
+  <Verb Name="enable">
+    <Noun Name="source" Version="3.1.200"
+       Description="enables an existing source in your NuGet configuration files." >
+      <Argument Name="name" Help="SourcesCommandNameDescription" />
+      <SingleValueOption Name="configfile" Help="Option_ConfigFile"/>
+      <Example Title="Enable a source with name of `mySource`:" Command="dotnet nuget enable source mySource" />
+      <SeeAlso Title="Package source sections in NuGet.config files" Url="/nuget/reference/nuget-config-file#package-source-sections" />
+      <SeeAlso Title="sources command (nuget.exe)" Url="/nuget/reference/cli-reference/cli-ref-sources" />
+    </Noun>
+  </Verb>
   <Verb Name="list">
     <Noun Name="source" Version="3.1.200"
        Description="lists all existing sources from your NuGet configuration files." >
@@ -10,6 +61,53 @@
       <Example Title="List configured sources from the current directory:" Command="dotnet nuget list source" />
       <SeeAlso Title="Package source sections in NuGet.config files" Url="/nuget/reference/nuget-config-file#package-source-sections" />
       <SeeAlso Title="sources command (nuget.exe)" Url="/nuget/reference/cli-reference/cli-ref-sources" />
+    </Noun>
+    <Noun Name="client-cert" Version="3.1.200"
+       Description="lists all configured client certificates.">
+      <SingleValueOption Name="configfile" Help="Option_ConfigFile" />
+    </Noun>
+  </Verb>
+  <Verb Name="remove">
+    <Noun Name="source" Version="3.1.200"
+       Description="removes an existing source from your NuGet configuration files." >
+      <Argument Name="name" Help="SourcesCommandNameDescription" />
+      <SingleValueOption Name="configfile" Help="Option_ConfigFile"/>
+      <Example Title="Remove a source with name of `mySource`:" Command="dotnet nuget remove source mySource" />
+      <SeeAlso Title="Package source sections in NuGet.config files" Url="/nuget/reference/nuget-config-file#package-source-sections" />
+      <SeeAlso Title="sources command (nuget.exe)" Url="/nuget/reference/cli-reference/cli-ref-sources" />
+    </Noun>
+    <Noun Name="client-cert" Version="3.1.200"
+       Description="removes an existing client certificate configuration from your NuGet configuration files.">
+      <SingleValueOption Name="package-source" Shortcut="s" Help="Option_PackageSource"/>
+      <SingleValueOption Name="configfile" Help="Option_ConfigFile" />
+    </Noun>
+  </Verb>
+  <Verb Name="update">
+    <Noun Name="source" Version="3.1.200"
+       Description="updates an existing source in your NuGet configuration files." >
+      <Argument Name="name" Help="SourcesCommandNameDescription" />
+      <SingleValueOption Name="source" Shortcut="s" Help="SourcesCommandSourceDescription"/>
+      <SingleValueOption Name="username" Shortcut="u" Help="SourcesCommandUsernameDescription"/>
+      <SingleValueOption Name="password" Shortcut="p" Help="SourcesCommandPasswordDescription"/>
+      <SwitchOption Name="store-Password-In-Clear-Text" Help="SourcesCommandStorePasswordInClearTextDescription"/>
+      <SingleValueOption Name="valid-Authentication-Types" Help="SourcesCommandValidAuthenticationTypesDescription" />
+      <SingleValueOption Name="configfile" Help="Option_ConfigFile" />
+      <Example Title="Update a source with name of `mySource`:" Command="dotnet nuget update source mySource --source c:\packages" />
+      <SeeAlso Title="Package source sections in NuGet.config files" Url="/nuget/reference/nuget-config-file#package-source-sections" />
+      <SeeAlso Title="sources command (nuget.exe)" Url="/nuget/reference/cli-reference/cli-ref-sources" />
+    </Noun>
+    <Noun Name="client-cert" Version="3.1.200"
+       Description="updates an existing client certificate in your NuGet configuration files.">
+      <SingleValueOption Name="package-source" Shortcut="s" Help="Option_PackageSource"/>
+      <SingleValueOption Name="path" Help="Option_Path"/>
+      <SingleValueOption Name="password" Help="Option_Password"/>
+      <SwitchOption Name="store-password-in-clear-text" Help="Option_StorePasswordInClearText"/>
+      <SingleValueOption Name="store-location" Help="Option_StoreLocation"/>
+      <SingleValueOption Name="store-name" Help="Option_StoreName"/>
+      <SingleValueOption Name="find-by" Help="Option_FindBy"/>
+      <SingleValueOption Name="find-value" Help="Option_FindValue"/>
+      <SwitchOption Name="force" Shortcut="f" Help="Option_Force"/>
+      <SingleValueOption Name="configfile" Help="Option_ConfigFile" />
     </Noun>
   </Verb>
 </Commands>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/CustomBinders.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/CustomBinders.cs
@@ -11,6 +11,133 @@ using NuGet.Commands;
 
 namespace NuGet.CommandLine.XPlat.Commands
 {
+    internal partial class AddSourceCustomBinder : BinderBase<AddSourceArgs>
+    {
+        private readonly Argument<string> _source;
+        private readonly Option<string> _name;
+        private readonly Option<string> _username;
+        private readonly Option<string> _password;
+        private readonly Option<bool> _storePasswordInClearText;
+        private readonly Option<string> _validAuthenticationTypes;
+        private readonly Option<string> _configfile;
+
+        public AddSourceCustomBinder(Argument<string> source, Option<string> name, Option<string> username, Option<string> password, Option<bool> storePasswordInClearText, Option<string> validAuthenticationTypes, Option<string> configfile)
+        {
+            _source = source;
+            _name = name;
+            _username = username;
+            _password = password;
+            _storePasswordInClearText = storePasswordInClearText;
+            _validAuthenticationTypes = validAuthenticationTypes;
+            _configfile = configfile;
+        }
+
+        protected override AddSourceArgs GetBoundValue(BindingContext bindingContext)
+        {
+            var returnValue = new AddSourceArgs()
+            {
+                Source = bindingContext.ParseResult.GetValueForArgument(_source),
+                Name = bindingContext.ParseResult.GetValueForOption(_name),
+                Username = bindingContext.ParseResult.GetValueForOption(_username),
+                Password = bindingContext.ParseResult.GetValueForOption(_password),
+                StorePasswordInClearText = bindingContext.ParseResult.GetValueForOption(_storePasswordInClearText),
+                ValidAuthenticationTypes = bindingContext.ParseResult.GetValueForOption(_validAuthenticationTypes),
+                Configfile = bindingContext.ParseResult.GetValueForOption(_configfile),
+            };
+            return returnValue;
+        } // end GetBoundValue method
+    } // end class
+
+    internal partial class AddClientCertCustomBinder : BinderBase<AddClientCertArgs>
+    {
+        private readonly Option<string> _packageSource;
+        private readonly Option<string> _path;
+        private readonly Option<string> _password;
+        private readonly Option<bool> _storePasswordInClearText;
+        private readonly Option<string> _storeLocation;
+        private readonly Option<string> _storeName;
+        private readonly Option<string> _findBy;
+        private readonly Option<string> _findValue;
+        private readonly Option<bool> _force;
+        private readonly Option<string> _configfile;
+
+        public AddClientCertCustomBinder(Option<string> packageSource, Option<string> path, Option<string> password, Option<bool> storePasswordInClearText, Option<string> storeLocation, Option<string> storeName, Option<string> findBy, Option<string> findValue, Option<bool> force, Option<string> configfile)
+        {
+            _packageSource = packageSource;
+            _path = path;
+            _password = password;
+            _storePasswordInClearText = storePasswordInClearText;
+            _storeLocation = storeLocation;
+            _storeName = storeName;
+            _findBy = findBy;
+            _findValue = findValue;
+            _force = force;
+            _configfile = configfile;
+        }
+
+        protected override AddClientCertArgs GetBoundValue(BindingContext bindingContext)
+        {
+            var returnValue = new AddClientCertArgs()
+            {
+                PackageSource = bindingContext.ParseResult.GetValueForOption(_packageSource),
+                Path = bindingContext.ParseResult.GetValueForOption(_path),
+                Password = bindingContext.ParseResult.GetValueForOption(_password),
+                StorePasswordInClearText = bindingContext.ParseResult.GetValueForOption(_storePasswordInClearText),
+                StoreLocation = bindingContext.ParseResult.GetValueForOption(_storeLocation),
+                StoreName = bindingContext.ParseResult.GetValueForOption(_storeName),
+                FindBy = bindingContext.ParseResult.GetValueForOption(_findBy),
+                FindValue = bindingContext.ParseResult.GetValueForOption(_findValue),
+                Force = bindingContext.ParseResult.GetValueForOption(_force),
+                Configfile = bindingContext.ParseResult.GetValueForOption(_configfile),
+            };
+            return returnValue;
+        } // end GetBoundValue method
+    } // end class
+
+    internal partial class DisableSourceCustomBinder : BinderBase<DisableSourceArgs>
+    {
+        private readonly Argument<string> _name;
+        private readonly Option<string> _configfile;
+
+        public DisableSourceCustomBinder(Argument<string> name, Option<string> configfile)
+        {
+            _name = name;
+            _configfile = configfile;
+        }
+
+        protected override DisableSourceArgs GetBoundValue(BindingContext bindingContext)
+        {
+            var returnValue = new DisableSourceArgs()
+            {
+                Name = bindingContext.ParseResult.GetValueForArgument(_name),
+                Configfile = bindingContext.ParseResult.GetValueForOption(_configfile),
+            };
+            return returnValue;
+        } // end GetBoundValue method
+    } // end class
+
+    internal partial class EnableSourceCustomBinder : BinderBase<EnableSourceArgs>
+    {
+        private readonly Argument<string> _name;
+        private readonly Option<string> _configfile;
+
+        public EnableSourceCustomBinder(Argument<string> name, Option<string> configfile)
+        {
+            _name = name;
+            _configfile = configfile;
+        }
+
+        protected override EnableSourceArgs GetBoundValue(BindingContext bindingContext)
+        {
+            var returnValue = new EnableSourceArgs()
+            {
+                Name = bindingContext.ParseResult.GetValueForArgument(_name),
+                Configfile = bindingContext.ParseResult.GetValueForOption(_configfile),
+            };
+            return returnValue;
+        } // end GetBoundValue method
+    } // end class
+
     internal partial class ListSourceCustomBinder : BinderBase<ListSourceArgs>
     {
         private readonly Option<string> _format;
@@ -27,6 +154,152 @@ namespace NuGet.CommandLine.XPlat.Commands
             var returnValue = new ListSourceArgs()
             {
                 Format = bindingContext.ParseResult.GetValueForOption(_format),
+                Configfile = bindingContext.ParseResult.GetValueForOption(_configfile),
+            };
+            return returnValue;
+        } // end GetBoundValue method
+    } // end class
+
+    internal partial class ListClientCertCustomBinder : BinderBase<ListClientCertArgs>
+    {
+        private readonly Option<string> _configfile;
+
+        public ListClientCertCustomBinder(Option<string> configfile)
+        {
+            _configfile = configfile;
+        }
+
+        protected override ListClientCertArgs GetBoundValue(BindingContext bindingContext)
+        {
+            var returnValue = new ListClientCertArgs()
+            {
+                Configfile = bindingContext.ParseResult.GetValueForOption(_configfile),
+            };
+            return returnValue;
+        } // end GetBoundValue method
+    } // end class
+
+    internal partial class RemoveSourceCustomBinder : BinderBase<RemoveSourceArgs>
+    {
+        private readonly Argument<string> _name;
+        private readonly Option<string> _configfile;
+
+        public RemoveSourceCustomBinder(Argument<string> name, Option<string> configfile)
+        {
+            _name = name;
+            _configfile = configfile;
+        }
+
+        protected override RemoveSourceArgs GetBoundValue(BindingContext bindingContext)
+        {
+            var returnValue = new RemoveSourceArgs()
+            {
+                Name = bindingContext.ParseResult.GetValueForArgument(_name),
+                Configfile = bindingContext.ParseResult.GetValueForOption(_configfile),
+            };
+            return returnValue;
+        } // end GetBoundValue method
+    } // end class
+
+    internal partial class RemoveClientCertCustomBinder : BinderBase<RemoveClientCertArgs>
+    {
+        private readonly Option<string> _packageSource;
+        private readonly Option<string> _configfile;
+
+        public RemoveClientCertCustomBinder(Option<string> packageSource, Option<string> configfile)
+        {
+            _packageSource = packageSource;
+            _configfile = configfile;
+        }
+
+        protected override RemoveClientCertArgs GetBoundValue(BindingContext bindingContext)
+        {
+            var returnValue = new RemoveClientCertArgs()
+            {
+                PackageSource = bindingContext.ParseResult.GetValueForOption(_packageSource),
+                Configfile = bindingContext.ParseResult.GetValueForOption(_configfile),
+            };
+            return returnValue;
+        } // end GetBoundValue method
+    } // end class
+
+    internal partial class UpdateSourceCustomBinder : BinderBase<UpdateSourceArgs>
+    {
+        private readonly Argument<string> _name;
+        private readonly Option<string> _source;
+        private readonly Option<string> _username;
+        private readonly Option<string> _password;
+        private readonly Option<bool> _storePasswordInClearText;
+        private readonly Option<string> _validAuthenticationTypes;
+        private readonly Option<string> _configfile;
+
+        public UpdateSourceCustomBinder(Argument<string> name, Option<string> source, Option<string> username, Option<string> password, Option<bool> storePasswordInClearText, Option<string> validAuthenticationTypes, Option<string> configfile)
+        {
+            _name = name;
+            _source = source;
+            _username = username;
+            _password = password;
+            _storePasswordInClearText = storePasswordInClearText;
+            _validAuthenticationTypes = validAuthenticationTypes;
+            _configfile = configfile;
+        }
+
+        protected override UpdateSourceArgs GetBoundValue(BindingContext bindingContext)
+        {
+            var returnValue = new UpdateSourceArgs()
+            {
+                Name = bindingContext.ParseResult.GetValueForArgument(_name),
+                Source = bindingContext.ParseResult.GetValueForOption(_source),
+                Username = bindingContext.ParseResult.GetValueForOption(_username),
+                Password = bindingContext.ParseResult.GetValueForOption(_password),
+                StorePasswordInClearText = bindingContext.ParseResult.GetValueForOption(_storePasswordInClearText),
+                ValidAuthenticationTypes = bindingContext.ParseResult.GetValueForOption(_validAuthenticationTypes),
+                Configfile = bindingContext.ParseResult.GetValueForOption(_configfile),
+            };
+            return returnValue;
+        } // end GetBoundValue method
+    } // end class
+
+    internal partial class UpdateClientCertCustomBinder : BinderBase<UpdateClientCertArgs>
+    {
+        private readonly Option<string> _packageSource;
+        private readonly Option<string> _path;
+        private readonly Option<string> _password;
+        private readonly Option<bool> _storePasswordInClearText;
+        private readonly Option<string> _storeLocation;
+        private readonly Option<string> _storeName;
+        private readonly Option<string> _findBy;
+        private readonly Option<string> _findValue;
+        private readonly Option<bool> _force;
+        private readonly Option<string> _configfile;
+
+        public UpdateClientCertCustomBinder(Option<string> packageSource, Option<string> path, Option<string> password, Option<bool> storePasswordInClearText, Option<string> storeLocation, Option<string> storeName, Option<string> findBy, Option<string> findValue, Option<bool> force, Option<string> configfile)
+        {
+            _packageSource = packageSource;
+            _path = path;
+            _password = password;
+            _storePasswordInClearText = storePasswordInClearText;
+            _storeLocation = storeLocation;
+            _storeName = storeName;
+            _findBy = findBy;
+            _findValue = findValue;
+            _force = force;
+            _configfile = configfile;
+        }
+
+        protected override UpdateClientCertArgs GetBoundValue(BindingContext bindingContext)
+        {
+            var returnValue = new UpdateClientCertArgs()
+            {
+                PackageSource = bindingContext.ParseResult.GetValueForOption(_packageSource),
+                Path = bindingContext.ParseResult.GetValueForOption(_path),
+                Password = bindingContext.ParseResult.GetValueForOption(_password),
+                StorePasswordInClearText = bindingContext.ParseResult.GetValueForOption(_storePasswordInClearText),
+                StoreLocation = bindingContext.ParseResult.GetValueForOption(_storeLocation),
+                StoreName = bindingContext.ParseResult.GetValueForOption(_storeName),
+                FindBy = bindingContext.ParseResult.GetValueForOption(_findBy),
+                FindValue = bindingContext.ParseResult.GetValueForOption(_findValue),
+                Force = bindingContext.ParseResult.GetValueForOption(_force),
                 Configfile = bindingContext.ParseResult.GetValueForOption(_configfile),
             };
             return returnValue;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/Utils.tt
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/Utils.tt
@@ -256,30 +256,18 @@ public class OptionData
 
     string GenerateOptionNameVar(OptionData data)
     {
-        return data.Name + "_" + data.BaseClass;
+        return data.CamelCaseName + "_" + data.BaseClass;
     }
 
-    void GenerateAddOptionOrArgument(XElement parentNode, string commandVarName, int indent = 4)
+    void GenerateAddOptionOrArgument(IReadOnlyCollection<OptionData> options, string commandVarName, int indent = 4)
     {
-        foreach (XElement option in parentNode.Elements())
+        foreach (OptionData data in options)
         {
-            var optionXName = option.Name;
-            if (!isValidOption(option))
-            {
-                continue;
-            }
-
-            var data = new OptionData(option);
-            string optionNameVar =  GenerateOptionNameVar(data);
+            string optionNameVar = GenerateOptionNameVar(data);
             if (data.BaseClass == "Argument")
             {
                 // Generate Argument
-#>
-<#= Indent(indent) #>var <#= optionNameVar #> = new Argument<<#= data.DataType #>>(name: "<#= data.LongNameOrName #>", description: <#= data.Help #>)
-<#= Indent(indent) #>{
-<#= Indent(indent) #>    Arity = <#= data.OptionType #>,
-<#= Indent(indent) #>};
-<#+
+                WriteLine($@"var {optionNameVar} = new Argument<{data.DataType}>(name: ""{data.LongNameOrName}"", description: {data.Help})");
                 // End Generate argument
             }
             else if (data.BaseClass == "Option")
@@ -287,26 +275,20 @@ public class OptionData
                 // Generate Option
                 if (data.HasShortcut)
                 {
-#>
-<#= Indent(indent) #>var <#= optionNameVar #> = new Option<<#= data.DataType #>>(aliases: new[] { "<#= data.ShortcutName #>", "<#= data.FullName #>" }, description: <#= data.Help #>)
-<#+
+                    WriteLine($@"var {optionNameVar} = new Option<{data.DataType}>(aliases: new[] {{ ""{data.ShortcutName}"", ""{data.FullName}"" }}, description: {data.Help})");
                 }
                 else
                 {
-#>
-<#= Indent(indent) #>var <#= optionNameVar #> = new Option<<#= data.DataType #>>(name: "<#= data.FullName #>", description: <#= data.Help #>)
-<#+
+                    WriteLine($@"var {optionNameVar} = new Option<{data.DataType}>(name: ""{data.FullName}"", description: {data.Help})");
                 }
-#>
-<#= Indent(indent) #>{
-<#= Indent(indent) #>    Arity = <#= data.OptionType #>,
-<#= Indent(indent) #>};
-<#+
                 // End Generate option
             }
-#>
-<#= Indent(indent) #><#= commandVarName #>.Add(<#= optionNameVar #>);
-<#+
+            WriteLine("{");
+            PushIndent(Indent(indent));
+            WriteLine($@"Arity = {data.OptionType},");
+            PopIndent();
+            WriteLine("};");
+            WriteLine($@"{commandVarName}.Add({optionNameVar});");
         }
     }
 
@@ -363,7 +345,7 @@ public class OptionData
         PushIndent(Indent(indent));
         WriteLine($"{classVisibility} partial class {className}");
         WriteLine("{");
-        PushIndent("    ");
+        PushIndent(Indent(indent * 2));
         foreach (XElement option in nodeMembers.Elements())
         {
             if (IsArgumentOrOption(GetProperty(option)))
@@ -411,7 +393,7 @@ public class OptionData
 
     string GetNodeFormalName(XElement nodeWithArgs)
     {
-        string name = nodeWithArgs.Attribute(XName.Get("Name", ""))?.Value;
+        string name = nodeWithArgs?.Attribute(XName.Get("Name", ""))?.Value;
         string formalName = StringUtilities.GetFormalName(name);
 
         return formalName;
@@ -501,7 +483,7 @@ public class OptionData
             {
                 WriteLine($"{data.InitCapsName} = bindingContext.ParseResult.GetValueForOption({data.PrivateMemberName}),");
             }
-            else
+            else if (data.BaseClass == "Argument")
             {
                 WriteLine($"{data.InitCapsName} = bindingContext.ParseResult.GetValueForArgument({data.PrivateMemberName}),");
             }
@@ -533,5 +515,33 @@ public class OptionData
         IReadOnlyCollection<OptionData> options = GetOptionsFromNode(membersNode);
         GenerateBinderClass(binderClassName, binderTypeClassName, options);
         WriteLine(string.Empty);
+    }
+
+    void GenerateRegisterMethodForCommand(string runnerPrefix, XElement commandNode, string binderClassName)
+    {
+        IReadOnlyCollection<OptionData> options = GetOptionsFromNode(commandNode);
+        string customHandlerName = commandNode.Attribute(XName.Get("Handler", ""))?.Value;
+        bool hasHustomHandler = !string.IsNullOrEmpty(customHandlerName);
+
+        string cmdLocalName = "cmd";
+        WriteLine($@"private static void RegisterOptionsForCommand{runnerPrefix}(Command {cmdLocalName}, Func<ILogger> getLogger)");
+        WriteLine("{");
+        PushIndent(Indent(4));
+        GenerateAddOptionOrArgument(options, cmdLocalName);
+        if (hasHustomHandler)
+        {
+            GenerateSetCustomHandler(cmdLocalName, customHandlerName, options);
+        }
+        else
+        {
+            GenerateCommandHandlerCustomBinder(cmdLocalName, runnerPrefix, binderClassName, options);
+        }
+        PopIndent();
+        WriteLine("}");
+    }
+
+    void GenerateRegisterMehtodForCommandCall(string runnerPrefix, string commandNameVar, string loggerFuncNameVar)
+    {
+        WriteLine($@"RegisterOptionsForCommand{runnerPrefix}({commandNameVar}, {loggerFuncNameVar});");
     }
 #>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/VerbParsers.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/VerbParsers.cs
@@ -12,6 +12,230 @@ using NuGet.Common;
 
 namespace NuGet.CommandLine.XPlat.Commands
 {
+    internal partial class AddVerbParser
+    {
+        internal static Func<ILogger> GetLoggerFunction;
+
+        internal static Command Register(Command app, Func<ILogger> getLogger)
+        {
+            var AddCmd = new Command(name: "add", description: Strings.Add_Description);
+
+            // Options directly under the verb 'add'
+
+            // noun sub-command: add source
+            var SourceCmd = new Command(name: "source", description: Strings.AddSourceCommandDescription);
+
+            // Options under sub-command: add source
+            RegisterOptionsForCommandAddSource(SourceCmd, getLogger);
+
+            AddCmd.AddCommand(SourceCmd);
+
+            // noun sub-command: add client-cert
+            var ClientCertCmd = new Command(name: "client-cert", description: Strings.AddClientCertCommandDescription);
+
+            // Options under sub-command: add client-cert
+            RegisterOptionsForCommandAddClientCert(ClientCertCmd, getLogger);
+
+            AddCmd.AddCommand(ClientCertCmd);
+
+            GetLoggerFunction = getLogger;
+            app.AddCommand(AddCmd);
+
+            return AddCmd;
+        } // End noun method
+
+        private static void RegisterOptionsForCommandAddSource(Command cmd, Func<ILogger> getLogger)
+        {
+            var source_Argument = new Argument<string>(name: "PackageSourcePath", description: Strings.SourcesCommandSourceDescription)
+            {
+                Arity = ArgumentArity.ExactlyOne,
+            };
+            cmd.Add(source_Argument);
+            var name_Option = new Option<string>(aliases: new[] { "-n", "--name" }, description: Strings.SourcesCommandNameDescription)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(name_Option);
+            var username_Option = new Option<string>(aliases: new[] { "-u", "--username" }, description: Strings.SourcesCommandUsernameDescription)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(username_Option);
+            var password_Option = new Option<string>(aliases: new[] { "-p", "--password" }, description: Strings.SourcesCommandPasswordDescription)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(password_Option);
+            var storePasswordInClearText_Option = new Option<bool>(name: "--store-password-in-clear-text", description: Strings.SourcesCommandStorePasswordInClearTextDescription)
+            {
+                Arity = ArgumentArity.Zero,
+            };
+            cmd.Add(storePasswordInClearText_Option);
+            var validAuthenticationTypes_Option = new Option<string>(name: "--valid-authentication-types", description: Strings.SourcesCommandValidAuthenticationTypesDescription)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(validAuthenticationTypes_Option);
+            var configfile_Option = new Option<string>(name: "--configfile", description: Strings.Option_ConfigFile)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(configfile_Option);
+            // Create handler delegate handler for cmd
+            cmd.SetHandler((args) =>
+            {
+                AddSourceRunner.Run(args, getLogger);
+            }, new AddSourceCustomBinder(source_Argument, name_Option, username_Option, password_Option, storePasswordInClearText_Option, validAuthenticationTypes_Option, configfile_Option));
+        }
+
+        private static void RegisterOptionsForCommandAddClientCert(Command cmd, Func<ILogger> getLogger)
+        {
+            var packageSource_Option = new Option<string>(aliases: new[] { "-s", "--package-source" }, description: Strings.Option_PackageSource)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(packageSource_Option);
+            var path_Option = new Option<string>(name: "--path", description: Strings.Option_Path)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(path_Option);
+            var password_Option = new Option<string>(name: "--password", description: Strings.Option_Password)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(password_Option);
+            var storePasswordInClearText_Option = new Option<bool>(name: "--store-password-in-clear-text", description: Strings.Option_StorePasswordInClearText)
+            {
+                Arity = ArgumentArity.Zero,
+            };
+            cmd.Add(storePasswordInClearText_Option);
+            var storeLocation_Option = new Option<string>(name: "--store-location", description: Strings.Option_StoreLocation)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(storeLocation_Option);
+            var storeName_Option = new Option<string>(name: "--store-name", description: Strings.Option_StoreName)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(storeName_Option);
+            var findBy_Option = new Option<string>(name: "--find-by", description: Strings.Option_FindBy)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(findBy_Option);
+            var findValue_Option = new Option<string>(name: "--find-value", description: Strings.Option_FindValue)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(findValue_Option);
+            var force_Option = new Option<bool>(aliases: new[] { "-f", "--force" }, description: Strings.Option_Force)
+            {
+                Arity = ArgumentArity.Zero,
+            };
+            cmd.Add(force_Option);
+            var configfile_Option = new Option<string>(name: "--configfile", description: Strings.Option_ConfigFile)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(configfile_Option);
+            // Create handler delegate handler for cmd
+            cmd.SetHandler((args) =>
+            {
+                AddClientCertRunner.Run(args, getLogger);
+            }, new AddClientCertCustomBinder(packageSource_Option, path_Option, password_Option, storePasswordInClearText_Option, storeLocation_Option, storeName_Option, findBy_Option, findValue_Option, force_Option, configfile_Option));
+        }
+    } // end class
+
+    internal partial class DisableVerbParser
+    {
+        internal static Func<ILogger> GetLoggerFunction;
+
+        internal static Command Register(Command app, Func<ILogger> getLogger)
+        {
+            var DisableCmd = new Command(name: "disable", description: Strings.Disable_Description);
+
+            // Options directly under the verb 'disable'
+
+            // noun sub-command: disable source
+            var SourceCmd = new Command(name: "source", description: Strings.DisableSourceCommandDescription);
+
+            // Options under sub-command: disable source
+            RegisterOptionsForCommandDisableSource(SourceCmd, getLogger);
+
+            DisableCmd.AddCommand(SourceCmd);
+
+            GetLoggerFunction = getLogger;
+            app.AddCommand(DisableCmd);
+
+            return DisableCmd;
+        } // End noun method
+
+        private static void RegisterOptionsForCommandDisableSource(Command cmd, Func<ILogger> getLogger)
+        {
+            var name_Argument = new Argument<string>(name: "name", description: Strings.SourcesCommandNameDescription)
+            {
+                Arity = ArgumentArity.ExactlyOne,
+            };
+            cmd.Add(name_Argument);
+            var configfile_Option = new Option<string>(name: "--configfile", description: Strings.Option_ConfigFile)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(configfile_Option);
+            // Create handler delegate handler for cmd
+            cmd.SetHandler((args) =>
+            {
+                DisableSourceRunner.Run(args, getLogger);
+            }, new DisableSourceCustomBinder(name_Argument, configfile_Option));
+        }
+    } // end class
+
+    internal partial class EnableVerbParser
+    {
+        internal static Func<ILogger> GetLoggerFunction;
+
+        internal static Command Register(Command app, Func<ILogger> getLogger)
+        {
+            var EnableCmd = new Command(name: "enable", description: Strings.Enable_Description);
+
+            // Options directly under the verb 'enable'
+
+            // noun sub-command: enable source
+            var SourceCmd = new Command(name: "source", description: Strings.EnableSourceCommandDescription);
+
+            // Options under sub-command: enable source
+            RegisterOptionsForCommandEnableSource(SourceCmd, getLogger);
+
+            EnableCmd.AddCommand(SourceCmd);
+
+            GetLoggerFunction = getLogger;
+            app.AddCommand(EnableCmd);
+
+            return EnableCmd;
+        } // End noun method
+
+        private static void RegisterOptionsForCommandEnableSource(Command cmd, Func<ILogger> getLogger)
+        {
+            var name_Argument = new Argument<string>(name: "name", description: Strings.SourcesCommandNameDescription)
+            {
+                Arity = ArgumentArity.ExactlyOne,
+            };
+            cmd.Add(name_Argument);
+            var configfile_Option = new Option<string>(name: "--configfile", description: Strings.Option_ConfigFile)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(configfile_Option);
+            // Create handler delegate handler for cmd
+            cmd.SetHandler((args) =>
+            {
+                EnableSourceRunner.Run(args, getLogger);
+            }, new EnableSourceCustomBinder(name_Argument, configfile_Option));
+        }
+    } // end class
+
     internal partial class ListVerbParser
     {
         internal static Func<ILogger> GetLoggerFunction;
@@ -26,29 +250,263 @@ namespace NuGet.CommandLine.XPlat.Commands
             var SourceCmd = new Command(name: "source", description: Strings.ListSourceCommandDescription);
 
             // Options under sub-command: list source
-            var format_Option = new Option<string>(name: "--format", description: Strings.SourcesCommandFormatDescription)
-            {
-                Arity = ArgumentArity.ZeroOrOne,
-            };
-            SourceCmd.Add(format_Option);
-            var configfile_Option = new Option<string>(name: "--configfile", description: Strings.Option_ConfigFile)
-            {
-                Arity = ArgumentArity.ZeroOrOne,
-            };
-            SourceCmd.Add(configfile_Option);
-            // Create handler delegate handler for SourceCmd
-            SourceCmd.SetHandler((args) =>
-            {
-                ListSourceRunner.Run(args, getLogger);
-            }, new ListSourceCustomBinder(format_Option, configfile_Option));
+            RegisterOptionsForCommandListSource(SourceCmd, getLogger);
 
             ListCmd.AddCommand(SourceCmd);
+
+            // noun sub-command: list client-cert
+            var ClientCertCmd = new Command(name: "client-cert", description: Strings.ListClientCertCommandDescription);
+
+            // Options under sub-command: list client-cert
+            RegisterOptionsForCommandListClientCert(ClientCertCmd, getLogger);
+
+            ListCmd.AddCommand(ClientCertCmd);
 
             GetLoggerFunction = getLogger;
             app.AddCommand(ListCmd);
 
             return ListCmd;
         } // End noun method
+
+        private static void RegisterOptionsForCommandListSource(Command cmd, Func<ILogger> getLogger)
+        {
+            var format_Option = new Option<string>(name: "--format", description: Strings.SourcesCommandFormatDescription)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(format_Option);
+            var configfile_Option = new Option<string>(name: "--configfile", description: Strings.Option_ConfigFile)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(configfile_Option);
+            // Create handler delegate handler for cmd
+            cmd.SetHandler((args) =>
+            {
+                ListSourceRunner.Run(args, getLogger);
+            }, new ListSourceCustomBinder(format_Option, configfile_Option));
+        }
+
+        private static void RegisterOptionsForCommandListClientCert(Command cmd, Func<ILogger> getLogger)
+        {
+            var configfile_Option = new Option<string>(name: "--configfile", description: Strings.Option_ConfigFile)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(configfile_Option);
+            // Create handler delegate handler for cmd
+            cmd.SetHandler((args) =>
+            {
+                ListClientCertRunner.Run(args, getLogger);
+            }, new ListClientCertCustomBinder(configfile_Option));
+        }
+    } // end class
+
+    internal partial class RemoveVerbParser
+    {
+        internal static Func<ILogger> GetLoggerFunction;
+
+        internal static Command Register(Command app, Func<ILogger> getLogger)
+        {
+            var RemoveCmd = new Command(name: "remove", description: Strings.Remove_Description);
+
+            // Options directly under the verb 'remove'
+
+            // noun sub-command: remove source
+            var SourceCmd = new Command(name: "source", description: Strings.RemoveSourceCommandDescription);
+
+            // Options under sub-command: remove source
+            RegisterOptionsForCommandRemoveSource(SourceCmd, getLogger);
+
+            RemoveCmd.AddCommand(SourceCmd);
+
+            // noun sub-command: remove client-cert
+            var ClientCertCmd = new Command(name: "client-cert", description: Strings.RemoveClientCertCommandDescription);
+
+            // Options under sub-command: remove client-cert
+            RegisterOptionsForCommandRemoveClientCert(ClientCertCmd, getLogger);
+
+            RemoveCmd.AddCommand(ClientCertCmd);
+
+            GetLoggerFunction = getLogger;
+            app.AddCommand(RemoveCmd);
+
+            return RemoveCmd;
+        } // End noun method
+
+        private static void RegisterOptionsForCommandRemoveSource(Command cmd, Func<ILogger> getLogger)
+        {
+            var name_Argument = new Argument<string>(name: "name", description: Strings.SourcesCommandNameDescription)
+            {
+                Arity = ArgumentArity.ExactlyOne,
+            };
+            cmd.Add(name_Argument);
+            var configfile_Option = new Option<string>(name: "--configfile", description: Strings.Option_ConfigFile)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(configfile_Option);
+            // Create handler delegate handler for cmd
+            cmd.SetHandler((args) =>
+            {
+                RemoveSourceRunner.Run(args, getLogger);
+            }, new RemoveSourceCustomBinder(name_Argument, configfile_Option));
+        }
+
+        private static void RegisterOptionsForCommandRemoveClientCert(Command cmd, Func<ILogger> getLogger)
+        {
+            var packageSource_Option = new Option<string>(aliases: new[] { "-s", "--package-source" }, description: Strings.Option_PackageSource)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(packageSource_Option);
+            var configfile_Option = new Option<string>(name: "--configfile", description: Strings.Option_ConfigFile)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(configfile_Option);
+            // Create handler delegate handler for cmd
+            cmd.SetHandler((args) =>
+            {
+                RemoveClientCertRunner.Run(args, getLogger);
+            }, new RemoveClientCertCustomBinder(packageSource_Option, configfile_Option));
+        }
+    } // end class
+
+    internal partial class UpdateVerbParser
+    {
+        internal static Func<ILogger> GetLoggerFunction;
+
+        internal static Command Register(Command app, Func<ILogger> getLogger)
+        {
+            var UpdateCmd = new Command(name: "update", description: Strings.Update_Description);
+
+            // Options directly under the verb 'update'
+
+            // noun sub-command: update source
+            var SourceCmd = new Command(name: "source", description: Strings.UpdateSourceCommandDescription);
+
+            // Options under sub-command: update source
+            RegisterOptionsForCommandUpdateSource(SourceCmd, getLogger);
+
+            UpdateCmd.AddCommand(SourceCmd);
+
+            // noun sub-command: update client-cert
+            var ClientCertCmd = new Command(name: "client-cert", description: Strings.UpdateClientCertCommandDescription);
+
+            // Options under sub-command: update client-cert
+            RegisterOptionsForCommandUpdateClientCert(ClientCertCmd, getLogger);
+
+            UpdateCmd.AddCommand(ClientCertCmd);
+
+            GetLoggerFunction = getLogger;
+            app.AddCommand(UpdateCmd);
+
+            return UpdateCmd;
+        } // End noun method
+
+        private static void RegisterOptionsForCommandUpdateSource(Command cmd, Func<ILogger> getLogger)
+        {
+            var name_Argument = new Argument<string>(name: "name", description: Strings.SourcesCommandNameDescription)
+            {
+                Arity = ArgumentArity.ExactlyOne,
+            };
+            cmd.Add(name_Argument);
+            var source_Option = new Option<string>(aliases: new[] { "-s", "--source" }, description: Strings.SourcesCommandSourceDescription)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(source_Option);
+            var username_Option = new Option<string>(aliases: new[] { "-u", "--username" }, description: Strings.SourcesCommandUsernameDescription)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(username_Option);
+            var password_Option = new Option<string>(aliases: new[] { "-p", "--password" }, description: Strings.SourcesCommandPasswordDescription)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(password_Option);
+            var storePasswordInClearText_Option = new Option<bool>(name: "--store-password-in-clear-text", description: Strings.SourcesCommandStorePasswordInClearTextDescription)
+            {
+                Arity = ArgumentArity.Zero,
+            };
+            cmd.Add(storePasswordInClearText_Option);
+            var validAuthenticationTypes_Option = new Option<string>(name: "--valid-authentication-types", description: Strings.SourcesCommandValidAuthenticationTypesDescription)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(validAuthenticationTypes_Option);
+            var configfile_Option = new Option<string>(name: "--configfile", description: Strings.Option_ConfigFile)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(configfile_Option);
+            // Create handler delegate handler for cmd
+            cmd.SetHandler((args) =>
+            {
+                UpdateSourceRunner.Run(args, getLogger);
+            }, new UpdateSourceCustomBinder(name_Argument, source_Option, username_Option, password_Option, storePasswordInClearText_Option, validAuthenticationTypes_Option, configfile_Option));
+        }
+
+        private static void RegisterOptionsForCommandUpdateClientCert(Command cmd, Func<ILogger> getLogger)
+        {
+            var packageSource_Option = new Option<string>(aliases: new[] { "-s", "--package-source" }, description: Strings.Option_PackageSource)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(packageSource_Option);
+            var path_Option = new Option<string>(name: "--path", description: Strings.Option_Path)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(path_Option);
+            var password_Option = new Option<string>(name: "--password", description: Strings.Option_Password)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(password_Option);
+            var storePasswordInClearText_Option = new Option<bool>(name: "--store-password-in-clear-text", description: Strings.Option_StorePasswordInClearText)
+            {
+                Arity = ArgumentArity.Zero,
+            };
+            cmd.Add(storePasswordInClearText_Option);
+            var storeLocation_Option = new Option<string>(name: "--store-location", description: Strings.Option_StoreLocation)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(storeLocation_Option);
+            var storeName_Option = new Option<string>(name: "--store-name", description: Strings.Option_StoreName)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(storeName_Option);
+            var findBy_Option = new Option<string>(name: "--find-by", description: Strings.Option_FindBy)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(findBy_Option);
+            var findValue_Option = new Option<string>(name: "--find-value", description: Strings.Option_FindValue)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(findValue_Option);
+            var force_Option = new Option<bool>(aliases: new[] { "-f", "--force" }, description: Strings.Option_Force)
+            {
+                Arity = ArgumentArity.Zero,
+            };
+            cmd.Add(force_Option);
+            var configfile_Option = new Option<string>(name: "--configfile", description: Strings.Option_ConfigFile)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(configfile_Option);
+            // Create handler delegate handler for cmd
+            cmd.SetHandler((args) =>
+            {
+                UpdateClientCertRunner.Run(args, getLogger);
+            }, new UpdateClientCertCustomBinder(packageSource_Option, path_Option, password_Option, storePasswordInClearText_Option, storeLocation_Option, storeName_Option, findBy_Option, findValue_Option, force_Option, configfile_Option));
+        }
     } // end class
 
 } // end namespace

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/VerbParsers.tt
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/VerbParsers.tt
@@ -33,6 +33,7 @@ foreach (XElement verb in allElements)
     string commandName = verb.Attribute(XName.Get("Name", "")).Value;
     string commandFormalName = InitCaps(commandName);
     string commandFormalNameVar = commandFormalName + "Cmd";
+    IEnumerable<XElement> verbOpts = verb.Elements().Where(n => isValidOption(n));
 #>
     internal partial class <#= commandFormalName #><#= verb.Name.LocalName #>Parser
     {
@@ -44,8 +45,13 @@ foreach (XElement verb in allElements)
 
             // Options directly under the verb '<#= commandName #>'
 <#
-    GenerateAddOptionOrArgument(verb, commandFormalNameVar, 12);
-
+    PushIndent(Indent(12));
+    if (verbOpts.Any())
+    {
+        GenerateRegisterMehtodForCommandCall($@"{GetNodeFormalName(verb)}", commandFormalNameVar, "getLogger");
+    }
+    PopIndent();
+    
     foreach (XElement noun in verb.Descendants(XName.Get("Noun")))
     {
         string nounName = noun.Attribute(XName.Get("Name", ""))?.Value;
@@ -55,9 +61,6 @@ foreach (XElement verb in allElements)
             throw new ArgumentException("nounFormalName cannot be null");
         }
         string nounFormalNameVar = nounFormalName + "Cmd";
-        IReadOnlyCollection<OptionData> options = GetOptionsFromNode(noun);
-        string customHandlerName = noun.Attribute(XName.Get("Handler", ""))?.Value;
-        bool hasHustomHandler = !string.IsNullOrEmpty(customHandlerName);
 #>
 
             // noun sub-command: <#= commandName #> <#= nounName #>
@@ -66,26 +69,12 @@ foreach (XElement verb in allElements)
             // Options under sub-command: <#= commandName #> <#= nounName #>
 <#
         // Look for options directly under each noun
-        GenerateAddOptionOrArgument(noun, nounFormalNameVar, 12);
-
-        // Generate handler for noun
         PushIndent(Indent(12));
-        if (hasHustomHandler)
-        {
-            GenerateSetCustomHandler(nounFormalNameVar, customHandlerName, options);
-        }
-        else
-        {
-            string binderClassName = GetCustomBinderClassName(verb, noun);
-            GenerateCommandHandlerCustomBinder(nounFormalNameVar, commandFormalName + nounFormalName, binderClassName, options);
-        }
-
+        GenerateRegisterMehtodForCommandCall($@"{GetNodeFormalName(verb)}{GetNodeFormalName(noun)}", nounFormalNameVar, "getLogger");
         WriteLine(string.Empty);
         WriteLine($"{commandFormalNameVar}.AddCommand({nounFormalNameVar});");
         PopIndent();
     } // end noun foreach
-
-    // TODO: Generate handler for commands. See https://github.com/NuGet/Client.Engineering/issues/1817
 #>
 
             GetLoggerFunction = getLogger;
@@ -93,6 +82,25 @@ foreach (XElement verb in allElements)
 
             return <#= commandFormalNameVar #>;
         } // End noun method
+<#
+    PushIndent(Indent(8));
+
+    // Generate handler for nouns
+    foreach (XElement noun in verb.Descendants(XName.Get("Noun")))
+    {
+        WriteLine("");
+        GenerateRegisterMethodForCommand($@"{GetNodeFormalName(verb)}{GetNodeFormalName(noun)}", noun, GetCustomBinderClassName(verb, noun));
+    }
+
+    // Generate handler for verbs or commands
+    if (verbOpts.Any())
+    {
+        WriteLine("");
+        GenerateRegisterMethodForCommand($@"{GetNodeFormalName(verb)}", verb, GetCustomBinderClassName(verb));
+    }
+
+    PopIndent();
+#>
     } // end class
 
 <#

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/AddSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/AddSourceTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.CommandLine;
+using Microsoft.Extensions.CommandLineUtils;
+using NuGet.CommandLine.XPlat;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.Xplat.Tests
+{
+    public class AddSourceTests
+    {
+        [Fact]
+        public void AddSource_RunSameCommandInBothCommandLineInterfaces_CommandOutputEqual()
+        {
+            
+            using var root1 = new SimpleTestPathContext();
+            using var root2 = new SimpleTestPathContext();
+
+            // Arrange
+            var currentCli = new CommandLineApplication();
+            var testLoggerCurrent = new TestLogger();
+            AddVerbParser.Register(currentCli, () => testLoggerCurrent);
+
+            var newCli = new RootCommand();
+            var testLoggerNew = new TestLogger();
+            NuGet.CommandLine.XPlat.Commands.AddVerbParser.Register(newCli, () => testLoggerNew);
+
+            // Act
+            currentCli.Execute(new[] { "add", "source", "https://api.nuget.org/v3/index.json", "--name", "NuGetV3", "--configfile", root1.NuGetConfig });
+            newCli.Invoke(new[] { "add", "source", "https://api.nuget.org/v3/index.json", "--name", "NuGetV3", "--configfile", root2.NuGetConfig });
+
+            // Assert
+            Assert.False(testLoggerCurrent.Messages.IsEmpty);
+            Assert.False(testLoggerNew.Messages.IsEmpty);
+            Assert.Equal(testLoggerCurrent.Messages, testLoggerNew.Messages);
+
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/CommandTestUtils.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/CommandTestUtils.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.Xplat.Tests
+{
+    internal static class CommandTestUtils
+    {
+        internal static void AssertBothCommandSuccessfulExecution(int statusCurrent, int statusNew, TestLogger loggerCurrent, TestLogger loggerNew)
+        {
+            Assert.Equal(0, statusCurrent);
+            Assert.Equal(0, statusNew);
+            Assert.False(loggerCurrent.Messages.IsEmpty);
+            Assert.False(loggerNew.Messages.IsEmpty);
+            Assert.Equal(loggerCurrent.Messages, loggerNew.Messages);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/ListSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/ListSourceTests.cs
@@ -26,13 +26,11 @@ namespace NuGet.CommandLine.Xplat.Tests
             NuGet.CommandLine.XPlat.Commands.ListVerbParser.Register(newCli, () => testLoggerNew);
 
             // Act
-            currentCli.Execute(cmd);
-            newCli.Invoke(cmd);
+            int statusCurrent = currentCli.Execute(cmd);
+            int statusNew = newCli.Invoke(cmd);
 
             // Assert
-            Assert.False(testLoggerCurrent.Messages.IsEmpty);
-            Assert.False(testLoggerNew.Messages.IsEmpty);
-            Assert.Equal(testLoggerCurrent.Messages, testLoggerNew.Messages);
+            CommandTestUtils.AssertBothCommandSuccessfulExecution(statusCurrent, statusNew, testLoggerCurrent, testLoggerNew);
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -34,6 +34,12 @@ namespace NuGet.Test.Utility
             ConfigPath = path ?? throw new ArgumentNullException(nameof(path));
         }
 
+        public SimpleTestSettingsContext(string path)
+            : this(path, GetEmptyConfig())
+        {
+
+        }
+
         /// <summary>
         /// Save to disk
         /// </summary>
@@ -83,8 +89,7 @@ namespace NuGet.Test.Utility
             var doc = new XDocument();
             var configuration = new XElement(XName.Get("configuration"));
             doc.Add(configuration);
-
-            var config = GetOrAddSection(doc, "config");
+            _ = GetOrAddSection(doc, "config");
             var packageSources = GetOrAddSection(doc, "packageSources");
             var disabledSources = GetOrAddSection(doc, "disabledPackageSources");
             var fallbackFolders = GetOrAddSection(doc, "fallbackPackageFolders");


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11996

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- Generates code for existing commands in Commands.xml file
- Modifies VerbParser template to generate code for commands and nouns 


Command | Tests
------|------
`add source` | ✅ Yes
`add client-cert` | ✅ Yes
`disable source` | ✅ Yes
`enable source` | ✅ Yes
`list client-cert` | ✅ Yes
`remove source` | ✅ Yes
`remove client-cert` |  ⛔ No 
`update source`| ✅ Yes
`update client-cert` | ⛔ No

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added: 1 new test added. More in the way
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
