### PR TITLE
Fix NullReferenceException in static graph restore when using SetPlatform

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -935,9 +935,10 @@ namespace NuGet.Build.Tasks.Console
                             LoadSettings = ProjectLoadSettings.IgnoreEmptyImports | ProjectLoadSettings.IgnoreInvalidImports | ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition,
                             ProjectCollection = collection
                         };
-                        var projectInstance = ProjectInstance.FromFile(path, projectOptions);
 
-                        if (!projectInstance.Targets.ContainsKey("_IsProjectRestoreSupported") || properties.TryGetValue("TargetFramework", out var targetFramework) && string.IsNullOrWhiteSpace(targetFramework))
+                        ProjectInstance projectInstance = ProjectInstance.FromFile(path, projectOptions);
+
+                        if (!projectInstance.Targets.ContainsKey("_IsProjectRestoreSupported") || properties == null || properties.TryGetValue("TargetFramework", out string targetFramework) && string.IsNullOrWhiteSpace(targetFramework))
                         {
                             // In rare cases, users can set an empty TargetFramework value in a project-to-project reference.  Static Graph will respect that
                             // but NuGet does not need to do anything with that instance of the project since the actual project is still loaded correctly


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12177

Regression? Yes Last working version: 17.2

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Previous versions of MSBuild only call the project instance factory with a value for global properties.  A recent change added a new call where global properties are `null` which causes static graph restore to throw.  I added a check for `null` to just return the project instance.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - The current unit tests don't exercise this code path since it involves loading MSBuild and doing evaluations.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
