### PR TITLE
refactor NuGet migrations code

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
+++ b/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
@@ -31,7 +31,7 @@ namespace NuGet.Common.Migrations
                             {
                                 Migration1.Run();
                                 // Create file for the migration run, so that if an older version of NuGet is run, it doesn't try to run migrations again.
-                                File.Create(expectedMigrationFilename).Dispose();
+                                File.WriteAllText(expectedMigrationFilename, string.Empty);
                             }
                         }
                         catch { }

--- a/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
+++ b/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Threading;
 
@@ -12,17 +9,10 @@ namespace NuGet.Common.Migrations
 {
     public static class MigrationRunner
     {
-        private static readonly IReadOnlyList<Action> Migrations = new List<Action>()
-        {
-            Migration1.Run
-        };
         private const string MaxMigrationFilename = "1";
 
         public static void Run()
         {
-            // since migrations run once per machine, optimize for the scenario where the migration has already run
-            Debug.Assert(MaxMigrationFilename == Migrations.Count.ToString(CultureInfo.InvariantCulture));
-
             string migrationsDirectory = GetMigrationsDirectory();
             var expectedMigrationFilename = Path.Combine(migrationsDirectory, MaxMigrationFilename);
 
@@ -34,24 +24,21 @@ namespace NuGet.Common.Migrations
                 {
                     if (WaitForMutex(mutex))
                     {
-                        if (!File.Exists(expectedMigrationFilename))
+                        try
                         {
                             // Only run migrations that have not already been run
-                            int highestMigrationRun = GetHighestMigrationRun(migrationsDirectory);
-                            for (int i = highestMigrationRun + 1; i < Migrations.Count; i++)
+                            if (!File.Exists(expectedMigrationFilename))
                             {
-                                try
-                                {
-                                    Migrations[i]();
-                                    // Create file for every migration run, so that if an older version of NuGet is run, it doesn't try to run
-                                    // migrations again.
-                                    string migrationFile = Path.Combine(migrationsDirectory, (i + 1).ToString(CultureInfo.InvariantCulture));
-                                    File.WriteAllText(migrationFile, string.Empty);
-                                }
-                                catch { }
+                                Migration1.Run();
+                                // Create file for the migration run, so that if an older version of NuGet is run, it doesn't try to run migrations again.
+                                File.Create(expectedMigrationFilename).Dispose();
                             }
                         }
-                        mutex.ReleaseMutex();
+                        catch { }
+                        finally
+                        {
+                            mutex.ReleaseMutex();
+                        }
                     }
                 }
             }
@@ -89,20 +76,6 @@ namespace NuGet.Common.Migrations
             }
             Directory.CreateDirectory(migrationsDirectory);
             return migrationsDirectory;
-        }
-
-        private static int GetHighestMigrationRun(string directory)
-        {
-            for (int i = Migrations.Count - 1; i >= 0; --i)
-            {
-                var filename = Path.Combine(directory, (i + 1).ToString(CultureInfo.InvariantCulture));
-                if (File.Exists(filename))
-                {
-                    return i;
-                }
-            }
-
-            return -1;
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
-using System.Threading.Tasks;
 using NuGet.Common.Migrations;
 using Xunit;
 
@@ -15,7 +14,25 @@ namespace NuGet.Common.Test
     public class MigrationRunnerTests
     {
         [Fact]
-        public void WhenExecutedInParallelOnlyOneFileIsCreatedForEveryMigration_Success()
+        public void Run_WhenExecutedOnSingleThreadThenOneMigrationFileIsCreated_Success()
+        {
+            // Arrange
+            string directory = MigrationRunner.GetMigrationsDirectory();
+            if (Directory.Exists(directory))
+                Directory.Delete(path: directory, recursive: true);
+
+            // Act
+            MigrationRunner.Run();
+
+            // Assert
+            Assert.True(Directory.Exists(directory));
+            var files = Directory.GetFiles(directory);
+            Assert.Equal(1, files.Length);
+            Assert.Equal(Path.Combine(directory, "1"), files[0]);
+        }
+
+        [Fact]
+        public void Run_WhenExecutedInParallelThenOnlyOneMigrationFileIsCreated_Success()
         {
             var threads = new List<Thread>();
             int numThreads = 5;
@@ -41,7 +58,9 @@ namespace NuGet.Common.Test
 
             // Assert
             Assert.True(Directory.Exists(directory));
-            Assert.Equal(1, Directory.GetFiles(directory).Length);
+            var files = Directory.GetFiles(directory);
+            Assert.Equal(1, files.Length);
+            Assert.Equal(Path.Combine(directory, "1"), files[0]);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1936

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Thanks to @stephentoub for taking the time to review https://github.com/NuGet/NuGet.Client/pull/4859 PR offline. I have refactored the code based on the feedback received. At a high level here are the changes proposed in this PR.

1. Invoke `Mutex.ReleaseMutex();` in the `finally block` just to be on the safe side.
2. Removed logic to support running multiple migrations because it is not needed currently.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A
