### PR TITLE
Fixes CA2213 issues on NuGet client repo (release-6.3.x)

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -25,7 +25,10 @@ namespace NuGet.Protocol
         private readonly HttpClientHandler _clientHandler;
         private readonly ICredentialService _credentialService;
 
+#pragma warning disable CA2213
+        // TODO: https://github.com/NuGet/Home/issues/12116
         private readonly SemaphoreSlim _httpClientLock = new SemaphoreSlim(1, 1);
+#pragma warning restore CA2213
         private Dictionary<string, AmbientAuthenticationState> _authStates = new Dictionary<string, AmbientAuthenticationState>();
         private HttpSourceCredentials _credentials;
 

--- a/test/TestUtilities/Test.Utility/Protocol/TestContent.cs
+++ b/test/TestUtilities/Test.Utility/Protocol/TestContent.cs
@@ -11,8 +11,10 @@ namespace Test.Utility
 {
     public class TestContent : HttpContent
     {
+#pragma warning disable CA2213
+        // TODO: https://github.com/NuGet/Home/issues/12116
         private MemoryStream _stream;
-
+#pragma warning restore CA2213
         public TestContent(string s)
         {
             _stream = new MemoryStream(Encoding.UTF8.GetBytes(s));

--- a/test/TestUtilities/Test.Utility/ReadTimeoutHonoringSlowStream.cs
+++ b/test/TestUtilities/Test.Utility/ReadTimeoutHonoringSlowStream.cs
@@ -10,7 +10,10 @@ namespace Test.Utility
 {
     public class ReadTimeoutHonoringSlowStream : SlowStream
     {
+#pragma warning disable CA2213
+        // TODO: https://github.com/NuGet/Home/issues/12116
         private readonly Stream _innerStream;
+#pragma warning restore CA2213
         private readonly CancellationToken _cancellationToken;
 
         public ReadTimeoutHonoringSlowStream(Stream innerStream)

--- a/test/TestUtilities/Test.Utility/SlowStream.cs
+++ b/test/TestUtilities/Test.Utility/SlowStream.cs
@@ -10,7 +10,10 @@ namespace Test.Utility
 {
     public class SlowStream : Stream
     {
+#pragma warning disable CA2213
+        // TODO: https://github.com/NuGet/Home/issues/12116
         private readonly Stream _innerStream;
+#pragma warning restore CA2213
         private readonly CancellationToken _cancellationToken;
 
         public SlowStream(Stream innerStream)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1998
Tracking: https://github.com/NuGet/Home/issues/12116

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Cherry-pick https://github.com/NuGet/NuGet.Client/commit/c54393073e90c46d1e8cf38a04b9e0da09eadd5e to suppress CI failures in `release-6.3.x` branch because [PR build failed](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6948369&view=results) with the following error.

```
##[error]src\NuGet.Core\NuGet.Protocol\HttpSource\HttpSourceAuthenticationHandler.cs(28,40): Error CA2213: 'HttpSourceAuthenticationHandler' contains field '_httpClientLock' that is of IDisposable type 'SemaphoreSlim', but it is never disposed. Change the Dispose method on 'HttpSourceAuthenticationHandler' to call Close or Dispose on this field.
D:\a\_work\1\s\src\NuGet.Core\NuGet.Protocol\HttpSource\HttpSourceAuthenticationHandler.cs(28,40): error CA2213: 'HttpSourceAuthenticationHandler' contains field '_httpClientLock' that is of IDisposable type 'SemaphoreSlim', but it is never disposed. Change the Dispose method on 'HttpSourceAuthenticationHandler' to call Close or Dispose on this field. [D:\a\_work\1\s\src\NuGet.Core\NuGet.Protocol\NuGet.Protocol.csproj]
```
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A