### PR TITLE
Skip OptProfV2 steps from release-5.7.x branch

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -72,7 +72,7 @@ steps:
     optimizationInputsDropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
     ShouldSkipOptimize: $(ShouldSkipOptimize)
     AccessToken: $(System.AccessToken)
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+  condition: false
 
 - task: PowerShell@1
   displayName: "Restore dotnet tools"
@@ -316,14 +316,14 @@ steps:
   inputs:
     command: 'custom'
     arguments: 'sources add -Name VS -Source $(VsPackageFeedUrl) -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+  condition: false
 
 - task: NuGetCommand@2
   displayName: 'OptProfV2:  install the NuGet package for building .runsettingsproj file'
   inputs:
     command: 'custom'
     arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.308 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+  condition: false
 
 - task: ms-vseng.MicroBuildTasks.0e9d0d4d-71ec-4e4e-ae40-db9896f1ae74.MicroBuildBuildVSBootstrapper@2
   displayName: 'OptProfV2:  build a Visual Studio bootstrapper'
@@ -333,7 +333,7 @@ steps:
     manifests: '$(Build.Repository.LocalPath)\artifacts\$(VsixPublishDir)\Microsoft.VisualStudio.NuGet.Core.vsman'
     outputFolder: '$(Build.Repository.LocalPath)\artifacts\$(VsixPublishDir)'
   continueOnError: true
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+  condition: false
 
 - task: PublishBuildArtifacts@1
   displayName: 'OptProfV2:  publish BootstrapperInfo.json as a build artifact'
@@ -341,7 +341,7 @@ steps:
     PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
     ArtifactName: MicroBuildOutputs
     ArtifactType: Container
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+  condition: false
 
 - task: PowerShell@1
   displayName: 'OptProfV2:  set the TestDrop environment variable'
@@ -355,7 +355,7 @@ steps:
       [string] $testDropPath = $buildDropPath.Replace('/Products/', '/Tests/').Substring('https://vsdrop.corp.microsoft.com/file/v1/'.Length)
       Write-Host "Test drop:  $testDropPath"
       Write-Host "##vso[task.setvariable variable=TestDrop]$testDropPath"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+  condition: false
 
 - task: MSBuild@1
   displayName: 'OptProfV2:  generate a .runsettings file'
@@ -363,7 +363,7 @@ steps:
     solution: 'build\NuGet.OptProfV2.runsettingsproj'
     msbuildVersion: '16.0'
     msbuildArguments: '/p:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /p:TestDrop="$(TestDrop)" /p:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)"'
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+  condition: false
 
 - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
   displayName: 'OptProfV2:  publish the .runsettings file to artifact services'
@@ -374,7 +374,7 @@ steps:
     toLowerCase: false
     usePat: false
     dropMetadataContainerName: RunSettings
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['ShouldSkipOptimize'], 'false'))"
+  condition: false
 
 - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
   displayName: 'OptProfV2:  publish profiling inputs to artifact services'
@@ -384,7 +384,7 @@ steps:
     sourcePath: '$(Build.ArtifactStagingDirectory)\OptProf\ProfilingInputs'
     toLowerCase: false
     usePat: false
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['ShouldSkipOptimize'], 'false'))"
+  condition: false
 
 - task: PublishBuildArtifacts@1
   displayName: "Publish NuGet.exe VSIX and EndToEnd.zip as artifact"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2009

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
After I merged https://github.com/NuGet/NuGet.Client/pull/4969 PR, [official build failed](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7062177&view=logs&j=2ea8c801-c4c3-578e-0ff0-bcf4c12d9404&t=6e892554-de6e-5c7c-d46f-75f654e0162f) while generating VS bootstrapper because VS 2019 16.7 is out of support now. In this PR, I propose to skip OptProfV2 steps because OptProf pipeline can't run without the bootstrapper.

```
OptProfV2: build a Visual Studio bootstrapper

[View raw log](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/builds/7062177/logs/169)

Starting: OptProfV2:  build a Visual Studio bootstrapper
==============================================================================
Task         : MicroBuild Build VS Bootstrapper
Description  : Builds a VS Bootstrapper including the changes of the manifests from one or more components
Version      : 2.4.3
Author       : Microsoft
Help         : [More Information](http://aka.ms/MicroBuild)
==============================================================================
Using the following ID to create the bootstrapper output folder: 024748fb-4415-4be5-a838-8122c1afc203
Downloading the channel manifest using the channel int.d16.7
Downloading manifest from the url https://aka.ms/vs/16/int.d16.7/channel to the location D:\a\_work\1\a\MicroBuild\intermediate\024748fb-4415-4be5-a838-8122c1afc203\manifests\BaseChannelManifest.chman
##[error]Failed to download the url https://aka.ms/vs/16/int.d16.7/channel to location D:\a\_work\1\a\MicroBuild\intermediate\024748fb-4415-4be5-a838-8122c1afc203\manifests\BaseChannelManifest.chman, due to exception 'System.Net.WebException: The remote server returned an error: (404) Not Found.
   at Microsoft.PowerShell.Commands.WebRequestPSCmdlet.GetResponse(WebRequest request)
   at Microsoft.PowerShell.Commands.WebRequestPSCmdlet.ProcessRecord()'
Finishing: OptProfV2:  build a Visual Studio bootstrapper
```
FYI - I manually triggered an [official build for this branch](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7063154&view=results). I will merge this PR only if the official build succeeds.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A
