### PR TITLE
Migrate release-6.4.x to new archive feeds

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -6,8 +6,7 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="myget-legacy@Local" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy%40Local/nuget/v3/index.json" />
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
-    <add key="vside_vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
-    <add key="vside_vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+    <add key="vside" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <clear />
@@ -44,13 +43,16 @@
       <package pattern="nuget.client.endtoend.testdata" />
       <package pattern="nugetvalidator" />
     </packageSource>
-    <packageSource key = "vside_vssdk">
+    <packageSource key = "vside">
       <package pattern="envdte" />
       <package pattern="envdte100" />
       <package pattern="envdte80" />
       <package pattern="envdte90" />
       <package pattern="envdte90a" />
-      <package pattern="microsoft.*" />
+      <package pattern="microsoft.internal.visualstudio.*" />
+      <package pattern="microsoft.servicehub.*" />
+      <package pattern="microsoft.test.apex.visualstudio" />
+      <package pattern="microsoft.visualstudio.*" />
       <package pattern="stdole" />
       <package pattern="streamjsonrpc" />
       <package pattern="vslangproj" />
@@ -65,9 +67,6 @@
       <package pattern="vslangproj80" />
       <package pattern="vslangproj90" />
       <package pattern="vswebsite.interop" />
-    </packageSource>
-    <packageSource key = "vside_vs-impl">
-      <package pattern="microsoft.*" />
     </packageSource>
     <packageSource key = "myget-legacy@Local">
       <package pattern="microsoft.*" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <clear />
@@ -6,7 +6,8 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="myget-legacy@Local" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy%40Local/nuget/v3/index.json" />
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
-    <add key="vside" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/nuget/v3/index.json" />
+    <add key="vside_vs-impl-archived" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl-archived/nuget/v3/index.json" />
+    <add key="vside_vssdk-archived" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk-archived/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <clear />
@@ -43,16 +44,13 @@
       <package pattern="nuget.client.endtoend.testdata" />
       <package pattern="nugetvalidator" />
     </packageSource>
-    <packageSource key = "vside">
+    <packageSource key = "vside_vssdk-archived">
       <package pattern="envdte" />
       <package pattern="envdte100" />
       <package pattern="envdte80" />
       <package pattern="envdte90" />
       <package pattern="envdte90a" />
-      <package pattern="microsoft.internal.visualstudio.*" />
-      <package pattern="microsoft.servicehub.*" />
-      <package pattern="microsoft.test.apex.visualstudio" />
-      <package pattern="microsoft.visualstudio.*" />
+      <package pattern="microsoft.*" />
       <package pattern="stdole" />
       <package pattern="streamjsonrpc" />
       <package pattern="vslangproj" />
@@ -67,6 +65,9 @@
       <package pattern="vslangproj80" />
       <package pattern="vslangproj90" />
       <package pattern="vswebsite.interop" />
+    </packageSource>
+    <packageSource key = "vside_vs-impl-archived">
+      <package pattern="microsoft.*" />
     </packageSource>
     <packageSource key = "myget-legacy@Local">
       <package pattern="microsoft.*" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Part of: https://github.com/NuGet/Client.Engineering/issues/2159

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Dev branch was moved to `msft_consumption` feed in: https://github.com/NuGet/NuGet.Client/pull/4923

The new `msft_consumption` feed breaks the build of this servicing branch. As the NuGet tooling is older and doesn't support Package Source Mapping, the simplest mitigation is to switch to the new archive feeds replacing `vs-impl` and `vssdk`. Those archive feeds should be available in the March 2023 timeframe.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
