### PR TITLE
Test: re-enable test disabled by .NET SDK bug (#5005)

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -1487,7 +1487,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        [PlatformTheory(Platform.Windows, Skip = "https://github.com/dotnet/sdk/issues/28131")]
+        [PlatformTheory(Platform.Windows)]
         // Command line : /p:NuspecProperties=\"id=MyPackage;version=1.2.3;tags=tag1;description="hello world"\"
         [InlineData("/p:NuspecProperties=\\\"id=MyPackage;version=1.2.3;tags=tag1;description=\"hello world\"\\\"", "MyPackage",
             "1.2.3", "hello world", "tag1")]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/12151

Regression? Last working version:  .NET 6.x SDK

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This is a backport of https://github.com/NuGet/NuGet.Client/pull/5005 into the release-6.4.x branch.

.NET 7 SDK introduced a regression in parsing multiple key-value pairs as a property during pack. See https://github.com/dotnet/sdk/issues/28131. I [disabled a test](https://github.com/NuGet/NuGet.Client/pull/4791/commits/39651126c90acab817b2581b276ba3a8e1f5f650) impacted by this regression.

This PR re-enables that test.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A

