### PR TITLE
Improvements to the patching of dependencies for the dotnet.exe tests, don't overwrite higher versions of assemblies

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -193,7 +193,7 @@ namespace Dotnet.Integration.Test
         }
 
         [PlatformFact(Platform.Windows)]
-        public void PackCommand_NewSolution_ContinuousOutputInBothDefaultAndCustomPaths()
+        public void PackCommand_NewSolution_ContinuousOutputInDefaultPaths()
         {
             // Arrange
             using (var testDirectory = TestDirectory.Create())
@@ -249,19 +249,6 @@ namespace Dotnet.Integration.Test
                 // Assert
                 Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the default place");
                 Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the default place");
-
-                // With common publish path within solution folder
-
-                // Arrange
-                var publishDir = Path.Combine(testDirectory.Path, "publish");
-                nupkgPath = Path.Combine(publishDir, $"{projectName}.1.0.0.nupkg");
-                nuspecPath = Path.Combine(publishDir, $"{projectName}.1.0.0.nuspec");
-
-                msbuildFixture.PackSolution(testDirectory, solutionName, $"--no-build -o {publishDir}", publishDir);
-
-                // Assert
-                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
-                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
             }
         }
 
@@ -3331,12 +3318,11 @@ namespace ClassLibrary
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
 
-                msbuildFixture.RestoreSolution(testDirectory, solutionName, string.Empty);
-
+                msbuildFixture.RestoreSolution(testDirectory, solutionName, args: string.Empty);
                 // Act
-                msbuildFixture.PackSolution(testDirectory, solutionName, $"-o {testDirectory}");
+                msbuildFixture.PackSolution(testDirectory, solutionName, args: string.Empty);
 
-                var nupkgPath = Path.Combine(testDirectory, $"{projectName}.1.0.0.nupkg");
+                var nupkgPath = Path.Combine(projectFolder, "bin", "Debug", $"{projectName}.1.0.0.nupkg");
                 var nuspecPath = Path.Combine(projectFolder, "obj", $"{projectName}.1.0.0.nuspec");
                 Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
                 Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");

--- a/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
@@ -213,7 +213,7 @@ SDKs found: {string.Join(", ", Directory.EnumerateDirectories(SdkDirSource).Sele
                     {
                         var dependencyTargetPath = Path.Combine(pathToSdkInCli, file.Name);
 
-                        if (file.Name.StartsWith("NuGet"))
+                        if (file.Name.Contains("NuGet"))
                         {
                             file.CopyTo(dependencyTargetPath, overwrite: true);
                         }

--- a/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
@@ -210,7 +210,10 @@ SDKs found: {string.Join(", ", Directory.EnumerateDirectories(SdkDirSource).Sele
                 {
                     foreach (FileInfo file in frameworkArtifactsFolder.EnumerateFiles($"*{fileExtension}"))
                     {
-                        file.CopyTo(Path.Combine(pathToSdkInCli, file.Name), overwrite: true);
+                        if (file.Name.Contains("NuGet"))
+                        {
+                            file.CopyTo(Path.Combine(pathToSdkInCli, file.Name), overwrite: true);
+                        }
                     }
                 }
 

--- a/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
@@ -210,9 +211,27 @@ SDKs found: {string.Join(", ", Directory.EnumerateDirectories(SdkDirSource).Sele
                 {
                     foreach (FileInfo file in frameworkArtifactsFolder.EnumerateFiles($"*{fileExtension}"))
                     {
-                        if (file.Name.Contains("NuGet"))
+                        var dependencyTargetPath = Path.Combine(pathToSdkInCli, file.Name);
+
+                        if (file.Name.StartsWith("NuGet"))
                         {
-                            file.CopyTo(Path.Combine(pathToSdkInCli, file.Name), overwrite: true);
+                            file.CopyTo(dependencyTargetPath, overwrite: true);
+                        }
+                        else
+                        {
+                            if (File.Exists(dependencyTargetPath)) // If a dependency exists in the SDK, only copy it if our version is higher than the SDK version.
+                            {
+                                var targetFileVersion = new Version(FileVersionInfo.GetVersionInfo(dependencyTargetPath).FileVersion);
+                                var fileToPatchVersion = new Version(FileVersionInfo.GetVersionInfo(file.FullName).FileVersion);
+                                if (fileToPatchVersion > targetFileVersion)
+                                {
+                                    file.CopyTo(dependencyTargetPath, overwrite: true);
+                                }
+                            }
+                            else // If a dependency does not exist in the SDK, copy it, as we'll need it.
+                            {
+                                file.CopyTo(dependencyTargetPath, overwrite: true);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2157

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

When the new version of the .NET SDK shipped yesterday, it broke some of our tests as our infrastructure started downloading 7.0.200 instead of 7.0.1xx SDK it used.

The correct behavior is to test against newer versions, so we need fix our tests to work with that. 
This is a multi-fix PR;

- Stop calling dotnet.exe with `--output` on a solution file. This was disallowed. See https://github.com/dotnet/sdk/issues/30624, 
There was a fix in https://github.com/dotnet/sdk/pull/29065 for https://github.com/dotnet/sdk/issues/15607 which errors/warns for specifying output path for solution.

- In the past for our dotnet.exe integration tests, prior to https://github.com/NuGet/NuGet.Client/commit/84d99ce064a5f70628c89af9f30693581e84dc37, we used to patch only the NuGet assemblies. If we needed an extra assembly we'd hardcode it. In the linked change, we started copying the new dependencies automatically. Unfortunately this can cause problems sometimes because the version we'd copy would be older than the version in the .NET SDK and cause problems. 
  - You might wonder why only now?  https://github.com/dotnet/runtime/pull/80158/files  and https://github.com/dotnet/runtime/issues/78875 have the answer. 
  Instead of having a platform specific implementation, for the protecteddata dll, in newer runtimes, ashared implementation of the protecteddata.dll will be called. Unfortunately our patching would overwrite that shared implementation with an older version, which is NS2.0, and not appropriate. 
 
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
