### PR TITLE
fix null reference when changing package in PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
@@ -276,7 +276,7 @@ namespace NuGet.PackageManagement.UI
 
         private void Versions_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            PackageDetailControlModel.PreviousSelectedVersion = e.AddedItems.Count > 0 ? e.AddedItems[0].ToString() : string.Empty;
+            PackageDetailControlModel.PreviousSelectedVersion = e.AddedItems.Count > 0 && !e.AddedItems[0].Equals(null) ? e.AddedItems[0].ToString() : string.Empty;
 
             return;
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12184

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
When changing a package in PM UI there is a `_versions.Clear()` called that affects the `CollectionView` from the Combobox because the source of this component is `_versions`. A change in the source will also change the SelectionVersion and trigger `Versions_SelectionChanged` in which the selected item is going to be null.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - `Versions_SelectedChanged` is an override for an event handler from XAML ComboBox component
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
