### PR TITLE
Test:  update .NET 7 SDK version for testing

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -44,7 +44,7 @@
          6.0:6.0.100-preview.7.21379.14 means install the preview version 6.0.100-preview.7.21379.14.
     Refer to https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script#options for more details.
     -->
-    <CliBranchForTesting Condition="'$(CliBranchForTesting)' == ''">7.0:7.0.100-rtm.22510.17</CliBranchForTesting>
+    <CliBranchForTesting Condition="'$(CliBranchForTesting)' == ''">7.0</CliBranchForTesting>
   </PropertyGroup>
 
   <!-- Config -->


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/12302

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This PR changes the test .NET SDK version from an old preview release to the latest stable .NET 7 SDK release.  The PR also fixes 2 tests which I discovered to have an unstable verification when the test .NET SDK's fallback certificate bundles changed.

Side note:  I also intend to backport this change in a separate PR to the release-6.4.x branch.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
