### PR TITLE
Revert "Fix User-Agent when OSDescription has unmatched parenthesis (#4991) (#5013)"

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/UserAgentStringBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol/UserAgentStringBuilder.cs
@@ -36,12 +36,7 @@ namespace NuGet.Protocol.Core.Types
 
         public UserAgentStringBuilder WithOSDescription(string osInfo)
         {
-#if NETCOREAPP2_0_OR_GREATER
-            _osInfo = osInfo.Replace("(", @"\(", StringComparison.Ordinal).Replace(")", @"\)", StringComparison.Ordinal);
-#else
-            _osInfo = osInfo.Replace("(", @"\(").Replace(")", @"\)");
-#endif
-
+            _osInfo = osInfo;
             return this;
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/UserAgentStringBuilderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/UserAgentStringBuilderTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Net.Http;
 using NuGet.Protocol.Core.Types;
 using Xunit;
 using Xunit.Abstractions;
@@ -96,22 +95,6 @@ namespace NuGet.Protocol.Tests
             Assert.True(userAgentString2.Contains(builder.NuGetClientVersion));
             Assert.True(userAgentString3.Contains(builder.NuGetClientVersion));
             Assert.True(userAgentString4.Contains(builder.NuGetClientVersion));
-        }
-
-        [Theory]
-        [InlineData("Custom Kernel (123")]
-        [InlineData("Custom Kernel 123)")]
-        public void Build_OsDescriptionWithUnmatchedParenthesis_IsValid(string osDescription)
-        {
-            // Arrange
-            UserAgentStringBuilder target = new();
-
-            // Act
-            string result = target.WithOSDescription(osDescription).Build();
-
-            // Assert
-            HttpRequestMessage httpRequest = new();
-            httpRequest.Headers.Add("User-Agent", result);
         }
     }
 }


### PR DESCRIPTION
This reverts commit 92d3055feae06f398b95ab66c08be04a055c42b6.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
