### PR TITLE
Rename CI jobs running on DartLab

### DIFF
--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -26,8 +26,8 @@ parameters:
 stages:
   - template: stages\visual-studio\single-runsettings.yml@DartLabTemplates
     parameters:
-      stageName: VS_Apex_Tests
-      stageDisplayName: Apex Tests On Windows
+      name: VS_Apex_Tests
+      displayName: Apex Tests On Windows
       condition: ${{parameters.condition}}
       dependsOn: ${{parameters.dependsOn}}
       variables:

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -1,8 +1,4 @@
 parameters:
-  - name: stageName
-    type: string
-  - name: stageDisplayName
-    type: string
   - name: dependsOn
     type: object
   - name: bootstrapperUrl
@@ -30,8 +26,8 @@ parameters:
 stages:
   - template: stages\visual-studio\single-runsettings.yml@DartLabTemplates
     parameters:
-      name: ${{parameters.stageName}}
-      displayName: ${{parameters.stageDisplayName}}
+      stageName: VS_Apex_Tests
+      stageDisplayName: Apex Tests On Windows
       condition: ${{parameters.condition}}
       dependsOn: ${{parameters.dependsOn}}
       variables:
@@ -44,6 +40,10 @@ stages:
       dartLabEnvironment: ${{parameters.DartLabEnvironment}}
       visualStudioSigning: Test
       testMachineDeploymentJobTimeoutInMinutes: 240
+      testMachineConfigurationJobDisplayName: 'Apex Test Machine Configuration'
+      testMachineDeploymentJobDisplayName: 'Apex Test Machine Deployment'
+      testExecutionJobDisplayName: 'Apex Test Execution'
+      testMachineCleanUpJobDisplayName: 'Apex Test Machine Clean Up'
       testRunContinueOnError: ${{ parameters.isOfficialBuild }}
       testExecutionJobTimeoutInMinutes: ${{parameters.testExecutionJobTimeoutInMinutes}}
       testMachineCleanUpStrategy: ${{parameters.testMachineCleanUpStrategy}}

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -30,9 +30,13 @@ stages:
 - template: stages\visual-studio\agent.yml@DartLabTemplates
   parameters:
     name: ${{parameters.stageName}}
-    displayName: ${{parameters.stageDisplayName}}
+    displayName: 'E2E Tests ${{parameters.stageDisplayName}}'
     condition: ${{parameters.condition}}
     dependsOn: ${{parameters.dependsOn}}
+    testMachineConfigurationJobDisplayName: 'E2E ${{parameters.stageDisplayName}} Machine Configuration'
+    testMachineDeploymentJobDisplayName: 'E2E ${{parameters.stageDisplayName}} Machine Deployment'
+    testExecutionJobDisplayName: 'E2E ${{parameters.stageDisplayName}} Test Execution'
+    testMachineCleanUpJobDisplayName: 'E2E ${{parameters.stageDisplayName}} Machine Clean Up'
     testMachineDeploymentJobTimeoutInMinutes: 240
     testExecutionJobTimeoutInMinutes: ${{parameters.testExecutionJobTimeoutInMinutes}}
     variables:

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -250,8 +250,6 @@ stages:
 # Dartlab's template defines this in its own stage
 - template: Apex_Tests_On_Windows.yml
   parameters:
-    stageName: Visual_Studio_Apex_Tests
-    stageDisplayName: Apex Tests On Windows
     condition: "and(succeeded(), eq(variables['RunApexTests'], 'true'))"
     dependsOn:
       - Initialize

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -209,7 +209,7 @@ stages:
 - template: End_To_End_Tests_On_Windows.yml
   parameters:
     stageName: VS_EndToEnd_Part1
-    stageDisplayName: VS EndToEnd Tests Part 1
+    stageDisplayName: Part 1
     condition: "and(succeeded(), eq(variables['RunEndToEndTests'], 'true'))"
     dependsOn:
     - Initialize
@@ -230,7 +230,7 @@ stages:
 - template: End_To_End_Tests_On_Windows.yml
   parameters:
     stageName: VS_EndToEnd_Part2
-    stageDisplayName: VS EndToEnd Tests Part 2
+    stageDisplayName: Part 2
     condition: "and(succeeded(), eq(variables['RunEndToEndTests'], 'true'))"
     dependsOn:
     - Initialize


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1937

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Rename the jobs running on DartLab, so they're unique, allowing our CI Reliability report generator to tell us which DartLab stage a failure happened on.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
