### PR TITLE
Avoid trying hitting thread pool immediately after solution load

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSMachineWideSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSMachineWideSettings.cs
@@ -36,7 +36,13 @@ namespace NuGet.PackageManagement.VisualStudio
                     var version = dte.Version;
                     var sku = dte.GetSKU();
 
-                    await TaskScheduler.Default;
+                    // If UI thread is currently blocked on us, just inline on the
+                    // same thread to avoid waiting for a free thread pool thread.
+                    if (!NuGetUIThreadHelper.JoinableTaskFactory.Context.IsMainThreadBlocked())
+                    {
+                        await TaskScheduler.Default;
+                    }
+
                     return Configuration.Settings.LoadMachineWideSettings(
                         baseDirectory,
                         "VisualStudio",


### PR DESCRIPTION
## Bug

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1761278

Regression? Last working version:

## Description
NuGet initialization hits VsMachineWideSettings.Settings immediately after solution load on the UI thread and blocks on it. This leads to be sensitive to high thread pool latency. Instead, if the UI thread is already blocked on us, just read the settings on the UI thread - its doing absolutely nothing else anyway.,

