### PR TITLE
Add 3 test cases for WebSite project to Install/Update/Uninstall package

### DIFF
--- a/build/tests.dev17.vsconfig
+++ b/build/tests.dev17.vsconfig
@@ -101,6 +101,8 @@
     "Microsoft.Component.ClickOnce",
     "Microsoft.VisualStudio.Component.VisualStudioData",
     "Microsoft.Net.Component.4.6.1.SDK",
-    "Microsoft.Net.Component.4.7.2.SDK"
+    "Microsoft.Net.Component.4.7.2.SDK",
+    "Microsoft.VisualStudio.Component.Wcf.Tooling",
+    "Microsoft.VisualStudio.ComponentGroup.AdditionalWebProjectTemplates"
   ]
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -399,5 +399,75 @@ namespace NuGet.Tests.Apex
                 Interval,
                 $"{file.FullName} still existed after {Timeout}.");
         }
+
+        [StaFact]
+        public void InstallPackageToWebSiteProjectFromUI()
+        {
+            // Arrange
+            EnsureVisualStudioHost();
+            var dte = VisualStudio.Dte;
+            var solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution();
+            var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.WebSiteEmpty, ProjectTargetFramework.V48, "WebSiteEmpty");
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            // Act
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, XunitLogger);
+            var nugetTestService = GetNuGetTestService();
+            var uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI("log4net", "2.0.12");
+
+            // Assert
+            CommonUtility.AssertPackageInPackagesConfig(VisualStudio, project, "log4net", "2.0.12", XunitLogger);
+        }
+
+        [StaFact]
+        public void UpdateWebSitePackageFromUI()
+        {
+            // Arrange
+            EnsureVisualStudioHost();
+            var dte = VisualStudio.Dte;
+            var solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution();
+            var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.WebSiteEmpty, ProjectTargetFramework.V48, "WebSiteEmpty");
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            // Act
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, XunitLogger);
+            var nugetTestService = GetNuGetTestService();
+            var uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI("log4net", "2.0.13");
+            VisualStudio.ClearWindows();
+            uiwindow.UpdatePackageFromUI("log4net", "2.0.15");
+
+            // Assert
+            CommonUtility.AssertPackageInPackagesConfig(VisualStudio, project, "log4net", "2.0.15", XunitLogger);
+        }
+
+        [StaFact]
+        public void UninstallWebSitePackageFromUI()
+        {
+            // Arrange
+            EnsureVisualStudioHost();
+            var dte = VisualStudio.Dte;
+            var solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution();
+            var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.WebSiteEmpty, ProjectTargetFramework.V48, "WebSiteEmpty");
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            // Act
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, XunitLogger);
+            var nugetTestService = GetNuGetTestService();
+            var uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI("log4net", "2.0.15");
+            VisualStudio.ClearWindows();
+            uiwindow.UninstallPackageFromUI("log4net");
+
+            // Assert
+            CommonUtility.AssertPackageNotInPackagesConfig(VisualStudio, project, "log4net", XunitLogger);
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug
Fixes: https://github.com/NuGet/Client.Engineering/issues/2019

## Description
**Purpose:**
Testing installing/updating/uninstalling package into a non-SDK style project from PM UI with “packages.config” format by default.

**Add three test cases:**
1. InstallPackageToWebSiteFromUI: Install particular package to a C# ASP Web Site Project from PM UI.
2. UpdateWebSitePackageFromUI: Update package for a C# ASP Web Site Project in PM UI.
3. UninstallWebSitePackageFromUI: Uninstall particular package to a C# ASP Web Site Project from PM UI.

Notes:
1. Updated the "...\build\tests.dev17.vsconfig" to install Web Site project for testing.
2. The test cases were added into the end of the ...\NuGet.Tests.Apex\NuGetEndToEndTests\NuGetUITestCase.cs file.

## PR Checklist
- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added