### PR TITLE
Apex method `CreateAndInitProject` Saves All files and Logs Exceptions

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -27,7 +27,7 @@
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <VsTargetBranch>main</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
-    <VsTargetChannelForTests>int.d17.5</VsTargetChannelForTests>
+    <VsTargetChannelForTests>$(VsTargetChannel)</VsTargetChannelForTests>
 
     <!-- NuGet SDK VS package Semantic Version -->
     <NuGetSdkVsSemanticVersion>$(VsTargetMajorVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</NuGetSdkVsSemanticVersion>

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
@@ -456,7 +456,7 @@ namespace NuGet.Tests.Apex
             }
             catch (Exception ex)
             {
-                logger.LogInformation("DGTEST " + ex.ToString());
+                logger.LogInformation("[NuGet Fault in Apex]: " + ex.ToString());
                 throw ex;
             }
         }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
@@ -443,6 +443,9 @@ namespace NuGet.Tests.Apex
                 logger.LogInformation("Adding project");
                 var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
 
+                logger.LogInformation("Saving all open and dirty files");
+                solutionService.SaveAll();
+
                 logger.LogInformation("Saving solution");
                 solutionService.Save();
 
@@ -453,7 +456,7 @@ namespace NuGet.Tests.Apex
             }
             catch (Exception ex)
             {
-                logger.LogError(ex.ToString());
+                logger.LogInformation("DGTEST " + ex.ToString());
                 throw ex;
             }
         }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
@@ -435,19 +435,27 @@ namespace NuGet.Tests.Apex
 
         internal static ProjectTestExtension CreateAndInitProject(ProjectTemplate projectTemplate, SimpleTestPathContext pathContext, SolutionService solutionService, ILogger logger)
         {
-            logger.LogInformation("Creating solution");
-            solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
+            try
+            {
+                logger.LogInformation("Creating solution");
+                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
 
-            logger.LogInformation("Adding project");
-            var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
+                logger.LogInformation("Adding project");
+                var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
 
-            logger.LogInformation("Saving solution");
-            solutionService.Save();
+                logger.LogInformation("Saving solution");
+                solutionService.Save();
 
-            logger.LogInformation("Building solution");
-            project.Build();
+                logger.LogInformation("Building solution");
+                project.Build();
 
-            return project;
+                return project;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.ToString());
+                throw ex;
+            }
         }
 
         public static string AppendErrors(string s, VisualStudioHost visualStudio)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2201

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- `CreateAndInitProject` fails regularly and makes our CI flaky. A guess I have is that there's a file unsaved (maybe out of scope of our tests) which is affecting how the API saves the solution file. 

- Logging any exception with an easily searchable string `[NuGet Fault in Apex]:` for convenience and clarity when looking at logs
  - I think `ToString` here should show inner exceptions. If not, we'll need to modify that as the interesting error probably is there.
- I don't know if this PR solves our Apex flakiness problem, but I also think it doesn't hurt. The successful builds for my branch could be a coincidence:
![image](https://user-images.githubusercontent.com/49205731/225414699-bc145f69-c43d-4a39-bcec-429df633b2a8.png)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added - modified a test
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
