### PR TITLE
Remove redundant environment variables NUGET_PERSIST_DG and NUGET_PERSIST_DG_PATH

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -76,8 +76,6 @@ namespace NuGet.CommandLine.Test
             var dgPath = Path.Combine(pathContext.WorkingDirectory, "out.dg");
             var envVars = new Dictionary<string, string>()
                 {
-                    { "NUGET_PERSIST_DG", "true" },
-                    { "NUGET_PERSIST_DG_PATH", dgPath },
                     { "NUGET_HTTP_CACHE_PATH", pathContext.HttpCacheFolder }
                 };
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2202

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

cc @donnie-msft mentioned these variables internally.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled - https://github.com/NuGet/docs.microsoft.com-nuget/pull/3032
  - **OR**
  - [ ] N/A
