### PR TITLE
Display documents from packages in the dependencies tree

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.Designer.cs
@@ -457,6 +457,42 @@ namespace NuGet.VisualStudio.Implementation.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package Document.
+        /// </summary>
+        internal static string PackageDocumentBrowseObjectClassName {
+            get {
+                return ResourceManager.GetString("PackageDocumentBrowseObjectClassName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Documents.
+        /// </summary>
+        internal static string PackageDocumentGroupName {
+            get {
+                return ResourceManager.GetString("PackageDocumentGroupName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The document&apos;s path..
+        /// </summary>
+        internal static string PackageDocumentPathDescription {
+            get {
+                return ResourceManager.GetString("PackageDocumentPathDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path.
+        /// </summary>
+        internal static string PackageDocumentPathDisplayName {
+            get {
+                return ResourceManager.GetString("PackageDocumentPathDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Framework Assemblies.
         /// </summary>
         internal static string PackageFrameworkAssemblyGroupName {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.resx
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.resx
@@ -316,6 +316,18 @@ The string representation of the user's input framework name.</comment>
   <data name="PackageFrameworkAssemblyGroupName" xml:space="preserve">
     <value>Framework Assemblies</value>
   </data>
+  <data name="PackageDocumentGroupName" xml:space="preserve">
+    <value>Documents</value>
+  </data>
+  <data name="PackageDocumentBrowseObjectClassName" xml:space="preserve">
+    <value>Package Document</value>
+  </data>
+  <data name="PackageDocumentPathDisplayName" xml:space="preserve">
+    <value>Path</value>
+  </data>
+  <data name="PackageDocumentPathDescription" xml:space="preserve">
+    <value>The document's path.</value>
+  </data>
   <data name="PackageBuildFileGroupName" xml:space="preserve">
     <value>Build Files</value>
   </data>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/AssetsFileDependenciesTreeSearchProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/AssetsFileDependenciesTreeSearchProvider.cs
@@ -102,6 +102,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
                     SearchContentFiles(library);
                     SearchBuildFiles(library, library.BuildFiles, PackageBuildFileGroupType.Build);
                     SearchBuildFiles(library, library.BuildMultiTargetingFiles, PackageBuildFileGroupType.BuildMultiTargeting);
+                    SearchDocuments(library);
                 }
 
                 SearchLogMessages();
@@ -210,6 +211,17 @@ namespace NuGet.VisualStudio.SolutionExplorer
                         }
 
                         return null;
+                    }
+                }
+
+                void SearchDocuments(AssetsFileTargetLibrary library)
+                {
+                    foreach (string path in library.DocumentationFiles)
+                    {
+                        if (targetContext.IsMatch(path))
+                        {
+                            targetContext.SubmitResult(new PackageDocumentItem(target, library, path, _fileOpener, _fileIconProvider));
+                        }
                     }
                 }
             }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/AttachedItemPriority.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/AttachedItemPriority.cs
@@ -20,6 +20,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
         public const int Diagnostic = 100;
         public const int Package = 200;
         public const int Project = 300;
+        public const int DocumentGroup = 350;
         public const int CompileTimeAssemblyGroup = 400;
         public const int FrameworkAssemblyGroup = 500;
         public const int ContentFilesGroup = 600;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageDocumentGroupItem.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageDocumentGroupItem.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections;
+using NuGet.VisualStudio.Implementation.Resources;
+using NuGet.VisualStudio.SolutionExplorer.Models;
+
+namespace NuGet.VisualStudio.SolutionExplorer
+{
+    /// <summary>
+    /// Backing object for a group of documents within a package within the dependencies tree.
+    /// </summary>
+    /// <remarks>
+    /// Items within this group have type <see cref="PackageDocumentItem"/>.
+    /// </remarks>
+    internal sealed class PackageDocumentGroupItem : RelatableItemBase
+    {
+        public AssetsFileTarget Target { get; }
+        public AssetsFileTargetLibrary Library { get; }
+
+        public PackageDocumentGroupItem(AssetsFileTarget target, AssetsFileTargetLibrary library)
+            : base(VsResources.PackageDocumentGroupName)
+        {
+            Target = target;
+            Library = library;
+        }
+
+        public override object Identity => Library.Name;
+
+        public override int Priority => AttachedItemPriority.DocumentGroup;
+
+        public override ImageMoniker IconMoniker => KnownMonikers.DocumentsFolder;
+
+        public override ImageMoniker ExpandedIconMoniker => KnownMonikers.DocumentsFolder;
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageDocumentItem.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageDocumentItem.cs
@@ -1,0 +1,92 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Internal.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections;
+using Microsoft.VisualStudio.Shell;
+using NuGet.VisualStudio.Implementation.Resources;
+using NuGet.VisualStudio.SolutionExplorer.Models;
+
+namespace NuGet.VisualStudio.SolutionExplorer
+{
+    /// <summary>
+    /// Backing object for documents within a package within the dependencies tree.
+    /// </summary>
+    /// <remarks>
+    /// Items of this type are grouped within <see cref="PackageDocumentGroupItem"/>.
+    /// </remarks>
+    internal sealed class PackageDocumentItem : RelatableItemBase, IInvocationPattern, IInvocationController
+    {
+        public AssetsFileTarget Target { get; }
+        public AssetsFileTargetLibrary Library { get; }
+        public string Path { get; }
+
+        private readonly FileOpener _fileOpener;
+        private readonly IFileIconProvider _fileIconProvider;
+
+        public PackageDocumentItem(AssetsFileTarget target, AssetsFileTargetLibrary library, string path, FileOpener fileOpener, IFileIconProvider fileIconProvider)
+            : base(path)
+        {
+            Target = target;
+            Library = library;
+            Path = path;
+            _fileOpener = fileOpener;
+            _fileIconProvider = fileIconProvider;
+        }
+
+        public override object Identity => Tuple.Create(Library.Name, Path);
+
+        // All siblings are documentation files, so no prioritization needed (sort alphabetically)
+        public override int Priority => 0;
+
+        public override ImageMoniker IconMoniker => _fileIconProvider.GetFileExtensionImageMoniker(Path);
+
+        public bool CanPreview => true;
+
+        public IInvocationController InvocationController => this;
+
+        public bool Invoke(IEnumerable<object> items, InputSource inputSource, bool preview)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            bool result = false;
+
+            foreach (object itemObject in items)
+            {
+                if (itemObject is PackageDocumentItem { FullPath: { } path })
+                {
+                    _fileOpener.OpenFile(path, isReadOnly: true);
+                    result = true;
+                }
+            }
+            return result;
+        }
+
+        public string? FullPath => Target.TryResolvePackagePath(Library.Name, Library.Version, out string? fullPath)
+            ? System.IO.Path.GetFullPath(System.IO.Path.Combine(fullPath, Path))
+            : null;
+
+        public override object? GetBrowseObject() => new BrowseObject(this);
+
+        private sealed class BrowseObject : LocalizableProperties
+        {
+            private readonly PackageDocumentItem _item;
+
+            public BrowseObject(PackageDocumentItem item) => _item = item;
+
+            public override string GetComponentName() => _item.Text;
+
+            public override string GetClassName() => VsResources.PackageDocumentBrowseObjectClassName;
+
+            [BrowseObjectDisplayName(nameof(VsResources.PackageDocumentPathDisplayName))]
+            [BrowseObjectDescription(nameof(VsResources.PackageDocumentPathDescription))]
+            public string Path => _item.Path;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileDependenciesSnapshot.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileDependenciesSnapshot.cs
@@ -96,7 +96,7 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
                         this,
                         lockFileTarget.Name,
                         ParseLogMessages(lockFile, previousTarget, lockFileTarget.Name),
-                        ParseLibraries(lockFileTarget)));
+                        ParseLibraries(lockFile, lockFileTarget)));
             }
 
             DataByTarget = dataByTarget.ToImmutable();
@@ -138,13 +138,13 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
             }
         }
 
-        internal static ImmutableDictionary<string, AssetsFileTargetLibrary> ParseLibraries(LockFileTarget lockFileTarget)
+        internal static ImmutableDictionary<string, AssetsFileTargetLibrary> ParseLibraries(LockFile lockFile, LockFileTarget lockFileTarget)
         {
             ImmutableDictionary<string, AssetsFileTargetLibrary>.Builder builder = ImmutableDictionary.CreateBuilder<string, AssetsFileTargetLibrary>(StringComparer.OrdinalIgnoreCase);
 
             foreach (LockFileTargetLibrary lockFileLibrary in lockFileTarget.Libraries)
             {
-                if (AssetsFileTargetLibrary.TryCreate(lockFileLibrary, out AssetsFileTargetLibrary? library))
+                if (AssetsFileTargetLibrary.TryCreate(lockFile, lockFileLibrary, out AssetsFileTargetLibrary? library))
                 {
                     builder.Add(library.Name, library);
                 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileTargetLibrary.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileTargetLibrary.cs
@@ -97,9 +97,7 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
                 if (path.StartsWith("contentFiles/", StringComparison.OrdinalIgnoreCase))
                     return false;
 
-                return path.StartsWith("doc/", StringComparison.OrdinalIgnoreCase)
-                    || path.StartsWith("documentation/", StringComparison.OrdinalIgnoreCase)
-                    || path.EndsWith(".txt", StringComparison.OrdinalIgnoreCase)
+                return path.EndsWith(".txt", StringComparison.OrdinalIgnoreCase)
                     || path.EndsWith(".md", StringComparison.OrdinalIgnoreCase);
             }
         }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/DocumentGroupToDocumentRelation.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/DocumentGroupToDocumentRelation.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections;
+
+namespace NuGet.VisualStudio.SolutionExplorer
+{
+    [Export(typeof(IRelation))]
+    internal sealed class DocumentGroupToDocumentRelation : RelationBase<PackageDocumentGroupItem, PackageDocumentItem>
+    {
+        private readonly FileOpener _fileOpener;
+        private readonly IFileIconProvider _fileIconProvider;
+
+        [ImportingConstructor]
+        public DocumentGroupToDocumentRelation(
+            FileOpener fileOpener,
+            IFileIconProvider fileIconProvider)
+        {
+            _fileOpener = fileOpener;
+            _fileIconProvider = fileIconProvider;
+        }
+
+        protected override bool HasContainedItems(PackageDocumentGroupItem parent)
+        {
+            return parent.Library.DocumentationFiles.Length != 0;
+        }
+
+        protected override void UpdateContainsCollection(PackageDocumentGroupItem parent, AggregateContainsRelationCollectionSpan span)
+        {
+            span.UpdateContainsItems(
+                parent.Library.DocumentationFiles.OrderBy(path => path),
+                (path, item) => StringComparer.Ordinal.Compare(path, item.Path),
+                (path, item) => false,
+                path => new PackageDocumentItem(parent.Target, parent.Library, path, _fileOpener, _fileIconProvider));
+        }
+
+        protected override IEnumerable<PackageDocumentGroupItem>? CreateContainedByItems(PackageDocumentItem child)
+        {
+            yield return new PackageDocumentGroupItem(child.Target, child.Library);
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/PackageToDocumentGroupRelation.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Relations/PackageToDocumentGroupRelation.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections;
+using NuGet.VisualStudio.SolutionExplorer.Models;
+
+namespace NuGet.VisualStudio.SolutionExplorer
+{
+    [Export(typeof(IRelation))]
+    internal sealed class PackageToDocumentGroupRelation : RelationBase<PackageReferenceItem, PackageDocumentGroupItem>
+    {
+        protected override bool HasContainedItems(PackageReferenceItem parent) => parent.Library.ContentFiles.Length != 0;
+
+        protected override void UpdateContainsCollection(PackageReferenceItem parent, AggregateContainsRelationCollectionSpan span)
+        {
+            span.UpdateContainsItems(
+                parent.Library.DocumentationFiles.Length == 0 ? Enumerable.Empty<AssetsFileTargetLibrary>() : new[] { parent.Library },
+                (library, item) => 0,
+                (library, item) => false,
+                library => new PackageDocumentGroupItem(parent.Target, library));
+        }
+
+        protected override IEnumerable<PackageReferenceItem>? CreateContainedByItems(PackageDocumentGroupItem child)
+        {
+            yield return new PackageReferenceItem(child.Target, child.Library);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
@@ -59,7 +59,7 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
             var lockFileFormat = new LockFileFormat();
             var lockFile = lockFileFormat.Parse(lockFileContent, "In Memory");
 
-            var dependencies = AssetsFileDependenciesSnapshot.ParseLibraries(lockFile.Targets.First());
+            var dependencies = AssetsFileDependenciesSnapshot.ParseLibraries(lockFile, lockFile.Targets.First());
 
             Assert.Equal(1, dependencies.Count);
             Assert.True(dependencies.ContainsKey("system.runtime"));
@@ -86,7 +86,7 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
                 }
             };
 
-            var exception = Assert.Throws<ArgumentException>(() => AssetsFileDependenciesSnapshot.ParseLibraries(lockFileTarget));
+            var exception = Assert.Throws<ArgumentException>(() => AssetsFileDependenciesSnapshot.ParseLibraries(new LockFile(), lockFileTarget));
 
             Assert.Contains("PackageA", exception.Message);
         }
@@ -124,7 +124,7 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
                 }
             };
 
-            ImmutableDictionary<string, AssetsFileTargetLibrary> dependencies = AssetsFileDependenciesSnapshot.ParseLibraries(lockFileTarget);
+            ImmutableDictionary<string, AssetsFileTargetLibrary> dependencies = AssetsFileDependenciesSnapshot.ParseLibraries(new LockFile(), lockFileTarget);
 
             Assert.Equal(lockFileTarget.Libraries.Count, dependencies.Count);
             Assert.All<LockFileTargetLibrary>(lockFileTarget.Libraries,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/9621
Fixes: https://github.com/NuGet/Home/issues/9622
Fixes: https://developercommunity.visualstudio.com/t/open-package-readmeme-from-Dependencies/744260

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Packages may contain files such as README files, license text, etc. This change adds a "Documents" node beneath packages in the dependencies tree of Solution Explorer, when such files exist, allowing them to be opened and viewed in the editor.

It's also possible to search in Solution Explorer for these items, so long as the "Search within external items" option is checked.

![image](https://user-images.githubusercontent.com/350947/199475925-4742169a-7c86-4b2b-816d-52a9e5fb3bbd.png)

![image](https://user-images.githubusercontent.com/350947/199476073-ae1b2674-adec-42c2-8190-2bb6d1062d1c.png)

![image](https://user-images.githubusercontent.com/350947/199476319-9efdfe4b-8c1b-4a63-b1be-763bb480109e.png)

![image](https://user-images.githubusercontent.com/350947/199476508-ac3e7056-9683-4ff2-8c27-7f71999621d0.png)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
    - These files are mostly declarative relationships between entities. There's no current test infrastructure for these.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
