### PR TITLE
Revert hard coded VS version for tests

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -27,7 +27,7 @@
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <VsTargetBranch>main</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
-    <VsTargetChannelForTests>int.d17.5</VsTargetChannelForTests>
+    <VsTargetChannelForTests>$(VsTargetChannel)</VsTargetChannelForTests>
 
     <!-- NuGet SDK VS package Semantic Version -->
     <NuGetSdkVsSemanticVersion>$(VsTargetMajorVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</NuGetSdkVsSemanticVersion>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2118

Regression? Last working version: n/a

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Last 20 days [queued End2nd tests](https://devdiv.visualstudio.com/DevDiv/_build?context=allDefinitions&path=%5CNuGet&definitionId=8118&_a=completed&keywordFilter=dev-eryondon-end2endtest) almost daily so far DTE problem didn't repro, currently not possible to investigate without actual repro. It failed for other reasons like Dartlab or actual flaky test failure. I believe we can reopen the issue or file new issue if DTE issue resurfaces. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
