### PR TITLE
Use Assembly.LoadFrom in NuGet.exe to ensure dependencies are properly loaded

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildUser.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildUser.cs
@@ -38,8 +38,8 @@ namespace NuGet.Common
             }
 
             _msbuildDirectory = msbuildDirectory;
-            _msbuildAssembly = Assembly.LoadFile(microsoftBuildDllPath);
-            _frameworkAssembly = Assembly.LoadFile(Path.Combine(msbuildDirectory, "Microsoft.Build.Framework.dll"));
+            _msbuildAssembly = Assembly.LoadFrom(microsoftBuildDllPath);
+            _frameworkAssembly = Assembly.LoadFrom(Path.Combine(msbuildDirectory, "Microsoft.Build.Framework.dll"));
 
             LoadTypes();
         }

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Solution.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Solution.cs
@@ -28,7 +28,7 @@ namespace NuGet.Common
 
             try
             {
-                var msbuildAssembly = Assembly.LoadFile(
+                var msbuildAssembly = Assembly.LoadFrom(
                     Path.Combine(msbuildPath, "Microsoft.Build.dll"));
                 switch (msbuildAssembly.GetName().Version.Major)
                 {


### PR DESCRIPTION


<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12137

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
`Assembly.LoadFile()` uses a different context and does not fire the `AppDomain.CurrentDomain.AssemblyResolve` event.  This leads to our code throwing an exception on newer versions of MSBuild that now pull in new assemblies and our code does not resolve them.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - End-to-end and functional tests should ensure that nothing fundamental is broken and I manually tested this scenario of restoring with an older version of MSBuild.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
