### PR TITLE
Fix transitive dependencies cache problems

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -257,13 +257,18 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 InstalledPackages = installedPackages;
             }
-            lock (_transitiveOriginsLock)
+            // if includeTransitivePackages, update the cache with the new transitive packages information
+            // or if IsInstalledAndTransitiveComputationNeeded, clear the transitive packages cache, since we don't know when a dependency has been removed
+            if (includeTransitivePackages || IsInstalledAndTransitiveComputationNeeded)
             {
-                TransitiveOriginsCache = transitiveOrigins;
-            }
-            lock (_installedAndTransitivePackagesLock)
-            {
-                TransitivePackages = transitivePackages;
+                lock (_transitiveOriginsLock)
+                {
+                    TransitiveOriginsCache = transitiveOrigins;
+                }
+                lock (_installedAndTransitivePackagesLock)
+                {
+                    TransitivePackages = transitivePackages;
+                }
             }
 
             IsInstalledAndTransitiveComputationNeeded = false;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -163,6 +163,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     if (TransitivePackages == null)
                     {
                         transitivePackages = new T();
+                        transitiveOrigins = new Dictionary<string, TransitiveEntry>();
                     }
                     else
                     {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -4198,8 +4198,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             // do a restore
             project = PrepareCpsRestoredProject(initialProjectSpec, cache);
-
-            var installedPackages = await project.GetInstalledPackagesAsync(CancellationToken.None); // This will change IsInstalledAndTransitiveComputationNeeded to false
             result = await project.GetInstalledAndTransitivePackagesAsync(false, false, CancellationToken.None);
 
             // Assert I: Cache for transitive was cleared
@@ -4207,7 +4205,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.Equal(0, result.TransitivePackages.Count);
             Assert.All(result.TransitivePackages, pkg => Assert.Equal(0, pkg.TransitiveOrigins.Count()));
 
-            project = PrepareCpsRestoredProject(initialProjectSpec, cache);
             result = await project.GetInstalledAndTransitivePackagesAsync(true, true, CancellationToken.None);
 
             // Assert II: Transitive packages calculated correctly

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -3900,7 +3900,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 await result.CommitAsync(logger, CancellationToken.None);
                 ProjectPackages packages = await project.GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins: false, CancellationToken.None);
                 DateTime lastWriteTime = File.GetLastWriteTimeUtc(lockFilePath);
-                File.WriteAllText(lockFilePath, "** replaced file content to test cache **");
                 File.SetLastWriteTimeUtc(lockFilePath, lastWriteTime);
                 ProjectPackages cache_packages = await project.GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins: false, CancellationToken.None);
 
@@ -4125,6 +4124,107 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.NotEmpty(packages.InstalledPackages);
             Assert.NotEmpty(packages.TransitivePackages);
             Assert.All(packages.TransitivePackages, pkg => Assert.NotEmpty(pkg.TransitiveOrigins));
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task GetInstalledAndTransitivePackagesAsync_IsInstalledAndTransitiveComputationNeeded_False_Succeed(bool includeTransitivePackages, bool includeTransitiveOrigins)
+        {
+            using var rootDir = new SimpleTestPathContext();
+            await CreatePackagesAsync(rootDir, packageAVersion: "1.0.0");
+            IProjectSystemCache cache = new ProjectSystemCache();
+
+            // Arrange
+            PackageSpec initialProjectSpec = ProjectTestHelpers.GetPackageSpec("MyProject", rootDir.SolutionRoot, framework: "net472", dependencyName: "PackageA");
+            await RestorePackageSpecsAsync(rootDir, output: null, initialProjectSpec);
+
+            CpsPackageReferenceProject project = PrepareCpsRestoredProject(initialProjectSpec, cache);
+
+            // Act
+            var installedPackages = await project.GetInstalledPackagesAsync(CancellationToken.None); // This will change IsInstalledAndTransitiveComputationNeeded to false
+            ProjectPackages result = await project.GetInstalledAndTransitivePackagesAsync(includeTransitivePackages, includeTransitiveOrigins, CancellationToken.None);
+
+            // Assert
+            var transitivePackagesCount = includeTransitivePackages ? 1 : 0;
+            var transitiveOriginsCount = (includeTransitivePackages && includeTransitiveOrigins) ? 1 : 0;
+
+            Assert.Equal(result.InstalledPackages.Count, installedPackages.Count());
+            Assert.Equal(1, result.InstalledPackages.Count);
+            Assert.Equal(transitivePackagesCount, result.TransitivePackages.Count);
+            Assert.All(result.TransitivePackages, pkg => Assert.Equal(transitiveOriginsCount, pkg.TransitiveOrigins.Count()));
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task GetInstalledAndTransitivePackagesAsync_IsInstalledAndTransitiveComputationNeeded_True_Succeed(bool includeTransitivePackages, bool includeTransitiveOrigins)
+        {
+            using var rootDir = new SimpleTestPathContext();
+            await CreatePackagesAsync(rootDir, packageAVersion: "1.0.0");
+            IProjectSystemCache cache = new ProjectSystemCache();
+
+            // Arrange
+            PackageSpec initialProjectSpec = ProjectTestHelpers.GetPackageSpec("MyProject", rootDir.SolutionRoot, framework: "net472", dependencyName: "PackageA");
+            await RestorePackageSpecsAsync(rootDir, output: null, initialProjectSpec);
+
+            CpsPackageReferenceProject project = PrepareCpsRestoredProject(initialProjectSpec, cache);
+
+            // Act
+            ProjectPackages result = await project.GetInstalledAndTransitivePackagesAsync(includeTransitivePackages, includeTransitiveOrigins, CancellationToken.None);
+
+            // Assert
+            var transitivePackagesCount = includeTransitivePackages ? 1 : 0;
+            var transitiveOriginsCount = (includeTransitivePackages && includeTransitiveOrigins) ? 1 : 0;
+
+            Assert.Equal(1, result.InstalledPackages.Count);
+            Assert.Equal(transitivePackagesCount, result.TransitivePackages.Count);
+            Assert.All(result.TransitivePackages, pkg => Assert.Equal(transitiveOriginsCount, pkg.TransitiveOrigins.Count()));
+        }
+
+        [Fact]
+        public async Task GetInstalledAndTransitivePackagesAsync_HasExpectedCache_Succeed()
+        {
+            using var rootDir = new SimpleTestPathContext();
+            await CreatePackagesAsync(rootDir, packageAVersion: "1.0.0");
+            IProjectSystemCache cache = new ProjectSystemCache();
+
+            // Arrange
+            PackageSpec initialProjectSpec = ProjectTestHelpers.GetPackageSpec("MyProject", rootDir.SolutionRoot, framework: "net472", dependencyName: "PackageA");
+            await RestorePackageSpecsAsync(rootDir, output: null, initialProjectSpec);
+
+            CpsPackageReferenceProject project = PrepareCpsRestoredProject(initialProjectSpec, cache);
+
+            // Act
+            ProjectPackages result = await project.GetInstalledAndTransitivePackagesAsync(true, true, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(1, result.InstalledPackages.Count);
+            Assert.Equal(1, result.TransitivePackages.Count);
+            Assert.All(result.TransitivePackages, pkg => Assert.Equal(1, pkg.TransitiveOrigins.Count()));
+
+            // Act II, do a restore
+            project = PrepareCpsRestoredProject(initialProjectSpec, cache);
+
+            var installedPackages = await project.GetInstalledPackagesAsync(CancellationToken.None); // This will change IsInstalledAndTransitiveComputationNeeded to false
+            result = await project.GetInstalledAndTransitivePackagesAsync(false, false, CancellationToken.None);
+
+            // Assert II: Cache for transitive was cleared
+            Assert.Equal(1, result.InstalledPackages.Count);
+            Assert.Equal(0, result.TransitivePackages.Count);
+            Assert.All(result.TransitivePackages, pkg => Assert.Equal(0, pkg.TransitiveOrigins.Count()));
+
+            project = PrepareCpsRestoredProject(initialProjectSpec, cache);
+            result = await project.GetInstalledAndTransitivePackagesAsync(true, true, CancellationToken.None);
+
+            // Assert III: Transitive packages calculated correctly
+            Assert.Equal(1, result.InstalledPackages.Count);
+            Assert.Equal(1, result.TransitivePackages.Count);
+            Assert.All(result.TransitivePackages, pkg => Assert.Equal(1, pkg.TransitiveOrigins.Count()));
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -1430,7 +1430,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 Assert.True(result.Success);
                 ProjectPackages packages = await testProject.GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins: false, CancellationToken.None);
                 DateTime lastWriteTime = File.GetLastWriteTimeUtc(lockFilePath);
-                File.WriteAllText(lockFilePath, "** replaced file content to test cache **");
                 File.SetLastWriteTimeUtc(lockFilePath, lastWriteTime);
                 ProjectPackages cache_packages = await testProject.GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins: false, CancellationToken.None);
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12333
Fixes: https://github.com/NuGet/Home/issues/12360
Fixes: https://github.com/NuGet/Home/issues/12428

Regression? Last working version: Regression introduced by https://github.com/NuGet/NuGet.Client/commit/e7ea3a13d3fc4738c375f2a48306d0cc46207e36

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This PR fixed multiple bugs, those can be resumed in that transitive dependencies where not displaying correctly in the PM UI when you installed or uninstalled packages or transitive packages, this happened because the cache was not cleared correctly.  

The main problem is that the function `GetInstalledAndTransitivePackagesAsync` handles a lot of states using booleans, this function can return only Installed packages and not Transitives even though the name says otherwise. This causes that we cache wrong information when using `IsInstalledAndTransitiveComputationNeeded`.  GIATPA is called a lot of times when using the PM UI, sometimes there are multiple threads, so that complicates even more the handling of the booleans and its states.

GIATPA = GetInstalledAndTransitivePackagesAsync
IsComputationNeeded = IsInstalledAndTransitiveComputationNeeded

`IsComputationNeeded ` can tell us if there was a change in the assets file, and before this PR if we don't request for transitive data in GIATPA `IsComputationNeeded` will be set to false and transitive data won't be calculated, if we later ask GIATPA to return transitive and `IsComputationNeeded` will be false and returning wrong cached data. 

In this PR when `IsComputationNeeded` is `true`, we will clear all cached data from transitive since we don't know if there was a change that affected transitive data, this will force the calculation of transitive packages and origins when explicitly requested in GIATPA and the cache is clear. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
