### PR TITLE
Telemetry for Floating Versions

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -562,6 +562,7 @@ namespace NuGet.PackageManagement.UI
                 }
             }, cancellationToken);
         }
+
         internal static TelemetryEvent ToTelemetryPackage(string packageId, string packageVersion, string packageVersionRange)
         {
             var subEvent = new TelemetryEvent(eventName: null);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1700

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Adding Telemetry to know if the user is using Floating Versions in the PM UI and understand the rate of usage of Floating Versions in projects.

### Install
![image](https://user-images.githubusercontent.com/43253759/218185993-1b5cbb01-6e78-4ece-9553-dccdb0526f3e.png)

### Update
![image](https://user-images.githubusercontent.com/43253759/218185947-b45b1c31-9c65-4a21-b85a-ec33b91ee3bb.png)

### Uninstall
![image](https://user-images.githubusercontent.com/43253759/218185893-39999cf0-5a2c-4009-8dbd-53ec058649e4.png)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. --> I wasn't able to Mock the behavior of installing a package through the PM UI

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
