### PR TITLE
Recalculate PackageSource generated properties on Source change

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceFormatter.cs
@@ -50,7 +50,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                 }
             }
 
-            return new PackageSource(source, name, isEnabled)
+            return new PackageSource(source!, name!, isEnabled)
             {
                 IsMachineWide = isMachineWide
             };

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -55,7 +57,7 @@ namespace NuGet.Configuration
                 {
                     _isHttps = false;
                     _isHttp = false;
-                    Uri uri = TrySourceAsUri;
+                    Uri? uri = TrySourceAsUri;
                     _isLocal = uri != null ? uri.IsFile : false;
                 }
             }
@@ -64,7 +66,7 @@ namespace NuGet.Configuration
         /// <summary>
         /// Returns null if Source is an invalid URI
         /// </summary>
-        public Uri TrySourceAsUri => UriUtility.TryCreateSourceUri(Source, UriKind.Absolute);
+        public Uri? TrySourceAsUri => UriUtility.TryCreateSourceUri(Source, UriKind.Absolute);
 
         /// <summary>
         /// Throws if Source is an invalid URI
@@ -81,15 +83,15 @@ namespace NuGet.Configuration
 
         public bool IsEnabled { get; set; }
 
-        public PackageSourceCredential Credentials { get; set; }
+        public PackageSourceCredential? Credentials { get; set; }
 
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         public bool IsPersistable { get; private set; }
 
         public int MaxHttpRequestsPerSource { get; set; }
 
-        public IReadOnlyList<X509Certificate> ClientCertificates { get; set; }
+        public IReadOnlyList<X509Certificate>? ClientCertificates { get; set; }
 
         /// <summary>
         /// Gets or sets the protocol version of the source. Defaults to 2.
@@ -134,7 +136,7 @@ namespace NuGet.Configuration
             bool isPersistable = true)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
-            Source = source ?? throw new ArgumentNullException(nameof(source));
+            Source = _source = source ?? throw new ArgumentNullException(nameof(source));
             IsEnabled = isEnabled;
             IsOfficial = isOfficial;
             IsPersistable = isPersistable;
@@ -142,7 +144,7 @@ namespace NuGet.Configuration
 
         public SourceItem AsSourceItem()
         {
-            string protocolVersion = null;
+            string? protocolVersion = null;
             if (ProtocolVersion != DefaultProtocolVersion)
             {
                 protocolVersion = $"{ProtocolVersion}";
@@ -150,7 +152,7 @@ namespace NuGet.Configuration
             return new SourceItem(Name, Source, protocolVersion);
         }
 
-        public bool Equals(PackageSource other)
+        public bool Equals(PackageSource? other)
         {
             if (other == null)
             {
@@ -161,7 +163,7 @@ namespace NuGet.Configuration
                    Source.Equals(other.Source, StringComparison.OrdinalIgnoreCase);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var source = obj as PackageSource;
             if (source != null)

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -19,7 +19,6 @@ namespace NuGet.Configuration
         public const int DefaultProtocolVersion = 2;
 
         private int _hashCode;
-
         private string _source;
         private bool _isHttp;
         private bool _isHttps;
@@ -50,7 +49,7 @@ namespace NuGet.Configuration
                 {
                     _isHttps = false;
                     _isHttp = true;
-                    _isLocal = true;
+                    _isLocal = false;
                 }
                 else
                 {

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using NuGet.Common;
@@ -26,7 +25,7 @@ namespace NuGet.Configuration
         private bool _isHttps;
         private bool _isLocal;
 
-        public string Name { get; private set; }
+        public string Name { get; }
 
         public string Source
         {
@@ -87,7 +86,7 @@ namespace NuGet.Configuration
 
         public string? Description { get; set; }
 
-        public bool IsPersistable { get; private set; }
+        public bool IsPersistable { get; }
 
         public int MaxHttpRequestsPerSource { get; set; }
 
@@ -173,15 +172,9 @@ namespace NuGet.Configuration
             return base.Equals(obj);
         }
 
-        public override string ToString()
-        {
-            return Name + " [" + Source + "]";
-        }
+        public override string ToString() => Name + " [" + Source + "]";
 
-        public override int GetHashCode()
-        {
-            return _hashCode;
-        }
+        public override int GetHashCode() => _hashCode;
 
         public PackageSource Clone()
         {

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
@@ -125,15 +125,15 @@ NuGet.Configuration.PackagePatternItem
 ~NuGet.Configuration.PackagePatternItem.PackagePatternItem(string pattern) -> void
 ~NuGet.Configuration.PackagePatternItem.Pattern.get -> string
 NuGet.Configuration.PackageSource
-~NuGet.Configuration.PackageSource.AsSourceItem() -> NuGet.Configuration.SourceItem
-~NuGet.Configuration.PackageSource.ClientCertificates.get -> System.Collections.Generic.IReadOnlyList<System.Security.Cryptography.X509Certificates.X509Certificate>
-~NuGet.Configuration.PackageSource.ClientCertificates.set -> void
-~NuGet.Configuration.PackageSource.Clone() -> NuGet.Configuration.PackageSource
-~NuGet.Configuration.PackageSource.Credentials.get -> NuGet.Configuration.PackageSourceCredential
-~NuGet.Configuration.PackageSource.Credentials.set -> void
-~NuGet.Configuration.PackageSource.Description.get -> string
-~NuGet.Configuration.PackageSource.Description.set -> void
-~NuGet.Configuration.PackageSource.Equals(NuGet.Configuration.PackageSource other) -> bool
+NuGet.Configuration.PackageSource.AsSourceItem() -> NuGet.Configuration.SourceItem!
+NuGet.Configuration.PackageSource.ClientCertificates.get -> System.Collections.Generic.IReadOnlyList<System.Security.Cryptography.X509Certificates.X509Certificate!>?
+NuGet.Configuration.PackageSource.ClientCertificates.set -> void
+NuGet.Configuration.PackageSource.Clone() -> NuGet.Configuration.PackageSource!
+NuGet.Configuration.PackageSource.Credentials.get -> NuGet.Configuration.PackageSourceCredential?
+NuGet.Configuration.PackageSource.Credentials.set -> void
+NuGet.Configuration.PackageSource.Description.get -> string?
+NuGet.Configuration.PackageSource.Description.set -> void
+NuGet.Configuration.PackageSource.Equals(NuGet.Configuration.PackageSource? other) -> bool
 NuGet.Configuration.PackageSource.IsEnabled.get -> bool
 NuGet.Configuration.PackageSource.IsEnabled.set -> void
 NuGet.Configuration.PackageSource.IsHttp.get -> bool
@@ -146,17 +146,17 @@ NuGet.Configuration.PackageSource.IsOfficial.set -> void
 NuGet.Configuration.PackageSource.IsPersistable.get -> bool
 NuGet.Configuration.PackageSource.MaxHttpRequestsPerSource.get -> int
 NuGet.Configuration.PackageSource.MaxHttpRequestsPerSource.set -> void
-~NuGet.Configuration.PackageSource.Name.get -> string
-~NuGet.Configuration.PackageSource.PackageSource(string source) -> void
-~NuGet.Configuration.PackageSource.PackageSource(string source, string name) -> void
-~NuGet.Configuration.PackageSource.PackageSource(string source, string name, bool isEnabled) -> void
-~NuGet.Configuration.PackageSource.PackageSource(string source, string name, bool isEnabled, bool isOfficial, bool isPersistable = true) -> void
+NuGet.Configuration.PackageSource.Name.get -> string!
+NuGet.Configuration.PackageSource.PackageSource(string! source) -> void
+NuGet.Configuration.PackageSource.PackageSource(string! source, string! name) -> void
+NuGet.Configuration.PackageSource.PackageSource(string! source, string! name, bool isEnabled) -> void
+NuGet.Configuration.PackageSource.PackageSource(string! source, string! name, bool isEnabled, bool isOfficial, bool isPersistable = true) -> void
 NuGet.Configuration.PackageSource.ProtocolVersion.get -> int
 NuGet.Configuration.PackageSource.ProtocolVersion.set -> void
-~NuGet.Configuration.PackageSource.Source.get -> string
-~NuGet.Configuration.PackageSource.Source.set -> void
-~NuGet.Configuration.PackageSource.SourceUri.get -> System.Uri
-~NuGet.Configuration.PackageSource.TrySourceAsUri.get -> System.Uri
+NuGet.Configuration.PackageSource.Source.get -> string!
+NuGet.Configuration.PackageSource.Source.set -> void
+NuGet.Configuration.PackageSource.SourceUri.get -> System.Uri!
+NuGet.Configuration.PackageSource.TrySourceAsUri.get -> System.Uri?
 NuGet.Configuration.PackageSourceCredential
 ~NuGet.Configuration.PackageSourceCredential.AsCredentialsItem() -> NuGet.Configuration.CredentialsItem
 ~NuGet.Configuration.PackageSourceCredential.Equals(NuGet.Configuration.PackageSourceCredential other) -> bool
@@ -362,9 +362,9 @@ override NuGet.Configuration.OwnersItem.GetHashCode() -> int
 ~override NuGet.Configuration.PackagePatternItem.ElementName.get -> string
 ~override NuGet.Configuration.PackagePatternItem.Equals(object other) -> bool
 override NuGet.Configuration.PackagePatternItem.GetHashCode() -> int
-~override NuGet.Configuration.PackageSource.Equals(object obj) -> bool
+override NuGet.Configuration.PackageSource.Equals(object? obj) -> bool
 override NuGet.Configuration.PackageSource.GetHashCode() -> int
-~override NuGet.Configuration.PackageSource.ToString() -> string
+override NuGet.Configuration.PackageSource.ToString() -> string!
 ~override NuGet.Configuration.PackageSourceCredential.Equals(object other) -> bool
 override NuGet.Configuration.PackageSourceCredential.GetHashCode() -> int
 override NuGet.Configuration.PackageSourceMappingSourceItem.CanHaveChildren.get -> bool

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
@@ -49,5 +49,29 @@ namespace NuGet.Configuration.Test
 
             SettingsTestUtils.DeepEquals(source.AsSourceItem(), expectedItem).Should().BeTrue();
         }
+
+        [Fact]
+        public void CalculatedMembers_ChangingSource_UpdatesValues()
+        {
+            // Arrange
+            PackageSource source = new(source: "https://my.test/v3/index.json", name: "MySource");
+            bool httpBefore = source.IsHttp;
+            bool httpsBefore = source.IsHttps;
+            bool localBefore = source.IsLocal;
+            int hashCodeBefore = source.GetHashCode();
+
+            // Act
+            source.Source = @"c:\path\to\packages";
+
+            // Assert
+            httpBefore.Should().BeTrue();
+            httpsBefore.Should().BeTrue();
+            localBefore.Should().BeFalse();
+
+            source.IsHttp.Should().BeFalse();
+            source.IsHttps.Should().BeFalse();
+            source.IsLocal.Should().BeTrue();
+            source.GetHashCode().Should().NotBe(hashCodeBefore);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using FluentAssertions;
+using NuGet.Common;
 using Xunit;
 
 namespace NuGet.Configuration.Test
@@ -48,6 +49,45 @@ namespace NuGet.Configuration.Test
             var expectedItem = new SourceItem("SourceName", "Source", "43");
 
             SettingsTestUtils.DeepEquals(source.AsSourceItem(), expectedItem).Should().BeTrue();
+        }
+
+        [Fact]
+        void CalculatedMembers_ForHttpsSource_HasExpectedValues()
+        {
+            // Arrange & Act
+            PackageSource source = new("https://my.test/v3.index.json");
+
+            // Assert
+            source.IsHttps.Should().BeTrue();
+            source.IsHttp.Should().BeTrue();
+            source.IsLocal.Should().BeFalse();
+        }
+
+        [Fact]
+        void CalculatedMembers_ForHttpSource_HasExpectedValues()
+        {
+            // Arrange & Act
+            PackageSource source = new("http://my.test/v3.index.json");
+
+            // Assert
+            source.IsHttps.Should().BeFalse();
+            source.IsHttp.Should().BeTrue();
+            source.IsLocal.Should().BeFalse();
+        }
+
+        [Fact]
+        void CalculatedMembers_ForLocalSource_HasExpectedValues()
+        {
+            // Arrange & Act
+            var path = RuntimeEnvironmentHelper.IsWindows
+                ? @"c:\path\to\packages"
+                : "/path/to/packages";
+            PackageSource source = new(path);
+
+            // Assert
+            source.IsHttps.Should().BeFalse();
+            source.IsHttp.Should().BeFalse();
+            source.IsLocal.Should().BeTrue();
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10276

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Stop using `Lazy<bool>` for `IsHttp`, `IsHttps`, and `IsLocal`. I don't believe the time to calculate these are great, so I don't see the benefit in lazy-evaluating them. Especially when the most important code path, Restore, will certainly cause `IsHttp` and `IsHttps` to be evaluated.
* remove the `readonly` modified from the calculated hash code.
* Do these calculations in `PackageSource.Source`'s setter, so that if the source value changes, the values are recalcuated.
* I took the opportunity to enable nullability checking on this file.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
