### PR TITLE
Fix CI failure while communicating status to GitHub (release-5.7.x)

### DIFF
--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -14,7 +14,7 @@ Function Update-GitCommitStatus {
         [Parameter(Mandatory = $True)]
         [string]$PersonalAccessToken,
         [Parameter(Mandatory = $True)]
-        [ValidateSet( "Build_and_UnitTest_NonRTM", "Build_and_UnitTest_RTM", "Tests_On_Mac", "Tests_On_Linux", "Functional_Tests_On_Windows IsDesktop", "Functional_Tests_On_Windows IsCore", "End_To_End_Tests_On_Windows", "Apex_Tests_On_Windows", "Rebuild")]
+        [ValidateSet( "Unit Tests On Windows", "Build_and_UnitTest_NonRTM", "Build_and_UnitTest_RTM", "Tests_On_Mac", "Tests On Mac", "Tests_On_Linux", "Tests On Linux", "Functional_Tests_On_Windows IsDesktop", "Functional_Tests_On_Windows IsCore", "End_To_End_Tests_On_Windows", "EndToEnd Tests On Windows", "Apex_Tests_On_Windows", "Apex Tests On Windows", "Rebuild")]
         [string]$TestName,
         [Parameter(Mandatory = $True)]
         [ValidateSet( "pending", "success", "error", "failure")]

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -14,7 +14,7 @@ Function Update-GitCommitStatus {
         [Parameter(Mandatory = $True)]
         [string]$PersonalAccessToken,
         [Parameter(Mandatory = $True)]
-        [ValidateSet( "Unit Tests On Windows", "Tests On Mac", "Tests On Linux", "Functional_Tests_On_Windows IsDesktop", "Functional_Tests_On_Windows IsCore", "EndToEnd Tests On Windows", "Apex Tests On Windows", "Rebuild")]
+        [ValidateSet( "Build_and_UnitTest_NonRTM", "Build_and_UnitTest_RTM", "Tests_On_Mac", "Tests_On_Linux", "Functional_Tests_On_Windows IsDesktop", "Functional_Tests_On_Windows IsCore", "End_To_End_Tests_On_Windows", "Apex_Tests_On_Windows", "Rebuild")]
         [string]$TestName,
         [Parameter(Mandatory = $True)]
         [ValidateSet( "pending", "success", "error", "failure")]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2009

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

[PR build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6951065&view=logs&j=2ea8c801-c4c3-578e-0ff0-bcf4c12d9404&t=c7e57447-ce1f-5d80-6a2f-6885153e9d12) is failing while communicating the status to GitHub. It looks like Pipeline job names are out of sync with GiHub validation set in [NuGet.Client/PostGitCommitStatus.ps1 at release-5.7.x · NuGet/NuGet.Client · GitHub](https://github.com/NuGet/NuGet.Client/blob/e3675c6173f0e3e4f13272c814ff33c590defba9/scripts/utils/PostGitCommitStatus.ps1#L17). Updated the validation set in this PR to unblock.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A
