### PR TITLE
Process GlobalPackageReference items outside of a target

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -92,25 +92,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     </_GenerateRestoreGraphProjectEntryInputProperties>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' == 'true' And '$(RestoreEnableGlobalPackageReference)' != 'false'">
-    <!--
-        Add GlobalPackageReference items to the PackageReference item group with no version.  The PackageVersion items are added
-        in the CollectCentralPackageVersions target.
-
-        Global package references only include the same assets as a development dependency (runtime; build; native; contentfiles; analyzers)
-        because those kind of packages are the best candidate for a global package reference.  They are generally packages that
-        extend the build.
-
-        Global package references have all assets private because central package references are generally packages that provide
-        versioning, signing, etc and should not flow to downstream dependencies.  Also, central package references are already
-        referenced by every project in the tree so they don't need to be transitive.
-      -->
-    <PackageReference Include="@(GlobalPackageReference)"
-                      Version=""
-                      IncludeAssets="Runtime;Build;Native;contentFiles;Analyzers"
-                      PrivateAssets="All" />
-  </ItemGroup>
-
   <!-- Tasks -->
   <UsingTask TaskName="NuGet.Build.Tasks.RestoreTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.WriteRestoreGraphTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
@@ -202,6 +183,25 @@ Copyright (c) .NET Foundation. All rights reserved.
       <CollectPackageReferencesContinueOnError>$(ContinueOnError)</CollectPackageReferencesContinueOnError>
       <CollectPackageReferencesContinueOnError Condition="'$(ContinueOnError)' == '' ">false</CollectPackageReferencesContinueOnError>
     </PropertyGroup>
+
+    <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' == 'true' And '$(RestoreEnableGlobalPackageReference)' != 'false'">
+      <!--
+        Add GlobalPackageReference items to the PackageReference item group with no version.  The PackageVersion items are added
+        in the CollectCentralPackageVersions target.
+
+        Global package references only include the same assets as a development dependency (runtime; build; native; contentfiles; analyzers)
+        because those kind of packages are the best candidate for a global package reference.  They are generally packages that
+        extend the build.
+
+        Global package references have all assets private because central package references are generally packages that provide
+        versioning, signing, etc and should not flow to downstream dependencies.  Also, central package references are already
+        referenced by every project in the tree so they don't need to be transitive.
+      -->
+      <PackageReference Include="@(GlobalPackageReference)"
+                        Version=""
+                        IncludeAssets="Runtime;Build;Native;contentFiles;Analyzers"
+                        PrivateAssets="All" />
+    </ItemGroup>
 
     <CheckForDuplicateNuGetItemsTask
       Condition="'$(DisableCheckingDuplicateNuGetItems)' != 'true' "

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -92,6 +92,30 @@ Copyright (c) .NET Foundation. All rights reserved.
     </_GenerateRestoreGraphProjectEntryInputProperties>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' == 'true' And '$(RestoreEnableGlobalPackageReference)' != 'false'">
+    <!--
+        Add GlobalPackageReference items to the PackageReference item group with no version.
+
+        Global package references only include the same assets as a development dependency (runtime; build; native; contentfiles; analyzers)
+        because those kind of packages are the best candidate for a global package reference.  They are generally packages that
+        extend the build.
+
+        Global package references have all assets private because central package references are generally packages that provide
+        versioning, signing, etc and should not flow to downstream dependencies.  Also, central package references are already
+        referenced by every project in the tree so they don't need to be transitive.
+      -->
+    <PackageReference Include="@(GlobalPackageReference)"
+                      Version=""
+                      IncludeAssets="Runtime;Build;Native;contentFiles;Analyzers"
+                      PrivateAssets="All" />
+
+      <!--
+        Add GlobalPackageReference items to the PackageVersion item group with the version.
+      -->
+    <PackageVersion Include="@(GlobalPackageReference)"
+                    Version="%(Version)" />
+  </ItemGroup>
+
   <!-- Tasks -->
   <UsingTask TaskName="NuGet.Build.Tasks.RestoreTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.WriteRestoreGraphTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
@@ -184,25 +208,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <CollectPackageReferencesContinueOnError Condition="'$(ContinueOnError)' == '' ">false</CollectPackageReferencesContinueOnError>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' == 'true' And '$(RestoreEnableGlobalPackageReference)' != 'false'">
-      <!--
-        Add GlobalPackageReference items to the PackageReference item group with no version.  The PackageVersion items are added
-        in the CollectCentralPackageVersions target.
-
-        Global package references only include the same assets as a development dependency (runtime; build; native; contentfiles; analyzers)
-        because those kind of packages are the best candidate for a global package reference.  They are generally packages that
-        extend the build.
-
-        Global package references have all assets private because central package references are generally packages that provide
-        versioning, signing, etc and should not flow to downstream dependencies.  Also, central package references are already
-        referenced by every project in the tree so they don't need to be transitive.
-      -->
-      <PackageReference Include="@(GlobalPackageReference)"
-                        Version=""
-                        IncludeAssets="Runtime;Build;Native;contentFiles;Analyzers"
-                        PrivateAssets="All" />
-    </ItemGroup>
-
     <CheckForDuplicateNuGetItemsTask
       Condition="'$(DisableCheckingDuplicateNuGetItems)' != 'true' "
       Items="@(PackageReference)"
@@ -238,14 +243,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <CollectCentralPackageVersionsContinueOnError>$(ContinueOnError)</CollectCentralPackageVersionsContinueOnError>
       <CollectCentralPackageVersionsContinueOnError Condition="'$(ContinueOnError)' == '' ">false</CollectCentralPackageVersionsContinueOnError>
     </PropertyGroup>
-
-    <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' == 'true' And '$(RestoreEnableGlobalPackageReference)' != 'false'">
-      <!--
-        Add GlobalPackageReference items to the PackageVersion item group with the version.  The PackageReference items are added
-        in the CollectPackageReferences target.
-      -->
-      <PackageVersion Include="@(GlobalPackageReference)" Version="%(Version)" />
-    </ItemGroup>
 
     <CheckForDuplicateNuGetItemsTask
       Condition="'$(DisableCheckingDuplicateNuGetItems)' != 'true' "

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
@@ -22,9 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\..\src\NuGet.Core\NuGet.Build.Tasks\NuGet.targets">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <None Include="..\..\..\src\NuGet.Core\NuGet.Build.Tasks\NuGet.props"
+          CopyToOutputDirectory="Always" />
+    <None Include="..\..\..\src\NuGet.Core\NuGet.Build.Tasks\NuGet.targets"
+          CopyToOutputDirectory="Always" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12368

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This is a re-do of https://github.com/NuGet/NuGet.Client/pull/5064 which didn't move the logic of creating `<PackageVersion />` items with versions.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [ x Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - We don't have a good way of testing a restore when the targets like `CollectPackageReferences` haven't run like in this scenario.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
