### PR TITLE
added a comment indicating that 'ItemFilter.All' represents "Browse" tab in PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/ItemFilter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/ItemFilter.cs
@@ -6,7 +6,7 @@ namespace NuGet.PackageManagement.UI
     public enum ItemFilter
     {
         /// <summary>
-        /// Represents Browse tab in PM UI
+        /// The value All represents the Browse tab in PM UI
         /// </summary>
         All,
         Installed,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/ItemFilter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/ItemFilter.cs
@@ -5,6 +5,9 @@ namespace NuGet.PackageManagement.UI
 {
     public enum ItemFilter
     {
+        /// <summary>
+        /// Represents Browse tab in PM UI
+        /// </summary>
         All,
         Installed,
         UpdatesAvailable,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ItemFilter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ItemFilter.cs
@@ -6,7 +6,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
     public enum ItemFilter
     {
         /// <summary>
-        /// Represents Browse tab in PM UI
+        /// The value All represents the Browse tab in PM UI
         /// </summary>
         All,
         Installed,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ItemFilter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ItemFilter.cs
@@ -5,6 +5,9 @@ namespace NuGet.VisualStudio.Internal.Contracts
 {
     public enum ItemFilter
     {
+        /// <summary>
+        /// Represents Browse tab in PM UI
+        /// </summary>
         All,
         Installed,
         UpdatesAvailable,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2222

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
During [recent data analysis](https://github.com/NuGet/Client.Engineering/issues/2097#issuecomment-1490823705), I discovered that the PM UI `Browse` tab was named `All` in the code, causing confusion. To address this inconsistency, I added a comment in the source code. I initially proposed to rename the enum but as per team feedback ended up adding a comment.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A
