### PR TITLE
Revert "Signing: enable signature verification by default on Linux in .NET 8 SDK (#5006)"

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -530,7 +530,7 @@ namespace NuGet.Packaging
                 string signVerifyEnvVariable = _environmentVariableReader.GetEnvironmentVariable(
                     EnvironmentVariableConstants.DotNetNuGetSignatureVerification);
 
-                bool canVerify = RuntimeEnvironmentHelper.IsLinux;
+                bool canVerify = false;
 
                 if (!string.IsNullOrEmpty(signVerifyEnvVariable))
                 {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -2102,7 +2102,7 @@ namespace NuGet.Packaging.Test
 
         private static bool CanVerifySignedPackages(IEnvironmentVariableReader environmentVariableReader = null)
         {
-            return (RuntimeEnvironmentHelper.IsWindows || RuntimeEnvironmentHelper.IsLinux ||
+            return (RuntimeEnvironmentHelper.IsWindows ||
                 IsVerificationEnabledByEnvironmentVariable(environmentVariableReader)) &&
 #if IS_SIGNING_SUPPORTED
                 true;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/12387

Regression? Last working version:  N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This reverts commit 9836b4469a575b6b1aa7c9072c28b2f4ef6ec91d.

Because dev branch inserts into both .NET 7.0.2xx SDK and .NET 8.0.1xx SDK but we only want the verification enablement change for 8, we need to revert this change until we have plan for getting into 8 but not 7.

CC @aortiz-msft

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
