### PR TITLE
Ensure that copyright header is applied consistently across .cs files

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/CommandLineSourceRepositoryProvider.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/CommandLineSourceRepositoryProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 extern alias CoreV2;
 
 using System;

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/CommandAttribute.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/CommandAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using NuGet.CommandLine;
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/DeleteCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/DeleteCommand.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 using NuGet.Commands;
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ICommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ICommand.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/OptionAttribute.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/OptionAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using NuGet.CommandLine;
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 extern alias CoreV2;
 
 using System;

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SetApiKeyCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SetApiKeyCommand.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using NuGet.Common;
 using NuGet.Configuration;

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/CommandLineConstants.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/CommandLineConstants.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace NuGet.CommandLine
 {
     internal static class CommandLineConstants

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/CommandLineResponseFile.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/CommandLineResponseFile.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 #if IS_DESKTOP
 using System;
 using System.Collections.Generic;

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Globalization;
 using System.IO;

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/ConsoleCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/ConsoleCredentialProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Net;
 using System.Security;

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/IConsole.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/IConsole.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Security;
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildUser.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildUser.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Globalization;
 using System.IO;

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/PackageSourceProviderExtensions.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/PackageSourceProviderExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/ProjectHelper.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/ProjectHelper.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/ProjectInSolution.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/ProjectInSolution.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Globalization;
 using System.Reflection;

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Solution.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Solution.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/TypeHelper.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/TypeHelper.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/NuGet.Clients/NuGet.CommandLine/Credentials/CredentialProviderAdapter.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Credentials/CredentialProviderAdapter.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 extern alias CoreV2;
 
 using System;

--- a/src/NuGet.Clients/NuGet.CommandLine/Credentials/CredentialServiceAdapter.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Credentials/CredentialServiceAdapter.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 extern alias CoreV2;
 using System;
 using System.Collections.Generic;

--- a/src/NuGet.Clients/NuGet.CommandLine/ExtensionLocator.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/ExtensionLocator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/NuGet.Clients/NuGet.CommandLine/FileConflictAction.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/FileConflictAction.cs
@@ -1,3 +1,5 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace NuGet.CommandLine
 {

--- a/src/NuGet.Clients/NuGet.CommandLine/ICommandManager.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/ICommandManager.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;

--- a/src/NuGet.Clients/NuGet.CommandLine/SettingsCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/SettingsCredentialProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 extern alias CoreV2;
 
 using System;

--- a/src/NuGet.Clients/NuGet.CommandLine/StreamExtensions.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/StreamExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.IO;
 
 namespace NuGet.CommandLine

--- a/src/NuGet.Clients/NuGet.Indexing/CamelCaseFilter.cs
+++ b/src/NuGet.Clients/NuGet.Indexing/CamelCaseFilter.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/NuGet.Clients/NuGet.Indexing/DescriptionAnalyzer.cs
+++ b/src/NuGet.Clients/NuGet.Indexing/DescriptionAnalyzer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.IO;
 using Lucene.Net.Analysis;

--- a/src/NuGet.Clients/NuGet.Indexing/DotTokenizer.cs
+++ b/src/NuGet.Clients/NuGet.Indexing/DotTokenizer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 using Lucene.Net.Analysis;

--- a/src/NuGet.Clients/NuGet.Indexing/IdentifierAnalyzer.cs
+++ b/src/NuGet.Clients/NuGet.Indexing/IdentifierAnalyzer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.IO;
 using Lucene.Net.Analysis;
 

--- a/src/NuGet.Clients/NuGet.Indexing/IdentifierKeywordAnalyzer.cs
+++ b/src/NuGet.Clients/NuGet.Indexing/IdentifierKeywordAnalyzer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.IO;
 using Lucene.Net.Analysis;
 

--- a/src/NuGet.Clients/NuGet.Indexing/NuGetQuery.cs
+++ b/src/NuGet.Clients/NuGet.Indexing/NuGetQuery.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/NuGet.Clients/NuGet.Indexing/OwnerAnalyzer.cs
+++ b/src/NuGet.Clients/NuGet.Indexing/OwnerAnalyzer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.IO;
 using Lucene.Net.Analysis;

--- a/src/NuGet.Clients/NuGet.Indexing/PackageAnalyzer.cs
+++ b/src/NuGet.Clients/NuGet.Indexing/PackageAnalyzer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using Lucene.Net.Analysis;

--- a/src/NuGet.Clients/NuGet.Indexing/SemanticVersionFilter.cs
+++ b/src/NuGet.Clients/NuGet.Indexing/SemanticVersionFilter.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.Tokenattributes;
 using NuGet.Versioning;

--- a/src/NuGet.Clients/NuGet.Indexing/TagsAnalyzer.cs
+++ b/src/NuGet.Clients/NuGet.Indexing/TagsAnalyzer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.IO;
 using Lucene.Net.Analysis;

--- a/src/NuGet.Clients/NuGet.Indexing/TokenizingHelper.cs
+++ b/src/NuGet.Clients/NuGet.Indexing/TokenizingHelper.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/NuGet.Clients/NuGet.Indexing/VersionAnalyzer.cs
+++ b/src/NuGet.Clients/NuGet.Indexing/VersionAnalyzer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.IO;
 using Lucene.Net.Analysis;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/DebugConstants.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/DebugConstants.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 #if DEBUG
 using System.IO;
 namespace NuGetConsole.Host.PowerShell {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Common/ErrorFloodGate.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Common/ErrorFloodGate.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Concurrent;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/CollectionToStringConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/CollectionToStringConverter.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Windows.Data;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/EnumDescriptionValueConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/EnumDescriptionValueConverter.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.ComponentModel;
 using System.Globalization;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/NotEqualConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/NotEqualConverter.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Windows.Data;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/RadioBoolToIntConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/RadioBoolToIntConverter.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageIconMonikers.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageIconMonikers.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.VisualStudio.Imaging.Interop;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/ProjectVersionConstraint.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/ProjectVersionConstraint.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using NuGet.Versioning;
 
 namespace NuGet.PackageManagement

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourceCheckedListBox.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourceCheckedListBox.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Drawing;
 using System.Drawing.Text;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/VsUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/VsUtility.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ArrowGlyphAdorner.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ArrowGlyphAdorner.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LoadingStatusBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LoadingStatusBar.xaml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Windows;
 using System.Windows.Controls;
 using Microsoft.VisualStudio.Shell;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SortableColumnHeaderAttachedProperties.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SortableColumnHeaderAttachedProperties.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/ContinuationToken.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/ContinuationToken.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 namespace NuGet.PackageManagement.VisualStudio
 {
     /// <summary>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/PackageManagerUIRefreshEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/PackageManagerUIRefreshEvent.cs
@@ -1,4 +1,4 @@
-// All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IScriptPackageFile.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IScriptPackageFile.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Runtime.Versioning;
 
 namespace NuGet.PackageManagement.VisualStudio

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/PackageAssemblyReference.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/PackageAssemblyReference.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.IO;
 
 namespace NuGet.PackageManagement.VisualStudio

--- a/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/NuGetClientPackage.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.OnlineEnvironment.Client/NuGetClientPackage.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsGlobalPackagesInitScriptExecutor.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsGlobalPackagesInitScriptExecutor.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageInstaller2.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageInstaller2.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Runtime.InteropServices;
 using EnvDTE;

--- a/src/NuGet.Clients/NuGet.VisualStudio/IVsPackageManagerProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/IVsPackageManagerProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/src/NuGet.Clients/NuGet.VisualStudio/LegacyTypes/IFileSystem.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/LegacyTypes/IFileSystem.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace NuGet
 {
     /// <summary>

--- a/src/NuGet.Clients/NuGet.VisualStudio/LegacyTypes/IPackage.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/LegacyTypes/IPackage.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/NuGet.Clients/NuGet.VisualStudio/LegacyTypes/IPackageAssemblyReference.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/LegacyTypes/IPackageAssemblyReference.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace NuGet
 {
     /// <summary>

--- a/src/NuGet.Clients/NuGet.VisualStudio/LegacyTypes/IPackageFile.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/LegacyTypes/IPackageFile.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.Versioning;

--- a/src/NuGet.Clients/NuGet.VisualStudio/LegacyTypes/IPackageRepository.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/LegacyTypes/IPackageRepository.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 

--- a/src/NuGet.Clients/NuGet.VisualStudio/LegacyTypes/PackageSaveModes.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/LegacyTypes/PackageSaveModes.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace NuGet
 {
     /// <summary>

--- a/src/NuGet.Clients/NuGet.VisualStudio/LegacyTypes/SemanticVersion.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/LegacyTypes/SemanticVersion.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Globalization;
 using System.Text;

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/ConsoleLoggingQueue.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/ConsoleLoggingQueue.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 #if IS_DESKTOP
 extern alias MicrosoftBuildUtilitiesv4;
 #endif

--- a/src/NuGet.Core/NuGet.Common/AsyncEnumerable/IEnumerableAsync.cs
+++ b/src/NuGet.Core/NuGet.Common/AsyncEnumerable/IEnumerableAsync.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 namespace NuGet.Common
 {
     public interface IEnumerableAsync<T>

--- a/src/NuGet.Core/NuGet.Common/Logging/ILogger.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/ILogger.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 using System.Threading.Tasks;
 
 namespace NuGet.Common

--- a/src/NuGet.Core/NuGet.Common/Tokenizer/Token.cs
+++ b/src/NuGet.Core/NuGet.Common/Tokenizer/Token.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace NuGet.Common
 {
     public class Token

--- a/src/NuGet.Core/NuGet.Common/Tokenizer/TokenCategory.cs
+++ b/src/NuGet.Core/NuGet.Common/Tokenizer/TokenCategory.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace NuGet.Common
 {
     public enum TokenCategory

--- a/src/NuGet.Core/NuGet.Configuration/Credential/CredentialRequestType.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Credential/CredentialRequestType.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace NuGet.Configuration
 {
     public enum CredentialRequestType

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ImmutableSettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ImmutableSettings.cs
@@ -1,4 +1,4 @@
-// All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/DowngradeResult.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/DowngradeResult.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace NuGet.DependencyResolver
 {
     public class DowngradeResult<TItem>

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/VersionConflictResult.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/VersionConflictResult.cs
@@ -1,3 +1,5 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace NuGet.DependencyResolver
 {

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/INuGetProjectServices.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/INuGetProjectServices.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 namespace NuGet.ProjectManagement
 {
     /// <summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/IProjectSystemCapabilities.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/IProjectSystemCapabilities.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 namespace NuGet.ProjectManagement
 {
     /// <summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/NuGetProjectMetadataKeys.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/NuGetProjectMetadataKeys.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 namespace NuGet.ProjectManagement
 {
     public static class NuGetProjectMetadataKeys

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 namespace NuGet.ProjectManagement
 {
     /// <summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectItemProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectItemProperties.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 namespace NuGet.ProjectManagement
 {
     /// <summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectItems.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectItems.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 namespace NuGet.ProjectManagement
 {
     /// <summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/Telemetry/ActionEventBase.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Telemetry/ActionEventBase.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/NuGet.Core/NuGet.Packaging/Core/FrameworkNameValidatorUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Core/FrameworkNameValidatorUtility.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/NuGet.Core/NuGet.Packaging/PackageFileExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFileExtractor.cs
@@ -1,4 +1,3 @@
-
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 

--- a/src/NuGet.Core/NuGet.Packaging/Rules/ContentFolderInPackageReferenceProjectRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/ContentFolderInPackageReferenceProjectRule.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/NuGet.Core/NuGet.Packaging/Rules/InstallScriptInPackageReferenceProjectRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/InstallScriptInPackageReferenceProjectRule.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/NuGet.Core/NuGet.Packaging/Rules/NoRefOrLibFolderInPackageRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/NoRefOrLibFolderInPackageRule.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/NuGet.Core/NuGet.Packaging/Rules/PathTooLongRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/PathTooLongRule.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;

--- a/src/NuGet.Core/NuGet.Protocol/FeedType.cs
+++ b/src/NuGet.Core/NuGet.Protocol/FeedType.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace NuGet.Protocol
 {
     public enum FeedType

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedUtilities.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/NuGet.Core/NuGet.Protocol/NullSourceCacheContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/NullSourceCacheContext.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
@@ -1,3 +1,5 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/NuGet.Core/NuGet.Resolver/DependencyBehavior.cs
+++ b/src/NuGet.Core/NuGet.Resolver/DependencyBehavior.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace NuGet.Resolver
 {
     public enum DependencyBehavior

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingType.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingType.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
 namespace NuGet.CommandLine.Test.Caching

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingValidation.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingValidation.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingValidationType.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingValidationType.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace NuGet.CommandLine.Test.Caching
 {
     public enum CachingValidationType

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingValidations.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingValidations.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections;
 using System.Collections.Generic;
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Commands/ICachingCommand.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Commands/ICachingCommand.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using NuGet.Packaging.Core;
 
 namespace NuGet.CommandLine.Test.Caching

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Commands/InstallPackagesConfigCommand.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Commands/InstallPackagesConfigCommand.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using NuGet.Packaging.Core;
 
 namespace NuGet.CommandLine.Test.Caching

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Commands/InstallSpecificVersionCommand.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Commands/InstallSpecificVersionCommand.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using NuGet.Packaging.Core;
 
 namespace NuGet.CommandLine.Test.Caching

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Commands/RestorePackagesConfigCommand.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Commands/RestorePackagesConfigCommand.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using NuGet.Packaging.Core;
 
 namespace NuGet.CommandLine.Test.Caching

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Commands/RestoreProjectJsonCommand.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/Commands/RestoreProjectJsonCommand.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using NuGet.Packaging.Core;
 
 namespace NuGet.CommandLine.Test.Caching

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/NuGetExe/INuGetExe.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/NuGetExe/INuGetExe.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 using NuGet.Test.Utility;
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/NuGetExe/NuGetExe.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/NuGetExe/NuGetExe.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/ServerType.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/ServerType.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace NuGet.CommandLine.Test.Caching
 {
     public enum ServerType

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ConsoleCredentialProviderTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ConsoleCredentialProviderTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NativeMethods.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NativeMethods.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 using NuGet.Test.Utility;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetResponseFileTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetResponseFileTests.cs
@@ -1,6 +1,7 @@
-#if IS_DESKTOP
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if IS_DESKTOP
 
 using System;
 using System.IO;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/PackageCreator.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/PackageCreator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 using NuGet.Packaging;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreUAPPackageReferenceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreUAPPackageReferenceTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Configuration;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/XunitAttribute.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/XunitAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using NuGet.Common;
 using Xunit;

--- a/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetMSSignCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetMSSignCommandTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/VsTelemetrySessionTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/VsTelemetrySessionTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Globalization;
 using System.Linq;

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsSemanticVersionComparerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsSemanticVersionComparerTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using NuGet.VisualStudio.Implementation.Extensibility;
 using Xunit;

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/MSBuildStringUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/MSBuildStringUtilityTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/RestoreLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/RestoreLogMessageTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/NuGet.Core.Tests/NuGet.Credentials.Test/PluginCredentialProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Credentials.Test/PluginCredentialProviderTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Diagnostics;
 using System.Net;

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/Utility/PackagesConfigLockFileUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/Utility/PackagesConfigLockFileUtilityTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/Core/comparers/PackageIdentityComparerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/Core/comparers/PackageIdentityComparerTests.cs
@@ -1,3 +1,5 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet.Packaging.Core;
 using NuGet.Versioning;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NoRefOrLibFolderInPackageRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NoRefOrLibFolderInPackageRuleTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/RuleSetTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/RuleSetTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetAuthenticationCredentialsResponseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetAuthenticationCredentialsResponseTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Text;
 using NuGet.Protocol.Plugins;

--- a/test/NuGet.Tests.Apex/NuGet.OptProf/Assets/PackageReferenceSdk/PackageReferenceSdk/Class1.cs
+++ b/test/NuGet.Tests.Apex/NuGet.OptProf/Assets/PackageReferenceSdk/PackageReferenceSdk/Class1.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Newtonsoft.Json.Linq;
 
 namespace PackageReferenceSdk

--- a/test/NuGet.Tests.Apex/NuGet.OptProf/TestIVsPackageSourceProvider.cs
+++ b/test/NuGet.Tests.Apex/NuGet.OptProf/TestIVsPackageSourceProvider.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Microsoft.Test.Apex.VisualStudio;
 using NuGet.VisualStudio;

--- a/test/NuGet.Tests.Apex/NuGet.OptProf/Tests.cs
+++ b/test/NuGet.Tests.Apex/NuGet.OptProf/Tests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/ApexTestUIProject.cs
+++ b/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/ApexTestUIProject.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/VisualStudioHostExtension.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/VisualStudioHostExtension.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/TestExtensions/API.Test/Utils.cs
+++ b/test/TestExtensions/API.Test/Utils.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/TestExtensions/GenerateTestPackages/AssemblySourceFileGenerator_Partial.cs
+++ b/test/TestExtensions/GenerateTestPackages/AssemblySourceFileGenerator_Partial.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/TestExtensions/GenerateTestPackages/Program.cs
+++ b/test/TestExtensions/GenerateTestPackages/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;

--- a/test/TestExtensions/NuGet.StaFact/GlobalSuppressions.cs
+++ b/test/TestExtensions/NuGet.StaFact/GlobalSuppressions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 // This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given

--- a/test/TestExtensions/SampleCommandLineExtensions/HelloCommand.cs
+++ b/test/TestExtensions/SampleCommandLineExtensions/HelloCommand.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.ComponentModel.Composition;
 using NuGet;
 using NuGet.CommandLine;

--- a/test/TestExtensions/TestableVSCredentialProvider/Properties/AssemblyInfo.cs
+++ b/test/TestExtensions/TestableVSCredentialProvider/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Reflection;
 using System.Runtime.InteropServices;
 

--- a/test/TestExtensions/TestableVSCredentialProvider/TestCredentialProvider.cs
+++ b/test/TestExtensions/TestableVSCredentialProvider/TestCredentialProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.ComponentModel.Composition;
 using System.Diagnostics;

--- a/test/TestExtensions/TestableVSCredentialProvider/TestCredentialProvider2.cs
+++ b/test/TestExtensions/TestableVSCredentialProvider/TestCredentialProvider2.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.ComponentModel.Composition;
 using System.Diagnostics;

--- a/test/TestExtensions/TestableVSCredentialProvider/TestCredentials.cs
+++ b/test/TestExtensions/TestableVSCredentialProvider/TestCredentials.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Net;
 using System.Security;

--- a/test/TestUtilities/Test.Utility/MockServer.cs
+++ b/test/TestUtilities/Test.Utility/MockServer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/test/TestUtilities/Test.Utility/PlatformXunitAttributes/FileExistsFactAttribute.cs
+++ b/test/TestUtilities/Test.Utility/PlatformXunitAttributes/FileExistsFactAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/TestUtilities/Test.Utility/PlatformXunitAttributes/FileExistsInNuGetRoamingFactAttribute.cs
+++ b/test/TestUtilities/Test.Utility/PlatformXunitAttributes/FileExistsInNuGetRoamingFactAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/TestUtilities/Test.Utility/PlatformXunitAttributes/FileExistsInNuGetRoamingTheoryAttribute.cs
+++ b/test/TestUtilities/Test.Utility/PlatformXunitAttributes/FileExistsInNuGetRoamingTheoryAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/TestUtilities/Test.Utility/PlatformXunitAttributes/FileExistsTheoryAttribute.cs
+++ b/test/TestUtilities/Test.Utility/PlatformXunitAttributes/FileExistsTheoryAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PlatformTheoryAttribute.cs
+++ b/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PlatformTheoryAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/TestUtilities/Test.Utility/PlatformXunitAttributes/XunitAttributeUtility.cs
+++ b/test/TestUtilities/Test.Utility/PlatformXunitAttributes/XunitAttributeUtility.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 using System.Linq;

--- a/tools-local/ship-public-apis/Program.cs
+++ b/tools-local/ship-public-apis/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.CommandLine;


### PR DESCRIPTION
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12305

Regression? Last working version:

## Description

Missing copyright headers have been added to the .cs files that didn't contain them.  Unless otherwise stated in the file, the file is assumed to be licensed under Apache 2.0, and copyright assigned to the .NET Foundation.

In addition, consistent line spacing between the copyright header and first using/namespace line has been applied.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [ ] N/A
