### PR TITLE
unblock source build failing due to fatal: transport 'file' not allowed error

### DIFF
--- a/eng/source-build/build.sh
+++ b/eng/source-build/build.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+echo "git config --global protocol.file.allow always"
+git config --global protocol.file.allow always
+
 source="${BASH_SOURCE[0]}"
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1927

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

`Source build` started failing on CI resulting in private and official build failures.

```
Creating empty clone at: /home/vsts/work/1/s/artifacts/source-build/self/src/submodules/Common
  Cloning into '/home/vsts/work/1/s/artifacts/source-build/self/src/submodules/Common'...
  fatal: transport 'file' not allowed
  fatal: run_command returned non-zero status for submodules/Common
  .
/home/vsts/.nuget/packages/microsoft.dotnet.arcade.sdk/6.0.0-beta.21309.7/tools/SourceBuild/SourceBuildArcadeBuild.targets(147,5): error MSB3073: The command "git submodule foreach --recursive '/home/vsts/.nuget/packages/microsoft.dotnet.arcade.sdk/6.0.0-beta.21309.7/tools/SourceBuild/git-clone-to-dir.sh  --source . --dest "/home/vsts/work/1/s/artifacts/source-build/self/src/$sm_path" --copy-wip --clean'" exited with code 128. [/home/vsts/.nuget/packages/microsoft.dotnet.arcade.sdk/6.0.0-beta.21309.7/tools/Build.proj]
##[error]PowerShell exited with code '1'.
Finishing: Build source-build
```

@zivkan identified that this failure is related to following issues.
- https://github.com/dart-lang/pub/issues/3617
- https://bugs.launchpad.net/ubuntu/+source/git/+bug/1993586

The work around suggested in the above issues is to run `git config --global protocol.file.allow always` command.

https://vielmetti.typepad.com/logbook/2022/10/git-security-fixes-lead-to-fatal-transport-file-not-allowed-error-in-ci-systems-cve-2022-39253.html blog explains how different repositories responded to this issue. Majority of them executed the above workaround.

For example, another Microsoft repo applied the same work around. https://github.com/microsoft/go-infra/pull/71/files

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A
