### PR TITLE
Introduce NuGetLocalizationType parameter in YAML to support Pseudo-Localization in our CI

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -35,3 +35,4 @@ extends:
     E2EPart1AgentCleanup: ${{parameters.E2EPart1AgentCleanup}}
     E2EPart2AgentCleanup: ${{parameters.E2EPart2AgentCleanup}}
     ApexAgentCleanup: ${{parameters.ApexAgentCleanup}}
+    NuGetLocalizationType: Full

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -36,3 +36,4 @@ extends:
     E2EPart1AgentCleanup: ${{parameters.E2EPart1AgentCleanup}}
     E2EPart2AgentCleanup: ${{parameters.E2EPart2AgentCleanup}}
     ApexAgentCleanup: ${{parameters.ApexAgentCleanup}}
+    NuGetLocalizationType: Full

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -27,6 +27,13 @@ parameters:
   values:
   - delete
   - stop
+- name: NuGetLocalizationType
+  displayName: Whether to do production-ready localization (Full), or pseudo-localization, aka PLOC, (Pseudo) for testing.
+  type: string
+  default: Full
+  values:
+  - Full
+  - Pseudo
 
 extends:
   template: templates/pipeline.yml
@@ -35,3 +42,4 @@ extends:
     E2EPart1AgentCleanup: ${{parameters.E2EPart1AgentCleanup}}
     E2EPart2AgentCleanup: ${{parameters.E2EPart2AgentCleanup}}
     ApexAgentCleanup: ${{parameters.ApexAgentCleanup}}
+    NuGetLocalizationType: ${{parameters.NuGetLocalizationType}}

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -1,6 +1,8 @@
 parameters:
 - name: BuildRTM
   type: boolean
+- name: NuGetLocalizationType
+  type: string
 
 steps:
 - task: PowerShell@1
@@ -106,7 +108,7 @@ steps:
   inputs:
     solution: "build\\loc.proj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:AfterBuild /bl:$(Build.StagingDirectory)\\binlog\\03.Localize.binlog"
+    msbuildArguments: "/t:AfterBuild /bl:$(Build.StagingDirectory)\\binlog\\03.Localize.binlog /p:LocType=${{parameters.NuGetLocalizationType}}"
 
 - task: MSBuild@1
   displayName: "Build NuGet.exe Localized"

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -31,6 +31,13 @@ parameters:
   values:
   - delete
   - stop
+- name: NuGetLocalizationType
+  displayName: Whether to do production-ready localization (Full), or pseudo-localization, aka PLOC, (Pseudo) for testing.
+  type: string
+  default: Full
+  values:
+  - Full
+  - Pseudo
 
 resources:
   pipelines:
@@ -102,6 +109,7 @@ stages:
     - template: Build_and_UnitTest.yml
       parameters:
         BuildRTM: false
+        NuGetLocalizationType: ${{ parameters.NuGetLocalizationType }}
 
 - stage: Build_For_Publishing
   displayName: Build NuGet published to nuget.org
@@ -122,6 +130,7 @@ stages:
     - template: Build_and_UnitTest.yml
       parameters:
         BuildRTM: true
+        NuGetLocalizationType: Full
 
 - stage: Source_Build
   dependsOn: Initialize


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1920

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Introducing a variable in our CI will allow us to run Pseudo-localization (PLOC) builds on CI without having to run a script on our DevBoxes. This is quick and less messy, and the PLOC assemblies are handily available as artifacts. 

- Only supported on Private Dev Pipeline
- Default will be `Full` (as it is currently by default). 
- Changing the variable manually to `Pseudo` will result in PLOC assemblies being built for this build.

### Benefits I see:

- Offload the PLOC process from devboxes
- Easier to share PLOC assemblies for collaborative testing (ie, Azure artifacts)
- Community PRs currently have no way to PLOC test since the script is internal. This is a step toward automation. For now, we can manually trigger the pipeline with the variable set to at least get a VSIX we can use for testing.

### How to set it up?
1. Queue a build in our Private Dev Pipeline.
2. Find the parameter and set accordingly.
![image](https://user-images.githubusercontent.com/49205731/197121024-75d777e1-b8cc-43db-8ff0-ec117cbbc1cc.png)
3. After the build completes, the generated VSIX will contain pseudo-localized assemblies.
4. Install the VSIX and Test for compliance with PLOC.

# Examples
### Manually Triggered PrivateDev with `NuGetLocalizationType=Full` (Default)
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6840411&view=results

### Manually Triggered PrivateDev with `NuGetLocalizationType=Psuedo`
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6856926&view=logs&j=d80b2849-30d4-52dd-74cd-d6536ba98fe0&t=a58aab5a-1dfa-539b-0144-7e49553b2bae

### Triggered by PR / push (implicitly `NuGetLocalizationType=Full`)
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6856863&view=results

### Manually Triggered OfficialBuild (implicitly `NuGetLocalizationType=Full`)
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6857061&view=results

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled - https://github.com/NuGet/Client.Engineering/issues/1930 - May want to delete internal script and/or create public doc indicating that PLOC must be done on any UI changes, and how to do it (even if the HowTo is for internal response to community contributions).
  - **OR**
  - [ ] N/A
