### PR TITLE
Add Package Source Mapping Dialog uses native Window theming & will Autofocus on first control

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
@@ -14,7 +14,8 @@
              ResizeMode="NoResize"
              ShowInTaskbar="False"
              Title="{x:Static nuget:Resources.VSOptions_Label_AddPackageNamespace}"
-             WindowStartupLocation="CenterOwner">
+             WindowStartupLocation="CenterOwner"
+             Loaded="AddMappingDialogWindow_Loaded">
   <vsui:DialogWindow.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
@@ -140,7 +141,7 @@
       </Grid.ColumnDefinitions>
       <!-- The `Grid.Column="0"` is missing in order to push the next column to the far right of the grid. -->
       <Button Grid.Column="1" Style="{StaticResource PackageSourceMappingButtonStyle}" Command="{Binding AddMappingCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Add}"/>
-      <Button Grid.Column="2" Style="{StaticResource PackageSourceMappingButtonStyle}" Command ="{Binding HideDialogCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Cancel}"/>
+      <Button Grid.Column="2" Style="{StaticResource PackageSourceMappingButtonStyle}" Command ="{Binding HideDialogCommand}" Content="{x:Static nuget:Resources.VSOptions_Button_Cancel}" IsCancel="True"/>
     </Grid>
   </Grid>
 </vsui:DialogWindow>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
@@ -11,14 +11,10 @@
              x:Uid="AddMappingDialogWindow"
              Height="348"
              Width="480"
+             ResizeMode="NoResize"
              ShowInTaskbar="False"
-             WindowStyle="None"
              Title="{x:Static nuget:Resources.VSOptions_Label_AddPackageNamespace}"
-             AllowsTransparency="True"
-             WindowStartupLocation="CenterOwner"
-             BorderBrush="{DynamicResource {x:Static vsui:EnvironmentColors.PanelBorderBrushKey}}"
-             BorderThickness="1"
-             Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}">
+             WindowStartupLocation="CenterOwner">
   <vsui:DialogWindow.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
@@ -28,7 +24,6 @@
   </vsui:DialogWindow.Resources>
   <Grid>
     <Grid.RowDefinitions>
-      <RowDefinition Height="Auto"/>
       <RowDefinition Height="*"/>
       <RowDefinition Height="Auto"/>
     </Grid.RowDefinitions>
@@ -76,47 +71,13 @@
       </Style>
     </Grid.Resources>
     <Grid Grid.Row="0">
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="*"/>
-          <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-        <TextBlock AutomationProperties.Name="AddNewPackageNamespace"
-                   Grid.Column="0"
-                   Text="{x:Static nuget:Resources.VSOptions_Label_AddPackageNamespace}"
-                   Margin="12"/>
-        <Button x:Uid="ButtonClose"
-                       Height="25"
-                       Width="25"
-                       Grid.Column="1"
-                       HorizontalAlignment="Left"
-                       HorizontalContentAlignment="Stretch"
-                       VerticalAlignment="Top"
-                       VerticalContentAlignment="Center"
-                       Margin="0,6,6,0"
-                       Command="{Binding HideDialogCommand}"
-                       AutomationProperties.Name="Close"
-                       IsCancel="True"
-                       BorderBrush="Transparent"
-                       BorderThickness="0"
-                       Background="{Binding Path=(Window.Background), RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}">
-          <Canvas x:Uid="canvas" Width="12" Height="10">
-            <Path x:Uid="CloseButtonPath"
-                  Width="10"
-                  Height="8"
-                  Fill="{Binding Path=(TextElement.Foreground), RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}"
-                  Stretch="Uniform"
-                  Data="F1 M 0,0L 2,0L 5,3L 8,0L 10,0L 6,4L 10,8L 8,8L 5,5L 2,8L 0,8L 4,4L 0,0 Z" />
-          </Canvas>
-        </Button>
-      </Grid>
-    <Grid Grid.Row="1">
       <Grid.RowDefinitions>
         <RowDefinition Height="Auto"/>
         <RowDefinition Height="Auto"/>
         <RowDefinition Height="Auto"/>
         <RowDefinition Height="Auto"/>
       </Grid.RowDefinitions>
-      <TextBlock Grid.Row="0" Text="{x:Static nuget:Resources.VSOptions_Label_PackagePattern}" Margin="12,0,12,9"/>
+      <TextBlock Grid.Row="0" Text="{x:Static nuget:Resources.VSOptions_Label_PackagePattern}" Margin="12,12,12,9"/>
       <vsui:WatermarkedTextBox Grid.Row="1"
                                  BorderBrush="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderBrushKey}}"
                                  BorderThickness="1"
@@ -171,7 +132,7 @@
         </ListView.View>
       </nuget:ToggleableListView>
     </Grid>
-    <Grid Grid.Row="3" Margin="12,0,12,12">
+    <Grid Grid.Row="1" Margin="12,0,12,12">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="*" />
         <ColumnDefinition Width="Auto" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml.cs
@@ -160,5 +160,10 @@ namespace NuGet.Options
                 }
             }
         }
+
+        private void AddMappingDialogWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            Keyboard.Focus(_packageID);
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2034

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

1.  I noticed that opening this dialog window didn't automatically focus on the Package ID textbox. Fixed that in this PR.
1.  I discovered that some properties we had configured were causing this dialog to lose default, native border properties from Windows. Specifically, Win11 theming which can include rounded corners.
    - We now get Title bar text for free.
    - The X in the upper right now looks like any Windows close button (and we get it for free).
    - Note: some repos roll their own Window, and instead set properties directly. I decided to keep using the VS `DialogWindow`, which gives us some free. 
 
    - Windows 10: 
![image](https://user-images.githubusercontent.com/49205731/214222694-647635ab-06c2-49b1-99f8-dafd4d8566e6.png)
![image](https://user-images.githubusercontent.com/49205731/214222944-2fea83f6-aa8d-4b95-9d3a-78cc87dbdb88.png)

    - Windows 11 (opted-in to rounded corners):
![image](https://user-images.githubusercontent.com/49205731/214222739-b202a5e6-c02d-4579-8d18-8653d592d27b.png)
![image](https://user-images.githubusercontent.com/49205731/214222954-4e3af354-09f9-4033-8680-c66ca5c2c880.png)

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - manually tested, see screenshots
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
