### PR TITLE
Retry http 429 responses

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/EnhancedHttpRetryHelper.cs
+++ b/src/NuGet.Core/NuGet.Protocol/EnhancedHttpRetryHelper.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using NuGet.Common;
 
@@ -27,6 +29,11 @@ namespace NuGet.Protocol
         public const int DefaultRetryCount = 6;
 
         /// <summary>
+        /// The default value indicating whether or not to retry HTTP 429 responses.
+        /// </summary>
+        public const bool DefaultRetry429 = true;
+
+        /// <summary>
         /// The environment variable used to change the delay value.
         /// </summary>
         public const string DelayInMillisecondsEnvironmentVariableName = "NUGET_ENHANCED_NETWORK_RETRY_DELAY_MILLISECONDS";
@@ -41,6 +48,11 @@ namespace NuGet.Protocol
         /// </summary>
         public const string RetryCountEnvironmentVariableName = "NUGET_ENHANCED_MAX_NETWORK_TRY_COUNT";
 
+        /// <summary>
+        /// The environment variabled to to disable retrying HTTP 429 responses.
+        /// </summary>
+        public const string Retry429EnvironmentVariableName = "NUGET_RETRY_HTTP_429";
+
         private readonly IEnvironmentVariableReader _environmentVariableReader;
 
         private bool? _isEnabled = null;
@@ -48,6 +60,8 @@ namespace NuGet.Protocol
         private int? _retryCount = null;
 
         private int? _delayInMilliseconds = null;
+
+        private bool? _retry429 = null;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EnhancedHttpRetryHelper" /> class.
@@ -73,6 +87,11 @@ namespace NuGet.Protocol
         /// Gets a value indicating the delay in milliseconds to wait before retrying a connection.  The default value is 1000.
         /// </summary>
         internal int DelayInMilliseconds => _delayInMilliseconds ??= GetIntFromEnvironmentVariable(DelayInMillisecondsEnvironmentVariableName, defaultValue: DefaultDelayMilliseconds, _environmentVariableReader);
+
+        /// <summary>
+        /// Gets a value indicating whether or not retryable HTTP 4xx responses should be retried.
+        /// </summary>
+        internal bool Retry429 => _retry429 ??= GetBoolFromEnvironmentVariable(Retry429EnvironmentVariableName, defaultValue: true, _environmentVariableReader);
 
         /// <summary>
         /// Gets a <see cref="bool" /> value from the specified environment variable.
@@ -106,7 +125,7 @@ namespace NuGet.Protocol
         {
             try
             {
-                if (int.TryParse(environmentVariableReader.GetEnvironmentVariable(variableName), out int parsedValue))
+                if (int.TryParse(environmentVariableReader.GetEnvironmentVariable(variableName), out int parsedValue) && parsedValue >= 0)
                 {
                     return parsedValue;
                 }

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs
@@ -204,7 +204,11 @@ namespace NuGet.Protocol
                             requestUri,
                             bodyStopwatch.ElapsedMilliseconds));
 
-                        if ((int)response.StatusCode >= 500)
+                        int statusCode = (int)response.StatusCode;
+                        // 5xx == server side failure
+                        // 408 == request timeout
+                        // 429 == too many requests
+                        if (statusCode >= 500 || statusCode == 408 || statusCode == 429)
                         {
                             success = false;
                         }

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs
@@ -208,7 +208,7 @@ namespace NuGet.Protocol
                         // 5xx == server side failure
                         // 408 == request timeout
                         // 429 == too many requests
-                        if (statusCode >= 500 || statusCode == 408 || statusCode == 429)
+                        if (statusCode >= 500 || ((statusCode == 408 || statusCode == 429) && _enhancedHttpRetryHelper.Retry429))
                         {
                             success = false;
                         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/EnhancedHttpRetryHelperTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/EnhancedHttpRetryHelperTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class EnhancedHttpRetryHelperTests
+    {
+        [Fact]
+        public void NoEnvionrmentVaraiblesSet_UsesDefaultValues()
+        {
+            // Arrange
+            TestEnvironmentVariableReader testEnvironmentVariableReader = new TestEnvironmentVariableReader(new Dictionary<string, string>());
+
+            // Act
+            EnhancedHttpRetryHelper helper = new(testEnvironmentVariableReader);
+
+            // Assert
+            Assert.Equal(helper.IsEnabled, EnhancedHttpRetryHelper.DefaultEnabled);
+            Assert.Equal(helper.RetryCount, EnhancedHttpRetryHelper.DefaultRetryCount);
+            Assert.Equal(helper.DelayInMilliseconds, EnhancedHttpRetryHelper.DefaultDelayMilliseconds);
+            Assert.Equal(helper.Retry429, EnhancedHttpRetryHelper.DefaultRetry429);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("5")]
+        [InlineData("something")]
+        public void InvalidBoolValue_UsesDefault(string value)
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>()
+            {
+                [EnhancedHttpRetryHelper.IsEnabledEnvironmentVariableName] = value
+            };
+            var environmentReader = new TestEnvironmentVariableReader(dict);
+
+            // Act
+            EnhancedHttpRetryHelper helper = new(environmentReader);
+
+            // Assert
+            Assert.Equal(helper.IsEnabled, EnhancedHttpRetryHelper.DefaultEnabled);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ValidBoolValue_UsesValue(bool value)
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>()
+            {
+                [EnhancedHttpRetryHelper.IsEnabledEnvironmentVariableName] = value.ToString().ToLowerInvariant()
+            };
+            var environmentReader = new TestEnvironmentVariableReader(dict);
+
+            // Act
+            EnhancedHttpRetryHelper helper = new(environmentReader);
+
+            // Assert
+            Assert.Equal(helper.IsEnabled, value);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("true")]
+        [InlineData("something")]
+        [InlineData("-5")]
+        public void InvalidIntValue_UsesDefault(string value)
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>()
+            {
+                [EnhancedHttpRetryHelper.RetryCountEnvironmentVariableName] = value
+            };
+            var environmentReader = new TestEnvironmentVariableReader(dict);
+
+            // Act
+            EnhancedHttpRetryHelper helper = new(environmentReader);
+
+            // Assert
+            Assert.Equal(helper.RetryCount, EnhancedHttpRetryHelper.DefaultRetryCount);
+        }
+
+        [Theory]
+        [InlineData(5)]
+        [InlineData(10)]
+        [InlineData(100)]
+        public void ValidIntValue_UsesValue(int value)
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>()
+            {
+                [EnhancedHttpRetryHelper.RetryCountEnvironmentVariableName] = value.ToString().ToLowerInvariant()
+            };
+            var environmentReader = new TestEnvironmentVariableReader(dict);
+
+            // Act
+            EnhancedHttpRetryHelper helper = new(environmentReader);
+
+            // Assert
+            Assert.Equal(helper.RetryCount, value);
+        }
+
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpRetryHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpRetryHandlerTests.cs
@@ -21,7 +21,7 @@ namespace NuGet.Protocol.Tests
     public class HttpRetryHandlerTests
     {
         private const int MaxTries = 5;
-        private const string TestUrl = "https://test.local/test.json";
+        private const string TestUrl = "https://local.test/test.json";
         private static readonly TimeSpan SmallTimeout = TimeSpan.FromMilliseconds(50);
         private static readonly TimeSpan LargeTimeout = TimeSpan.FromSeconds(5);
 
@@ -100,12 +100,7 @@ namespace NuGet.Protocol.Tests
             // Arrange
             TimeSpan retryDelay = TimeSpan.Zero;
 
-            TestEnvironmentVariableReader testEnvironmentVariableReader = new TestEnvironmentVariableReader(
-                 new Dictionary<string, string>()
-                 {
-                     [EnhancedHttpRetryHelper.RetryCountEnvironmentVariableName] = MaxTries.ToString(),
-                     [EnhancedHttpRetryHelper.DelayInMillisecondsEnvironmentVariableName] = retryDelay.TotalMilliseconds.ToString()
-                 });
+            TestEnvironmentVariableReader testEnvironmentVariableReader = GetEnhancedHttpRetryEnvironmentVariables();
 
             var requests = new HashSet<HttpRequestMessage>();
             Func<HttpRequestMessage, HttpResponseMessage> handler = requestMessage =>
@@ -140,12 +135,7 @@ namespace NuGet.Protocol.Tests
             // Arrange
             TimeSpan retryDelay = TimeSpan.Zero;
 
-            TestEnvironmentVariableReader testEnvironmentVariableReader = new TestEnvironmentVariableReader(
-                 new Dictionary<string, string>()
-                 {
-                     [EnhancedHttpRetryHelper.RetryCountEnvironmentVariableName] = MaxTries.ToString(),
-                     [EnhancedHttpRetryHelper.DelayInMillisecondsEnvironmentVariableName] = retryDelay.TotalMilliseconds.ToString()
-                 });
+            TestEnvironmentVariableReader testEnvironmentVariableReader = GetEnhancedHttpRetryEnvironmentVariables();
             var requestToken = CancellationToken.None;
             Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler = async (requestMessage, token) =>
             {
@@ -182,12 +172,7 @@ namespace NuGet.Protocol.Tests
             // Arrange
             TimeSpan retryDelay = TimeSpan.Zero;
 
-            TestEnvironmentVariableReader testEnvironmentVariableReader = new TestEnvironmentVariableReader(
-                 new Dictionary<string, string>()
-                 {
-                     [EnhancedHttpRetryHelper.RetryCountEnvironmentVariableName] = MaxTries.ToString(),
-                     [EnhancedHttpRetryHelper.DelayInMillisecondsEnvironmentVariableName] = retryDelay.TotalMilliseconds.ToString()
-                 });
+            TestEnvironmentVariableReader testEnvironmentVariableReader = GetEnhancedHttpRetryEnvironmentVariables();
             Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler = async (requestMessage, token) =>
             {
                 await Task.Delay(LargeTimeout);
@@ -220,12 +205,7 @@ namespace NuGet.Protocol.Tests
             // Arrange
             TimeSpan retryDelay = SmallTimeout;
 
-            TestEnvironmentVariableReader testEnvironmentVariableReader = new TestEnvironmentVariableReader(
-                 new Dictionary<string, string>()
-                 {
-                     [EnhancedHttpRetryHelper.RetryCountEnvironmentVariableName] = MaxTries.ToString(),
-                     [EnhancedHttpRetryHelper.DelayInMillisecondsEnvironmentVariableName] = retryDelay.TotalMilliseconds.ToString()
-                 });
+            TestEnvironmentVariableReader testEnvironmentVariableReader = GetEnhancedHttpRetryEnvironmentVariables();
             Func<HttpRequestMessage, HttpResponseMessage> handler = requestMessage =>
             {
                 return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
@@ -266,12 +246,7 @@ namespace NuGet.Protocol.Tests
             // Arrange
             TimeSpan retryDelay = TimeSpan.Zero;
 
-            TestEnvironmentVariableReader testEnvironmentVariableReader = new TestEnvironmentVariableReader(
-                 new Dictionary<string, string>()
-                 {
-                     [EnhancedHttpRetryHelper.RetryCountEnvironmentVariableName] = MaxTries.ToString(),
-                     [EnhancedHttpRetryHelper.DelayInMillisecondsEnvironmentVariableName] = retryDelay.TotalMilliseconds.ToString()
-                 });
+            TestEnvironmentVariableReader testEnvironmentVariableReader = GetEnhancedHttpRetryEnvironmentVariables();
             var hits = 0;
 
             Func<HttpRequestMessage, HttpResponseMessage> handler = requestMessage =>
@@ -307,12 +282,7 @@ namespace NuGet.Protocol.Tests
             // Arrange
             TimeSpan retryDelay = TimeSpan.Zero;
 
-            TestEnvironmentVariableReader testEnvironmentVariableReader = new TestEnvironmentVariableReader(
-                 new Dictionary<string, string>()
-                 {
-                     [EnhancedHttpRetryHelper.RetryCountEnvironmentVariableName] = MaxTries.ToString(),
-                     [EnhancedHttpRetryHelper.DelayInMillisecondsEnvironmentVariableName] = retryDelay.TotalMilliseconds.ToString()
-                 });
+            TestEnvironmentVariableReader testEnvironmentVariableReader = GetEnhancedHttpRetryEnvironmentVariables();
             var hits = 0;
 
             Func<HttpRequestMessage, HttpResponseMessage> handler = requestMessage =>
@@ -347,12 +317,7 @@ namespace NuGet.Protocol.Tests
             // Arrange
             TimeSpan retryDelay = TimeSpan.Zero;
 
-            TestEnvironmentVariableReader testEnvironmentVariableReader = new TestEnvironmentVariableReader(
-                 new Dictionary<string, string>()
-                 {
-                     [EnhancedHttpRetryHelper.RetryCountEnvironmentVariableName] = MaxTries.ToString(),
-                     [EnhancedHttpRetryHelper.DelayInMillisecondsEnvironmentVariableName] = retryDelay.TotalMilliseconds.ToString()
-                 });
+            TestEnvironmentVariableReader testEnvironmentVariableReader = GetEnhancedHttpRetryEnvironmentVariables();
             var hits = 0;
 
             Func<HttpRequestMessage, HttpResponseMessage> handler = requestMessage =>
@@ -432,12 +397,7 @@ namespace NuGet.Protocol.Tests
             // Arrange
             TimeSpan retryDelay = TimeSpan.Zero;
 
-            TestEnvironmentVariableReader testEnvironmentVariableReader = new TestEnvironmentVariableReader(
-                 new Dictionary<string, string>()
-                 {
-                     [EnhancedHttpRetryHelper.RetryCountEnvironmentVariableName] = MaxTries.ToString(),
-                     [EnhancedHttpRetryHelper.DelayInMillisecondsEnvironmentVariableName] = retryDelay.TotalMilliseconds.ToString()
-                 });
+            TestEnvironmentVariableReader testEnvironmentVariableReader = GetEnhancedHttpRetryEnvironmentVariables();
             var tries = 0;
             var sent503 = false;
 
@@ -501,13 +461,7 @@ namespace NuGet.Protocol.Tests
                 }
             };
 
-            TestEnvironmentVariableReader testEnvironmentVariableReader = new TestEnvironmentVariableReader(
-                new Dictionary<string, string>()
-                {
-                    [EnhancedHttpRetryHelper.IsEnabledEnvironmentVariableName] = bool.TrueString,
-                    [EnhancedHttpRetryHelper.RetryCountEnvironmentVariableName] = "11",
-                    [EnhancedHttpRetryHelper.DelayInMillisecondsEnvironmentVariableName] = "3"
-                });
+            TestEnvironmentVariableReader testEnvironmentVariableReader = GetEnhancedHttpRetryEnvironmentVariables(retryCount: 11, delayMilliseconds: 3);
 
             EnhancedHttpRetryHelper helper = new EnhancedHttpRetryHelper(testEnvironmentVariableReader);
             Assert.Equal(helper.IsEnabled, true);
@@ -564,10 +518,49 @@ namespace NuGet.Protocol.Tests
             Assert.Equal(helper.DelayInMilliseconds, EnhancedHttpRetryHelper.DefaultDelayMilliseconds);
         }
 
+        [Fact]
+        public async Task HttpRetryHandler_RetriesOn429()
+        {
+            // Arrange
+            int attempt = 0;
+            // .NET Framework don't have HttpStatusCode.TooManyRequests
+            HttpStatusCode tooManyRequestsStatusCode = (HttpStatusCode)429;
+
+            var busyServer = new HttpRetryTestHandler((req, cancellationToken) =>
+                attempt++ < 2
+                ? Task.FromResult(new HttpResponseMessage(tooManyRequestsStatusCode))
+                : Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+            var client = new HttpClient(busyServer);
+
+            var httpRetryHandlerRequest = new HttpRetryHandlerRequest(client, () => new HttpRequestMessage(HttpMethod.Get, TestUrl));
+            TestEnvironmentVariableReader environmentVariables = GetEnhancedHttpRetryEnvironmentVariables();
+            var httpRetryHandler = new HttpRetryHandler(environmentVariables);
+            var logger = new TestLogger();
+
+            // Act
+            var response = await httpRetryHandler.SendAsync(httpRetryHandlerRequest, logger, CancellationToken.None);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            attempt.Should().Be(3);
+
+            string expectedMessagePrefix = "  " + tooManyRequestsStatusCode.ToString() + " " + TestUrl;
+            logger.Messages.Where(m => m.StartsWith(expectedMessagePrefix, StringComparison.Ordinal)).Count().Should().Be(2);
+        }
+
         private static TimeSpan GetRetryMinTime(int tries, TimeSpan retryDelay)
         {
             return TimeSpan.FromTicks((tries - 1) * retryDelay.Ticks);
         }
+
+        private static TestEnvironmentVariableReader GetEnhancedHttpRetryEnvironmentVariables(bool? isEnabled = true, int? retryCount = MaxTries, int? delayMilliseconds = 0)
+        => new TestEnvironmentVariableReader(
+            new Dictionary<string, string>()
+            {
+                [EnhancedHttpRetryHelper.IsEnabledEnvironmentVariableName] = isEnabled?.ToString(),
+                [EnhancedHttpRetryHelper.RetryCountEnvironmentVariableName] = retryCount?.ToString(),
+                [EnhancedHttpRetryHelper.DelayInMillisecondsEnvironmentVariableName] = delayMilliseconds?.ToString()
+            });
 
         private class TestHandler : DelegatingHandler
         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12214

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

I looked though [Wikipedia's list of HTTP status codes](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes), and in addition to 429, it looks like 408 is theoretically worth trying as well. I've never seen a customer complain about it though, and I think that pushing a nupkg is the only scenario that might feasibly happen. 🤷 

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled: https://github.com/NuGet/Client.Engineering/issues/1995
  - **OR**
  - [ ] N/A
