### PR TITLE
Unblock build failures changing VSTargetChannelForTests to use VS 17.…

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -27,7 +27,7 @@
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <VsTargetBranch>main</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
-    <VsTargetChannelForTests>$(VsTargetChannel)</VsTargetChannelForTests>
+    <VsTargetChannelForTests>int.d17.4</VsTargetChannelForTests>
 
     <!-- NuGet SDK VS package Semantic Version -->
     <NuGetSdkVsSemanticVersion>$(VsTargetMajorVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</NuGetSdkVsSemanticVersion>

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -111,8 +111,7 @@ function LaunchVSAndWaitForDTE {
 
         $dte2 = GetDTE2 -dteName $dteName
         if ($dte2) {
-            Write-Host 'Obtained DTE. Wait for 5 seconds...'
-            start-sleep 5
+            Write-Host 'Obtained DTE.'
             return $dte2
         }
 

--- a/test/EndToEnd/tests/NetCoreProjectTest.ps1
+++ b/test/EndToEnd/tests/NetCoreProjectTest.ps1
@@ -139,7 +139,7 @@ function Test-NetCoreConsoleAppRebuildDoesNotDeleteCacheFile {
 }
 
 function Test-NetCoreVSandMSBuildNoOp {
-    
+
     # Arrange
     $project = New-NetCoreConsoleApp ConsoleApp
     Build-Solution
@@ -148,11 +148,11 @@ function Test-NetCoreVSandMSBuildNoOp {
     $cacheFile = Get-ProjectCacheFilePath $project
 
     #Act
-    
+
     $VSRestoreTimestamp =( [datetime](Get-ItemProperty -Path $cacheFile -Name LastWriteTime).lastwritetime).Ticks
-    
+
     $MSBuildExe = Get-MSBuildExe
-    
+
     & "$MSBuildExe" /t:restore  $project.FullName
     Assert-True ($LASTEXITCODE -eq 0)
 
@@ -163,7 +163,7 @@ function Test-NetCoreVSandMSBuildNoOp {
 }
 
 function Test-NetCoreTargetFrameworksVSandMSBuildNoOp {
-    
+
     # Arrange
     $project = New-NetCoreConsoleTargetFrameworksApp ConsoleApp
     Build-Solution
@@ -172,9 +172,9 @@ function Test-NetCoreTargetFrameworksVSandMSBuildNoOp {
     $cacheFile = Get-ProjectCacheFilePath $project
 
     #Act
-    
+
     $VSRestoreTimestamp =( [datetime](Get-ItemProperty -Path $cacheFile -Name LastWriteTime).lastwritetime).Ticks
-    
+
     $MSBuildExe = Get-MSBuildExe
 
     & "$MSBuildExe" /t:restore  $project.FullName
@@ -198,11 +198,11 @@ function Test-NetCoreMultipleTargetFrameworksVSandMSBuildNoOp {
     $cacheFile = Get-ProjectCacheFilePath $project
 
     #Act
-    
+
     $VSRestoreTimestamp =( [datetime](Get-ItemProperty -Path $cacheFile -Name LastWriteTime).lastwritetime).Ticks
-    
+
     $MSBuildExe = Get-MSBuildExe
-    
+
     & "$MSBuildExe" /t:restore  $project.FullName
     Assert-True ($LASTEXITCODE -eq 0)
 
@@ -213,18 +213,20 @@ function Test-NetCoreMultipleTargetFrameworksVSandMSBuildNoOp {
 }
 
 function Test-NetCoreToolsVSandMSBuildNoOp {
-    
+    [SkipTest('https://github.com/NuGet/Home/issues/11231')]
+    param ()
+
     # Arrange
     $project = New-NetCoreWebApp10 ConsoleApp
     Assert-NetCoreProjectCreation $project
 
     $ToolsCacheFile = Get-ProjectToolsCacheFilePath $project
-    
+
     #Act
     $VSRestoreTimestamp =( [datetime](Get-ItemProperty -Path $ToolsCacheFile -Name LastWriteTime).lastwritetime).Ticks
-    
+
     $MSBuildExe = Get-MSBuildExe
-    
+
     & "$MSBuildExe" /t:restore  $project.FullName
     Assert-True ($LASTEXITCODE -eq 0)
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Tracking: https://github.com/NuGet/Client.Engineering/issues/2042

Regression? Last working version: No

## Description
Cherry-picking fix #5007 to release build with description: Unblock CI build failures changing VSTargetChannelForTests to use VS 17.4 version and skip a flaky apex test.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
