### PR TITLE
Fix release-6.4.x branch by update testing sdk version to 7.0.1xx

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -43,7 +43,7 @@
          6.0:6.0.100-preview.7.21379.14 means install the preview version 6.0.100-preview.7.21379.14.
     Refer to https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script#options for more details.
     -->
-    <CliBranchForTesting Condition="'$(CliBranchForTesting)' == ''">7.0</CliBranchForTesting>
+    <CliBranchForTesting Condition="'$(CliBranchForTesting)' == ''">7.0.1xx</CliBranchForTesting>
   </PropertyGroup>
 
   <!-- Config -->


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2198

Regression? Last working version:

## Description
1. Change the testing sdk from "latest version from channel 7.0", to "latest version from channel 7.0.1xx"

**Context**
For the testing SDK, we download the latest version from a specified SDK channel in https://github.com/NuGet/NuGet.Client/blob/dev/build/config.props#L47.
So for dev branch, we are downloading the latest version from 7.0 channel, which is 7.0.200 right now.
But according to https://learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs#lifecycle, the SDK version in VS17.4(which matches our release-6.4.x) is 7.0.1xx.
Reference: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script#options

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
