### PR TITLE
Log warnings from server also when using an http proxy (X-NuGet-Warning)

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
@@ -66,7 +66,12 @@ namespace NuGet.Protocol
 
             if (proxy != null)
             {
-                messageHandler = new ProxyAuthenticationHandler(clientHandler, HttpHandlerResourceV3.CredentialService?.Value, ProxyCache.Instance);
+                var innerHandler = messageHandler;
+
+                messageHandler = new ProxyAuthenticationHandler(clientHandler, HttpHandlerResourceV3.CredentialService?.Value, ProxyCache.Instance)
+                {
+                    InnerHandler = innerHandler
+                };
             }
 
 #if !IS_CORECLR

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
@@ -15,11 +15,19 @@ namespace NuGet.Protocol
 {
     public class HttpHandlerResourceV3Provider : ResourceProvider
     {
+        private readonly IProxyCache _proxyCache;
+
         public HttpHandlerResourceV3Provider()
+            : this(ProxyCache.Instance)
+        {
+        }
+
+        internal HttpHandlerResourceV3Provider(IProxyCache proxyCache)
             : base(typeof(HttpHandlerResource),
                   nameof(HttpHandlerResourceV3Provider),
                   NuGetResourceProviderPositions.Last)
         {
+            _proxyCache = proxyCache ?? throw new ArgumentNullException(nameof(proxyCache));
         }
 
         public override Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
@@ -36,10 +44,10 @@ namespace NuGet.Protocol
             return Task.FromResult(new Tuple<bool, INuGetResource>(curResource != null, curResource));
         }
 
-        private static HttpHandlerResourceV3 CreateResource(PackageSource packageSource)
+        private HttpHandlerResourceV3 CreateResource(PackageSource packageSource)
         {
             var sourceUri = packageSource.SourceUri;
-            var proxy = ProxyCache.Instance.GetProxy(sourceUri);
+            var proxy = _proxyCache.GetProxy(sourceUri);
 
             // replace the handler with the proxy aware handler
             var clientHandler = new HttpClientHandler


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/5004

Regression? Last working version: Not a regression, logging server warnings has never worked when using an http proxy

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The fix sets the inner handler of the `ProxyAuthenticationHandler`, just like it's done for other handlers (`StsAuthenticationHandler` and `HttpSourceAuthenticationHandler`).

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
  The behaviour depends on the machine proxy settings and I have no idea how to mock this for a test.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
  This change does not warrant a documentation update. From a user point of view it is expected that warnings are logged regardless of whether a proxy is used or not.
