### PR TITLE
Error out if output version not used with json output

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
@@ -183,6 +183,10 @@ namespace NuGet.CommandLine.XPlat
 
             if (outputFormat == ReportOutputFormat.Console)
             {
+                if (!string.IsNullOrEmpty(outputVersionOption))
+                {
+                    throw new ArgumentException(string.Format(Strings.ListPkg_OutputVersionNotApplicable));
+                }
                 return new ListPackageConsoleRenderer();
             }
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -835,6 +835,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;--output-version&apos; option not applicable for console output, it can only be used together with `--format json` option..
+        /// </summary>
+        internal static string ListPkg_OutputVersionNotApplicable {
+            get {
+                return ResourceManager.GetString("ListPkg_OutputVersionNotApplicable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A path to a project, solution file or directory..
         /// </summary>
         internal static string ListPkg_PathDescription {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -781,5 +781,6 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
   </data>
   <data name="ListPkg_OutputVersionNotApplicable" xml:space="preserve">
     <value>'--output-version' option not applicable for console output, it can only be used together with `--format json` option.</value>
+    <comment>Don't localize '--output-version' and `--format json`</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -779,4 +779,7 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
     <value>Unsupported output format version {0} was requested.  The accepted format version value is {1}.</value>
     <comment>{0} - argument name in version option {1} - the possible value of the argument.</comment>
   </data>
+  <data name="ListPkg_OutputVersionNotApplicable" xml:space="preserve">
+    <value>'--output-version' option not applicable for console output, it can only be used together with `--format json` option.</value>
+  </data>
 </root>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -105,7 +105,6 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("--format JSON")]
         [InlineData("--format json --output-version 1")]
         [InlineData("--format console")]
-        [InlineData("--format console --output-version 1")]
         public void BasicListPackage_OutputFormat_CorrectInput_Parsing_Succeeds(string outputFormatCommmand)
         {
             VerifyCommand(
@@ -132,7 +131,11 @@ namespace NuGet.XPlat.FuncTest
 
         [Theory]
         [InlineData("--format xml")]
+        [InlineData("--format json --output-version 0")]
         [InlineData("--format json --output-version 2")]
+        [InlineData("--format console --output-version 1")]
+        [InlineData("--output-version 0")]
+        [InlineData("--output-version 1")]
         public void BasicListPackage_OutputFormat_BadInput_Parsing_Fails(string outputFormatCommmand)
         {
             VerifyCommand(


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12293

Regression? Last working version:

## Description
`--output-version` option for `dotnet list package` command only applicable for `--format json` option.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception. 
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
