### PR TITLE
Add APEX test cases for Dotnet SDK style project to install/update/uninstall package

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -251,6 +251,113 @@ namespace NuGet.Tests.Apex
             }
         }
 
+        [NuGetWpfTheory]
+        [MemberData(nameof(GetNetCoreTemplates))]
+        public async Task InstallPackageToNetCoreProjectFromUI(ProjectTemplate projectTemplate)
+        {
+            EnsureVisualStudioHost();
+
+            using (var simpleTestPathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                string solutionDirectory = simpleTestPathContext.SolutionRoot;
+                var testRepositoryPath = Path.Combine(solutionDirectory, "NetCoreInstallTestRepository");
+                Directory.CreateDirectory(testRepositoryPath);
+                var packageName = "NetCoreInstallTestPackage";
+                var packageVersion = "1.0.0";
+                await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, packageVersion);
+
+                using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, addNetStandardFeeds: true, simpleTestPathContext: simpleTestPathContext))
+                {
+                    VisualStudio.AssertNoErrors();
+
+                    // Act
+                    CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, XunitLogger);
+                    var nugetTestService = GetNuGetTestService();
+                    var uiwindow = nugetTestService.GetUIWindowfromProject(testContext.Project);
+                    uiwindow.InstallPackageFromUI(packageName, packageVersion);
+
+                    // Assert
+                    VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
+                    CommonUtility.AssertPackageReferenceExists(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
+                }
+            }
+        }
+
+        [NuGetWpfTheory]
+        [MemberData(nameof(GetNetCoreTemplates))]
+        public async Task UpdatePackageToNetCoreProjectFromUI(ProjectTemplate projectTemplate)
+        {
+            EnsureVisualStudioHost();
+
+            using (var simpleTestPathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                string solutionDirectory = simpleTestPathContext.SolutionRoot;
+                var testRepositoryPath = Path.Combine(solutionDirectory, "NetCoreUpdateTestRepository");
+                Directory.CreateDirectory(testRepositoryPath);
+                var packageName = "NetCoreUpdateTestPackage";
+                var packageVersion1 = "1.0.0";
+                var packageVersion2 = "2.0.0";
+
+                await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, packageVersion1);
+                await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, packageVersion2);
+
+                using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, addNetStandardFeeds: true, simpleTestPathContext: simpleTestPathContext))
+                {
+                    VisualStudio.AssertNoErrors();
+
+                    // Act
+                    CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, XunitLogger);
+                    var nugetTestService = GetNuGetTestService();
+                    var uiwindow = nugetTestService.GetUIWindowfromProject(testContext.Project);
+                    uiwindow.InstallPackageFromUI(packageName, packageVersion1);
+                    uiwindow.SwitchTabToUpdate();
+                    uiwindow.UpdatePackageFromUI(packageName, packageVersion2);
+
+                    // Assert
+                    VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
+                    CommonUtility.AssertPackageReferenceExists(VisualStudio, testContext.Project, packageName, packageVersion2, XunitLogger);
+                }
+            }
+        }
+
+        [NuGetWpfTheory]
+        [MemberData(nameof(GetNetCoreTemplates))]
+        public async Task UninstallPackageFromNetCoreProjectFromUI(ProjectTemplate projectTemplate)
+        {
+            EnsureVisualStudioHost();
+
+            using (var simpleTestPathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                string solutionDirectory = simpleTestPathContext.SolutionRoot;
+                var testRepositoryPath = Path.Combine(solutionDirectory, "NetCoreUninstallTestRepository");
+                Directory.CreateDirectory(testRepositoryPath);
+                var packageName = "NetCoreUninstallTestPackage";
+                var packageVersion = "1.0.0";
+
+                await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, packageVersion);
+
+                using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger, addNetStandardFeeds: true, simpleTestPathContext: simpleTestPathContext))
+                {
+                    VisualStudio.AssertNoErrors();
+
+                    // Act
+                    CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, XunitLogger);
+                    var nugetTestService = GetNuGetTestService();
+                    var uiwindow = nugetTestService.GetUIWindowfromProject(testContext.Project);
+                    uiwindow.InstallPackageFromUI(packageName, packageVersion);
+                    uiwindow.SwitchTabToInstalled();
+                    uiwindow.UninstallPackageFromUI(packageName);
+
+                    // Assert
+                    VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
+                    CommonUtility.AssertPackageReferenceDoesNotExist(VisualStudio, testContext.Project, packageName, XunitLogger);
+                }
+            }
+        }
+
         // There  is a bug with VS or Apex where NetCoreConsoleApp and NetCoreClassLib create netcore 2.1 projects that are not supported by the sdk
         // Commenting out any NetCoreConsoleApp or NetCoreClassLib template and swapping it for NetStandardClassLib as both are package ref.
 


### PR DESCRIPTION
## Bug
https://github.com/NuGet/Client.Engineering/issues/2116

## Description
**Purpose:**
Add test cases to test installing/updating/uninstalling package into a Dotnet SDK style project from PM UI with “PackageReference” format by default.

**Add three test cases:**
InstallPackageToNetCoreProjectFromUI: Install a local-created package to a C# Net Standard Class Library Project from PM UI.
UpdatePackageToNetCoreProjectFromUI: Install a local-created package and update to latest version for a C# Net Standard Class Library Project in PM UI.
UninstallPackageFromNetCoreProjectFromUI: Install a local-created package and uninstall it from a C# Net Standard Class Library Project from PM UI.

**Notes:**
1.The test cases were added at the end of the .../NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs file.
2.We use the "C# Net Standard Class Library Project" instead of "C# Net Core Console App"/"C# Net Core Class Library" because there  is a bug with VS or Apex where NetCoreConsoleApp and NetCoreClassLib create netcore 2.1 projects that are not supported by the sdk.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added
