### PR TITLE
Add test case-verify cache file inside obj folder.

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -683,37 +683,29 @@ namespace NuGet.Tests.Apex
         }
 
         [NuGetWpfTheory]
-        [MemberData(nameof(GetPackagesConfigTemplates))]
-        public async Task VerifyCatchFileInsideObjFolder(ProjectTemplate projectTemplate)
+        [MemberData(nameof(GetNetCoreTemplates))]
+        public async Task VerifyCacheFileInsideObjFolder(ProjectTemplate projectTemplate)
         {
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
             {
                 //Arrange
-                var packageName = "TestPackage";
+                var packageName = "VerifyCacheFilePackage";
                 var packageVersion = "1.0.0";
-                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion);
-                var project = testContext.SolutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.NetCoreConsoleApp, "NetCore");
-                var solutionService = VisualStudio.Get<SolutionService>();
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion);                
                 var nugetConsole = GetConsole(testContext.Project);
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
-                FileInfo CatchFilePath = CommonUtility.GetCatchFilePath(project.FullPath);
+                FileInfo CacheFilePath = CommonUtility.GetCacheFilePath(testContext.Project.FullPath);
 
                 //Act
                 testContext.SolutionService.Build();
                 testContext.NuGetApexTestService.WaitForAutoRestore();
-                CommonUtility.WaitForFileExists(CatchFilePath);
+                CommonUtility.WaitForFileExists(CacheFilePath);
 
-                project.Rebuild();
-                CommonUtility.WaitForFileExists(CatchFilePath);
+                testContext.Project.Rebuild();
+                CommonUtility.WaitForFileExists(CacheFilePath);
 
-                project.Clean();
-                CommonUtility.WaitForFileNotExists(CatchFilePath);
-
-                nugetConsole.Execute("dotnet restore");
-                CommonUtility.WaitForFileExists(CatchFilePath);
-
-                nugetConsole.Clear();
-                solutionService.Save();
+                testContext.Project.Clean();
+                CommonUtility.WaitForFileNotExists(CacheFilePath);
             }
         }
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -686,17 +686,21 @@ namespace NuGet.Tests.Apex
         [MemberData(nameof(GetNetCoreTemplates))]
         public async Task VerifyCacheFileInsideObjFolder(ProjectTemplate projectTemplate)
         {
+            // Arrange
+            EnsureVisualStudioHost();
+
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
-            {
-                //Arrange
+            {                
                 var packageName = "VerifyCacheFilePackage";
                 var packageVersion = "1.0.0";
                 await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion);                
                 var nugetConsole = GetConsole(testContext.Project);
+
+                //Act
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
                 FileInfo CacheFilePath = CommonUtility.GetCacheFilePath(testContext.Project.FullPath);
 
-                //Act
+                // Assert
                 testContext.SolutionService.Build();
                 testContext.NuGetApexTestService.WaitForAutoRestore();
                 CommonUtility.WaitForFileExists(CacheFilePath);

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -19,9 +19,6 @@ namespace NuGet.Tests.Apex
         private const string PrimarySourceName = "source";
         private const string SecondarySourceName = "SecondarySource";
 
-        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
-        private static readonly TimeSpan Interval = TimeSpan.FromSeconds(2);
-
         private readonly SimpleTestPathContext _pathContext = new SimpleTestPathContext();
 
         public NuGetUITestCase(VisualStudioHostFixtureFactory visualStudioHostFixtureFactory, ITestOutputHelper output)
@@ -129,14 +126,14 @@ namespace NuGet.Tests.Apex
             NuGetUIProjectTestExtension uiwindow = nugetTestService.GetUIWindowfromProject(project);
             uiwindow.InstallPackageFromUI(TestPackageName, TestPackageVersionV1);
 
-            WaitForFileExists(packagesConfigFile);
+            CommonUtility.WaitForFileExists(packagesConfigFile);
 
             VisualStudio.ClearWindows();
 
             // Act
             uiwindow.UninstallPackageFromUI(TestPackageName);
 
-            WaitForFileNotExists(packagesConfigFile);
+            CommonUtility.WaitForFileNotExists(packagesConfigFile);
 
             // Assert
             CommonUtility.AssertPackageNotInPackagesConfig(VisualStudio, project, TestPackageName, XunitLogger);
@@ -382,23 +379,6 @@ namespace NuGet.Tests.Apex
             return new FileInfo(Path.Combine(projectFile.DirectoryName, "packages.config"));
         }
 
-        private static void WaitForFileExists(FileInfo file)
-        {
-            Omni.Common.WaitFor.IsTrue(
-                () => File.Exists(file.FullName),
-                Timeout,
-                Interval,
-                $"{file.FullName} did not exist within {Timeout}.");
-        }
-
-        private static void WaitForFileNotExists(FileInfo file)
-        {
-            Omni.Common.WaitFor.IsTrue(
-                () => !File.Exists(file.FullName),
-                Timeout,
-                Interval,
-                $"{file.FullName} still existed after {Timeout}.");
-        }
 
         [StaFact]
         public void InstallPackageToWebSiteProjectFromUI()

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
@@ -417,7 +417,7 @@ namespace NuGet.Tests.Apex
             return Path.Combine(projectDirectory, "obj", "project.assets.json");
         }
 
-        public static FileInfo GetCatchFilePath(string projectPath)
+        public static FileInfo GetCacheFilePath(string projectPath)
         {
             var projectDirectory = Path.GetDirectoryName(projectPath);
             return new FileInfo(Path.Combine(projectDirectory, "obj", "project.nuget.cache"));

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
@@ -27,6 +27,9 @@ namespace NuGet.Tests.Apex
 {
     public class CommonUtility
     {
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan Interval = TimeSpan.FromSeconds(2);
+
         public static async Task CreatePackageInSourceAsync(string packageSource, string packageName, string packageVersion)
         {
             var package = CreatePackage(packageName, packageVersion);
@@ -230,7 +233,7 @@ namespace NuGet.Tests.Apex
             testService.WaitForAutoRestore();
 
             var assetsFilePath = GetAssetsFilePath(project.FullPath);
-            
+
             // Project has an assets file, let's look there to assert
             var inAssetsFile = IsPackageInstalledInAssetsFile(assetsFilePath, packageName, packageVersion, true);
 
@@ -271,7 +274,7 @@ namespace NuGet.Tests.Apex
             testService.WaitForAutoRestore();
 
             var assetsFilePath = GetAssetsFilePath(project.FullPath);
-            
+
             // Project has an assets file, let's look there to assert
             var inAssetsFile = IsPackageInstalledInAssetsFile(assetsFilePath, packageName, packageVersion, false);
             logger.LogInformation($"Exists: {inAssetsFile}");
@@ -412,6 +415,30 @@ namespace NuGet.Tests.Apex
         {
             var projectDirectory = Path.GetDirectoryName(projectPath);
             return Path.Combine(projectDirectory, "obj", "project.assets.json");
+        }
+
+        public static FileInfo GetCatchFilePath(string projectPath)
+        {
+            var projectDirectory = Path.GetDirectoryName(projectPath);
+            return new FileInfo(Path.Combine(projectDirectory, "obj", "project.nuget.cache"));
+        }
+
+        public static void WaitForFileExists(FileInfo file)
+        {
+            Omni.Common.WaitFor.IsTrue(
+                () => File.Exists(file.FullName),
+                Timeout,
+                Interval,
+                $"{file.FullName} did not exist within {Timeout}.");
+        }
+
+        public static void WaitForFileNotExists(FileInfo file)
+        {
+            Omni.Common.WaitFor.IsTrue(
+                () => !File.Exists(file.FullName),
+                Timeout,
+                Interval,
+                $"{file.FullName} still existed after {Timeout}.");
         }
 
         public static void UIInvoke(Action action)


### PR DESCRIPTION
## Bug 
Fixes: https://github.com/NuGet/Client.Engineering/issues/2193
## Description

1. Add test case-verify cache file inside obj folder after building/rebuilding/cleaning/restoring the test project to "C:\NuGet.Client\test\NuGet.Tests.Apex\NuGet.Tests.Apex\NuGetEndToEndTests\NuGetConsoleTestCase.cs".
2. Move WaitForFileExists() and WaitForFileNotExists() methods from [NuGetUITestCase.cs](https://github.com/NuGet/NuGet.Client/blob/3ab7d1462029e0b211a88040c952c9b8a679708d/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs#L385) to [CommonUtility.cs](https://github.com/NuGet/NuGet.Client/blob/3ab7d1462029e0b211a88040c952c9b8a679708d/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs#L28) for reduced code duplication, as this new case added also uses these two methods.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added