### PR TITLE
Stop embedding PMC's ps1 script as localizable resource

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/PSTypeWrapper.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/PSTypeWrapper.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Management.Automation;
 using System.Reflection;
 using LocalResources = NuGet.PackageManagement.PowerShellCmdlets.Resources;
@@ -43,8 +44,14 @@ namespace NuGetConsole.Host.PowerShell.Implementation
         {
             get
             {
-                return _addWrapperMembersScript ??
-                       (_addWrapperMembersScript = ScriptBlock.Create(LocalResources.Add_WrapperMembers));
+                if (_addWrapperMembersScript == null)
+                {
+                    string extensionRoot = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                    string scriptPath = Path.Combine(extensionRoot, "Modules", "NuGet", "Add-WrapperMembers.ps1");
+                    string scriptContents = File.ReadAllText(scriptPath);
+                    _addWrapperMembersScript = ScriptBlock.Create(scriptContents);
+                }
+                return _addWrapperMembersScript;
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Resources.Designer.cs
@@ -61,39 +61,6 @@ namespace NuGet.PackageManagement.PowerShellCmdlets {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to #
-        ///# This private script adds $InterfaceType members to $psObject which invokes on $wrappedObject
-        ///#
-        ///Param(
-        ///    $psObject,
-        ///    $wrappedObject,
-        ///    [Type]$InterfaceType
-        ///)
-        ///
-        ///function GetInvoker
-        ///{
-        ///    Param(
-        ///        $Target,
-        ///        $Method
-        ///    )
-        ///
-        ///    if ($Method.IsGenericMethodDefinition) {
-        ///        return {
-        ///            $t = $Target
-        ///            $m = $Method.MakeGenericMethod($args)
-        ///            
-        ///            if (!$m.GetParameters()) {
-        ///                return $m.Invoke($t, @())
-        ///            }
-        ///  [rest of string was truncated]&quot;;.
-        /// </summary>
-        internal static string Add_WrapperMembers {
-            get {
-                return ResourceManager.GetString("Add_WrapperMembers", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to All.
         /// </summary>
         internal static string AggregateSourceName {

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Resources.resx
@@ -117,10 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="Add_WrapperMembers" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>Scripts\Add-WrapperMembers.ps1;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
-  </data>
   <data name="AggregateSourceName" xml:space="preserve">
     <value>All</value>
   </data>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2134

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The loc team translates all resources in the resx file, so we shouldn't be giving them this powershell script. I copied the pattern used to tell PowerShell how to find profile.ps1 (extension install directory + "Modules\NuGet\Add-WrapperMembers.ps1").

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: Validated manually with a breakpoint. There's no change in behaviour, it's just a backend change. Hopefully one of our many existing E2E or Apex tests hit this codepath.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
