### PR TITLE
Fix empty combobox when package is not present in project file

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -842,7 +842,7 @@ namespace NuGet.PackageManagement.UI
             // add all the versions blocked to disable the update button
             foreach (var version in blockedVersions)
             {
-                _versions.Add(new DisplayVersion(version, string.Empty, isValidVersion: false));
+                _versions.Add(new DisplayVersion(version, additionalInfo: null, isValidVersion: false));
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -167,7 +167,7 @@ namespace NuGet.PackageManagement.UI
             var latestStableVersion = allVersionsAllowed.FirstOrDefault(v => !v.version.IsPrerelease);
 
             // Add installed version if the project is PackageReference
-            if (_nugetProjects.Any() && installedDependency != null && installedDependency.VersionRange != null && _nugetProjects.First().ProjectStyle.Equals(ProjectModel.ProjectStyle.PackageReference))
+            if (_nugetProjects.Any() && installedDependency != null && installedDependency.VersionRange.OriginalString != null && _nugetProjects.First().ProjectStyle.Equals(ProjectModel.ProjectStyle.PackageReference))
             {
                 VersionRange installedVersionRange = VersionRange.Parse(installedDependency.VersionRange.OriginalString, true);
                 NuGetVersion bestVersion = installedVersionRange.FindBestMatch(allVersionsAllowed.Select(v => v.version));
@@ -311,13 +311,14 @@ namespace NuGet.PackageManagement.UI
             OnPropertyChanged(nameof(IsInstalledVersionTopLevel));
         }
 
+
         public bool IsSelectedVersionInstalled
         {
             get
             {
                 return SelectedVersion != null
                     && InstalledVersion != null
-                    && (IsProjectPackageReference ? SelectedVersion?.Range?.OriginalString == InstalledVersionRange?.OriginalString : true)
+                    && ((IsProjectPackageReference && InstalledVersionRange?.OriginalString != null) ? SelectedVersion?.Range?.OriginalString == InstalledVersionRange?.OriginalString : true)
                     && SelectedVersion.Version == InstalledVersion;
             }
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -318,7 +318,7 @@ namespace NuGet.PackageManagement.UI
             {
                 return SelectedVersion != null
                     && InstalledVersion != null
-                    && ((IsProjectPackageReference && InstalledVersionRange?.OriginalString != null) ? SelectedVersion?.Range?.OriginalString == InstalledVersionRange.OriginalString : true)
+                    && (IsProjectPackageReference ? SelectedVersion?.Range?.OriginalString == InstalledVersionRange?.OriginalString : true)
                     && SelectedVersion.Version == InstalledVersion;
             }
         }
@@ -327,7 +327,7 @@ namespace NuGet.PackageManagement.UI
         {
             get
             {
-                return SelectedVersion != null && !IsSelectedVersionInstalled;
+                return SelectedVersion != null && !IsSelectedVersionInstalled && !InstalledVersionIsAutoReferenced;
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -318,7 +318,7 @@ namespace NuGet.PackageManagement.UI
             {
                 return SelectedVersion != null
                     && InstalledVersion != null
-                    && ((IsProjectPackageReference && InstalledVersionRange?.OriginalString != null) ? SelectedVersion?.Range?.OriginalString == InstalledVersionRange?.OriginalString : true)
+                    && ((IsProjectPackageReference && InstalledVersionRange?.OriginalString != null) ? SelectedVersion?.Range?.OriginalString == InstalledVersionRange.OriginalString : true)
                     && SelectedVersion.Version == InstalledVersion;
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12057

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
For some type of projects there are installed packages that are not listed in the project file (.csproj). This was not considered when developing the combobox version and breaks when trying to get the OriginalVersion.

Before:
![image](https://user-images.githubusercontent.com/43253759/194008452-1379a69d-9fb7-473f-bf28-5dc22767095b.png)

After:
![image](https://user-images.githubusercontent.com/43253759/194008437-d5268f3d-81d8-4eed-a97a-a39002aff125.png)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
