### PR TITLE
Add missing IVsSolutionRestoreStatusProvider.IsRestoreCompleteAsync counter to VS extensibility collector

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/ExtensibilityTelemetryCollector.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/ExtensibilityTelemetryCollector.cs
@@ -64,6 +64,12 @@ namespace NuGet.VisualStudio.Telemetry
                 // IVsGlobalPackagesInitScriptExecutor
                 [nameof(IVsGlobalPackagesInitScriptExecutor) + "." + nameof(IVsGlobalPackagesInitScriptExecutor.ExecuteInitScriptAsync)] = new Count(),
 
+                // IVsNuGetProjectUpdateEvents
+                [nameof(IVsNuGetProjectUpdateEvents) + "." + nameof(IVsNuGetProjectUpdateEvents.SolutionRestoreStarted)] = new Count(),
+                [nameof(IVsNuGetProjectUpdateEvents) + "." + nameof(IVsNuGetProjectUpdateEvents.SolutionRestoreFinished)] = new Count(),
+                [nameof(IVsNuGetProjectUpdateEvents) + "." + nameof(IVsNuGetProjectUpdateEvents.ProjectUpdateStarted)] = new Count(),
+                [nameof(IVsNuGetProjectUpdateEvents) + "." + nameof(IVsNuGetProjectUpdateEvents.ProjectUpdateFinished)] = new Count(),
+
                 // IVsPackageInstaller
                 [nameof(IVsPackageInstaller) + "." + nameof(IVsPackageInstaller.InstallPackage) + ".1"] = new Count(),
                 [nameof(IVsPackageInstaller) + "." + nameof(IVsPackageInstaller.InstallPackage) + ".2"] = new Count(),
@@ -159,11 +165,8 @@ namespace NuGet.VisualStudio.Telemetry
                 // IVsSolutionRestoreService4
                 [nameof(IVsSolutionRestoreService4) + "." + nameof(IVsSolutionRestoreService4.RegisterRestoreInfoSourceAsync)] = new Count(),
 
-                // IVsNuGetProjectUpdateEvents
-                [nameof(IVsNuGetProjectUpdateEvents) + "." + nameof(IVsNuGetProjectUpdateEvents.SolutionRestoreStarted)] = new Count(),
-                [nameof(IVsNuGetProjectUpdateEvents) + "." + nameof(IVsNuGetProjectUpdateEvents.SolutionRestoreFinished)] = new Count(),
-                [nameof(IVsNuGetProjectUpdateEvents) + "." + nameof(IVsNuGetProjectUpdateEvents.ProjectUpdateStarted)] = new Count(),
-                [nameof(IVsNuGetProjectUpdateEvents) + "." + nameof(IVsNuGetProjectUpdateEvents.ProjectUpdateFinished)] = new Count(),
+                // IVsSolutionRestoreStatusProvider
+                [nameof(IVsSolutionRestoreStatusProvider) + "." + nameof(IVsSolutionRestoreStatusProvider.IsRestoreCompleteAsync)] = new Count(),
             };
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1933

Regression? No

## Description

* Add missing counter to VS extensibility telemetry collector
* Sort counters

When running a debug build of the NuGet VSIX, a Debug.Assert message box occasionally appears, which comes from https://github.com/NuGet/NuGet.Client/blob/5ac4851cf360b73eddc236f312117d95c25ff37a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Telemetry/ExtensibilityTelemetryCollector.cs#L238

This means there is a missing counter earlier in the file.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
