### PR TITLE
Properly handle alternate console stream encodings in StaticGraphRestoreArguments

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/Program.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/Program.cs
@@ -112,7 +112,7 @@ namespace NuGet.Build.Tasks.Console
             {
                 using Stream stream = System.Console.OpenStandardInput();
 
-                staticGraphRestoreArguments = StaticGraphRestoreArguments.Read(stream);
+                staticGraphRestoreArguments = StaticGraphRestoreArguments.Read(stream, System.Console.InputEncoding);
 
                 return staticGraphRestoreArguments != null;
             }

--- a/src/NuGet.Core/NuGet.Build.Tasks/StaticGraphRestoreArguments.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/StaticGraphRestoreArguments.cs
@@ -35,7 +35,7 @@ namespace NuGet.Build.Tasks
         {
             using var reader = new BinaryReader(stream, encoding, leaveOpen: true);
 
-            int count = SkipPreamble();
+            int count = SkipPreamble(reader, encoding);
 
             return new StaticGraphRestoreArguments
             {
@@ -45,10 +45,7 @@ namespace NuGet.Build.Tasks
 
             Dictionary<string, string> ReadDictionary(int count = -1)
             {
-                if (count == -1)
-                {
-                    count = reader.ReadInt32();
-                }
+                count = count == -1 ? reader.ReadInt32() : count;
 
                 var dictionary = new Dictionary<string, string>(capacity: count, StringComparer.OrdinalIgnoreCase);
 
@@ -60,51 +57,6 @@ namespace NuGet.Build.Tasks
                 }
 
                 return dictionary;
-            }
-
-            int SkipPreamble()
-            {
-                // Get the preamble from the current encoding which should only be a maximum of 4 bytes
-                byte[] preamble = encoding.GetPreamble();
-
-                if (preamble.Length == 0)
-                {
-                    // Return -1 to the caller if there is no preamble for the encoding meaning that the stream is at the beginning of the expected content
-                    return -1;
-                }
-
-                // Create a buffer for the preamble which should be a maximum of 4 bytes
-                byte[] buffer = new byte[4];
-
-                // Read 
-                int readBytes = reader.Read(buffer, 0, buffer.Length);
-
-                int matchingPreambleLength = 0;
-
-                for (int i = 0; i < preamble.Length; i++)
-                {
-                    if (buffer[i] != preamble[i])
-                    {
-                        break;
-                    }
-
-                    matchingPreambleLength++;
-                }
-
-                if (matchingPreambleLength == preamble.Length)
-                {
-                    int index = matchingPreambleLength;
-
-                    for (int i = 0; i < buffer.Length - matchingPreambleLength; i++)
-                    {
-                        buffer[i] = buffer[index];
-                    }
-
-                    reader.Read(buffer, buffer.Length - matchingPreambleLength, matchingPreambleLength);
-
-                }
-
-                return BitConverter.ToInt32(buffer, 0);
             }
         }
 
@@ -129,6 +81,100 @@ namespace NuGet.Build.Tasks
                     writer.Write(item.Value);
                 }
             }
+        }
+
+        /// <summary>Skips the preamble in the specified <see cref="BinaryReader" />if any and returns the value of the first integer in the stream.</summary>
+        /// <param name="reader">The <see cref="BinaryReader "/> that contains the preamble to skip.</param>
+        /// <param name="encoding">The <see cref="Encoding" /> of the content.</param>
+        /// <returns>The first integer in the stream after the preamble if one was found, otherwise -1.</returns>
+        /// <remarks>
+        /// Preambles are variable length from 2 to 4 bytes.  The first 4 bytes are either:
+        ///   -Variable length preamble and any remaining bytes of the actual content
+        ///   -No preamble and just the integer representing the number of items in the first dictionary
+        ///
+        /// Since the preamble could be 3 bytes, that means that the last byte in the buffer will be the first byte of the next segment. So this code
+        /// determines how long the preamble is, replaces the remaining bytes at the beginning of the buffer, and copies the next set of bytes.  This
+        /// effectively "skips" the preamble by eventually having the buffer contain the first 4 bytes of the content that should actually be read.
+        ///
+        /// Example stream:
+        /// 
+        /// |   3 byte preamble  |      4 byte integer       |
+        /// |------|------|------|------|------|------|------|
+        /// | 0xFF | 0XEF | 0x00 | 0x07 | 0x00 | 0x00 | 0x00 |
+        ///
+        /// The first 4 bytes are read into the buffer (notice one of the bytes is actually not the preamble):
+        /// 
+        /// |       4 byte buffer       |
+        /// |------|------|------|------|
+        /// | 0xFF | 0XEF | 0x00 | 0x07 |
+        ///
+        /// If the first three bytes match the preamble (0xFF, 0xEF, 0x00), then the array is shifted so that last item becomes the first:
+        /// 
+        /// |       4 byte buffer       |
+        /// |------|------|------|------|
+        /// | 0x07 | 0XEF | 0x00 | 0x07 |
+        ///
+        /// Since only 1 byte was moved up in the buffer, then the next 3 bytes from the stream are read:
+        ///
+        /// |       4 byte buffer       |
+        /// |------|------|------|------|
+        /// | 0x07 | 0X00 | 0x00 | 0x00 |
+        ///
+        /// Now the buffer contains the first integer in the stream and the preamble is skipped.
+        /// 
+        /// </remarks>
+        private static int SkipPreamble(BinaryReader reader, Encoding encoding)
+        {
+            // Get the preamble from the current encoding which should only be a maximum of 4 bytes
+            byte[] preamble = encoding.GetPreamble();
+
+            if (preamble.Length == 0)
+            {
+                // Return -1 to the caller if there is no preamble for the encoding meaning that the stream is at the beginning of the expected content
+                return -1;
+            }
+
+            // Create a buffer for the preamble which should be a maximum of 4 bytes
+            byte[] buffer = new byte[4];
+
+            // Read the first 4 bytes of the stream which should be either a preamble of 2 to 4 bytes or a 4 byte integer, if less than 4 bytes were read
+            // then the buffer contains nothing.
+            if (reader.Read(buffer, 0, buffer.Length) != buffer.Length)
+            {
+                return -1;
+            }
+
+            int matchingPreambleLength = 0;
+
+            // Loop through the buffer and verify each byte of the preamble.
+            for (int i = 0; i < preamble.Length; i++)
+            {
+                if (buffer[i] != preamble[i])
+                {
+                    break;
+                }
+
+                matchingPreambleLength++;
+            }
+
+            // If the first set of bytes were the preamble then it needs to be skipped
+            if (matchingPreambleLength == preamble.Length)
+            {
+                int index = matchingPreambleLength;
+
+                // Copy the last set of bytes after the preamble back to the beginning of the buffer
+                for (int i = 0; i < buffer.Length - matchingPreambleLength; i++)
+                {
+                    buffer[i] = buffer[index];
+                }
+
+                // Read in the next set of bytes into the buffer so it contains the first 4 bytes after the preamble
+                reader.Read(buffer, buffer.Length - matchingPreambleLength, matchingPreambleLength);
+
+            }
+
+            // Convert the buffer to an integer
+            return BitConverter.ToInt32(buffer, 0);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/StaticGraphRestoreArguments.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/StaticGraphRestoreArguments.cs
@@ -160,17 +160,11 @@ namespace NuGet.Build.Tasks
             // If the first set of bytes were the preamble then it needs to be skipped
             if (matchingPreambleLength == preamble.Length)
             {
-                int index = matchingPreambleLength;
+                // Copy the bytes after the preamble to the start of the buffer
+                Array.Copy(buffer, matchingPreambleLength, buffer, 0, buffer.Length - matchingPreambleLength);
 
-                // Copy the last set of bytes after the preamble back to the beginning of the buffer
-                for (int i = 0; i < buffer.Length - matchingPreambleLength; i++)
-                {
-                    buffer[i] = buffer[index];
-                }
-
-                // Read in the next set of bytes into the buffer so it contains the first 4 bytes after the preamble
+                // Read in the next bytes from the stream into the buffer so it contains the first 4 bytes after the preamble
                 reader.Read(buffer, buffer.Length - matchingPreambleLength, matchingPreambleLength);
-
             }
 
             // Convert the buffer to an integer

--- a/src/NuGet.Core/NuGet.Build.Tasks/StaticGraphRestoreTaskBase.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/StaticGraphRestoreTaskBase.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 
 #if !IS_CORECLR
 
@@ -120,7 +119,7 @@ namespace NuGet.Build.Tasks
 
                         process.Start();
 
-                        WriteArguments(process.StandardInput.BaseStream);
+                        WriteArguments(process.StandardInput);
 
                         process.BeginOutputReadLine();
 
@@ -258,7 +257,7 @@ namespace NuGet.Build.Tasks
             };
         }
 
-        internal void WriteArguments(Stream stream)
+        internal void WriteArguments(StreamWriter streamWriter)
         {
             var arguments = new StaticGraphRestoreArguments
             {
@@ -266,7 +265,7 @@ namespace NuGet.Build.Tasks
                 Options = GetOptions(),
             };
 
-            arguments.Write(stream);
+            arguments.Write(streamWriter);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GenerateRestoreGraphFileTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GenerateRestoreGraphFileTaskTests.cs
@@ -52,7 +52,9 @@ namespace NuGet.Build.Tasks.Test
                 {
                     using var stream = new MemoryStream();
 
-                    task.WriteArguments(stream);
+                    using var streamWriter = new StreamWriter(stream, Encoding.UTF8);
+
+                    task.WriteArguments(streamWriter);
 
                     string actualArguments = task.GetCommandLineArguments(msbuildBinPath);
 
@@ -71,7 +73,7 @@ namespace NuGet.Build.Tasks.Test
 
                     stream.Position = 0;
 
-                    var arguments = StaticGraphRestoreArguments.Read(stream);
+                    var arguments = StaticGraphRestoreArguments.Read(stream, streamWriter.Encoding);
 
                     arguments.Options.Should().BeEquivalentTo(new Dictionary<string, string>()
                     {

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
@@ -58,9 +58,10 @@ namespace NuGet.Build.Tasks.Test
                     MSBuildStartupDirectory = testDirectory,
                 })
                 {
-                    using MemoryStream stream = new MemoryStream();
+                    using var stream = new MemoryStream();
+                    using var streamWriter = new StreamWriter(stream, Encoding.UTF8);
 
-                    task.WriteArguments(stream);
+                    task.WriteArguments(streamWriter);
 
                     string actualArguments = task.GetCommandLineArguments(msbuildBinPath);
 
@@ -79,7 +80,7 @@ namespace NuGet.Build.Tasks.Test
 
                     stream.Position = 0;
 
-                    StaticGraphRestoreArguments arguments = StaticGraphRestoreArguments.Read(stream);
+                    StaticGraphRestoreArguments arguments = StaticGraphRestoreArguments.Read(stream, streamWriter.Encoding);
 
                     arguments.Options.Should().BeEquivalentTo(new Dictionary<string, string>()
                     {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12373

Regression? Yes Last working version: 17.4

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
When you enable alternate region encodings, Windows appears to write a preamble to `Console.StandardInput` causing the logic in `StaticGraphRestoreArguments` to fail to read the stream correctly.

My fix is to write take into account the encoding of the stream and skip the preamble if one is found.   This is done by looking at the encoding's preamble, reading the first 4 bytes of the stream, skipping the preamble, and reading the next set of bytes.  This results in the buffer containing the first integer in the stream so the rest of the code can read the content normally.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
