### PR TITLE
Fix NuGet.Client code format

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml.cs
@@ -3,9 +3,9 @@
 
 using System.Collections.Generic;
 using System.Threading;
-using System.Windows.Automation.Peers;
-using System.Windows.Automation;
 using System.Windows;
+using System.Windows.Automation;
+using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Microsoft.ServiceHub.Framework;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourceCheckedListBox.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourceCheckedListBox.cs
@@ -8,12 +8,12 @@ using System.Windows.Forms;
 using System.Windows.Forms.VisualStyles;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using NuGet.Configuration;
 using NuGet.PackageManagement.UI;
 using NuGet.VisualStudio.Internal.Contracts;
 using GelUtilities = Microsoft.Internal.VisualStudio.PlatformUI.Utilities;
-using NuGet.Configuration;
-using Microsoft.VisualStudio.Shell;
 
 namespace NuGet.Options
 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourceViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourceViewModel.cs
@@ -1,10 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using NuGet.PackageManagement.UI;
 using System.ComponentModel;
-using NuGet.VisualStudio.Internal.Contracts;
 using System.Runtime.CompilerServices;
+using NuGet.PackageManagement.UI;
+using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.Options
 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -14,6 +14,8 @@ using System.Windows.Forms;
 using Microsoft;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Configuration;
@@ -23,13 +25,11 @@ using NuGet.VisualStudio;
 using NuGet.VisualStudio.Common;
 using NuGet.VisualStudio.Internal.Contracts;
 using NuGet.VisualStudio.Telemetry;
-using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
-using GelUtilities = Microsoft.Internal.VisualStudio.PlatformUI.Utilities;
-using Task = System.Threading.Tasks.Task;
-using Microsoft.VisualStudio.Imaging.Interop;
-using Microsoft.VisualStudio.Imaging;
 using StreamJsonRpc;
 using StreamJsonRpc.Protocol;
+using GelUtilities = Microsoft.Internal.VisualStudio.PlatformUI.Utilities;
+using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
+using Task = System.Threading.Tasks.Task;
 
 namespace NuGet.Options
 {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/ListPackage/ListPackageJsonRenderer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/ListPackage/ListPackageJsonRenderer.cs
@@ -4,12 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Newtonsoft.Json;
 using System.Linq;
+using Newtonsoft.Json;
 using NuGet.Common;
-using NuGet.Versioning;
-using NuGet.Protocol;
 using NuGet.Configuration;
+using NuGet.Protocol;
+using NuGet.Versioning;
 
 namespace NuGet.CommandLine.XPlat.ListPackage
 {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -8,8 +8,8 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.CommandLineUtils;
-using NuGet.Common;
 using NuGet.Commands;
+using NuGet.Common;
 
 namespace NuGet.CommandLine.XPlat
 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -174,7 +174,7 @@ namespace NuGet.Commands
                     {
                         request.DependencyProviders.PackageFileCache.UpdateLastAccessTime(metadataFile);
                     }
-                    catch(Exception ex)
+                    catch (Exception ex)
                     {
                         request.Log.Log(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1802,
                             string.Format(CultureInfo.InvariantCulture, Strings.Error_CouldNotUpdateMetadataLastAccessTime,

--- a/src/NuGet.Core/NuGet.Protocol/PackagesFolder/LocalPackageFileCache.cs
+++ b/src/NuGet.Core/NuGet.Protocol/PackagesFolder/LocalPackageFileCache.cs
@@ -108,9 +108,9 @@ namespace NuGet.Protocol
         public void UpdateLastAccessTime(string nupkgMetadataPath)
         {
             var exists = _metadataFileCache.ContainsKey(nupkgMetadataPath);
-            if (exists) 
+            if (exists)
             {
-            	return;
+                return;
             }
 
             try

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/LocalizedResourceManagerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/LocalizedResourceManagerTests.cs
@@ -36,7 +36,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Theory]
-        [InlineData("SpecCommandCreatedNuSpec", typeof(NuGetResources) )]
+        [InlineData("SpecCommandCreatedNuSpec", typeof(NuGetResources))]
         [InlineData("UpdateCommandPrerelease", typeof(NuGetCommand))]
         public void GetString_ExistingResourcesInOtherResources_ReturnsStringResource(string resourceName, Type resourceType)
         {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -336,7 +336,7 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void CombinePathWithVerboseError_CombinesPaths()
         {
-            var paths = new[] {"C:\\", "directory/", "\\folder", "file.txt"};
+            var paths = new[] { "C:\\", "directory/", "\\folder", "file.txt" };
             Assert.Equal(Path.Combine(paths), MsBuildUtility.CombinePathWithVerboseError(paths));
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -199,7 +199,7 @@ namespace NuGet.PackageManagement.UI.Test
 
         public static IEnumerable<object[]> GetInstallActionTestData()
         {
-            foreach(var activeTab in Enum.GetValues(typeof(ContractsItemFilter)))
+            foreach (var activeTab in Enum.GetValues(typeof(ContractsItemFilter)))
             {
                 yield return new object[] { activeTab, true, "transitiveA", null, }; // don't care in expectedValue in this case (solution PM UI)
                 yield return new object[] { activeTab, false, "transitiveA", true, }; // installs a package that was a transitive dependency

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
@@ -85,8 +85,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
     {
         private readonly Dictionary<Type, Task<object>> _services = new Dictionary<Type, Task<object>>(TypeEquivalenceComparer.Instance);
         private readonly PackageDetailControlModel _testInstance;
-    public V3PackageDetailControlModelTests(GlobalServiceProvider sp, V3PackageSearchMetadataFixture testData)
-            : base(sp, testData)
+        public V3PackageDetailControlModelTests(GlobalServiceProvider sp, V3PackageSearchMetadataFixture testData)
+                : base(sp, testData)
         {
             var solMgr = new Mock<INuGetSolutionManagerService>();
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Common/IProjectContextInfoExtensionsTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Common/IProjectContextInfoExtensionsTests.cs
@@ -305,7 +305,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Theory]
-        [InlineData(new string[] {}, 0)]
+        [InlineData(new string[] { }, 0)]
         [InlineData(new string[] { "folder1" }, 1)]
         [InlineData(new string[] { "folder1", "folder2" }, 2)]
         public async Task GetPackageFoldersAsync_OneProject_ReturnsPackageFolderAsync(IReadOnlyCollection<string> folderCollection, int expected)

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -304,7 +304,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
                 projectBuildProperties
-                    .Setup(x => x.GetPropertyValue(It.Is<string>( x => x.Equals(ProjectBuildProperties.RestorePackagesPath))))
+                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestorePackagesPath))))
                     .Returns(restorePackagesPath);
 
                 projectBuildProperties
@@ -942,7 +942,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         restorePackagesWithLockFile: null,
                         nuGetLockFilePath: null,
                         restoreLockedMode: false,
-                        projectPackageVersions: new List<(string Id, string Version)>() {  },
+                        projectPackageVersions: new List<(string Id, string Version)>() { },
                         CentralPackageTransitivePinningEnabled: transitiveDependencyPinning);
 
             var legacyPRProject = new LegacyPackageReferenceProject(
@@ -1454,7 +1454,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Theory]
-        [InlineData(null,null,null, 0, 0)]
+        [InlineData(null, null, null, 0, 0)]
         [InlineData("win-x64", null, null, 1, 0)]
         [InlineData("win-x64", "win-x86", null, 2, 0)]
         [InlineData("win-x64", "win-x86;win-x64", null, 2, 0)]

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Projects/PackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Projects/PackageReferenceProjectTests.cs
@@ -35,7 +35,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             TransitivePackageReference transitivePackageReference = PackageReferenceProject<List<object>, object>.MergeTransitiveOrigin(pr, te);
 
             var transitiveOrigin = transitivePackageReference.TransitiveOrigins.Single();
-            
+
             Assert.Equal(NuGetVersion.Parse("0.0.2"), transitiveOrigin.PackageIdentity.Version);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
@@ -1355,7 +1355,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             await Assert.ThrowsAsync<ArgumentException>(async () =>
             {
-                await _projectManager.GetPackageFoldersAsync(new[] { "unknownProject" } , CancellationToken.None);
+                await _projectManager.GetPackageFoldersAsync(new[] { "unknownProject" }, CancellationToken.None);
             });
         }
 
@@ -1422,7 +1422,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.True(File.Exists(pajFilepath));
 
             // Act
-            IReadOnlyCollection<string> folders = await _projectManager.GetPackageFoldersAsync(new[] {projectId}, CancellationToken.None);
+            IReadOnlyCollection<string> folders = await _projectManager.GetPackageFoldersAsync(new[] { projectId }, CancellationToken.None);
 
             // Assert
             Assert.Equal(1, folders.Count); // only globalPackagesFolder is listed
@@ -1459,7 +1459,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 LockFilePath = Path.Combine(testDirectory, "obj", "project.assets.json")
             };
 
-            await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, "packageA", "1.0.0", new PackageDependency[]{});
+            await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, "packageA", "1.0.0", new PackageDependency[] { });
 
             var command = new RestoreCommand(request);
             RestoreResult result = await command.ExecuteAsync();

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -684,7 +684,7 @@ namespace Dotnet.Integration.Test
                 stream.CopyToFile(destinationFilePath);
             }
         }
-        
+
         public async Task AddPkg_WithCPM_WhenPackageVersionDoesNotExistAndVersionCLIArgNotPassed_Success()
         {
             using var pathContext = new SimpleTestPathContext();
@@ -734,7 +734,7 @@ namespace Dotnet.Integration.Test
         }
 
         [Fact]
-        public async Task AddPkg_WithCPM_WhenPackageVersionDoesNotExistAndVersionCLIArgPassed_Success() 
+        public async Task AddPkg_WithCPM_WhenPackageVersionDoesNotExistAndVersionCLIArgPassed_Success()
         {
             using var pathContext = new SimpleTestPathContext();
 
@@ -783,7 +783,7 @@ namespace Dotnet.Integration.Test
         }
 
         [Fact]
-        public async Task AddPkg_WithCPM_WhenPackageVersionExistsAndVersionCLIArgNotPassed_NoOp() 
+        public async Task AddPkg_WithCPM_WhenPackageVersionExistsAndVersionCLIArgNotPassed_NoOp()
         {
             using var pathContext = new SimpleTestPathContext();
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/SignCommandTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/SignCommandTestFixture.cs
@@ -88,7 +88,7 @@ namespace Dotnet.Integration.Test
                         TestDirectory.Path,
                         configureLeafCrl: true,
                         leafCertificateActionGenerator: SigningTestUtility.CertificateModificationGeneratorForInvalidEkuCert))
-                    { 
+                    {
                         StoreLocation rootStoreLocation = CertificateStoreUtilities.GetTrustedCertificateStoreLocation(readOnly: false);
 
                         _invalidEkuCertificateChain.Add(CreateX509StoreCertificate(StoreLocation.CurrentUser, StoreName.My, chain[0], X509StorePurpose.CodeSigning));

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -1083,7 +1083,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 Version = "1.0.0"
             });
             // But create only 2.0.0 on the server.
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, new SimpleTestPackageContext { Id ="x", Version = "2.0.0" });
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, new SimpleTestPackageContext { Id = "x", Version = "2.0.0" });
             projectA.Properties.Add("TreatWarningsAsErrors", "true");
             projectA.Properties.Add("WarningsNotAsErrors", "NU1603");
             solution.Projects.Add(projectA);

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/HttpRetryHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/HttpRetryHandlerTests.cs
@@ -135,7 +135,7 @@ namespace NuGet.Core.FuncTest
 #endif
         }
 
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/12191")] 
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/12191")]
         public async Task HttpRetryHandler_HandlesNameResolutionFailure()
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatListPackageJsonRendererTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatListPackageJsonRendererTests.cs
@@ -79,7 +79,7 @@ namespace NuGet.XPlat.FuncTest
                                     }
                                 }
                             },
-                            projectProblems : null
+                            projectProblems: null
                         ),
                         (
                             projectBPath,
@@ -106,7 +106,7 @@ namespace NuGet.XPlat.FuncTest
                                     }
                                 }
                           },
-                          projectProblems : null
+                          projectProblems: null
                       )
                     );
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
@@ -21,7 +21,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         {
             MSBuildLocator.RegisterDefaults();
         }
-        
+
         [PlatformFact(Platform.Windows)]
         public void GetDirectoryBuildPropsRootElementWhenItExists_Success()
         {

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/PackagesWithRelatedFilesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/PackagesWithRelatedFilesTests.cs
@@ -86,9 +86,9 @@ namespace NuGet.Commands.Test
         }
 
         [Theory]
-        [InlineData(".dll", "A", new[] { "A.B.dll", "A.B.C.dll"}, null)]
+        [InlineData(".dll", "A", new[] { "A.B.dll", "A.B.C.dll" }, null)]
         [InlineData(".exe", "A", new[] { "A.dll", "A.B.dll", "A.B.exe" }, null)]
-        [InlineData(".dll", "A", new string[] { "A.exe", "A.B.EXE", "A.B.C.DLL", "A.B.C.dll","A.B.winmd" }, null)]
+        [InlineData(".dll", "A", new string[] { "A.exe", "A.B.EXE", "A.B.C.DLL", "A.B.C.dll", "A.B.winmd" }, null)]
         public async Task RelatedProperty_TopLevelPackageWithAssemblyExtensions_RelatedPropertyAddedCorrectly(
             string assemblyExtension,
             string assemblyName,

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -2276,7 +2276,7 @@ namespace NuGet.Commands.Test
                     Directory = Directory.CreateDirectory(Path.Combine(pathContext.SolutionRoot, "ProjectA")),
                     Path = new FileInfo(Path.Combine(pathContext.SolutionRoot, "ProjectA", "Project1.csproj")).FullName
                 };
-                
+
                 var logger = new TestLogger();
 
                 // PackageA 1.0.0 -> PackageB 1.0.0 -> PackageC 1.0.0 -> PackageD 1.0.0
@@ -2303,7 +2303,7 @@ namespace NuGet.Commands.Test
                 packageAContext.AddFile("lib/net46/PackageA.dll");
                 packageAContext.Dependencies.Add(packageBContext);
                 await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, packageAContext);
-                
+
                 var tfi = CreateTargetFrameworkInformation(
                     new List<LibraryDependency>
                     {
@@ -2343,7 +2343,7 @@ namespace NuGet.Commands.Test
                     projectInfo.Path,
                     centralPackageManagementEnabled: true,
                     centralPackageTransitivePinningEnabled: true);
-                
+
 
                 var dgspec = new DependencyGraphSpec();
                 dgspec.AddProject(packageSpec);
@@ -2506,7 +2506,7 @@ namespace NuGet.Commands.Test
                 };
 
                 var logger = new TestLogger();
-                
+
                 var packageA = new PackageIdentity("PackageA", new NuGetVersion("1.0.0"));
                 var packageB = new PackageIdentity("PackageB", new NuGetVersion("1.0.0"));
                 var packageC1_0 = new PackageIdentity("PackageC", new NuGetVersion("1.0.0"));
@@ -3014,12 +3014,12 @@ namespace NuGet.Commands.Test
 
                 var tfiB = CreateTargetFrameworkInformation(
                     new List<LibraryDependency>(), // no direct dependencies
-                    new List<CentralPackageVersion>() {centralVersion3},
+                    new List<CentralPackageVersion>() { centralVersion3 },
                     framework);
 
                 var tfiC = CreateTargetFrameworkInformation(
-                    new List<LibraryDependency>() {dependencyD}, // direct dependency
-                    new List<CentralPackageVersion>() {centralVersion2},
+                    new List<LibraryDependency>() { dependencyD }, // direct dependency
+                    new List<CentralPackageVersion>() { centralVersion2 },
                     framework);
 
                 PackageSpec packageSpecA = CreatePackageSpec(new List<TargetFrameworkInformation>() { tfiA }, framework, projectNameA, projectPathA, centralPackageManagementEnabled: true);
@@ -3040,8 +3040,8 @@ namespace NuGet.Commands.Test
                     ProjectStyle = ProjectStyle.PackageReference,
                 };
 
-                var externalProjectA = new ExternalProjectReference(projectNameA, packageSpecA, projectPathA, new[] {projectNameB});
-                var externalProjectB = new ExternalProjectReference(projectNameB, packageSpecB, projectPathB, new[] {projectNameC});
+                var externalProjectA = new ExternalProjectReference(projectNameA, packageSpecA, projectPathA, new[] { projectNameB });
+                var externalProjectB = new ExternalProjectReference(projectNameB, packageSpecB, projectPathB, new[] { projectNameC });
                 var externalProjectC = new ExternalProjectReference(projectNameC, packageSpecC, projectPathC, new string[] { });
                 request.ExternalProjects.Add(externalProjectA);
                 request.ExternalProjects.Add(externalProjectB);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
@@ -893,7 +893,8 @@ namespace NuGet.Commands.Test
                 library.Dependencies.Should().HaveCount(1);
                 var dependencies = library.Dependencies.Single();
                 dependencies.Name.Should().Be("full.framework");
-            } else
+            }
+            else
             {
                 library.Dependencies.Should().HaveCount(0);
             }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceMappingProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceMappingProviderTests.cs
@@ -77,7 +77,7 @@ namespace NuGet.Configuration.Test
 
             // Act & Assert
             var exception = Assert.Throws<NuGetConfigurationException>(
-                () => Settings.LoadSettingsGivenConfigPaths(new string[] { configPath}));
+                () => Settings.LoadSettingsGivenConfigPaths(new string[] { configPath }));
             Assert.Equal(string.Format(CultureInfo.CurrentCulture, "PackageSourceMapping is enabled and there are multiple package sources associated with the same key(s): dotnet, nuget.org. Path: {0}", configPath), exception.Message);
         }
 

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/GraphNodeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/GraphNodeTests.cs
@@ -29,8 +29,8 @@ namespace NuGet.DependencyResolver.Core.Tests
             }
             else
             {
-                nodeA = new GraphNode<RemoteResolveResult>(libraryRangeA, hasInnerNodes:true, hasParentNodes.Value);
-                nodeB = new GraphNode<RemoteResolveResult>(libraryRangeB, hasInnerNodes:true, hasParentNodes.Value);
+                nodeA = new GraphNode<RemoteResolveResult>(libraryRangeA, hasInnerNodes: true, hasParentNodes.Value);
+                nodeB = new GraphNode<RemoteResolveResult>(libraryRangeB, hasInnerNodes: true, hasParentNodes.Value);
             }
 
             if (!parentNodesHasNode)
@@ -69,8 +69,8 @@ namespace NuGet.DependencyResolver.Core.Tests
             }
             else
             {
-                nodeA = new GraphNode<RemoteResolveResult>(libraryRangeA, hasInnerNodes.Value, hasParentNodes : true);
-                nodeB = new GraphNode<RemoteResolveResult>(libraryRangeB, hasInnerNodes.Value, hasParentNodes : true);
+                nodeA = new GraphNode<RemoteResolveResult>(libraryRangeA, hasInnerNodes.Value, hasParentNodes: true);
+                nodeB = new GraphNode<RemoteResolveResult>(libraryRangeB, hasInnerNodes.Value, hasParentNodes: true);
             }
 
             if (!innerNodesHasNode)

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
@@ -649,7 +649,7 @@ namespace NuGet.ProjectModel.Test
                     }
                 }
             };
-                
+
             var lockFileFormat = new LockFileFormat();
 
             // Act


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2000
Related issue: https://github.com/NuGet/Client.Engineering/issues/1431

Regression? Last working version:

## Description
I saw some formatting was broken recently, slipped through our code enforcers.
I just run it on my local, it looks 28 files affected. Of course, people can do `Ctrl+K, Ctrl+D` to format it.
Should we check our `editorconfig` and `stylecop` why those 28 files are not captured by them? 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
