### PR TITLE
Fix code analysis warning in a test utility method

### DIFF
--- a/test/TestUtilities/Test.Utility/ZipExtensions.cs
+++ b/test/TestUtilities/Test.Utility/ZipExtensions.cs
@@ -73,8 +73,9 @@ namespace NuGet.Test.Utility
 
                 entryFullName = Uri.UnescapeDataString(entryFullName.Replace('/', Path.DirectorySeparatorChar));
 
-                var targetFile = Path.Combine(targetPath, entryFullName);
-                if (!targetFile.StartsWith(targetPath, StringComparison.OrdinalIgnoreCase))
+                string targetFile = Path.GetFullPath(Path.Combine(targetPath, entryFullName));
+                string fullDestDirPath = Path.GetFullPath(targetPath + Path.DirectorySeparatorChar);
+                if (!targetFile.StartsWith(fullDestDirPath, StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }

--- a/test/TestUtilities/Test.Utility/ZipExtensions.cs
+++ b/test/TestUtilities/Test.Utility/ZipExtensions.cs
@@ -63,6 +63,7 @@ namespace NuGet.Test.Utility
 
         public static void ExtractAll(this ZipArchive archive, string targetPath)
         {
+            string fullDestDirPath = Path.GetFullPath(targetPath + Path.DirectorySeparatorChar);
             foreach (var entry in archive.Entries)
             {
                 var entryFullName = entry.FullName;
@@ -74,7 +75,6 @@ namespace NuGet.Test.Utility
                 entryFullName = Uri.UnescapeDataString(entryFullName.Replace('/', Path.DirectorySeparatorChar));
 
                 string targetFile = Path.GetFullPath(Path.Combine(targetPath, entryFullName));
-                string fullDestDirPath = Path.GetFullPath(targetPath + Path.DirectorySeparatorChar);
                 if (!targetFile.StartsWith(fullDestDirPath, StringComparison.OrdinalIgnoreCase))
                 {
                     continue;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2027

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Please refer to the Az DO work item linked in the tracking bug for more details.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A
