### PR TITLE
Update projects in local-tools to work with central package management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -65,6 +65,7 @@
     <PackageVersion Include="Portable.BouncyCastle" Version="1.8.10" />
     <PackageVersion Include="SharpZipLib" Version="1.3.3" />
     <PackageVersion Include="System.Collections" Version="$(SystemPackagesVersion)" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.ComponentModel.Composition" Version="4.5.0" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
     <PackageVersion Include="System.Diagnostics.Debug" Version="$(SystemPackagesVersion)" />

--- a/tools-local/doc.tasks/doc.tasks.csproj
+++ b/tools-local/doc.tasks/doc.tasks.csproj
@@ -1,16 +1,10 @@
-<Project>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'NuGet.sln'))\build\common.props" />
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(NetStandardVersion)</TargetFramework>
     <TargetFrameworks />
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.4.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.4.0" />
+    <PackageReference Include="Microsoft.Build.Framework" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
   </ItemGroup>
-
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/tools-local/ship-public-apis/ship-public-apis.csproj
+++ b/tools-local/ship-public-apis/ship-public-apis.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2018

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Update `tools-local\doc.tasks\doc.tasks.csproj` and `tools-local\ship-public-apis\ship-public-apis.csproj` to use central package management.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
