### PR TITLE
Better error message when adding a source in VS Options 

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -291,10 +291,14 @@ namespace NuGet.Options
                     remoteException.DeserializedErrorData is CommonErrorData commonError)
                 {
                     if (commonError.TypeName == typeof(NuGetConfigurationException).FullName || // Thrown during creating or saving NuGet.Config.
-                        commonError.TypeName == typeof(InvalidOperationException).FullName || // Thrown if no nuget.config found.
-                        commonError.TypeName == typeof(UnauthorizedAccessException).FullName)
+                        commonError.TypeName == typeof(InvalidOperationException).FullName) // Thrown if no nuget.config found.
                     {
                         MessageHelper.ShowErrorMessage(ex.Message, Resources.ErrorDialogBoxTitle);
+                        return false;
+                    }
+                    else if (commonError.TypeName == typeof(UnauthorizedAccessException).FullName)
+                    {
+                        MessageHelper.ShowErrorMessage(Resources.ShowError_ConfigUnauthorizedAccess, Resources.ErrorDialogBoxTitle);
                         return false;
                     }
                 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -28,6 +28,8 @@ using GelUtilities = Microsoft.Internal.VisualStudio.PlatformUI.Utilities;
 using Task = System.Threading.Tasks.Task;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Imaging;
+using StreamJsonRpc;
+using StreamJsonRpc.Protocol;
 
 namespace NuGet.Options
 {
@@ -303,7 +305,20 @@ namespace NuGet.Options
             // Unknown exception.
             catch (Exception ex)
             {
-                MessageHelper.ShowErrorMessage(Resources.ShowError_ApplySettingFailed, Resources.ErrorDialogBoxTitle);
+                if (ex is RemoteInvocationException remoteException
+                && remoteException.DeserializedErrorData is CommonErrorData commonError)
+                {
+                    if (commonError.TypeName == typeof(NuGetConfigurationException).FullName)
+                    {
+                        MessageHelper.ShowErrorMessage(ex.Message, Resources.ErrorDialogBoxTitle);
+                        return false;
+                    }
+                }
+                else
+                {
+                    MessageHelper.ShowErrorMessage(Resources.ShowError_ApplySettingFailed, Resources.ErrorDialogBoxTitle);
+                }
+
                 ActivityLog.LogError(NuGetUI.LogEntrySource, ex.ToString());
                 return false;
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -305,8 +305,8 @@ namespace NuGet.Options
             // Unknown exception.
             catch (Exception ex)
             {
-                if (ex is RemoteInvocationException remoteException
-                && remoteException.DeserializedErrorData is CommonErrorData commonError)
+                if (ex is RemoteInvocationException remoteException &&
+                    remoteException.DeserializedErrorData is CommonErrorData commonError)
                 {
                     if (commonError.TypeName == typeof(NuGetConfigurationException).FullName)
                     {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -285,30 +285,14 @@ namespace NuGet.Options
                     await _nugetSourcesService.SavePackageSourceContextInfosAsync(packageSources, cancellationToken);
                 }
             }
-            // Thrown during creating or saving NuGet.Config.
-            catch (NuGetConfigurationException ex)
-            {
-                MessageHelper.ShowErrorMessage(ex.Message, Resources.ErrorDialogBoxTitle);
-                return false;
-            }
-            // Thrown if no nuget.config found.
-            catch (InvalidOperationException ex)
-            {
-                MessageHelper.ShowErrorMessage(ex.Message, Resources.ErrorDialogBoxTitle);
-                return false;
-            }
-            catch (UnauthorizedAccessException)
-            {
-                MessageHelper.ShowErrorMessage(Resources.ShowError_ConfigUnauthorizedAccess, Resources.ErrorDialogBoxTitle);
-                return false;
-            }
-            // Unknown exception.
             catch (Exception ex)
             {
                 if (ex is RemoteInvocationException remoteException &&
                     remoteException.DeserializedErrorData is CommonErrorData commonError)
                 {
-                    if (commonError.TypeName == typeof(NuGetConfigurationException).FullName)
+                    if (commonError.TypeName == typeof(NuGetConfigurationException).FullName || // Thrown during creating or saving NuGet.Config.
+                        commonError.TypeName == typeof(InvalidOperationException).FullName || // Thrown if no nuget.config found.
+                        commonError.TypeName == typeof(UnauthorizedAccessException).FullName)
                     {
                         MessageHelper.ShowErrorMessage(ex.Message, Resources.ErrorDialogBoxTitle);
                         return false;

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -680,9 +680,9 @@ namespace NuGet.Configuration
                 var duplicatedKey = existingDisabledSources
                     .GroupBy(s => s.Key, StringComparer.OrdinalIgnoreCase)
                     .Where(g => g.Count() > 1)
-                    .First()
-                    .Select(g => g);
-                throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.ShowError_ConfigDuplicateDisabledSources), e);
+                    .Select(g => g.First())
+                    .First();
+                throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.ShowError_ConfigDuplicateDisabledSources, duplicatedKey.Key, duplicatedKey.Origin.ConfigFilePath), e);
             }
 
             var credentialsSection = Settings.GetSection(ConfigurationConstants.CredentialsSectionName);

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -676,6 +676,12 @@ namespace NuGet.Configuration
             }
             catch (ArgumentException e)
             {
+                var path = Settings.GetConfigFilePaths();
+                var duplicatedKey = existingDisabledSources
+                    .GroupBy(s => s.Key, StringComparer.OrdinalIgnoreCase)
+                    .Where(g => g.Count() > 1)
+                    .First()
+                    .Select(g => g);
                 throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.ShowError_ConfigDuplicateDisabledSources), e);
             }
 

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NuGet.Common;
@@ -667,7 +668,16 @@ namespace NuGet.Configuration
 
             var disabledSourcesSection = Settings.GetSection(ConfigurationConstants.DisabledPackageSources);
             var existingDisabledSources = disabledSourcesSection?.Items.OfType<AddItem>();
-            var existingDisabledSourcesLookup = existingDisabledSources?.ToDictionary(setting => setting.Key, StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, AddItem> existingDisabledSourcesLookup = null;
+
+            try
+            {
+                existingDisabledSourcesLookup = existingDisabledSources?.ToDictionary(setting => setting.Key, StringComparer.OrdinalIgnoreCase);
+            }
+            catch (ArgumentException e)
+            {
+                throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.ShowError_ConfigDuplicateDisabledSources), e);
+            }
 
             var credentialsSection = Settings.GetSection(ConfigurationConstants.CredentialsSectionName);
             var existingCredentials = credentialsSection?.Items.OfType<CredentialsItem>();

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -676,8 +676,7 @@ namespace NuGet.Configuration
             }
             catch (ArgumentException e)
             {
-                var path = Settings.GetConfigFilePaths();
-                var duplicatedKey = existingDisabledSources
+                AddItem duplicatedKey = existingDisabledSources
                     .GroupBy(s => s.Key, StringComparer.OrdinalIgnoreCase)
                     .Where(g => g.Count() > 1)
                     .Select(g => g.First())

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -403,6 +403,15 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot update package sources. NuGet.Config contains a duplicated key in the disabled package sources section..
+        /// </summary>
+        internal static string ShowError_ConfigDuplicateDisabledSources {
+            get {
+                return ResourceManager.GetString("ShowError_ConfigDuplicateDisabledSources", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0}: NuGet.Config has an invalid package source value &apos;{1}&apos;. Reason: {2}.
         /// </summary>
         internal static string ShowError_ConfigHasInvalidPackageSource {

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -403,7 +403,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot update package sources. NuGet.Config contains a duplicated key in the disabled package sources section..
+        ///   Looks up a localized string similar to Cannot update package sources, config file contains a duplicated key &apos;{0}&apos; in the disabled package sources section. Path: &apos;{1}&apos;.
         /// </summary>
         internal static string ShowError_ConfigDuplicateDisabledSources {
             get {

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -304,6 +304,9 @@
     <comment>0 - package sources separated with comma 1 - path</comment>
   </data>
   <data name="ShowError_ConfigDuplicateDisabledSources" xml:space="preserve">
-    <value>Cannot update package sources. NuGet.Config contains a duplicated key in the disabled package sources section.</value>
+    <value>Cannot update package sources, config file contains a duplicated key '{0}' in the disabled package sources section. Path: '{1}'</value>
+    <comment>0 - key 
+1 - config file path
+</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -303,4 +303,7 @@
     <value>PackageSourceMapping is enabled and there are multiple package sources associated with the same key(s): {0}. Path: {1}</value>
     <comment>0 - package sources separated with comma 1 - path</comment>
   </data>
+  <data name="ShowError_ConfigDuplicateDisabledSources" xml:space="preserve">
+    <value>Cannot update package sources. NuGet.Config contains a duplicated key in the disabled package sources section.</value>
+  </data>
 </root>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/8407

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
When looking at the disabledPackageSources section we store them in a dictionary using StringComparer.OrdinalIgnoreCase which will cause a duplicate key problem if the user has something like:

```
<disabledPackageSources>
     <add key="nuget.org" value="true" />
     <add key="Nuget.org" value="false" />
</disabledPackageSources>
```

In this PR I'm displaying a better error message to the user
![image](https://user-images.githubusercontent.com/43253759/199296390-86c5e42d-1c0a-45b1-848a-43f51f588218.png)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
