### PR TITLE
Don't log telemetry when cancellation requested in VsSolutionRestoreStatusProvider

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreStatusProvider.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreStatusProvider.cs
@@ -74,7 +74,7 @@ namespace NuGet.SolutionRestoreManager
 
                 return complete;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!(ex is OperationCanceledException && token.IsCancellationRequested))
             {
                 await _telemetryProvider.PostFaultAsync(ex, nameof(VsSolutionRestoreStatusProvider));
                 throw;

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreStatusProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreStatusProviderTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NuGet.PackageManagement.VisualStudio;
+using NuGet.ProjectManagement;
+using NuGet.VisualStudio;
+using NuGet.VisualStudio.Telemetry;
+using Xunit;
+
+namespace NuGet.SolutionRestoreManager.Test
+{
+    public class VsSolutionRestoreStatusProviderTests
+    {
+        [Fact]
+        public async Task IsRestoreCompleteAsync_WithCancelledToken_DoesNotLogFault()
+        {
+            // Arrange
+            Mock<ISolutionRestoreWorker> worker = new();
+
+            Mock<NuGetProject> project = new();
+
+            Mock<IVsSolutionManager> solutionManager = new();
+            solutionManager.Setup(sm => sm.IsSolutionOpenAsync())
+                .Returns(Task.FromResult(true));
+            solutionManager.SetupGet(sm => sm.IsSolutionOpen)
+                .Returns(true);
+            solutionManager.Setup(sm => sm.GetNuGetProjectsAsync())
+                .Returns(Task.FromResult<IEnumerable<NuGetProject>>(new[] { project.Object }));
+
+            Mock<INuGetTelemetryProvider> telemetryProvider = new();
+
+            VsSolutionRestoreStatusProvider target =
+                new(
+                    new Lazy<ISolutionRestoreWorker>(() => worker.Object),
+                    new Lazy<IVsSolutionManager>(() => solutionManager.Object),
+                    telemetryProvider.Object);
+
+            // Act
+            var cancellationToken = new CancellationToken(canceled: true);
+            bool exceptionCaught = false;
+            try
+            {
+                _ = await target.IsRestoreCompleteAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                exceptionCaught = true;
+            }
+
+            // Assert
+            exceptionCaught.Should().BeTrue();
+            telemetryProvider
+                .Verify(tp => tp.PostFault(It.IsAny<Exception>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IDictionary<string, object>>()),
+                    Times.Never);
+            telemetryProvider
+                .Verify(tp => tp.PostFaultAsync(It.IsAny<Exception>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IDictionary<string, object>>()),
+                    Times.Never);
+        }
+    }
+}


### PR DESCRIPTION
Cherry-pick https://github.com/NuGet/NuGet.Client/pull/4996 onto release branch

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2114

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Cherry-pick https://github.com/NuGet/NuGet.Client/pull/4996 onto release branch

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
