### PR TITLE
Add 3 new test cases for Dotnet SDK style project to Install/Update/Un…

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -258,5 +258,100 @@ namespace NuGet.Tests.Apex
         {
             yield return new object[] { ProjectTemplate.NetStandardClassLib };
         }
+
+        [NuGetWpfTheory]
+        [MemberData(nameof(GetNetCoreProjects))]
+        public void InstallPackageToNetCoreProjectFromUI(ProjectTemplate projectTemplate, string projectName, string packageName, string packageVersion)
+        {
+            // Arrange
+            EnsureVisualStudioHost();
+            var dte = VisualStudio.Dte;
+            var solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution();
+
+            var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, projectName);
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            // Act
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, XunitLogger);
+            var nugetTestService = GetNuGetTestService();
+            var uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI(packageName, packageVersion);
+
+            // Assert
+            VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
+            CommonUtility.AssertPackageReferenceExists(VisualStudio, project, packageName, packageVersion, XunitLogger);
+        }
+
+        public static IEnumerable<object[]> GetNetCoreProjects()
+        {
+            yield return new object[] { ProjectTemplate.NetStandardClassLib, "NetStandardClassLib", "NetStandard.Library", "2.0.1" };
+        }
+
+
+        [NuGetWpfTheory]
+        [MemberData(nameof(UpdateNetCoreProjects))]
+        public void UpdatePackageToNetCoreProjectFromUI(ProjectTemplate projectTemplate, string projectName, string packageName, string installVersion, string updateVersion)
+        {
+            // Arrange
+            EnsureVisualStudioHost();
+            var dte = VisualStudio.Dte;
+            var solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution();
+
+            var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, projectName);
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            // Act
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, XunitLogger);
+            var nugetTestService = GetNuGetTestService();
+            var uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI(packageName, installVersion);
+            uiwindow.SwitchTabToUpdate();
+            uiwindow.UpdatePackageFromUI(packageName, updateVersion);
+
+            // Assert
+            VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
+            CommonUtility.AssertPackageReferenceExists(VisualStudio, project, packageName, updateVersion, XunitLogger);
+        }
+
+        public static IEnumerable<object[]> UpdateNetCoreProjects()
+        {
+            yield return new object[] { ProjectTemplate.NetStandardClassLib, "NetStandardClassLib", "NetStandard.Library", "2.0.2", "2.0.3" };
+        }
+
+        [NuGetWpfTheory]
+        [MemberData(nameof(UninstallNetCoreProjects))]
+        public void UninstallPackageFromNetCoreProjectFromUI(ProjectTemplate projectTemplate, string projectName, string packageName, string packageVersion)
+        {
+            // Arrange
+            EnsureVisualStudioHost();
+            var dte = VisualStudio.Dte;
+            var solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution();
+
+            var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, projectName);
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            // Act
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, XunitLogger);
+            var nugetTestService = GetNuGetTestService();
+            var uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI(packageName, packageVersion);
+            uiwindow.SwitchTabToInstalled();
+            uiwindow.UninstallPackageFromUI(packageName);
+
+            // Assert
+            VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
+            CommonUtility.AssertPackageReferenceDoesNotExist(VisualStudio, project, packageName, XunitLogger);
+        }
+
+        public static IEnumerable<object[]> UninstallNetCoreProjects()
+        {
+            yield return new object[] { ProjectTemplate.NetStandardClassLib, "NetStandardClassLib", "NetStandard.Library", "2.0.3" };
+        }
     }
 }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Client.Engineering/issues/2116

## Description
**Purpose:**
Add test cases to test installing/updating/uninstalling package into a Dotnet SDK style project from PM UI with “PackageReference” format by default.

**Add three test cases:**

InstallPackageToNetCoreProjectFromUI: Install particular package to a C# Net Standard Class Library Project from PM UI.
UpdatePackageToNetCoreProjectFromUI: Update package for a C# Net Standard Class Library Project in PM UI.
UninstallPackageFromNetCoreProjectFromUI: Uninstall particular package to a C# Net Standard Class Library Project from PM UI.

**Notes:**
The test cases were added into the end of the ...\NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs file.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.

- **Tests**
  - [X] Automated tests added
