### PR TITLE
Fix transitive dependencies not updating in PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -134,11 +134,14 @@ namespace NuGet.PackageManagement.VisualStudio
             IList<LockFileTarget> targetsList = null;
             T installedPackages;
             T transitivePackages = default;
-            if (includeTransitivePackages || IsInstalledAndTransitiveComputationNeeded)
+            if (IsInstalledAndTransitiveComputationNeeded)
             {
                 // clear the transitive packages cache, since we don't know when a dependency has been removed
                 installedPackages = new T();
-                transitivePackages = new T();
+                if (includeTransitivePackages)
+                {
+                    transitivePackages = new T();
+                }
                 targetsList = await GetTargetsListAsync(assetsFilePath, token);
             }
             else
@@ -183,7 +186,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             // get transitive packages
             IEnumerable<PackageReference> calculatedTransitivePackages = Enumerable.Empty<PackageReference>();
-            if (includeTransitivePackages || IsInstalledAndTransitiveComputationNeeded)
+            if (includeTransitivePackages)
             {
                 calculatedTransitivePackages = packageSpec
                     .TargetFrameworks
@@ -199,8 +202,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 // Compute Transitive Origins
                 Dictionary<string, TransitiveEntry> transitiveOrigins;
                 if (includeTransitivePackages || IsInstalledAndTransitiveComputationNeeded
-                    || TransitiveOriginsCache == null // If any data race left the cache as null
-                    || (TransitiveOriginsCache.Any() && calculatedTransitivePackages.Any())) // We have transitive packages, but no transitive origins and the call is requesting transitive origins
+                    || TransitiveOriginsCache == null) // If any data race left the cache as null
                 {
                     // Special case: Installed and Transitive lists (<see cref="InstalledPackages" />, <see cref="TransitivePackages" /> respectively) are populated,
                     // but Transitive Origins Cache <see cref="TransitiveOriginsCache" /> is not populated.

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -134,7 +134,7 @@ namespace NuGet.PackageManagement.VisualStudio
             IList<LockFileTarget> targetsList = null;
             T installedPackages;
             T transitivePackages = default;
-            if (IsInstalledAndTransitiveComputationNeeded)
+            if (IsInstalledAndTransitiveComputationNeeded) // Cache invalidation
             {
                 // clear the transitive packages cache, since we don't know when a dependency has been removed
                 installedPackages = new T();
@@ -183,7 +183,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             // get transitive packages
             IEnumerable<PackageReference> calculatedTransitivePackages = Enumerable.Empty<PackageReference>();
-            if (includeTransitivePackages || IsInstalledAndTransitiveComputationNeeded)
+            if (includeTransitivePackages || IsInstalledAndTransitiveComputationNeeded) // Cache invalidation
             {
                 calculatedTransitivePackages = packageSpec
                     .TargetFrameworks
@@ -194,14 +194,13 @@ namespace NuGet.PackageManagement.VisualStudio
 
             CounterfactualLoggers.TransitiveDependencies.EmitIfNeeded(); // Emit only one event per VS session
             IEnumerable<TransitivePackageReference> transitivePackagesWithOrigins = Enumerable.Empty<TransitivePackageReference>();
-            if (includeTransitivePackages || IsInstalledAndTransitiveComputationNeeded)
+            if (includeTransitivePackages || IsInstalledAndTransitiveComputationNeeded) // Cache invalidation
             {
                 if (includeTransitiveOrigins && await ExperimentUtility.IsTransitiveOriginExpEnabled.GetValueAsync(token))
                 {
                     // Compute Transitive Origins
                     Dictionary<string, TransitiveEntry> transitiveOrigins;
-                    if (IsInstalledAndTransitiveComputationNeeded // Cache invalidation
-                        || TransitiveOriginsCache == null // If any data race left the cache as null
+                    if (TransitiveOriginsCache == null // If any data race left the cache as null
                         || (!TransitiveOriginsCache.Any() && calculatedTransitivePackages.Any())) // We have transitive packages, but no transitive origins and the call is requesting transitive origins
                     {
                         // Special case: Installed and Transitive lists (<see cref="InstalledPackages" />, <see cref="TransitivePackages" /> respectively) are populated,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -138,10 +138,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 // clear the transitive packages cache, since we don't know when a dependency has been removed
                 installedPackages = new T();
-                if (includeTransitivePackages)
-                {
-                    transitivePackages = new T();
-                }
+                transitivePackages = new T();
                 targetsList = await GetTargetsListAsync(assetsFilePath, token);
             }
             else
@@ -186,7 +183,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             // get transitive packages
             IEnumerable<PackageReference> calculatedTransitivePackages = Enumerable.Empty<PackageReference>();
-            if (includeTransitivePackages)
+            if (includeTransitivePackages || IsInstalledAndTransitiveComputationNeeded)
             {
                 calculatedTransitivePackages = packageSpec
                     .TargetFrameworks
@@ -197,7 +194,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             CounterfactualLoggers.TransitiveDependencies.EmitIfNeeded(); // Emit only one event per VS session
             IEnumerable<TransitivePackageReference> transitivePackagesWithOrigins = Enumerable.Empty<TransitivePackageReference>();
-            if (includeTransitivePackages)
+            if (includeTransitivePackages || IsInstalledAndTransitiveComputationNeeded)
             {
                 if (includeTransitiveOrigins && await ExperimentUtility.IsTransitiveOriginExpEnabled.GetValueAsync(token))
                 {
@@ -254,7 +251,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 InstalledPackages = installedPackages;
             }
-            if (includeTransitivePackages)
+            if (includeTransitivePackages || IsInstalledAndTransitiveComputationNeeded)
             {
                 lock (_installedAndTransitivePackagesLock)
                 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -134,7 +134,7 @@ namespace NuGet.PackageManagement.VisualStudio
             IList<LockFileTarget> targetsList = null;
             T installedPackages;
             T transitivePackages = default;
-            if (IsInstalledAndTransitiveComputationNeeded) // Cache invalidation
+            if (includeTransitivePackages || IsInstalledAndTransitiveComputationNeeded)
             {
                 // clear the transitive packages cache, since we don't know when a dependency has been removed
                 installedPackages = new T();
@@ -194,7 +194,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             CounterfactualLoggers.TransitiveDependencies.EmitIfNeeded(); // Emit only one event per VS session
             IEnumerable<TransitivePackageReference> transitivePackagesWithOrigins = Enumerable.Empty<TransitivePackageReference>();
-            if (includeTransitivePackages || IsInstalledAndTransitiveComputationNeeded) // Cache invalidation
+            if (includeTransitivePackages || IsInstalledAndTransitiveComputationNeeded)
             {
                 if (includeTransitiveOrigins && await ExperimentUtility.IsTransitiveOriginExpEnabled.GetValueAsync(token))
                 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -183,7 +183,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             // get transitive packages
             IEnumerable<PackageReference> calculatedTransitivePackages = Enumerable.Empty<PackageReference>();
-            if (includeTransitivePackages || IsInstalledAndTransitiveComputationNeeded) // Cache invalidation
+            if (includeTransitivePackages || IsInstalledAndTransitiveComputationNeeded)
             {
                 calculatedTransitivePackages = packageSpec
                     .TargetFrameworks

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -250,7 +250,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 InstalledPackages = installedPackages;
             }
-            if (includeTransitivePackages || IsInstalledAndTransitiveComputationNeeded)
+            if (includeTransitivePackages)
             {
                 lock (_installedAndTransitivePackagesLock)
                 {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -12,7 +12,6 @@ using FluentAssertions;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.Sdk.TestFramework;
-using Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi;
 using Microsoft.VisualStudio.Threading;
 using Moq;
 using NuGet.Commands;
@@ -4111,13 +4110,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async Task GetInstalledAndTransitivePackagesAsync_IncludeTranstivePackages_TransitiveOriginsParamSetToTrue_ReturnsPackagesWithTransitiveOriginsAsync()
+        public async Task GetInstalledAndTransitivePackagesAsync_DontIncludeTranstivePackages_TransitiveOriginsParamSetToTrue_ReturnsNoPackagesWithTransitiveOriginsAsync()
         {
             using var rootDir = new SimpleTestPathContext();
             await CreatePackagesAsync(rootDir, packageAVersion: "1.0.0");
             IProjectSystemCache cache = new ProjectSystemCache();
 
-            // Arrange I: A project with no packages
+            // Arrange
             PackageSpec initialProjectSpec = ProjectTestHelpers.GetPackageSpec("MyProject", rootDir.SolutionRoot, framework: "net472", dependencyName: "PackageA");
             await RestorePackageSpecsAsync(rootDir, output: null, initialProjectSpec);
 
@@ -4128,8 +4127,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             // Assert
             Assert.NotEmpty(result.InstalledPackages);
-            Assert.NotEmpty(result.TransitivePackages);
-            Assert.All(result.TransitivePackages, pkg => Assert.NotEmpty(pkg.TransitiveOrigins));
+            Assert.Empty(result.TransitivePackages);
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectFactories.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectFactories.cs
@@ -165,6 +165,23 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 });
         }
 
+        internal static async Task CreatePackagesAsyncMulitple(SimpleTestPathContext rootDir, string packageAVersion = "2.15.3", string packageBVersion = "1.0.0", string packageCVersion = " 2.0.0", string packageDVersion = "2.0.0")
+        {
+            await SimpleTestPackageUtility.CreateFullPackageAsync(rootDir.PackageSource, "packageB", packageBVersion);
+            await SimpleTestPackageUtility.CreateFullPackageAsync(rootDir.PackageSource, "packageA", packageAVersion,
+                new Packaging.Core.PackageDependency[]
+                {
+                    new Packaging.Core.PackageDependency("packageB", VersionRange.Parse(packageBVersion))
+                });
+
+            await SimpleTestPackageUtility.CreateFullPackageAsync(rootDir.PackageSource, "packageD", packageDVersion);
+            await SimpleTestPackageUtility.CreateFullPackageAsync(rootDir.PackageSource, "packageC", packageCVersion,
+                new Packaging.Core.PackageDependency[]
+                {
+                    new Packaging.Core.PackageDependency("packageD", VersionRange.Parse(packageDVersion))
+                });
+        }
+
         internal static CpsPackageReferenceProject PrepareCpsRestoredProject(PackageSpec packageSpec, IProjectSystemCache projectSystemCache = null)
         {
             var projectCache = projectSystemCache ?? new ProjectSystemCache();

--- a/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
@@ -357,6 +357,27 @@ namespace NuGet.Commands.Test
             return GetPackageSpecWithProjectNameAndSpec(projectName, rootPath, spec);
         }
 
+        public static PackageSpec GetPackageSpec(string projectName, string rootPath, string framework, string dependencyName, string secondDependencyName, bool useAssetTargetFallback = false, string assetTargetFallbackFrameworks = "", bool asAssetTargetFallback = true)
+        {
+            var actualAssetTargetFallback = GetFallbackString(useAssetTargetFallback, assetTargetFallbackFrameworks, asAssetTargetFallback);
+
+            const string referenceSpec = @"
+                {
+                    ""frameworks"": {
+                        ""TARGET_FRAMEWORK"": {
+                            ""dependencies"": {
+                                ""DEPENDENCY_NAME"" : ""1.0.0"",
+                                ""SECOND_DEPENDENCY_NAME"" : ""2.0.0""
+                            }
+                            ASSET_TARGET_FALLBACK
+                        }
+                    }
+                }";
+
+            var spec = referenceSpec.Replace("TARGET_FRAMEWORK", framework).Replace("SECOND_DEPENDENCY_NAME", secondDependencyName).Replace("DEPENDENCY_NAME", dependencyName).Replace("ASSET_TARGET_FALLBACK", actualAssetTargetFallback);
+            return GetPackageSpecWithProjectNameAndSpec(projectName, rootPath, spec);
+        }
+
         private static string GetFallbackString(bool useAssetTargetFallback, string assetTargetFallbackFrameworks, bool asAssetTargetFallback = true)
         {
             const string assetTargetFallback = @",


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12333
Fixes: https://github.com/NuGet/Home/issues/12360
Fixes: https://github.com/NuGet/Home/issues/12428

Regression? Last working version: Regression introduced by https://github.com/NuGet/NuGet.Client/commit/e7ea3a13d3fc4738c375f2a48306d0cc46207e36

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Previously we tried to optimize this code path but introduced a regression. `IsInstalledAndTransitiveComputationNeeded` can tell us if a calculation of transitive dependencies is needed since its set to `True` when there is a change in assets file https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs#L386. 

This PR changes so that `IsInstalledAndTransitiveComputationNeeded` is true, we will always recalculate the transitive dependencies, if we don't do it, we will have an unsynchronized cache between transitive and installed dependencies and their transitive origins.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Already existing tests, adding manual testing videos for scenarios without tests
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
