### PR TITLE
Signing:  log additional context when root is untrusted on Linux and macOS

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -553,6 +553,11 @@ namespace NuGet.Common
         NU3041 = 3041,
 
         /// <summary>
+        /// An X.509 trust store does not contain a root certificate observed in a package signature.
+        /// </summary>
+        NU3042 = 3042,
+
+        /// <summary>
         /// Undefined Package Error.
         /// </summary>
         NU5000 = 5000,

--- a/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+NuGet.Common.NuGetLogCode.NU3042 = 3042 -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Packaging/Signing/ChainBuilding/DefaultX509ChainBuildPolicy.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/ChainBuilding/DefaultX509ChainBuildPolicy.cs
@@ -12,7 +12,7 @@ namespace NuGet.Packaging.Signing
 
         private DefaultX509ChainBuildPolicy() { }
 
-        public bool Build(X509Chain chain, X509Certificate2 certificate)
+        public bool Build(IX509Chain chain, X509Certificate2 certificate)
         {
             if (chain is null)
             {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/ChainBuilding/IX509ChainBuildPolicy.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/ChainBuilding/IX509ChainBuildPolicy.cs
@@ -11,6 +11,6 @@ namespace NuGet.Packaging.Signing
     /// </summary>
     internal interface IX509ChainBuildPolicy
     {
-        bool Build(X509Chain chain, X509Certificate2 certificate);
+        bool Build(IX509Chain chain, X509Certificate2 certificate);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/ChainBuilding/RetriableX509ChainBuildPolicy.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/ChainBuilding/RetriableX509ChainBuildPolicy.cs
@@ -36,7 +36,7 @@ namespace NuGet.Packaging.Signing
             SleepInterval = sleepInterval;
         }
 
-        public bool Build(X509Chain chain, X509Certificate2 certificate)
+        public bool Build(IX509Chain chain, X509Certificate2 certificate)
         {
             if (chain is null)
             {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
@@ -249,7 +249,7 @@ namespace NuGet.Packaging.Signing
                         {
                             if (settings.ReportUntrustedRoot)
                             {
-                                LogAdditionalContext(chain, issues);
+                                SignatureUtility.LogAdditionalContext(chain, issues);
 
                                 issues.Add(SignatureLog.Issue(!settings.AllowUntrusted, NuGetLogCode.NU3018, string.Format(CultureInfo.CurrentCulture, Strings.VerifyChainBuildingIssue_UntrustedRoot, FriendlyName)));
                             }
@@ -422,21 +422,6 @@ namespace NuGet.Packaging.Signing
             }
 
             return timestampList;
-        }
-
-        private static void LogAdditionalContext(IX509Chain chain, List<SignatureLog> issues)
-        {
-            ILogMessage logMessage = chain.AdditionalContext;
-
-            if (logMessage is not null)
-            {
-                SignatureLog issue = SignatureLog.Issue(
-                    fatal: false,
-                    logMessage.Code,
-                    logMessage.Message);
-
-                issues.Add(issue);
-            }
         }
 #endif
     }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
@@ -192,7 +192,7 @@ namespace NuGet.Packaging.Signing
                 timestamp = timestamp ?? new Timestamp();
                 using (X509ChainHolder chainHolder = X509ChainHolder.CreateForCodeSigning())
                 {
-                    var chain = chainHolder.Chain;
+                    IX509Chain chain = chainHolder.Chain2;
 
                     // This flag should only be set for verification scenarios, not signing.
                     chain.ChainPolicy.VerificationFlags = X509VerificationFlags.IgnoreNotTimeValid;
@@ -209,7 +209,7 @@ namespace NuGet.Packaging.Signing
                     }
 
                     var chainBuildingSucceeded = CertificateChainUtility.BuildCertificateChain(chain, certificate, out var chainStatuses);
-                    var x509ChainString = CertificateUtility.X509ChainToString(chain, fingerprintAlgorithm);
+                    string x509ChainString = CertificateUtility.X509ChainToString(chain.PrivateReference, fingerprintAlgorithm);
 
                     if (!string.IsNullOrWhiteSpace(x509ChainString))
                     {
@@ -249,6 +249,8 @@ namespace NuGet.Packaging.Signing
                         {
                             if (settings.ReportUntrustedRoot)
                             {
+                                LogAdditionalContext(chain, issues);
+
                                 issues.Add(SignatureLog.Issue(!settings.AllowUntrusted, NuGetLogCode.NU3018, string.Format(CultureInfo.CurrentCulture, Strings.VerifyChainBuildingIssue_UntrustedRoot, FriendlyName)));
                             }
 
@@ -420,6 +422,21 @@ namespace NuGet.Packaging.Signing
             }
 
             return timestampList;
+        }
+
+        private static void LogAdditionalContext(IX509Chain chain, List<SignatureLog> issues)
+        {
+            ILogMessage logMessage = chain.AdditionalContext;
+
+            if (logMessage is not null)
+            {
+                SignatureLog issue = SignatureLog.Issue(
+                    fatal: false,
+                    logMessage.Code,
+                    logMessage.Message);
+
+                issues.Add(issue);
+            }
         }
 #endif
     }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Timestamp.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Timestamp.cs
@@ -195,7 +195,7 @@ namespace NuGet.Packaging.Signing
 
                     if (CertificateChainUtility.TryGetStatusAndMessage(chainStatusList, X509ChainStatusFlags.UntrustedRoot, out messages))
                     {
-                        LogAdditionalContext(chain, issues);
+                        SignatureUtility.LogAdditionalContext(chain, issues);
 
                         issues.Add(SignatureLog.Error(NuGetLogCode.NU3028, string.Format(CultureInfo.CurrentCulture, Strings.VerifyTimestampChainBuildingIssue_UntrustedRoot, signature.FriendlyName)));
 
@@ -272,21 +272,6 @@ namespace NuGet.Packaging.Signing
             }
 
             return flags;
-        }
-
-        private static void LogAdditionalContext(IX509Chain chain, List<SignatureLog> issues)
-        {
-            ILogMessage logMessage = chain.AdditionalContext;
-
-            if (logMessage is not null)
-            {
-                SignatureLog issue = SignatureLog.Issue(
-                    fatal: false,
-                    logMessage.Code,
-                    logMessage.Message);
-
-                issues.Add(issue);
-            }
         }
 #endif
     }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/CertificateBundleX509ChainFactory.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/CertificateBundleX509ChainFactory.cs
@@ -15,8 +15,6 @@ namespace NuGet.Packaging.Signing
 {
     internal abstract class CertificateBundleX509ChainFactory : IX509ChainFactory
     {
-        internal const string NU3042HelpUrl = "https://aka.ms/nuget/nu3042";
-
         public X509Certificate2Collection Certificates { get; }
         public string FilePath { get; }
 
@@ -95,7 +93,6 @@ namespace NuGet.Packaging.Signing
                     message = string.Format(
                         CultureInfo.CurrentCulture,
                         Strings.UntrustedRoot_WithoutCertificateBundle,
-                        NU3042HelpUrl,
                         subject,
                         fingerprint,
                         pem);
@@ -106,7 +103,6 @@ namespace NuGet.Packaging.Signing
                         CultureInfo.CurrentCulture,
                         Strings.UntrustedRoot_WithCertificateBundle,
                         FilePath,
-                        NU3042HelpUrl,
                         subject,
                         fingerprint,
                         pem);

--- a/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/CertificateBundleX509ChainFactory.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/CertificateBundleX509ChainFactory.cs
@@ -4,14 +4,19 @@
 #if NET5_0_OR_GREATER
 
 using System;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using NuGet.Common;
 
 namespace NuGet.Packaging.Signing
 {
     internal abstract class CertificateBundleX509ChainFactory : IX509ChainFactory
     {
+        internal const string NU3042HelpUrl = "https://aka.ms/nuget/nu3042";
+
         public X509Certificate2Collection Certificates { get; }
         public string FilePath { get; }
 
@@ -21,7 +26,7 @@ namespace NuGet.Packaging.Signing
             FilePath = filePath;
         }
 
-        public X509Chain Create()
+        public IX509Chain Create()
         {
             X509Chain x509Chain = new();
 
@@ -32,7 +37,7 @@ namespace NuGet.Packaging.Signing
                 x509Chain.ChainPolicy.CustomTrustStore.AddRange(Certificates);
             }
 
-            return x509Chain;
+            return new X509ChainWrapper(x509Chain, GetAdditionalContext);
         }
 
         protected static bool TryImportFromPemFile(string filePath, out X509Certificate2Collection certificates)
@@ -56,6 +61,68 @@ namespace NuGet.Packaging.Signing
             }
 
             return false;
+        }
+
+        private ILogMessage GetAdditionalContext(X509Chain chain)
+        {
+            if (chain is null)
+            {
+                throw new ArgumentNullException(nameof(chain));
+            }
+
+            ILogMessage logMessage = null;
+            int lastIndex = chain.ChainElements.Count - 1;
+
+            if (lastIndex < 0)
+            {
+                return logMessage;
+            }
+
+            X509ChainElement root = chain.ChainElements[lastIndex];
+
+            // If a certificate chain is untrusted simply the root certificate is untrusted, then create
+            // an additional message explaining how one might resolve this lack of trust.
+            if (root.ChainElementStatus.Any(status => status.Status.HasFlag(X509ChainStatusFlags.UntrustedRoot)) &&
+                !Certificates.Contains(root.Certificate))
+            {
+                string subject = root.Certificate.Subject;
+                string fingerprint = CertificateUtility.GetHashString(root.Certificate, Common.HashAlgorithmName.SHA256);
+                string pem = GetPemEncodedCertificate(root.Certificate);
+                string message;
+
+                if (string.IsNullOrEmpty(FilePath))
+                {
+                    message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.UntrustedRoot_WithoutCertificateBundle,
+                        NU3042HelpUrl,
+                        subject,
+                        fingerprint,
+                        pem);
+                }
+                else
+                {
+                    message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.UntrustedRoot_WithCertificateBundle,
+                        FilePath,
+                        NU3042HelpUrl,
+                        subject,
+                        fingerprint,
+                        pem);
+                }
+
+                logMessage = new LogMessage(LogLevel.Warning, message, NuGetLogCode.NU3042);
+            }
+
+            return logMessage;
+        }
+
+        private static string GetPemEncodedCertificate(X509Certificate2 certificate)
+        {
+            ReadOnlyMemory<char> pem = PemEncoding.Write("CERTIFICATE", certificate.RawData);
+
+            return new string(pem.Span);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/DotNetDefaultTrustStoreX509ChainFactory.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/DotNetDefaultTrustStoreX509ChainFactory.cs
@@ -7,9 +7,9 @@ namespace NuGet.Packaging.Signing
 {
     internal sealed class DotNetDefaultTrustStoreX509ChainFactory : IX509ChainFactory
     {
-        public X509Chain Create()
+        public IX509Chain Create()
         {
-            return new X509Chain();
+            return new X509ChainWrapper(new X509Chain());
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/IX509Chain.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/IX509Chain.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using NuGet.Common;
+
+namespace NuGet.Packaging.Signing
+{
+    internal interface IX509Chain : IDisposable
+    {
+        ILogMessage AdditionalContext { get; }
+
+        /// <summary>
+        /// This exists purely to avoid breaking existing public API's which require an <see cref="X509Chain" /> instance.
+        /// Internally, we should be cautious about using <see cref="PrivateReference" />.
+        /// Calling X509Chain.Build(...) directly (vs. IX509Chain.Build(...)) will break <see cref="AdditionalContext" />.
+        /// Calling any other X509Chain member is safe.
+        /// </summary>
+        X509Chain PrivateReference { get; }
+        X509ChainElementCollection ChainElements { get; }
+        X509ChainPolicy ChainPolicy { get; }
+        X509ChainStatus[] ChainStatus { get; }
+
+        bool Build(X509Certificate2 certificate);
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/IX509ChainFactory.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/IX509ChainFactory.cs
@@ -1,12 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Security.Cryptography.X509Certificates;
-
 namespace NuGet.Packaging.Signing
 {
     internal interface IX509ChainFactory
     {
-        X509Chain Create();
+        IX509Chain Create();
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/X509ChainWrapper.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/X509ChainWrapper.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using NuGet.Common;
+
+namespace NuGet.Packaging.Signing
+{
+    internal sealed class X509ChainWrapper : IX509Chain
+    {
+        private readonly X509Chain _chain;
+        private readonly Func<X509Chain, ILogMessage> _getAdditionalContext;
+
+        public ILogMessage AdditionalContext { get; private set; }
+        public X509ChainElementCollection ChainElements => _chain.ChainElements;
+        public X509ChainPolicy ChainPolicy => _chain.ChainPolicy;
+        public X509ChainStatus[] ChainStatus => _chain.ChainStatus;
+        public X509Chain PrivateReference => _chain;
+
+        internal X509ChainWrapper(X509Chain chain)
+            : this(chain, getAdditionalContext: null)
+        {
+        }
+
+        internal X509ChainWrapper(X509Chain chain, Func<X509Chain, ILogMessage> getAdditionalContext)
+        {
+            if (chain is null)
+            {
+                throw new ArgumentNullException(nameof(chain));
+            }
+
+            _chain = chain;
+            _getAdditionalContext = getAdditionalContext;
+        }
+
+        public bool Build(X509Certificate2 certificate)
+        {
+            if (certificate is null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            bool result = _chain.Build(certificate);
+
+            if (!result && _getAdditionalContext is not null)
+            {
+                AdditionalContext = _getAdditionalContext(_chain);
+            }
+
+            return result;
+        }
+
+        public void Dispose()
+        {
+            _chain.Dispose();
+
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateChainUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateChainUtility.cs
@@ -56,7 +56,7 @@ namespace NuGet.Packaging.Signing
             using (X509ChainHolder chainHolder = certificateType == CertificateType.Signature
                 ? X509ChainHolder.CreateForCodeSigning() : X509ChainHolder.CreateForTimestamping())
             {
-                var chain = chainHolder.Chain;
+                IX509Chain chain = chainHolder.Chain2;
 
                 SetCertBuildChainPolicy(
                     chain.ChainPolicy,
@@ -68,7 +68,7 @@ namespace NuGet.Packaging.Signing
 
                 if (BuildWithPolicy(chain, certificate))
                 {
-                    return GetCertificateChain(chain);
+                    return GetCertificateChain(chain.PrivateReference);
                 }
 
                 X509ChainStatusFlags errorStatusFlags;
@@ -78,6 +78,8 @@ namespace NuGet.Packaging.Signing
 
                 var fatalStatuses = new List<X509ChainStatus>();
                 var logCode = certificateType == CertificateType.Timestamp ? NuGetLogCode.NU3028 : NuGetLogCode.NU3018;
+
+                LogAdditionalContext(chain, logger);
 
                 foreach (var chainStatus in chain.ChainStatus)
                 {
@@ -102,7 +104,7 @@ namespace NuGet.Packaging.Signing
                     throw new SignatureException(logCode, Strings.CertificateChainValidationFailed);
                 }
 
-                return GetCertificateChain(chain);
+                return GetCertificateChain(chain.PrivateReference);
             }
         }
 
@@ -178,7 +180,7 @@ namespace NuGet.Packaging.Signing
             }
         }
 
-        internal static bool BuildCertificateChain(X509Chain chain, X509Certificate2 certificate, out X509ChainStatus[] status)
+        internal static bool BuildCertificateChain(IX509Chain chain, X509Certificate2 certificate, out X509ChainStatus[] status)
         {
             if (certificate == null)
             {
@@ -193,7 +195,7 @@ namespace NuGet.Packaging.Signing
             return buildSuccess && !CertificateUtility.IsCertificateValidityPeriodInTheFuture(certificate);
         }
 
-        internal static bool BuildWithPolicy(X509Chain chain, X509Certificate2 certificate)
+        internal static bool BuildWithPolicy(IX509Chain chain, X509Certificate2 certificate)
         {
             if (chain is null)
             {
@@ -251,6 +253,16 @@ namespace NuGet.Packaging.Signing
                 .Select(x => $"{x.Status}: {x.StatusInformation?.Trim()}")
                 .Distinct(StringComparer.Ordinal)
                 .OrderBy(x => x, StringComparer.Ordinal);
+        }
+
+        private static void LogAdditionalContext(IX509Chain chain, ILogger logger)
+        {
+            ILogMessage additionalContext = chain.AdditionalContext;
+
+            if (additionalContext is not null)
+            {
+                logger.Log(additionalContext);
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateUtility.cs
@@ -313,7 +313,7 @@ namespace NuGet.Packaging.Signing
 
             using (X509ChainHolder chainHolder = X509ChainHolder.CreateForCodeSigning())
             {
-                X509Chain chain = chainHolder.Chain;
+                IX509Chain chain = chainHolder.Chain2;
 
                 chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
                 chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority |

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SignatureUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SignatureUtility.cs
@@ -629,7 +629,7 @@ namespace NuGet.Packaging.Signing
             using (X509ChainHolder chainHolder = certificateType == CertificateType.Signature
                 ? X509ChainHolder.CreateForCodeSigning() : X509ChainHolder.CreateForTimestamping())
             {
-                X509Chain chain = chainHolder.Chain;
+                IX509Chain chain = chainHolder.Chain2;
 
                 chain.ChainPolicy.ExtraStore.AddRange(extraStore);
 
@@ -645,7 +645,7 @@ namespace NuGet.Packaging.Signing
                     return null;
                 }
 
-                return CertificateChainUtility.GetCertificateChain(chain);
+                return CertificateChainUtility.GetCertificateChain(chain.PrivateReference);
             }
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SignatureUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SignatureUtility.cs
@@ -3,6 +3,7 @@
 
 #if IS_SIGNING_SUPPORTED
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;
@@ -287,6 +288,31 @@ namespace NuGet.Packaging.Signing
             }
 
             return false;
+        }
+
+        internal static void LogAdditionalContext(IX509Chain chain, List<SignatureLog> issues)
+        {
+            if (chain is null)
+            {
+                throw new ArgumentNullException(nameof(chain));
+            }
+
+            if (issues is null)
+            {
+                throw new ArgumentNullException(nameof(issues));
+            }
+
+            ILogMessage logMessage = chain.AdditionalContext;
+
+            if (logMessage is not null)
+            {
+                SignatureLog issue = SignatureLog.Issue(
+                    fatal: false,
+                    logMessage.Code,
+                    logMessage.Message);
+
+                issues.Add(issue);
+            }
         }
 
         internal static IX509CertificateChain GetTimestampCertificates(

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/X509ChainHolder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/X509ChainHolder.cs
@@ -18,20 +18,26 @@ namespace NuGet.Packaging.Signing
     {
         private bool _isDisposed;
 
+        /// <summary>
+        /// Avoid using this internally.
+        /// </summary>
         public X509Chain Chain { get; }
+        internal IX509Chain Chain2 { get; }
 
         public X509ChainHolder()
         {
             IX509ChainFactory creator = X509TrustStore.GetX509ChainFactory(X509StorePurpose.CodeSigning, NullLogger.Instance);
 
-            Chain = creator.Create();
+            Chain2 = creator.Create();
+            Chain = Chain2.PrivateReference;
         }
 
         private X509ChainHolder(X509StorePurpose storePurpose)
         {
             IX509ChainFactory creator = X509TrustStore.GetX509ChainFactory(storePurpose, NullLogger.Instance);
 
-            Chain = creator.Create();
+            Chain2 = creator.Create();
+            Chain = Chain2.PrivateReference;
         }
 
         internal static X509ChainHolder CreateForCodeSigning()
@@ -48,7 +54,7 @@ namespace NuGet.Packaging.Signing
         {
             if (!_isDisposed)
             {
-                foreach (var chainElement in Chain.ChainElements)
+                foreach (X509ChainElement chainElement in Chain2.PrivateReference.ChainElements)
                 {
                     chainElement.Certificate.Dispose();
                 }

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -1726,6 +1726,32 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The following X.509 root certificate is untrusted because it is not present in the certificate bundle at {0}.  For more information, visit {1}.
+        ///    Subject:  {2}
+        ///    Fingerprint (SHA-256):  {3}
+        ///    Certificate (PEM):
+        ///{4}.
+        /// </summary>
+        internal static string UntrustedRoot_WithCertificateBundle {
+            get {
+                return ResourceManager.GetString("UntrustedRoot_WithCertificateBundle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The following X.509 root certificate is untrusted because no certificate bundle was found.  For more information, visit {0}.
+        ///    Subject:  {1}
+        ///    Fingerprint (SHA-256):  {2}
+        ///    Certificate (PEM):
+        ///{3}.
+        /// </summary>
+        internal static string UntrustedRoot_WithoutCertificateBundle {
+            get {
+                return ResourceManager.GetString("UntrustedRoot_WithoutCertificateBundle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Verifying the {0} with certificate: {1}.
         /// </summary>
         internal static string VerificationCertDisplay {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -1726,11 +1726,11 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The following X.509 root certificate is untrusted because it is not present in the certificate bundle at {0}.  For more information, visit {1}.
-        ///    Subject:  {2}
-        ///    Fingerprint (SHA-256):  {3}
+        ///   Looks up a localized string similar to The following X.509 root certificate is untrusted because it is not present in the certificate bundle at {0}.  For more information, see documentation for NU3042.
+        ///    Subject:  {1}
+        ///    Fingerprint (SHA-256):  {2}
         ///    Certificate (PEM):
-        ///{4}.
+        ///{3}.
         /// </summary>
         internal static string UntrustedRoot_WithCertificateBundle {
             get {
@@ -1739,11 +1739,11 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The following X.509 root certificate is untrusted because no certificate bundle was found.  For more information, visit {0}.
-        ///    Subject:  {1}
-        ///    Fingerprint (SHA-256):  {2}
+        ///   Looks up a localized string similar to The following X.509 root certificate is untrusted because no certificate bundle was found.  For more information, see documentation for NU3042.
+        ///    Subject:  {0}
+        ///    Fingerprint (SHA-256):  {1}
         ///    Certificate (PEM):
-        ///{3}.
+        ///{2}.
         /// </summary>
         internal static string UntrustedRoot_WithoutCertificateBundle {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -871,19 +871,19 @@ Valid from:</comment>
     <value>X.509 certificate chain validation will use the default trust store selected by .NET for timestamping.</value>
   </data>
   <data name="UntrustedRoot_WithCertificateBundle" xml:space="preserve">
-    <value>The following X.509 root certificate is untrusted because it is not present in the certificate bundle at {0}.  For more information, visit {1}.
-    Subject:  {2}
-    Fingerprint (SHA-256):  {3}
-    Certificate (PEM):
-{4}</value>
-    <comment>0 is a file path, 1 is a URL, 2 is a certificate subject, 3 is a certificate fingerprint, and 4 is a PEM-encoded certificate.</comment>
-  </data>
-  <data name="UntrustedRoot_WithoutCertificateBundle" xml:space="preserve">
-    <value>The following X.509 root certificate is untrusted because no certificate bundle was found.  For more information, visit {0}.
+    <value>The following X.509 root certificate is untrusted because it is not present in the certificate bundle at {0}.  For more information, see documentation for NU3042.
     Subject:  {1}
     Fingerprint (SHA-256):  {2}
     Certificate (PEM):
 {3}</value>
-    <comment>0 is a URL, 1 is a certificate subject, 2 is a certificate fingerprint, and 3 is a PEM-encoded certificate.</comment>
+    <comment>0 is a file path, 1 is a certificate subject, 2 is a certificate fingerprint, and 3 is a PEM-encoded certificate.</comment>
+  </data>
+  <data name="UntrustedRoot_WithoutCertificateBundle" xml:space="preserve">
+    <value>The following X.509 root certificate is untrusted because no certificate bundle was found.  For more information, see documentation for NU3042.
+    Subject:  {0}
+    Fingerprint (SHA-256):  {1}
+    Certificate (PEM):
+{2}</value>
+    <comment>0 is a certificate subject, 1 is a certificate fingerprint, and 2 is a PEM-encoded certificate.</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -870,4 +870,20 @@ Valid from:</comment>
   <data name="ChainBuilding_UsingDefaultTrustStoreForTimestamping" xml:space="preserve">
     <value>X.509 certificate chain validation will use the default trust store selected by .NET for timestamping.</value>
   </data>
+  <data name="UntrustedRoot_WithCertificateBundle" xml:space="preserve">
+    <value>The following X.509 root certificate is untrusted because it is not present in the certificate bundle at {0}.  For more information, visit {1}.
+    Subject:  {2}
+    Fingerprint (SHA-256):  {3}
+    Certificate (PEM):
+{4}</value>
+    <comment>0 is a file path, 1 is a URL, 2 is a certificate subject, 3 is a certificate fingerprint, and 4 is a PEM-encoded certificate.</comment>
+  </data>
+  <data name="UntrustedRoot_WithoutCertificateBundle" xml:space="preserve">
+    <value>The following X.509 root certificate is untrusted because no certificate bundle was found.  For more information, visit {0}.
+    Subject:  {1}
+    Fingerprint (SHA-256):  {2}
+    Certificate (PEM):
+{3}</value>
+    <comment>0 is a URL, 1 is a certificate subject, 2 is a certificate fingerprint, and 3 is a PEM-encoded certificate.</comment>
+  </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
@@ -382,7 +382,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (var intermediateCertificate = SigningTestUtility.GetCertificate("intermediate.crt"))
             using (var leafCertificate = SigningTestUtility.GetCertificate("leaf.crt"))
             {
-                var chain = chainHolder.Chain;
                 var extraStore = new X509Certificate2Collection() { rootCertificate, intermediateCertificate };
                 var logger = new TestLogger();
 
@@ -395,9 +394,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 Assert.Equal(NuGetLogCode.NU3018, exception.Code);
                 Assert.Equal("Certificate chain validation failed.", exception.Message);
-
                 Assert.Equal(1, logger.Errors);
-                Assert.Equal(RuntimeEnvironmentHelper.IsWindows ? 2 : 1, logger.Warnings);
 
                 SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Error);
                 SigningTestUtility.AssertOfflineRevocation(logger.LogMessages, LogLevel.Warning);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/X509ChainHolderTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/X509ChainHolderTests.cs
@@ -20,7 +20,7 @@ namespace Dotnet.Integration.Test
         {
             using (X509ChainHolder chainHolder = X509ChainHolder.CreateForCodeSigning())
             {
-                X509ChainPolicy policy = chainHolder.Chain.ChainPolicy;
+                X509ChainPolicy policy = chainHolder.Chain2.ChainPolicy;
 
                 // Code signing certificates that chain to this root certificate are widely used on nuget.org.
                 // CN=DigiCert Assured ID Root CA, OU=www.digicert.com, O=DigiCert Inc, C=US
@@ -33,7 +33,7 @@ namespace Dotnet.Integration.Test
         {
             using (X509ChainHolder chainHolder = X509ChainHolder.CreateForTimestamping())
             {
-                X509ChainPolicy policy = chainHolder.Chain.ChainPolicy;
+                X509ChainPolicy policy = chainHolder.Chain2.ChainPolicy;
 
                 // Timestamping certificates that chain to this root certificate are widely used on nuget.org.
                 // CN=VeriSign Universal Root Certification Authority, OU="(c) 2008 VeriSign, Inc. - For authorized use only", OU=VeriSign Trust Network, O="VeriSign, Inc.", C=US

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PackageSignatureVerifierTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PackageSignatureVerifierTests.cs
@@ -762,13 +762,14 @@ namespace NuGet.Packaging.FuncTest
                         _verifyCommandSettings,
                         CancellationToken.None);
                     IEnumerable<PackageVerificationResult> resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
+                    IEnumerable<ILogMessage> allIssues = result.Results.SelectMany(r => r.Issues);
                     IEnumerable<ILogMessage> totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
                     result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     totalErrorIssues.Count().Should().Be(3);
-                    SigningTestUtility.AssertUntrustedRoot(totalErrorIssues, NuGetLogCode.NU3028, LogLevel.Error);
+                    SigningTestUtility.AssertUntrustedRoot(allIssues, NuGetLogCode.NU3028, LogLevel.Error);
                 }
             }
         }

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTests.cs
@@ -84,7 +84,7 @@ namespace NuGet.Packaging.FuncTest
 
                 Assert.Equal(SignatureVerificationStatus.Valid, result.Status);
                 Assert.Equal(0, result.Issues.Count(issue => issue.Level == LogLevel.Error));
-                Assert.Equal(1, result.Issues.Count(issue => issue.Level == LogLevel.Warning));
+                Assert.NotEqual(0, result.Issues.Count(issue => issue.Level == LogLevel.Warning));
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -89,7 +89,7 @@ namespace NuGet.Packaging.FuncTest
                 // rebuild the chain to get the list of certificates
                 using (X509ChainHolder chainHolder = X509ChainHolder.CreateForTimestamping())
                 {
-                    var chain = chainHolder.Chain;
+                    IX509Chain chain = chainHolder.Chain2;
                     var policy = chain.ChainPolicy;
 
                     policy.ApplicationPolicy.Add(new Oid(Oids.TimeStampingEku));
@@ -99,7 +99,7 @@ namespace NuGet.Packaging.FuncTest
 
                     var timestampSignerCertificate = timestampCms.SignerInfos[0].Certificate;
                     chainBuildSuccess = chain.Build(timestampSignerCertificate);
-                    certificateChain = CertificateChainUtility.GetCertificateChain(chain);
+                    certificateChain = CertificateChainUtility.GetCertificateChain(chain.PrivateReference);
                 }
 
                 using (certificateChain)

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/CertificateBundleX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/CertificateBundleX509ChainFactoryTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET5_0_OR_GREATER
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography;
+using System.IO;
+using NuGet.Test.Utility;
+using Test.Utility.Signing;
+
+namespace NuGet.Packaging.FuncTest.SigningTests
+{
+    public abstract class CertificateBundleX509ChainFactoryTests
+    {
+        protected SigningTestFixture Fixture { get; }
+
+        public CertificateBundleX509ChainFactoryTests(SigningTestFixture fixture)
+        {
+            Fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+        }
+
+        protected static FileInfo CreateCertificateBundle(TestDirectory directory)
+        {
+            FileInfo file = new(Path.Combine(directory.Path, "certificate.bundle"));
+
+            TestCertificate otherRootCertificate = TestCertificate.Generate(
+                X509StorePurpose.CodeSigning,
+                SigningTestUtility.CertificateModificationGeneratorForCodeSigningEkuCert);
+
+            using (otherRootCertificate.Cert)
+            {
+                string pem = GetPemEncodedCertificate(otherRootCertificate.Cert);
+
+                using (StreamWriter writer = new(file.FullName))
+                {
+                    writer.WriteLine(pem);
+                }
+            }
+
+            return file;
+        }
+
+        protected static string GetCertificateFingerprint(X509Certificate2 certificate)
+        {
+            return certificate.GetCertHashString(HashAlgorithmName.SHA256);
+        }
+
+        protected static string GetPemEncodedCertificate(X509Certificate2 certificate)
+        {
+            ReadOnlyMemory<char> pem = PemEncoding.Write("CERTIFICATE", certificate.RawData);
+
+            return new string(pem.Span);
+        }
+    }
+}
+
+#endif

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/DotNetDefaultTrustStoreX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/DotNetDefaultTrustStoreX509ChainFactoryTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET5_0_OR_GREATER
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using NuGet.Packaging.Signing;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Packaging.FuncTest.SigningTests
+{
+    [Collection(SigningTestCollection.Name)]
+    public class DotNetDefaultTrustStoreX509ChainFactoryTests
+    {
+        private readonly SigningTestFixture _fixture;
+
+        public DotNetDefaultTrustStoreX509ChainFactoryTests(SigningTestFixture fixture)
+        {
+            _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+        }
+
+        [CIOnlyFact]
+        public void AdditionalContext_WhenRootCertificateIsUntrusted_ReturnsNull()
+        {
+            DotNetDefaultTrustStoreX509ChainFactory factory = new();
+
+            using (IX509Chain chain = factory.Create())
+            {
+                X509Certificate2 certificate = _fixture.UntrustedTestCertificate.Cert;
+
+                Assert.False(chain.Build(certificate));
+                Assert.Null(chain.AdditionalContext);
+            }
+        }
+    }
+}
+
+#endif

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/FallbackCertificateBundleX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/FallbackCertificateBundleX509ChainFactoryTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET5_0_OR_GREATER
+
+using System.Globalization;
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Packaging.FuncTest.SigningTests
+{
+    [Collection(SigningTestCollection.Name)]
+    public class FallbackCertificateBundleX509ChainFactoryTests : CertificateBundleX509ChainFactoryTests
+    {
+        public FallbackCertificateBundleX509ChainFactoryTests(SigningTestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        [CIOnlyFact]
+        public void AdditionalContext_WhenRootCertificateIsUntrusted_ReturnsLogMessage()
+        {
+            using (TestDirectory directory = TestDirectory.Create())
+            {
+                FileInfo certificateBundle = CreateCertificateBundle(directory);
+                Assert.True(FallbackCertificateBundleX509ChainFactory.TryCreate(
+                    X509StorePurpose.CodeSigning,
+                    certificateBundle.FullName,
+                    out FallbackCertificateBundleX509ChainFactory factory));
+
+                using (IX509Chain chain = factory.Create())
+                {
+                    X509Certificate2 certificate = Fixture.UntrustedTestCertificate.Cert;
+
+                    string expectedMessage = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.UntrustedRoot_WithCertificateBundle,
+                        certificateBundle.FullName,
+                        CertificateBundleX509ChainFactory.NU3042HelpUrl,
+                        certificate.Subject,
+                        GetCertificateFingerprint(certificate),
+                        GetPemEncodedCertificate(certificate));
+
+                    Assert.False(chain.Build(certificate));
+                    Assert.NotNull(chain.AdditionalContext);
+
+                    ILogMessage logMessage = chain.AdditionalContext;
+
+                    Assert.Equal(NuGetLogCode.NU3042, logMessage.Code);
+                    Assert.Equal(LogLevel.Warning, logMessage.Level);
+                    Assert.Equal(expectedMessage, logMessage.Message);
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/FallbackCertificateBundleX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/FallbackCertificateBundleX509ChainFactoryTests.cs
@@ -40,7 +40,6 @@ namespace NuGet.Packaging.FuncTest.SigningTests
                         CultureInfo.CurrentCulture,
                         Strings.UntrustedRoot_WithCertificateBundle,
                         certificateBundle.FullName,
-                        CertificateBundleX509ChainFactory.NU3042HelpUrl,
                         certificate.Subject,
                         GetCertificateFingerprint(certificate),
                         GetPemEncodedCertificate(certificate));

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/NoCertificateBundleX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/NoCertificateBundleX509ChainFactoryTests.cs
@@ -32,7 +32,6 @@ namespace NuGet.Packaging.FuncTest.SigningTests
                 string expectedMessage = string.Format(
                     CultureInfo.CurrentCulture,
                     Strings.UntrustedRoot_WithoutCertificateBundle,
-                    CertificateBundleX509ChainFactory.NU3042HelpUrl,
                     certificate.Subject,
                     GetCertificateFingerprint(certificate),
                     GetPemEncodedCertificate(certificate));

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/NoCertificateBundleX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/NoCertificateBundleX509ChainFactoryTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET5_0_OR_GREATER
+
+using System.Globalization;
+using System.Security.Cryptography.X509Certificates;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Packaging.FuncTest.SigningTests
+{
+    [Collection(SigningTestCollection.Name)]
+    public class NoCertificateBundleX509ChainFactoryTests : CertificateBundleX509ChainFactoryTests
+    {
+        public NoCertificateBundleX509ChainFactoryTests(SigningTestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        [CIOnlyFact]
+        public void AdditionalContext_WhenRootCertificateIsUntrusted_ReturnsLogMessage()
+        {
+            NoCertificateBundleX509ChainFactory factory = new();
+
+            using (IX509Chain chain = factory.Create())
+            {
+                X509Certificate2 certificate = Fixture.UntrustedTestCertificate.Cert;
+
+                string expectedMessage = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.UntrustedRoot_WithoutCertificateBundle,
+                    CertificateBundleX509ChainFactory.NU3042HelpUrl,
+                    certificate.Subject,
+                    GetCertificateFingerprint(certificate),
+                    GetPemEncodedCertificate(certificate));
+
+                Assert.False(chain.Build(certificate));
+                Assert.NotNull(chain.AdditionalContext);
+
+                ILogMessage logMessage = chain.AdditionalContext;
+
+                Assert.Equal(NuGetLogCode.NU3042, logMessage.Code);
+                Assert.Equal(LogLevel.Warning, logMessage.Level);
+                Assert.Equal(expectedMessage, logMessage.Message);
+            }
+        }
+    }
+}
+
+#endif

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/SystemCertificateBundleX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/SystemCertificateBundleX509ChainFactoryTests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET5_0_OR_GREATER
+
+using System.Globalization;
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Packaging.FuncTest.SigningTests
+{
+    [Collection(SigningTestCollection.Name)]
+    public class SystemCertificateBundleX509ChainFactoryTests : CertificateBundleX509ChainFactoryTests
+    {
+        public SystemCertificateBundleX509ChainFactoryTests(SigningTestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        [CIOnlyFact]
+        public void AdditionalContext_WhenRootCertificateIsUntrusted_ReturnsLogMessage()
+        {
+            using (TestDirectory directory = TestDirectory.Create())
+            {
+                FileInfo certificateBundle = CreateCertificateBundle(directory);
+                Assert.True(SystemCertificateBundleX509ChainFactory.TryCreate(
+                    new[] { certificateBundle.FullName },
+                    out SystemCertificateBundleX509ChainFactory factory));
+
+                using (IX509Chain chain = factory.Create())
+                {
+                    X509Certificate2 certificate = Fixture.UntrustedTestCertificate.Cert;
+
+                    string expectedMessage = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.UntrustedRoot_WithCertificateBundle,
+                        certificateBundle.FullName,
+                        CertificateBundleX509ChainFactory.NU3042HelpUrl,
+                        certificate.Subject,
+                        GetCertificateFingerprint(certificate),
+                        GetPemEncodedCertificate(certificate));
+
+                    Assert.False(chain.Build(certificate));
+                    Assert.NotNull(chain.AdditionalContext);
+
+                    ILogMessage logMessage = chain.AdditionalContext;
+
+                    Assert.Equal(NuGetLogCode.NU3042, logMessage.Code);
+                    Assert.Equal(LogLevel.Warning, logMessage.Level);
+                    Assert.Equal(expectedMessage, logMessage.Message);
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/SystemCertificateBundleX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/SystemCertificateBundleX509ChainFactoryTests.cs
@@ -39,7 +39,6 @@ namespace NuGet.Packaging.FuncTest.SigningTests
                         CultureInfo.CurrentCulture,
                         Strings.UntrustedRoot_WithCertificateBundle,
                         certificateBundle.FullName,
-                        CertificateBundleX509ChainFactory.NU3042HelpUrl,
                         certificate.Subject,
                         GetCertificateFingerprint(certificate),
                         GetPemEncodedCertificate(certificate));

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateUtilityTests.cs
@@ -124,14 +124,14 @@ namespace NuGet.Packaging.Test
             using (var intermediateCertificate = SigningTestUtility.GetCertificate("intermediate.crt"))
             using (var leafCertificate = SigningTestUtility.GetCertificate("leaf.crt"))
             {
-                var chain = chainHolder.Chain;
+                IX509Chain chain = chainHolder.Chain2;
 
                 chain.ChainPolicy.ExtraStore.Add(rootCertificate);
                 chain.ChainPolicy.ExtraStore.Add(intermediateCertificate);
 
                 chain.Build(leafCertificate);
 
-                using (var certificateChain = CertificateChainUtility.GetCertificateChain(chain))
+                using (IX509CertificateChain certificateChain = CertificateChainUtility.GetCertificateChain(chain.PrivateReference))
                 {
                     Assert.Equal(3, certificateChain.Count);
                     Assert.Equal(leafCertificate.Thumbprint, certificateChain[0].Thumbprint);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ChainBuilding/DefaultX509ChainBuildPolicyTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ChainBuilding/DefaultX509ChainBuildPolicyTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Security.Cryptography.X509Certificates;
+using Moq;
 using NuGet.Packaging.Signing;
 using Xunit;
 
@@ -42,20 +43,17 @@ namespace NuGet.Packaging.Test
         [Fact]
         public void Build_WhenCertificateIsNull_Throws()
         {
-            using (var chain = new X509Chain())
-            {
-                ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                    () => DefaultX509ChainBuildPolicy.Instance.Build(chain, certificate: null));
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => DefaultX509ChainBuildPolicy.Instance.Build(Mock.Of<IX509Chain>(), certificate: null));
 
-                Assert.Equal("certificate", exception.ParamName);
-            }
+            Assert.Equal("certificate", exception.ParamName);
         }
 
 #if NET5_0_OR_GREATER || IS_DESKTOP
         [Fact]
         public void Build_WhenArgumentsAreValid_ReturnsExpectedResult()
         {
-            using (var chain = new X509Chain())
+            using (X509ChainWrapper chain = new(new X509Chain()))
             using (X509Certificate2 expectedCertificate = _fixture.GetDefaultCertificate())
             {
                 bool actualResult = DefaultX509ChainBuildPolicy.Instance.Build(chain, expectedCertificate);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureUtilityTests.cs
@@ -3,9 +3,11 @@
 
 #if IS_SIGNING_SUPPORTED
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using NuGet.Common;
 using NuGet.Packaging.Signing;
 using NuGet.Test.Utility;
@@ -246,6 +248,59 @@ namespace NuGet.Packaging.Test
                     Assert.True(hasRepoCountersignature);
                 }
             }
+        }
+
+        [Fact]
+        public void LogAdditionalContext_WhenChainIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => SignatureUtility.LogAdditionalContext(chain: null, new List<SignatureLog>()));
+
+            Assert.Equal("chain", exception.ParamName);
+        }
+
+        [Fact]
+        public void LogAdditionalContext_WhenIssuesIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => SignatureUtility.LogAdditionalContext(Mock.Of<IX509Chain>(), issues: null));
+
+            Assert.Equal("issues", exception.ParamName);
+        }
+
+        [Fact]
+        public void LogAdditionalContext_WhenChainAdditionalContextIsNull_DoesNotLog()
+        {
+            Mock<IX509Chain> chain = new(MockBehavior.Strict);
+
+            chain.SetupGet(x => x.AdditionalContext)
+                .Returns((ILogMessage)null);
+
+            List<SignatureLog> issues = new();
+
+            SignatureUtility.LogAdditionalContext(chain.Object, issues);
+
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void LogAdditionalContext_WhenChainAdditionalContextIsNotNull_Logs()
+        {
+            Mock<IX509Chain> chain = new(MockBehavior.Strict);
+            LogMessage logMessage = LogMessage.CreateWarning(NuGetLogCode.NU3042, "abc");
+
+            chain.SetupGet(x => x.AdditionalContext)
+                .Returns(logMessage);
+
+            List<SignatureLog> issues = new();
+
+            SignatureUtility.LogAdditionalContext(chain.Object, issues);
+
+            SignatureLog signatureLog = Assert.Single(issues);
+
+            Assert.Equal(LogLevel.Warning, signatureLog.Level);
+            Assert.Equal(logMessage.Code, signatureLog.Code);
+            Assert.Equal(logMessage.Message, signatureLog.Message);
         }
 
         private static PrimarySignature GeneratePrimarySignatureWithNoCertificates(PrimarySignature signature)

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
@@ -111,19 +111,12 @@ namespace NuGet.Packaging.Test
 
                 Assert.Equal(1, logger.Errors);
 
+#if !NETCORE5_0
                 if (RuntimeEnvironmentHelper.IsLinux)
                 {
-#if NETCORE5_0
-                    Assert.Equal(1, logger.Warnings);
-#else
-                    Assert.Equal(2, logger.Warnings);
                     SigningTestUtility.AssertRevocationStatusUnknown(logger.LogMessages, LogLevel.Warning);
+                }
 #endif
-                }
-                else
-                {
-                    Assert.Equal(1, logger.Warnings);
-                }
 
                 SigningTestUtility.AssertNotTimeValid(logger.LogMessages, LogLevel.Error);
                 SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Warning);
@@ -141,12 +134,6 @@ namespace NuGet.Packaging.Test
                 SigningUtility.Verify(request, logger);
 
                 Assert.Equal(0, logger.Errors);
-#if (IS_DESKTOP || NETCORE5_0)
-                Assert.Equal(1, logger.Warnings);
-#else
-                Assert.Equal(RuntimeEnvironmentHelper.IsLinux ? 2 : 1, logger.Warnings);
-#endif
-
                 SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Warning);
 
 
@@ -539,7 +526,6 @@ namespace NuGet.Packaging.Test
                 Assert.Equal("Certificate chain validation failed.", exception.Message);
 
                 Assert.Equal(1, test.Logger.Errors);
-                Assert.Equal(1, test.Logger.Warnings);
                 SigningTestUtility.AssertNotTimeValid(test.Logger.LogMessages, LogLevel.Error);
                 SigningTestUtility.AssertUntrustedRoot(test.Logger.LogMessages, LogLevel.Warning);
             }
@@ -562,8 +548,6 @@ namespace NuGet.Packaging.Test
                 Assert.True(await SignedArchiveTestUtility.IsSignedAsync(test.Options.OutputPackageStream));
 
                 Assert.Equal(0, test.Logger.Errors);
-                Assert.Equal(1, test.Logger.Warnings);
-                Assert.Equal(1, test.Logger.Messages.Count());
                 SigningTestUtility.AssertUntrustedRoot(test.Logger.LogMessages, LogLevel.Warning);
             }
         }
@@ -606,8 +590,6 @@ namespace NuGet.Packaging.Test
 
                     Assert.Equal(0, test.Options.OutputPackageStream.Length);
                     Assert.Equal(0, test.Logger.Errors);
-                    Assert.Equal(1, test.Logger.Warnings);
-                    Assert.Equal(1, test.Logger.Messages.Count());
                     SigningTestUtility.AssertUntrustedRoot(test.Logger.LogMessages, LogLevel.Warning);
                 }
             }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/TrustStore/DotNetDefaultTrustStoreX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/TrustStore/DotNetDefaultTrustStoreX509ChainFactoryTests.cs
@@ -16,7 +16,7 @@ namespace NuGet.Packaging.Test
         {
             DotNetDefaultTrustStoreX509ChainFactory factory = new();
 
-            using (X509Chain chain = factory.Create())
+            using (IX509Chain chain = factory.Create())
             {
                 Assert.Equal(X509ChainTrustMode.System, chain.ChainPolicy.TrustMode);
             }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/TrustStore/FallbackCertificateBundleX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/TrustStore/FallbackCertificateBundleX509ChainFactoryTests.cs
@@ -108,7 +108,7 @@ namespace NuGet.Packaging.Test
 
             Assert.True(wasCreated);
 
-            using (X509Chain chain = factory.Create())
+            using (IX509Chain chain = factory.Create())
             {
                 Assert.Equal(X509ChainTrustMode.CustomRootTrust, chain.ChainPolicy.TrustMode);
                 Assert.Empty(chain.ChainPolicy.CustomTrustStore);
@@ -128,7 +128,7 @@ namespace NuGet.Packaging.Test
 
                 Assert.True(wasCreated);
 
-                using (X509Chain chain = factory.Create())
+                using (IX509Chain chain = factory.Create())
                 {
                     Assert.Equal(X509ChainTrustMode.CustomRootTrust, chain.ChainPolicy.TrustMode);
                     Assert.Equal(1, chain.ChainPolicy.CustomTrustStore.Count);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/TrustStore/NoCertificateBundleX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/TrustStore/NoCertificateBundleX509ChainFactoryTests.cs
@@ -33,7 +33,7 @@ namespace NuGet.Packaging.Test
         [Fact]
         public void Create_Always_ReturnsInstance()
         {
-            using (X509Chain chain = _factory.Create())
+            using (IX509Chain chain = _factory.Create())
             {
                 Assert.Equal(X509ChainTrustMode.CustomRootTrust, chain.ChainPolicy.TrustMode);
                 Assert.Empty(chain.ChainPolicy.CustomTrustStore);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/TrustStore/SystemCertificateBundleX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/TrustStore/SystemCertificateBundleX509ChainFactoryTests.cs
@@ -84,7 +84,7 @@ namespace NuGet.Packaging.Test
 
                 Assert.True(wasCreated);
 
-                using (X509Chain chain = factory.Create())
+                using (IX509Chain chain = factory.Create())
                 {
                     Assert.Equal(X509ChainTrustMode.CustomRootTrust, chain.ChainPolicy.TrustMode);
                     Assert.Equal(1, chain.ChainPolicy.CustomTrustStore.Count);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/TrustStore/X509ChainWrapperTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/TrustStore/X509ChainWrapperTests.cs
@@ -1,0 +1,194 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET5_0_OR_GREATER
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using Moq;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    [Collection(SigningTestsCollection.Name)]
+    public class X509ChainWrapperTests
+    {
+        private readonly CertificatesFixture _fixture;
+
+        public X509ChainWrapperTests(CertificatesFixture fixture)
+        {
+            _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+        }
+
+        [Fact]
+        public void ConstructorWithOneParameter_WhenChainIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new X509ChainWrapper(chain: null));
+
+            Assert.Equal("chain", exception.ParamName);
+        }
+
+        [Fact]
+        public void ConstructorWithTwoParameters_WhenChainIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new X509ChainWrapper(chain: null, getAdditionalContext: null!));
+
+            Assert.Equal("chain", exception.ParamName);
+        }
+
+        [Fact]
+        public void Dispose_Always_CallsBaseDispose()
+        {
+            using (X509ChainSpy spy = new())
+            {
+                Assert.False(spy.IsDisposed);
+
+                using (X509ChainWrapper wrapper = new(spy))
+                {
+                }
+
+                Assert.True(spy.IsDisposed);
+            }
+        }
+
+        [Fact]
+        public void Build_WhenCertificateIsNull_Throws()
+        {
+            using (X509ChainWrapper wrapper = new(Mock.Of<X509Chain>()))
+            {
+                ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                   () => wrapper.Build(certificate: null!));
+
+                Assert.Equal("certificate", exception.ParamName);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void AdditionalContext_WhenGetAdditionalContextIsNull_ReturnsNull(bool buildResponse)
+        {
+            using (X509Certificate2 certificate = _fixture.GetDefaultCertificate())
+            using (X509ChainWrapper wrapper = new(CreateX509Chain(certificate, buildResponse)))
+            {
+                Assert.Equal(buildResponse, wrapper.Build(certificate));
+                Assert.Null(wrapper.AdditionalContext);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void AdditionalContext_WhenGetAdditionalContextReturnsNull_ReturnsNull(bool buildResponse)
+        {
+            using (X509Certificate2 certificate = _fixture.GetDefaultCertificate())
+            using (X509ChainWrapper wrapper = new(CreateX509Chain(certificate, buildResponse), chain => null))
+            {
+                Assert.Equal(buildResponse, wrapper.Build(certificate));
+                Assert.Null(wrapper.AdditionalContext);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void AdditionalContext_WhenGetAdditionalContextReturnsObject_ReturnsObjectOnlyIfBuildReturnsFalse(bool buildResponse)
+        {
+            ILogMessage logMessage = Mock.Of<ILogMessage>();
+
+            using (X509Certificate2 certificate = _fixture.GetDefaultCertificate())
+            using (X509ChainWrapper wrapper = new(CreateX509Chain(certificate, buildResponse), chain => logMessage))
+            {
+                Assert.Equal(buildResponse, wrapper.Build(certificate));
+
+                if (buildResponse)
+                {
+                    Assert.Null(wrapper.AdditionalContext);
+                }
+                else
+                {
+                    Assert.Same(logMessage, wrapper.AdditionalContext);
+                }
+            }
+        }
+
+        [Fact]
+        public void ChainElements_Always_ReturnsInnerChainElements()
+        {
+            using (X509Certificate2 certificate = _fixture.GetDefaultCertificate())
+            using (X509Chain chain = CreateX509Chain(certificate, buildResponse: true))
+            using (X509ChainWrapper wrapper = new(chain))
+            {
+                Assert.True(wrapper.Build(certificate));
+                Assert.Same(chain.ChainElements, wrapper.ChainElements);
+            }
+        }
+
+        [Fact]
+        public void ChainPolicy_Always_ReturnsInnerChainPolicy()
+        {
+            using (X509Certificate2 certificate = _fixture.GetDefaultCertificate())
+            using (X509Chain chain = CreateX509Chain(certificate, buildResponse: true))
+            using (X509ChainWrapper wrapper = new(chain))
+            {
+                Assert.True(wrapper.Build(certificate));
+                Assert.Same(chain.ChainPolicy, wrapper.ChainPolicy);
+            }
+        }
+
+        [Fact]
+        public void ChainStatus_Always_ReturnsInnerChainStatus()
+        {
+            using (X509Certificate2 certificate = _fixture.GetDefaultCertificate())
+            using (X509Chain chain = CreateX509Chain(certificate, buildResponse: true))
+            using (X509ChainWrapper wrapper = new(chain))
+            {
+                Assert.True(wrapper.Build(certificate));
+                Assert.Same(chain.ChainStatus, wrapper.ChainStatus);
+            }
+        }
+
+        [Fact]
+        public void PrivateReference_Always_ReturnsInnerInstance()
+        {
+            using (X509Certificate2 certificate = _fixture.GetDefaultCertificate())
+            using (X509Chain chain = CreateX509Chain(certificate, buildResponse: true))
+            using (X509ChainWrapper wrapper = new(chain))
+            {
+                Assert.Same(chain, wrapper.PrivateReference);
+            }
+        }
+
+        private static X509Chain CreateX509Chain(X509Certificate2 certificate, bool buildResponse)
+        {
+            X509Chain chain = new();
+
+            if (buildResponse)
+            {
+                chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                chain.ChainPolicy.CustomTrustStore.Add(certificate);
+                chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+            }
+
+            return chain;
+        }
+
+        private sealed class X509ChainSpy : X509Chain
+        {
+            internal bool IsDisposed { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                base.Dispose(disposing);
+
+                IsDisposed = true;
+            }
+        }
+    }
+}
+
+#endif

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -857,6 +857,15 @@ namespace Test.Utility.Signing
                  issue.Message.Split(new[] { ' ', ':' }).Any(WORDEXTFLAGS => WORDEXTFLAGS == untrustedRoot)));
 
             Assert.True(isUntrustedRoot);
+
+#if NET5_0_OR_GREATER
+            if (!RuntimeEnvironmentHelper.IsWindows)
+            {
+                bool hasNU3042 = issues.Any(issue => issue.Code == NuGetLogCode.NU3042);
+
+                Assert.True(hasNU3042);
+            }
+#endif
         }
 
         public static void AssertUntrustedRoot(IEnumerable<ILogMessage> issues, LogLevel logLevel)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/12459

Regression? Last working version:  No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This change improves the signed package verification user experience on Linux and macOS when verification fails because a root certificate is untrusted.  This change raises a new warning (NU3042) to accompany an existing NU3018/NU3028 warning.  The new warning provides actionable information on how to resolve these warnings.

TODO:  create the aka.ms link

CC @JonDouglas, @aortiz-msft

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [X] Documentation PR https://github.com/NuGet/docs.microsoft.com-nuget/pull/3034
  - **OR**
  - [ ] N/A
