### PR TITLE
fix a logic error that caused AbandonedMutexException while executing migrations (release-5.7.x)

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Migrations/Migration1.cs
+++ b/src/NuGet.Core/NuGet.Common/Migrations/Migration1.cs
@@ -79,7 +79,7 @@ namespace NuGet.Common.Migrations
             {
                 pathsToCheck.Add(path);
 
-                if (!path.StartsWith(homePath, StringComparison.Ordinal))
+                if (!path.StartsWith(homePath + Path.DirectorySeparatorChar, StringComparison.Ordinal))
                 {
                     return;
                 }
@@ -156,13 +156,13 @@ namespace NuGet.Common.Migrations
             {
                 PosixPermissions correctedPermissions = permissions.Value.WithUmask(umask);
                 string correctedPermissionsString = correctedPermissions.ToString();
-                Exec("chmod", correctedPermissionsString + " " + path);
+                Exec("chmod", correctedPermissionsString + " " + path.FormatWithDoubleQuotes());
             }
         }
 
         internal static PosixPermissions? GetPermissions(string path)
         {
-            string output = Exec("ls", "-ld " + path);
+            string output = Exec("ls", "-ld " + path.FormatWithDoubleQuotes());
             if (output == null)
             {
                 return null;

--- a/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
+++ b/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
@@ -41,23 +41,23 @@ namespace NuGet.Common.Migrations
                         }
                     }
                 }
-            }
+            } 
+        }
 
-            static bool WaitForMutex(Mutex mutex)
+        private static bool WaitForMutex(Mutex mutex)
+        {
+            bool captured;
+
+            try
             {
-                bool captured;
-
-                try
-                {
-                    captured = mutex.WaitOne(TimeSpan.FromMinutes(1), false);
-                }
-                catch (AbandonedMutexException)
-                {
-                    captured = true;
-                }
-
-                return captured;
+                captured = mutex.WaitOne(TimeSpan.FromMinutes(1), false);
             }
+            catch (AbandonedMutexException)
+            {
+                captured = true;
+            }
+
+            return captured;
         }
 
         internal static string GetMigrationsDirectory()

--- a/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
+++ b/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
@@ -32,31 +32,48 @@ namespace NuGet.Common.Migrations
                 // so use a global mutex and then check if someone else already did the work.
                 using (var mutex = new Mutex(false, "NuGet-Migrations"))
                 {
-                    bool signal = mutex.WaitOne(TimeSpan.FromMinutes(1), false);
-                    if (signal && !File.Exists(expectedMigrationFilename))
+                    if (WaitForMutex(mutex))
                     {
-                        // Only run migrations that have not already been run
-                        int highestMigrationRun = GetHighestMigrationRun(migrationsDirectory);
-                        for (int i = highestMigrationRun + 1; i < Migrations.Count; i++)
+                        if (!File.Exists(expectedMigrationFilename))
                         {
-                            try
+                            // Only run migrations that have not already been run
+                            int highestMigrationRun = GetHighestMigrationRun(migrationsDirectory);
+                            for (int i = highestMigrationRun + 1; i < Migrations.Count; i++)
                             {
-                                Migrations[i]();
-                                // Create file for every migration run, so that if an older version of NuGet is run, it doesn't try to run
-                                // migrations again.
-                                string migrationFile = Path.Combine(migrationsDirectory, (i + 1).ToString(CultureInfo.InvariantCulture));
-                                File.WriteAllText(migrationFile, string.Empty);
+                                try
+                                {
+                                    Migrations[i]();
+                                    // Create file for every migration run, so that if an older version of NuGet is run, it doesn't try to run
+                                    // migrations again.
+                                    string migrationFile = Path.Combine(migrationsDirectory, (i + 1).ToString(CultureInfo.InvariantCulture));
+                                    File.WriteAllText(migrationFile, string.Empty);
+                                }
+                                catch { }
                             }
-                            catch { }
                         }
-
                         mutex.ReleaseMutex();
                     }
                 }
             }
+
+            static bool WaitForMutex(Mutex mutex)
+            {
+                bool captured;
+
+                try
+                {
+                    captured = mutex.WaitOne(TimeSpan.FromMinutes(1), false);
+                }
+                catch (AbandonedMutexException)
+                {
+                    captured = true;
+                }
+
+                return captured;
+            }
         }
 
-        private static string GetMigrationsDirectory()
+        internal static string GetMigrationsDirectory()
         {
             string migrationsDirectory;
             if (RuntimeEnvironmentHelper.IsWindows)

--- a/src/NuGet.Core/NuGet.Common/StringExtensions.cs
+++ b/src/NuGet.Core/NuGet.Common/StringExtensions.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Common
+{
+    internal static class StringExtensions
+    {
+        internal static string FormatWithDoubleQuotes(this string s)
+        {
+            return s == null ? s : $@"""{s}""";
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/Migration1Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/Migration1Tests.cs
@@ -57,11 +57,11 @@ namespace NuGet.Common.Test
         {
             using (var testDirectory = TestDirectory.Create())
             {
-                var v3cachePath = Path.Combine(testDirectory, "v3-cache");
+                var v3cachePath = Path.Combine(testDirectory, "my documents", "v3-cache");
                 var v3cacheSubDirectoryInfo = Directory.CreateDirectory(Path.Combine(v3cachePath, "subDirectory"));
                 Migration1.Exec("chmod", currentPermissions + " " + testDirectory.Path);
-                Migration1.Exec("chmod", currentPermissions + " " + v3cachePath);
-                Migration1.Exec("chmod", currentPermissions + " " + v3cacheSubDirectoryInfo.FullName);
+                Migration1.Exec("chmod", currentPermissions + " " + v3cachePath.FormatWithDoubleQuotes());
+                Migration1.Exec("chmod", currentPermissions + " " + v3cacheSubDirectoryInfo.FullName.FormatWithDoubleQuotes());
                 HashSet<string> pathsToCheck = new HashSet<string>() { testDirectory.Path, v3cachePath, v3cacheSubDirectoryInfo.FullName };
 
                 Migration1.EnsureExpectedPermissions(pathsToCheck, PosixPermissions.Parse(umask));

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
-using System.Threading.Tasks;
 using NuGet.Common.Migrations;
 using Xunit;
 
@@ -15,7 +14,25 @@ namespace NuGet.Common.Test
     public class MigrationRunnerTests
     {
         [Fact]
-        public void WhenExecutedInParallelOnlyOneFileIsCreatedForEveryMigration_Success()
+        public void Run_WhenExecutedOnSingleThreadThenOneMigrationFileIsCreated_Success()
+        {
+            // Arrange
+            string directory = MigrationRunner.GetMigrationsDirectory();
+            if (Directory.Exists(directory))
+                Directory.Delete(path: directory, recursive: true);
+
+            // Act
+            MigrationRunner.Run();
+
+            // Assert
+            Assert.True(Directory.Exists(directory));
+            var files = Directory.GetFiles(directory);
+            Assert.Equal(1, files.Length);
+            Assert.Equal(Path.Combine(directory, "1"), files[0]);
+        }
+
+        [Fact]
+        public void Run_WhenExecutedInParallelThenOnlyOneMigrationFileIsCreated_Success()
         {
             var threads = new List<Thread>();
             int numThreads = 5;
@@ -41,7 +58,9 @@ namespace NuGet.Common.Test
 
             // Assert
             Assert.True(Directory.Exists(directory));
-            Assert.Equal(1, Directory.GetFiles(directory).Length);
+            var files = Directory.GetFiles(directory);
+            Assert.Equal(1, files.Length);
+            Assert.Equal(Path.Combine(directory, "1"), files[0]);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common.Migrations;
+using Xunit;
+
+namespace NuGet.Common.Test
+{
+    [CollectionDefinition("MigrationRunner", DisableParallelization = true)]
+    public class MigrationRunnerTests
+    {
+        [Fact]
+        public void WhenExecutedInParallelOnlyOneFileIsCreatedForEveryMigration_Success()
+        {
+            var threads = new List<Thread>();
+            int numThreads = 5;
+            int timeoutInSeconds = 90;
+
+            // Arrange
+            string directory = MigrationRunner.GetMigrationsDirectory();
+            if (Directory.Exists(directory))
+                Directory.Delete(path: directory, recursive: true);
+
+            // Act
+            for (int i = 0; i < numThreads; i++)
+            {
+                var thread = new Thread(MigrationRunner.Run);
+                thread.Start();
+                threads.Add(thread);
+            }
+
+            foreach (var thread in threads)
+            {
+                thread.Join(timeout: TimeSpan.FromSeconds(timeoutInSeconds));
+            }
+
+            // Assert
+            Assert.True(Directory.Exists(directory));
+            Assert.Equal(1, Directory.GetFiles(directory).Length);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/StringExtensionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/StringExtensionsTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGet.Common.Test
+{
+    public class StringExtensionsTests
+    {
+        [Fact]
+        public void FormatWithDoubleQuotes_WhenNullIsPassedReturnsNull_Success()
+        {
+            string actual = null;
+            string formatted = actual.FormatWithDoubleQuotes();
+            Assert.Equal(actual, formatted);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("/home/user/NuGet AppData/share")]
+        [InlineData("/home/user/NuGet/share")]
+        [InlineData(@"c:\users\NuGet App\Share")]
+        [InlineData(@"c:\users\NuGet\Share")]
+        public void FormatWithDoubleQuotes_WhenNonNullStringIsPassedReturnsFormattedString_Success(string actual)
+        {
+            string formatted = actual.FormatWithDoubleQuotes();
+            Assert.Equal($@"""{actual}""", formatted);
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Tracking: https://github.com/NuGet/Home/issues/12159 & https://github.com/NuGet/Client.Engineering/issues/1978

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Cherry-picked https://github.com/NuGet/NuGet.Client/commit/d658c898cc3fc6b429809a96f6f0c879c2213bea and https://github.com/NuGet/NuGet.Client/commit/0acb9ac80e4336e9dd8bb788a4fad68c65ab1c8f commits to fix the linked issue in `release-5.7.x` branch.  C# 7.3 doesn't support static local functions. Hence refactored `WaitForMutex` method as `private static` function instead.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A