### PR TITLE
Signing:  distinguish X.509 trust store messages by purpose (i.e.:  code signing vs. timestamping) on Windows

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/X509TrustStore.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/X509TrustStore.cs
@@ -162,7 +162,16 @@ namespace NuGet.Packaging.Signing
         // Non-private for testing purposes only
         internal static IX509ChainFactory CreateX509ChainFactory(X509StorePurpose storePurpose, ILogger logger)
         {
-            logger.LogInformation(Strings.ChainBuilding_UsingDefaultTrustStore);
+            switch (storePurpose)
+            {
+                case X509StorePurpose.CodeSigning:
+                    logger.LogInformation(Strings.ChainBuilding_UsingDefaultTrustStoreForCodeSigning);
+                    break;
+
+                case X509StorePurpose.Timestamping:
+                    logger.LogInformation(Strings.ChainBuilding_UsingDefaultTrustStoreForTimestamping);
+                    break;
+            }
 
             return new DotNetDefaultTrustStoreX509ChainFactory();
         }

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -169,11 +169,20 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to X.509 certificate chain validation will use the default trust store selected by .NET..
+        ///   Looks up a localized string similar to X.509 certificate chain validation will use the default trust store selected by .NET for code signing..
         /// </summary>
-        internal static string ChainBuilding_UsingDefaultTrustStore {
+        internal static string ChainBuilding_UsingDefaultTrustStoreForCodeSigning {
             get {
-                return ResourceManager.GetString("ChainBuilding_UsingDefaultTrustStore", resourceCulture);
+                return ResourceManager.GetString("ChainBuilding_UsingDefaultTrustStoreForCodeSigning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to X.509 certificate chain validation will use the default trust store selected by .NET for timestamping..
+        /// </summary>
+        internal static string ChainBuilding_UsingDefaultTrustStoreForTimestamping {
+            get {
+                return ResourceManager.GetString("ChainBuilding_UsingDefaultTrustStoreForTimestamping", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -850,9 +850,6 @@ Valid from:</comment>
     <value>The {0}'s timestamping certificate is not trusted by the trust provider.</value>
     <comment>0 -Signature friendly name</comment>
   </data>
-  <data name="ChainBuilding_UsingDefaultTrustStore" xml:space="preserve">
-    <value>X.509 certificate chain validation will use the default trust store selected by .NET.</value>
-  </data>
   <data name="ChainBuilding_UsingFallbackCertificateBundle" xml:space="preserve">
     <value>X.509 certificate chain validation will use the fallback certificate bundle at '{0}'.</value>
     <comment>{0} is the file path</comment>
@@ -866,5 +863,11 @@ Valid from:</comment>
   </data>
   <data name="InvalidX509StorePurpose" xml:space="preserve">
     <value>Invalid X.509 store purpose.</value>
+  </data>
+  <data name="ChainBuilding_UsingDefaultTrustStoreForCodeSigning" xml:space="preserve">
+    <value>X.509 certificate chain validation will use the default trust store selected by .NET for code signing.</value>
+  </data>
+  <data name="ChainBuilding_UsingDefaultTrustStoreForTimestamping" xml:space="preserve">
+    <value>X.509 certificate chain validation will use the default trust store selected by .NET for timestamping.</value>
   </data>
 </root>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -649,7 +649,12 @@ namespace Dotnet.Integration.Test
                 {
                     result.AllOutput.Should()
                         .Contain(
-                            Strings.ChainBuilding_UsingDefaultTrustStore,
+                            Strings.ChainBuilding_UsingDefaultTrustStoreForCodeSigning,
+                            because: result.AllOutput);
+
+                    result.AllOutput.Should()
+                        .Contain(
+                            Strings.ChainBuilding_UsingDefaultTrustStoreForTimestamping,
                             because: result.AllOutput);
                 }
                 else

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/X509TrustStoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/X509TrustStoreTests.cs
@@ -60,7 +60,17 @@ namespace Dotnet.Integration.Test
             Assert.Equal(5, _logger.Messages.Count);
             Assert.Equal(1, _logger.InformationMessages.Count);
             Assert.True(_logger.InformationMessages.TryPeek(out string actualMessage));
-            Assert.Equal(Strings.ChainBuilding_UsingDefaultTrustStore, actualMessage);
+
+            switch (storePurpose)
+            {
+                case X509StorePurpose.CodeSigning:
+                    Assert.Equal(Strings.ChainBuilding_UsingDefaultTrustStoreForCodeSigning, actualMessage);
+                    break;
+
+                case X509StorePurpose.Timestamping:
+                    Assert.Equal(Strings.ChainBuilding_UsingDefaultTrustStoreForTimestamping, actualMessage);
+                    break;
+            }
         }
 
         [PlatformTheory(Platform.Linux)]

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/X509TrustStoreTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/X509TrustStoreTests.cs
@@ -49,7 +49,7 @@ namespace NuGet.Packaging.FuncTest
             Assert.Equal(1, _logger.Messages.Count);
             Assert.Equal(1, _logger.InformationMessages.Count);
             Assert.True(_logger.InformationMessages.TryDequeue(out string actualMessage));
-            Assert.Equal(Strings.ChainBuilding_UsingDefaultTrustStore, actualMessage);
+            Assert.Equal(Strings.ChainBuilding_UsingDefaultTrustStoreForCodeSigning, actualMessage);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/12339

Regression? Last working version:  No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
NuGet client displays which X.509 trust stores will be used for later signed package verification.  On Windows, the same message is displayed for both code signing and timestamping, leading to this issue (duplicate messages).

This change modifies the messages on Windows to indicate that the trust stores are used for code signing and timestamping.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
