### PR TITLE
Migrate to new vside consumption feed

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -49,7 +49,9 @@
       <package pattern="envdte80" />
       <package pattern="envdte90" />
       <package pattern="envdte90a" />
-      <package pattern="microsoft.*" />
+      <package pattern="microsoft.internal.visualstudio.*" />
+      <package pattern="microsoft.servicehub.*" />
+      <package pattern="microsoft.visualstudio.*" />
       <package pattern="stdole" />
       <package pattern="streamjsonrpc" />
       <package pattern="vslangproj" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -6,8 +6,7 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="myget-legacy@Local" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy%40Local/nuget/v3/index.json" />
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
-    <add key="vside_vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
-    <add key="vside_vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+    <add key="vside" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <clear />
@@ -44,7 +43,7 @@
       <package pattern="nuget.client.endtoend.testdata" />
       <package pattern="nugetvalidator" />
     </packageSource>
-    <packageSource key = "vside_vssdk">
+    <packageSource key = "vside">
       <package pattern="envdte" />
       <package pattern="envdte100" />
       <package pattern="envdte80" />
@@ -65,9 +64,6 @@
       <package pattern="vslangproj80" />
       <package pattern="vslangproj90" />
       <package pattern="vswebsite.interop" />
-    </packageSource>
-    <packageSource key = "vside_vs-impl">
-      <package pattern="microsoft.*" />
     </packageSource>
     <packageSource key = "myget-legacy@Local">
       <package pattern="microsoft.*" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -51,6 +51,7 @@
       <package pattern="envdte90a" />
       <package pattern="microsoft.internal.visualstudio.*" />
       <package pattern="microsoft.servicehub.*" />
+      <package pattern="microsoft.test.apex.visualstudio" />
       <package pattern="microsoft.visualstudio.*" />
       <package pattern="stdole" />
       <package pattern="streamjsonrpc" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1990

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Remove deprecated vside feeds and replace with new one.  I will send follow-up PRs for each service branch once this is merged.

I tested by setting `NUGET_PACKAGES` to an empty folder, running `nuget locals all -clear`, and running restore of our repo.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
