### PR TITLE
Make the dialog resizable for Add Package Source Mapping in VS Options

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
@@ -10,8 +10,10 @@
              mc:Ignorable="d" 
              x:Uid="AddMappingDialogWindow"
              Height="348"
+             MinHeight="348"
              Width="480"
-             ResizeMode="NoResize"
+             MinWidth="480"
+             ResizeMode="CanResize"
              ShowInTaskbar="False"
              Title="{x:Static nuget:Resources.VSOptions_Label_AddPackageNamespace}"
              WindowStartupLocation="CenterOwner"
@@ -25,6 +27,8 @@
   </vsui:DialogWindow.Resources>
   <Grid>
     <Grid.RowDefinitions>
+      <RowDefinition Height="Auto"/>
+      <RowDefinition Height="Auto"/>
       <RowDefinition Height="*"/>
       <RowDefinition Height="Auto"/>
     </Grid.RowDefinitions>
@@ -71,15 +75,8 @@
         </Setter>
       </Style>
     </Grid.Resources>
-    <Grid Grid.Row="0">
-      <Grid.RowDefinitions>
-        <RowDefinition Height="Auto"/>
-        <RowDefinition Height="Auto"/>
-        <RowDefinition Height="Auto"/>
-        <RowDefinition Height="Auto"/>
-      </Grid.RowDefinitions>
-      <TextBlock Grid.Row="0" Text="{x:Static nuget:Resources.VSOptions_Label_PackagePattern}" Margin="12,12,12,9"/>
-      <vsui:WatermarkedTextBox Grid.Row="1"
+    <TextBlock Grid.Row="0" Text="{x:Static nuget:Resources.VSOptions_Label_PackagePattern}" Margin="12,12,12,9"/>
+    <vsui:WatermarkedTextBox Grid.Row="1"
                                  BorderBrush="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderBrushKey}}"
                                  BorderThickness="1"
                                  AutomationProperties.Name="{x:Static nuget:Resources.VSOptions_Watermark_AddPackageNamespace}"
@@ -88,52 +85,50 @@
                                  Margin="12,0,12,0"
                                  Watermark="{x:Static nuget:Resources.VSOptions_Watermark_AddPackageNamespace}"
                                  TextChanged="PackageID_TextChanged"/>
-      <nuget:ToggleableListView Grid.Row="2"
+    <nuget:ToggleableListView Grid.Row="2"
                     x:Name="_sourcesListBox"
                     AutomationProperties.Name="{x:Static nuget:Resources.VSOptions_Accessibility_SourcesList}"
                     ItemsSource="{Binding SourcesCollection}"
                     PreviewKeyUp="SourcesListBox_PreviewKeyUp"
-                    Margin="12"
-                    Height="184">
-        <ListView.ItemContainerStyle>
-          <Style>
-            <Setter Property="AutomationProperties.Name" Value="{Binding SourceInfo.Name}"/>
-          </Style>
-        </ListView.ItemContainerStyle>
-        <ListView.Resources>
-          <Style x:Key="{x:Static GridView.GridViewScrollViewerStyleKey}" TargetType="{x:Type ScrollViewer}" BasedOn="{StaticResource {x:Static vs:VsResourceKeys.UnthemedGridViewScrollViewerStyleKey}}" />
-          <Style TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource {x:Static vs:VsResourceKeys.UnthemedScrollBarStyleKey}}"/>
-        </ListView.Resources>
-        <ListView.View>
-          <GridView>
-            <!-- checkbox column -->
-            <GridViewColumn>
-              <GridViewColumn.CellTemplate>
-                <DataTemplate>
-                  <CheckBox IsTabStop="False"
+                    Margin="12">
+      <ListView.ItemContainerStyle>
+        <Style>
+          <Setter Property="AutomationProperties.Name" Value="{Binding SourceInfo.Name}"/>
+        </Style>
+      </ListView.ItemContainerStyle>
+      <ListView.Resources>
+        <Style x:Key="{x:Static GridView.GridViewScrollViewerStyleKey}" TargetType="{x:Type ScrollViewer}" BasedOn="{StaticResource {x:Static vs:VsResourceKeys.UnthemedGridViewScrollViewerStyleKey}}" />
+        <Style TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource {x:Static vs:VsResourceKeys.UnthemedScrollBarStyleKey}}"/>
+      </ListView.Resources>
+      <ListView.View>
+        <GridView>
+          <!-- checkbox column -->
+          <GridViewColumn>
+            <GridViewColumn.CellTemplate>
+              <DataTemplate>
+                <CheckBox IsTabStop="False"
                                 AutomationProperties.Name="{x:Static nuget:Resources.CheckBox_Selected}"
                                 IsChecked="{Binding Path=IsSelected}"
                                 Checked="CheckBox_Checked"
                                 Unchecked="CheckBox_Checked"/>
-                </DataTemplate>
-              </GridViewColumn.CellTemplate>
-            </GridViewColumn>
-            <!-- the text column -->
-            <GridViewColumn>
-              <GridViewColumnHeader Content="{x:Static nuget:Resources.VSOptions_Label_Source}" HorizontalContentAlignment="Left"/>
-              <GridViewColumn.CellTemplate>
-                <DataTemplate>
-                  <StackPanel Orientation="Horizontal">
-                    <TextBlock Text="{Binding SourceInfo.Name}"/>
-                  </StackPanel>
-                </DataTemplate>
-              </GridViewColumn.CellTemplate>
-            </GridViewColumn>
-          </GridView>
-        </ListView.View>
-      </nuget:ToggleableListView>
-    </Grid>
-    <Grid Grid.Row="1" Margin="12,0,12,12">
+              </DataTemplate>
+            </GridViewColumn.CellTemplate>
+          </GridViewColumn>
+          <!-- the text column -->
+          <GridViewColumn>
+            <GridViewColumnHeader Content="{x:Static nuget:Resources.VSOptions_Label_Source}" HorizontalContentAlignment="Left"/>
+            <GridViewColumn.CellTemplate>
+              <DataTemplate>
+                <StackPanel Orientation="Horizontal">
+                  <TextBlock Text="{Binding SourceInfo.Name}"/>
+                </StackPanel>
+              </DataTemplate>
+            </GridViewColumn.CellTemplate>
+          </GridViewColumn>
+        </GridView>
+      </ListView.View>
+    </nuget:ToggleableListView>
+    <Grid Grid.Row="3" Margin="12,0,12,12">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="*" />
         <ColumnDefinition Width="Auto" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2128

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Based on feedback in https://github.com/NuGet/NuGet.Client/pull/5028#discussion_r1084962892, I think it is a good idea to go ahead and enable resizing this dialog. As I pointed out in that thread, the size is not remembered after re-opening VS Options, so if that's something customers use a lot, we may want to enhance this to remember preferred dimensions.

  - For Testing, I verified the ListView expands as the Window expands. I didn't see any clipping or unusual behavior. 
  - Removed a Grid that was unnecessary.
  - Win11:
![image](https://user-images.githubusercontent.com/49205731/214367528-6aaf8b0c-4d7b-43d0-af5e-5ce6a7eadc59.png)
  - Win10: 
![image](https://user-images.githubusercontent.com/49205731/214368681-da305ee1-314e-405d-88bb-6cbcd4ccc96d.png)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
