### PR TITLE
use different Visual Studio bootstrappers for apex/e2e tests and optprof pipeline

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -27,6 +27,7 @@
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <VsTargetBranch>main</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
+    <VsTargetChannelForTests>int.d$(VsTargetMajorVersion).3</VsTargetChannelForTests>
 
     <!-- NuGet SDK VS package Semantic Version -->
     <NuGetSdkVsSemanticVersion>$(VsTargetMajorVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</NuGetSdkVsSemanticVersion>
@@ -85,6 +86,9 @@
   </Target>
   <Target Name="GetVsTargetChannel">
     <Message Text="$(VsTargetChannel)" Importance="High"/>
+  </Target>
+  <Target Name="GetVsTargetChannelForTests">
+    <Message Text="$(VsTargetChannelForTests)" Importance="High"/>
   </Target>
   <Target Name="GetCliBranchForTesting">
       <Message Text="$(CliBranchForTesting)" Importance="High"/>

--- a/build/config.props
+++ b/build/config.props
@@ -27,7 +27,6 @@
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <VsTargetBranch>main</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
-    <VsTargetChannelForTests>int.d$(VsTargetMajorVersion).3</VsTargetChannelForTests>
 
     <!-- NuGet SDK VS package Semantic Version -->
     <NuGetSdkVsSemanticVersion>$(VsTargetMajorVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</NuGetSdkVsSemanticVersion>
@@ -86,9 +85,6 @@
   </Target>
   <Target Name="GetVsTargetChannel">
     <Message Text="$(VsTargetChannel)" Importance="High"/>
-  </Target>
-  <Target Name="GetVsTargetChannelForTests">
-    <Message Text="$(VsTargetChannelForTests)" Importance="High"/>
   </Target>
   <Target Name="GetCliBranchForTesting">
       <Message Text="$(CliBranchForTesting)" Importance="High"/>

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -141,7 +141,7 @@ stages:
       name: SetRunSettingsURI
     - download: ComponentBuildUnderTest
       artifact: VS15
-      patterns: "VS15/*"
+      patterns: "VS15/Microsoft.*"
       displayName: 'Download VS15 files from official build'
     - task: MicroBuildSigningPlugin@1
       inputs:

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -143,6 +143,11 @@ stages:
       artifact: VS15
       patterns: "VS15/*"
       displayName: 'Download VS15 files from official build'
+    - task: MicroBuildSigningPlugin@1
+      inputs:
+        signType: "real"
+        esrpSigning: "true"
+      displayName: "Install Signing Plugin"
     - task: MicroBuildSwixPlugin@4
       displayName: "Install Swix Plugin"
     - task: MicroBuildBuildVSBootstrapper@2

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -74,7 +74,7 @@ stages:
         $commit = "$(Resources.Pipeline.ComponentBuildUnderTest.SourceCommit)"
         $buildNumber = "$(Build.BuildNumber)"
 
-        $BuildName = "${branch}_${commit}_$(buildNumber)"
+        $BuildName = "${branch}_${commit}_${buildNumber}"
         Write-Host "Settings build name = $BuildName"
         Write-Host "##vso[build.updatebuildnumber]$BuildName"
       displayName: 'Set Build Name'

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -82,7 +82,7 @@ stages:
       displayName: 'Download buildinfo.json'
     - powershell: |
         try {
-          Write-Host "Set VSBranch variable"
+          Write-Host "Set VSBranch, VsTargetChannel &  VsTargetMajorVersion variables"
           $buildInfoJsonFilePath = "$(Pipeline.Workspace)\ComponentBuildUnderTest\BuildInfo\buildinfo.json"
 
           Write-Host "buildinfo.json drop URI:  $buildInfoJsonFilePath"
@@ -105,10 +105,18 @@ stages:
 
           Write-Host "Target Visual Studio branch: $VSBranch"
           Set-AzurePipelinesVariable 'VSBranch' $VSBranch
+
+          $VsTargetChannel = $buildInfoJson.VsTargetChannel
+          Write-Host "Visual Studio target channel: $VsTargetChannel"
+          Set-AzurePipelinesVariable 'VsTargetChannel' $VsTargetChannel
+
+          $VsTargetMajorVersion = $buildInfoJson.VsTargetMajorVersion
+          Write-Host "Visual Studio major version: $VsTargetMajorVersion"
+          Set-AzurePipelinesVariable 'VsTargetMajorVersion' $VsTargetMajorVersion
         }
         catch {
           Write-Host $_
-          Write-Error "Failed to set VSBranch pipeline variable"
+          Write-Error "Failed to set VSBranch, VsTargetChannel &  VsTargetMajorVersion pipeline variables"
           throw
         }
       displayName: 'Set VSBranch variable'
@@ -131,15 +139,23 @@ stages:
         }
       displayName: 'Set RunSettingsURI variable'
       name: SetRunSettingsURI
-    - download: ComponentBuildUnderTest
-      artifact: MicroBuildOutputs
-      patterns: '**\BootstrapperInfo.json'
-      displayName: Download Bootstrapper Information
+    - task: MicroBuildBuildVSBootstrapper@2
+      displayName: 'Build a Visual Studio bootstrapper'
+      inputs:
+        channelName: "$(VsTargetChannel)"
+        vsMajorVersion: "$(VsTargetMajorVersion)"
+        manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
+        outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish BootstrapperInfo.json as a pipeline artifact'
+      inputs:
+        publishLocation: $(Pipeline.Workspace)\MicroBuild\Output
+      condition: succeeded()    
     - task: PowerShell@2
       displayName: Set 'VisualStudio.InstallationUnderTest.BootstrapperURL'
       inputs:
         filePath: $(DartLab.Path)\Scripts\VisualStudio\Bootstrapper\Get-BootstrapperURL.ps1
-        arguments: -BootstrapperInfoJsonURI '$(Pipeline.Workspace)\ComponentBuildUnderTest\MicroBuildOutputs\BootstrapperInfo.json' -VSBranch '$(VSBranch)' -OutVariableName 'VisualStudio.InstallationUnderTest.BootstrapperURL'
+        arguments: -BootstrapperInfoJsonURI '$(Pipeline.Workspace)\MicroBuild\Output\MicroBuildOutputs\BootstrapperInfo.json' -VSBranch '$(VSBranch)' -OutVariableName 'VisualStudio.InstallationUnderTest.BootstrapperURL'
     # Remove this step hook and it's task if you don't want LKG support
     prePublishOptimizationInputsDropStepList:
     # Set parameter for PreviousOptimizationInputsDropName 

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -72,8 +72,9 @@ stages:
         }
         $branch = $branch.Replace('/', '_')
         $commit = "$(Resources.Pipeline.ComponentBuildUnderTest.SourceCommit)"
+        $buildNumber = "$(Build.BuildNumber)"
 
-        $BuildName = "${branch}_${commit}"
+        $BuildName = "${branch}_${commit}_$(buildNumber)"
         Write-Host "Settings build name = $BuildName"
         Write-Host "##vso[build.updatebuildnumber]$BuildName"
       displayName: 'Set Build Name'

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -141,7 +141,11 @@ stages:
       name: SetRunSettingsURI
     - download: ComponentBuildUnderTest
       artifact: VS15
-      patterns: "VS15/Microsoft.*"
+      patterns: |
+        VS15/*
+        !EndtoEnd.zip
+        !NuGet.*
+        !!NuGet.Tools.vsix
       displayName: 'Download VS15 files from official build'
     - task: MicroBuildSigningPlugin@1
       inputs:

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -141,8 +141,10 @@ stages:
       name: SetRunSettingsURI
     - download: ComponentBuildUnderTest
       artifact: VS15
-      patterns: "*"
+      patterns: "VS15/*"
       displayName: 'Download VS15 files from official build'
+    - task: MicroBuildSwixPlugin@4
+      displayName: "Install Swix Plugin"
     - task: MicroBuildBuildVSBootstrapper@2
       displayName: 'Build a Visual Studio bootstrapper'
       inputs:

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -161,6 +161,8 @@ stages:
       displayName: 'Publish BootstrapperInfo.json as a pipeline artifact'
       inputs:
         publishLocation: $(Build.StagingDirectory)\MicroBuild\Output
+        ArtifactName: MicroBuildOutputs
+        ArtifactType: Container
     - task: PowerShell@2
       displayName: Set 'VisualStudio.InstallationUnderTest.BootstrapperURL'
       inputs:

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -82,7 +82,7 @@ stages:
       displayName: 'Download buildinfo.json'
     - powershell: |
         try {
-          Write-Host "Set VSBranch variable"
+          Write-Host "Set VSBranch, VsTargetChannel &  VsTargetMajorVersion variables"
           $buildInfoJsonFilePath = "$(Pipeline.Workspace)\ComponentBuildUnderTest\BuildInfo\buildinfo.json"
 
           Write-Host "buildinfo.json drop URI:  $buildInfoJsonFilePath"
@@ -105,10 +105,18 @@ stages:
 
           Write-Host "Target Visual Studio branch: $VSBranch"
           Set-AzurePipelinesVariable 'VSBranch' $VSBranch
+
+          $VsTargetChannel = $buildInfoJson.VsTargetChannel
+          Write-Host "Visual Studio target channel: $VsTargetChannel"
+          Set-AzurePipelinesVariable 'VsTargetChannel' $VsTargetChannel
+
+          $VsTargetMajorVersion = $buildInfoJson.VsTargetMajorVersion
+          Write-Host "Visual Studio major version: $VsTargetMajorVersion"
+          Set-AzurePipelinesVariable 'VsTargetMajorVersion' $VsTargetMajorVersion
         }
         catch {
           Write-Host $_
-          Write-Error "Failed to set VSBranch pipeline variable"
+          Write-Error "Failed to set VSBranch, VsTargetChannel &  VsTargetMajorVersion pipeline variables"
           throw
         }
       displayName: 'Set VSBranch variable'
@@ -132,14 +140,34 @@ stages:
       displayName: 'Set RunSettingsURI variable'
       name: SetRunSettingsURI
     - download: ComponentBuildUnderTest
-      artifact: MicroBuildOutputs
-      patterns: '**\BootstrapperInfo.json'
-      displayName: Download Bootstrapper Information
+      artifact: VS15
+      itemPattern: "*"
+      displayName: 'Download VS15 files from official build'
+    - task: MicroBuildBuildVSBootstrapper@2
+      displayName: 'Build a Visual Studio bootstrapper'
+      inputs:
+        channelName: "$(VsTargetChannel)"
+        vsMajorVersion: "$(VsTargetMajorVersion)"
+        manifests: '$(Pipeline.Workspace)\ComponentBuildUnderTest\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
+        outputFolder: '$(Pipeline.Workspace)\ComponentBuildUnderTest\VS15'
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish BootstrapperInfo.json as a pipeline artifact'
+      inputs:
+        publishLocation: $(Build.StagingDirectory)\MicroBuild\Output
     - task: PowerShell@2
       displayName: Set 'VisualStudio.InstallationUnderTest.BootstrapperURL'
       inputs:
         filePath: $(DartLab.Path)\Scripts\VisualStudio\Bootstrapper\Get-BootstrapperURL.ps1
-        arguments: -BootstrapperInfoJsonURI '$(Pipeline.Workspace)\ComponentBuildUnderTest\MicroBuildOutputs\BootstrapperInfo.json' -VSBranch '$(VSBranch)' -OutVariableName 'VisualStudio.InstallationUnderTest.BootstrapperURL'
+        arguments: -BootstrapperInfoJsonURI '$(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json' -VSBranch '$(VSBranch)' -OutVariableName 'VisualStudio.InstallationUnderTest.BootstrapperURL'
+    - task: artifactDropTask@0
+      displayName: "Upload VSTS Drop"
+      inputs:
+        dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
+        buildNumber: 'Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
+        sourcePath: "$(Pipeline.Workspace)\\ComponentBuildUnderTest\\VS15"
+        toLowerCase: false
+        usePat: true
+        dropMetadataContainerName: "DropMetadata-Product"
     # Remove this step hook and it's task if you don't want LKG support
     prePublishOptimizationInputsDropStepList:
     # Set parameter for PreviousOptimizationInputsDropName 

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -82,7 +82,7 @@ stages:
       displayName: 'Download buildinfo.json'
     - powershell: |
         try {
-          Write-Host "Set VSBranch, VsTargetChannel &  VsTargetMajorVersion variables"
+          Write-Host "Set VSBranch variable"
           $buildInfoJsonFilePath = "$(Pipeline.Workspace)\ComponentBuildUnderTest\BuildInfo\buildinfo.json"
 
           Write-Host "buildinfo.json drop URI:  $buildInfoJsonFilePath"
@@ -105,18 +105,10 @@ stages:
 
           Write-Host "Target Visual Studio branch: $VSBranch"
           Set-AzurePipelinesVariable 'VSBranch' $VSBranch
-
-          $VsTargetChannel = $buildInfoJson.VsTargetChannel
-          Write-Host "Visual Studio target channel: $VsTargetChannel"
-          Set-AzurePipelinesVariable 'VsTargetChannel' $VsTargetChannel
-
-          $VsTargetMajorVersion = $buildInfoJson.VsTargetMajorVersion
-          Write-Host "Visual Studio major version: $VsTargetMajorVersion"
-          Set-AzurePipelinesVariable 'VsTargetMajorVersion' $VsTargetMajorVersion
         }
         catch {
           Write-Host $_
-          Write-Error "Failed to set VSBranch, VsTargetChannel &  VsTargetMajorVersion pipeline variables"
+          Write-Error "Failed to set VSBranch pipeline variable"
           throw
         }
       displayName: 'Set VSBranch variable'
@@ -139,22 +131,15 @@ stages:
         }
       displayName: 'Set RunSettingsURI variable'
       name: SetRunSettingsURI
-    - task: MicroBuildBuildVSBootstrapper@2
-      displayName: 'Build a Visual Studio bootstrapper'
-      inputs:
-        channelName: "$(VsTargetChannel)"
-        vsMajorVersion: "$(VsTargetMajorVersion)"
-        manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
-        outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
-    - task: PublishPipelineArtifact@1
-      displayName: 'Publish BootstrapperInfo.json as a pipeline artifact'
-      inputs:
-        publishLocation: $(Pipeline.Workspace)\MicroBuild\Output          
+    - download: ComponentBuildUnderTest
+      artifact: MicroBuildOutputs
+      patterns: '**\BootstrapperInfo.json'
+      displayName: Download Bootstrapper Information
     - task: PowerShell@2
       displayName: Set 'VisualStudio.InstallationUnderTest.BootstrapperURL'
       inputs:
         filePath: $(DartLab.Path)\Scripts\VisualStudio\Bootstrapper\Get-BootstrapperURL.ps1
-        arguments: -BootstrapperInfoJsonURI '$(Pipeline.Workspace)\MicroBuild\Output\BootstrapperInfo.json' -VSBranch '$(VSBranch)' -OutVariableName 'VisualStudio.InstallationUnderTest.BootstrapperURL'
+        arguments: -BootstrapperInfoJsonURI '$(Pipeline.Workspace)\ComponentBuildUnderTest\MicroBuildOutputs\BootstrapperInfo.json' -VSBranch '$(VSBranch)' -OutVariableName 'VisualStudio.InstallationUnderTest.BootstrapperURL'
     # Remove this step hook and it's task if you don't want LKG support
     prePublishOptimizationInputsDropStepList:
     # Set parameter for PreviousOptimizationInputsDropName 

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -144,8 +144,8 @@ stages:
       patterns: |
         VS15/*
         !VS15/EndToEnd.zip
-        !*.exe
-        !*.pdb
+        !VS15/*.exe
+        !VS15/*.pdb
       displayName: 'Download VS15 files from official build'
     - task: MicroBuildSigningPlugin@1
       inputs:

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -157,12 +157,6 @@ stages:
         vsMajorVersion: "$(VsTargetMajorVersion)"
         manifests: '$(Pipeline.Workspace)\ComponentBuildUnderTest\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
         outputFolder: '$(Pipeline.Workspace)\ComponentBuildUnderTest\VS15'
-    - task: PublishPipelineArtifact@1
-      displayName: 'Publish BootstrapperInfo.json as a pipeline artifact'
-      inputs:
-        targetPath: $(Build.StagingDirectory)\MicroBuild\Output
-        artifactName: 'MicroBuildOutputs'
-        artifactType: 'pipeline'
     - task: PowerShell@2
       displayName: Set 'VisualStudio.InstallationUnderTest.BootstrapperURL'
       inputs:

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -146,7 +146,6 @@ stages:
         !EndToEnd.zip
         !*.exe
         !*.pdb
-        !!NuGet.Tools.vsix
       displayName: 'Download VS15 files from official build'
     - task: MicroBuildSigningPlugin@1
       inputs:

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -160,9 +160,9 @@ stages:
     - task: PublishPipelineArtifact@1
       displayName: 'Publish BootstrapperInfo.json as a pipeline artifact'
       inputs:
-        publishLocation: $(Build.StagingDirectory)\MicroBuild\Output
-        ArtifactName: MicroBuildOutputs
-        ArtifactType: Container
+        targetPath: $(Build.StagingDirectory)\MicroBuild\Output
+        artifactName: 'MicroBuildOutputs'
+        artifactType: 'pipeline'
     - task: PowerShell@2
       displayName: Set 'VisualStudio.InstallationUnderTest.BootstrapperURL'
       inputs:

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -143,8 +143,9 @@ stages:
       artifact: VS15
       patterns: |
         VS15/*
-        !EndtoEnd.zip
-        !NuGet.*
+        !EndToEnd.zip
+        !*.exe
+        !*.pdb
         !!NuGet.Tools.vsix
       displayName: 'Download VS15 files from official build'
     - task: MicroBuildSigningPlugin@1

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -170,7 +170,7 @@ stages:
       displayName: "Upload VSTS Drop"
       inputs:
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: 'OptProf/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
+        buildNumber: 'Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
         sourcePath: "$(Pipeline.Workspace)\\ComponentBuildUnderTest\\VS15"
         toLowerCase: false
         usePat: true

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -172,7 +172,7 @@ stages:
       displayName: "Upload VSTS Drop"
       inputs:
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: 'Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
+        buildNumber: 'OptProf/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
         sourcePath: "$(Pipeline.Workspace)\\ComponentBuildUnderTest\\VS15"
         toLowerCase: false
         usePat: true

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -143,7 +143,7 @@ stages:
       artifact: VS15
       patterns: |
         VS15/*
-        !EndToEnd.zip
+        !VS15/EndToEnd.zip
         !*.exe
         !*.pdb
       displayName: 'Download VS15 files from official build'

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -141,7 +141,7 @@ stages:
       name: SetRunSettingsURI
     - download: ComponentBuildUnderTest
       artifact: VS15
-      itemPattern: "*"
+      patterns: "*"
       displayName: 'Download VS15 files from official build'
     - task: MicroBuildBuildVSBootstrapper@2
       displayName: 'Build a Visual Studio bootstrapper'

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -142,7 +142,6 @@ stages:
     - download: ComponentBuildUnderTest
       artifact: VS15
       patterns: "*"
-      path: $(Pipeline.Workspace)\ComponentBuildUnderTest\VS15
       displayName: 'Download VS15 files from official build'
     - task: MicroBuildBuildVSBootstrapper@2
       displayName: 'Build a Visual Studio bootstrapper'

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -142,6 +142,7 @@ stages:
     - download: ComponentBuildUnderTest
       artifact: VS15
       patterns: "*"
+      path: $(Pipeline.Workspace)\ComponentBuildUnderTest\VS15
       displayName: 'Download VS15 files from official build'
     - task: MicroBuildBuildVSBootstrapper@2
       displayName: 'Build a Visual Studio bootstrapper'

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -149,13 +149,12 @@ stages:
     - task: PublishPipelineArtifact@1
       displayName: 'Publish BootstrapperInfo.json as a pipeline artifact'
       inputs:
-        publishLocation: $(Pipeline.Workspace)\MicroBuild\Output
-      condition: succeeded()    
+        publishLocation: $(Pipeline.Workspace)\MicroBuild\Output          
     - task: PowerShell@2
       displayName: Set 'VisualStudio.InstallationUnderTest.BootstrapperURL'
       inputs:
         filePath: $(DartLab.Path)\Scripts\VisualStudio\Bootstrapper\Get-BootstrapperURL.ps1
-        arguments: -BootstrapperInfoJsonURI '$(Pipeline.Workspace)\MicroBuild\Output\MicroBuildOutputs\BootstrapperInfo.json' -VSBranch '$(VSBranch)' -OutVariableName 'VisualStudio.InstallationUnderTest.BootstrapperURL'
+        arguments: -BootstrapperInfoJsonURI '$(Pipeline.Workspace)\MicroBuild\Output\BootstrapperInfo.json' -VSBranch '$(VSBranch)' -OutVariableName 'VisualStudio.InstallationUnderTest.BootstrapperURL'
     # Remove this step hook and it's task if you don't want LKG support
     prePublishOptimizationInputsDropStepList:
     # Set parameter for PreviousOptimizationInputsDropName 

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -420,7 +420,7 @@ steps:
 
 - task: PowerShell@1
   displayName: "Set Bootstrapper URL variable for tests"
-  name: "vsbootstrapper"
+  name: "vsbootstrapperfortests"
   inputs:
     scriptType: "inlineScript"
     inlineScript: |

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -339,23 +339,6 @@ inputs:
   ArtifactType: Container
 condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-- task: PowerShell@1
-displayName: "Set Bootstrapper URL variable"
-name: "vsbootstrapper"
-inputs:
-  scriptType: "inlineScript"
-  inlineScript: |
-    try {
-      $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
-      $bootstrapperUrl = $json[0].bootstrapperUrl;
-      Write-Host "Bootstrapper URL: $bootstrapperUrl"
-      Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
-    } catch {
-      Write-Host "##vso[task.LogIssue type=error;]Unable to set bootstrapperUrl: $_"
-      exit 1
-    }
-condition: "false"
-
 - task: MSBuild@1
   displayName: 'Generate .runsettings files'
   inputs:

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -332,12 +332,29 @@ steps:
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: PublishBuildArtifacts@1
-displayName: 'Publish BootstrapperInfo.json as a build artifact'
-inputs:
-  PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
-  ArtifactName: MicroBuildOutputs
-  ArtifactType: Container
-condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  displayName: 'Publish BootstrapperInfo.json as a build artifact'
+  inputs:
+    PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
+    ArtifactName: MicroBuildOutputs
+    ArtifactType: Container
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+- task: PowerShell@1
+  displayName: "Set Bootstrapper URL variable"
+  name: "vsbootstrapper"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      try {
+        $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
+        $bootstrapperUrl = $json[0].bootstrapperUrl;
+        Write-Host "Bootstrapper URL: $bootstrapperUrl"
+        Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
+      } catch {
+        Write-Host "##vso[task.LogIssue type=error;]Unable to set bootstrapperUrl: $_"
+        exit 1
+      }
+  condition: "false"
 
 - task: MSBuild@1
   displayName: 'Generate .runsettings files'

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -325,7 +325,7 @@ steps:
 - task: MicroBuildBuildVSBootstrapper@2
   displayName: 'Build a Visual Studio bootstrapper'
   inputs:
-    channelName: "$(VsTargetChannel)"
+    channelName: "$(VsTargetChannelForTests)"
     vsMajorVersion: "$(VsTargetMajorVersion)"
     manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
     outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
@@ -340,7 +340,7 @@ steps:
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: PowerShell@1
-  displayName: "Set Bootstrapper URL variable"
+  displayName: "Set Bootstrapper URL variable for tests"
   name: "vsbootstrapper"
   inputs:
     scriptType: "inlineScript"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -325,36 +325,37 @@ steps:
 - task: MicroBuildBuildVSBootstrapper@2
   displayName: 'Build a Visual Studio bootstrapper'
   inputs:
-    channelName: "$(VsTargetChannelForTests)"
+    channelName: "$(VsTargetChannel)"
     vsMajorVersion: "$(VsTargetMajorVersion)"
     manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
     outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: PublishBuildArtifacts@1
-  displayName: 'Publish BootstrapperInfo.json as a build artifact'
-  inputs:
-    PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
-    ArtifactName: MicroBuildOutputs
-    ArtifactType: Container
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+displayName: 'Publish BootstrapperInfo.json as a build artifact'
+inputs:
+  PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
+  ArtifactName: MicroBuildOutputs
+  ArtifactType: Container
+condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: PowerShell@1
-  displayName: "Set Bootstrapper URL variable for tests"
-  name: "vsbootstrapper"
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      try {
-        $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
-        $bootstrapperUrl = $json[0].bootstrapperUrl;
-        Write-Host "Bootstrapper URL: $bootstrapperUrl"
-        Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
-      } catch {
-        Write-Host "##vso[task.LogIssue type=error;]Unable to set bootstrapperUrl: $_"
-        exit 1
-      }
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+displayName: "Set Bootstrapper URL variable"
+condition: false
+name: "vsbootstrapper"
+inputs:
+  scriptType: "inlineScript"
+  inlineScript: |
+    try {
+      $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
+      $bootstrapperUrl = $json[0].bootstrapperUrl;
+      Write-Host "Bootstrapper URL: $bootstrapperUrl"
+      Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
+    } catch {
+      Write-Host "##vso[task.LogIssue type=error;]Unable to set bootstrapperUrl: $_"
+      exit 1
+    }
+condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1
   displayName: 'Generate .runsettings files'
@@ -400,6 +401,40 @@ steps:
     usePat: true
     dropMetadataContainerName: 'DropMetadata-ProfilingInputs'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+- task: MicroBuildBuildVSBootstrapper@2
+  displayName: 'Build a Visual Studio bootstrapper for tests'
+  inputs:
+    channelName: "$(VsTargetChannelForTests)"
+    vsMajorVersion: "$(VsTargetMajorVersion)"
+    manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
+    outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish BootstrapperInfo.json as a build artifact'
+  inputs:
+    PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
+    ArtifactName: MicroBuildOutputsForTests
+    ArtifactType: Container
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+- task: PowerShell@1
+  displayName: "Set Bootstrapper URL variable for tests"
+  name: "vsbootstrapper"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      try {
+        $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
+        $bootstrapperUrl = $json[0].bootstrapperUrl;
+        Write-Host "Bootstrapper URL: $bootstrapperUrl"
+        Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
+      } catch {
+        Write-Host "##vso[task.LogIssue type=error;]Unable to set bootstrapperUrl: $_"
+        exit 1
+      }
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: PublishBuildArtifacts@1
   displayName: "Publish NuGet.exe VSIX and EndToEnd.zip as artifact"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -339,23 +339,6 @@ steps:
     ArtifactType: Container
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-- task: PowerShell@1
-  displayName: "Set Bootstrapper URL variable"
-  name: "vsbootstrapper"
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      try {
-        $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
-        $bootstrapperUrl = $json[0].bootstrapperUrl;
-        Write-Host "Bootstrapper URL: $bootstrapperUrl"
-        Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
-      } catch {
-        Write-Host "##vso[task.LogIssue type=error;]Unable to set bootstrapperUrl: $_"
-        exit 1
-      }
-  condition: "false"
-
 - task: MSBuild@1
   displayName: 'Generate .runsettings files'
   inputs:
@@ -420,13 +403,13 @@ steps:
 
 - task: PowerShell@1
   displayName: "Set Bootstrapper URL variable for tests"
-  name: "vsbootstrapperfortests"
+  name: "vsbootstrapper"
   inputs:
     scriptType: "inlineScript"
     inlineScript: |
       try {
         $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
-        $bootstrapperUrl = $json[0].bootstrapperUrl;
+        $bootstrapperUrl = $json[1].bootstrapperUrl;
         Write-Host "Bootstrapper URL: $bootstrapperUrl"
         Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
       } catch {

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -341,7 +341,6 @@ condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: PowerShell@1
 displayName: "Set Bootstrapper URL variable"
-condition: false
 name: "vsbootstrapper"
 inputs:
   scriptType: "inlineScript"
@@ -355,7 +354,7 @@ inputs:
       Write-Host "##vso[task.LogIssue type=error;]Unable to set bootstrapperUrl: $_"
       exit 1
     }
-condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+condition: false
 
 - task: MSBuild@1
   displayName: 'Generate .runsettings files'

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -354,7 +354,7 @@ inputs:
       Write-Host "##vso[task.LogIssue type=error;]Unable to set bootstrapperUrl: $_"
       exit 1
     }
-condition: false
+condition: "false"
 
 - task: MSBuild@1
   displayName: 'Generate .runsettings files'

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -323,9 +323,9 @@ steps:
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: MicroBuildBuildVSBootstrapper@2
-  displayName: 'Build a Visual Studio bootstrapper'
+  displayName: 'Build a Visual Studio bootstrapper for tests'
   inputs:
-    channelName: "$(VsTargetChannel)"
+    channelName: "$(VsTargetChannelForTests)"
     vsMajorVersion: "$(VsTargetMajorVersion)"
     manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
     outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
@@ -337,6 +337,23 @@ steps:
     PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
     ArtifactName: MicroBuildOutputs
     ArtifactType: Container
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+- task: PowerShell@1
+  displayName: "Set Bootstrapper URL variable for tests"
+  name: "vsbootstrapper"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      try {
+        $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
+        $bootstrapperUrl = $json[0].bootstrapperUrl;
+        Write-Host "Bootstrapper URL: $bootstrapperUrl"
+        Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
+      } catch {
+        Write-Host "##vso[task.LogIssue type=error;]Unable to set bootstrapperUrl: $_"
+        exit 1
+      }
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1
@@ -383,40 +400,6 @@ steps:
     usePat: true
     dropMetadataContainerName: 'DropMetadata-ProfilingInputs'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
-
-- task: MicroBuildBuildVSBootstrapper@2
-  displayName: 'Build a Visual Studio bootstrapper for tests'
-  inputs:
-    channelName: "$(VsTargetChannelForTests)"
-    vsMajorVersion: "$(VsTargetMajorVersion)"
-    manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
-    outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish BootstrapperInfo.json as a build artifact'
-  inputs:
-    PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
-    ArtifactName: MicroBuildOutputsForTests
-    ArtifactType: Container
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
-- task: PowerShell@1
-  displayName: "Set Bootstrapper URL variable for tests"
-  name: "vsbootstrapper"
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      try {
-        $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
-        $bootstrapperUrl = $json[1].bootstrapperUrl;
-        Write-Host "Bootstrapper URL: $bootstrapperUrl"
-        Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
-      } catch {
-        Write-Host "##vso[task.LogIssue type=error;]Unable to set bootstrapperUrl: $_"
-        exit 1
-      }
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: PublishBuildArtifacts@1
   displayName: "Publish NuGet.exe VSIX and EndToEnd.zip as artifact"

--- a/eng/pipelines/templates/Initialize_Build.yml
+++ b/eng/pipelines/templates/Initialize_Build.yml
@@ -30,9 +30,12 @@ steps:
           $targetChannel = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetChannel
           $targetChannel = $targetChannel.Trim()
         }
+        $targetChannelForTests = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetChannelForTests
+        $targetChannelForTests = $targetChannelForTests.Trim()
         $targetMajorVersion = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetMajorVersion
         $targetMajorVersion = $targetMajorVersion.Trim()
         Write-Host "##vso[task.setvariable variable=VsTargetChannel;isOutput=true]$targetChannel"
+        Write-Host "##vso[task.setvariable variable=VsTargetChannelForTests;isOutput=true]$targetChannelForTests"
         Write-Host "##vso[task.setvariable variable=VsTargetMajorVersion;isOutput=true]$targetMajorVersion"
         Write-Host "##vso[build.updatebuildnumber]$FullBuildNumber"
         Write-Host "##vso[task.setvariable variable=BuildNumber;isOutput=true]$(BuildRevision)"

--- a/eng/pipelines/templates/Initialize_Build.yml
+++ b/eng/pipelines/templates/Initialize_Build.yml
@@ -30,8 +30,12 @@ steps:
           $targetChannel = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetChannel
           $targetChannel = $targetChannel.Trim()
         }
-        $targetChannelForTests = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetChannelForTests
-        $targetChannelForTests = $targetChannelForTests.Trim()
+        if ([System.String]::IsNullOrEmpty($env:VsTargetChannelOverrideForTests) -eq $false) {
+          $targetChannel = $env:VsTargetChannelOverrideForTests
+        } else {
+          $targetChannelForTests = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetChannelForTests
+          $targetChannelForTests = $targetChannelForTests.Trim()
+        }
         $targetMajorVersion = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetMajorVersion
         $targetMajorVersion = $targetMajorVersion.Trim()
         Write-Host "##vso[task.setvariable variable=VsTargetChannel;isOutput=true]$targetChannel"

--- a/eng/pipelines/templates/Initialize_Build.yml
+++ b/eng/pipelines/templates/Initialize_Build.yml
@@ -31,10 +31,9 @@ steps:
           $targetChannel = $targetChannel.Trim()
         }
         if ([System.String]::IsNullOrEmpty($env:VsTargetChannelOverrideForTests) -eq $false) {
-          $targetChannel = $env:VsTargetChannelOverrideForTests
+          $targetChannelForTests = $env:VsTargetChannelOverrideForTests
         } else {
-          $targetChannelForTests = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetChannelForTests
-          $targetChannelForTests = $targetChannelForTests.Trim()
+          $targetChannelForTests = $targetChannel
         }
         $targetMajorVersion = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetMajorVersion
         $targetMajorVersion = $targetMajorVersion.Trim()

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -101,6 +101,7 @@ stages:
       BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
       FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
       VsTargetChannel: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
+      VsTargetChannelForTests: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannelForTests']]
       VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
       SDKVersionForBuild: $[stageDependencies.Initialize.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
       BuildRTM: "false"
@@ -123,6 +124,7 @@ stages:
       BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
       FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
       VsTargetChannel: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
+      VsTargetChannelForTests: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannelForTests']]
       VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
       SDKVersionForBuild: $[stageDependencies.Initialize.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
       BuildRTM: "true"

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -173,8 +173,6 @@ else
     $newBuildCounter = $BuildNumber
     $VsTargetBranch = & dotnet msbuild $RepositoryPath\build\config.props /v:m /nologo /t:GetVsTargetBranch
     $NuGetSdkVsVersion = & dotnet msbuild $RepositoryPath\build\config.props /v:m /nologo /t:GetNuGetSdkVsSemanticVersion
-    $VsTargetChannel = & dotnet msbuild $RepositoryPath\build\config.props /v:m /nologo /t:GetVsTargetChannel
-    $VsTargetMajorVersion = & dotnet msbuild $RepositoryPath\build\config.props /v:m /nologo /t:GetVsTargetMajorVersion
     Write-Host "VS target branch: $VsTargetBranch"
     $jsonRepresentation = @{
         BuildNumber = $newBuildCounter
@@ -183,8 +181,6 @@ else
         LocalizationRepositoryBranch = $NuGetLocalizationRepoBranch
         LocalizationRepositoryCommitHash = $LocalizationRepoCommitHash
         VsTargetBranch = $VsTargetBranch.Trim()
-        VsTargetChannel = $VstargetChannel.Trim()
-        VsTargetMajorVersion = $VsTargetMajorVersion.Trim()
         NuGetSdkVsVersion = $NuGetSdkVsVersion.Trim()
     }
 

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -173,6 +173,8 @@ else
     $newBuildCounter = $BuildNumber
     $VsTargetBranch = & dotnet msbuild $RepositoryPath\build\config.props /v:m /nologo /t:GetVsTargetBranch
     $NuGetSdkVsVersion = & dotnet msbuild $RepositoryPath\build\config.props /v:m /nologo /t:GetNuGetSdkVsSemanticVersion
+    $VsTargetChannel = & dotnet msbuild $RepositoryPath\build\config.props /v:m /nologo /t:GetVsTargetChannel
+    $VsTargetMajorVersion = & dotnet msbuild $RepositoryPath\build\config.props /v:m /nologo /t:GetVsTargetMajorVersion
     Write-Host "VS target branch: $VsTargetBranch"
     $jsonRepresentation = @{
         BuildNumber = $newBuildCounter
@@ -181,6 +183,8 @@ else
         LocalizationRepositoryBranch = $NuGetLocalizationRepoBranch
         LocalizationRepositoryCommitHash = $LocalizationRepoCommitHash
         VsTargetBranch = $VsTargetBranch.Trim()
+        VsTargetChannel = $VstargetChannel.Trim()
+        VsTargetMajorVersion = $VsTargetMajorVersion.Trim()
         NuGetSdkVsVersion = $NuGetSdkVsVersion.Trim()
     }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1889

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Currently, CI produces a single VS bootstrapper that is used for running VS apex/e2e tests & OptProf pipeline on DartLab. In very rare cases we may have to run VS apex/e2e tests on a different channel such as `intpreview` or `release` instead of `int.main`. The reason for this is any regression in `int.main` branch causing VS apex/e2e tests to fail will block team members from merging their pull requests. Refer to https://github.com/NuGet/Home/issues/12104 and for one example that impacted team velocity during Hackathon 2022 week. Official builds failed last week because of https://developercommunity.visualstudio.com/t/Visual-Studio-freezes-and-needs-to-be-ki/10182087 issue.

This PR addresses @zivkan comment in https://github.com/NuGet/NuGet.Client/pull/4821#discussion_r980707961 to `Maybe it's worthwhile having the OptProf pipeline build its own bootstrapper, that way the build pipeline only builds one (used for E2E and Apex), and we don't need to worry about OptProf re-using it.`

The way I tried to implement this change is by default we use `VSTargetChannel` from config.props for running Apex/E2E tests. In an event where a regression is blocking our builds then we can override the `VS channel` on which we run the tests by overriding `VSTargetChannelForTests` pipeline variable. I added this variable to both PR and official builds.

I triggered [official build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6897274&view=results) and [optprof pipeline](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6898381&view=results) for this private build and both of them succeeded. 

There are few improvements/clean-ups that can be made to this PR, but I would like to merge it as soon as possible to unblock official CI builds and do the clean-ups in the follow-up PR.

- Do we need to add `VSTargetChannelForTests` in config.props just like `VSSTargetChannel` property?https://github.com/NuGet/NuGet.Client/blob/6a3a3400c4778de9c7f55c97fc21464bbc9b579c/build/config.props#L29
- Can we publish the `MicroBuildOutputs` in a single task instead of two separate tasks introduced in this PR?
 https://github.com/NuGet/NuGet.Client/blob/dev/eng/pipelines/templates/Build_and_UnitTest.yml#L334-L340

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A