### PR TITLE
Skip 17 E2E bindingRedirect tests

### DIFF
--- a/test/EndToEnd/tests/InstallPackageTest.ps1
+++ b/test/EndToEnd/tests/InstallPackageTest.ps1
@@ -695,6 +695,7 @@ function Test-InstallPackageWorksWithProjectsHavingSameNames {
 }
 
 function Test-SimpleBindingRedirects {
+    [SkipTest('https://github.com/NuGet/Home/issues/12292')]
     param(
         $context
     )
@@ -721,6 +722,7 @@ function Test-SimpleBindingRedirects {
 # Tests that when there are multip config files, the binding redirects will
 # be added to the right file.
 function Test-SimpleBindingRedirectsMultipleConfigs {
+    [SkipTest('https://github.com/NuGet/Home/issues/12292')]
     param(
         $context
     )
@@ -745,6 +747,9 @@ function Test-SimpleBindingRedirectsMultipleConfigs {
 }
 
 function Test-SimpleBindingRedirectsClassLibraryUpdatePackage {
+    [SkipTest('https://github.com/NuGet/Home/issues/12292')]
+    param($context)
+
     # Arrange
     $a = New-ClassLibrary
 
@@ -765,6 +770,7 @@ function Test-SimpleBindingRedirectsClassLibraryUpdatePackage {
 }
 
 function Test-SimpleBindingRedirectsClassLibraryReference {
+    [SkipTest('https://github.com/NuGet/Home/issues/12292')]
     param(
         $context
     )
@@ -797,6 +803,7 @@ function Test-SimpleBindingRedirectsClassLibraryReference {
 }
 
 function Test-SimpleBindingRedirectsIndirectReference {
+    [SkipTest('https://github.com/NuGet/Home/issues/12292')]
     param($context)
 
     # Arrange
@@ -841,6 +848,7 @@ function Test-SimpleBindingRedirectsNonWeb {
 }
 
 function Test-BindingRedirectComplex {
+    [SkipTest('https://github.com/NuGet/Home/issues/12292')]
     param($context)
 
     # Arrange
@@ -865,6 +873,7 @@ function Test-BindingRedirectComplex {
 }
 
 function Test-SimpleBindingRedirectsWebsite {
+    [SkipTest('https://github.com/NuGet/Home/issues/12292')]
     param(
         $context
     )
@@ -882,6 +891,7 @@ function Test-SimpleBindingRedirectsWebsite {
 
 
 function Test-BindingRedirectInstallLargeProject {
+    [SkipTest('https://github.com/NuGet/Home/issues/12292')]
     param($context)
 
     $numProjects = 25
@@ -900,6 +910,7 @@ function Test-BindingRedirectInstallLargeProject {
 }
 
 function Test-BindingRedirectDuplicateReferences {
+    [SkipTest('https://github.com/NuGet/Home/issues/12292')]
     param($context)
 
     # Arrange
@@ -924,6 +935,7 @@ function Test-BindingRedirectDuplicateReferences {
 }
 
 function Test-BindingRedirectClassLibraryWithDifferentDependents {
+    [SkipTest('https://github.com/NuGet/Home/issues/12292')]
     param($context)
 
     # Arrange
@@ -948,6 +960,7 @@ function Test-BindingRedirectClassLibraryWithDifferentDependents {
 }
 
 function Test-BindingRedirectProjectsThatReferenceSameAssemblyFromDifferentLocations {
+    [SkipTest('https://github.com/NuGet/Home/issues/12292')]
     param($context)
 
     # Arrange
@@ -977,6 +990,7 @@ function Test-BindingRedirectProjectsThatReferenceSameAssemblyFromDifferentLocat
 }
 
 function Test-BindingRedirectsMixNonStrongNameAndStrongNameAssemblies {
+    [SkipTest('https://github.com/NuGet/Home/issues/12292')]
     param(
         $context
     )
@@ -999,6 +1013,7 @@ function Test-BindingRedirectsMixNonStrongNameAndStrongNameAssemblies {
 }
 
 function Test-BindingRedirectProjectsThatReferenceDifferentVersionsOfSameAssembly {
+    [SkipTest('https://github.com/NuGet/Home/issues/12292')]
     param($context)
 
     # Arrange
@@ -2404,6 +2419,9 @@ function Test-InstallMetadataPackageAddPackageToProject
 
 function Test-FrameworkAssemblyReferenceShouldNotHaveBindingRedirect
 {
+    [SkipTest('https://github.com/NuGet/Home/issues/12292')]
+    param($context)
+
     # Arrange
     $p1 = New-ConsoleApplication -ProjectName Hello
 
@@ -2424,6 +2442,9 @@ function Test-FrameworkAssemblyReferenceShouldNotHaveBindingRedirect
 
 function Test-NonFrameworkAssemblyReferenceShouldHaveABindingRedirect
 {
+    [SkipTest('https://github.com/NuGet/Home/issues/12292')]
+    param($context)
+
     # Arrange
     $p = New-ConsoleApplication -ProjectName Hello
 

--- a/test/EndToEnd/tests/ServicesTest.ps1
+++ b/test/EndToEnd/tests/ServicesTest.ps1
@@ -707,6 +707,7 @@ function Test-RestorePackageAPINoPackage
 
 function Test-InstallPackageAPIBindingRedirect
 {
+    [SkipTest('https://github.com/NuGet/Home/issues/12292')]
     param($context)
 
     # Arrange

--- a/test/EndToEnd/tests/UpdatePackageTest.ps1
+++ b/test/EndToEnd/tests/UpdatePackageTest.ps1
@@ -345,6 +345,7 @@ function Test-SubTreeUpdateWithConflict {
 }
 
 function Test-AddingBindingRedirectAfterUpdate {
+    [SkipTest('https://github.com/NuGet/Home/issues/12292')]
     param(
         $context
     )
@@ -1742,6 +1743,7 @@ function Test-UpdatePackageWithToHighestMinorFlag {
 }
 
 function Test-UpdatingBindingRedirectAfterUpdate {
+    [SkipTest('https://github.com/NuGet/Home/issues/12292')]
     param(
         $context
     )


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug
Skip 17 E2E tests constantly fail recently.
Tracking issue: https://github.com/NuGet/Home/issues/12292

Regression? Last working version:

## Description
Skip the following 17 E2E tests:
Part 1
Failed InstallPackageAPIBindingRedirect 0ms

Part 2
Failed SimpleBindingRedirects 0ms
Failed SimpleBindingRedirectsClassLibraryUpdatePackage 0ms
Failed SimpleBindingRedirectsMultipleConfigs 0ms
Failed SimpleBindingRedirectsClassLibraryReference 0ms
Failed SimpleBindingRedirectsIndirectReference 0ms
Failed BindingRedirectComplex 0ms
Failed SimpleBindingRedirectsWebsite 0ms
Failed BindingRedirectInstallLargeProject 0ms
Failed BindingRedirectDuplicateReferences 0ms
Failed BindingRedirectClassLibraryWithDifferentDependents 0ms
Failed BindingRedirectProjectsThatReferenceSameAssemblyFromDifferentLocations 0ms
Failed BindingRedirectsMixNonStrongNameAndStrongNameAssemblies 0ms
Failed BindingRedirectProjectsThatReferenceDifferentVersionsOfSameAssembly 0ms
Failed FrameworkAssemblyReferenceShouldNotHaveBindingRedirect 0ms
Failed NonFrameworkAssemblyReferenceShouldHaveABindingRedirect 0ms
Failed AddingBindingRedirectAfterUpdate 0ms
Failed UpdatingBindingRedirectAfterUpdate 0ms

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
