### PR TITLE
Fix project restore when CentralPackageVersionOverrideEnabled=false

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -470,12 +470,17 @@ namespace NuGet.Commands
             if (restoreRequest.Project.RestoreMetadata.CentralPackageVersionOverrideDisabled)
             {
                 // Emit a error if VersionOverride was specified for a package reference but that functionality is disabled
+                bool hasVersionOverrides = false;
                 foreach (var item in dependenciesWithVersionOverride)
                 {
                     await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1013, string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageVersions_VersionOverrideDisabled, item.Name)));
+                    hasVersionOverrides = true;
                 }
 
-                return false;
+                if (hasVersionOverrides)
+                {
+                    return false;
+                }
             }
 
             if (!restoreRequest.PackageSourceMapping.IsEnabled && httpSourcesCount > 1)


### PR DESCRIPTION
This is fix restoring of the project under CPM. If adding `<CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>` to clean project then `dotnet restore` fails to work.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/nuget/home/issues/12500

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
