### PR TITLE
Return default format in SemanticVersion's last chance ToString

### DIFF
--- a/src/NuGet.Core/NuGet.Versioning/SemanticVersionBase.cs
+++ b/src/NuGet.Core/NuGet.Versioning/SemanticVersionBase.cs
@@ -42,12 +42,10 @@ namespace NuGet.Versioning
         /// </summary>
         public virtual string ToString(string format, IFormatProvider formatProvider)
         {
-            string formattedString = null;
-
             if (formatProvider == null
-                || !TryFormatter(format, formatProvider, out formattedString))
+                || !TryFormatter(format, formatProvider, out string formattedString))
             {
-                formattedString = ToString();
+                formattedString = Major + "." + Minor + "." + Patch;
             }
 
             return formattedString;

--- a/src/NuGet.Core/NuGet.Versioning/SemanticVersionBase.cs
+++ b/src/NuGet.Core/NuGet.Versioning/SemanticVersionBase.cs
@@ -45,7 +45,7 @@ namespace NuGet.Versioning
             if (formatProvider == null
                 || !TryFormatter(format, formatProvider, out string formattedString))
             {
-                formattedString = Major + "." + Minor + "." + Patch;
+                return ToString();
             }
 
             return formattedString;

--- a/src/NuGet.Core/NuGet.Versioning/VersionFormatter.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionFormatter.cs
@@ -54,7 +54,7 @@ namespace NuGet.Versioning
         {
             if (formatType == typeof(ICustomFormatter)
                 || formatType == typeof(NuGetVersion)
-                || formatType == typeof(SemanticVersion))
+                || typeof(SemanticVersion).IsAssignableFrom(formatType))
             {
                 return this;
             }

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/SemanticVersionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/SemanticVersionTests.cs
@@ -97,5 +97,23 @@ namespace NuGet.Versioning.Test
             Assert.False(result);
             Assert.Null(semanticVersion);
         }
+
+        [Fact]
+        public void ToString_ClassExtendingSemanticVersion_ReturnsDefaultFormat()
+        {
+            ExtendedSemanticVersion target = new(1, 2, 3);
+
+            string result = target.ToString();
+
+            Assert.Equal("1.2.3", result);
+        }
+
+        private class ExtendedSemanticVersion : SemanticVersion
+        {
+            public ExtendedSemanticVersion(int major, int minor, int patch)
+                : base(major, minor, patch)
+            {
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12330

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

`SemanticVersion.ToString()` calls `ToNormalizedString()`, which calls `ToString("N", VersionFormatter.Instance)`, however, `VersionFormatter` does type checking and refuses to work except with `SemanticVersion` and `NuGetVersion`. In which case, `ToString(string, IFormatProvider)` will fall back to `ToString()`, which therefore causes infinite recursion until stack overflow.

This PR changes `VersionFormatter` to work with anything that extends `SemanticVersion`, so default `ToString()` works without having to override anything.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
