### PR TITLE
Make ConfigurationDefaults.cs thread safe

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/ConfigurationDefaults.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ConfigurationDefaults.cs
@@ -55,18 +55,20 @@ namespace NuGet.Configuration
             {
                 if (_defaultPackageSources == null)
                 {
-                    _defaultPackageSources = new List<PackageSource>();
+                    List<PackageSource> defaultPackageSources = new();
                     var disabledPackageSources = _settingsManager.GetSection(ConfigurationConstants.DisabledPackageSources)?.Items.OfType<AddItem>() ?? Enumerable.Empty<AddItem>();
                     var packageSources = _settingsManager.GetSection(ConfigurationConstants.PackageSources)?.Items.OfType<SourceItem>() ?? Enumerable.Empty<SourceItem>();
 
                     foreach (var source in packageSources)
                     {
                         // In a SettingValue representing a package source, the Key represents the name of the package source and the Value its source
-                        _defaultPackageSources.Add(new PackageSource(source.GetValueAsPath(),
+                        defaultPackageSources.Add(new PackageSource(source.GetValueAsPath(),
                             source.Key,
                             isEnabled: !disabledPackageSources.Any(p => p.Key.Equals(source.Key, StringComparison.OrdinalIgnoreCase)),
                             isOfficial: true));
                     }
+
+                    _defaultPackageSources = defaultPackageSources;
                 }
                 return _defaultPackageSources;
             }
@@ -79,8 +81,8 @@ namespace NuGet.Configuration
                 if (_defaultPushSource == null
                     && !_defaultPackageSourceInitialized)
                 {
-                    _defaultPackageSourceInitialized = true;
                     _defaultPushSource = SettingsUtility.GetDefaultPushSource(_settingsManager);
+                    _defaultPackageSourceInitialized = true;
                 }
 
                 return _defaultPushSource;

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/ConfigurationDefaultsThreadSafetyTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/ConfigurationDefaultsThreadSafetyTests.cs
@@ -1,0 +1,129 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using FluentAssertions;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Configuration.Test
+{
+    // Since these tests try to hit multi-threaded timing bugs, ensure other tests are not running in prallel.
+    [Collection(nameof(NotThreadSafeResourceCollection))]
+    public class ConfigurationDefaultsThreadSafetyTests
+    {
+        [Fact]
+        public void DefaultPackageSources_CalledConcurrently_ReturnsCorrectPackageSources()
+        {
+            // Arrange
+            using SimpleTestPathContext testContext = new();
+
+            var packageSource1 = Path.Combine(testContext.WorkingDirectory, "1");
+            var packageSource2 = Path.Combine(testContext.WorkingDirectory, "2");
+            var packageSource3 = Path.Combine(testContext.WorkingDirectory, "3");
+
+            testContext.Settings.AddSource("1", packageSource1);
+            testContext.Settings.AddSource("2", packageSource2);
+            testContext.Settings.AddSource("3", packageSource3);
+
+            var expectedPackageSources = new[]
+            {
+                testContext.PackageSource,
+                packageSource1,
+                packageSource2,
+                packageSource3
+            };
+
+            for (int attempt = 0; attempt < 10; attempt++)
+            {
+                ConfigurationDefaults configurationDefaults = new(Path.GetDirectoryName(testContext.NuGetConfig), Path.GetFileName(testContext.NuGetConfig));
+
+                // Act
+                RunInParallel(EnumerateDefaultSources, attempt);
+
+                // Assert
+                configurationDefaults.DefaultPackageSources.Count().Should().Be(expectedPackageSources.Length);
+
+                configurationDefaults.DefaultPackageSources.Select(s => s.Source).Should().BeEquivalentTo(expectedPackageSources);
+
+                void EnumerateDefaultSources()
+                {
+                    IEnumerable<PackageSource> sources = configurationDefaults.DefaultPackageSources;
+                    foreach (PackageSource source in sources)
+                    {
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void DefaultPushSource_CalledConcurrently_ReturnsCorrectPackageSource()
+        {
+            for (int attempt = 0; attempt < 10; attempt++)
+            {
+                // Arrange
+                using SimpleTestPathContext testContext = new();
+                testContext.Settings.SetDefaultPushSource(testContext.PackageSource);
+
+                ConfigurationDefaults configurationDefaults = new(Path.GetDirectoryName(testContext.NuGetConfig), Path.GetFileName(testContext.NuGetConfig));
+
+                // Act
+                RunInParallel(CheckDefaultPushSource, attempt);
+
+                // Assert
+                configurationDefaults.DefaultPushSource.Should().Be(testContext.PackageSource);
+
+                void CheckDefaultPushSource()
+                {
+                    string source = configurationDefaults.DefaultPushSource;
+                    if (source == null)
+                    {
+                        throw new Exception("Default package source is null");
+                    }
+                }
+            }
+        }
+
+        private void RunInParallel(Action action, int attempt)
+        {
+            ConcurrentQueue<Exception> exceptions = new();
+            ManualResetEventSlim resetEvent = new(initialState: false);
+            Thread[] threads = new Thread[Environment.ProcessorCount];
+
+            for (int i = 0; i < threads.Length; i++)
+            {
+                threads[i] = new Thread(Run);
+                threads[i].Start();
+            }
+
+            resetEvent.Set();
+            for (int i = 0; i < threads.Length; i++)
+            {
+                threads[i].Join();
+            }
+
+            if (exceptions.TryDequeue(out Exception ex))
+            {
+                throw new Exception("At least one thread did not complete successfully on attempt " + (attempt + 1), ex);
+            }
+
+            void Run()
+            {
+                try
+                {
+                    resetEvent.Wait();
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Enqueue(ex);
+                }
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/NotThreadSafeResourceCollection.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/NotThreadSafeResourceCollection.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGet.Configuration.Test
+{
+    [CollectionDefinition(nameof(NotThreadSafeResourceCollection), DisableParallelization = true)]
+    public class NotThreadSafeResourceCollection
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition]
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/NuGet.Configuration.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/NuGet.Configuration.Test.csproj
@@ -3,7 +3,6 @@
     <TargetFrameworks>$(TargetFrameworksExe)</TargetFrameworks>
     <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Configuration.</Description>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
 using NuGet.Common;
+using NuGet.Configuration;
 
 namespace NuGet.Test.Utility
 {
@@ -246,6 +247,13 @@ namespace NuGet.Test.Utility
             }
 
             doc.Save(nugetConfigPath);
+        }
+
+        public void SetDefaultPushSource(string packageSource)
+        {
+            XElement config = GetOrAddSection(XML, ConfigurationConstants.Config);
+            AddEntry(config, ConfigurationConstants.DefaultPushSource, packageSource);
+            Save();
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12246

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Make the two properties in `ConfigurationDefaults` thread safe by making them idempotent.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
