### PR TITLE
Publish hosted build binlogs if System.Debug is true

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -493,7 +493,7 @@ steps:
   inputs:
     artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
     targetPath: $(Build.StagingDirectory)\binlog
-  condition: " or(failed(), eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true')) "
+  condition: " or(failed(), eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['System.debug'], 'true')) "
 
 - task: MicroBuildCleanup@1
   displayName: "Perform Cleanup Tasks"

--- a/eng/pipelines/templates/CrossFramework_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/CrossFramework_Tests_On_Windows.yml
@@ -102,4 +102,4 @@ steps:
   inputs:
     artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
     targetPath: $(Build.StagingDirectory)\binlog
-  condition: " failed() "
+  condition: " or(failed(), eq(variables['System.debug'], 'true')) "

--- a/eng/pipelines/templates/Functional_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Functional_Tests_On_Windows.yml
@@ -91,4 +91,4 @@ steps:
   inputs:
     artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
     targetPath: $(Build.StagingDirectory)\binlog
-  condition: " failed() "
+  condition: " or(failed(), eq(variables['System.debug'], 'true')) "

--- a/eng/pipelines/templates/Source_Build.yml
+++ b/eng/pipelines/templates/Source_Build.yml
@@ -9,7 +9,7 @@ steps:
 
 - task: PublishBuildArtifacts@1
   displayName: Upload source-build log
-  condition: "always()"
+  condition: "or(failed(), eq(variables['System.debug'], 'true'))"
   continueOnError: true
   inputs:
     PathToPublish: "artifacts/source-build/self/log/source-build.binlog"

--- a/eng/pipelines/templates/Static_Source_Analysis.yml
+++ b/eng/pipelines/templates/Static_Source_Analysis.yml
@@ -71,12 +71,5 @@ steps:
   continueOnError: ${{ parameters.isOfficialBuild }}
   condition: succeededOrFailed()
 
-- task: PublishPipelineArtifact@1
-  displayName: "Publish binlogs"
-  inputs:
-    artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
-    targetPath: $(Build.StagingDirectory)\binlog
-  condition: " or(failed(), eq(variables['System.debug'], 'true')) "
-
 - task: ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'

--- a/eng/pipelines/templates/Static_Source_Analysis.yml
+++ b/eng/pipelines/templates/Static_Source_Analysis.yml
@@ -76,7 +76,7 @@ steps:
   inputs:
     artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
     targetPath: $(Build.StagingDirectory)\binlog
-  condition: " failed() "
+  condition: " or(failed(), eq(variables['System.debug'], 'true')) "
 
 - task: ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'

--- a/eng/pipelines/templates/Tests_On_Linux.yml
+++ b/eng/pipelines/templates/Tests_On_Linux.yml
@@ -57,7 +57,7 @@ steps:
   inputs:
     artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
     targetPath: $(Build.StagingDirectory)/binlog
-  condition: " failed() "
+  condition: " or(failed(), eq(variables['System.debug'], 'true')) "
 
 - task: ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'

--- a/eng/pipelines/templates/Tests_On_Mac.yml
+++ b/eng/pipelines/templates/Tests_On_Mac.yml
@@ -63,7 +63,7 @@ steps:
   inputs:
     artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
     targetPath: $(Build.StagingDirectory)/binlog
-  condition: " failed() "
+  condition: " or(failed(), eq(variables['System.debug'], 'true')) "
 
 - task: ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2245

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Currently, binlogs are only published for failing stages of the build.  In some rare cases, we want to see binlogs for successful builds.  This change makes it so you can schedule a build and check the "Enable system diagnostics" option to get binlogs.

![image](https://user-images.githubusercontent.com/17556515/231821633-a90e1674-e642-4fcf-9f1c-f6c4aa6dbdc9.png)

## PR Checklist
- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
