### PR TITLE
Use accessible Foreground on WatermarkedTextbox in Add Package Source Mapping dialog

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
@@ -27,6 +27,47 @@
       <Style TargetType="ScrollBar">
         <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ScrollBarColorKey}}"/>
       </Style>
+      <!-- Copied from ThemedDialogResources.xaml. See https://github.com/NuGet/Home/issues/12163 -->
+      <Style TargetType="{x:Type vsui:WatermarkedTextBox}">
+        <Setter Property="Padding" Value="6,8,6,8" />
+        <Setter Property="AutomationProperties.HelpText" Value="{Binding Watermark}" />
+        <Setter Property="Template">
+          <Setter.Value>
+            <ControlTemplate TargetType="{x:Type vsui:WatermarkedTextBox}">
+              <Border x:Name="border"
+                      BorderBrush="{TemplateBinding BorderBrush}"
+                      BorderThickness="{TemplateBinding BorderThickness}"
+                      Background="{TemplateBinding Background}"
+                      SnapsToDevicePixels="True">
+                <Grid>
+                  <ScrollViewer x:Name="PART_ContentHost"
+                                Padding="{TemplateBinding Padding}"
+                                Focusable="false"
+                                HorizontalScrollBarVisibility="Hidden"
+                                VerticalScrollBarVisibility="Hidden"/>
+                  <TextBlock VerticalAlignment="Center"
+                             x:Name="WatermarkTextBlock"
+                             Visibility="Collapsed"
+                             Cursor="IBeam"
+                             Padding="{TemplateBinding Padding}"
+                             Margin="2,0,0,0"
+                             Text="{TemplateBinding Watermark}"
+                             IsHitTestVisible="False"
+                             Foreground="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                </Grid>
+              </Border>
+              <ControlTemplate.Triggers>
+                <Trigger Property="IsEnabled" Value="false">
+                  <Setter Property="Opacity" TargetName="border" Value="0.56"/>
+                </Trigger>
+                <Trigger Property="Text" Value="">
+                  <Setter TargetName="WatermarkTextBlock" Property="Visibility" Value="Visible" />
+                </Trigger>
+              </ControlTemplate.Triggers>
+            </ControlTemplate>
+          </Setter.Value>
+        </Setter>
+      </Style>
     </Grid.Resources>
     <StackPanel Grid.Row="0">
       <Grid>
@@ -63,18 +104,18 @@
     <StackPanel Grid.Row="1">
       <Grid>
         <Grid.RowDefinitions>
-          <RowDefinition Height="48"/>
-          <RowDefinition Height="*"/>
-          <RowDefinition Height="36"/>
+          <RowDefinition Height="Auto"/>
+          <RowDefinition Height="Auto"/>
+          <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <vsui:WatermarkedTextBox Grid.Row="0"
+                                 BorderBrush="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderBrushKey}}"
+                                 BorderThickness="1"
                                  AutomationProperties.Name="{x:Static nuget:Resources.VSOptions_Watermark_AddPackageNamespace}"
                                  x:Name="_packageID"
                                  MaxLength="100"
                                  Margin="12,6,12,6"
                                  Watermark="{x:Static nuget:Resources.VSOptions_Watermark_AddPackageNamespace}"
-                                 Foreground="{Binding Path=(TextElement.Foreground), RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}"
-                                 Background="{Binding Path=(Window.Background), RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}"
                                  TextChanged="PackageID_TextChanged"/>
         <StackPanel Orientation="Vertical"  Grid.Row="1">
           <nuget:ProjectsListView AutomationProperties.Name="{x:Static nuget:Resources.VSOptions_Accessibility_SourcesList}"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12141

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Until the VS Platform supports inheritance for this control, and rather than create our own WatermarkedTextbox, I've chosen to copy just the styles we need, and set an appropriate Foreground.

I've commented in XAML with the issue that contains context on when we can remove the styles and just use the Platform styles directly.

### Before this PR:
![image](https://user-images.githubusercontent.com/49205731/195952362-4bae34d7-9b6a-45f6-b41c-2332beedb30d.png)


### After this PR:
![image](https://user-images.githubusercontent.com/49205731/195952316-116c8109-bab2-4b4f-ac4d-bbddad5a0b8c.png)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled https://github.com/NuGet/docs.microsoft.com-nuget/issues/2799
  - **OR**
  - [ ] N/A
