### PR TITLE
Stale the community PRs sooner, to make the review process better

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -587,7 +587,7 @@
           {
             "name": "noActivitySince",
             "parameters": {
-              "days": 30
+              "days": 7
             }
           },
           {
@@ -605,7 +605,7 @@
             }
           }
         ],
-        "taskName": "[stale community PR] [5-1] Search for community PRs with no activity over 30 days and warn.",
+        "taskName": "[stale community PR] [5-1] Search for community PRs with no activity over 7 days and warn.",
         "actions": [
           {
             "name": "addLabel",
@@ -616,7 +616,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "This PR has been automatically marked as stale because it has no activity for **30 days**. It will be closed if no further activity occurs **within another 60 days** of this comment. If it is closed, you may reopen it anytime when you're ready again, as long as you don't delete the branch."
+              "comment": "This PR has been automatically marked as stale because it has no activity for **7 days**. It will be closed if no further activity occurs **within another 90 days** of this comment. If it is closed, you may reopen it anytime when you're ready again, as long as you don't delete the branch."
             }
           }
         ]
@@ -879,11 +879,11 @@
           {
             "name": "noActivitySince",
             "parameters": {
-              "days": 60
+              "days": 90
             }
           }
         ],
-        "taskName": "[stale community PR] [5-5] Close PRs with no activity over 60 days after warn.",
+        "taskName": "[stale community PR] [5-5] Close PRs with no activity over 90 days after warn.",
         "actions": [
           {
             "name": "closeIssue",


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/2013

Regression? Last working version:

## Description
Currently in NuGet.Client repo, we wait for 30 days to add `No recent activity` label to community PRs to mark it stale.
This doesn't work with our weekly review meeting well. We have to check community PRs without any activity for 20+ days sometimes.
This is to mark community PRs stale after 7 days, close stale after another 90 days.
(previously, mark community PRs stale after 30 days, close stale after another 60 days)

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
