### PR TITLE
Remove missing project references in static graph-based restore

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -706,6 +706,9 @@ namespace NuGet.Build.Tasks.Console
                 // Fix project reference casings to match the original project on case insensitive file systems.
                 MSBuildRestoreUtility.NormalizePathCasings(projectPathLookup, dependencyGraphSpec);
 
+                // Remove references to projects that could not be read by restore.
+                MSBuildRestoreUtility.RemoveMissingProjects(dependencyGraphSpec);
+
                 // Add all entry projects if they support restore.  In most cases this is just a single project but if the entry
                 // project is a solution, then all projects in the solution are added (if they support restore)
                 foreach (var entryPoint in entryProjects)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -316,6 +316,7 @@ namespace NuGet.Commands
             {
                 foreach (var framework in project.RestoreMetadata.TargetFrameworks)
                 {
+                    // Loop through the items in reverse order so items can be removed from the collection safely
                     for (int i = framework.ProjectReferences.Count - 1; i >= 0; i--)
                     {
                         if (!existingProjects.Contains(framework.ProjectReferences[i].ProjectPath))

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -316,11 +316,11 @@ namespace NuGet.Commands
             {
                 foreach (var framework in project.RestoreMetadata.TargetFrameworks)
                 {
-                    foreach (var projectReference in framework.ProjectReferences)
+                    for (int i = framework.ProjectReferences.Count - 1; i >= 0; i--)
                     {
-                        if (!existingProjects.Contains(projectReference.ProjectPath))
+                        if (!existingProjects.Contains(framework.ProjectReferences[i].ProjectPath))
                         {
-                            framework.ProjectReferences.Remove(projectReference);
+                            framework.ProjectReferences.Remove(framework.ProjectReferences[i]);
                         }
                     }
                 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -316,7 +316,7 @@ namespace NuGet.Commands
             {
                 foreach (var framework in project.RestoreMetadata.TargetFrameworks)
                 {
-                    foreach (var projectReference in framework.ProjectReferences.ToArray())
+                    foreach (var projectReference in framework.ProjectReferences)
                     {
                         if (!existingProjects.Contains(projectReference.ProjectPath))
                         {

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -810,6 +810,56 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
         [PlatformTheory(Platform.Windows)]
         [InlineData(true)]
         [InlineData(false)]
+        public void MsbuildRestore_WithMissingProjectReferences_HandlesProjectReferencesToUnsupportedProjects(bool restoreUseStaticGraphEvaluation)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                NuGetFramework targetFramework = NuGetFramework.Parse("net461");
+
+                var projectA = new SimpleTestProjectContext("ProjectA", ProjectStyle.PackageReference, pathContext.SolutionRoot)
+                {
+                    ToolingVersion15 = true
+                };
+
+                var projectB = new SimpleTestProjectContext("b", ProjectStyle.PackageReference, pathContext.SolutionRoot);
+
+                var projectAFrameworkContext = new SimpleTestProjectFrameworkContext(targetFramework);
+
+                projectAFrameworkContext.ProjectReferences.Add(projectB);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                projectA.Frameworks.Add(projectAFrameworkContext);
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                File.WriteAllText(
+                    projectB.ProjectPath,
+                    @"<Project />");
+
+                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore /p:RestoreUseStaticGraphEvaluation={restoreUseStaticGraphEvaluation} {projectA.ProjectPath}", ignoreExitCode: true);
+
+                // Assert
+                result.ExitCode.Should().Be(0, result.AllOutput);
+
+                //result.AllOutput.Should().Contain($"error MSB4025: The project file could not be loaded. Could not find file '{projectB.ProjectPath}'");
+            }
+        }
+
+        [PlatformTheory(Platform.Windows)]
+        [InlineData(true)]
+        [InlineData(false)]
         public async Task MsbuildRestore_WithCPPCliVcxproj_RestoresSuccessfullyWithPackageReference(bool isStaticGraphRestore)
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12322

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Static graph-based restore will leave project references for projects that don't actually exist in the graph.  Regular restore manually removes any projects that don't support restore so this update just adds a call to the existing method.  In performance testing, this added very little overhead.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception 
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
