### PR TITLE
Fix fault at UpdateResolvedVersion when updating package version

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/GetPackageReferenceUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/GetPackageReferenceUtility.cs
@@ -27,8 +27,6 @@ namespace NuGet.PackageManagement.VisualStudio.Utility
         /// <param name="installedPackages">Installed packages information from the project.</param>
         internal static PackageIdentity UpdateResolvedVersion(LibraryDependency projectLibrary, NuGetFramework targetFramework, IReadOnlyList<LockFileTarget> targets, Dictionary<string, ProjectInstalledPackage> installedPackages)
         {
-            NuGetVersion resolvedVersion = default;
-
             // Returns the installed version if the package:
             // 1. Already exists in the installedPackages
             // 2. The range is the same as the installed one
@@ -38,7 +36,7 @@ namespace NuGet.PackageManagement.VisualStudio.Utility
                 return installedVersion.InstalledPackage;
             }
 
-            resolvedVersion = GetInstalledVersion(projectLibrary.Name, targetFramework, targets);
+            NuGetVersion resolvedVersion = GetInstalledVersion(projectLibrary.Name, targetFramework, targets);
 
             if (resolvedVersion == null)
             {
@@ -48,11 +46,11 @@ namespace NuGet.PackageManagement.VisualStudio.Utility
             // Add or update the the version of the package in the project
             if (installedPackages.TryGetValue(projectLibrary.Name, out ProjectInstalledPackage installedPackage))
             {
-                installedPackages[projectLibrary.Name] = new ProjectInstalledPackage(projectLibrary.LibraryRange.VersionRange, new PackageIdentity(projectLibrary.Name, resolvedVersion));
+                installedPackages[projectLibrary.Name] = new ProjectInstalledPackage(projectLibrary?.LibraryRange?.VersionRange ?? new VersionRange(resolvedVersion), new PackageIdentity(projectLibrary.Name, resolvedVersion));
             }
             else
             {
-                ProjectInstalledPackage newInstalledPackage = new ProjectInstalledPackage(projectLibrary.LibraryRange.VersionRange, new PackageIdentity(projectLibrary.Name, resolvedVersion));
+                ProjectInstalledPackage newInstalledPackage = new ProjectInstalledPackage(projectLibrary?.LibraryRange?.VersionRange ?? new VersionRange(resolvedVersion), new PackageIdentity(projectLibrary.Name, resolvedVersion));
                 installedPackages.Add(projectLibrary.Name, newInstalledPackage);
             }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11917

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

This error occurs when the project is not using <PackageReference> convention and using a custom .csproj. In those cases LibraryRange is going to be null.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
