### PR TITLE
Fix User-Agent when OSDescription has unmatched parenthesis

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/UserAgentStringBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol/UserAgentStringBuilder.cs
@@ -36,7 +36,12 @@ namespace NuGet.Protocol.Core.Types
 
         public UserAgentStringBuilder WithOSDescription(string osInfo)
         {
-            _osInfo = osInfo;
+#if NETCOREAPP2_0_OR_GREATER
+            _osInfo = osInfo.Replace("(", @"\(", StringComparison.Ordinal).Replace(")", @"\)", StringComparison.Ordinal);
+#else
+            _osInfo = osInfo.Replace("(", @"\(").Replace(")", @"\)");
+#endif
+
             return this;
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/UserAgentStringBuilderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/UserAgentStringBuilderTests.cs
@@ -103,11 +103,14 @@ namespace NuGet.Protocol.Tests
         [InlineData("Custom Kernel 123)")]
         public void Build_OsDescriptionWithUnmatchedParenthesis_IsValid(string osDescription)
         {
-            var target = new UserAgentStringBuilder();
+            // Arrange
+            UserAgentStringBuilder target = new();
 
-            var result = target.WithOSDescription(osDescription).Build();
+            // Act
+            string result = target.WithOSDescription(osDescription).Build();
 
-            var httpRequest = new HttpRequestMessage();
+            // Assert
+            HttpRequestMessage httpRequest = new();
             httpRequest.Headers.Add("User-Agent", result);
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/UserAgentStringBuilderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/UserAgentStringBuilderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Net.Http;
 using NuGet.Protocol.Core.Types;
 using Xunit;
 using Xunit.Abstractions;
@@ -95,6 +96,19 @@ namespace NuGet.Protocol.Tests
             Assert.True(userAgentString2.Contains(builder.NuGetClientVersion));
             Assert.True(userAgentString3.Contains(builder.NuGetClientVersion));
             Assert.True(userAgentString4.Contains(builder.NuGetClientVersion));
+        }
+
+        [Theory]
+        [InlineData("Custom Kernel (123")]
+        [InlineData("Custom Kernel 123)")]
+        public void Build_OsDescriptionWithUnmatchedParenthesis_IsValid(string osDescription)
+        {
+            var target = new UserAgentStringBuilder();
+
+            var result = target.WithOSDescription(osDescription).Build();
+
+            var httpRequest = new HttpRequestMessage();
+            httpRequest.Headers.Add("User-Agent", result);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11995

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

HTTP header syntax has [a section/token/syntax called `comment`](https://httpwg.org/specs/rfc9110.html#comments), which is surrounded by parenthesis, but the comment itself can have a nested comment. In other words, the opening and closing parenthesis must be balanced.

Since we pass `RuntimeInformation.OSDescription` as a comment in NuGet's `User-Agent` header, we need to sanitize the input (escape the parenthesis), just in case it has unbalanced parenthesis. Even when they are balanced, NuGet isn't using it to provide a comment on the rest of the string, so I believe it's valid to always escape them.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
