### PR TITLE
Safe ApexTestContext dispose

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
+using Microsoft.Build.Utilities;
 using Microsoft.Test.Apex.VisualStudio;
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using NuGet.Common;
@@ -62,6 +64,7 @@ namespace NuGet.Tests.Apex
                 catch (Exception ex)
                 {
                     _logger.LogInformation($"Failed to close VS on dispose. Attempt #{attempt}");
+                    Thread.Sleep(TimeSpan.FromSeconds(3));
                     ExceptionUtilities.LogException(ex, _logger);
                 }
             }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
@@ -52,8 +52,19 @@ namespace NuGet.Tests.Apex
         public void Dispose()
         {
             _logger.LogInformation("Test complete, closing solution.");
-
-            SolutionService.SaveAndClose();
+            for (int attempt = 1; attempt <= 3; attempt++)
+            {
+                try
+                {
+                    SolutionService.SaveAndClose();
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogInformation($"Failed to close VS on dispose. Attempt #{attempt}");
+                    ExceptionUtilities.LogException(ex, _logger);
+                }
+            }
             _pathContext.Dispose();
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2190

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The expectation with dispose is that it never throws.

*Many* of our Apex tests fail due to the fact VS solution service fails to close. 
We should not fail the whole test case because of that. 

example:

```
----- Inner Stack Trace #1 (System.Runtime.Remoting.RemotingException) -----

Server stack trace: 
   at System.Runtime.Remoting.Channels.Ipc.IpcPort.Connect(String portName, Boolean secure, TokenImpersonationLevel impersonationLevel, Int32 timeout)
   at System.Runtime.Remoting.Channels.Ipc.ConnectionCache.GetConnection(String portName, Boolean secure, TokenImpersonationLevel level, Int32 timeout)
   at System.Runtime.Remoting.Channels.Ipc.IpcClientTransportSink.ProcessMessage(IMessage msg, ITransportHeaders requestHeaders, Stream requestStream, ITransportHeaders& responseHeaders, Stream& responseStream)
   at System.Runtime.Remoting.Channels.BinaryClientFormatterSink.SyncProcessMessage(IMessage msg)

Exception rethrown at [0]: 
   at System.Runtime.Remoting.Proxies.RealProxy.HandleReturnMessage(IMessage reqMsg, IMessage retMsg)
   at System.Runtime.Remoting.Proxies.RealProxy.PrivateInvoke(MessageData& msgData, Int32 type)
   at Microsoft.Test.Apex.VisualStudio.Solution.SolutionService.SaveAndClose()
   at NuGet.Tests.Apex.ApexTestContext.Dispose() in D:\a\_work\1\s\test\NuGet.Tests.Apex\NuGet.Tests.Apex\Apex\ApexTestContext.cs:line 54
   at NuGet.Tests.Apex.RepositoryCountersignedPackageTestCase.<WithExpiredAuthorCertificateAtCountersigning_InstallFromPMCForPC_WarnAsync>d__5.MoveNext() in D:\a\_work\1\s\test\NuGet.Tests.Apex\NuGet.Tests.Apex\NuGetPackageSigningTests\RepositoryCountersignedPackageTestCase.cs:line 137
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
----- Inner Stack Trace #2 (System.Runtime.Remoting.RemotingException) -----

Server stack trace: 
   at System.Runtime.Remoting.Channels.Ipc.IpcPort.Connect(String portName, Boolean secure, TokenImpersonationLevel impersonationLevel, Int32 timeout)
   at System.Runtime.Remoting.Channels.Ipc.ConnectionCache.GetConnection(String portName, Boolean secure, TokenImpersonationLevel level, Int32 timeout)
   at System.Runtime.Remoting.Channels.Ipc.IpcClientTransportSink.ProcessMessage(IMessage msg, ITransportHeaders requestHeaders, Stream requestStream, ITransportHeaders& responseHeaders, Stream& responseStream)
   at System.Runtime.Remoting.Channels.BinaryClientFormatterSink.SyncProcessMessage(IMessage msg)

Exception rethrown at [0]: 
   at System.Runtime.Remoting.Proxies.RealProxy.HandleReturnMessage(IMessage reqMsg, IMessage retMsg)
   at System.Runtime.Remoting.Proxies.RealProxy.PrivateInvoke(MessageData& msgData, Int32 type)
   at NuGet.Tests.Apex.NuGetConsoleTestExtension.GetText()
   at NuGet.Tests.Apex.SharedVisualStudioHostTestClass.Dispose() in D:\a\_work\1\s\test\NuGet.Tests.Apex\NuGet.Tests.Apex\Apex\SharedVisualStudioHostTestClass.cs:line 97
   at ReflectionAbstractionExtensions.DisposeTestClass(ITest test, Object testClass, IMessageBus messageBus, ExecutionTimer timer, CancellationTokenSource cancellationTokenSource) in C:\Dev\xunit\xunit\src\xunit.execution\Extensions\ReflectionAbstractionExtensions.cs:line 79
```

I don't really know how many of our tests this will fix, but looking at a few builds, they all have tests failed with the above stack trace: 

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7445492&view=ms.vss-test-web.build-test-results-tab&runId=70312867&resultId=100025&paneView=debug

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7447787&view=ms.vss-test-web.build-test-results-tab&runId=70360403&resultId=100032&paneView=debug

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
