### PR TITLE
UTs for ReportAbuseResourceV3Provider class

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/ReportAbuseResourceV3ProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/ReportAbuseResourceV3ProviderTests.cs
@@ -27,7 +27,7 @@ namespace NuGet.Protocol.Tests.Providers
         }
 
         [Fact]
-        public async Task TryCreate_WhenResourceDoesNotExist_ReturnsFallbackUri()
+        public async Task TryCreate_WhenResourceDoesNotExist_ReturnsFallbackUriAsync()
         {
             var resourceProviders = new ResourceProvider[]
             {
@@ -36,7 +36,7 @@ namespace NuGet.Protocol.Tests.Providers
             };
             var sourceRepository = new SourceRepository(_packageSource, resourceProviders);
 
-            var result = await _target.TryCreate(sourceRepository, CancellationToken.None);
+            Tuple<bool, INuGetResource> result = await _target.TryCreate(sourceRepository, CancellationToken.None);
 
             Assert.True(result.Item1);
             Assert.IsType<ReportAbuseResourceV3>(result.Item2);
@@ -51,7 +51,7 @@ namespace NuGet.Protocol.Tests.Providers
         [InlineData(null)]
         [InlineData("")]
         [InlineData("  \t\n")]
-        public async Task TryCreate_WhenResourceHasInvalidAbsoluteUri_ReturnsFallbackUri(string uri)
+        public async Task TryCreate_WhenResourceHasInvalidAbsoluteUri_ReturnsFallbackUriAsync(string uri)
         {
             var serviceEntry = new RawServiceIndexEntry(uri, ResourceType);
             var resourceProviders = new ResourceProvider[]
@@ -61,7 +61,7 @@ namespace NuGet.Protocol.Tests.Providers
             };
             var sourceRepository = new SourceRepository(_packageSource, resourceProviders);
 
-            var result = await _target.TryCreate(sourceRepository, CancellationToken.None);
+            Tuple<bool, INuGetResource> result = await _target.TryCreate(sourceRepository, CancellationToken.None);
 
             Assert.True(result.Item1);
             Assert.IsType<ReportAbuseResourceV3>(result.Item2);
@@ -69,11 +69,9 @@ namespace NuGet.Protocol.Tests.Providers
                          ((ReportAbuseResourceV3)result.Item2).GetReportAbuseUrl("MyPackage", NuGetVersion.Parse("1.0.0")).OriginalString);
         }
 
-        [Fact]
-        public async Task TryCreate_WhenResourceExists_ReturnsValidResource()
+        [Fact(Skip = "The behavior of ReportAbuseResourceV3Provider in this case is incorrect, and was reported in issue: https://github.com/NuGet/Home/issues/7478")]
+        public async Task TryCreate_WhenResourceExists_ReturnsValidResourceAsync()
         {
-            // The behavior of ReportAbuseResourceV3Provider in this case is incorrect, and was reported in issue: https://github.com/NuGet/Home/issues/7478
-
             var serviceEntry = new RawServiceIndexEntry("https://unit.test/packages/{id}/{version}/ReportAbuse", ResourceType);
             var resourceProviders = new ResourceProvider[]
             {
@@ -82,12 +80,12 @@ namespace NuGet.Protocol.Tests.Providers
             };
             var sourceRepository = new SourceRepository(_packageSource, resourceProviders);
 
-            var result = await _target.TryCreate(sourceRepository, CancellationToken.None);
+            Tuple<bool, INuGetResource> result = await _target.TryCreate(sourceRepository, CancellationToken.None);
 
             Assert.True(result.Item1);
             Assert.IsType<ReportAbuseResourceV3>(result.Item2);
             Assert.Equal(
-                "https://unit.test/packages/%7Bid%7D/%7Bversion%7D/ReportAbuse",
+                "https://unit.test/packages/MyPackage/1.0.0/ReportAbuse",
                 ((ReportAbuseResourceV3)result.Item2).GetReportAbuseUrl("MyPackage", NuGetVersion.Parse("1.0.0")).OriginalString);
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/RepositorySignatureResourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/RepositorySignatureResourceProviderTests.cs
@@ -20,14 +20,14 @@ namespace NuGet.Protocol.Providers.Tests
     [Collection(nameof(NotThreadSafeResourceCollection))]
     public class RepositorySignatureResourceProviderTests
     {
-        private const string _resourceType470 = "RepositorySignatures/4.7.0";
-        private const string _resourceType490 = "RepositorySignatures/4.9.0";
-        private const string _resourceType500 = "RepositorySignatures/5.0.0";
-        private const string _resourceUri470 = "https://unit.test/4.7.0";
-        private const string _resourceUri490 = "https://unit.test/4.9.0";
-        private const string _resourceUri500 = "https://unit.test/5.0.0";
+        private const string ResourceType470 = "RepositorySignatures/4.7.0";
+        private const string ResourceType490 = "RepositorySignatures/4.9.0";
+        private const string ResourceType500 = "RepositorySignatures/5.0.0";
+        private const string ResourceUri470 = "https://unit.test/4.7.0";
+        private const string ResourceUri490 = "https://unit.test/4.9.0";
+        private const string ResourceUri500 = "https://unit.test/5.0.0";
 
-        private static readonly SemanticVersion _defaultVersion = new SemanticVersion(0, 0, 0);
+        private static readonly SemanticVersion DefaultVersion = new SemanticVersion(0, 0, 0);
 
         private readonly PackageSource _packageSource;
         private readonly RepositorySignatureResourceProvider _repositorySignatureResourceProvider;
@@ -55,11 +55,11 @@ namespace NuGet.Protocol.Providers.Tests
         }
 
         [Theory]
-        [InlineData("http://unit.test/4.9.0", _resourceType490)]
-        [InlineData(@"\\localhost\unit\test\4.9.0", _resourceType490)]
+        [InlineData("http://unit.test/4.9.0", ResourceType490)]
+        [InlineData(@"\\localhost\unit\test\4.9.0", ResourceType490)]
         public async Task TryCreate_WhenUrlIsInvalid_Throws(string resourceUrl, string resourceType)
         {
-            var serviceEntry = new ServiceIndexEntry(new Uri(resourceUrl), resourceType, _defaultVersion);
+            var serviceEntry = new ServiceIndexEntry(new Uri(resourceUrl), resourceType, DefaultVersion);
             var resourceProviders = new ResourceProvider[]
             {
                 CreateServiceIndexResourceV3Provider(serviceEntry),
@@ -79,12 +79,12 @@ namespace NuGet.Protocol.Providers.Tests
         }
 
         [Theory]
-        [InlineData(_resourceUri500, _resourceType500)]
-        [InlineData(_resourceUri490, _resourceType490)]
-        [InlineData(_resourceUri470, _resourceType470)]
+        [InlineData(ResourceUri500, ResourceType500)]
+        [InlineData(ResourceUri490, ResourceType490)]
+        [InlineData(ResourceUri470, ResourceType470)]
         public async Task TryCreate_WhenOnlyOneResourceIsPresent_ReturnsThatResource(string resourceUrl, string resourceType)
         {
-            var serviceEntry = new ServiceIndexEntry(new Uri(resourceUrl), resourceType, _defaultVersion);
+            var serviceEntry = new ServiceIndexEntry(new Uri(resourceUrl), resourceType, DefaultVersion);
             var resourceProviders = new ResourceProvider[]
             {
                 CreateServiceIndexResourceV3Provider(serviceEntry),
@@ -111,9 +111,9 @@ namespace NuGet.Protocol.Providers.Tests
         [Fact]
         public async Task TryCreate_WhenMultipleResourcesArePresent_Returns500Resource()
         {
-            var serviceEntry470 = new ServiceIndexEntry(new Uri(_resourceUri470), _resourceType470, _defaultVersion);
-            var serviceEntry490 = new ServiceIndexEntry(new Uri(_resourceUri490), _resourceType490, _defaultVersion);
-            var serviceEntry500 = new ServiceIndexEntry(new Uri(_resourceUri500), _resourceType500, _defaultVersion);
+            var serviceEntry470 = new ServiceIndexEntry(new Uri(ResourceUri470), ResourceType470, DefaultVersion);
+            var serviceEntry490 = new ServiceIndexEntry(new Uri(ResourceUri490), ResourceType490, DefaultVersion);
+            var serviceEntry500 = new ServiceIndexEntry(new Uri(ResourceUri500), ResourceType500, DefaultVersion);
             var resourceProviders = new ResourceProvider[]
             {
                 CreateServiceIndexResourceV3Provider(serviceEntry470, serviceEntry490, serviceEntry500),
@@ -141,12 +141,12 @@ namespace NuGet.Protocol.Providers.Tests
         }
 
         [Theory]
-        [InlineData(_resourceUri500, _resourceType500, "repository_signatures_5.0.0")]
-        [InlineData(_resourceUri490, _resourceType490, "repository_signatures_4.9.0")]
-        [InlineData(_resourceUri470, _resourceType470, "repository_signatures_4.7.0")]
+        [InlineData(ResourceUri500, ResourceType500, "repository_signatures_5.0.0")]
+        [InlineData(ResourceUri490, ResourceType490, "repository_signatures_4.9.0")]
+        [InlineData(ResourceUri470, ResourceType470, "repository_signatures_4.7.0")]
         public async Task TryCreate_WhenResourceIsPresent_CreatesVersionedHttpCacheEntry(string resourceUrl, string resourceType, string expectedCacheKey)
         {
-            var serviceEntry = new ServiceIndexEntry(new Uri(resourceUrl), resourceType, _defaultVersion);
+            var serviceEntry = new ServiceIndexEntry(new Uri(resourceUrl), resourceType, DefaultVersion);
             var responses = new Dictionary<string, string>()
             {
                 { serviceEntry.Uri.AbsoluteUri, GetRepositorySignaturesResourceJson(resourceUrl) }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: 
Progress towards fixing https://github.com/NuGet/Home/issues/7478
Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
I was looking into a fix for `good first issue` https://github.com/NuGet/Home/issues/7478 
The root cause seems to be in https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Protocol/Providers/ReportAbuseResourceV3Provider.cs#L27 (the usage of AbsoluteUri).
Since this code isn't covered with UTs, I'm adding those in this PR, before fixing the issue. 

There are existing UTs here: https://github.com/NuGet/NuGet.Client/blob/dev/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ReportAbuseResourceV3Tests.cs
That cover a subset of the business logic. The new UTs duplicate some of those test cases, and we might consider combining/de-duping here.

Any and all feedback is welcome :)


p.s.
I have also updated naming of some members in other test files, because they were causing naming convention errors.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
