### PR TITLE
.NET 8 SDK:  enable signed package verification by default on Linux

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -530,7 +530,7 @@ namespace NuGet.Packaging
                 string signVerifyEnvVariable = _environmentVariableReader.GetEnvironmentVariable(
                     EnvironmentVariableConstants.DotNetNuGetSignatureVerification);
 
-                bool canVerify = false;
+                bool canVerify = RuntimeEnvironmentHelper.IsLinux;
 
                 if (!string.IsNullOrEmpty(signVerifyEnvVariable))
                 {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -2102,7 +2102,7 @@ namespace NuGet.Packaging.Test
 
         private static bool CanVerifySignedPackages(IEnvironmentVariableReader environmentVariableReader = null)
         {
-            return (RuntimeEnvironmentHelper.IsWindows ||
+            return (RuntimeEnvironmentHelper.IsWindows || RuntimeEnvironmentHelper.IsLinux ||
                 IsVerificationEnabledByEnvironmentVariable(environmentVariableReader)) &&
 #if IS_SIGNING_SUPPORTED
                 true;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/11262

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This change re-enables signed package verification by default on Linux for .NET 8 SDK Preview 1.  Verification remains disabled by default on macOS.

With [this .NET 7 SDK-era change](https://github.com/dotnet/sdk/pull/28541), there are no known major blockers to enabling verification by default on Linux.  As always, the `DOTNET_NUGET_SIGNATURE_VERIFICATION` environment variable provides an escape hatch, if necessary.

CC @aortiz-msft, @skofman1, @richlander

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->  We have existing test coverage.

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [X] Documentation PR or issue filled  https://github.com/dotnet/docs/issues/33502
  - **OR**
  - [ ] N/A
