### PR TITLE
Adds projectKind and projectId to PMUIRefresh event

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -361,19 +361,24 @@ namespace NuGet.PackageManagement.UI
 
         private void EmitRefreshEvent(TimeSpan timeSpan, RefreshOperationSource refreshOperationSource, RefreshOperationStatus status, bool isUIFiltering = false, double? duration = null)
         {
-            NuGetProjectKind projectKind = NuGetProjectKind.Unknown;
-            string projectId = null;
             if (Model.IsSolution)
             {
-                IProjectContextInfo project = Model.Context.Projects.First();
-                projectId = project.ProjectId;
-                projectKind = project.ProjectKind;
-            }
-
-            TelemetryActivity.EmitTelemetryEvent(
-                new PackageManagerUIRefreshEvent(
+                TelemetryActivity.EmitTelemetryEvent(PackageManagerUIRefreshEvent.ForSolution(
                     _sessionGuid,
-                    Model.IsSolution,
+                    refreshOperationSource,
+                    status,
+                    _topPanel.Filter.ToString(),
+                    isUIFiltering,
+                    timeSpan,
+                    duration));
+            }
+            else
+            {
+                IProjectContextInfo project = Model.Context.Projects.First();
+                string projectId = project.ProjectId;
+                NuGetProjectKind projectKind = project.ProjectKind;
+                TelemetryActivity.EmitTelemetryEvent(PackageManagerUIRefreshEvent.ForProject(
+                    _sessionGuid,
                     refreshOperationSource,
                     status,
                     _topPanel.Filter.ToString(),
@@ -382,6 +387,7 @@ namespace NuGet.PackageManagement.UI
                     duration,
                     projectId,
                     projectKind));
+            }
         }
 
         private void EmitPMUIClosingTelemetry()

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -367,7 +367,7 @@ namespace NuGet.PackageManagement.UI
                     _sessionGuid,
                     refreshOperationSource,
                     status,
-                    _topPanel.Filter.ToString(),
+                    UIUtility.ToContractsItemFilter(_topPanel.Filter),
                     isUIFiltering,
                     timeSpan,
                     duration));
@@ -381,7 +381,7 @@ namespace NuGet.PackageManagement.UI
                     _sessionGuid,
                     refreshOperationSource,
                     status,
-                    _topPanel.Filter.ToString(),
+                    UIUtility.ToContractsItemFilter(_topPanel.Filter),
                     isUIFiltering,
                     timeSpan,
                     duration,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -375,8 +375,6 @@ namespace NuGet.PackageManagement.UI
             else
             {
                 IProjectContextInfo project = Model.Context.Projects.First();
-                string projectId = project.ProjectId;
-                NuGetProjectKind projectKind = project.ProjectKind;
                 TelemetryActivity.EmitTelemetryEvent(PackageManagerUIRefreshEvent.ForProject(
                     _sessionGuid,
                     refreshOperationSource,
@@ -385,8 +383,8 @@ namespace NuGet.PackageManagement.UI
                     isUIFiltering,
                     timeSpan,
                     duration,
-                    projectId,
-                    projectKind));
+                    project.ProjectId,
+                    project.ProjectKind));
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -351,6 +351,10 @@ namespace NuGet.PackageManagement.UI
             if (_isExecutingAction)
             {
                 _isRefreshRequired = true;
+                if (Model.IsSolution)
+                {
+                    
+                }
                 EmitRefreshEvent(timeSpanSinceLastRefresh, source, RefreshOperationStatus.NoOp, isUIFiltering: false, duration: 0);
             }
             else
@@ -359,7 +363,7 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private void EmitRefreshEvent(TimeSpan timeSpan, RefreshOperationSource refreshOperationSource, RefreshOperationStatus status, bool isUIFiltering = false, double? duration = null)
+        private void EmitRefreshEvent(TimeSpan timeSpan, RefreshOperationSource refreshOperationSource, RefreshOperationStatus status, NuGetProjectKind projectKind, bool isUIFiltering = false, double? duration = null)
         {
             TelemetryActivity.EmitTelemetryEvent(
                 new PackageManagerUIRefreshEvent(
@@ -370,7 +374,8 @@ namespace NuGet.PackageManagement.UI
                     _topPanel.Filter.ToString(),
                     isUIFiltering,
                     timeSpan,
-                    duration));
+                    duration,
+                    projectKind));
         }
 
         private void EmitPMUIClosingTelemetry()
@@ -1259,7 +1264,8 @@ namespace NuGet.PackageManagement.UI
             finally
             {
                 sw.Stop();
-                EmitRefreshEvent(lastRefresh, source, refreshStatus, isUIFiltering, sw.Elapsed.TotalMilliseconds);
+                NuGetProjectKind projectKind = Model.IsSolution ? NuGetProjectKind.Unknown : Model.Context.Projects.First().ProjectKind;
+                EmitRefreshEvent(lastRefresh, source, refreshStatus, projectKind, isUIFiltering, sw.Elapsed.TotalMilliseconds);
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -361,7 +361,14 @@ namespace NuGet.PackageManagement.UI
 
         private void EmitRefreshEvent(TimeSpan timeSpan, RefreshOperationSource refreshOperationSource, RefreshOperationStatus status, bool isUIFiltering = false, double? duration = null)
         {
-            NuGetProjectKind projectKind = Model.IsSolution ? NuGetProjectKind.Unknown : Model.Context.Projects.First().ProjectKind;
+            NuGetProjectKind projectKind = NuGetProjectKind.Unknown;
+            string projectId = null;
+            if (Model.IsSolution)
+            {
+                IProjectContextInfo project = Model.Context.Projects.First();
+                projectId = project.ProjectId;
+                projectKind = project.ProjectKind;
+            }
 
             TelemetryActivity.EmitTelemetryEvent(
                 new PackageManagerUIRefreshEvent(
@@ -373,6 +380,7 @@ namespace NuGet.PackageManagement.UI
                     isUIFiltering,
                     timeSpan,
                     duration,
+                    projectId,
                     projectKind));
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -351,10 +351,6 @@ namespace NuGet.PackageManagement.UI
             if (_isExecutingAction)
             {
                 _isRefreshRequired = true;
-                if (Model.IsSolution)
-                {
-                    
-                }
                 EmitRefreshEvent(timeSpanSinceLastRefresh, source, RefreshOperationStatus.NoOp, isUIFiltering: false, duration: 0);
             }
             else
@@ -363,8 +359,10 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private void EmitRefreshEvent(TimeSpan timeSpan, RefreshOperationSource refreshOperationSource, RefreshOperationStatus status, NuGetProjectKind projectKind, bool isUIFiltering = false, double? duration = null)
+        private void EmitRefreshEvent(TimeSpan timeSpan, RefreshOperationSource refreshOperationSource, RefreshOperationStatus status, bool isUIFiltering = false, double? duration = null)
         {
+            NuGetProjectKind projectKind = Model.IsSolution ? NuGetProjectKind.Unknown : Model.Context.Projects.First().ProjectKind;
+
             TelemetryActivity.EmitTelemetryEvent(
                 new PackageManagerUIRefreshEvent(
                     _sessionGuid,
@@ -1264,8 +1262,7 @@ namespace NuGet.PackageManagement.UI
             finally
             {
                 sw.Stop();
-                NuGetProjectKind projectKind = Model.IsSolution ? NuGetProjectKind.Unknown : Model.Context.Projects.First().ProjectKind;
-                EmitRefreshEvent(lastRefresh, source, refreshStatus, projectKind, isUIFiltering, sw.Elapsed.TotalMilliseconds);
+                EmitRefreshEvent(lastRefresh, source, refreshStatus, isUIFiltering, sw.Elapsed.TotalMilliseconds);
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/PackageManagerUIRefreshEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/PackageManagerUIRefreshEvent.cs
@@ -3,6 +3,7 @@
 
 using System;
 using NuGet.Common;
+using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.PackageManagement.Telemetry
 {
@@ -18,7 +19,8 @@ namespace NuGet.PackageManagement.Telemetry
             string tab,
             bool isUIFiltering,
             TimeSpan timeSinceLastRefresh,
-            double? duration) : base(EventName)
+            double? duration,
+            NuGetProjectKind projectType) : base(EventName)
         {
             base["ParentId"] = parentId.ToString();
             base["IsSolutionLevel"] = isSolutionLevel;
@@ -27,6 +29,11 @@ namespace NuGet.PackageManagement.Telemetry
             base["Tab"] = tab;
             base["IsUIFiltering"] = isUIFiltering;
             base["TimeSinceLastRefresh"] = timeSinceLastRefresh.TotalMilliseconds;
+
+            if (!isSolutionLevel)
+            {
+                base["ProjectKind"] = projectType;
+            }
 
             if (duration.HasValue)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/PackageManagerUIRefreshEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/PackageManagerUIRefreshEvent.cs
@@ -16,7 +16,7 @@ namespace NuGet.PackageManagement.Telemetry
             bool isSolutionLevel,
             RefreshOperationSource refreshSource,
             RefreshOperationStatus refreshStatus,
-            string tab,
+            ItemFilter tab,
             bool isUIFiltering,
             TimeSpan timeSinceLastRefresh,
             double? duration,
@@ -27,7 +27,7 @@ namespace NuGet.PackageManagement.Telemetry
             base["IsSolutionLevel"] = isSolutionLevel;
             base["RefreshSource"] = refreshSource;
             base["RefreshStatus"] = refreshStatus;
-            base["Tab"] = tab ?? throw new ArgumentNullException(nameof(tab));
+            base["Tab"] = tab;
             base["IsUIFiltering"] = isUIFiltering;
             base["TimeSinceLastRefresh"] = timeSinceLastRefresh.TotalMilliseconds;
 
@@ -53,7 +53,7 @@ namespace NuGet.PackageManagement.Telemetry
             Guid parentId,
             RefreshOperationSource refreshSource,
             RefreshOperationStatus refreshStatus,
-            string tab,
+            ItemFilter tab,
             bool isUIFiltering,
             TimeSpan timeSinceLastRefresh,
             double? duration,
@@ -79,7 +79,7 @@ namespace NuGet.PackageManagement.Telemetry
                 Guid parentId,
                 RefreshOperationSource refreshSource,
                 RefreshOperationStatus refreshStatus,
-                string tab,
+                ItemFilter tab,
                 bool isUIFiltering,
                 TimeSpan timeSinceLastRefresh,
                 double? duration)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/PackageManagerUIRefreshEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/PackageManagerUIRefreshEvent.cs
@@ -20,7 +20,8 @@ namespace NuGet.PackageManagement.Telemetry
             bool isUIFiltering,
             TimeSpan timeSinceLastRefresh,
             double? duration,
-            NuGetProjectKind projectType) : base(EventName)
+            string projectId,
+            NuGetProjectKind projectKind) : base(EventName)
         {
             base["ParentId"] = parentId.ToString();
             base["IsSolutionLevel"] = isSolutionLevel;
@@ -32,7 +33,8 @@ namespace NuGet.PackageManagement.Telemetry
 
             if (!isSolutionLevel)
             {
-                base["ProjectKind"] = projectType;
+                base["ProjectKind"] = projectKind;
+                base["ProjectId"] = projectId;
             }
 
             if (duration.HasValue)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/PackageManagerUIRefreshEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/PackageManagerUIRefreshEvent.cs
@@ -11,7 +11,7 @@ namespace NuGet.PackageManagement.Telemetry
     {
         private const string EventName = "PMUIRefresh";
 
-        public PackageManagerUIRefreshEvent(
+        private PackageManagerUIRefreshEvent(
             Guid parentId,
             bool isSolutionLevel,
             RefreshOperationSource refreshSource,
@@ -20,27 +20,81 @@ namespace NuGet.PackageManagement.Telemetry
             bool isUIFiltering,
             TimeSpan timeSinceLastRefresh,
             double? duration,
-            string projectId,
-            NuGetProjectKind projectKind) : base(EventName)
+            string projectId = null,
+            NuGetProjectKind? projectKind = null) : base(EventName)
         {
             base["ParentId"] = parentId.ToString();
             base["IsSolutionLevel"] = isSolutionLevel;
             base["RefreshSource"] = refreshSource;
             base["RefreshStatus"] = refreshStatus;
-            base["Tab"] = tab;
+            base["Tab"] = tab ?? throw new ArgumentNullException(nameof(tab));
             base["IsUIFiltering"] = isUIFiltering;
             base["TimeSinceLastRefresh"] = timeSinceLastRefresh.TotalMilliseconds;
 
             if (!isSolutionLevel)
             {
-                base["ProjectKind"] = projectKind;
-                base["ProjectId"] = projectId;
+                if (projectId != null)
+                {
+                    base["ProjectId"] = projectId;
+                }
+                if (projectKind.HasValue)
+                {
+                    base["ProjectKind"] = projectKind;
+                }
             }
 
             if (duration.HasValue)
             {
                 base["Duration"] = duration;
             }
+        }
+
+        public static PackageManagerUIRefreshEvent ForProject(
+            Guid parentId,
+            RefreshOperationSource refreshSource,
+            RefreshOperationStatus refreshStatus,
+            string tab,
+            bool isUIFiltering,
+            TimeSpan timeSinceLastRefresh,
+            double? duration,
+            string projectId,
+            NuGetProjectKind projectKind)
+        {
+            var evt = new PackageManagerUIRefreshEvent(
+                parentId,
+                isSolutionLevel: false,
+                refreshSource,
+                refreshStatus,
+                tab,
+                isUIFiltering,
+                timeSinceLastRefresh,
+                duration,
+                projectId,
+                projectKind);
+
+            return evt;
+        }
+
+        public static PackageManagerUIRefreshEvent ForSolution(
+                Guid parentId,
+                RefreshOperationSource refreshSource,
+                RefreshOperationStatus refreshStatus,
+                string tab,
+                bool isUIFiltering,
+                TimeSpan timeSinceLastRefresh,
+                double? duration)
+        {
+            var evt = new PackageManagerUIRefreshEvent(
+                parentId,
+                isSolutionLevel: true,
+                refreshSource,
+                refreshStatus,
+                tab,
+                isUIFiltering,
+                timeSinceLastRefresh,
+                duration);
+
+            return evt;
         }
     }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Services\TestSharedServiceState.cs" />
     <Compile Include="Services\NuGetPackageSearchServiceTests.cs" />
     <Compile Include="Telemetry\ActionsTelemetryServiceTests.cs" />
+    <Compile Include="Telemetry\PackageManagerUIRefreshTelemetryTests.cs" />
     <Compile Include="Telemetry\TelemetryOnceEmitterTests.cs" />
     <Compile Include="Telemetry\HyperlinkClickedTelemetryEventTests.cs" />
     <Compile Include="Telemetry\IntervalTrackerTests.cs" />

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NuGetTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NuGetTelemetryServiceTests.cs
@@ -106,7 +106,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var expectedTab = "All";
             var expectedTimeSinceLastRefresh = TimeSpan.FromSeconds(1);
             var expectedDuration = TimeSpan.FromSeconds(1);
-            var refreshEvent = new PackageManagerUIRefreshEvent(expectedGuid, expectedIsSolutionLevel, expectedRefreshSource, expectedRefreshStatus, expectedTab, isUIFiltering: expectedUiFiltering, expectedTimeSinceLastRefresh, expectedDuration.TotalMilliseconds, It.IsAny<string>(), It.IsAny<NuGetProjectKind>());
+            var refreshEvent = PackageManagerUIRefreshEvent.ForSolution(expectedGuid, expectedRefreshSource, expectedRefreshStatus, expectedTab, isUIFiltering: expectedUiFiltering, expectedTimeSinceLastRefresh, expectedDuration.TotalMilliseconds);
             var target = new NuGetVSTelemetryService(telemetrySession.Object);
 
             // Act

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NuGetTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NuGetTelemetryServiceTests.cs
@@ -140,7 +140,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             var tab = lastTelemetryEvent["Tab"];
             Assert.NotNull(tab);
-            Assert.IsType<string>(tab);
+            Assert.IsType<ItemFilter>(tab);
             Assert.Equal(expectedTab, tab);
 
             var isUIFiltering = lastTelemetryEvent["IsUIFiltering"];

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NuGetTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NuGetTelemetryServiceTests.cs
@@ -106,7 +106,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var expectedTab = "All";
             var expectedTimeSinceLastRefresh = TimeSpan.FromSeconds(1);
             var expectedDuration = TimeSpan.FromSeconds(1);
-            var refreshEvent = new PackageManagerUIRefreshEvent(expectedGuid, expectedIsSolutionLevel, expectedRefreshSource, expectedRefreshStatus, expectedTab, isUIFiltering: expectedUiFiltering, expectedTimeSinceLastRefresh, expectedDuration.TotalMilliseconds, It.IsAny<NuGetProjectKind>());
+            var refreshEvent = new PackageManagerUIRefreshEvent(expectedGuid, expectedIsSolutionLevel, expectedRefreshSource, expectedRefreshStatus, expectedTab, isUIFiltering: expectedUiFiltering, expectedTimeSinceLastRefresh, expectedDuration.TotalMilliseconds, It.IsAny<string>(), It.IsAny<NuGetProjectKind>());
             var target = new NuGetVSTelemetryService(telemetrySession.Object);
 
             // Act

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NuGetTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NuGetTelemetryServiceTests.cs
@@ -7,6 +7,7 @@ using Moq;
 using NuGet.Common;
 using NuGet.PackageManagement.Telemetry;
 using NuGet.VisualStudio;
+using NuGet.VisualStudio.Internal.Contracts;
 using Xunit;
 
 namespace NuGet.PackageManagement.VisualStudio.Test
@@ -105,7 +106,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var expectedTab = "All";
             var expectedTimeSinceLastRefresh = TimeSpan.FromSeconds(1);
             var expectedDuration = TimeSpan.FromSeconds(1);
-            var refreshEvent = new PackageManagerUIRefreshEvent(expectedGuid, expectedIsSolutionLevel, expectedRefreshSource, expectedRefreshStatus, expectedTab, isUIFiltering: expectedUiFiltering, expectedTimeSinceLastRefresh, expectedDuration.TotalMilliseconds);
+            var refreshEvent = new PackageManagerUIRefreshEvent(expectedGuid, expectedIsSolutionLevel, expectedRefreshSource, expectedRefreshStatus, expectedTab, isUIFiltering: expectedUiFiltering, expectedTimeSinceLastRefresh, expectedDuration.TotalMilliseconds, It.IsAny<NuGetProjectKind>());
             var target = new NuGetVSTelemetryService(telemetrySession.Object);
 
             // Act

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NuGetTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NuGetTelemetryServiceTests.cs
@@ -103,7 +103,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             var expectedGuid = Guid.NewGuid();
             var expectedIsSolutionLevel = true;
-            var expectedTab = "All";
+            var expectedTab = ItemFilter.All;
             var expectedTimeSinceLastRefresh = TimeSpan.FromSeconds(1);
             var expectedDuration = TimeSpan.FromSeconds(1);
             var refreshEvent = PackageManagerUIRefreshEvent.ForSolution(expectedGuid, expectedRefreshSource, expectedRefreshStatus, expectedTab, isUIFiltering: expectedUiFiltering, expectedTimeSinceLastRefresh, expectedDuration.TotalMilliseconds);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/PackageManagerUIRefreshTelemetryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/PackageManagerUIRefreshTelemetryTests.cs
@@ -15,6 +15,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         public void PackageManagerUIRefreshEvent_Constructor_NoProjectKindIfIsSolutionLevelSetToTrue()
         {
             NuGetProjectKind kind = NuGetProjectKind.PackageReference;
+            string projectId = "simulated-project-id-Guid";
             var telemetryEvent = new PackageManagerUIRefreshEvent(
                 It.IsAny<Guid>(),
                 isSolutionLevel: true,
@@ -24,15 +25,18 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 isUIFiltering: It.IsAny<bool>(),
                 It.IsAny<TimeSpan>(),
                 It.IsAny<double?>(),
+                projectId,
                 kind);
 
             Assert.Null(telemetryEvent["ProjectKind"]);
+            Assert.Null(telemetryEvent["ProjectId"]);
         }
 
         [Fact]
         public void PackageManagerUIRefreshEvent_Constructor_ProjectKindIfIsSolutionLevelSetToFalse()
         {
             NuGetProjectKind kind = NuGetProjectKind.PackageReference;
+            string projectId = "simulated-project-id-Guid";
             var telemetryEvent = new PackageManagerUIRefreshEvent(
                 It.IsAny<Guid>(),
                 isSolutionLevel: false,
@@ -42,9 +46,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 isUIFiltering: It.IsAny<bool>(),
                 It.IsAny<TimeSpan>(),
                 It.IsAny<double?>(),
+                projectId,
                 kind);
 
             Assert.NotNull(telemetryEvent["ProjectKind"]);
+            Assert.NotNull(telemetryEvent["ProjectId"]);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/PackageManagerUIRefreshTelemetryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/PackageManagerUIRefreshTelemetryTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Moq;
+using NuGet.PackageManagement.Telemetry;
+using NuGet.VisualStudio.Internal.Contracts;
+using Xunit;
+
+namespace NuGet.PackageManagement.VisualStudio.Test
+{
+    public class PackageManagerUIRefreshTelemetryTests
+    {
+        [Fact]
+        public void PackageManagerUIRefreshEvent_Constructor_NoProjectKindIfIsSolutionLevelSetToTrue()
+        {
+            NuGetProjectKind kind = NuGetProjectKind.PackageReference;
+            var telemetryEvent = new PackageManagerUIRefreshEvent(
+                It.IsAny<Guid>(),
+                isSolutionLevel: true,
+                It.IsAny<RefreshOperationSource>(),
+                It.IsAny<RefreshOperationStatus>(),
+                tab: It.IsAny<string>(),
+                isUIFiltering: It.IsAny<bool>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<double?>(),
+                kind);
+
+            Assert.Null(telemetryEvent["ProjectKind"]);
+        }
+
+        [Fact]
+        public void PackageManagerUIRefreshEvent_Constructor_ProjectKindIfIsSolutionLevelSetToFalse()
+        {
+            NuGetProjectKind kind = NuGetProjectKind.PackageReference;
+            var telemetryEvent = new PackageManagerUIRefreshEvent(
+                It.IsAny<Guid>(),
+                isSolutionLevel: false,
+                It.IsAny<RefreshOperationSource>(),
+                It.IsAny<RefreshOperationStatus>(),
+                tab: It.IsAny<string>(),
+                isUIFiltering: It.IsAny<bool>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<double?>(),
+                kind);
+
+            Assert.NotNull(telemetryEvent["ProjectKind"]);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/PackageManagerUIRefreshTelemetryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/PackageManagerUIRefreshTelemetryTests.cs
@@ -12,34 +12,28 @@ namespace NuGet.PackageManagement.VisualStudio.Test
     public class PackageManagerUIRefreshTelemetryTests
     {
         [Fact]
-        public void PackageManagerUIRefreshEvent_Constructor_NoProjectKindIfIsSolutionLevelSetToTrue()
+        public void ForSolution_SimulatedData_NoProjectKindIfIsSolutionLevelSetToTrue()
         {
-            NuGetProjectKind kind = NuGetProjectKind.PackageReference;
-            string projectId = "simulated-project-id-Guid";
-            var telemetryEvent = new PackageManagerUIRefreshEvent(
+            var telemetryEvent = PackageManagerUIRefreshEvent.ForSolution(
                 It.IsAny<Guid>(),
-                isSolutionLevel: true,
                 It.IsAny<RefreshOperationSource>(),
                 It.IsAny<RefreshOperationStatus>(),
                 tab: It.IsAny<string>(),
                 isUIFiltering: It.IsAny<bool>(),
                 It.IsAny<TimeSpan>(),
-                It.IsAny<double?>(),
-                projectId,
-                kind);
+                It.IsAny<double?>());
 
             Assert.Null(telemetryEvent["ProjectKind"]);
             Assert.Null(telemetryEvent["ProjectId"]);
         }
 
         [Fact]
-        public void PackageManagerUIRefreshEvent_Constructor_ProjectKindIfIsSolutionLevelSetToFalse()
+        public void ForProject_SimulatedData_ProjectKindAndProjectIdSet()
         {
             NuGetProjectKind kind = NuGetProjectKind.PackageReference;
             string projectId = "simulated-project-id-Guid";
-            var telemetryEvent = new PackageManagerUIRefreshEvent(
+            var telemetryEvent = PackageManagerUIRefreshEvent.ForProject(
                 It.IsAny<Guid>(),
-                isSolutionLevel: false,
                 It.IsAny<RefreshOperationSource>(),
                 It.IsAny<RefreshOperationStatus>(),
                 tab: It.IsAny<string>(),

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/PackageManagerUIRefreshTelemetryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/PackageManagerUIRefreshTelemetryTests.cs
@@ -18,7 +18,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 It.IsAny<Guid>(),
                 It.IsAny<RefreshOperationSource>(),
                 It.IsAny<RefreshOperationStatus>(),
-                tab: It.IsAny<string>(),
+                tab: It.IsAny<ItemFilter>(),
                 isUIFiltering: It.IsAny<bool>(),
                 It.IsAny<TimeSpan>(),
                 It.IsAny<double?>());
@@ -36,7 +36,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 It.IsAny<Guid>(),
                 It.IsAny<RefreshOperationSource>(),
                 It.IsAny<RefreshOperationStatus>(),
-                tab: It.IsAny<string>(),
+                tab: It.IsAny<ItemFilter>(),
                 isUIFiltering: It.IsAny<bool>(),
                 It.IsAny<TimeSpan>(),
                 It.IsAny<double?>(),


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1997

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- Adds projectId and projectKind to PMUIRefresh event. These values are only emitted when PM UI is open for a project.
- Added two unit-tests.
- Modified type of `tab` parameter to ItemFilter enum values to mitigate unknown values.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added: 2 new tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A: No product changes


### Validation

On Project PM UI

![image](https://user-images.githubusercontent.com/1192347/207168659-af96def2-3829-437f-b66e-d86497842db9.png)


On Solution PM UI, no projectId and no projectKind

![image](https://user-images.githubusercontent.com/1192347/207168807-552e51b2-09fd-4aed-87a9-76d5a0a4570d.png)
