### PR TITLE
Fall back to using API key also for pushing symbol packages if nothing else was specified as parameter or config

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -62,8 +62,17 @@ namespace NuGet.Commands
                 if (symbolPackageUpdateResource != null)
                 {
                     symbolSource = symbolPackageUpdateResource.SourceUri.AbsoluteUri;
-                    symbolApiKey = apiKey;
                 }
+            }
+
+            // Precedence for package API key: -ApiKey param, config
+            apiKey ??= CommandRunnerUtility.GetApiKey(settings, packageUpdateResource.SourceUri.AbsoluteUri, source);
+
+            // Precedence for symbol package API key: -SymbolApiKey param, config, package API key
+            if (!string.IsNullOrEmpty(symbolSource))
+            {
+                symbolApiKey ??= CommandRunnerUtility.GetApiKey(settings, symbolSource, symbolSource);
+                symbolApiKey ??= apiKey;
             }
 
             await packageUpdateResource.Push(
@@ -71,8 +80,8 @@ namespace NuGet.Commands
                 symbolSource,
                 timeoutSeconds,
                 disableBuffering,
-                endpoint => apiKey ?? CommandRunnerUtility.GetApiKey(settings, endpoint, source),
-                symbolsEndpoint => symbolApiKey ?? CommandRunnerUtility.GetApiKey(settings, symbolsEndpoint, symbolSource),
+                _ => apiKey,
+                _ => symbolApiKey,
                 noServiceEndpoint,
                 skipDuplicate,
                 symbolPackageUpdateResource,

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -68,11 +68,16 @@ namespace NuGet.Commands
             // Precedence for package API key: -ApiKey param, config
             apiKey ??= CommandRunnerUtility.GetApiKey(settings, packageUpdateResource.SourceUri.AbsoluteUri, source);
 
-            // Precedence for symbol package API key: -SymbolApiKey param, config, package API key
+            // Precedence for symbol package API key: -SymbolApiKey param, config, package API key (Only for symbol source from SymbolPackagePublish service)
             if (!string.IsNullOrEmpty(symbolSource))
             {
                 symbolApiKey ??= CommandRunnerUtility.GetApiKey(settings, symbolSource, symbolSource);
-                symbolApiKey ??= apiKey;
+
+                // Only allow falling back to API key when the symbol source was obtained from SymbolPackagePublish service
+                if (symbolPackageUpdateResource != null)
+                {
+                    symbolApiKey ??= apiKey;
+                }
             }
 
             await packageUpdateResource.Push(


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes: https://github.com/NuGet/Home/issues/11846

Regression? Last working version:

## Description
Currently it is not possible to reuse the package API key also for symbol sources on 3rd party NuGet servers.
For nuget.org this is possible because it receives a special treatment in [CommandRunnerUtility.GetApiKey()](https://github.com/NuGet/NuGet.Client/blob/8fba90f6c5524abf3dbae2eb36cf99a66465dc3e/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs#L58-L65).

This change makes it possible for the symbol source API key to fall back to the package source API key if nothing else is specified via parameter or config.

Additional documentation should not be required, as this change brings it in line what is already documented [here](https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#publishing-a-symbol-package) (Step 3 in particular).

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
