### PR TITLE
Enable nullable in UIActionEngine, fix NRE during the update operation

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -18,7 +20,6 @@ using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
-using NuGet.Versioning;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
 using Task = System.Threading.Tasks.Task;
@@ -98,7 +99,7 @@ namespace NuGet.PackageManagement.UI
             IServiceBroker serviceBroker = context.ServiceBroker;
             NuGetProjectUpgradeWindowModel upgradeInformationWindowModel;
 
-            using (INuGetProjectManagerService projectManager = await serviceBroker.GetProxyAsync<INuGetProjectManagerService>(
+            using (INuGetProjectManagerService? projectManager = await serviceBroker.GetProxyAsync<INuGetProjectManagerService>(
                 NuGetServices.ProjectManagerService,
                 CancellationToken.None))
             {
@@ -139,7 +140,7 @@ namespace NuGet.PackageManagement.UI
             }
 
             var progressDialogData = new ProgressDialogData(Resources.NuGetUpgrade_WaitMessage);
-            string projectName = await project.GetUniqueNameOrNameAsync(
+            string? projectName = await project.GetUniqueNameOrNameAsync(
                 uiService.UIContext.ServiceBroker,
                 CancellationToken.None);
             string backupPath;
@@ -164,17 +165,15 @@ namespace NuGet.PackageManagement.UI
             if (!string.IsNullOrEmpty(backupPath))
             {
                 string htmlLogFile = GenerateUpgradeReport(projectName, backupPath, upgradeInformationWindowModel);
-
-                Process process = null;
                 try
                 {
-                    process = Process.Start(htmlLogFile);
+                    var process = Process.Start(htmlLogFile);
                 }
                 catch { }
             }
         }
 
-        private static string GenerateUpgradeReport(string projectName, string backupPath, NuGetProjectUpgradeWindowModel upgradeInformationWindowModel)
+        private static string GenerateUpgradeReport(string? projectName, string backupPath, NuGetProjectUpgradeWindowModel upgradeInformationWindowModel)
         {
             using (var upgradeLogger = new UpgradeLogger(projectName, backupPath))
             {
@@ -205,7 +204,7 @@ namespace NuGet.PackageManagement.UI
         {
             IServiceBroker serviceBroker = uiService.UIContext.ServiceBroker;
 
-            using (INuGetProjectManagerService projectManagerService = await serviceBroker.GetProxyAsync<INuGetProjectManagerService>(
+            using (INuGetProjectManagerService? projectManagerService = await serviceBroker.GetProxyAsync<INuGetProjectManagerService>(
                 NuGetServices.ProjectManagerService,
                 cancellationToken: cancellationToken))
             {
@@ -249,14 +248,14 @@ namespace NuGet.PackageManagement.UI
 
         private async Task PerformActionAsync(
             INuGetUI uiService,
-            UserAction userAction,
+            UserAction? userAction,
             NuGetOperationType operationType,
             ResolveActionsAsync resolveActionsAsync,
             CancellationToken cancellationToken)
         {
             IServiceBroker serviceBroker = uiService.UIContext.ServiceBroker;
 
-            using (INuGetProjectManagerService projectManagerService = await serviceBroker.GetProxyAsync<INuGetProjectManagerService>(
+            using (INuGetProjectManagerService? projectManagerService = await serviceBroker.GetProxyAsync<INuGetProjectManagerService>(
                 NuGetServices.ProjectManagerService,
                 cancellationToken: cancellationToken))
             {
@@ -282,7 +281,7 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private static Tuple<string, string, string> CreatePackageTuple(IPackageReferenceContextInfo pkg)
+        private static Tuple<string, string, string?> CreatePackageTuple(IPackageReferenceContextInfo pkg)
         {
             PackageIdentity package = pkg.Identity;
             return Tuple.Create(package.Id, package.Version == null ? string.Empty : package.Version.ToNormalizedString(), pkg?.AllowedVersions?.OriginalString ?? null);
@@ -294,7 +293,7 @@ namespace NuGet.PackageManagement.UI
             INuGetUI uiService,
             ResolveActionsAsync resolveActionsAsync,
             NuGetOperationType operationType,
-            UserAction userAction,
+            UserAction? userAction,
             CancellationToken cancellationToken)
         {
             var status = NuGetOperationStatus.Succeeded;
@@ -304,11 +303,11 @@ namespace NuGet.PackageManagement.UI
             var continueAfterPreview = true;
             var acceptedLicense = true;
 
-            List<string> removedPackages = null;
-            var existingPackages = new HashSet<Tuple<string, string, string>>();
-            List<Tuple<string, string>> addedPackages = null;
-            List<Tuple<string, string>> updatedPackagesOld = null;
-            List<Tuple<string, string>> updatedPackagesNew = null;
+            List<string>? removedPackages = null;
+            var existingPackages = new HashSet<Tuple<string, string, string?>>();
+            List<Tuple<string, string>>? addedPackages = null;
+            List<Tuple<string, string>>? updatedPackagesOld = null;
+            List<Tuple<string, string>>? updatedPackagesNew = null;
             bool? packageToInstallWasTransitive = null;
 
             // Enable granular level telemetry events for nuget ui operation
@@ -320,11 +319,11 @@ namespace NuGet.PackageManagement.UI
             {
                 IServiceBroker sb = uiService.UIContext.ServiceBroker;
                 int projectsCount = uiService.Projects.Count();
-                IEnumerable<IPackageReferenceContextInfo> installedPackages = null;
+                IEnumerable<IPackageReferenceContextInfo>? installedPackages = null;
                 // collect the install state of the existing packages
                 foreach (IProjectContextInfo project in uiService.Projects) // only one project when PM UI is in project mode
                 {
-                    if (projectsCount == 1 && !userAction.IsSolutionLevel && userAction.Action == NuGetProjectActionType.Install && project.ProjectStyle == ProjectModel.ProjectStyle.PackageReference && project.ProjectKind == NuGetProjectKind.PackageReference)
+                    if (projectsCount == 1 && userAction != null && !userAction.IsSolutionLevel && userAction.Action == NuGetProjectActionType.Install && project.ProjectStyle == ProjectModel.ProjectStyle.PackageReference && project.ProjectKind == NuGetProjectKind.PackageReference)
                     {
                         IInstalledAndTransitivePackages installedAndTransitives = await project.GetInstalledAndTransitivePackagesAsync(sb, cancellationToken);
                         installedPackages = installedAndTransitives.InstalledPackages;
@@ -363,7 +362,7 @@ namespace NuGet.PackageManagement.UI
                 {
                     uiService.BeginOperation();
 
-                    using (INuGetProjectUpgraderService projectUpgrader = await serviceBroker.GetProxyAsync<INuGetProjectUpgraderService>(
+                    using (INuGetProjectUpgraderService? projectUpgrader = await serviceBroker.GetProxyAsync<INuGetProjectUpgraderService>(
                         NuGetServices.ProjectUpgraderService,
                         cancellationToken))
                     {
@@ -563,7 +562,7 @@ namespace NuGet.PackageManagement.UI
             }, cancellationToken);
         }
 
-        internal static TelemetryEvent ToTelemetryPackage(string packageId, string packageVersion, string packageVersionRange)
+        internal static TelemetryEvent ToTelemetryPackage(string packageId, string packageVersion, string? packageVersionRange)
         {
             var subEvent = new TelemetryEvent(eventName: null);
             subEvent.AddPiiData("id", VSTelemetryServiceUtility.NormalizePackageId(packageId));
@@ -583,23 +582,22 @@ namespace NuGet.PackageManagement.UI
             return list;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "We require lowercase package names in telemetry so that the hashes are consistent")]
         internal static void AddUiActionEngineTelemetryProperties(
             VSActionsTelemetryEvent actionTelemetryEvent,
             bool continueAfterPreview,
             bool acceptedLicense,
-            UserAction userAction,
+            UserAction? userAction,
             int? selectedIndex,
             int? recommendedCount,
             bool? recommendPackages,
             (string modelVersion, string vsixVersion)? recommenderVersion,
             int topLevelVulnerablePackagesCount,
             List<int> topLevelVulnerablePackagesMaxSeverities,
-            HashSet<Tuple<string, string, string>> existingPackages,
-            List<Tuple<string, string>> addedPackages,
-            List<string> removedPackages,
-            List<Tuple<string, string>> updatedPackagesOld,
-            List<Tuple<string, string>> updatedPackagesNew,
+            HashSet<Tuple<string, string, string?>>? existingPackages,
+            List<Tuple<string, string>>? addedPackages,
+            List<string>? removedPackages,
+            List<Tuple<string, string>>? updatedPackagesOld,
+            List<Tuple<string, string>>? updatedPackagesNew,
             IReadOnlyCollection<string> targetFrameworks)
         {
             // log possible cancel reasons
@@ -651,7 +649,7 @@ namespace NuGet.PackageManagement.UI
                 foreach (var package in addedPackages)
                 {
                     // Update package VersionRange if it is the selected one
-                    if (package.Item1.Equals(userAction.PackageId, StringComparison.OrdinalIgnoreCase))
+                    if (userAction != null && package.Item1.Equals(userAction.PackageId, StringComparison.OrdinalIgnoreCase))
                     {
                         packages.Add(ToTelemetryPackage(package.Item1, package.Item2, userAction.VersionRange?.OriginalString));
                     }
@@ -683,7 +681,7 @@ namespace NuGet.PackageManagement.UI
 
                 foreach (var package in updatedPackagesNew)
                 {
-                    if (package.Item1.Equals(userAction.PackageId, StringComparison.OrdinalIgnoreCase))
+                    if (userAction != null && package.Item1.Equals(userAction.PackageId, StringComparison.OrdinalIgnoreCase))
                     {
                         packages.Add(ToTelemetryPackage(package.Item1, package.Item2, userAction.VersionRange?.OriginalString));
                     }
@@ -709,10 +707,15 @@ namespace NuGet.PackageManagement.UI
         }
 
         private async Task<bool> CheckPackageManagementFormatAsync(
-            INuGetProjectUpgraderService projectUpgrader,
+            INuGetProjectUpgraderService? projectUpgrader,
             INuGetUI uiService,
             CancellationToken cancellationToken)
         {
+            if (projectUpgrader == null)
+            {
+                return false;
+            } // todo nk?
+
             IReadOnlyCollection<string> projectIds = uiService.Projects.Select(project => project.ProjectId).ToArray();
             IReadOnlyCollection<IProjectContextInfo> upgradeableProjects = await projectUpgrader.GetUpgradeableProjectsAsync(
                 projectIds,
@@ -969,10 +972,11 @@ namespace NuGet.PackageManagement.UI
                     }
                 }
 
-                string projectName;
 
                 IProjectMetadataContextInfo projectMetadata = await projectManagerService.GetMetadataAsync(actions.Key, cancellationToken);
 
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+                string projectName;
                 if (projectMetadata is null || string.IsNullOrEmpty(projectMetadata.UniqueName))
                 {
                     projectName = Resources.Preview_UnknownProject;
@@ -981,6 +985,7 @@ namespace NuGet.PackageManagement.UI
                 {
                     projectName = projectMetadata.UniqueName;
                 }
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
 
                 var result = new PreviewResult(projectName, added, deleted, updated);
 
@@ -1012,22 +1017,25 @@ namespace NuGet.PackageManagement.UI
             using (var sourceCacheContext = new SourceCacheContext())
             {
                 // first check all the packages with local sources.
-                var completed = (await TaskCombinators.ThrottledAsync(
+#pragma warning disable CS8619 // Nullability of reference types in value doesn't match target type.
+                IPackageSearchMetadata[] completed = (await TaskCombinators.ThrottledAsync(
                     allPackages,
                     (p, t) => GetPackageMetadataAsync(localSources, sourceCacheContext, p, t),
                     token)).Where(metadata => metadata != null).ToArray();
+#pragma warning restore CS8619 // Nullability of reference types in value doesn't match target type.
 
                 results.AddRange(completed);
 
                 if (completed.Length != allPackages.Length)
                 {
                     // get remaining package's metadata from remote repositories
-                    var remainingPackages = allPackages.Where(package => !completed.Any(pack => pack.Identity.Equals(package)));
-
-                    var remoteResults = (await TaskCombinators.ThrottledAsync(
+                    var remainingPackages = allPackages.Where(package => package != null && !completed.Any(pack => pack != null && pack.Identity.Equals(package)));
+#pragma warning disable CS8619 // Nullability of reference types in value doesn't match target type.
+                    IPackageSearchMetadata[] remoteResults = (await TaskCombinators.ThrottledAsync(
                         remainingPackages,
                         (p, t) => GetPackageMetadataAsync(sources, sourceCacheContext, p, t),
                         token)).Where(metadata => metadata != null).ToArray();
+#pragma warning restore CS8619 // Nullability of reference types in value doesn't match target type.
 
                     results.AddRange(remoteResults);
                 }
@@ -1035,7 +1043,7 @@ namespace NuGet.PackageManagement.UI
             // check if missing metadata for any package
             if (allPackages.Length != results.Count)
             {
-                var package = allPackages.First(pkg => !results.Any(result => result.Identity.Equals(pkg)));
+                var package = allPackages.First(pkg => !results.Any(result => result != null && result.Identity.Equals(pkg)));
 
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "Unable to find metadata of {0}", package));
             }
@@ -1043,7 +1051,7 @@ namespace NuGet.PackageManagement.UI
             return results;
         }
 
-        private static async Task<IPackageSearchMetadata> GetPackageMetadataAsync(
+        private static async Task<IPackageSearchMetadata?> GetPackageMetadataAsync(
             IEnumerable<SourceRepository> sources,
             SourceCacheContext sourceCacheContext,
             PackageIdentity package,
@@ -1064,7 +1072,7 @@ namespace NuGet.PackageManagement.UI
                     var packageMetadata = await metadataResource.GetMetadataAsync(
                         package,
                         sourceCacheContext,
-                        log: Common.NullLogger.Instance,
+                        log: NullLogger.Instance,
                         token: token);
                     if (packageMetadata != null)
                     {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -1029,7 +1029,7 @@ namespace NuGet.PackageManagement.UI
                 if (completed.Length != allPackages.Length)
                 {
                     // get remaining package's metadata from remote repositories
-                    var remainingPackages = allPackages.Where(package => package != null && !completed.Any(pack => pack != null && pack.Identity.Equals(package)));
+                    var remainingPackages = allPackages.Where(package => package != null && !completed.Any(packageMetadata => packageMetadata != null && packageMetadata.Identity.Equals(package)));
 #pragma warning disable CS8619 // Nullability of reference types in value doesn't match target type.
                     IPackageSearchMetadata[] remoteResults = (await TaskCombinators.ThrottledAsync(
                         remainingPackages,
@@ -1043,8 +1043,7 @@ namespace NuGet.PackageManagement.UI
             // check if missing metadata for any package
             if (allPackages.Length != results.Count)
             {
-                var package = allPackages.First(pkg => !results.Any(result => result != null && result.Identity.Equals(pkg)));
-
+                PackageIdentity package = allPackages.First(pkg => !results.Any(result => result != null && result.Identity.Equals(pkg)));
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "Unable to find metadata of {0}", package));
             }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -369,6 +369,7 @@ namespace NuGet.PackageManagement.UI
                         bool isAcceptedFormat = await CheckPackageManagementFormatAsync(projectUpgrader, uiService, cancellationToken);
                         if (!isAcceptedFormat)
                         {
+                            status = NuGetOperationStatus.Cancelled;
                             return;
                         }
                     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -582,6 +582,7 @@ namespace NuGet.PackageManagement.UI
             return list;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "We require lowercase package names in telemetry so that the hashes are consistent")]
         internal static void AddUiActionEngineTelemetryProperties(
             VSActionsTelemetryEvent actionTelemetryEvent,
             bool continueAfterPreview,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -167,7 +167,7 @@ namespace NuGet.PackageManagement.UI
                 string htmlLogFile = GenerateUpgradeReport(projectName, backupPath, upgradeInformationWindowModel);
                 try
                 {
-                    var process = Process.Start(htmlLogFile);
+                    using var process = Process.Start(htmlLogFile);
                 }
                 catch { }
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -714,7 +714,7 @@ namespace NuGet.PackageManagement.UI
             if (projectUpgrader == null)
             {
                 return false;
-            } // todo nk?
+            }
 
             IReadOnlyCollection<string> projectIds = uiService.Projects.Select(project => project.ProjectId).ToArray();
             IReadOnlyCollection<IProjectContextInfo> upgradeableProjects = await projectUpgrader.GetUpgradeableProjectsAsync(

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -308,7 +308,8 @@ namespace NuGet.PackageManagement.UI.Test
 
             // Assert
             Assert.NotNull(lastTelemetryEvent);
-            Assert.Equal(NuGetOperationStatus.Succeeded, lastTelemetryEvent[nameof(ActionEventBase.Status)]);
+            // expect cancelled action because we mocked just enough objects to emit telemetry
+            Assert.Equal(NuGetOperationStatus.Cancelled, lastTelemetryEvent[nameof(ActionEventBase.Status)]);
             Assert.Equal(NuGetOperationType.Install, lastTelemetryEvent[nameof(ActionsTelemetryEvent.OperationType)]);
             Assert.Equal(isSolutionLevel, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.IsSolutionLevel)]);
             Assert.Equal(activeTab, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.Tab)]);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -308,8 +308,7 @@ namespace NuGet.PackageManagement.UI.Test
 
             // Assert
             Assert.NotNull(lastTelemetryEvent);
-            // expect failed action because we mocked just enough objects to emit telemetry
-            Assert.Equal(NuGetOperationStatus.Failed, lastTelemetryEvent[nameof(ActionEventBase.Status)]);
+            Assert.Equal(NuGetOperationStatus.Succeeded, lastTelemetryEvent[nameof(ActionEventBase.Status)]);
             Assert.Equal(NuGetOperationType.Install, lastTelemetryEvent[nameof(ActionsTelemetryEvent.OperationType)]);
             Assert.Equal(isSolutionLevel, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.IsSolutionLevel)]);
             Assert.Equal(activeTab, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.Tab)]);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12472

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Since Action can be null, 2. Set a breakpoint in https://github.com/NuGet/NuGet.Client/blob/f49ca00e27297fe7b4b82a2557d5b0caad907a06/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs#L327 can throw an NRE. Once I fixed this NRE, I started hitting other ones.

In order to avoid any of these issues in the future, I've enabled nullable in the whole class, and addressed all the warnings.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
