### PR TITLE
Put a condition on 5.11.x Build Task: `Add Apex Feed Source`

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -90,6 +90,7 @@ steps:
   inputs:
     command: "custom"
     arguments: "sources add -Name ApexFeed -Source $(ApexPackageFeedUrl) -UserName $(ApexPackageFeedUsername) -Password $(ApexPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\\NuGet.config"
+  condition: " and(succeeded(), eq(variables['AddApexFeedSource'], 'true'))"
 
 - task: MSBuild@1
   displayName: "Restore for VS2019"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Part of: https://github.com/NuGet/Client.Engineering/issues/2159

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Since moving to the archive feeds (https://github.com/NuGet/NuGet.Client/pull/5056) we no longer need a special feed for Apex packages. I'm adding a condition so that by default, this step will be skipped. It can be turned on with a build variable. The feed URL is already configurable with a build variable.

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
