### PR TITLE
Change OptProf git tag manual override to false

### DIFF
--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -28,9 +28,9 @@ resources:
 
 parameters:
 # Whether or not commit should be tagged for manual deployments
-- name: optEnableOptProfTagging
+- name: CreateGitTagOnManualRun
   type: boolean
-  default: true
+  default: false
 
 # Whether or not to delete the test machines after the run completes.
 - name: testMachineCleanUpStrategy
@@ -170,6 +170,6 @@ stages:
     - template: \steps\powershell\execute-script.yml@DartLabTemplates
       parameters:
         displayName: Create OptimizationInputs Tag in Repository
-        condition: or(and(succeeded(), in(variables['Build.Reason'], 'ResourceTrigger')), eq('${{parameters.optEnableOptProfTagging}}', 'true'))
+        condition: and(succeeded(), or(in(variables['Build.Reason'], 'ResourceTrigger'), eq('${{parameters.CreateGitTagOnManualRun}}', 'true')))
         filePath: $(DartLab.Path)\Scripts\AzureDevOps\Repos\New-GitAnnotatedTag.ps1
         arguments: -InstanceURL '$(System.CollectionUri)' -ProjectName '$(System.TeamProject)' -RepositoryName '$(Build.Repository.Name)' -CommitID '$(resources.pipeline.ComponentBuildUnderTest.sourceCommit)' -TagName '$(optDropName)' -JSON @{ releaseWebURL = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)" } -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1913

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The intent of the condition on the git tag step was to tag commits that were triggered by the product build completing, and not tag on manual runs (for example, when testing the optprof pipeline). I didn't read the comment above the parameter, so I had incorrectly set it to true, which effectively meant that it would always tag.

Additionally, since OptProf uses the tag to find optimization data, I don't think there's a point to create the tag on failed pipelines, even when manually run, so I changed the condition a little so even when the parameter is set to true, it still needs the job to be successful up to that point.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
