### PR TITLE
Display Warning As Error when warning elevated to error

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
@@ -160,7 +160,7 @@ namespace NuGet.Commands
                 {
                     // If the project wide AllWarningsAsErrors is true and the message has a valid code or
                     // Project wide WarningsAsErrors contains the message code then upgrade to error.
-                    message.Message = "(WarningsAsErrors) " + message.Message;
+                    message.Message = Strings.WarningAsError + ": " + message.Message;
                     message.Level = LogLevel.Error;
                 }
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
@@ -160,6 +160,7 @@ namespace NuGet.Commands
                 {
                     // If the project wide AllWarningsAsErrors is true and the message has a valid code or
                     // Project wide WarningsAsErrors contains the message code then upgrade to error.
+                    message.Message = "(WarningsAsErrors) " + message.Message;
                     message.Level = LogLevel.Error;
                 }
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Linq;
 using NuGet.Common;
 using NuGet.Frameworks;
@@ -160,7 +161,7 @@ namespace NuGet.Commands
                 {
                     // If the project wide AllWarningsAsErrors is true and the message has a valid code or
                     // Project wide WarningsAsErrors contains the message code then upgrade to error.
-                    message.Message = Strings.WarningAsError + ": " + message.Message;
+                    message.Message = string.Format(CultureInfo.CurrentCulture, Strings.WarningAsError, message.Message);
                     message.Level = LogLevel.Error;
                 }
             }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -2430,7 +2430,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Warning As Error.
+        ///   Looks up a localized string similar to Warning As Error: {0}.
         /// </summary>
         internal static string WarningAsError {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -2428,5 +2428,14 @@ namespace NuGet.Commands {
                 return ResourceManager.GetString("Warning_VersionAboveUpperBound", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Warning As Error.
+        /// </summary>
+        internal static string WarningAsError {
+            get {
+                return ResourceManager.GetString("WarningAsError", resourceCulture);
+            }
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1037,4 +1037,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
 Non-HTTPS access will be removed in a future version. Consider migrating to 'HTTPS' sources.</value>
     <comment>0 - The command name. Ex. Push/Delete. 1 - list of server URIs</comment>
   </data>
+  <data name="WarningAsError" xml:space="preserve">
+    <value>Warning As Error</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1038,6 +1038,7 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
     <comment>0 - The command name. Ex. Push/Delete. 1 - list of server URIs</comment>
   </data>
   <data name="WarningAsError" xml:space="preserve">
-    <value>Warning As Error</value>
+    <value>Warning As Error: {0}</value>
+    <comment>{0} is a warning message</comment>
   </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
@@ -285,7 +285,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 errors.Count().Should().Be(1);
                 errors.First().Code.Should().Be(NuGetLogCode.NU3005);
-                errors.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource));
+                errors.First().Message.Should().Be("(WarningsAsErrors) " + SigningTestUtility.AddSignatureLogPrefix(NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource));
                 errors.First().LibraryId.Should().Be(packageX.Id);
 
                 warnings.Count().Should().Be(0);

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
@@ -281,11 +281,11 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(1);
-                result.Errors.Should().Contain(string.Format(NU3005, "(WarningsAsErrors) " + SigningTestUtility.AddSignatureLogPrefix(NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource)));
+                result.Errors.Should().Contain(string.Format(NU3005, "Warning As Error: " + SigningTestUtility.AddSignatureLogPrefix(NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource)));
 
                 errors.Count().Should().Be(1);
                 errors.First().Code.Should().Be(NuGetLogCode.NU3005);
-                errors.First().Message.Should().Be("(WarningsAsErrors) " + SigningTestUtility.AddSignatureLogPrefix(NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource));
+                errors.First().Message.Should().Be("Warning As Error: " + SigningTestUtility.AddSignatureLogPrefix(NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource));
                 errors.First().LibraryId.Should().Be(packageX.Id);
 
                 warnings.Count().Should().Be(0);

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
@@ -281,7 +281,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(1);
-                result.Errors.Should().Contain(string.Format(NU3005, SigningTestUtility.AddSignatureLogPrefix(NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource)));
+                result.Errors.Should().Contain(string.Format(NU3005, "(WarningsAsErrors) " + SigningTestUtility.AddSignatureLogPrefix(NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource)));
 
                 errors.Count().Should().Be(1);
                 errors.First().Code.Should().Be(NuGetLogCode.NU3005);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/CollectorLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/CollectorLoggerTests.cs
@@ -393,7 +393,7 @@ namespace NuGet.Commands.Test
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Once(), NuGetLogCode.NU1601);
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Warning", Times.Once(), NuGetLogCode.NU1500);
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "(WarningsAsErrors) Warning", Times.Once(), NuGetLogCode.NU1500);
         }
 
 
@@ -426,7 +426,7 @@ namespace NuGet.Commands.Test
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Never());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Warning", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "(WarningsAsErrors) Warning", Times.Once());
         }
 
         [Fact]
@@ -460,7 +460,7 @@ namespace NuGet.Commands.Test
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Never());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Warning", Times.Exactly(3));
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "(WarningsAsErrors) Warning", Times.Exactly(3));
         }
 
         [Fact]
@@ -1038,7 +1038,7 @@ namespace NuGet.Commands.Test
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Verbose, "Verbose", Times.Once());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Never());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Warning", Times.Once(), NuGetLogCode.NU1107);
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "(WarningsAsErrors) Warning", Times.Once(), NuGetLogCode.NU1107);
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/CollectorLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/CollectorLoggerTests.cs
@@ -393,7 +393,7 @@ namespace NuGet.Commands.Test
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Once(), NuGetLogCode.NU1601);
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "(WarningsAsErrors) Warning", Times.Once(), NuGetLogCode.NU1500);
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Warning As Error: Warning", Times.Once(), NuGetLogCode.NU1500);
         }
 
 
@@ -426,7 +426,7 @@ namespace NuGet.Commands.Test
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Never());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "(WarningsAsErrors) Warning", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Warning As Error: Warning", Times.Once());
         }
 
         [Fact]
@@ -460,7 +460,7 @@ namespace NuGet.Commands.Test
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Never());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "(WarningsAsErrors) Warning", Times.Exactly(3));
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Warning As Error: Warning", Times.Exactly(3));
         }
 
         [Fact]
@@ -1038,7 +1038,7 @@ namespace NuGet.Commands.Test
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Verbose, "Verbose", Times.Once());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Never());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "(WarningsAsErrors) Warning", Times.Once(), NuGetLogCode.NU1107);
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Warning As Error: Warning", Times.Once(), NuGetLogCode.NU1107);
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/8803

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

I had another PR open, but I left it for too long before the bot closed it as stale. During this time, I discovered that Roslyn previosly used the prefix `Warning As Error: `, which I thought is better than my first PR, so I switched to it. Unfortunately, nobody responded to my query as to why Roslyn stopped using it. I hope it's because analyzer levels became customizable via editorconfig, so the concept of "warning elevated to error" in roslyn doesn't really exist any longer. If it was done for some other reason, I tried to learn from their experience, but I just couldn't find the reason they stopped doing it.

Prepend `Warning As Error: ` when a warning is elevated to an error.

For example:

**Before**

```text
D:\src\test\hasWarning\hasWarning.csproj : error NU1605: Detected package downgrade: NuGet.Frameworks from 6.3.0 to 6.2.0. Reference the package directly from the project to select a different version.
D:\src\test\hasWarning\hasWarning.csproj : error NU1605:  hasWarning -> NuGet.Protocol 6.3.0 -> NuGet.Packaging 6.3.0 -> NuGet.Configuration 6.3.0 -> NuGet.Common 6.3.0 -> NuGet.Frameworks (>= 6.3.0)
D:\src\test\hasWarning\hasWarning.csproj : error NU1605:  hasWarning -> NuGet.Frameworks (>= 6.2.0)
```

**After**
```text
D:\src\test\hasWarning\hasWarning.csproj : error NU1605: Warning As Error: Detected package downgrade: NuGet.Frameworks from 6.3.0 to 6.2.0. Reference the package directly from the project to select a different version.
D:\src\test\hasWarning\hasWarning.csproj : error NU1605:  hasWarning -> NuGet.Protocol 6.3.0 -> NuGet.Packaging 6.3.0 -> NuGet.Configuration 6.3.0 -> NuGet.Common 6.3.0 -> NuGet.Frameworks (>= 6.3.0)
D:\src\test\hasWarning\hasWarning.csproj : error NU1605:  hasWarning -> NuGet.Frameworks (>= 6.2.0)
```

This gives knowledgeable customers a sufficient hint that `NoWarn="NU1605"` would give them a work around. Otherwise, it's very difficult for customers to know that 1. their project is treating the warning (possibly all warnings) as errors, and 2. that a specific "error" code is really a warning that was elevated.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
