### PR TITLE
Add building and waiting for auto-restore steps after updating/uninstalling package to fix bug 12441

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -1,9 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
-using EnvDTE;
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using NuGet.StaFact;
 using NuGet.Test.Utility;
@@ -281,7 +278,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [NuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/12441")]
+        [NuGetWpfTheory]
         [MemberData(nameof(GetNetCoreTemplates))]
         public async Task UpdatePackageToNetCoreProjectFromUI(ProjectTemplate projectTemplate)
         {
@@ -308,6 +305,8 @@ namespace NuGet.Tests.Apex
                     uiwindow.InstallPackageFromUI(packageName, packageVersion1);
                     uiwindow.SwitchTabToUpdate();
                     uiwindow.UpdatePackageFromUI(packageName, packageVersion2);
+                    testContext.SolutionService.Build();
+                    testContext.NuGetApexTestService.WaitForAutoRestore();
 
                     // Assert
                     VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
@@ -316,7 +315,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [NuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/12441")]
+        [NuGetWpfTheory]
         [MemberData(nameof(GetNetCoreTemplates))]
         public async Task UninstallPackageFromNetCoreProjectFromUI(ProjectTemplate projectTemplate)
         {
@@ -341,6 +340,8 @@ namespace NuGet.Tests.Apex
                     uiwindow.InstallPackageFromUI(packageName, packageVersion);
                     uiwindow.SwitchTabToInstalled();
                     uiwindow.UninstallPackageFromUI(packageName);
+                    testContext.SolutionService.Build();
+                    testContext.NuGetApexTestService.WaitForAutoRestore();
 
                     // Assert
                     VisualStudio.AssertNuGetOutputDoesNotHaveErrors();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -303,7 +303,10 @@ namespace NuGet.Tests.Apex
                     var nugetTestService = GetNuGetTestService();
                     var uiwindow = nugetTestService.GetUIWindowfromProject(testContext.Project);
                     uiwindow.InstallPackageFromUI(packageName, packageVersion1);
+                    testContext.SolutionService.Build();
+                    testContext.NuGetApexTestService.WaitForAutoRestore();
                     uiwindow.SwitchTabToUpdate();
+
                     uiwindow.UpdatePackageFromUI(packageName, packageVersion2);
                     testContext.SolutionService.Build();
                     testContext.NuGetApexTestService.WaitForAutoRestore();
@@ -338,7 +341,10 @@ namespace NuGet.Tests.Apex
                     var nugetTestService = GetNuGetTestService();
                     var uiwindow = nugetTestService.GetUIWindowfromProject(testContext.Project);
                     uiwindow.InstallPackageFromUI(packageName, packageVersion);
+                    testContext.SolutionService.Build();
+                    testContext.NuGetApexTestService.WaitForAutoRestore();
                     uiwindow.SwitchTabToInstalled();
+
                     uiwindow.UninstallPackageFromUI(packageName);
                     testContext.SolutionService.Build();
                     testContext.NuGetApexTestService.WaitForAutoRestore();


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/12441

## Description
1.Add building and waiting for auto-restore steps after updating/uninstalling package to previous test cases to fix bug 12441.
2.Remove unnecessary using directives.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes