### PR TITLE
Simplification of Linq Any method

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -200,8 +200,7 @@ namespace NuGet.CommandLine
                 packageSaveMode = EffectivePackageSaveMode;
             }
 
-            var missingPackageReferences = installedPackageReferences.Where(reference =>
-                !nuGetPackageManager.PackageExistsInPackagesFolder(reference.PackageIdentity, packageSaveMode)).Any();
+            var missingPackageReferences = installedPackageReferences.Any(reference => !nuGetPackageManager.PackageExistsInPackagesFolder(reference.PackageIdentity, packageSaveMode));
 
             if (!missingPackageReferences)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -230,8 +230,7 @@ namespace NuGet.PackageManagement.UI
             CancellationToken token)
         {
             bool includePrerelease = packagesToUpdate
-                .Where(package => package.Version.IsPrerelease)
-                .Any();
+                .Any(package => package.Version.IsPrerelease);
 
             string[] projectIds = uiService.Projects.Select(project => project.ProjectId).ToArray();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -746,9 +746,9 @@ namespace NuGet.PackageManagement.UI
         internal void AddPackageLevelGrouping()
         {
             ItemsView.Refresh();
-            if (ItemsView.OfType<PackageItemViewModel>()
-                    .Where(p => p.PackageLevel == PackageLevel.Transitive)
-                    .Any() == true)
+            if (ItemsView
+                    .OfType<PackageItemViewModel>()
+                    .Any(p => p.PackageLevel == PackageLevel.Transitive))
             {
                 ItemsView.GroupDescriptions.Add(new PropertyGroupDescription(nameof(PackageItemViewModel.PackageLevel)));
             }

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -1059,7 +1059,7 @@ namespace NuGet.Packaging
                         if (packageExtractionContext.Logger is ICollectorLogger collectorLogger)
                         {
                             // collectorLogger.Errors is a collection of errors and warnings, we just need to fail if there are errors.
-                            if (collectorLogger.Errors.Where(e => e.Level >= LogLevel.Error).Any())
+                            if (collectorLogger.Errors.Any(e => e.Level >= LogLevel.Error))
                             {
                                 // Send empty results since errors and warnings have already been logged
                                 throw new SignatureException(results: Enumerable.Empty<PackageVerificationResult>().ToList(), package: package);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -3598,7 +3598,7 @@ namespace NuGet.CommandLine.Test
                 // Find all non _._ compile assets
                 var flowingCompile = assetsFile.Targets.Single(target => string.IsNullOrEmpty(target.RuntimeIdentifier)).Libraries
                     .Where(e => e.Type == "project")
-                    .Where(e => e.CompileTimeAssemblies.Where(f => !f.Path.EndsWith("_._")).Any())
+                    .Where(e => e.CompileTimeAssemblies.Any(f => !f.Path.EndsWith("_._")))
                     .Select(e => e.Name)
                     .OrderBy(s => s, StringComparer.OrdinalIgnoreCase);
 
@@ -3607,7 +3607,7 @@ namespace NuGet.CommandLine.Test
                 // Runtime should always flow
                 var flowingRuntime = assetsFile.Targets.Single(target => string.IsNullOrEmpty(target.RuntimeIdentifier)).Libraries
                     .Where(e => e.Type == "project")
-                    .Where(e => e.RuntimeAssemblies.Where(f => !f.Path.EndsWith("_._")).Any())
+                    .Where(e => e.RuntimeAssemblies.Any(f => !f.Path.EndsWith("_._")))
                     .Select(e => e.Name)
                     .OrderBy(s => s, StringComparer.OrdinalIgnoreCase);
 
@@ -3702,7 +3702,7 @@ namespace NuGet.CommandLine.Test
                 // Find all non _._ compile assets
                 var flowingCompile = assetsFile.Targets.Single(e => string.IsNullOrEmpty(e.RuntimeIdentifier)).Libraries
                     .Where(e => e.Type == "project")
-                    .Where(e => e.CompileTimeAssemblies.Where(f => !f.Path.EndsWith("_._")).Any())
+                    .Where(e => e.CompileTimeAssemblies.Any(f => !f.Path.EndsWith("_._")))
                     .Select(e => e.Name)
                     .OrderBy(s => s, StringComparer.OrdinalIgnoreCase);
 
@@ -3711,7 +3711,7 @@ namespace NuGet.CommandLine.Test
                 // Runtime should always flow
                 var flowingRuntime = assetsFile.Targets.Single(e => string.IsNullOrEmpty(e.RuntimeIdentifier)).Libraries
                     .Where(e => e.Type == "project")
-                    .Where(e => e.RuntimeAssemblies.Where(f => !f.Path.EndsWith("_._")).Any())
+                    .Where(e => e.RuntimeAssemblies.Any(f => !f.Path.EndsWith("_._")))
                     .Select(e => e.Name)
                     .OrderBy(s => s, StringComparer.OrdinalIgnoreCase);
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/NETCoreProject2ProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/NETCoreProject2ProjectTests.cs
@@ -212,7 +212,7 @@ namespace NuGet.Commands.Test
                 // Find all non _._ compile assets
                 var flowingCompile = assetsFile.Targets.Single().Libraries
                     .Where(e => e.Type == "project")
-                    .Where(e => e.CompileTimeAssemblies.Where(f => !f.Path.EndsWith("_._")).Any())
+                    .Where(e => e.CompileTimeAssemblies.Any(f => !f.Path.EndsWith("_._")))
                     .Select(e => e.Name)
                     .OrderBy(s => s, StringComparer.OrdinalIgnoreCase);
 
@@ -221,7 +221,7 @@ namespace NuGet.Commands.Test
                 // Runtime should always flow
                 var flowingRuntime = assetsFile.Targets.Single().Libraries
                     .Where(e => e.Type == "project")
-                    .Where(e => e.RuntimeAssemblies.Where(f => !f.Path.EndsWith("_._")).Any())
+                    .Where(e => e.RuntimeAssemblies.Any(f => !f.Path.EndsWith("_._")))
                     .Select(e => e.Name)
                     .OrderBy(s => s, StringComparer.OrdinalIgnoreCase);
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -2254,7 +2254,7 @@ namespace NuGet.Commands.Test
                 Assert.True(result.Success);
                 Assert.NotNull(targetLib);
                 Assert.Equal(1, targetLib.Dependencies.Count);
-                Assert.True(targetLib.Dependencies.Where(d => d.Id == packageName).Any());
+                Assert.True(targetLib.Dependencies.Any(d => d.Id == packageName));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -4457,7 +4457,7 @@ namespace NuGet.Test
                 // Check the number of packages and packages returned by PackagesConfigProject after the installation
                 packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
                 Assert.Equal(2, packagesInPackagesConfig.Count);
-                Assert.True(packagesInPackagesConfig.Where(p => p.PackageIdentity.Equals(sharpDXDXGIv263Package)).Any());
+                Assert.True(packagesInPackagesConfig.Any(p => p.PackageIdentity.Equals(sharpDXDXGIv263Package)));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -5114,9 +5114,9 @@ namespace NuGet.Packaging.Test
         {
             var directoryPath = Path.GetDirectoryName(expectedFilePath);
 
-            return Directory.GetFiles(directoryPath, "*", SearchOption.TopDirectoryOnly)
-                .Where(filePath => string.Equals(filePath, expectedFilePath, StringComparison.Ordinal))
-                .Any();
+            return Directory
+                .GetFiles(directoryPath, "*", SearchOption.TopDirectoryOnly)
+                .Any(filePath => string.Equals(filePath, expectedFilePath, StringComparison.Ordinal));
         }
 
         private sealed class ExtractPackageAsyncTest : IDisposable

--- a/test/TestUtilities/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
+++ b/test/TestUtilities/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
@@ -135,7 +135,7 @@ namespace Test.Utility
 
         public bool FileExistsInProject(string path)
         {
-            return Files.Where(c => path.Equals(c, StringComparison.OrdinalIgnoreCase)).Any();
+            return Files.Any(c => path.Equals(c, StringComparison.OrdinalIgnoreCase));
         }
 
         public void SetPropertyValue(string propertyName, dynamic value)

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -796,7 +796,7 @@ namespace Test.Utility.Signing
             bool isOfflineRevocation = issues.Any(issue =>
                 issue.Code == NuGetLogCode.NU3018 &&
                 issue.Level == logLevel &&
-                issue.Message.Split(new[] { ' ', ':' }).Where(WORDEXTFLAGS => WORDEXTFLAGS == offlineRevocation).Any());
+                issue.Message.Split(new[] { ' ', ':' }).Any(WORDEXTFLAGS => WORDEXTFLAGS == offlineRevocation));
 
             Assert.True(isOfflineRevocation);
         }
@@ -841,7 +841,7 @@ namespace Test.Utility.Signing
             bool isRevocationStatusUnknown = issues.Any(issue =>
                 issue.Code == code &&
                 issue.Level == logLevel &&
-                issue.Message.Split(new[] { ' ', ':' }).Where(WORDEXTFLAGS => WORDEXTFLAGS == revocationStatusUnknown).Any());
+                issue.Message.Split(new[] { ' ', ':' }).Any(WORDEXTFLAGS => WORDEXTFLAGS == revocationStatusUnknown));
 
             Assert.True(isRevocationStatusUnknown);
         }
@@ -854,7 +854,7 @@ namespace Test.Utility.Signing
                 issue.Code == code &&
                 issue.Level == logLevel &&
                 (issue.Message.Contains("certificate is not trusted by the trust provider") ||
-                    issue.Message.Split(new[] { ' ', ':' }).Where(WORDEXTFLAGS => WORDEXTFLAGS == untrustedRoot).Any()));
+                 issue.Message.Split(new[] { ' ', ':' }).Any(WORDEXTFLAGS => WORDEXTFLAGS == untrustedRoot)));
 
             Assert.True(isUntrustedRoot);
         }
@@ -871,7 +871,7 @@ namespace Test.Utility.Signing
             bool isNotTimeValid = issues.Any(issue =>
                 issue.Code == NuGetLogCode.NU3018 &&
                 issue.Level == logLevel &&
-                issue.Message.Split(new[] { ' ', ':' }).Where(WORDEXTFLAGS => WORDEXTFLAGS == notTimeValid).Any());
+                issue.Message.Split(new[] { ' ', ':' }).Any(WORDEXTFLAGS => WORDEXTFLAGS == notTimeValid));
 
             Assert.True(isNotTimeValid);
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12193

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
The current code is inefficient, where we use "Where().Any()" when "Any()" applies better.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
