### PR TITLE
Test:  remove hack for testing preview .NET SDK

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -332,7 +332,6 @@ namespace Dotnet.Integration.Test
                     tfmProps["TargetFrameworkIdentifier"] = ".NETCoreApp";
                     tfmProps["TargetFrameworkVersion"] = "v3.1";
                     tfmProps["TargetFrameworkMoniker"] = ".NETCoreApp,Version=v3.1";
-                    tfmProps["RuntimeFrameworkVersion"] = "6.0";
                     ProjectFileUtils.AddProperties(xml, tfmProps, " '$(TargetFramework)' == 'myalias' ");
 
                     ProjectFileUtils.WriteXmlToFile(xml, stream);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/12150

Regression? Last working version:  N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This change removes a [workaround](https://github.com/NuGet/NuGet.Client/pull/4791/commits/02834c173867187a8044e4f5ed03b0e34b673b9f) that was necessary for a test to pass on an incoherent preview release of .NET 7 SDK.  [Now that we're testing a coherent GA release of .NET 7 SDK](https://github.com/NuGet/Home/issues/12302), the underlying issue is gone, and the workaround can be removed.

Side note: I also intend to backport this change in a separate PR to the release-6.4.x branch.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
