### PR TITLE
Fix build import order when using transitive pinning

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -750,9 +750,9 @@ namespace NuGet.Commands
 
             foreach (var item in items)
             {
-                var dependencies =
-                    item.Data?.Dependencies?.Select(
-                        dependency => new PackageDependency(dependency.Name, VersionRange.All));
+                IEnumerable<PackageDependency> dependencies = item.Data?.Dependencies?
+                    .Where(i => i.ReferenceType != LibraryDependencyReferenceType.None) // Ignore transitively pinned dependencies
+                    .Select(dependency => new PackageDependency(dependency.Name, VersionRange.All));
 
                 result.Add(new PackageDependencyInfo(item.Key.Name, item.Key.Version, dependencies));
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -751,7 +751,7 @@ namespace NuGet.Commands
             foreach (var item in items)
             {
                 IEnumerable<PackageDependency> dependencies = item.Data?.Dependencies?
-                    .Where(i => i.ReferenceType != LibraryDependencyReferenceType.None) // Ignore transitively pinned dependencies
+                    .Where(i => i.ReferenceType == LibraryDependencyReferenceType.Direct) // Ignore transitively pinned dependencies
                     .Select(dependency => new PackageDependency(dependency.Name, VersionRange.All));
 
                 result.Add(new PackageDependencyInfo(item.Key.Name, item.Key.Version, dependencies));


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12278

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
I'm not 100% sure how this manifests.  I was unable to repro with a simple set up but could repro with a very complicated set of projects and packages.  Under the debugger, this fixed the issue and seems like it might also help with performance when you're using transitive pinning because in that scenario there could be hundreds of packages to sort.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - I am not able to repro the problem with a simple project.  The only repro involved 15 projects and 160 packages.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
