### PR TITLE
Get IsImplicitlyDefined from non-SDK PackageRefs

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
@@ -30,7 +30,7 @@ namespace NuGet.PackageManagement.VisualStudio
         , IProjectSystemReferencesReader
         , IProjectSystemReferencesService
     {
-        private static readonly Array ReferenceMetadata;
+        private static readonly string[] ReferenceMetadata;
 
         private readonly IVsProjectAdapter _vsProjectAdapter;
         private readonly IVsProjectThreadingService _threadingService;
@@ -58,14 +58,17 @@ namespace NuGet.PackageManagement.VisualStudio
 
         static VsManagedLanguagesProjectSystemServices()
         {
-            ReferenceMetadata = Array.CreateInstance(typeof(string), 7);
-            ReferenceMetadata.SetValue(ProjectItemProperties.IncludeAssets, 0);
-            ReferenceMetadata.SetValue(ProjectItemProperties.ExcludeAssets, 1);
-            ReferenceMetadata.SetValue(ProjectItemProperties.PrivateAssets, 2);
-            ReferenceMetadata.SetValue(ProjectItemProperties.NoWarn, 3);
-            ReferenceMetadata.SetValue(ProjectItemProperties.GeneratePathProperty, 4);
-            ReferenceMetadata.SetValue(ProjectItemProperties.Aliases, 5);
-            ReferenceMetadata.SetValue(ProjectItemProperties.VersionOverride, 6);
+            ReferenceMetadata = new string[]
+            {
+                ProjectItemProperties.IncludeAssets,
+                ProjectItemProperties.ExcludeAssets,
+                ProjectItemProperties.PrivateAssets,
+                ProjectItemProperties.NoWarn,
+                ProjectItemProperties.GeneratePathProperty,
+                ProjectItemProperties.Aliases,
+                ProjectItemProperties.VersionOverride,
+                ProjectItemProperties.IsImplicitlyDefined,
+            };
         }
 
         public VsManagedLanguagesProjectSystemServices(


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12377

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Add IsImplicitlyDefined to list of metadata we ask the project system for. Also changed the syntax, because frankly the previous syntax seems really weird for just creating a string array.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: I can't think of a way to write a unit test that would likely catch regressions, and since the array is used in a call to an external API, we can't feasibly mock the API that the array is used in. Integration tests are slow and difficult to write, so I'm not sure this uncommonly used feature warrants such an effort. Even if we created a test that uses a csproj with a relevant PackageReference, I don't know how to validate the value gets passed though (how to validate that the PM UI versions list is disabled).
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
