### PR TITLE
unblock source build failure due to fatal: transport 'file' not allowed error (release/6.0.x)

### DIFF
--- a/eng/source-build/build.sh
+++ b/eng/source-build/build.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+echo "git config --global protocol.file.allow always"
+git config --global protocol.file.allow always
+
 source="${BASH_SOURCE[0]}"
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1956

Regression? Last working version: No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Cherry-pick https://github.com/NuGet/NuGet.Client/commit/a3c234023de02f994fc4074e9b38548181dea3fd commit into release-6.0.x branch to unblock CI failures. Source build failed in the [release-6.0.x official build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6896761&view=results).

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A
