### PR TITLE
Test:  enable signature verification on Linux CI machines

### DIFF
--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -146,6 +146,7 @@ stages:
       FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
       SDKVersionForBuild: $[stageDependencies.Initialize.Initialize_Build.outputs['getSDKVersionForBuild.SDKVersionForBuild']]
       BuildRTM: "false"
+      DOTNET_NUGET_SIGNATURE_VERIFICATION: true
     pool:
       vmImage: ubuntu-latest
     steps:

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -182,6 +182,7 @@ stages:
       MSBUILDDISABLENODEREUSE: 1
       # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
       MSBuildEnableWorkloadResolver: false
+      DOTNET_NUGET_SIGNATURE_VERIFICATION: true
     condition: "and(succeeded(), eq(variables['RunTestsOnLinux'], 'true'))"
     pool:
       vmImage: ubuntu-latest

--- a/eng/source-build/global.json
+++ b/eng/source-build/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "7.0.100-preview.6.22352.1"
+    "dotnet": "7.0.100"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21309.7"

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -527,7 +527,8 @@ namespace NuGet.Packaging
             else if (RuntimeEnvironmentHelper.IsLinux || RuntimeEnvironmentHelper.IsMacOSX)
             {
                 // Please note: Linux/MAC case sensitive for env var name.
-                string signVerifyEnvVariable = _environmentVariableReader.GetEnvironmentVariable("DOTNET_NUGET_SIGNATURE_VERIFICATION");
+                string signVerifyEnvVariable = _environmentVariableReader.GetEnvironmentVariable(
+                    EnvironmentVariableConstants.DotNetNuGetSignatureVerification);
 
                 bool canVerify = false;
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/EnvironmentVariableConstants.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/EnvironmentVariableConstants.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Packaging.Signing
+{
+    internal static class EnvironmentVariableConstants
+    {
+        internal const string DotNetNuGetSignatureVerification = "DOTNET_NUGET_SIGNATURE_VERIFICATION";
+    }
+}

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -196,7 +196,7 @@ EndGlobal";
         }
 
 #if IS_SIGNING_SUPPORTED
-        [PlatformFact(Platform.Windows)]
+        [PlatformFact(Platform.Windows, Platform.Linux)]
         public async Task DotnetRestore_WithUnSignedPackageAndSignatureValidationModeAsRequired_FailsAsync()
         {
             using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetVerifyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetVerifyTests.cs
@@ -51,8 +51,7 @@ namespace Dotnet.Integration.Test
         }
 
         // https://github.com/NuGet/Home/issues/11178
-        // https://github.com/NuGet/Home/issues/11892
-        [PlatformFact(Platform.Windows)]
+        [PlatformFact(Platform.Windows, Platform.Linux)]
         public void Verify_AuthorSignedAndTimestampedPackageWithOptionAll_Succeeds()
         {
             // Arrange
@@ -96,9 +95,8 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/11892
         // https://github.com/NuGet/Home/issues/11178
-        [PlatformFact(Platform.Windows)]
+        [PlatformFact(Platform.Windows, Platform.Linux)]
         public void Verify_SignedPackageWithAllowedCertificate_Succeeds()
         {
             // Arrange
@@ -120,8 +118,7 @@ namespace Dotnet.Integration.Test
         }
 
         // https://github.com/NuGet/Home/issues/11178
-        // https://github.com/NuGet/Home/issues/11892
-        [PlatformFact(Platform.Windows)]
+        [PlatformFact(Platform.Windows, Platform.Linux)]
         public void Verify_MultipleSignedPackagesWithWildCardAndDetailedVerbosity_MixedResults()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/12357, https://github.com/NuGet/Home/issues/11892

Regression? Last working version:  N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This change enables signed package verification by default on our Linux CI machines.  [Since we're already using .NET 7 SDK](https://github.com/NuGet/NuGet.Client/blob/ba3fa10c1ae0fc4b57f4fa01c8fda0abf47f865a/eng/pipelines/templates/Tests_On_Linux.yml#L2-L7), we should enable signed package verification on Linux by default.

This change also bumps source build's .NET SDK version from 7.0.100-preview.6.22352.1 to 7.0.100 because the necessary .NET SDK support for verifying signed packages on Linux [first appeared in .NET 7.0.100 SDK (GA)](https://github.com/dotnet/sdk/pull/28541).

This PR introduces no behavioral changes to the product itself.

CC @aortiz-msft, @skofman1
FYI @dotnet/source-build-internal, @lbussell for source build-related changes

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
