### PR TITLE
Fix an NRE that occurs when versions selection is changed

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
@@ -276,7 +276,7 @@ namespace NuGet.PackageManagement.UI
 
         private void Versions_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            PackageDetailControlModel.PreviousSelectedVersion = e.AddedItems.Count > 0 && !e.AddedItems[0].Equals(null) ? e.AddedItems[0].ToString() : string.Empty;
+            PackageDetailControlModel.PreviousSelectedVersion = e.AddedItems.Count > 0 && e.AddedItems[0] != null ? e.AddedItems[0].ToString() : string.Empty;
 
             return;
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12184

Regression? Last working version: N/A

## Description
An NRE occurs when the package version selection is changed, and the added item array contains a null item as its first element. A previous attempt to fix this in https://github.com/NuGet/NuGet.Client/pull/4935 still attempted to dereference the element to compare it to null. This fix uses a null safe comparison and short circuits if the item is null, setting the PreviousSelectedVersion to an empty string.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
Code is in the UI code behind. Manually tested by attaching a debugger, turning on exceptions, setting a breakpoint, and validating that when AddedItems[0] is null, an NRE is not thrown.
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
