### PR TITLE
Fix WebSite projects opened from IIS

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -25,8 +25,7 @@ namespace NuGet.VisualStudio
         public static string GetProjectPath(IVsHierarchy project)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            var format = (IPersistFileFormat)project;
-            format.GetCurFile(out string projectPath, out uint _);
+            project.GetCanonicalName((uint)VSConstants.VSITEMID.Root, out string projectPath);
             return projectPath;
         }
 


### PR DESCRIPTION
IPersistFileFormat.GetCurFile was strangely returning the IIS http(s) URL, not the local folder name.
GetCanonicalName is returning the path, with trailing \, so that Path.GetDirectory will still return the same path

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12337

Regression? **yes**
Last working version: 6.3.x

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

https://github.com/NuGet/NuGet.Client/pull/4698 was aimed at reducing usage of `DTE`, but it also changed `VsHierarchyUtility.GetProjectPath` from using `IVsHierarchy.GetCanonicalName` to `IPersistFileFormat.GetCurFile`.

However, when a WebSite project is loaded from the UI to select a local IIS directory, rather than loading a solution file that already has the path to the folder, `IPersistFileFormat` will strangely return the `http(s)` URL, not the filesystem path, to the project/website folder.

Given the previous PR was aimed at reducing `DTE` usage, and `IVsHierarchy` is not `DTE`, it's not clear to me why this was changed. It's not described in the PR either, so I don't see any reason to assume there's a problem changing it back.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] **Test exception**: Requires IIS to be installed on the test machine, IIS must have a web application configured, and the website project to be loaded from the IIS configuration, not a solution file or new project.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
