### PR TITLE
Fix include flags calculation for transitively pinned centrally managed dependencies

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/IncludeFlagUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/IncludeFlagUtils.cs
@@ -47,7 +47,7 @@ namespace NuGet.Commands
                 directDependencies.AddRange(specFramework.Dependencies);
             }
 
-            // Override the flags for direct dependencies. This lets the 
+            // Override the flags for direct dependencies. This lets the
             // user take control when needed.
             foreach (var dependency in directDependencies)
             {
@@ -74,7 +74,7 @@ namespace NuGet.Commands
             var unifiedNodes = new Dictionary<string, GraphItem<RemoteResolveResult>>(StringComparer.OrdinalIgnoreCase);
 
             // Create a look up table of id -> library
-            // This should contain only packages and projects. If there is a project with the 
+            // This should contain only packages and projects. If there is a project with the
             // same name as a package, use the project.
             // Projects take precedence over packages here to match the resolver behavior.
             foreach (var item in targetGraph.Flattened
@@ -142,8 +142,11 @@ namespace NuGet.Commands
 
                 foreach (var dependency in node.Item.Data.Dependencies)
                 {
+                    if (dependency.ReferenceType != LibraryDependencyReferenceType.Direct)
+                        continue;
+
                     // Any nodes that are not in unifiedNodes are types that should be ignored
-                    // We should also ignore dependencies that are excluded to match the dependency 
+                    // We should also ignore dependencies that are excluded to match the dependency
                     // resolution phase.
                     // Note that we cannot stop here if there are no flags since we still need to mark
                     // the child nodes as having no flags. SuppressParent=all is a special case.
@@ -165,7 +168,7 @@ namespace NuGet.Commands
         }
 
         /// <summary>
-        /// Find the flags for a node. 
+        /// Find the flags for a node.
         /// Include - Exclude - ParentExclude
         /// </summary>
         private static LibraryIncludeFlags GetDependencyType(
@@ -179,7 +182,7 @@ namespace NuGet.Commands
 
             var flags = match.IncludeType;
 
-            // Unless the root project is the grand parent here, the suppress flag should be applied directly to the 
+            // Unless the root project is the grand parent here, the suppress flag should be applied directly to the
             // child since it has no effect on the parent.
             if (parent.OuterNode != null)
             {

--- a/test/TestUtilities/Test.Utility/Commands/PackageReferenceSpecBuilder.cs
+++ b/test/TestUtilities/Test.Utility/Commands/PackageReferenceSpecBuilder.cs
@@ -10,6 +10,7 @@ using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.ProjectModel;
 using NuGet.RuntimeModel;
+using NuGet.Versioning;
 
 namespace Test.Utility.Commands
 {
@@ -23,6 +24,9 @@ namespace Test.Utility.Commands
         private string _projectDirectory;
         private bool _isLockedMode;
         private bool _isRestorePackagesWithLockFile;
+        private bool _centralPackageVersionsEnabled;
+        private bool _centralPackageTransitivePinningEnabled;
+
         private PackageReferenceSpecBuilder()
         {
         }
@@ -62,6 +66,18 @@ namespace Test.Utility.Commands
             return this;
         }
 
+        public PackageReferenceSpecBuilder WithCentralPackageVersionsEnabled()
+        {
+            _centralPackageVersionsEnabled = true;
+            return this;
+        }
+
+        public PackageReferenceSpecBuilder WithCentralPackageTransitivePinningEnabled()
+        {
+            _centralPackageTransitivePinningEnabled = true;
+            return this;
+        }
+
         public PackageSpec Build()
         {
             var projectPath = Path.Combine(_projectDirectory, _projectName + ".csproj");
@@ -81,7 +97,10 @@ namespace Test.Utility.Commands
                 ProjectPath = projectPath,
                 ConfigFilePaths = new List<string>(),
                 RestoreLockProperties = new RestoreLockProperties(_isRestorePackagesWithLockFile.ToString(), Path.Combine(_projectDirectory, PackagesLockFileFormat.LockFileName), _isLockedMode),
+                CentralPackageVersionsEnabled = _centralPackageVersionsEnabled,
+                CentralPackageTransitivePinningEnabled = _centralPackageTransitivePinningEnabled,
             };
+
             packageSpec.RestoreMetadata.TargetFrameworks.AddRange(packageSpec.TargetFrameworks.Select(e => new ProjectRestoreMetadataFrameworkInfo { FrameworkName = e.FrameworkName }));
 
             return packageSpec;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12274

Regression? Last working version: no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

When the include flags are calculated, only real (`LibraryDependencyReferenceType.Direct`) dependencies should be followed. The graph flattening algorithm should skip helper references (`LibraryDependencyReferenceType.None` and `LibraryDependencyReferenceType.Transitive`).

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
