### PR TITLE
 Cleanup unnecessary GetInstalledPackagesAsync method in the IPackageReferenceProject and clean-up respective tests

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/IPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/IPackageReferenceProject.cs
@@ -19,14 +19,6 @@ namespace NuGet.PackageManagement.VisualStudio
         public Task<ProjectPackages> GetInstalledAndTransitivePackagesAsync(bool includeTransitiveOrigins, CancellationToken token);
 
         /// <summary>
-        /// Gets the both the installed (top level) and transitive package references for this project.
-        /// Returns the package reference as two separate lists (installed and transitive).
-        /// </summary>
-        /// <param name="token">Cancellation token</param>
-        /// <returns>A <see cref="ProjectPackages"/> object with two lists: Installed and transitive packages</returns>
-        public Task<ProjectPackages> GetInstalledAndTransitivePackagesAsync(CancellationToken token);
-
-        /// <summary>
         /// Gets packageFolders section from assets file
         /// </summary>
         /// <param name="ct">Cancellation token</param>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -267,9 +267,6 @@ namespace NuGet.PackageManagement.VisualStudio
             return new ProjectPackages(calculatedInstalledPackages, transitivePkgsResult);
         }
 
-        /// <inheritdoc/>
-        public virtual async Task<ProjectPackages> GetInstalledAndTransitivePackagesAsync(CancellationToken token) => await GetInstalledAndTransitivePackagesAsync(includeTransitivePackages: true, includeTransitiveOrigins: false, token);
-
         protected abstract IEnumerable<PackageReference> ResolvedInstalledPackagesList(IEnumerable<LibraryDependency> libraries, NuGetFramework targetFramework, IList<LockFileTarget> targets, T installedPackages);
 
         protected abstract IReadOnlyList<PackageReference> ResolvedTransitivePackagesList(NuGetFramework targetFramework, IList<LockFileTarget> targets, T installedPackages, T transitivePackages);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -116,9 +116,9 @@ namespace NuGet.PackageManagement.VisualStudio
             return (packageSpec, assetsPath);
         }
 
-        public async Task<ProjectPackages> GetInstalledAndTransitivePackagesAsync(bool includeTransitiveOrigins, CancellationToken token) => await GetInstalledAndTransitivePackagesAsync(includeTransitivePackages: true, includeTransitiveOrigins, token);
+        public virtual async Task<ProjectPackages> GetInstalledAndTransitivePackagesAsync(bool includeTransitiveOrigins, CancellationToken token) => await GetInstalledAndTransitivePackagesAsync(includeTransitivePackages: true, includeTransitiveOrigins, token);
 
-        public async Task<ProjectPackages> GetInstalledAndTransitivePackagesAsync(bool includeTransitivePackages, bool includeTransitiveOrigins, CancellationToken token)
+        internal async Task<ProjectPackages> GetInstalledAndTransitivePackagesAsync(bool includeTransitivePackages, bool includeTransitiveOrigins, CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/NuGetProjectService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/NuGetProjectService.cs
@@ -160,7 +160,7 @@ namespace NuGet.VisualStudio.Implementation.Extensibility
 
             if (project is IPackageReferenceProject packageReferenceProject)
             {
-                var installed = await packageReferenceProject.GetInstalledAndTransitivePackagesAsync(cancellationToken);
+                var installed = await packageReferenceProject.GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins: false, cancellationToken);
                 directPackages = installed.InstalledPackages;
                 transitivePackages = installed.TransitivePackages;
             }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetProjectManagerService.cs
@@ -21,6 +21,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         ValueTask<IInstalledAndTransitivePackages> GetInstalledAndTransitivePackagesAsync(
             IReadOnlyCollection<string> projectIds,
             CancellationToken cancellationToken);
+
         /// <summary>
         /// Obtains the installed and transitive packages from all given projects, optionally including transitive origins for transitive packages.
         /// </summary>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -1276,7 +1276,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 RestoreResult result = await command.ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 Assert.True(result.Success);
-                ProjectPackages packages = await testProject.GetInstalledAndTransitivePackagesAsync(CancellationToken.None);
+                ProjectPackages packages = await testProject.GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins: false, CancellationToken.None);
 
                 // Assert
                 packages.InstalledPackages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("2.15.3"))));
@@ -1334,7 +1334,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 RestoreResult result = await command.ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 Assert.True(result.Success);
-                ProjectPackages packages = await testProject.GetInstalledAndTransitivePackagesAsync(CancellationToken.None);
+                ProjectPackages packages = await testProject.GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins: false, CancellationToken.None);
 
                 // Assert
                 packages.InstalledPackages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("2.15.3"))));
@@ -1377,7 +1377,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 RestoreResult result = await command.ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 Assert.True(result.Success);
-                ProjectPackages packages = await testProject.GetInstalledAndTransitivePackagesAsync(CancellationToken.None);
+                ProjectPackages packages = await testProject.GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins: false, CancellationToken.None);
 
                 // Assert
                 packages.InstalledPackages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("2.15.3"))));
@@ -1428,11 +1428,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 RestoreResult result = await command.ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 Assert.True(result.Success);
-                ProjectPackages packages = await testProject.GetInstalledAndTransitivePackagesAsync(CancellationToken.None);
+                ProjectPackages packages = await testProject.GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins: false, CancellationToken.None);
                 DateTime lastWriteTime = File.GetLastWriteTimeUtc(lockFilePath);
                 File.WriteAllText(lockFilePath, "** replaced file content to test cache **");
                 File.SetLastWriteTimeUtc(lockFilePath, lastWriteTime);
-                ProjectPackages cache_packages = await testProject.GetInstalledAndTransitivePackagesAsync(CancellationToken.None);
+                ProjectPackages cache_packages = await testProject.GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins: false, CancellationToken.None);
 
                 // Assert
                 cache_packages.InstalledPackages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("2.15.3"))));

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
@@ -673,7 +673,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             // Act I: We will not have transitive packages data
 
-            var installedProject1 = await prProject.GetInstalledAndTransitivePackagesAsync(CancellationToken.None);
+            var installedProject1 = await prProject.GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins: false, CancellationToken.None);
             Assert.NotEmpty(installedProject1.InstalledPackages);
             Assert.Empty(installedProject1.TransitivePackages);
 
@@ -694,7 +694,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             // Act II: From this point, we will have transitive packages
 
-            var installedProject2 = await prProject.GetInstalledAndTransitivePackagesAsync(CancellationToken.None);
+            var installedProject2 = await prProject.GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins: false, CancellationToken.None);
             Assert.NotEmpty(installedProject2.InstalledPackages);
             Assert.NotEmpty(installedProject2.TransitivePackages);
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/NuGetProjectServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/NuGetProjectServiceTests.cs
@@ -153,6 +153,14 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                 throw new NotImplementedException();
             }
 
+            public override Task<ProjectPackages> GetInstalledAndTransitivePackagesAsync(bool includeTransitiveOrigins, CancellationToken token)
+            {
+                var transitivePackages = TransitivePackages.Select(p => new TransitivePackageReference(p));
+
+                var projectPackages = new ProjectPackages(InstalledPackages.ToList(), transitivePackages.ToList());
+                return Task.FromResult(projectPackages);
+            }
+
             public override Task<IEnumerable<PackageReference>> GetInstalledPackagesAsync(CancellationToken token)
             {
                 throw new NotImplementedException();

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/NuGetProjectServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/NuGetProjectServiceTests.cs
@@ -153,14 +153,6 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                 throw new NotImplementedException();
             }
 
-            public override Task<ProjectPackages> GetInstalledAndTransitivePackagesAsync(CancellationToken token)
-            {
-                var transitivePackages = TransitivePackages.Select(p => new TransitivePackageReference(p));
-
-                var projectPackages = new ProjectPackages(InstalledPackages.ToList(), transitivePackages.ToList());
-                return Task.FromResult(projectPackages);
-            }
-
             public override Task<IEnumerable<PackageReference>> GetInstalledPackagesAsync(CancellationToken token)
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12098

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Addressing some feedback from earlier PRs. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
