### PR TITLE
Updated NU1012 error message to display item paths

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -830,7 +830,7 @@ namespace NuGet.Packaging
             };
             var warnPaths = new HashSet<string>();
 
-            var frameworksMissingPlatformVersion = new HashSet<string>();
+            var itemsWithFrameworkMissingPlatformVersion = new HashSet<string>();
             List<ContentItemGroup> targetedItemGroups = new();
             foreach (var pattern in frameworkPatterns)
             {
@@ -848,15 +848,15 @@ namespace NuGet.Packaging
 
                         if (framework.HasPlatform && framework.PlatformVersion == FrameworkConstants.EmptyVersion)
                         {
-                            frameworksMissingPlatformVersion.Add(framework.GetShortFolderName());
+                            itemsWithFrameworkMissingPlatformVersion.Add(item.Path);
                         }
                     }
                 }
             }
 
-            if (frameworksMissingPlatformVersion.Any())
+            if (itemsWithFrameworkMissingPlatformVersion.Any())
             {
-                throw new PackagingException(NuGetLogCode.NU1012, string.Format(CultureInfo.CurrentCulture, Strings.MissingTargetPlatformVersionsFromIncludedFiles, string.Join(", ", frameworksMissingPlatformVersion.OrderBy(str => str))));
+                throw new PackagingException(NuGetLogCode.NU1012, string.Format(CultureInfo.CurrentCulture, Strings.MissingTargetPlatformVersionsFromIncludedFiles, string.Join(", ", itemsWithFrameworkMissingPlatformVersion.OrderBy(str => str))));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -1509,15 +1509,15 @@ namespace NuGet.Packaging.Test
             ExceptionAssert.Throws<PackagingException>(() => builder.Save(new MemoryStream()),
                 "Some included files are included under TFMs which are missing a platform version: " + string.Join(", ", new string[]
                 {
-                  "net5.0-windows",
-                  "net6.0-windows",
-                  "net7.0-windows",
-                  "net8.0-windows",
-                  "net9.0-windows",
-                  "net10.0-windows",
-                  "net11.0-windows",
-                  "net12.0-windows",
-                  "net13.0-windows"
+                  "lib/net5.0-windows/Foo.dll",
+                  "ref/net6.0-windows/Foo.dll",
+                  "runtimes/win7-x64/lib/net7.0-windows/Foo.dll",
+                  "runtimes/win7-x64/nativeassets/net8.0-windows/Foo.dll",
+                  "build/net9.0-windows/foo.props",
+                  "contentFiles/csharp/net10.0-windows/Foo.txt",
+                  "tools/net11.0-windows/win7-x64/Foo.exe",
+                  "embed/net12.0-windows/Foo.dll",
+                  "buildTransitive/net13.0-windows/foo.props"
                 }.OrderBy(str => str)));
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11905

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Updated the NU1012 error message created in `PackageBuilder` to display a comma-delimited list of item paths instead of a list of frameworks.  Updated the `SavingPackageValidatesMissingTPVInFiles` unit test in `PackageBuilderTests` to adjust the expected results accordingly.  The comment for the `MissingTargetPlatformVersionsFromIncludedFiles` string resource in **Strings.resx** ("0 - comma-separated list of files with bad TFMs") suggests that this was the original intent for this message.  Resolves #11905.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled: https://github.com/NuGet/docs.microsoft.com-nuget/issues/2912
  - **OR**
  - [ ] N/A
