### PR TITLE
add missing test coverage for AbandonedMutexException in NuGet migrations logic

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
@@ -88,7 +88,7 @@ namespace NuGet.Common.Test
 
             void AbandonMutex()
             {
-                _orphan.WaitOne();
+                _orphan.WaitOne(TimeSpan.FromMinutes(1), false);
                 // Abandon the mutex by exiting the method without releasing
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
@@ -89,7 +89,7 @@ namespace NuGet.Common.Test
             void AbandonMutex()
             {
                 _orphan.WaitOne();
-                // Abandon the mutexes by exiting without releasing the it by invoking _orphan1.ReleaseMutex() method.
+                // Abandon the mutexes by exiting without releasing it by invoking _orphan1.ReleaseMutex() method.
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
@@ -89,7 +89,7 @@ namespace NuGet.Common.Test
             void AbandonMutex()
             {
                 _orphan.WaitOne();
-                // Abandon the mutexes by exiting without releasing it by invoking _orphan1.ReleaseMutex() method.
+                // Abandon the mutex by exiting the method without releasing
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
@@ -88,7 +88,7 @@ namespace NuGet.Common.Test
 
             void AbandonMutex()
             {
-                _orphan.WaitOne(TimeSpan.FromMinutes(1), false);
+                _ = _orphan.WaitOne(TimeSpan.FromMinutes(1), false);
                 // Abandon the mutex by exiting the method without releasing
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
@@ -73,22 +73,21 @@ namespace NuGet.Common.Test
             Thread t = new Thread(new ThreadStart(AbandonMutex));
             t.Start();
             t.Join();
+            Assert.True(signal, userMessage: "Failed to acquire the mutex.");
+            
+            string directory = MigrationRunner.GetMigrationsDirectory();
+            if (Directory.Exists(directory))
+                Directory.Delete(path: directory, recursive: true);
 
-            if (signal)
-            {
-                string directory = MigrationRunner.GetMigrationsDirectory();
-                if (Directory.Exists(directory))
-                    Directory.Delete(path: directory, recursive: true);
+            // Act
+            MigrationRunner.Run();
 
-                // Act
-                MigrationRunner.Run();
-
-                // Assert
-                Assert.True(Directory.Exists(directory));
-                var files = Directory.GetFiles(directory);
-                Assert.Equal(1, files.Length);
-                Assert.Equal(Path.Combine(directory, "1"), files[0]);
-            }
+            // Assert
+            Assert.True(Directory.Exists(directory));
+            var files = Directory.GetFiles(directory);
+            Assert.Equal(1, files.Length);
+            Assert.Equal(Path.Combine(directory, "1"), files[0]);
+            
 
             void AbandonMutex()
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Tracking: https://github.com/NuGet/Home/issues/12159

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

I noticed that test coverage is missing for a scenario when I addressed the linked (tracking) issue in https://github.com/NuGet/NuGet.Client/commit/41c08c5549ac3c738d5bf369014da059eff53fbd and https://github.com/NuGet/NuGet.Client/commit/3f3f9ecc62ead356dd0ec2f129d1c2806f8b73a4 commits. Basically, the scenario is, whenever a thread is abandoned because of the application has been terminated abruptly ([for example, by using Windows Task Manager](https://learn.microsoft.com/en-us/dotnet/api/system.threading.waithandle.waitone?view=net-7.0#Remarks)) then the next migration run executes successfully. No product changes are introduced in this PR.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A