### PR TITLE
Package Source Mapping Options Dialogs meet Design and PLOC guidelines

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -106,7 +106,7 @@ steps:
   inputs:
     solution: "build\\loc.proj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:AfterBuild /bl:$(Build.StagingDirectory)\\binlog\\03.Localize.binlog"
+    msbuildArguments: "/t:AfterBuild /bl:$(Build.StagingDirectory)\\binlog\\03.Localize.binlog /p:LocType=$(NuGetLocType)"
 
 - task: MSBuild@1
   displayName: "Build NuGet.exe Localized"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -106,7 +106,7 @@ steps:
   inputs:
     solution: "build\\loc.proj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/t:AfterBuild /bl:$(Build.StagingDirectory)\\binlog\\03.Localize.binlog /p:LocType=$(NuGetLocType)"
+    msbuildArguments: "/t:AfterBuild /bl:$(Build.StagingDirectory)\\binlog\\03.Localize.binlog"
 
 - task: MSBuild@1
   displayName: "Build NuGet.exe Localized"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -89,6 +89,9 @@
     <Compile Include="Options\AddMappingDialog.xaml.cs">
       <DependentUpon>AddMappingDialog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Options\Resources.xaml.cs">
+      <DependentUpon>Resources.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Options\SourceMappingViewModel.cs" />
     <Compile Include="Options\PackageSourceViewModel.cs" />
     <Compile Include="Options\PackageSourceMappingOptionsControl.xaml.cs">
@@ -319,6 +322,9 @@
     </Page>
     <Page Include="Options\PackageSourceMappingOptionsControl.xaml">
       <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Options\Resources.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Themes\generic.xaml">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
@@ -78,16 +78,20 @@
     <Grid Grid.Row="0">
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="*"/>
-          <ColumnDefinition Width="24"/>
+          <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
         <TextBlock AutomationProperties.Name="AddNewPackageNamespace"
                    Grid.Column="0"
                    Text="{x:Static nuget:Resources.VSOptions_Label_AddPackageNamespace}"
                    Margin="12"/>
         <Button x:Uid="ButtonClose"
+                       Height="25"
+                       Width="25"
                        Grid.Column="1"
                        HorizontalAlignment="Left"
+                       HorizontalContentAlignment="Stretch"
                        VerticalAlignment="Top"
+                       VerticalContentAlignment="Center"
                        Margin="0,6,6,0"
                        Command="{Binding HideDialogCommand}"
                        AutomationProperties.Name="Close"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
@@ -2,7 +2,8 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vs="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:nuget="clr-namespace:NuGet.PackageManagement.UI"
              xmlns:options="clr-namespace:NuGet.Options"
@@ -32,9 +33,6 @@
       <RowDefinition Height="Auto"/>
     </Grid.RowDefinitions>
     <Grid.Resources>
-      <Style TargetType="ScrollBar">
-        <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ScrollBarColorKey}}"/>
-      </Style>
       <!-- Copied from ThemedDialogResources.xaml. See https://github.com/NuGet/Home/issues/12163 -->
       <Style TargetType="{x:Type vsui:WatermarkedTextBox}">
         <Setter Property="Padding" Value="6,8,6,8" />
@@ -134,6 +132,10 @@
             <Setter Property="AutomationProperties.Name" Value="{Binding SourceInfo.Name}"/>
           </Style>
         </ListView.ItemContainerStyle>
+        <ListView.Resources>
+          <Style x:Key="{x:Static GridView.GridViewScrollViewerStyleKey}" TargetType="{x:Type ScrollViewer}" BasedOn="{StaticResource {x:Static vs:VsResourceKeys.UnthemedGridViewScrollViewerStyleKey}}" />
+          <Style TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource {x:Static vs:VsResourceKeys.UnthemedScrollBarStyleKey}}"/>
+        </ListView.Resources>
         <ListView.View>
           <GridView>
             <!-- checkbox column -->

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
@@ -8,8 +8,8 @@
              xmlns:options="clr-namespace:NuGet.Options"
              mc:Ignorable="d" 
              x:Uid="AddMappingDialogWindow"
-             Height="304"
-             Width="456"
+             Height="324"
+             Width="480"
              ShowInTaskbar="False"
              WindowStyle="None"
              Title="{x:Static nuget:Resources.VSOptions_Label_AddPackageNamespace}"
@@ -27,9 +27,9 @@
   </vsui:DialogWindow.Resources>
   <Grid>
     <Grid.RowDefinitions>
-      <RowDefinition Height="30"/>
+      <RowDefinition Height="Auto"/>
       <RowDefinition Height="*"/>
-      <RowDefinition Height="36"/>
+      <RowDefinition Height="Auto"/>
     </Grid.RowDefinitions>
     <Grid.Resources>
       <Style TargetType="ScrollBar">
@@ -77,8 +77,7 @@
         </Setter>
       </Style>
     </Grid.Resources>
-    <StackPanel Grid.Row="0">
-      <Grid>
+    <Grid Grid.Row="0">
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="*"/>
           <ColumnDefinition Width="24"/>
@@ -86,7 +85,7 @@
         <TextBlock AutomationProperties.Name="AddNewPackageNamespace"
                    Grid.Column="0"
                    Text="{x:Static nuget:Resources.VSOptions_Label_AddPackageNamespace}"
-                   Margin="12,12,0,0"/>
+                   Margin="12"/>
         <Button x:Uid="ButtonClose"
                        Grid.Column="1"
                        HorizontalAlignment="Left"
@@ -108,69 +107,71 @@
           </Canvas>
         </Button>
       </Grid>
-    </StackPanel>
-    <StackPanel Grid.Row="1">
-      <Grid>
-        <Grid.RowDefinitions>
-          <RowDefinition Height="Auto"/>
-          <RowDefinition Height="Auto"/>
-          <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-        <vsui:WatermarkedTextBox Grid.Row="0"
+    <Grid Grid.Row="1">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+      </Grid.RowDefinitions>
+      <vsui:WatermarkedTextBox Grid.Row="0"
                                  BorderBrush="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderBrushKey}}"
                                  BorderThickness="1"
                                  AutomationProperties.Name="{x:Static nuget:Resources.VSOptions_Watermark_AddPackageNamespace}"
                                  x:Name="_packageID"
                                  MaxLength="100"
-                                 Margin="12,6,12,6"
+                                 Margin="12,0,12,0"
                                  Watermark="{x:Static nuget:Resources.VSOptions_Watermark_AddPackageNamespace}"
                                  TextChanged="PackageID_TextChanged"/>
-        <StackPanel Orientation="Vertical"  Grid.Row="1">
-          <nuget:ProjectsListView AutomationProperties.Name="{x:Static nuget:Resources.VSOptions_Accessibility_SourcesList}"
+      <nuget:ProjectsListView Grid.Row="1"
                     x:Name="_sourcesListBox"
+                    AutomationProperties.Name="{x:Static nuget:Resources.VSOptions_Accessibility_SourcesList}"
                     ItemsSource="{Binding SourcesCollection}"
                     PreviewKeyUp="SourcesListBox_PreviewKeyUp"
-                    Margin="12,0,12,12"
+                    Margin="12"
                     Height="184">
-            <ListView.ItemContainerStyle>
-              <Style>
-                <Setter Property="AutomationProperties.Name" Value="{Binding SourceInfo.Name}"/>
-              </Style>
-            </ListView.ItemContainerStyle>
-            <ListView.View>
-              <GridView>
-                <!-- checkbox column -->
-                <GridViewColumn>
-                  <GridViewColumn.CellTemplate>
-                    <DataTemplate>
-                      <CheckBox IsTabStop="False"
+        <ListView.ItemContainerStyle>
+          <Style>
+            <Setter Property="AutomationProperties.Name" Value="{Binding SourceInfo.Name}"/>
+          </Style>
+        </ListView.ItemContainerStyle>
+        <ListView.View>
+          <GridView>
+            <!-- checkbox column -->
+            <GridViewColumn>
+              <GridViewColumn.CellTemplate>
+                <DataTemplate>
+                  <CheckBox IsTabStop="False"
                                 AutomationProperties.Name="{x:Static nuget:Resources.CheckBox_Selected}"
                                 IsChecked="{Binding Path=IsSelected}"
                                 Checked="CheckBox_Checked"
                                 Unchecked="CheckBox_Checked"/>
-                    </DataTemplate>
-                  </GridViewColumn.CellTemplate>
-                </GridViewColumn>
-                <!-- the text column -->
-                <GridViewColumn>
-                  <GridViewColumnHeader Content="{x:Static nuget:Resources.VSOptions_Label_Source}" HorizontalContentAlignment="Left"/>
-                  <GridViewColumn.CellTemplate>
-                    <DataTemplate>
-                      <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="{Binding SourceInfo.Name}"/>
-                      </StackPanel>
-                    </DataTemplate>
-                  </GridViewColumn.CellTemplate>
-                </GridViewColumn>
-              </GridView>
-            </ListView.View>
-          </nuget:ProjectsListView>
-        </StackPanel>
-      </Grid>
-    </StackPanel>
-    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
-      <Button Style="{StaticResource PackageSourceMappingButtonStyle}" Command="{Binding AddMappingCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Add}"/>
-      <Button Style="{StaticResource PackageSourceMappingButtonStyle}" Command ="{Binding HideDialogCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Cancel}"/>
-    </StackPanel>
+                </DataTemplate>
+              </GridViewColumn.CellTemplate>
+            </GridViewColumn>
+            <!-- the text column -->
+            <GridViewColumn>
+              <GridViewColumnHeader Content="{x:Static nuget:Resources.VSOptions_Label_Source}" HorizontalContentAlignment="Left"/>
+              <GridViewColumn.CellTemplate>
+                <DataTemplate>
+                  <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="{Binding SourceInfo.Name}"/>
+                  </StackPanel>
+                </DataTemplate>
+              </GridViewColumn.CellTemplate>
+            </GridViewColumn>
+          </GridView>
+        </ListView.View>
+      </nuget:ProjectsListView>
+    </Grid>
+    <Grid Grid.Row="2" Margin="12,0,12,12">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="Auto" />
+        <ColumnDefinition Width="Auto" />
+      </Grid.ColumnDefinitions>
+      <!-- The `Grid.Column="0"` is missing in order to push the next column to the far right of the grid. -->
+      <Button Grid.Column="1" Style="{StaticResource PackageSourceMappingButtonStyle}" Command="{Binding AddMappingCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Add}"/>
+      <Button Grid.Column="2" Style="{StaticResource PackageSourceMappingButtonStyle}" Command ="{Binding HideDialogCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Cancel}"/>
+    </Grid>
   </Grid>
 </vsui:DialogWindow>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
@@ -168,15 +168,9 @@
         </StackPanel>
       </Grid>
     </StackPanel>
-    <Grid Grid.Row="2">
-      <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="*"/>
-        <ColumnDefinition Width="190"/>
-      </Grid.ColumnDefinitions>
-      <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"  Grid.Column="1">
-        <Button Style="{StaticResource PackageSourceMappingButtonStyle}" Command="{Binding AddMappingCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Add}"/>
-        <Button Style="{StaticResource PackageSourceMappingButtonStyle}" Command ="{Binding HideDialogCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Cancel}"/>
-      </StackPanel>
-    </Grid>
+    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+      <Button Style="{StaticResource PackageSourceMappingButtonStyle}" Command="{Binding AddMappingCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Add}"/>
+      <Button Style="{StaticResource PackageSourceMappingButtonStyle}" Command ="{Binding HideDialogCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Cancel}"/>
+    </StackPanel>
   </Grid>
 </vsui:DialogWindow>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:nuget="clr-namespace:NuGet.PackageManagement.UI"
+             xmlns:options="clr-namespace:NuGet.Options"
              mc:Ignorable="d" 
              x:Uid="AddMappingDialogWindow"
              Height="304"
@@ -17,6 +18,13 @@
              BorderBrush="{DynamicResource {x:Static vsui:EnvironmentColors.PanelBorderBrushKey}}"
              BorderThickness="1"
              Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}">
+  <vsui:DialogWindow.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <options:SharedResources />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </vsui:DialogWindow.Resources>
   <Grid>
     <Grid.RowDefinitions>
       <RowDefinition Height="30"/>
@@ -166,8 +174,8 @@
         <ColumnDefinition Width="190"/>
       </Grid.ColumnDefinitions>
       <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"  Grid.Column="1">
-        <Button Height="24" Width="86" Command="{Binding AddMappingCommand}" Margin="0,0,3,12" Content="{x:Static nuget:Resources.VSOptions_Button_Add}"/>
-        <Button Height="24" Width="86"  Command ="{Binding HideDialogCommand}" Margin="3,0,12,12" Content="{x:Static nuget:Resources.VSOptions_Button_Cancel}"/>
+        <Button Style="{StaticResource PackageSourceMappingButtonStyle}" Command="{Binding AddMappingCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Add}"/>
+        <Button Style="{StaticResource PackageSourceMappingButtonStyle}" Command ="{Binding HideDialogCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Cancel}"/>
       </StackPanel>
     </Grid>
   </Grid>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
@@ -9,7 +9,7 @@
              xmlns:options="clr-namespace:NuGet.Options"
              mc:Ignorable="d" 
              x:Uid="AddMappingDialogWindow"
-             Height="324"
+             Height="348"
              Width="480"
              ShowInTaskbar="False"
              WindowStyle="None"
@@ -110,8 +110,10 @@
         <RowDefinition Height="Auto"/>
         <RowDefinition Height="Auto"/>
         <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
       </Grid.RowDefinitions>
-      <vsui:WatermarkedTextBox Grid.Row="0"
+      <TextBlock Grid.Row="0" Text="{x:Static nuget:Resources.VSOptions_Label_PackagePattern}" Margin="12,0,12,9"/>
+      <vsui:WatermarkedTextBox Grid.Row="1"
                                  BorderBrush="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderBrushKey}}"
                                  BorderThickness="1"
                                  AutomationProperties.Name="{x:Static nuget:Resources.VSOptions_Watermark_AddPackageNamespace}"
@@ -120,7 +122,7 @@
                                  Margin="12,0,12,0"
                                  Watermark="{x:Static nuget:Resources.VSOptions_Watermark_AddPackageNamespace}"
                                  TextChanged="PackageID_TextChanged"/>
-      <nuget:ProjectsListView Grid.Row="1"
+      <nuget:ProjectsListView Grid.Row="2"
                     x:Name="_sourcesListBox"
                     AutomationProperties.Name="{x:Static nuget:Resources.VSOptions_Accessibility_SourcesList}"
                     ItemsSource="{Binding SourcesCollection}"
@@ -165,7 +167,7 @@
         </ListView.View>
       </nuget:ProjectsListView>
     </Grid>
-    <Grid Grid.Row="2" Margin="12,0,12,12">
+    <Grid Grid.Row="3" Margin="12,0,12,12">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="*" />
         <ColumnDefinition Width="Auto" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourceMappingOptionsControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourceMappingOptionsControl.xaml
@@ -35,7 +35,7 @@
     <ListBox Name="_mappingList"
              ItemsSource="{Binding SourceMappingsCollection}"
              Grid.Row="1"
-             Margin="6,6,6,6"
+             Margin="0,12,0,12"
              ItemTemplate="{StaticResource MappingItemTemplate}"
              IsSynchronizedWithCurrentItem="True"
              ScrollViewer.VerticalScrollBarVisibility="Auto"
@@ -47,7 +47,7 @@
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
-      <Button Grid.Column="0" Style="{StaticResource PackageSourceMappingButtonStyle}" Command="{Binding ShowAddDialogCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Add}"/>
+      <Button Grid.Column="0" Style="{StaticResource PackageSourceMappingFirstRowButtonStyle}" Command="{Binding ShowAddDialogCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Add}"/>
       <Button Grid.Column="1" Style="{StaticResource PackageSourceMappingButtonStyle}" Command="{Binding RemoveMappingCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Remove}"/>
       <!-- The `Grid.Column="2"` is missing in order to push the next column to the far right of the grid. -->
       <Button Grid.Column="3" Style="{StaticResource PackageSourceMappingButtonStyle}" Command="{Binding RemoveAllMappingsCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_RemoveAll}"/>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourceMappingOptionsControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourceMappingOptionsControl.xaml
@@ -4,10 +4,18 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:nuget="clr-namespace:NuGet.PackageManagement.UI"
+             xmlns:options="clr-namespace:NuGet.Options"
              Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
              Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <options:SharedResources />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </UserControl.Resources>
   <Grid>
     <Grid.RowDefinitions>
       <RowDefinition Height="Auto"></RowDefinition>
@@ -31,19 +39,18 @@
              ItemTemplate="{StaticResource MappingItemTemplate}"
              IsSynchronizedWithCurrentItem="True"
              ScrollViewer.VerticalScrollBarVisibility="Auto"
-             AutomationProperties.Name="{x:Static nuget:Resources.VSOptions_Label_PackageSourceMappings}">
-
-    </ListBox>
-    <Grid Grid.Row="3">
+             AutomationProperties.Name="{x:Static nuget:Resources.VSOptions_Label_PackageSourceMappings}" />
+    <Grid Grid.Row="2">
       <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="101"/>
-        <ColumnDefinition Width="89"/>
+        <ColumnDefinition Width="Auto"/>
+        <ColumnDefinition Width="Auto"/>
         <ColumnDefinition Width="*"/>
-        <ColumnDefinition Width="101"/>
+        <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
-      <Button Grid.Column="0" Width="86" Height="24" Command="{Binding ShowAddDialogCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Add}"/>
-      <Button Grid.Column="1" Width="86" Height="24" Margin = "3,0,0,0" Command="{Binding RemoveMappingCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Remove}"/>
-      <Button Grid.Column="3" Width="86" Height="24"  Command="{Binding RemoveAllMappingsCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_RemoveAll}"/>
+      <Button Grid.Column="0" Style="{StaticResource PackageSourceMappingButtonStyle}" Command="{Binding ShowAddDialogCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Add}"/>
+      <Button Grid.Column="1" Style="{StaticResource PackageSourceMappingButtonStyle}" Command="{Binding RemoveMappingCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Remove}"/>
+      <!-- The `Grid.Column="2"` is missing in order to push the next column to the far right of the grid. -->
+      <Button Grid.Column="3" Style="{StaticResource PackageSourceMappingButtonStyle}" Command="{Binding RemoveAllMappingsCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_RemoveAll}"/>
     </Grid>
   </Grid>
 </UserControl>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/Resources.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/Resources.xaml
@@ -1,0 +1,16 @@
+<ResourceDictionary
+  x:Class="NuGet.Options.SharedResources"
+  x:ClassModifier="internal"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  
+  <Style x:Key="PackageSourceMappingButtonStyle" TargetType="{x:Type Button}">
+    <Setter Property="MinWidth" Value="86" />
+    <Setter Property="Height" Value="24" />
+    <Setter Property="Padding" Value="10,1,10,1" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="Margin" Value="3,6" />
+  </Style>
+  
+</ResourceDictionary>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/Resources.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/Resources.xaml
@@ -10,7 +10,9 @@
     <Setter Property="Padding" Value="10,1,10,1" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="HorizontalContentAlignment" Value="Center" />
-    <Setter Property="Margin" Value="3,6" />
+    <Setter Property="Margin" Value="6,0,0,0" />
   </Style>
-  
+  <Style x:Key="PackageSourceMappingFirstRowButtonStyle" TargetType="{x:Type Button}" BasedOn="{StaticResource PackageSourceMappingButtonStyle}">
+    <Setter Property="Margin" Value="0" />
+  </Style>
 </ResourceDictionary>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/Resources.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/Resources.xaml.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Windows;
+
+namespace NuGet.Options
+{
+    internal partial class SharedResources : ResourceDictionary
+    {
+        public SharedResources()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -2340,6 +2340,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package pattern:.
+        /// </summary>
+        public static string VSOptions_Label_PackagePattern {
+            get {
+                return ResourceManager.GetString("VSOptions_Label_PackagePattern", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Package Source Mappings:.
         /// </summary>
         public static string VSOptions_Label_PackageSourceMappings {
@@ -2358,7 +2367,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enter a valid Package pattern (Example: Contoso.Contracts or System.*).
+        ///   Looks up a localized string similar to Example: Contoso.Contracts or System.*.
         /// </summary>
         public static string VSOptions_Watermark_AddPackageNamespace {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -963,7 +963,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <value>Source</value>
   </data>
   <data name="VSOptions_Watermark_AddPackageNamespace" xml:space="preserve">
-    <value>Enter a valid Package pattern (Example: Contoso.Contracts or System.*)</value>
+    <value>Example: Contoso.Contracts or System.*</value>
     <comment>"Contoso.Contracts" and "System.*" are examples of a package ID pattern and a package prefix pattern, respectively, so these two specific examples should not be translated.</comment>
   </data>
   <data name="PackageSourceMappingOptions_OnActivated" xml:space="preserve">
@@ -971,5 +971,8 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   </data>
   <data name="VSOptions_Accessibility_SourcesList" xml:space="preserve">
     <value>Package sources list</value>
+  </data>
+  <data name="VSOptions_Label_PackagePattern" xml:space="preserve">
+    <value>Package pattern:</value>
   </data>
 </root>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1834

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Addressed Design Guideline issues, PLOC issues, and made a few design changes to the Add Package Source Mapping dialog.
The new **Resources XAML file** for button styles that apply to both pages, and likely will be used on other Options pages in the future.

Below is a detailed listing of what I changed and the before after.
A general example of the result:
![image](https://user-images.githubusercontent.com/49205731/197081885-5c1dd29a-6350-4d5f-b482-87f368130f75.png)
![image](https://user-images.githubusercontent.com/49205731/197081925-320d6f43-8116-408d-b7b6-6a2eb5c9a6c8.png)
_(while hovering over the close button)_

# Before this PR
![image](https://user-images.githubusercontent.com/49205731/197080801-98d041f5-350c-4d5a-8784-c39b17dc0d09.png)

- Spacing of controls does not meet Design guidance
- Localization would lead to buttons not resizing appropriately (Notice "Remove All" button text is truncated)

![image](https://user-images.githubusercontent.com/49205731/197080903-6b985c91-95ff-479a-a591-979a63bb54e2.png)

- Spacing of controls does not meet Design guidance
- - Localization would lead to buttons not resizing appropriately (Notice "Cancel" button text is truncated)
- Watermark in textbox is too large when localized (and in general). The full PLOC string should be: `!6nvWe!Enter a valid Package pattern (Example: Contoso.Contracts or System.*) 表©鷗字㌍ 表©!`
- Scrollbar has dark theme coming through (dark rectangle in lower right)
- Close button has a very small selectable area (see blue highlight: ![image](https://user-images.githubusercontent.com/49205731/197081480-ad037081-5af7-444c-aac6-f86b399083b6.png))

# After this PR

![image](https://user-images.githubusercontent.com/49205731/197081274-b2e8fb60-2ff2-4f4a-a02d-0556833e2cf0.png)
_(shown at minimum VS supported resolution with 200% DPI scaling)_

- Control spacing meets guidelines
- Text growth does not get truncated in buttons or cause control wrapping

![image](https://user-images.githubusercontent.com/49205731/197080612-d9802ad0-3abd-4deb-88ed-6f30f615eb44.png)
_(shown at minimum VS supported resolution with 200% DPI scaling)_

- Control spacing meets guidelines
- Text growth does not get truncated in buttons or cause control wrapping
- Close Button has larger surface area; easier to select and looks more natural (square selectable area)
- Scrollbars are using Un-themed Styles (lower right rectangle matches scrollbar color)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Tested manually:
    - WPF tools to verify spacing meets Design guidance
    - PLOC tool to increase text size to mimic larger localization
    - Accessibility Insights & Narrator to verify no errors or issues reading controls
    - also tested Minimum Screen Resolution + 200% DPI Scaling
 - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled https://github.com/NuGet/docs.microsoft.com-nuget/issues/2799
  - **OR**
  - [ ] N/A
