### PR TITLE
Set results directory when running unit tests so they are uploaded correctly

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -390,8 +390,6 @@
     <MakeDir Directories="$(TestResultsDirectory)" />
 
     <PropertyGroup>
-      <DesktopTestResultsTrx Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)\$(TestResultsFileName)-desktop.trx</DesktopTestResultsTrx>
-      <CoreTestResultsTrx Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)\$(TestResultsFileName)-core.trx</CoreTestResultsTrx>
       <DotNetTestConsoleVerbosity Condition="'$(DotNetTestConsoleVerbosity)' == '' And '$(System_Debug)' == 'true'">detailed</DotNetTestConsoleVerbosity>
       <DotNetTestConsoleVerbosity Condition="'$(DotNetTestConsoleVerbosity)' == ''">minimal</DotNetTestConsoleVerbosity>
     </PropertyGroup>
@@ -401,8 +399,7 @@
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(SkipDesktopAssemblies)' != 'true' ">
-      <DesktopTestCommand>&quot;$(DotnetExePath)&quot; test @(DesktopInputTestAssemblies->'&quot;%(Identity)&quot;', ' ') --logger:&quot;console;verbosity=$(DotNetTestConsoleVerbosity)&quot; --settings:&quot;$(MSBuildThisFileDirectory)xunit.runsettings&quot;</DesktopTestCommand>
-      <DesktopTestCommand Condition=" '$(DesktopTestResultsTrx)' != '' ">$(DesktopTestCommand) --logger:&quot;trx;LogFilePath=$(DesktopTestResultsTrx)&quot;</DesktopTestCommand>
+      <DesktopTestCommand>&quot;$(DotnetExePath)&quot; test @(DesktopInputTestAssemblies->'&quot;%(Identity)&quot;', ' ') --logger:&quot;console;verbosity=$(DotNetTestConsoleVerbosity)&quot; --settings:&quot;$(MSBuildThisFileDirectory)xunit.runsettings&quot; --ResultsDirectory:&quot;$(TestResultsDirectory)&quot; --logger:&quot;trx&quot;</DesktopTestCommand>
     </PropertyGroup>
 
     <ItemGroup Condition=" '$(SkipCoreAssemblies)' != 'true' ">
@@ -410,8 +407,7 @@
     </ItemGroup>
     
     <PropertyGroup Condition=" '$(SkipCoreAssemblies)' != 'true' ">
-      <CoreTestCommand>&quot;$(DotnetExePath)&quot; test @(CoreInputTestAssemblies->'&quot;%(Identity)&quot;', ' ') --logger:&quot;console;verbosity=$(DotNetTestConsoleVerbosity)&quot; --settings:&quot;$(MSBuildThisFileDirectory)xunit.runsettings&quot;</CoreTestCommand>
-      <CoreTestCommand Condition=" '$(CoreTestResultsTrx)' != '' ">$(CoreTestCommand) --logger:&quot;trx;LogFilePath=$(CoreTestResultsTrx)&quot;</CoreTestCommand>
+      <CoreTestCommand>&quot;$(DotnetExePath)&quot; test @(CoreInputTestAssemblies->'&quot;%(Identity)&quot;', ' ') --logger:&quot;console;verbosity=$(DotNetTestConsoleVerbosity)&quot; --settings:&quot;$(MSBuildThisFileDirectory)xunit.runsettings&quot; --ResultsDirectory:&quot;$(TestResultsDirectory)&quot; --logger:&quot;trx&quot;</CoreTestCommand>
     </PropertyGroup>
 
     <!-- Desktop -->
@@ -439,17 +435,17 @@
       <Output TaskParameter="ExitCode" PropertyName="VSTestErrorCode"/>
     </Exec>
 
-    <Error Text="Desktop $(TestResultsFileName) tests failed! Results: $(DesktopTestResultsTrx)"
+    <Error Text="Desktop $(TestResultsFileName) tests failed!"
            Condition=" '$(SkipDesktopAssemblies)' != 'true' AND '$(DesktopTestErrorCode)' != '0' AND '$(DesktopTestErrorCode)' != '' " />
     
-    <Error Text="NETCore $(TestResultsFileName) tests failed! Results: $(CoreTestResultsTrx)"
+    <Error Text="NETCore $(TestResultsFileName) tests failed!"
            Condition=" '$(SkipCoreAssemblies)' != 'true' AND '$(VSTestErrorCode)' != '0' AND '$(VSTestErrorCode)' != '' " />
 
-    <Message Text="Desktop $(TestResultsFileName) tests passed! Results: $(DesktopTestResultsTrx)"
+    <Message Text="Desktop $(TestResultsFileName) tests passed!"
              Importance="High"
              Condition=" '$(SkipDesktopAssemblies)' != 'true' AND '$(DesktopTestErrorCode)' == '0' " />
 
-    <Message Text="NETCore $(TestResultsFileName) tests passed! Results: $(CoreTestResultsTrx)"
+    <Message Text="NETCore $(TestResultsFileName) tests passed!"
              Importance="High"
              Condition=" '$(SkipCoreAssemblies)' != 'true' AND '$(VSTestErrorCode)' == '0' " />
   </Target>

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -183,7 +183,7 @@ fi
 #run mono test
 TestDir="$DIR/artifacts/NuGet.CommandLine.Test/"
 VsTestConsole="$DIR/artifacts/NuGet.CommandLine.Test/vstest/vstest.console.exe"
-TestResultsTrx="$DIR/build/TestResults/monoonmac.trx"
+TestResultsDir="$DIR/build/TestResults"
 VsTestVerbosity="minimal"
 
 if [ "$SYSTEM_DEBUG" == "true" ]; then
@@ -198,8 +198,8 @@ rm -rf "$TestDir/System.*" "$TestDir/WindowsBase.dll" "$TestDir/Microsoft.CSharp
 case "$(uname -s)" in
 		Linux)
 			# We are not testing Mono on linux currently, so comment it out.
-			#echo "mono $VsTestConsole $TestDir/NuGet.CommandLine.Test.dll --TestCaseFilter:Platform!=Windows&Platform!=Darwin --logger:console;verbosity=$VsTestVerbosity --logger:trx;LogFilePath=$TestResultsTrx"
-			#mono $VsTestConsole "$TestDir/NuGet.CommandLine.Test.dll" --TestCaseFilter:"Platform!=Windows&Platform!=Darwin" --logger:"console;verbosity=$VsTestVerbosity" --logger:"trx;LogFilePath=$TestResultsTrx"
+			#echo "mono $VsTestConsole $TestDir/NuGet.CommandLine.Test.dll --TestCaseFilter:Platform!=Windows&Platform!=Darwin --logger:console;verbosity=$VsTestVerbosity --logger:"trx" --ResultsDirectory:$TestResultsDir"
+			#mono $VsTestConsole "$TestDir/NuGet.CommandLine.Test.dll" --TestCaseFilter:"Platform!=Windows&Platform!=Darwin" --logger:"console;verbosity=$VsTestVerbosity" --logger:"trx" --ResultsDirectory:"$TestResultsDir"
 			if [ $RESULTCODE -ne '0' ]; then
 				RESULTCODE=$?
 				echo "Unit Tests or Core Func Tests failed on Linux"
@@ -207,8 +207,8 @@ case "$(uname -s)" in
 			fi
 			;;
 		Darwin)
-			echo "mono $VsTestConsole $TestDir/NuGet.CommandLine.Test.dll --TestCaseFilter:Platform!=Windows&Platform!=Linux --logger:console;verbosity=$VsTestVerbosity --logger:trx;LogFilePath=$TestResultsTrx"
-			mono $VsTestConsole "$TestDir/NuGet.CommandLine.Test.dll" --TestCaseFilter:"Platform!=Windows&Platform!=Linux" --logger:"console;verbosity=$VsTestVerbosity" --logger:"trx;LogFilePath=$TestResultsTrx"
+			echo "mono $VsTestConsole $TestDir/NuGet.CommandLine.Test.dll --TestCaseFilter:Platform!=Windows&Platform!=Linux --logger:console;verbosity=$VsTestVerbosity --logger:"trx" --ResultsDirectory:$TestResultsDir"
+			mono $VsTestConsole "$TestDir/NuGet.CommandLine.Test.dll" --TestCaseFilter:"Platform!=Windows&Platform!=Linux" --logger:"console;verbosity=$VsTestVerbosity" --logger:"trx" --ResultsDirectory:"$TestResultsDir"
 			if [ $? -ne '0' ]; then
 				RESULTCODE=$?
 				echo "Mono tests failed!"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1534

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Mac unit tests are invoked three separate ways and for some reason the TRX files aren't ending up in the same place.  Instead of specifying the full path to the TRX file, this change specifies the `--ResultsDirectory` argument for `vstest.console.exe` / `dotnet test` instead which fixes the issue.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
