### PR TITLE
Fix VS API InstallPackagesFromVSExtensionRepository stack overflow

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
@@ -278,7 +278,7 @@ namespace NuGet.VisualStudio.Implementation.Extensibility
             const string eventName = nameof(IVsPackageInstaller) + "." + nameof(InstallPackagesFromVSExtensionRepository) + ".1";
             using var _ = NuGetETW.ExtensibilityEventSource.StartStopEvent(eventName);
 
-            InstallPackagesFromVSExtensionRepository(
+            InstallPackagesFromVSExtensionRepositoryImpl(
                 extensionId,
                 isPreUnzipped,
                 skipAssemblyReferences,
@@ -292,7 +292,7 @@ namespace NuGet.VisualStudio.Implementation.Extensibility
             const string eventName = nameof(IVsPackageInstaller) + "." + nameof(InstallPackagesFromVSExtensionRepository) + ".2";
             using var _ = NuGetETW.ExtensibilityEventSource.StartStopEvent(eventName);
 
-            InstallPackagesFromVSExtensionRepository(
+            InstallPackagesFromVSExtensionRepositoryImpl(
                 extensionId,
                 isPreUnzipped,
                 skipAssemblyReferences,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12192

Regression? **yes** Last working version: VS 17.1
(broken with https://github.com/NuGet/NuGet.Client/pull/4340)

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The bug was introduced in https://github.com/NuGet/NuGet.Client/pull/4340. Before that, the method had public 2 overloads, where one called the second, and the second did the work. However, the PR that introduced the bug emits ETW events, and we don't want the first overload to cause the second overload to emit an ETW event as well. Therefore, the implementation was moved to an internal method, but the public methods were incorrectly calling themselves, rather than the private implementation.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: The service uses DTE.project, plus the static ServiceLocator, so just isn't unit testable.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
