### PR TITLE
Correctly update a conditional reference in CPS based projects in Visual Studio

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
@@ -294,6 +294,12 @@ namespace NuGet.PackageManagement.VisualStudio
                         TargetFrameworkCondition,
                         originalFramework);
 
+                    // This is the update operation
+                    if (!reference.IsAdded)
+                    {
+                        await reference.Metadata.SetPropertyValueAsync("Version", formattedRange);
+                    }
+
                     // SuppressParent could be set to All if developmentDependency flag is true in package nuspec file.
                     if (installationContext.SuppressParent != LibraryIncludeFlagUtils.DefaultSuppressParent &&
                         installationContext.IncludeType != LibraryIncludeFlags.All)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2177

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->


We're using the API incorrectly. We don't check for an item already existing when writing.
Today this leads to a no-op.

We already do a similar thing in the unconfigured version. 

API: https://github.com/NuGet/NuGet.Client/blob/7a789759ef0707c7a4e47a117e30429a2c7cf700/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs#L291

Example of how it should work in the non-conditional path:

https://github.com/NuGet/NuGet.Client/blob/7a789759ef0707c7a4e47a117e30429a2c7cf700/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs#L323-L328

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - This change is not exposed through too many scenarios today, but is necessary to add future improvements in this area.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
