### PR TITLE
NoWarn for NETSDK1138

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -50,7 +50,7 @@
     <MicroBuildDirectory>$(SolutionPackagesFolder)microsoft.visualstudioeng.microbuild.core\1.0.0\build\</MicroBuildDirectory>
     <MicrosoftDotNetBuildTasksFeedFilePath>$(SolutionPackagesFolder)microsoft.dotnet.build.tasks.feed\6.0.0-beta.20528.5\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.Feed.dll</MicrosoftDotNetBuildTasksFeedFilePath>
     <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.21378.2\tools\netcoreapp3.1\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
-    <NoWarn>$(NoWarn);NU5105;MSB3277</NoWarn>
+    <NoWarn>$(NoWarn);NU5105;MSB3277;NETSDK1138</NoWarn>
     <!-- additional warnings new in .NET 6 that we need to disable when building with source-build -->
     <NoWarn Condition="'$(DotNetBuildFromSource)' == 'true'">$(NoWarn);CS1998;CA1416;CS0618;CS1574</NoWarn>
   </PropertyGroup>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
@@ -7,7 +7,7 @@
     <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Packaging.</Description>
     <!-- remove warnings for obsolete types and methods: SYSLIB0023: RNGCryptoServiceProvider, SYSLIB0026: X509Certificate2() blank constructor -->
-    <NoWarn>SYSLIB0023;SYSLIB0026</NoWarn>
+    <NoWarn>$(NoWarn);SYSLIB0023;SYSLIB0026</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestExtensions/GenerateLicenseList/GenerateLicenseList.csproj
+++ b/test/TestExtensions/GenerateLicenseList/GenerateLicenseList.csproj
@@ -7,7 +7,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>GenerateLicenseList</AssemblyName>
-    <NoWarn>NU1505</NoWarn> <!-- Remove NoWarn when https://github.com/dotnet/sdk/issues/24747 is fixed -->
+    <NoWarn>$(NoWarn);NU1505</NoWarn> <!-- Remove NoWarn when https://github.com/dotnet/sdk/issues/24747 is fixed -->
     <Description>A utility for updating the NuGet license list from the SPDX source.</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12158

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
As a library targeting an EOL version of the framework, this error is attempting to suggest we should upgrade. We ultimately don't have a dependency on the .NET 5 runtime, as the .NET SDK determines that. 

This PR disables the compiler warning. See suggested changes to this behavior in https://github.com/dotnet/sdk/issues/24747.

Warning/Error that goes away with this PR:
```
C:\Program Files\dotnet\sdk\7.0.100-rc.2.22477.23\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.EolTargetFrameworks.targ
ets(28,5): error NETSDK1138: The target framework 'netcoreapp5.0' is out of support and will not receive security updat
es in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy.

```

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
