### PR TITLE
added VsTargetChannelForTests property in config.props to unblock release-* builds

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -27,6 +27,7 @@
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <VsTargetBranch>main</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
+    <VsTargetChannelForTests>int.d$(VsTargetMajorVersion).4</VsTargetChannelForTests>
 
     <!-- NuGet SDK VS package Semantic Version -->
     <NuGetSdkVsSemanticVersion>$(VsTargetMajorVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</NuGetSdkVsSemanticVersion>
@@ -85,6 +86,9 @@
   </Target>
   <Target Name="GetVsTargetChannel">
     <Message Text="$(VsTargetChannel)" Importance="High"/>
+  </Target>
+  <Target Name="GetVsTargetChannelForTests">
+    <Message Text="$(VsTargetChannelForTests)" Importance="High"/>
   </Target>
   <Target Name="GetCliBranchForTesting">
       <Message Text="$(CliBranchForTesting)" Importance="High"/>

--- a/build/config.props
+++ b/build/config.props
@@ -27,7 +27,7 @@
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <VsTargetBranch>main</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
-    <VsTargetChannelForTests>int.d$(VsTargetMajorVersion).4</VsTargetChannelForTests>
+    <VsTargetChannelForTests>$(VsTargetChannel)</VsTargetChannelForTests>
 
     <!-- NuGet SDK VS package Semantic Version -->
     <NuGetSdkVsSemanticVersion>$(VsTargetMajorVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</NuGetSdkVsSemanticVersion>

--- a/eng/pipelines/templates/Initialize_Build.yml
+++ b/eng/pipelines/templates/Initialize_Build.yml
@@ -33,7 +33,8 @@ steps:
         if ([System.String]::IsNullOrEmpty($env:VsTargetChannelOverrideForTests) -eq $false) {
           $targetChannelForTests = $env:VsTargetChannelOverrideForTests
         } else {
-          $targetChannelForTests = $targetChannel
+          $targetChannelForTests = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetChannelForTests
+          $targetChannelForTests = $targetChannelForTests.Trim()
         }
         $targetMajorVersion = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetMajorVersion
         $targetMajorVersion = $targetMajorVersion.Trim()


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1963

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
@zivkan raised a good point in https://github.com/NuGet/NuGet.Client/pull/4884#pullrequestreview-1165952056 comment.

> I'm a bit hesitant to use this on the official builds, since it will cause release-* branches to also use the override, at which time they might fail because they'll be running against versions of VS that they're really not designed for.

This PR address the above comment by adding `VsTargetChannelForTests` property in `config.props`.  Ideally the value of this property should be equal to `VsTargetChannel` but in rare cases when tests are failing on `int.main` branch (because of regression caused by partner team) then it provides an option to override the value. Given that Apex/E2E tests are failing on CI on `int.main` channel hence in this PR, I set the value of `VsTargetChannelForTests` to `int.d17.4`. 

Before merging this PR, I am going to remove `VsTargetChannelOverrideForTests` pipeline variable from Official build pipeline. I will remove `VsTargetChannelOverrideForTests` pipeline from PR builds by end of this week (team members have to rebase to have green CI). I will create a follow-up PR setting `VsTargetChannelForTests` property to `VsTargetChannel` once the regression on `int.main` is fixed.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. --> - Manually tested these changes by removing `VsTargetChannelOverrideForTests` variable from Private build pipeline temporarily to ensure `VSTargetChannelForTests` is fetched from `config.props` which is configured as `int.d17.4` currently. I added the `VsTargetChannelOverrideForTests` pipeline variable back to unblock PR builds of other team members.

- **Documentation**
  - [x] N/A
