### PR TITLE
NuGetSdkVersion in buildinfo.json should be the standard product version

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -29,7 +29,7 @@
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
 
     <!-- NuGet SDK VS package Semantic Version -->
-    <NuGetSdkVsSemanticVersion>$(VsTargetMajorVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</NuGetSdkVsSemanticVersion>
+    <NuGetSdkVsSemanticVersion>$(MajorNuGetVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</NuGetSdkVsSemanticVersion>
 
     <!-- This branches are used for creating insertion PRs -->
     <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetBranch>

--- a/build/config.props
+++ b/build/config.props
@@ -29,7 +29,7 @@
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
 
     <!-- NuGet SDK VS package Semantic Version -->
-    <NuGetSdkVsSemanticVersion>$(MajorNuGetVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</NuGetSdkVsSemanticVersion>
+    <NuGetSdkVsSemanticVersion>$(SemanticVersion)</NuGetSdkVsSemanticVersion>
 
     <!-- This branches are used for creating insertion PRs -->
     <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetBranch>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2155

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Bad cherry-pick of https://github.com/NuGet/NuGet.Client/commit/8400b7dc54fc79f33f608f90d46011f7ea06e820#diff-bd4ef9ba7459727e37706ab7197bdfaa3868ec01297f168ff0b6e243f087d239R32 bug caused some RPS test failures in the 5.11.x and 6.0.x branches

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
