### PR TITLE
Migrates dotnet.exe NuGet sources commands to System.CommandLine

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/CommandParsers.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/CommandParsers.cs
@@ -18,7 +18,11 @@ namespace NuGet.CommandLine.XPlat.Commands
         public static void Register(Command app, Func<ILogger> getLogger, Func<Exception, int> commandExceptionHandler)
         {
             AddVerbParser.Register(app, getLogger, commandExceptionHandler);
+            DisableVerbParser.Register(app, getLogger, commandExceptionHandler);
+            EnableVerbParser.Register(app, getLogger, commandExceptionHandler);
             ListVerbParser.Register(app, getLogger, commandExceptionHandler);
+            RemoveVerbParser.Register(app, getLogger, commandExceptionHandler);
+            UpdateVerbParser.Register(app, getLogger, commandExceptionHandler);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/Commands.xml
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/Commands.xml
@@ -20,12 +20,57 @@
       <SeeAlso Title="sources command (nuget.exe)" Url="/nuget/reference/cli-reference/cli-ref-sources" />
     </Noun>
   </Verb>
+  <Verb Name="disable">
+    <Noun Name="source" Version="3.1.200"
+       Description="disables an existing source in your NuGet configuration files." >
+      <Argument Name="name" Help="SourcesCommandNameDescription" />
+      <SingleValueOption Name="configfile" Help="Option_ConfigFile"/>
+      <Example Title="Disable a source with name of `mySource`:" Command="dotnet nuget disable source mySource" />
+      <SeeAlso Title="Package source sections in NuGet.config files" Url="/nuget/reference/nuget-config-file#package-source-sections" />
+      <SeeAlso Title="sources command (nuget.exe)" Url="/nuget/reference/cli-reference/cli-ref-sources" />
+    </Noun>
+  </Verb>
+  <Verb Name="enable">
+    <Noun Name="source" Version="3.1.200"
+       Description="enables an existing source in your NuGet configuration files." >
+      <Argument Name="name" Help="SourcesCommandNameDescription" />
+      <SingleValueOption Name="configfile" Help="Option_ConfigFile"/>
+      <Example Title="Enable a source with name of `mySource`:" Command="dotnet nuget enable source mySource" />
+      <SeeAlso Title="Package source sections in NuGet.config files" Url="/nuget/reference/nuget-config-file#package-source-sections" />
+      <SeeAlso Title="sources command (nuget.exe)" Url="/nuget/reference/cli-reference/cli-ref-sources" />
+    </Noun>
+  </Verb>
   <Verb Name="list">
     <Noun Name="source" Version="3.1.200"
        Description="lists all existing sources from your NuGet configuration files." >
       <SingleValueOption Name="format" Help="SourcesCommandFormatDescription" />
       <SingleValueOption Name="configfile" Help="Option_ConfigFile"/>
       <Example Title="List configured sources from the current directory:" Command="dotnet nuget list source" />
+      <SeeAlso Title="Package source sections in NuGet.config files" Url="/nuget/reference/nuget-config-file#package-source-sections" />
+      <SeeAlso Title="sources command (nuget.exe)" Url="/nuget/reference/cli-reference/cli-ref-sources" />
+    </Noun>
+  </Verb>
+  <Verb Name="remove">
+    <Noun Name="source" Version="3.1.200"
+       Description="removes an existing source from your NuGet configuration files." >
+      <Argument Name="name" Help="SourcesCommandNameDescription" />
+      <SingleValueOption Name="configfile" Help="Option_ConfigFile"/>
+      <Example Title="Remove a source with name of `mySource`:" Command="dotnet nuget remove source mySource" />
+      <SeeAlso Title="Package source sections in NuGet.config files" Url="/nuget/reference/nuget-config-file#package-source-sections" />
+      <SeeAlso Title="sources command (nuget.exe)" Url="/nuget/reference/cli-reference/cli-ref-sources" />
+    </Noun>
+  </Verb>
+  <Verb Name="update">
+    <Noun Name="source" Version="3.1.200"
+       Description="updates an existing source in your NuGet configuration files." >
+      <Argument Name="name" Help="SourcesCommandNameDescription" />
+      <SingleValueOption Name="source" Shortcut="s" Help="SourcesCommandSourceDescription"/>
+      <SingleValueOption Name="username" Shortcut="u" Help="SourcesCommandUsernameDescription"/>
+      <SingleValueOption Name="password" Shortcut="p" Help="SourcesCommandPasswordDescription"/>
+      <SwitchOption Name="store-Password-In-Clear-Text" Help="SourcesCommandStorePasswordInClearTextDescription"/>
+      <SingleValueOption Name="valid-Authentication-Types" Help="SourcesCommandValidAuthenticationTypesDescription" />
+      <SingleValueOption Name="configfile" Help="Option_ConfigFile" />
+      <Example Title="Update a source with name of `mySource`:" Command="dotnet nuget update source mySource --source c:\packages" />
       <SeeAlso Title="Package source sections in NuGet.config files" Url="/nuget/reference/nuget-config-file#package-source-sections" />
       <SeeAlso Title="sources command (nuget.exe)" Url="/nuget/reference/cli-reference/cli-ref-sources" />
     </Noun>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/Commands.xml
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/Commands.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright (c) .NET Foundation. All rights reserved.
      Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. -->
+<!-- 
+Run CommandParsers.tt, CustomBinders.tt, VerbParsers.tt in this folder to update System.CommandLine command binding code
+-->
 <Commands>
   <Verb Name="add">
     <Noun Name="source" Version="3.1.200"

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/CustomBinders.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/CustomBinders.cs
@@ -52,6 +52,54 @@ namespace NuGet.CommandLine.XPlat.Commands
 
     /// <summary>Generated with CustomBinders.tt</summary>
     [System.CodeDom.Compiler.GeneratedCode("Microsoft.VisualStudio.TextTemplating.VSHost.TextTemplatingService", null)]
+    internal partial class DisableSourceCustomBinder : BinderBase<DisableSourceArgs>
+    {
+        private readonly Argument<string> _name;
+        private readonly Option<string> _configfile;
+
+        public DisableSourceCustomBinder(Argument<string> name, Option<string> configfile)
+        {
+            _name = name;
+            _configfile = configfile;
+        }
+
+        protected override DisableSourceArgs GetBoundValue(BindingContext bindingContext)
+        {
+            var returnValue = new DisableSourceArgs()
+            {
+                Name = bindingContext.ParseResult.GetValueForArgument(_name),
+                Configfile = bindingContext.ParseResult.GetValueForOption(_configfile),
+            };
+            return returnValue;
+        } // end GetBoundValue method
+    } // end class
+
+    /// <summary>Generated with CustomBinders.tt</summary>
+    [System.CodeDom.Compiler.GeneratedCode("Microsoft.VisualStudio.TextTemplating.VSHost.TextTemplatingService", null)]
+    internal partial class EnableSourceCustomBinder : BinderBase<EnableSourceArgs>
+    {
+        private readonly Argument<string> _name;
+        private readonly Option<string> _configfile;
+
+        public EnableSourceCustomBinder(Argument<string> name, Option<string> configfile)
+        {
+            _name = name;
+            _configfile = configfile;
+        }
+
+        protected override EnableSourceArgs GetBoundValue(BindingContext bindingContext)
+        {
+            var returnValue = new EnableSourceArgs()
+            {
+                Name = bindingContext.ParseResult.GetValueForArgument(_name),
+                Configfile = bindingContext.ParseResult.GetValueForOption(_configfile),
+            };
+            return returnValue;
+        } // end GetBoundValue method
+    } // end class
+
+    /// <summary>Generated with CustomBinders.tt</summary>
+    [System.CodeDom.Compiler.GeneratedCode("Microsoft.VisualStudio.TextTemplating.VSHost.TextTemplatingService", null)]
     internal partial class ListSourceCustomBinder : BinderBase<ListSourceArgs>
     {
         private readonly Option<string> _format;
@@ -68,6 +116,69 @@ namespace NuGet.CommandLine.XPlat.Commands
             var returnValue = new ListSourceArgs()
             {
                 Format = bindingContext.ParseResult.GetValueForOption(_format),
+                Configfile = bindingContext.ParseResult.GetValueForOption(_configfile),
+            };
+            return returnValue;
+        } // end GetBoundValue method
+    } // end class
+
+    /// <summary>Generated with CustomBinders.tt</summary>
+    [System.CodeDom.Compiler.GeneratedCode("Microsoft.VisualStudio.TextTemplating.VSHost.TextTemplatingService", null)]
+    internal partial class RemoveSourceCustomBinder : BinderBase<RemoveSourceArgs>
+    {
+        private readonly Argument<string> _name;
+        private readonly Option<string> _configfile;
+
+        public RemoveSourceCustomBinder(Argument<string> name, Option<string> configfile)
+        {
+            _name = name;
+            _configfile = configfile;
+        }
+
+        protected override RemoveSourceArgs GetBoundValue(BindingContext bindingContext)
+        {
+            var returnValue = new RemoveSourceArgs()
+            {
+                Name = bindingContext.ParseResult.GetValueForArgument(_name),
+                Configfile = bindingContext.ParseResult.GetValueForOption(_configfile),
+            };
+            return returnValue;
+        } // end GetBoundValue method
+    } // end class
+
+    /// <summary>Generated with CustomBinders.tt</summary>
+    [System.CodeDom.Compiler.GeneratedCode("Microsoft.VisualStudio.TextTemplating.VSHost.TextTemplatingService", null)]
+    internal partial class UpdateSourceCustomBinder : BinderBase<UpdateSourceArgs>
+    {
+        private readonly Argument<string> _name;
+        private readonly Option<string> _source;
+        private readonly Option<string> _username;
+        private readonly Option<string> _password;
+        private readonly Option<bool> _storePasswordInClearText;
+        private readonly Option<string> _validAuthenticationTypes;
+        private readonly Option<string> _configfile;
+
+        public UpdateSourceCustomBinder(Argument<string> name, Option<string> source, Option<string> username, Option<string> password, Option<bool> storePasswordInClearText, Option<string> validAuthenticationTypes, Option<string> configfile)
+        {
+            _name = name;
+            _source = source;
+            _username = username;
+            _password = password;
+            _storePasswordInClearText = storePasswordInClearText;
+            _validAuthenticationTypes = validAuthenticationTypes;
+            _configfile = configfile;
+        }
+
+        protected override UpdateSourceArgs GetBoundValue(BindingContext bindingContext)
+        {
+            var returnValue = new UpdateSourceArgs()
+            {
+                Name = bindingContext.ParseResult.GetValueForArgument(_name),
+                Source = bindingContext.ParseResult.GetValueForOption(_source),
+                Username = bindingContext.ParseResult.GetValueForOption(_username),
+                Password = bindingContext.ParseResult.GetValueForOption(_password),
+                StorePasswordInClearText = bindingContext.ParseResult.GetValueForOption(_storePasswordInClearText),
+                ValidAuthenticationTypes = bindingContext.ParseResult.GetValueForOption(_validAuthenticationTypes),
                 Configfile = bindingContext.ParseResult.GetValueForOption(_configfile),
             };
             return returnValue;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/VerbParsers.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/SystemCommandLine/VerbParsers.cs
@@ -98,6 +98,122 @@ namespace NuGet.CommandLine.XPlat.Commands
 
     /// <summary>Generated with VerbParsers.tt</summary>
     [System.CodeDom.Compiler.GeneratedCode("Microsoft.VisualStudio.TextTemplating.VSHost.TextTemplatingService", null)]
+    internal partial class DisableVerbParser
+    {
+        internal static Func<ILogger> GetLoggerFunction;
+        internal static Func<Exception, int> CommandExceptionHandler;
+
+        internal static Command Register(Command app, Func<ILogger> getLogger, Func<Exception, int> commandExceptionHandler)
+        {
+            var DisableCmd = new Command(name: "disable", description: Strings.Disable_Description);
+
+            // Options directly under the verb 'disable'
+
+            // noun sub-command: disable source
+            var SourceCmd = new Command(name: "source", description: Strings.DisableSourceCommandDescription);
+
+            // Options under sub-command: disable source
+            RegisterOptionsForCommandDisableSource(SourceCmd, getLogger);
+
+            DisableCmd.AddCommand(SourceCmd);
+
+            GetLoggerFunction = getLogger;
+            CommandExceptionHandler = commandExceptionHandler;
+            app.AddCommand(DisableCmd);
+
+            return DisableCmd;
+        } // End noun method
+
+        private static void RegisterOptionsForCommandDisableSource(Command cmd, Func<ILogger> getLogger)
+        {
+            var name_Argument = new Argument<string>(name: "name", description: Strings.SourcesCommandNameDescription)
+            {
+                Arity = ArgumentArity.ExactlyOne,
+            };
+            cmd.Add(name_Argument);
+            var configfile_Option = new Option<string>(name: "--configfile", description: Strings.Option_ConfigFile)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(configfile_Option);
+            // Create handler delegate handler for cmd
+            cmd.SetHandler((args) =>
+            {
+                int exitCode;
+                try
+                {
+                    DisableSourceRunner.Run(args, getLogger);
+                    exitCode = 0;
+                }
+                catch (Exception e)
+                {
+                    exitCode = CommandExceptionHandler(e);
+                }
+                return Task.FromResult(exitCode);
+            }, new DisableSourceCustomBinder(name_Argument, configfile_Option));
+        }
+    } // end class
+
+    /// <summary>Generated with VerbParsers.tt</summary>
+    [System.CodeDom.Compiler.GeneratedCode("Microsoft.VisualStudio.TextTemplating.VSHost.TextTemplatingService", null)]
+    internal partial class EnableVerbParser
+    {
+        internal static Func<ILogger> GetLoggerFunction;
+        internal static Func<Exception, int> CommandExceptionHandler;
+
+        internal static Command Register(Command app, Func<ILogger> getLogger, Func<Exception, int> commandExceptionHandler)
+        {
+            var EnableCmd = new Command(name: "enable", description: Strings.Enable_Description);
+
+            // Options directly under the verb 'enable'
+
+            // noun sub-command: enable source
+            var SourceCmd = new Command(name: "source", description: Strings.EnableSourceCommandDescription);
+
+            // Options under sub-command: enable source
+            RegisterOptionsForCommandEnableSource(SourceCmd, getLogger);
+
+            EnableCmd.AddCommand(SourceCmd);
+
+            GetLoggerFunction = getLogger;
+            CommandExceptionHandler = commandExceptionHandler;
+            app.AddCommand(EnableCmd);
+
+            return EnableCmd;
+        } // End noun method
+
+        private static void RegisterOptionsForCommandEnableSource(Command cmd, Func<ILogger> getLogger)
+        {
+            var name_Argument = new Argument<string>(name: "name", description: Strings.SourcesCommandNameDescription)
+            {
+                Arity = ArgumentArity.ExactlyOne,
+            };
+            cmd.Add(name_Argument);
+            var configfile_Option = new Option<string>(name: "--configfile", description: Strings.Option_ConfigFile)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(configfile_Option);
+            // Create handler delegate handler for cmd
+            cmd.SetHandler((args) =>
+            {
+                int exitCode;
+                try
+                {
+                    EnableSourceRunner.Run(args, getLogger);
+                    exitCode = 0;
+                }
+                catch (Exception e)
+                {
+                    exitCode = CommandExceptionHandler(e);
+                }
+                return Task.FromResult(exitCode);
+            }, new EnableSourceCustomBinder(name_Argument, configfile_Option));
+        }
+    } // end class
+
+    /// <summary>Generated with VerbParsers.tt</summary>
+    [System.CodeDom.Compiler.GeneratedCode("Microsoft.VisualStudio.TextTemplating.VSHost.TextTemplatingService", null)]
     internal partial class ListVerbParser
     {
         internal static Func<ILogger> GetLoggerFunction;
@@ -151,6 +267,147 @@ namespace NuGet.CommandLine.XPlat.Commands
                 }
                 return Task.FromResult(exitCode);
             }, new ListSourceCustomBinder(format_Option, configfile_Option));
+        }
+    } // end class
+
+    /// <summary>Generated with VerbParsers.tt</summary>
+    [System.CodeDom.Compiler.GeneratedCode("Microsoft.VisualStudio.TextTemplating.VSHost.TextTemplatingService", null)]
+    internal partial class RemoveVerbParser
+    {
+        internal static Func<ILogger> GetLoggerFunction;
+        internal static Func<Exception, int> CommandExceptionHandler;
+
+        internal static Command Register(Command app, Func<ILogger> getLogger, Func<Exception, int> commandExceptionHandler)
+        {
+            var RemoveCmd = new Command(name: "remove", description: Strings.Remove_Description);
+
+            // Options directly under the verb 'remove'
+
+            // noun sub-command: remove source
+            var SourceCmd = new Command(name: "source", description: Strings.RemoveSourceCommandDescription);
+
+            // Options under sub-command: remove source
+            RegisterOptionsForCommandRemoveSource(SourceCmd, getLogger);
+
+            RemoveCmd.AddCommand(SourceCmd);
+
+            GetLoggerFunction = getLogger;
+            CommandExceptionHandler = commandExceptionHandler;
+            app.AddCommand(RemoveCmd);
+
+            return RemoveCmd;
+        } // End noun method
+
+        private static void RegisterOptionsForCommandRemoveSource(Command cmd, Func<ILogger> getLogger)
+        {
+            var name_Argument = new Argument<string>(name: "name", description: Strings.SourcesCommandNameDescription)
+            {
+                Arity = ArgumentArity.ExactlyOne,
+            };
+            cmd.Add(name_Argument);
+            var configfile_Option = new Option<string>(name: "--configfile", description: Strings.Option_ConfigFile)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(configfile_Option);
+            // Create handler delegate handler for cmd
+            cmd.SetHandler((args) =>
+            {
+                int exitCode;
+                try
+                {
+                    RemoveSourceRunner.Run(args, getLogger);
+                    exitCode = 0;
+                }
+                catch (Exception e)
+                {
+                    exitCode = CommandExceptionHandler(e);
+                }
+                return Task.FromResult(exitCode);
+            }, new RemoveSourceCustomBinder(name_Argument, configfile_Option));
+        }
+    } // end class
+
+    /// <summary>Generated with VerbParsers.tt</summary>
+    [System.CodeDom.Compiler.GeneratedCode("Microsoft.VisualStudio.TextTemplating.VSHost.TextTemplatingService", null)]
+    internal partial class UpdateVerbParser
+    {
+        internal static Func<ILogger> GetLoggerFunction;
+        internal static Func<Exception, int> CommandExceptionHandler;
+
+        internal static Command Register(Command app, Func<ILogger> getLogger, Func<Exception, int> commandExceptionHandler)
+        {
+            var UpdateCmd = new Command(name: "update", description: Strings.Update_Description);
+
+            // Options directly under the verb 'update'
+
+            // noun sub-command: update source
+            var SourceCmd = new Command(name: "source", description: Strings.UpdateSourceCommandDescription);
+
+            // Options under sub-command: update source
+            RegisterOptionsForCommandUpdateSource(SourceCmd, getLogger);
+
+            UpdateCmd.AddCommand(SourceCmd);
+
+            GetLoggerFunction = getLogger;
+            CommandExceptionHandler = commandExceptionHandler;
+            app.AddCommand(UpdateCmd);
+
+            return UpdateCmd;
+        } // End noun method
+
+        private static void RegisterOptionsForCommandUpdateSource(Command cmd, Func<ILogger> getLogger)
+        {
+            var name_Argument = new Argument<string>(name: "name", description: Strings.SourcesCommandNameDescription)
+            {
+                Arity = ArgumentArity.ExactlyOne,
+            };
+            cmd.Add(name_Argument);
+            var source_Option = new Option<string>(aliases: new[] { "-s", "--source" }, description: Strings.SourcesCommandSourceDescription)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(source_Option);
+            var username_Option = new Option<string>(aliases: new[] { "-u", "--username" }, description: Strings.SourcesCommandUsernameDescription)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(username_Option);
+            var password_Option = new Option<string>(aliases: new[] { "-p", "--password" }, description: Strings.SourcesCommandPasswordDescription)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(password_Option);
+            var storePasswordInClearText_Option = new Option<bool>(name: "--store-password-in-clear-text", description: Strings.SourcesCommandStorePasswordInClearTextDescription)
+            {
+                Arity = ArgumentArity.Zero,
+            };
+            cmd.Add(storePasswordInClearText_Option);
+            var validAuthenticationTypes_Option = new Option<string>(name: "--valid-authentication-types", description: Strings.SourcesCommandValidAuthenticationTypesDescription)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(validAuthenticationTypes_Option);
+            var configfile_Option = new Option<string>(name: "--configfile", description: Strings.Option_ConfigFile)
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+            cmd.Add(configfile_Option);
+            // Create handler delegate handler for cmd
+            cmd.SetHandler((args) =>
+            {
+                int exitCode;
+                try
+                {
+                    UpdateSourceRunner.Run(args, getLogger);
+                    exitCode = 0;
+                }
+                catch (Exception e)
+                {
+                    exitCode = CommandExceptionHandler(e);
+                }
+                return Task.FromResult(exitCode);
+            }, new UpdateSourceCustomBinder(name_Argument, source_Option, username_Option, password_Option, storePasswordInClearText_Option, validAuthenticationTypes_Option, configfile_Option));
         }
     } // end class
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/AddSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/AddSourceTests.cs
@@ -39,7 +39,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             int statusNew = newCli.Invoke(new[] { "add", "source", "https://api.nuget.org/v3/index.json", "--name", "NuGetV3", "--configfile", file2 });
 
             // Assert
-            CommandTestUtils.AssertBothCommandSuccessfulExecution(statusCurrent, statusNew, testLoggerCurrent, testLoggerNew);
+            CommandTestUtils.AssertEqualCommandOutput(statusCurrent, statusNew, testLoggerCurrent, testLoggerNew);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/CommandTestUtils.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/CommandTestUtils.cs
@@ -10,7 +10,7 @@ namespace NuGet.CommandLine.Xplat.Tests
 {
     internal static class CommandTestUtils
     {
-        internal static void AssertBothCommandSuccessfulExecution(int statusCurrent, int statusNew, TestLogger loggerCurrent, TestLogger loggerNew)
+        internal static void AssertEqualCommandOutput(int statusCurrent, int statusNew, TestLogger loggerCurrent, TestLogger loggerNew)
         {
             Assert.Equal(0, statusCurrent);
             Assert.Equal(0, statusNew);

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/DisableSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/DisableSourceTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.CommandLine;
+using Microsoft.Extensions.CommandLineUtils;
+using NuGet.CommandLine.XPlat;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.Xplat.Tests
+{
+    public class DisableSourceTests
+    {
+        [Fact]
+        public void DisableSource_RunSameCommandInBothCommandLineInterfaces_CommandOutputEqual()
+        {
+            // Arrange
+            string file1 = Path.GetTempFileName();
+            string file2 = Path.GetTempFileName();
+
+            var prepareSourceCmd1 = new[] {"add", "source", "https://api.nuget.org/v3/index.json", "--name", "NuGetV3", "--configfile", file1};
+            var prepareSourceCmd2 = new[] {"add", "source", "https://api.nuget.org/v3/index.json", "--name", "NuGetV3", "--configfile", file2};
+            var cmd1 = new[] {"disable", "source", "NuGetV3", "--configfile", file1};
+            var cmd2 = new[] {"disable", "source", "NuGetV3", "--configfile", file2};
+
+            var currentCli = new CommandLineApplication();
+            var testLoggerCurrent = new TestLogger();
+            ListVerbParser.Register(currentCli, () => testLoggerCurrent);
+
+            var newCli = new RootCommand();
+            var testLoggerNew = new TestLogger();
+            XPlat.Commands.ListVerbParser.Register(newCli, getLogger: () => testLoggerNew, commandExceptionHandler: e =>
+            {
+                XPlat.Program.LogException(e, testLoggerNew);
+                return 1;
+            });
+
+            // Arrange sources
+            Assert.Equal(0, currentCli.Execute(prepareSourceCmd1));
+            Assert.Equal(0, newCli.Execute(prepareSourceCmd2));
+
+            // Act
+            int statusCurrent = currentCli.Execute(cmd1);
+            int statusNew = newCli.Invoke(cmd2);
+
+            // Assert
+            CommandTestUtils.AssertBothCommandSuccessfulExecution(statusCurrent, statusNew, testLoggerCurrent, testLoggerNew);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/DisableSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/DisableSourceTests.cs
@@ -53,7 +53,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             int statusNew = newCli.Invoke(cmd2);
 
             // Assert
-            CommandTestUtils.AssertBothCommandSuccessfulExecution(statusCurrent, statusNew, testLoggerCurrent, testLoggerNew);
+            CommandTestUtils.AssertEqualCommandOutput(statusCurrent, statusNew, testLoggerCurrent, testLoggerNew);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/EnableSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/EnableSourceTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.CommandLine;
+using System.IO;
+using Microsoft.Extensions.CommandLineUtils;
+using NuGet.CommandLine.XPlat;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.Xplat.Tests
+{
+    public class EnableSourceTests
+    {
+        [Fact]
+        public void EnableSource_RunSameCommandInBothCommandLineInterfaces_CommandOutputEqual()
+        {
+            // Arrange
+            string file1 = Path.GetTempFileName();
+            string file2 = Path.GetTempFileName();
+            string initialConfig = @"<configuration>
+  <packageSources>
+    <add key=""nugetv3"" value=""https://api.nuget.org/v3/index.json2"" />
+  </packageSources>
+  <disabledPackageSources>
+    <add key=""nugetv3"" value=""true"" />
+  </disabledPackageSources>
+</configuration>";
+            File.WriteAllText(file1, initialConfig);
+            File.WriteAllText(file2, initialConfig);
+
+            var enableSourceCmd1 = new[] {"enable", "source", "NuGetV3", "--configfile", file1};
+            var enableSourceCmd2 = new[] {"enable", "source", "NuGetV3", "--configfile", file2};
+
+            var currentCli = new CommandLineApplication();
+            var testLoggerCurrent = new TestLogger();
+            EnableVerbParser.Register(currentCli, () => testLoggerCurrent);
+
+            var newCli = new RootCommand();
+            var testLoggerNew = new TestLogger();
+            XPlat.Commands.EnableVerbParser.Register(newCli, getLogger: () => testLoggerNew, commandExceptionHandler: e =>
+            {
+                XPlat.Program.LogException(e, testLoggerNew);
+                return 1;
+            });
+
+            // Act
+            int statusCurrent = currentCli.Execute(enableSourceCmd1);
+            int statusNew = newCli.Invoke(enableSourceCmd2);
+
+            // Assert
+            CommandTestUtils.AssertBothCommandSuccessfulExecution(statusCurrent, statusNew, testLoggerCurrent, testLoggerNew);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/EnableSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/EnableSourceTests.cs
@@ -49,7 +49,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             int statusNew = newCli.Invoke(enableSourceCmd2);
 
             // Assert
-            CommandTestUtils.AssertBothCommandSuccessfulExecution(statusCurrent, statusNew, testLoggerCurrent, testLoggerNew);
+            CommandTestUtils.AssertEqualCommandOutput(statusCurrent, statusNew, testLoggerCurrent, testLoggerNew);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/ListSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/ListSourceTests.cs
@@ -34,7 +34,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             int statusNew = newCli.Invoke(cmd);
 
             // Assert
-            CommandTestUtils.AssertBothCommandSuccessfulExecution(statusCurrent, statusNew, testLoggerCurrent, testLoggerNew);
+            CommandTestUtils.AssertEqualCommandOutput(statusCurrent, statusNew, testLoggerCurrent, testLoggerNew);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/RemoveSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/RemoveSourceTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.CommandLine;
+using System.IO;
+using Microsoft.Extensions.CommandLineUtils;
+using NuGet.CommandLine.XPlat;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.Xplat.Tests
+{
+    public class RemoveSourceTests
+    {
+        [Fact]
+        public void RemoveSource_RunSameCommandInBothCommandLineInterfaces_CommandOutputEqual()
+        {
+            // Arrange
+            string file1 = Path.GetTempFileName();
+            string file2 = Path.GetTempFileName();
+            string initialConfig = @"<configuration>
+  <packageSources>
+    <add key=""nugetv3"" value=""https://api.nuget.org/v3/index.json2"" />
+  </packageSources>
+</configuration>";
+            File.WriteAllText(file1, initialConfig);
+            File.WriteAllText(file2, initialConfig);
+
+            var enableSourceCmd1 = new[] {"remove", "source", "NuGetV3", "--configfile", file1};
+            var enableSourceCmd2 = new[] {"remove", "source", "NuGetV3", "--configfile", file2};
+
+            var currentCli = new CommandLineApplication();
+            var testLoggerCurrent = new TestLogger();
+            RemoveVerbParser.Register(currentCli, () => testLoggerCurrent);
+
+            var newCli = new RootCommand();
+            var testLoggerNew = new TestLogger();
+            XPlat.Commands.RemoveVerbParser.Register(newCli, getLogger: () => testLoggerNew, commandExceptionHandler: e =>
+            {
+                XPlat.Program.LogException(e, testLoggerNew);
+                return 1;
+            });
+
+            // Act
+            int statusCurrent = currentCli.Execute(enableSourceCmd1);
+            int statusNew = newCli.Invoke(enableSourceCmd2);
+
+            // Assert
+            CommandTestUtils.AssertBothCommandSuccessfulExecution(statusCurrent, statusNew, testLoggerCurrent, testLoggerNew);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/RemoveSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/RemoveSourceTests.cs
@@ -46,7 +46,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             int statusNew = newCli.Invoke(enableSourceCmd2);
 
             // Assert
-            CommandTestUtils.AssertBothCommandSuccessfulExecution(statusCurrent, statusNew, testLoggerCurrent, testLoggerNew);
+            CommandTestUtils.AssertEqualCommandOutput(statusCurrent, statusNew, testLoggerCurrent, testLoggerNew);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/UpdateSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/UpdateSourceTests.cs
@@ -46,7 +46,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             int statusNew = newCli.Invoke(enableSourceCmd2);
 
             // Assert
-            CommandTestUtils.AssertBothCommandSuccessfulExecution(statusCurrent, statusNew, testLoggerCurrent, testLoggerNew);
+            CommandTestUtils.AssertEqualCommandOutput(statusCurrent, statusNew, testLoggerCurrent, testLoggerNew);
             Assert.NotEqual(initialConfig, File.ReadAllText(file1));
             Assert.NotEqual(initialConfig, File.ReadAllText(file2));
         }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/UpdateSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/UpdateSourceTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.CommandLine;
+using System.IO;
+using Microsoft.Extensions.CommandLineUtils;
+using NuGet.CommandLine.XPlat;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.Xplat.Tests
+{
+    public class UpdateSourceTests
+    {
+        [Fact]
+        public void UpdateSource_RunSameCommandInBothCommandLineInterfaces_CommandOutputEqual()
+        {
+            // Arrange
+            string file1 = Path.GetTempFileName();
+            string file2 = Path.GetTempFileName();
+            string initialConfig = @"<configuration>
+  <packageSources>
+    <add key=""nugetv3"" value=""https://api.nuget.org/v3/index.json2"" />
+  </packageSources>
+</configuration>";
+            File.WriteAllText(file1, initialConfig);
+            File.WriteAllText(file2, initialConfig);
+
+            var enableSourceCmd1 = new[] {"update", "source", "nugetv3", "--configfile", file1, "--username", "user", "--password", "pass", "--store-password-in-clear-text"};
+            var enableSourceCmd2 = new[] {"update", "source", "nugetv3", "--configfile", file2, "--username", "user", "--password", "pass", "--store-password-in-clear-text"};
+
+            var currentCli = new CommandLineApplication();
+            var testLoggerCurrent = new TestLogger();
+            UpdateVerbParser.Register(currentCli, () => testLoggerCurrent);
+
+            var newCli = new RootCommand();
+            var testLoggerNew = new TestLogger();
+            XPlat.Commands.UpdateVerbParser.Register(newCli, getLogger: () => testLoggerNew, commandExceptionHandler: e =>
+            {
+                XPlat.Program.LogException(e, testLoggerNew);
+                return 1;
+            });
+
+            // Act
+            int statusCurrent = currentCli.Execute(enableSourceCmd1);
+            int statusNew = newCli.Invoke(enableSourceCmd2);
+
+            // Assert
+            CommandTestUtils.AssertBothCommandSuccessfulExecution(statusCurrent, statusNew, testLoggerCurrent, testLoggerNew);
+            Assert.NotEqual(initialConfig, File.ReadAllText(file1));
+            Assert.NotEqual(initialConfig, File.ReadAllText(file2));
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2094

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- Migrates remove, disable, enable, update sources commands to System.CommandLine. This code is autogenerated using the templates
- Adds tests to verify both command implementations (System.CommandLine and CommandLineUtils) have the same command output in simple scenarios

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A: Not major product changes.
