### PR TITLE
Collect xunit test host crash dump, previously only collect hang dump

### DIFF
--- a/build/xunit.runsettings
+++ b/build/xunit.runsettings
@@ -10,6 +10,9 @@
         <DataCollectors>
             <DataCollector friendlyName="blame" enabled="True">
                 <Configuration>
+                    <!-- Enables crash dump-->
+                    <CollectDump DumpType="Full" />
+                    <!-- Enables hang dump-->
                     <CollectDumpOnTestSessionHang TestTimeout="15min" HangDumpType="full" />
                     <ResultsDirectory>%AGENT_TEMPDIRECTORY%</ResultsDirectory>
                 </Configuration>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2017

Regression? Last working version:

## Description
As part of my effort to reduce flaky test investigation I found some test tasks fail without any details other than `[error]build\build.proj(418,5): Error : The active test run was aborted. Reason: `[Test host process crashed](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6953446&view=logs&j=106ab241-4188-5d29-8df9-3fba036cc1ed&t=16b2ebcd-f324-51bf-b1f0-feedee00c8c2&l=1131), it's hard to diagnose without any stack trace or memory dump.
After looking at https://learn.microsoft.com/en-us/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file?view=vs-2022#blame-data-collector, there is option to add test host process crash dump too.

![image](https://user-images.githubusercontent.com/8766776/202234648-f7f899e7-b9c3-4d26-bd7b-5850463ad8c7.png)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
