### PR TITLE
Add two test cases for updating all packages in PMC

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -740,7 +740,6 @@ namespace NuGet.Tests.Apex
                     // Act
                     nugetConsole.InstallPackageFromPMC(packageName1, packageVersion1);
                     nugetConsole.InstallPackageFromPMC(packageName2, packageVersion3);
-
                     nugetConsole.Execute("update-package");
 
                     //Asset
@@ -783,9 +782,9 @@ namespace NuGet.Tests.Apex
                     nugetConsole.Execute("update-package");
 
                     // Assert
+                    VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
                     CommonUtility.AssertPackageReferenceExists(VisualStudio, testContext.Project, packageName1, packageVersion2, XunitLogger);
                     CommonUtility.AssertPackageReferenceExists(VisualStudio, testContext.Project, packageName2, packageVersion4, XunitLogger);
-                    VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
                     Assert.True(VisualStudio.HasNoErrorsInOutputWindows());
                 }
             }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -736,10 +736,11 @@ namespace NuGet.Tests.Apex
                     nugetConsole.InstallPackageFromPMC(packageName1, packageVersion1);
                     nugetConsole.InstallPackageFromPMC(packageName2, packageVersion3);
                     nugetConsole.Execute("update-package");
+                    testContext.SolutionService.Build();
+                    testContext.NuGetApexTestService.WaitForAutoRestore();
 
                     // Assert
-                    VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
-                    if (testContext.Project.ProjectTemplate == ProjectTemplate.ClassLibrary)
+                    if (testContext.Project.ProjectTemplate.ToString().Equals("ClassLibrary"))
                     {
                         CommonUtility.AssertPackageInPackagesConfig(VisualStudio, testContext.Project, packageName1, packageVersion2, XunitLogger);
                         CommonUtility.AssertPackageInPackagesConfig(VisualStudio, testContext.Project, packageName2, packageVersion4, XunitLogger);
@@ -749,6 +750,7 @@ namespace NuGet.Tests.Apex
                         CommonUtility.AssertPackageReferenceExists(VisualStudio, testContext.Project, packageName1, packageVersion2, XunitLogger);
                         CommonUtility.AssertPackageReferenceExists(VisualStudio, testContext.Project, packageName2, packageVersion4, XunitLogger);
                     }
+                    VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
                     Assert.True(VisualStudio.HasNoErrorsInOutputWindows());
                 }
             }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -740,7 +740,7 @@ namespace NuGet.Tests.Apex
                     testContext.NuGetApexTestService.WaitForAutoRestore();
 
                     // Assert
-                    if (testContext.Project.ProjectTemplate.ToString().Equals("ClassLibrary"))
+                    if (projectTemplate.ToString().Equals("ClassLibrary"))
                     {
                         CommonUtility.AssertPackageInPackagesConfig(VisualStudio, testContext.Project, packageName1, packageVersion2, XunitLogger);
                         CommonUtility.AssertPackageInPackagesConfig(VisualStudio, testContext.Project, packageName2, packageVersion4, XunitLogger);

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -735,6 +735,9 @@ namespace NuGet.Tests.Apex
                     // Act
                     nugetConsole.InstallPackageFromPMC(packageName1, packageVersion1);
                     nugetConsole.InstallPackageFromPMC(packageName2, packageVersion3);
+                    testContext.SolutionService.Build();
+                    testContext.NuGetApexTestService.WaitForAutoRestore();
+
                     nugetConsole.Execute("update-package");
                     testContext.SolutionService.Build();
                     testContext.NuGetApexTestService.WaitForAutoRestore();


### PR DESCRIPTION
## Bug
https://github.com/NuGet/Client.Engineering/issues/2214
## Description
**We added below test cases into "NuGet.Client\test\NuGet.Tests.Apex\NuGet.Tests.Apex\NuGetEndToEndTests\NuGetConsoleTestCase.cs"**

1. Implement updating all the packages for two kinds of projects (.NET Framework & .NET Core) in PMC.
2. Pass the package info from InlineData to the method.
3. Condition the assert method based on the template.
4. Delete an unnecessary "using System.Diagnostics".

## PR Checklist
- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes
- **Tests**
  - [X] Automated tests added