### PR TITLE
fix a logic error that caused AbandonedMutexException while executing migrations

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Migrations/Migration1.cs
+++ b/src/NuGet.Core/NuGet.Common/Migrations/Migration1.cs
@@ -79,7 +79,8 @@ namespace NuGet.Common.Migrations
             {
                 pathsToCheck.Add(path);
 
-                if (!path.StartsWith(homePath, StringComparison.Ordinal))
+                // Unix-based systems support only the forward slash which is returned by Path.AltDirectorySeparatorChar
+                if (!path.StartsWith(homePath + Path.AltDirectorySeparatorChar, StringComparison.Ordinal))
                 {
                     return;
                 }
@@ -156,13 +157,13 @@ namespace NuGet.Common.Migrations
             {
                 PosixPermissions correctedPermissions = permissions.Value.WithUmask(umask);
                 string correctedPermissionsString = correctedPermissions.ToString();
-                Exec("chmod", correctedPermissionsString + " " + path);
+                Exec("chmod", correctedPermissionsString + " " + "" + path + "");
             }
         }
 
         internal static PosixPermissions? GetPermissions(string path)
         {
-            string output = Exec("ls", "-ld " + path);
+            string output = Exec("ls", "-ld " + "" + path + "");
             if (output == null)
             {
                 return null;

--- a/src/NuGet.Core/NuGet.Common/Migrations/Migration1.cs
+++ b/src/NuGet.Core/NuGet.Common/Migrations/Migration1.cs
@@ -79,8 +79,7 @@ namespace NuGet.Common.Migrations
             {
                 pathsToCheck.Add(path);
 
-                // Unix-based systems support only the forward slash which is returned by Path.AltDirectorySeparatorChar
-                if (!path.StartsWith(homePath + Path.AltDirectorySeparatorChar, StringComparison.Ordinal))
+                if (!path.StartsWith(homePath + Path.DirectorySeparatorChar, StringComparison.Ordinal))
                 {
                     return;
                 }

--- a/src/NuGet.Core/NuGet.Common/Migrations/Migration1.cs
+++ b/src/NuGet.Core/NuGet.Common/Migrations/Migration1.cs
@@ -156,13 +156,13 @@ namespace NuGet.Common.Migrations
             {
                 PosixPermissions correctedPermissions = permissions.Value.WithUmask(umask);
                 string correctedPermissionsString = correctedPermissions.ToString();
-                Exec("chmod", correctedPermissionsString + " " + "\"" + path + "\"");
+                Exec("chmod", correctedPermissionsString + " " + path.FormatWithDoubleQuotes());
             }
         }
 
         internal static PosixPermissions? GetPermissions(string path)
         {
-            string output = Exec("ls", "-ld " + "\"" + path + "\"");
+            string output = Exec("ls", "-ld " + path.FormatWithDoubleQuotes());
             if (output == null)
             {
                 return null;

--- a/src/NuGet.Core/NuGet.Common/Migrations/Migration1.cs
+++ b/src/NuGet.Core/NuGet.Common/Migrations/Migration1.cs
@@ -157,13 +157,13 @@ namespace NuGet.Common.Migrations
             {
                 PosixPermissions correctedPermissions = permissions.Value.WithUmask(umask);
                 string correctedPermissionsString = correctedPermissions.ToString();
-                Exec("chmod", correctedPermissionsString + " " + "" + path + "");
+                Exec("chmod", correctedPermissionsString + " " + "\"" + path + "\"");
             }
         }
 
         internal static PosixPermissions? GetPermissions(string path)
         {
-            string output = Exec("ls", "-ld " + "" + path + "");
+            string output = Exec("ls", "-ld " + "\"" + path + "\"");
             if (output == null)
             {
                 return null;

--- a/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
+++ b/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
@@ -28,12 +28,12 @@ namespace NuGet.Common.Migrations
 
             if (!File.Exists(expectedMigrationFilename))
             {
+                // Multiple processes or threads might be trying to call this concurrently (especially via NuGetSdkResolver)
+                // so use a global mutex and then check if someone else already did the work.
                 using (var mutex = new Mutex(false, "NuGet-Migrations"))
                 {
                     try
                     {
-                        // Multiple processes or threads might be trying to call this concurrently (especially via NuGetSdkResolver)
-                        // so use a global mutex and then check if someone else already did the work.
                         if (mutex.WaitOne(TimeSpan.FromMinutes(1), false))
                         {
                             if (!File.Exists(expectedMigrationFilename))

--- a/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
+++ b/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
@@ -64,7 +64,7 @@ namespace NuGet.Common.Migrations
             }
         }
 
-        private static string GetMigrationsDirectory()
+        internal static string GetMigrationsDirectory()
         {
             string migrationsDirectory;
             if (RuntimeEnvironmentHelper.IsWindows)

--- a/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
+++ b/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
@@ -32,33 +32,36 @@ namespace NuGet.Common.Migrations
                 // so use a global mutex and then check if someone else already did the work.
                 using (var mutex = new Mutex(false, "NuGet-Migrations"))
                 {
+                    bool captured;
                     try
                     {
-                        if (mutex.WaitOne(TimeSpan.FromMinutes(1), false))
-                        {
-                            if (!File.Exists(expectedMigrationFilename))
-                            {
-                                // Only run migrations that have not already been run
-                                int highestMigrationRun = GetHighestMigrationRun(migrationsDirectory);
-                                for (int i = highestMigrationRun + 1; i < Migrations.Count; i++)
-                                {
-                                    try
-                                    {
-                                        Migrations[i]();
-                                        // Create file for every migration run, so that if an older version of NuGet is run, it doesn't try to run
-                                        // migrations again.
-                                        string migrationFile = Path.Combine(migrationsDirectory, (i + 1).ToString(CultureInfo.InvariantCulture));
-                                        File.WriteAllText(migrationFile, string.Empty);
-                                    }
-                                    catch { }
-                                }
-                            }
-                            mutex.ReleaseMutex();
-                        }
+                        captured = mutex.WaitOne(TimeSpan.FromMinutes(1), false);
                     }
                     catch (AbandonedMutexException ex)
                     {
                         ex.Mutex?.ReleaseMutex();
+                        captured = true;
+                    }
+                    if (captured)
+                    {
+                        if (!File.Exists(expectedMigrationFilename))
+                        {
+                            // Only run migrations that have not already been run
+                            int highestMigrationRun = GetHighestMigrationRun(migrationsDirectory);
+                            for (int i = highestMigrationRun + 1; i < Migrations.Count; i++)
+                            {
+                                try
+                                {
+                                    Migrations[i]();
+                                    // Create file for every migration run, so that if an older version of NuGet is run, it doesn't try to run
+                                    // migrations again.
+                                    string migrationFile = Path.Combine(migrationsDirectory, (i + 1).ToString(CultureInfo.InvariantCulture));
+                                    File.WriteAllText(migrationFile, string.Empty);
+                                }
+                                catch { }
+                            }
+                        }
+                        mutex.ReleaseMutex();
                     }
                 }
             }

--- a/src/NuGet.Core/NuGet.Common/StringExtensions.cs
+++ b/src/NuGet.Core/NuGet.Common/StringExtensions.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Common
+{
+    internal static class StringExtensions
+    {
+        internal static string FormatWithDoubleQuotes(this string s)
+        {
+            return s == null ? s : $@"""{s}""";
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/Migration1Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/Migration1Tests.cs
@@ -60,8 +60,8 @@ namespace NuGet.Common.Test
                 var v3cachePath = Path.Combine(testDirectory, "my documents", "v3-cache");
                 var v3cacheSubDirectoryInfo = Directory.CreateDirectory(Path.Combine(v3cachePath, "subDirectory"));
                 Migration1.Exec("chmod", currentPermissions + " " + testDirectory.Path);
-                Migration1.Exec("chmod", currentPermissions + " " + "\"" + v3cachePath + "\"");
-                Migration1.Exec("chmod", currentPermissions + " " + "\"" + v3cacheSubDirectoryInfo.FullName + "\"");
+                Migration1.Exec("chmod", currentPermissions + " " + v3cachePath.FormatWithDoubleQuotes());
+                Migration1.Exec("chmod", currentPermissions + " " + v3cacheSubDirectoryInfo.FullName.FormatWithDoubleQuotes());
                 HashSet<string> pathsToCheck = new HashSet<string>() { testDirectory.Path, v3cachePath, v3cacheSubDirectoryInfo.FullName };
 
                 Migration1.EnsureExpectedPermissions(pathsToCheck, PosixPermissions.Parse(umask));

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/Migration1Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/Migration1Tests.cs
@@ -49,19 +49,19 @@ namespace NuGet.Common.Test
         }
 
         [PlatformTheory(Platform.Darwin, Platform.Linux)]
-        [InlineData("777", "022", "755")]
-        [InlineData("775", "002", "775")]
-        [InlineData("700", "022", "700")]
-        [InlineData("700", "002", "700")]
-        public void EnsureExpectedPermissions_Directories_Success(string currentPermissions, string umask, string newPermissions)
+        [InlineData("777", "022", "755", "v3-cache")]
+        [InlineData("775", "002", "775", "v3 cache")]
+        [InlineData("700", "022", "700", "v3-cache")]
+        [InlineData("700", "002", "700", "v3 cache")]
+        public void EnsureExpectedPermissions_Directories_Success(string currentPermissions, string umask, string newPermissions, string path)
         {
             using (var testDirectory = TestDirectory.Create())
             {
-                var v3cachePath = Path.Combine(testDirectory, "v3-cache");
+                var v3cachePath = Path.Combine(testDirectory, path);
                 var v3cacheSubDirectoryInfo = Directory.CreateDirectory(Path.Combine(v3cachePath, "subDirectory"));
                 Migration1.Exec("chmod", currentPermissions + " " + testDirectory.Path);
-                Migration1.Exec("chmod", currentPermissions + " " + v3cachePath);
-                Migration1.Exec("chmod", currentPermissions + " " + v3cacheSubDirectoryInfo.FullName);
+                Migration1.Exec("chmod", currentPermissions + " " + "" + v3cachePath + "");
+                Migration1.Exec("chmod", currentPermissions + " " + "" + v3cacheSubDirectoryInfo.FullName + "");
                 HashSet<string> pathsToCheck = new HashSet<string>() { testDirectory.Path, v3cachePath, v3cacheSubDirectoryInfo.FullName };
 
                 Migration1.EnsureExpectedPermissions(pathsToCheck, PosixPermissions.Parse(umask));

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/Migration1Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/Migration1Tests.cs
@@ -60,8 +60,8 @@ namespace NuGet.Common.Test
                 var v3cachePath = Path.Combine(testDirectory, path);
                 var v3cacheSubDirectoryInfo = Directory.CreateDirectory(Path.Combine(v3cachePath, "subDirectory"));
                 Migration1.Exec("chmod", currentPermissions + " " + testDirectory.Path);
-                Migration1.Exec("chmod", currentPermissions + " " + "" + v3cachePath + "");
-                Migration1.Exec("chmod", currentPermissions + " " + "" + v3cacheSubDirectoryInfo.FullName + "");
+                Migration1.Exec("chmod", currentPermissions + " " + "\"" + v3cachePath + "\"");
+                Migration1.Exec("chmod", currentPermissions + " " + "\"" + v3cacheSubDirectoryInfo.FullName + "\"");
                 HashSet<string> pathsToCheck = new HashSet<string>() { testDirectory.Path, v3cachePath, v3cacheSubDirectoryInfo.FullName };
 
                 Migration1.EnsureExpectedPermissions(pathsToCheck, PosixPermissions.Parse(umask));

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/Migration1Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/Migration1Tests.cs
@@ -49,15 +49,15 @@ namespace NuGet.Common.Test
         }
 
         [PlatformTheory(Platform.Darwin, Platform.Linux)]
-        [InlineData("777", "022", "755", "v3-cache")]
-        [InlineData("775", "002", "775", "v3 cache")]
-        [InlineData("700", "022", "700", "v3-cache")]
-        [InlineData("700", "002", "700", "v3 cache")]
-        public void EnsureExpectedPermissions_Directories_Success(string currentPermissions, string umask, string newPermissions, string path)
+        [InlineData("777", "022", "755")]
+        [InlineData("775", "002", "775")]
+        [InlineData("700", "022", "700")]
+        [InlineData("700", "002", "700")]
+        public void EnsureExpectedPermissions_Directories_Success(string currentPermissions, string umask, string newPermissions)
         {
             using (var testDirectory = TestDirectory.Create())
             {
-                var v3cachePath = Path.Combine(testDirectory, path);
+                var v3cachePath = Path.Combine(testDirectory, "my documents", "v3-cache");
                 var v3cacheSubDirectoryInfo = Directory.CreateDirectory(Path.Combine(v3cachePath, "subDirectory"));
                 Migration1.Exec("chmod", currentPermissions + " " + testDirectory.Path);
                 Migration1.Exec("chmod", currentPermissions + " " + "\"" + v3cachePath + "\"");

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
@@ -1,10 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using NuGet.Common.Migrations;
+using NuGet.PackageManagement;
 using Xunit;
 
 namespace NuGet.Common.Test
@@ -13,7 +15,7 @@ namespace NuGet.Common.Test
     public class MigrationRunnerTests
     {
         [Fact]
-        public async Task WhenMigrationsAreExecutedInParallelThenNoThreadSynchronizationIssuesAreIdentified_SuccessAsync()
+        public async Task WhenExecutedInParallelOnlyOneFileIsCreatedForEveryMigration_SuccessAsync()
         {
             var tasks = new List<Task>();
 
@@ -23,7 +25,7 @@ namespace NuGet.Common.Test
                 Directory.Delete(path: directory, recursive: true);
 
             // Act
-            for(int count = 0; count < 10; count++)           
+            for(int count = 0; count < 5; count++)           
                 tasks.Add(Task.Run(() => MigrationRunner.Run()));  
 
             Task t = Task.WhenAll(tasks);

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
@@ -1,9 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using NuGet.Common.Migrations;
 using Xunit;
 
@@ -16,6 +18,8 @@ namespace NuGet.Common.Test
         public void WhenExecutedInParallelOnlyOneFileIsCreatedForEveryMigration_Success()
         {
             var threads = new List<Thread>();
+            int numThreads = 5;
+            int timeoutInSeconds = 90;
 
             // Arrange
             string directory = MigrationRunner.GetMigrationsDirectory();
@@ -23,7 +27,7 @@ namespace NuGet.Common.Test
                 Directory.Delete(path: directory, recursive: true);
 
             // Act
-            for (int count = 0; count < 5; count++)
+            for (int i = 0; i < numThreads; i++)
             {
                 var thread = new Thread(MigrationRunner.Run);
                 thread.Start();
@@ -32,7 +36,7 @@ namespace NuGet.Common.Test
 
             foreach (var thread in threads)
             {
-                thread.Join();
+                thread.Join(timeout: TimeSpan.FromSeconds(timeoutInSeconds));
             }
 
             // Assert

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using NuGet.Common.Migrations;
+using Xunit;
+
+namespace NuGet.Common.Test
+{
+    [CollectionDefinition("MigrationRunner", DisableParallelization = true)]
+    public class MigrationRunnerTests
+    {
+        [Fact]
+        public async Task WhenMigrationsAreExecutedInParallelThenNoThreadSynchronizationIssuesAreIdentified_SuccessAsync()
+        {
+            var tasks = new List<Task>();
+
+            // Arrange
+            string directory = MigrationRunner.GetMigrationsDirectory();
+            if (Directory.Exists(directory))
+                Directory.Delete(path: directory, recursive: true);
+
+            // Act
+            for(int count = 0; count < 10; count++)           
+                tasks.Add(Task.Run(() => MigrationRunner.Run()));  
+
+            Task t = Task.WhenAll(tasks);
+            await t;
+
+            // Assert
+            Assert.True(t.IsCompleted);
+            Assert.Equal(TaskStatus.RanToCompletion, t.Status);
+            Assert.True(Directory.Exists(directory));
+            Assert.Equal(1, Directory.GetFiles(directory).Length);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/StringExtensionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/StringExtensionsTests.cs
@@ -1,11 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace NuGet.Common.Test

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/StringExtensionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/StringExtensionsTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NuGet.Common.Test
+{
+    public class StringExtensionsTests
+    {
+        [Fact]
+        public void FormatWithDoubleQuotes_WhenNullIsPassedReturnsNull_Success()
+        {
+            string actual = null;
+            string formatted = actual.FormatWithDoubleQuotes();
+            Assert.Equal(actual, formatted);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("/home/user/NuGet AppData/share")]
+        [InlineData("/home/user/NuGet/share")]
+        [InlineData(@"c:\users\NuGet App\Share")]
+        [InlineData(@"c:\users\NuGet\Share")]
+        public void FormatWithDoubleQuotes_WhenNonNullStringIsPassedReturnsFormattedString_Success(string actual)
+        {
+            string formatted = actual.FormatWithDoubleQuotes();
+            Assert.Equal($@"""{actual}""", formatted);
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12159

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

In https://github.com/NuGet/NuGet.Client/commit/0966444b35d8a74fa25adf0368b983f389884377, we added logic to fix permissions on non-Windows platforms which is executed only once per machine. Customers have reported a regression after October 2022 servicing release https://github.com/dotnet/sdk/issues/28488. In this PR, I propose changes to fix the logical error that caused `AbandonedMutexException` when multiple migrations code is invoked in parallel.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A
