### PR TITLE
Change client sdk dependencies to versions that exist on nuget.org

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)' == ''">3.0.0</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <NewtonsoftJsonPackageVersion Condition="'$(NewtonsoftJsonPackageVersion)' == ''">13.0.1</NewtonsoftJsonPackageVersion>
     <SystemPackagesVersion Condition="'$(SystemPackagesVersion)' == ''">4.3.0</SystemPackagesVersion>
-    <VSFrameworkVersion Condition="'$(VSFrameworkVersion)' == ''">17.2.0-preview-2-32304-091</VSFrameworkVersion>
+    <VSFrameworkVersion Condition="'$(VSFrameworkVersion)' == ''">17.4.33103.184</VSFrameworkVersion>
     <VSServicesVersion Condition="'$(VSServicesVersion)' == ''">16.153.0</VSServicesVersion>
     <!-- Default MSBuild version -->
     <MicrosoftBuildVersion Condition="'$(MicrosoftBuildVersion)' == ''">17.3.1</MicrosoftBuildVersion>
@@ -94,7 +94,6 @@
       To resolve runtime assembly binding failures, we'll downgrade the package from 4.11.1 to 4.9.0.
     -->
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
-    <PackageVersion Include="VSSDK.TemplateWizardInterface" Version="12.0.4" />
     <PackageVersion Include="VsWebSite.Interop" Version="$(VSFrameworkVersion)" />
     <PackageVersion Include="xunit" Version="2.4.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
@@ -113,8 +112,8 @@
               '$(MSBuildProjectFile)' == 'NuGet.VisualStudio.Contracts.csproj' OR
               '$(MSBuildProjectFile)' == 'NuGet.VisualStudio.Interop.csproj' OR
               '$(MSBuildProjectFile)' == 'NuGet.SolutionRestoreManager.Interop.csproj'">
-    <PackageVersion Include="Microsoft.ServiceHub.Framework" Version="2.7.327-preview" />
-    <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost" Version="17.0.67-g9e37b637e6" />
+    <PackageVersion Include="Microsoft.ServiceHub.Framework" Version="4.1.112" />
+    <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost" Version="17.4.255" />
     <PackageVersion Update="Microsoft.VisualStudio.SDK" Version="" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="$(VSFrameworkVersion)" />
   </ItemGroup>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -21,6 +21,7 @@
       <package pattern="messagepack.annotations" />
       <package pattern="messagepackanalyzer" />
       <package pattern="microsoft.*" />
+      <package pattern="Microsoft.VisualStudio.*" />
       <package pattern="moq" />
       <package pattern="MSTest.TestAdapter" />
       <package pattern="MSTest.TestFramework" />

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
@@ -14,7 +14,6 @@ Microsoft.Internal.VisualStudio.Interop.dll
 Microsoft.Internal.VisualStudio.Shell.Framework.dll
 Microsoft.IO.Redist.dll
 Microsoft.NET.StringTools.dll
-Microsoft.ServiceHub.Client.dll
 Microsoft.ServiceHub.Framework.dll
 Microsoft.ServiceHub.Framework.resources.dll
 Microsoft.ServiceHub.Resources.dll


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12164

Regression? probably, but it's not very impactful (just causes a NU warning on restore for anyone refernencing the package), so I'm not motivated to dig into the history to figure out when it regressed.

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Update the versions of `Microsoft.ServiceHub.Framework`,`Microsoft.VisualStudio.ComponentModelHost`, and any package using our `VSFrameworkVersion` property (such as `Microsoft.VisualStudio.SDK` and `Microsoft.VisualStudio.TemplateWizardInterface`) to versions that are available on nuget.org
* Update package source mapping config to get `Microsoft.VisualStudio.*` from nuget.org only.
  * This was necessary, because the VS SDK feed was returning HTTP 401 responses, rather than 404, causing restore to fail, even though the packages are available from nuget.org

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
