### PR TITLE
Update calls to targets in config.props to account for multiple lines of output

### DIFF
--- a/eng/pipelines/templates/Initialize_Build.yml
+++ b/eng/pipelines/templates/Initialize_Build.yml
@@ -27,17 +27,14 @@ steps:
         if ([System.String]::IsNullOrEmpty($env:VsTargetChannelOverride) -eq $false) {
           $targetChannel = $env:VsTargetChannelOverride
         } else {
-          $targetChannel = (& dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetChannel) -Join [Environment]::NewLine
-          $targetChannel = $targetChannel.Trim()
+          $targetChannel = ((& dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetChannel) | Out-String).Trim()
         }
         if ([System.String]::IsNullOrEmpty($env:VsTargetChannelOverrideForTests) -eq $false) {
           $targetChannelForTests = $env:VsTargetChannelOverrideForTests
         } else {
-          $targetChannelForTests = (& dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetChannelForTests) -Join [Environment]::NewLine
-          $targetChannelForTests = $targetChannelForTests.Trim()
+          $targetChannelForTests = ((& dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetChannelForTests) | Out-String).Trim()
         }
-        $targetMajorVersion = (& dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetMajorVersion) -Join [Environment]::NewLine
-        $targetMajorVersion = $targetMajorVersion.Trim()
+        $targetMajorVersion = ((& dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetMajorVersion) | Out-String).Trim()
         Write-Host "##vso[task.setvariable variable=VsTargetChannel;isOutput=true]$targetChannel"
         Write-Host "##vso[task.setvariable variable=VsTargetChannelForTests;isOutput=true]$targetChannelForTests"
         Write-Host "##vso[task.setvariable variable=VsTargetMajorVersion;isOutput=true]$targetMajorVersion"

--- a/eng/pipelines/templates/Initialize_Build_SemanticVersion.yml
+++ b/eng/pipelines/templates/Initialize_Build_SemanticVersion.yml
@@ -12,7 +12,7 @@ steps:
     scriptType: "inlineScript"
     inlineScript: |
       try {
-        $version = (& dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetSemanticVersion) -Join [Environment]::NewLine
+        $version = ((& dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetSemanticVersion) | Out-String).Trim()
         if ($LASTEXITCODE -ne 0) { throw $version }
         $version = $version.Trim()
         Write-Host "##vso[task.setvariable variable=SemanticVersion;isOutput=true]$version"

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -171,10 +171,10 @@ else
 {
     Write-Host "##vso[task.setvariable variable=VsixPublishDir;]VS15"
     $newBuildCounter = $BuildNumber
-    $VsTargetBranch = & dotnet msbuild $RepositoryPath\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetBranch
-    $NuGetSdkVsVersion = & dotnet msbuild $RepositoryPath\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetNuGetSdkVsSemanticVersion
-    $VsTargetChannel = & dotnet msbuild $RepositoryPath\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetChannel
-    $VsTargetMajorVersion = & dotnet msbuild $RepositoryPath\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetMajorVersion
+    $VsTargetBranch = ((& dotnet msbuild $RepositoryPath\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetBranch) | Out-String).Trim()
+    $NuGetSdkVsVersion = ((& dotnet msbuild $RepositoryPath\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetNuGetSdkVsSemanticVersion) | Out-String).Trim()
+    $VsTargetChannel = ((& dotnet msbuild $RepositoryPath\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetChannel) | Out-String).Trim()
+    $VsTargetMajorVersion = ((& dotnet msbuild $RepositoryPath\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetMajorVersion) | Out-String).Trim()
     Write-Host "VS target branch: $VsTargetBranch"
     $jsonRepresentation = @{
         BuildNumber = $newBuildCounter
@@ -182,10 +182,10 @@ else
         BuildBranch = $BranchName
         LocalizationRepositoryBranch = $NuGetLocalizationRepoBranch
         LocalizationRepositoryCommitHash = $LocalizationRepoCommitHash
-        VsTargetBranch = $VsTargetBranch.Trim()
-        VsTargetChannel = $VstargetChannel.Trim()
-        VsTargetMajorVersion = $VsTargetMajorVersion.Trim()
-        NuGetSdkVsVersion = $NuGetSdkVsVersion.Trim()
+        VsTargetBranch = $VsTargetBranch
+        VsTargetChannel = $VstargetChannel
+        VsTargetMajorVersion = $VsTargetMajorVersion
+        NuGetSdkVsVersion = $NuGetSdkVsVersion
     }
 
     # First create the file locally so that we can laster publish it as a build artifact from a local source file instead of a remote source file.

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -4,7 +4,7 @@ $VSInstallerProcessName = "VSIXInstaller"
 
 function Get-VisualStudioVersionRangeFromConfig
 {
-    $VsVersion = & dotnet msbuild "$PSScriptRoot\..\..\build\config.props" /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVSTargetMajorVersion
+    $VsVersion = ((& dotnet msbuild "$PSScriptRoot\..\..\build\config.props" /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVSTargetMajorVersion) | Out-String).Trim()
     Write-Host "config.props targets VS version $vsVersion"
     $VsVersionRange = "["+$VsVersion+".0,"+(1+$VsVersion)+".0)"
     return $VsVersionRange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2170

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This is a follow-up to https://github.com/NuGet/NuGet.Client/pull/5072 because I found a few more places where this was a problem.  I also found a way to simplify the code.

The `buildinfo.json` in builds contains arrays now which is causing release failures:

```json
{
    "BuildNumber":  "6.6.0.123",
    "BuildBranch":  "dev",
    "NuGetSdkVsVersion":  [
                              "",
                              "17.6.0"
                          ],
    "LocalizationRepositoryCommitHash":  "SHA",
    "VsTargetMajorVersion":  [
                                 "",
                                 "17"
                             ],
    "VsTargetBranch":  [
                           "",
                           "rel/d17.5"
                       ],
    "LocalizationRepositoryBranch":  "dev",
    "VsTargetChannel":  [
                            "",
                            "int.d17.6"
                        ],
    "CommitHash":  "SHA"
}
```
But it should look like this:

```json
{
    "BuildNumber":  "6.6.0.123",
    "BuildBranch":  "dev",
    "NuGetSdkVsVersion":  "17.6.0",
    "LocalizationRepositoryCommitHash":  "SHA",
    "VsTargetMajorVersion":  "17",
    "VsTargetBranch":  "rel/d17.5",
    "LocalizationRepositoryBranch":  "dev",
    "VsTargetChannel":  "int.d17.6",
    "CommitHash":  "SHA"
}
```

I have updated the release pipeline to work around the issue for now as well.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
