### PR TITLE
Ensure client sdk dependencies exist on nuget.org

### DIFF
--- a/NuGet.sln
+++ b/NuGet.sln
@@ -159,7 +159,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.SolutionRestoreManage
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Tools", "src\NuGet.Clients\NuGet.Tools\NuGet.Tools.csproj", "{D0F9864B-D782-4471-81A2-29555E5DC0D7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.PackageManagement.VisualStudio", "src\NuGet.Clients\NuGet.PackageManagement.VisualStudio\NuGet.PackageManagement.VisualStudio.csproj", "{306CDDFA-FF0B-4299-930C-9EC6C9308160}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.PackageManagement.VisualStudio", "src\NuGet.Clients\NuGet.PackageManagement.VisualStudio\NuGet.PackageManagement.VisualStudio.csproj", "{306CDDFA-FF0B-4299-930C-9EC6C9308160}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleCommandLineExtensions", "test\TestExtensions\SampleCommandLineExtensions\SampleCommandLineExtensions.csproj", "{F2F53B1A-B973-4932-80CB-5EDA38F9D74C}"
 EndProject
@@ -321,6 +321,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GenerateLicenseList", "test\TestExtensions\GenerateLicenseList\GenerateLicenseList.csproj", "{D792897C-D5D7-40A6-9565-8FA4ACE0EBFA}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GenerateTestPackages", "test\TestExtensions\GenerateTestPackages\GenerateTestPackages.csproj", "{1BCC177E-D529-4015-93E2-4C254FA015AA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ensure-nupkg-dependencies-on-source", "tools-local\ensure-nupkg-dependencies-on-source\ensure-nupkg-dependencies-on-source.csproj", "{719AC60C-59EF-4A63-AC9E-7841DF14179D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -696,6 +698,10 @@ Global
 		{1BCC177E-D529-4015-93E2-4C254FA015AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1BCC177E-D529-4015-93E2-4C254FA015AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1BCC177E-D529-4015-93E2-4C254FA015AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{719AC60C-59EF-4A63-AC9E-7841DF14179D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{719AC60C-59EF-4A63-AC9E-7841DF14179D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{719AC60C-59EF-4A63-AC9E-7841DF14179D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{719AC60C-59EF-4A63-AC9E-7841DF14179D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -812,6 +818,7 @@ Global
 		{DB4FB5FB-6E00-4648-8DCB-40BFF972D3AD} = {01BC4531-1E25-48D7-A8FD-A47D6FEC47FB}
 		{D792897C-D5D7-40A6-9565-8FA4ACE0EBFA} = {23CEFC88-9365-4464-A517-700224ECA033}
 		{1BCC177E-D529-4015-93E2-4C254FA015AA} = {23CEFC88-9365-4464-A517-700224ECA033}
+		{719AC60C-59EF-4A63-AC9E-7841DF14179D} = {CE4C7E1B-6883-49C3-A407-F807094777CC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3747A66A-00D1-41B8-A9C5-ED0D7BEA9D25}

--- a/eng/pipelines/templates/Validate_Build_Output.yml
+++ b/eng/pipelines/templates/Validate_Build_Output.yml
@@ -1,0 +1,38 @@
+parameters:
+- name: isOfficialBuild
+  type: boolean
+- name: DartLabEnvironment
+  displayName: DartLab Environment
+  type: string
+  default: Production
+  values:
+  - Production
+  - Staging
+
+steps:
+- task: DownloadBuildArtifacts@1
+  displayName: "Download nupkgs"
+  name: DownloadNupkgs
+  inputs:
+    artifactName: "nupkgs - RTM"
+    downloadPath: "$(System.ArtifactsDirectory)/nupkgs"
+
+- task: PowerShell@2
+  name: check_nupkg_dependencies
+  displayName: Check package dependencies
+  inputs:
+    targetType: inline
+    script: |
+      $nupkgs = Get-ChildItem $(System.ArtifactsDirectory)/nupkgs/*.nupkg -Exclude *.symbols.nupkg
+      if ($nupkgs.Count -eq 0) { throw "Could not find nupkgs" }
+      "nupkgs:"
+      $nupkgs.FullName
+      ""
+      "Building validation tool"
+      dotnet run --project tools-local/ensure-nupkg-dependencies-on-source/ -- $nupkgs -s https://api.nuget.org/v3/index.json
+      if ($LASTEXITCODE -ne 0) { throw "Build was not successful" }
+      ""
+      "Running validation tool"
+      dotnet run --project tools-local/ensure-nupkg-dependencies-on-source/ --no-build -- $nupkgs -s https://api.nuget.org/v3/index.json
+  condition: "and(succeededOrFailed(), or(eq(variables['SkipNupkgDependenciesCheck'], 'true'), eq(variables['SkipNupkgDependenciesCheck'], '')))"
+  continueOnError: ${{ parameters.isOfficialBuild }}

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -133,6 +133,17 @@ stages:
       parameters:
         BuildRTM: true
         NuGetLocalizationType: Full
+  - job: Validate_Publishing_Artifacts
+    displayName: 'Validate Publishing build artifacts'
+    dependsOn: Build_and_UnitTest_RTM
+    timeoutInMinutes: 15
+    pool:
+      vmImage: windows-latest
+    steps:
+    - template: Validate_Build_Output.yml
+      parameters:
+        isOfficialBuild: ${{ parameters.isOfficialBuild }}
+
 
 - stage: Source_Build
   dependsOn: Initialize

--- a/tools-local/ensure-nupkg-dependencies-on-source/NuGetFeed.cs
+++ b/tools-local/ensure-nupkg-dependencies-on-source/NuGetFeed.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Protocol.Core.Types;
+
+namespace ensure_nupkg_dependencies_on_source
+{
+    internal class NuGetFeed
+    {
+        private readonly SourceRepository _sourceRepository;
+        private FindPackageByIdResource? _findPackageByIdResource;
+
+        public NuGetFeed(SourceRepository sourceRepository)
+        {
+            _sourceRepository = sourceRepository;
+        }
+
+        public async ValueTask<FindPackageByIdResource> GetFindPackageByIdResourceAsync()
+        {
+            if (_findPackageByIdResource == null)
+            {
+                _findPackageByIdResource = await _sourceRepository.GetResourceAsync<FindPackageByIdResource>();
+            }
+
+            return _findPackageByIdResource;
+        }
+    }
+}

--- a/tools-local/ensure-nupkg-dependencies-on-source/PackageInfo.cs
+++ b/tools-local/ensure-nupkg-dependencies-on-source/PackageInfo.cs
@@ -1,0 +1,9 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Packaging.Core;
+
+namespace ensure_nupkg_dependencies_on_source
+{
+    record PackageInfo(PackageIdentity PackageIdentity, IReadOnlyList<PackageIdentity> Dependencies);
+}

--- a/tools-local/ensure-nupkg-dependencies-on-source/Program.cs
+++ b/tools-local/ensure-nupkg-dependencies-on-source/Program.cs
@@ -1,0 +1,194 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.CommandLine;
+using ensure_nupkg_dependencies_on_source;
+using NuGet.Common;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+
+internal class Program
+{
+    private static async Task<int> Main(string[] args)
+    {
+        var rootCommand = new RootCommand("Check that nupkg dependencies are available on specified source(s).");
+
+        var nupkgsArgument = new Argument<List<FileInfo>>("nupkgs");
+        nupkgsArgument.Arity = ArgumentArity.OneOrMore;
+        nupkgsArgument.Description = "Nupkgs to check";
+        rootCommand.Add(nupkgsArgument);
+
+        var sourcesOption = new Option<List<string>>("--source");
+        sourcesOption.AddAlias("-s");
+        sourcesOption.IsRequired = true;
+        sourcesOption.Arity = ArgumentArity.OneOrMore;
+        rootCommand.Add(sourcesOption);
+
+        rootCommand.SetHandler(ExecuteAsync, nupkgsArgument, sourcesOption);
+        var exitCode = await rootCommand.InvokeAsync(args);
+        return exitCode;
+    }
+
+    private static async Task<int> ExecuteAsync(List<FileInfo> files, List<string> sourcesList)
+    {
+        if (!CheckAllFilesExist(files))
+        {
+            return -1;
+        }
+
+        IReadOnlyList<NuGetFeed> sources = GetSources(sourcesList);
+        List<string> messages = new();
+        IReadOnlyDictionary<string, PackageInfo> nupkgs = GetNupkgInfo(files, messages);
+
+        await CheckDependenciesExistAsync(nupkgs, sources, messages);
+
+        if (messages.Count == 0)
+        {
+            Console.WriteLine("No missing dependencies found");
+            return 0;
+        }
+        else
+        {
+            foreach (var message in messages)
+            {
+                Console.WriteLine(message);
+            }
+            return -1;
+        }
+    }
+
+    private static async Task CheckDependenciesExistAsync(
+        IReadOnlyDictionary<string, PackageInfo> nupkgs,
+        IReadOnlyList<NuGetFeed> sources,
+        List<string> messages)
+    {
+        Dictionary<PackageIdentity, bool> checkedPackages = new();
+
+        // The packages provided are intended to be pushed, so pretend they're already there
+        foreach (var packageInfo in nupkgs.Values)
+        {
+            checkedPackages.Add(packageInfo.PackageIdentity, true);
+        }
+
+        using (var cacheContext = new SourceCacheContext())
+        {
+            foreach (var (nupkgPath, packageInfo) in nupkgs)
+            {
+                foreach (var dependency in packageInfo.Dependencies)
+                {
+                    bool exists;
+                    if (!checkedPackages.TryGetValue(dependency, out exists))
+                    {
+                        foreach (var source in sources)
+                        {
+                            FindPackageByIdResource resource = await source.GetFindPackageByIdResourceAsync();
+                            exists = await resource.DoesPackageExistAsync(dependency.Id, dependency.Version, cacheContext, NullLogger.Instance, CancellationToken.None);
+                            if (exists)
+                            {
+                                break;
+                            }
+                        }
+
+                        checkedPackages.Add(dependency, exists);
+                    }
+
+                    if (!exists)
+                    {
+                        var message = $"{nupkgPath}: Dependency {dependency} could not be found";
+                        messages.Add(message);
+                    }
+                }
+            }
+        }
+    }
+
+    private static IReadOnlyDictionary<string, PackageInfo> GetNupkgInfo(List<FileInfo> files, List<string> messages)
+    {
+        Dictionary<string, PackageInfo> packages = new();
+
+        foreach (FileInfo file in files)
+        {
+            PackageInfo packageInfo = GetNupkgInfo(file, messages);
+            packages.Add(file.FullName, packageInfo);
+        }
+
+        return packages;
+    }
+
+    private static PackageInfo GetNupkgInfo(FileInfo file, List<string> messages)
+    {
+        using (var package = new PackageArchiveReader(file.FullName))
+        {
+            var nuspecReader = package.NuspecReader;
+            var packageIdentity = nuspecReader.GetIdentity();
+
+            HashSet<PackageIdentity> packageDependencies = new();
+            foreach (PackageDependencyGroup? tfmGroup in nuspecReader.GetDependencyGroups())
+            {
+                if (tfmGroup == null) { continue; }
+                foreach (var packageDependency in tfmGroup.Packages)
+                {
+                    var versionRange = packageDependency.VersionRange;
+                    if (versionRange == null)
+                    {
+                        var message = $"{file.FullName}: dependency {packageDependency.Id} does not have a version range";
+                        messages.Add(message);
+                    }
+                    else if (versionRange.MinVersion == null)
+                    {
+                        var message = $"{file.FullName}: dependency {packageDependency.Id} does not have a min version";
+                    }
+                    else
+                    {
+                        var dependencyIdentity = new PackageIdentity(packageDependency.Id, versionRange.MinVersion);
+                        packageDependencies.Add(dependencyIdentity);
+                    }
+                }
+            }
+
+            var result = new PackageInfo(packageIdentity, packageDependencies.OrderBy(d => d.Id).ToList());
+            return result;
+        }
+    }
+
+    private static IReadOnlyList<NuGetFeed> GetSources(List<string> sourcesList)
+    {
+        List<NuGetFeed> sources = new();
+
+        foreach (var packageSource in sourcesList)
+        {
+            SourceRepository source = Repository.Factory.GetCoreV3(packageSource);
+            NuGetFeed feed = new(source);
+            sources.Add(feed);
+        }
+
+        return sources;
+    }
+
+    private static bool CheckAllFilesExist(List<FileInfo> files)
+    {
+        var allExist = true;
+        var hasGlob = false;
+        foreach (var file in files)
+        {
+            if (!file.Exists)
+            {
+                allExist = false;
+                Console.WriteLine(file.FullName + " does not exist.");
+                if (file.Name.Contains("*"))
+                {
+                    hasGlob = true;
+                }
+            }
+        }
+
+        if (hasGlob)
+        {
+            Console.WriteLine("This app does not support file globbing. Please use your shell to expand the file list.");
+        }
+
+        return allExist;
+    }
+}

--- a/tools-local/ensure-nupkg-dependencies-on-source/ensure-nupkg-dependencies-on-source.csproj
+++ b/tools-local/ensure-nupkg-dependencies-on-source/ensure-nupkg-dependencies-on-source.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <RootNamespace>ensure_nupkg_dependencies_on_source</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Description>Checks that the dependencies of one or more nupkgs are available on specified NuGet source(s)</Description>
+    <SkipShared>true</SkipShared>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Related: https://github.com/NuGet/Home/issues/12164

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Wrote a little app that will parse the package dependencies of the created nupkgs, and then check nuget.org to make sure they exist. This will prevent regressions. I edited the CI pipeline to run this app after build.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
