### PR TITLE
Skip Apex test failing with IPC errors (#4993)

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
@@ -133,7 +133,7 @@ namespace NuGet.Tests.Apex
             File.Exists(uniqueContentFile).Should().BeTrue($"'{uniqueContentFile}' should exist");
         }
 
-        [StaFact]
+        [StaFact(Skip = "https://github.com/NuGet/Home/issues/11308")]
         public async Task SimpleInstallFromIVsInstaller_PackageSourceMapping_WithMultipleFeedsWithIdenticalPackages_InstallsCorrectPackage()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Tracking issue: https://github.com/NuGet/Home/issues/11308

Regression? Last working version: No

## Description
Cherry picking #4993 with description:

Test SimpleInstallFromIVsInstaller_PackageSourceMapping_WithMultipleFeedsWithIdenticalPackages_InstallsCorrectPackage is failing with IPC errors, like several other Apex tests. I have an email thread with VSEng asking for help. Just need to wait for people to get back to work following the holiday peiod.

This test has been failing more than 50% of the time on the dev branch!
image
(also why do we have a single test that takes 5 minutes to execute? No, it doesn't take that long only when it fails.)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
