### PR TITLE
Add RollForward to NuGet.Build.Tasks.Console

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
@@ -15,6 +15,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <UsePublicApiAnalyzer>false</UsePublicApiAnalyzer>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: [#12528](https://github.com/NuGet/Home/issues/12528)

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Currently, NuGet.Build.Tasks.Console contains an executable which targets the .NET 5 runtime, so to use the package either the .NET 5 runtime (an EOL runtime) needs to be installed, or as the insertion process does the application is [retargetted](https://github.com/dotnet/sdk/blob/main/src/Layout/redist/targets/GenerateLayout.targets#L392) on the fly.

This change adds rollforward to the runtimeconfig so that the application is runnable on newer versions of the runtime. In theory, this makes the retargetting unnecessary, but I'm not proposing that process changes for now.

Note: for context, NuGet.Build.Tasks.Console is either told where to find dotnet explicitly, or it just looks [two directories up](https://github.com/NuGet/NuGet.Client/blob/91f6fdb26b09e16c4520b1d13ee30bb38172a7bd/src/NuGet.Core/NuGet.Build.Tasks/StaticGraphRestoreTaskBase.cs#L240-L252) for it. So this change just allows either of those to be newer runtimes and not just crash.

Additionally, the NuGet.Build.Tasks.Console package is used in the MSBuild boottrapper, which is a fundamental part of MSBuild's CI process (it builds, then uses the output to build itself again with the new bits). So this would bring that scenario a bit more inline with how it actually works in the SDK.

FYI @jeffkl with whom I discussed offline

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
