### PR TITLE
Fix SBOMfile path

### DIFF
--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
@@ -26,7 +26,7 @@
 
   <ItemGroup Condition=" '$(IsVsixBuild)' != 'true' ">
     <MergeManifest Include="$(VsixPublishDestination)$(MSBuildProjectName).json"
-      SBOMFileLocation="$(ManifestDirPath)_manifest\spdx_2.2\manifest.spdx.json"
+      SBOMFileLocation="$(ManifestDirPath)\_manifest\spdx_2.2\manifest.spdx.json"
       />
   </ItemGroup>
 

--- a/setup/Microsoft.VisualStudio.NuGet.Core.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.Core.vsmanproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <MergeManifest Include="$(VsixPublishDestination)Microsoft.VisualStudio.NuGet.Core.json"
-      SBOMFileLocation="$(ManifestDirPath)_manifest\spdx_2.2\manifest.spdx.json"
+      SBOMFileLocation="$(ManifestDirPath)\_manifest\spdx_2.2\manifest.spdx.json"
       />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2124

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The insertion PRs are failing on SBOM checks because the path to the SBOM manifest file is missing a slash. This was previously working for some reason, but now the code that does the path discovery is failing to find the file and we need to fix the path.

### Previously warning in 14.GenerateVSManifestForVSIX 

![image](https://user-images.githubusercontent.com/43253759/214372749-e02e5ba5-dc03-454c-976b-91e2eb9dd79a.png)

### With the new change the warning in gone

![image](https://user-images.githubusercontent.com/43253759/214372954-3efd8979-342a-4d92-902e-b31f3a45aed5.png)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
