### PR TITLE
Embed NuGet files in the binary log after restore completes

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
@@ -33,6 +33,9 @@ Copyright (c) .NET Foundation. All rights reserved.
         ProcessFileName="$(NuGetConsoleProcessFileName)"
         MSBuildStartupDirectory="$(MSBuildStartupDirectory)"
         />
+
+    <!-- When Restore fails, still try to embed the results of restore in the binary log -->
+    <OnError ExecuteTargets="EmbedNuGetFilesInBinLog" />
   </Target>
 
  <!--

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -140,6 +140,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       Interactive="$(NuGetInteractive)"
       RestoreForceEvaluate="$(RestoreForceEvaluate)"
       RestorePackagesConfig="$(RestorePackagesConfig)"/>
+
+    <!-- When Restore fails, still try to embed the results of restore in the binary log -->
+    <OnError ExecuteTargets="EmbedNuGetFilesInBinLog" />
   </Target>
 
   <!--
@@ -1456,5 +1459,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Import Project="NuGet.RestoreEx.targets" Condition="'$(RestoreUseStaticGraphEvaluation)' == 'true' And Exists('NuGet.RestoreEx.targets')" />
+
+  <!--
+    ============================================================
+    EmbedNuGetFilesInBinLog
+    Adds files to be embedded in the binary log.  These files are results of a restore
+    so they need to be added after restore is complete.
+    ============================================================
+  -->
+  <Target Name="EmbedNuGetFilesInBinLog"
+        AfterTargets="Restore"
+        Condition="'$(EmbedNuGetFilesInBinLog)' != 'false'">
+    <ItemGroup>
+      <EmbedInBinlog Include="$(ProjectAssetsFile)" Condition="Exists('$(ProjectAssetsFile)') AND $(EmbedProjectAssetsFile) != false" />
+      <EmbedInBinlog Include="$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).nuget.*" />
+    </ItemGroup>
+  </Target>
 
 </Project>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12374

Regression? No Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This updates the Restore task to embed NuGet files in the binlog after Restore is complete.  Even if restore fails, any files that exist will be embedded:

![image](https://user-images.githubusercontent.com/17556515/213536317-175bfafe-2fe1-4836-b21c-d11f7df28b57.png)

In this case the package name is wrong and the `.dgspec` is still in the binlog.

For static graph-based restore, the output paths are logged back to the RestoreTaskEx so it can embed the files in the binlog at the end of the actual build.  I could not find a way to embed them in the `nuget.binlog` that contains evaluation...

Related to https://github.com/dotnet/sdk/pull/16840

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - It would be hard to verify the contents of the binlog at the moment.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
