### PR TITLE
set VSTargetChannelForTests variable to correct value

### DIFF
--- a/eng/pipelines/templates/Initialize_Build.yml
+++ b/eng/pipelines/templates/Initialize_Build.yml
@@ -33,7 +33,7 @@ steps:
         if ([System.String]::IsNullOrEmpty($env:VsTargetChannelOverrideForTests) -eq $false) {
           $targetChannelForTests = $env:VsTargetChannelOverrideForTests
         } else {
-          $targetChannelForTests = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetChannelForTests
+          $targetChannelForTests = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetChannelForTests
           $targetChannelForTests = $targetChannelForTests.Trim()
         }
         $targetMajorVersion = & dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetMajorVersion


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Tracking: https://github.com/NuGet/Client.Engineering/issues/1963

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

PR private build succeeded for https://github.com/NuGet/NuGet.Client/pull/4894 PR but [official build failed](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6993253&view=results) after merging the said PR into dev. It looks like there has been some changes to the same file in `dev` in https://github.com/NuGet/NuGet.Client/commit/2407dd2541d2dbc3236aeddde9c146a5fa2570b8 recently and my PR branch didn't have this commit.
There was a bug in the logic that caused `VSTARGETCHANNELFORTESTS` variable to set as `int.main  Build succeeded. 0 Warning(s) 0 Error(s)  Time Elapsed  00:00:00.09` instead of just `int.main`.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A
