### PR TITLE
Cache solution dir evaluation

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -434,15 +434,34 @@ namespace NuGet.PackageManagement.VisualStudio
             });
         }
 
-        public string SolutionDirectory => NuGetUIThreadHelper.JoinableTaskFactory.Run(GetSolutionDirectoryAsync);
+        private string _solutionDir;
+        public string SolutionDirectory
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(_solutionDir))
+                {
+                    return _solutionDir;
+                }
+
+                _solutionDir = NuGetUIThreadHelper.JoinableTaskFactory.Run(GetSolutionDirectoryAsync);
+                return _solutionDir;
+            }
+        }
 
         public async Task<string> GetSolutionDirectoryAsync()
         {
+            if (!string.IsNullOrEmpty(_solutionDir))
+            {
+                return _solutionDir;
+            }
+
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             var vsSolution = await _asyncVSSolution.GetValueAsync();
             if (IsSolutionOpenFromVSSolution(vsSolution))
             {
-                return (string)GetVSSolutionProperty(vsSolution, (int)__VSPROPID.VSPROPID_SolutionDirectory);
+                _solutionDir = (string)GetVSSolutionProperty(vsSolution, (int)__VSPROPID.VSPROPID_SolutionDirectory);
+                return _solutionDir;
             }
             return null;
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -544,6 +544,7 @@ namespace NuGet.PackageManagement.VisualStudio
             SolutionClosed?.Invoke(this, EventArgs.Empty);
 
             _solutionOpenedRaised = false;
+            _solutionDir = null;
         }
 
         private void OnBeforeClosing()

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -67,6 +66,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private bool _initialized;
         private bool _cacheInitialized;
+        private string _solutionDirectory;
 
         //add solutionOpenedRasied to make sure ProjectRename and ProjectAdded event happen after solutionOpened event
         private bool _solutionOpenedRaised;
@@ -434,34 +434,33 @@ namespace NuGet.PackageManagement.VisualStudio
             });
         }
 
-        private string _solutionDir;
         public string SolutionDirectory
         {
             get
             {
-                if (!string.IsNullOrEmpty(_solutionDir))
+                if (!string.IsNullOrEmpty(_solutionDirectory))
                 {
-                    return _solutionDir;
+                    return _solutionDirectory;
                 }
 
-                _solutionDir = NuGetUIThreadHelper.JoinableTaskFactory.Run(GetSolutionDirectoryAsync);
-                return _solutionDir;
+                _solutionDirectory = NuGetUIThreadHelper.JoinableTaskFactory.Run(GetSolutionDirectoryAsync);
+                return _solutionDirectory;
             }
         }
 
         public async Task<string> GetSolutionDirectoryAsync()
         {
-            if (!string.IsNullOrEmpty(_solutionDir))
+            if (!string.IsNullOrEmpty(_solutionDirectory))
             {
-                return _solutionDir;
+                return _solutionDirectory;
             }
 
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             var vsSolution = await _asyncVSSolution.GetValueAsync();
             if (IsSolutionOpenFromVSSolution(vsSolution))
             {
-                _solutionDir = (string)GetVSSolutionProperty(vsSolution, (int)__VSPROPID.VSPROPID_SolutionDirectory);
-                return _solutionDir;
+                _solutionDirectory = (string)GetVSSolutionProperty(vsSolution, (int)__VSPROPID.VSPROPID_SolutionDirectory);
+                return _solutionDirectory;
             }
             return null;
         }
@@ -544,7 +543,7 @@ namespace NuGet.PackageManagement.VisualStudio
             SolutionClosed?.Invoke(this, EventArgs.Empty);
 
             _solutionOpenedRaised = false;
-            _solutionDir = null;
+            _solutionDirectory = null;
         }
 
         private void OnBeforeClosing()


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1893

Regression? Last working version:

## Description
Currently getting solution dir need VS solution still be open, but we have some processing([VsDeleteOnRestartManager.DeleteMarkedPackageDirectoriesAsync](https://github.com/NuGet/NuGet.Client/blob/84d99ce064a5f70628c89af9f30693581e84dc37/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs#L168)) works which happen when VS close the solution, due to some race condition [it couldn't access](https://github.com/NuGet/NuGet.Client/blob/84d99ce064a5f70628c89af9f30693581e84dc37/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs#L174) the `solution dir` property for solution just closed. It waits for it on main thread, then blocks other thread pool threads. 
We could cache the value and use later even solution is closed for above method, of course we reset to `null` at end of solution closing to prevent cross solution contamination. 
I believe we gain some perf improvement considering this is hot path and [we don't switch to UI thread often](https://github.com/NuGet/NuGet.Client/blob/84d99ce064a5f70628c89af9f30693581e84dc37/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs#L441), only once.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
