### PR TITLE
Check PackageReference projects for packages with known vulnerabilities

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -406,13 +406,10 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
             }
 
-            string nugetAuditValue = _vsProjectAdapter.BuildProperties.GetPropertyValue(ProjectBuildProperties.NuGetAudit);
-            bool auditEnabled = string.Equals("enable", nugetAuditValue, StringComparison.InvariantCultureIgnoreCase);
-            string auditLevel = _vsProjectAdapter.BuildProperties.GetPropertyValue(ProjectBuildProperties.NuGetAuditLevel);
             RestoreAuditProperties auditProperties = new RestoreAuditProperties()
             {
-                EnableAudit = auditEnabled,
-                AuditLevel = auditLevel
+                EnableAudit = _vsProjectAdapter.BuildProperties.GetPropertyValue(ProjectBuildProperties.NuGetAudit),
+                AuditLevel = _vsProjectAdapter.BuildProperties.GetPropertyValue(ProjectBuildProperties.NuGetAuditLevel)
             };
 
             var msbuildProjectExtensionsPath = await GetMSBuildProjectExtensionsPathAsync();

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -406,6 +406,15 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
             }
 
+            string nugetAuditValue = _vsProjectAdapter.BuildProperties.GetPropertyValue(ProjectBuildProperties.NuGetAudit);
+            bool auditEnabled = string.Equals("enable", nugetAuditValue, StringComparison.InvariantCultureIgnoreCase);
+            string auditLevel = _vsProjectAdapter.BuildProperties.GetPropertyValue(ProjectBuildProperties.NuGetAuditLevel);
+            RestoreAuditProperties auditProperties = new RestoreAuditProperties()
+            {
+                EnableAudit = auditEnabled,
+                AuditLevel = auditLevel
+            };
+
             var msbuildProjectExtensionsPath = await GetMSBuildProjectExtensionsPathAsync();
             return new PackageSpec(tfis)
             {
@@ -448,6 +457,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     CentralPackageVersionsEnabled = isCpvmEnabled,
                     CentralPackageVersionOverrideDisabled = GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.CentralPackageVersionOverrideEnabled).EqualsFalse(),
                     CentralPackageTransitivePinningEnabled = MSBuildStringUtility.IsTrue(GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.CentralPackageTransitivePinningEnabled)),
+                    RestoreAuditProperties = auditProperties,
                 }
             };
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -406,11 +406,15 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
             }
 
-            RestoreAuditProperties auditProperties = new RestoreAuditProperties()
-            {
-                EnableAudit = _vsProjectAdapter.BuildProperties.GetPropertyValue(ProjectBuildProperties.NuGetAudit),
-                AuditLevel = _vsProjectAdapter.BuildProperties.GetPropertyValue(ProjectBuildProperties.NuGetAuditLevel)
-            };
+            string enableAudit = _vsProjectAdapter.BuildProperties.GetPropertyValue(ProjectBuildProperties.NuGetAudit);
+            string auditLevel = _vsProjectAdapter.BuildProperties.GetPropertyValue(ProjectBuildProperties.NuGetAuditLevel);
+            RestoreAuditProperties auditProperties = !string.IsNullOrEmpty(enableAudit) || !string.IsNullOrEmpty(auditLevel)
+                ? new RestoreAuditProperties()
+                {
+                    EnableAudit = enableAudit,
+                    AuditLevel = auditLevel
+                }
+                : null;
 
             var msbuildProjectExtensionsPath = await GetMSBuildProjectExtensionsPathAsync();
             return new PackageSpec(tfis)

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -305,11 +305,13 @@ namespace NuGet.SolutionRestoreManager
             string enableAudit = GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.NuGetAudit, s => s);
             string auditLevel = GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.NuGetAuditLevel, s => s);
 
-            return new RestoreAuditProperties()
-            {
-                EnableAudit = enableAudit,
-                AuditLevel = auditLevel
-            };
+            return !string.IsNullOrEmpty(enableAudit) || !string.IsNullOrEmpty(auditLevel)
+                ? new RestoreAuditProperties()
+                {
+                    EnableAudit = enableAudit,
+                    AuditLevel = auditLevel
+                }
+                : null;
         }
 
         private static NuGetFramework GetToolFramework(IEnumerable targetFrameworks)

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -300,6 +300,21 @@ namespace NuGet.SolutionRestoreManager
             return GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.CentralPackageTransitivePinningEnabled, MSBuildStringUtility.IsTrue);
         }
 
+        internal static RestoreAuditProperties GetRestoreAuditProperties(IEnumerable tfms)
+        {
+            bool enableAudit = GetSingleNonEvaluatedPropertyOrNull(
+                tfms,
+                ProjectBuildProperties.NuGetAudit,
+                value => string.Equals(value, "enable", StringComparison.InvariantCultureIgnoreCase));
+            string auditLevel = GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.NuGetAuditLevel, s => s);
+
+            return new RestoreAuditProperties()
+            {
+                EnableAudit = enableAudit,
+                AuditLevel = auditLevel
+            };
+        }
+
         private static NuGetFramework GetToolFramework(IEnumerable targetFrameworks)
         {
             return GetSingleNonEvaluatedPropertyOrNull(

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -302,10 +302,7 @@ namespace NuGet.SolutionRestoreManager
 
         internal static RestoreAuditProperties GetRestoreAuditProperties(IEnumerable tfms)
         {
-            bool enableAudit = GetSingleNonEvaluatedPropertyOrNull(
-                tfms,
-                ProjectBuildProperties.NuGetAudit,
-                value => string.Equals(value, "enable", StringComparison.InvariantCultureIgnoreCase));
+            string enableAudit = GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.NuGetAudit, s => s);
             string auditLevel = GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.NuGetAuditLevel, s => s);
 
             return new RestoreAuditProperties()

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -350,6 +350,7 @@ namespace NuGet.SolutionRestoreManager
                     CentralPackageVersionsEnabled = cpvmEnabled,
                     CentralPackageVersionOverrideDisabled = VSNominationUtilities.IsCentralPackageVersionOverrideDisabled(TargetFrameworks),
                     CentralPackageTransitivePinningEnabled = VSNominationUtilities.IsCentralPackageTransitivePinningEnabled(TargetFrameworks),
+                    RestoreAuditProperties = VSNominationUtilities.GetRestoreAuditProperties(TargetFrameworks),
                 },
                 RuntimeGraph = VSNominationUtilities.GetRuntimeGraph(TargetFrameworks),
                 RestoreSettings = new ProjectRestoreSettings() { HideWarningsAndErrors = true }
@@ -387,6 +388,7 @@ namespace NuGet.SolutionRestoreManager
                     ProjectPath = projectPath,
                     OutputPath = outputPath,
                     CacheFilePath = NoOpRestoreUtilities.GetProjectCacheFilePath(outputPath),
+                    RestoreAuditProperties = new RestoreAuditProperties()
                 }
             };
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -388,7 +388,6 @@ namespace NuGet.SolutionRestoreManager
                     ProjectPath = projectPath,
                     OutputPath = outputPath,
                     CacheFilePath = NoOpRestoreUtilities.GetProjectCacheFilePath(outputPath),
-                    RestoreAuditProperties = new RestoreAuditProperties()
                 }
             };
 

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -799,6 +799,8 @@ namespace NuGet.Build.Tasks.Console
 
             (bool isCentralPackageManagementEnabled, bool isCentralPackageVersionOverrideDisabled, bool isCentralPackageTransitivePinningEnabled) = GetCentralPackageManagementSettings(project, projectStyleOrNull);
 
+            RestoreAuditProperties auditProperties = GetRestoreAuditProperties(project);
+
             List<TargetFrameworkInformation> targetFrameworkInfos = GetTargetFrameworkInfos(projectsByTargetFramework, isCentralPackageManagementEnabled);
 
             (ProjectStyle ProjectStyle, bool IsPackageReferenceCompatibleProjectStyle, string PackagesConfigFilePath) projectStyleResult = BuildTasksUtility.GetProjectRestoreStyle(
@@ -843,6 +845,7 @@ namespace NuGet.Build.Tasks.Console
                     CentralPackageVersionsEnabled = isCentralPackageManagementEnabled && projectStyle == ProjectStyle.PackageReference,
                     CentralPackageVersionOverrideDisabled = isCentralPackageVersionOverrideDisabled,
                     CentralPackageTransitivePinningEnabled = isCentralPackageTransitivePinningEnabled,
+                    RestoreAuditProperties = auditProperties
                 };
             }
 
@@ -865,6 +868,20 @@ namespace NuGet.Build.Tasks.Console
             restoreMetadata.TargetFrameworks = GetProjectRestoreMetadataFrameworkInfos(targetFrameworkInfos, projectsByTargetFramework);
 
             return (restoreMetadata, targetFrameworkInfos);
+        }
+
+        private RestoreAuditProperties GetRestoreAuditProperties(IMSBuildProject project)
+        {
+            string enableAudit = project.GetProperty("NuGetAudit");
+            string auditLevel = project.GetProperty("AuditLevel");
+
+            return !string.IsNullOrEmpty(enableAudit) || !string.IsNullOrEmpty(auditLevel)
+                ? new RestoreAuditProperties()
+                {
+                    EnableAudit = enableAudit,
+                    AuditLevel = auditLevel
+                }
+                : null;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -849,6 +849,8 @@ Copyright (c) .NET Foundation. All rights reserved.
         <_CentralPackageVersionsEnabled>$(_CentralPackageVersionsEnabled)</_CentralPackageVersionsEnabled>
         <CentralPackageVersionOverrideEnabled>$(CentralPackageVersionOverrideEnabled)</CentralPackageVersionOverrideEnabled>
         <CentralPackageTransitivePinningEnabled>$(CentralPackageTransitivePinningEnabled)</CentralPackageTransitivePinningEnabled>
+        <NuGetAudit>$(NuGetAudit)</NuGetAudit>
+        <NuGetAuditLevel>$(NuGetAuditLevel)</NuGetAuditLevel>
       </_RestoreGraphEntry>
     </ItemGroup>
 

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+~NuGet.Commands.SourceRepositoryDependencyProvider.SourceRepository.get -> NuGet.Protocol.Core.Types.SourceRepository

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+~NuGet.Commands.SourceRepositoryDependencyProvider.SourceRepository.get -> NuGet.Protocol.Core.Types.SourceRepository

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+~NuGet.Commands.SourceRepositoryDependencyProvider.SourceRepository.get -> NuGet.Protocol.Core.Types.SourceRepository

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/IVulnerabilityInformationProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/IVulnerabilityInformationProvider.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Protocol.Model;
+
+namespace NuGet.Commands
+{
+    /// <summary>A class that caches the vulnerability database for a package source, so it only needs to be read once.</summary>
+    internal interface IVulnerabilityInformationProvider
+    {
+        /// <summary>Get the vulnerability database for the package source.</summary>
+        /// <param name="cancellationToken">A cancelation token to cancel the operation.</param>
+        /// <returns>null if the package source doesn't contain any vulnerability data, or the result if it does.</returns>
+        Task<GetVulnerabilityInfoResult?> GetVulnerabilityInformationAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -280,7 +280,12 @@ namespace NuGet.Commands
                 if (_request.Project.RestoreMetadata.RestoreAuditProperties.EnableAudit == true)
                 {
                     telemetry.StartIntervalMeasure();
-                    AuditUtility audit = new AuditUtility(_request.Project.RestoreMetadata.RestoreAuditProperties, _request.Project.FilePath, graphs, _request.DependencyProviders.RemoteProviders, _logger);
+                    AuditUtility audit = new AuditUtility(
+                        _request.Project.RestoreMetadata.RestoreAuditProperties,
+                        _request.Project.FilePath,
+                        graphs,
+                        _request.DependencyProviders.VulnerabilityInfoProviders,
+                        _logger);
                     await audit.CheckPackageVulnerabilitiesAsync(token);
                     telemetry.EndIntervalMeasure(VulnerablePackageCheck);
                 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -277,7 +277,7 @@ namespace NuGet.Commands
                     });
                 }
 
-                if (string.Equals(_request.Project.RestoreMetadata.RestoreAuditProperties.EnableAudit, "enable", StringComparison.InvariantCultureIgnoreCase))
+                if (string.Equals(_request.Project.RestoreMetadata?.RestoreAuditProperties?.EnableAudit, "enable", StringComparison.InvariantCultureIgnoreCase))
                 {
                     telemetry.StartIntervalMeasure();
                     AuditUtility audit = new AuditUtility(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -1355,6 +1355,16 @@ namespace NuGet.Commands
                 }
             }
 
+            if (allVulnerabilityData.Exceptions != null)
+            {
+                foreach (Exception exception in allVulnerabilityData.Exceptions.InnerExceptions)
+                {
+                    string messageText = "Error occurred while getting package vulnerability data: " + exception.Message;
+                    RestoreLogMessage logMessage = RestoreLogMessage.CreateError(NuGetLogCode.NU1900, messageText);
+                    logger.Log(logMessage);
+                }
+            }
+
             int ParseAuditLevel(string? auditLevel, ILogger logger)
             {
                 if (auditLevel == null)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -277,7 +277,7 @@ namespace NuGet.Commands
                     });
                 }
 
-                if (_request.Project.RestoreMetadata.RestoreAuditProperties.EnableAudit == true)
+                if (string.Equals(_request.Project.RestoreMetadata.RestoreAuditProperties.EnableAudit, "enable", StringComparison.InvariantCultureIgnoreCase))
                 {
                     telemetry.StartIntervalMeasure();
                     AuditUtility audit = new AuditUtility(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -277,7 +277,9 @@ namespace NuGet.Commands
                     });
                 }
 
-                if (string.Equals(_request.Project.RestoreMetadata?.RestoreAuditProperties?.EnableAudit, "enable", StringComparison.InvariantCultureIgnoreCase))
+                string enableAudit = _request.Project.RestoreMetadata?.RestoreAuditProperties?.EnableAudit;
+                if (string.Equals(enableAudit, "enable", StringComparison.InvariantCultureIgnoreCase)
+                    || string.Equals(enableAudit, bool.TrueString, StringComparison.InvariantCultureIgnoreCase))
                 {
                     telemetry.StartIntervalMeasure();
                     AuditUtility audit = new AuditUtility(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProviders.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProviders.cs
@@ -147,8 +147,8 @@ namespace NuGet.Commands
                 remoteProviders.Add(provider);
             }
 
-            var vulnerabilityInfoProviders = new List<IVulnerabilityInformationProvider>(sources.Count());
-            foreach (var source in sources)
+            var vulnerabilityInfoProviders = new List<IVulnerabilityInformationProvider>(remoteProviders.Count);
+            foreach (SourceRepository source in sources)
             {
                 var provider = new VulnerabilityInformationProvider(source, log);
                 vulnerabilityInfoProviders.Add(provider);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProviders.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProviders.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NuGet.Common;
 using NuGet.DependencyResolver;
 using NuGet.Protocol;
@@ -24,18 +25,44 @@ namespace NuGet.Commands
         /// <param name="localProviders">This is typically just a provider for the global packages folder.</param>
         /// <param name="remoteProviders">All dependency providers.</param>
         /// <param name="packageFileCache">Nuspec and package file cache.</param>
+        [Obsolete("Create via RestoreCommandProvidersCache")]
         public RestoreCommandProviders(
             NuGetv3LocalRepository globalPackages,
             IReadOnlyList<NuGetv3LocalRepository> fallbackPackageFolders,
             IReadOnlyList<IRemoteDependencyProvider> localProviders,
             IReadOnlyList<IRemoteDependencyProvider> remoteProviders,
             LocalPackageFileCache packageFileCache)
+            : this(globalPackages, fallbackPackageFolders, localProviders, remoteProviders, packageFileCache, CreateVulnerabilityInfoProviders(remoteProviders))
+        {
+        }
+
+        private static IReadOnlyList<IVulnerabilityInformationProvider> CreateVulnerabilityInfoProviders(IReadOnlyList<IRemoteDependencyProvider> remoteProviders)
+        {
+            List<IVulnerabilityInformationProvider> providers = new(remoteProviders.Count);
+            for (int i = 0; i < remoteProviders.Count; i++)
+            {
+                if (remoteProviders[i].SourceRepository != null)
+                {
+                    providers.Add(new VulnerabilityInformationProvider(remoteProviders[i].SourceRepository, NullLogger.Instance));
+                }
+            }
+            return providers;
+        }
+
+        internal RestoreCommandProviders(
+            NuGetv3LocalRepository globalPackages,
+            IReadOnlyList<NuGetv3LocalRepository> fallbackPackageFolders,
+            IReadOnlyList<IRemoteDependencyProvider> localProviders,
+            IReadOnlyList<IRemoteDependencyProvider> remoteProviders,
+            LocalPackageFileCache packageFileCache,
+            IReadOnlyList<IVulnerabilityInformationProvider> vulnerabilityInformationProviders)
         {
             GlobalPackages = globalPackages ?? throw new ArgumentNullException(nameof(globalPackages));
             LocalProviders = localProviders ?? throw new ArgumentNullException(nameof(localProviders));
             RemoteProviders = remoteProviders ?? throw new ArgumentNullException(nameof(remoteProviders));
             FallbackPackageFolders = fallbackPackageFolders ?? throw new ArgumentNullException(nameof(fallbackPackageFolders));
             PackageFileCache = packageFileCache ?? throw new ArgumentNullException(nameof(packageFileCache));
+            VulnerabilityInfoProviders = vulnerabilityInformationProviders;
         }
 
         /// <summary>
@@ -52,6 +79,8 @@ namespace NuGet.Commands
         public IReadOnlyList<IRemoteDependencyProvider> RemoteProviders { get; }
 
         public LocalPackageFileCache PackageFileCache { get; }
+
+        internal IReadOnlyList<IVulnerabilityInformationProvider> VulnerabilityInfoProviders { get; }
 
         public static RestoreCommandProviders Create(
             string globalFolderPath,
@@ -118,12 +147,20 @@ namespace NuGet.Commands
                 remoteProviders.Add(provider);
             }
 
+            var vulnerabilityInfoProviders = new List<IVulnerabilityInformationProvider>(sources.Count());
+            foreach (var source in sources)
+            {
+                var provider = new VulnerabilityInformationProvider(source, log);
+                vulnerabilityInfoProviders.Add(provider);
+            }
+
             return new RestoreCommandProviders(
                 globalPackages,
                 fallbackPackageFolders,
                 localProviders,
                 remoteProviders,
-                packageFileCache);
+                packageFileCache,
+                vulnerabilityInfoProviders);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProvidersCache.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProvidersCache.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using NuGet.Common;
@@ -25,6 +24,9 @@ namespace NuGet.Commands
 
         private readonly ConcurrentDictionary<string, NuGetv3LocalRepository> _globalCache
             = new ConcurrentDictionary<string, NuGetv3LocalRepository>(PathUtility.GetStringComparerBasedOnOS());
+
+        private readonly ConcurrentDictionary<SourceRepository, IVulnerabilityInformationProvider> _vulnerabilityInformationProviders
+            = new ConcurrentDictionary<SourceRepository, IVulnerabilityInformationProvider>();
 
         private readonly LocalPackageFileCache _fileCache = new LocalPackageFileCache();
 
@@ -115,7 +117,14 @@ namespace NuGet.Commands
                 remoteProviders.Add(remoteProvider);
             }
 
-            return new RestoreCommandProviders(globalCache, fallbackFolders, localProviders, remoteProviders, _fileCache);
+            var vulnerabilityInfoProviders = new List<IVulnerabilityInformationProvider>(sources.Count);
+            foreach (var source in sources)
+            {
+                IVulnerabilityInformationProvider provider = _vulnerabilityInformationProviders.GetOrAdd(source, s => new VulnerabilityInformationProvider(s, log));
+                vulnerabilityInfoProviders.Add(provider);
+            }
+
+            return new RestoreCommandProviders(globalCache, fallbackFolders, localProviders, remoteProviders, _fileCache, vulnerabilityInfoProviders);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProvidersCache.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProvidersCache.cs
@@ -117,14 +117,14 @@ namespace NuGet.Commands
                 remoteProviders.Add(remoteProvider);
             }
 
-            var vulnerabilityInfoProviders = new List<IVulnerabilityInformationProvider>(sources.Count);
-            foreach (var source in sources)
+            var vulnerabilityInformationProviders = new List<IVulnerabilityInformationProvider>(sources.Count);
+            foreach (SourceRepository source in sources)
             {
                 IVulnerabilityInformationProvider provider = _vulnerabilityInformationProviders.GetOrAdd(source, s => new VulnerabilityInformationProvider(s, log));
-                vulnerabilityInfoProviders.Add(provider);
+                vulnerabilityInformationProviders.Add(provider);
             }
 
-            return new RestoreCommandProviders(globalCache, fallbackFolders, localProviders, remoteProviders, _fileCache, vulnerabilityInfoProviders);
+            return new RestoreCommandProviders(globalCache, fallbackFolders, localProviders, remoteProviders, _fileCache, vulnerabilityInformationProviders);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -153,6 +153,8 @@ namespace NuGet.Commands
         /// <remarks>Optional. This will be <c>null</c> for project providers.</remarks>
         public PackageSource Source => _sourceRepository.PackageSource;
 
+        public SourceRepository SourceRepository => _sourceRepository;
+
         /// <summary>
         /// Asynchronously discovers all versions of a package from a source and selects the best match.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
@@ -59,7 +59,7 @@ namespace NuGet.Commands.Restore.Utility
         {
             foreach (Exception exception in exceptions.InnerExceptions)
             {
-                string messageText = "Error occurred while getting package vulnerability data: " + exception.Message;
+                string messageText = string.Format(Strings.Error_VulnerabilityDataFetch, exception.Message);
                 RestoreLogMessage logMessage = RestoreLogMessage.CreateError(NuGetLogCode.NU1900, messageText);
                 _logger.Log(logMessage);
             }
@@ -140,7 +140,7 @@ namespace NuGet.Commands.Restore.Utility
                 case 3:
                     return (Strings.Vulnerability_Severity_3, NuGetLogCode.NU1903);
                 case 4:
-                    return (Strings.Vulnerability_Severity_1, NuGetLogCode.NU1901);
+                    return (Strings.Vulnerability_Severity_4, NuGetLogCode.NU1904);
                 default:
                     return (Strings.Vulnerability_Severity_unknown, NuGetLogCode.NU1900);
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
@@ -72,6 +72,7 @@ namespace NuGet.Commands.Restore.Utility
 
             if (packagesWithKnownVulnerabilities != null)
             {
+                // no-op checks DGSpec hash, which means the order of everything must be deterministic.
                 // .NET Framework and .NET Standard don't have Deconstructor methods for KeyValuePair
                 foreach (var kvp1 in packagesWithKnownVulnerabilities.OrderBy(p => p.Key.Id))
                 {
@@ -91,7 +92,7 @@ namespace NuGet.Commands.Restore.Utility
                             RestoreLogMessage.CreateWarning(logCode,
                             message,
                             package.Id,
-                            affectedGraphs.ToArray());
+                            affectedGraphs.OrderBy(s => s).ToArray());
                         restoreLogMessage.ProjectPath = _projectFullPath;
                         _logger.Log(restoreLogMessage);
                     }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
@@ -1,0 +1,304 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.LibraryModel;
+using NuGet.Packaging.Core;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Model;
+using NuGet.Versioning;
+
+namespace NuGet.Commands.Restore.Utility
+{
+    internal struct AuditUtility
+    {
+        private readonly ProjectModel.RestoreAuditProperties _restoreAuditProperties;
+        private readonly string _projectFullPath;
+        private readonly IEnumerable<RestoreTargetGraph> _targetGraphs;
+        private readonly IReadOnlyList<DependencyResolver.IRemoteDependencyProvider> _remoteProviders;
+        private readonly ILogger _logger;
+
+        public AuditUtility(
+            ProjectModel.RestoreAuditProperties restoreAuditProperties,
+            string projectFullPath,
+            IEnumerable<RestoreTargetGraph> graphs,
+            IReadOnlyList<DependencyResolver.IRemoteDependencyProvider> remoteProviders,
+            ILogger logger)
+        {
+            _restoreAuditProperties = restoreAuditProperties;
+            _projectFullPath = projectFullPath;
+            _targetGraphs = graphs;
+            _remoteProviders = remoteProviders;
+            _logger = logger;
+        }
+
+        public async Task CheckPackageVulnerabilitiesAsync(CancellationToken cancellationToken)
+        {
+            GetVulnerabilityInfoResult? allVulnerabilityData = await GetAllVulnerabilityDataAsync(cancellationToken);
+            if (allVulnerabilityData == null) return;
+
+
+            if (allVulnerabilityData.Exceptions != null)
+            {
+                ReplayErrors(allVulnerabilityData.Exceptions);
+            }
+
+            if (allVulnerabilityData.KnownVulnerabilities != null)
+            {
+                CheckPackageVulnerabilities(allVulnerabilityData.KnownVulnerabilities);
+            }
+        }
+
+        private void ReplayErrors(AggregateException exceptions)
+        {
+            foreach (Exception exception in exceptions.InnerExceptions)
+            {
+                string messageText = "Error occurred while getting package vulnerability data: " + exception.Message;
+                RestoreLogMessage logMessage = RestoreLogMessage.CreateError(NuGetLogCode.NU1900, messageText);
+                _logger.Log(logMessage);
+            }
+        }
+
+        private void CheckPackageVulnerabilities(IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities)
+        {
+            Dictionary<PackageIdentity, Dictionary<PackageVulnerabilityInfo, List<string>>>? packagesWithKnownVulnerabilities =
+                FindPackagesWithKnownVulnerabilities(knownVulnerabilities);
+
+            if (packagesWithKnownVulnerabilities != null)
+            {
+                // .NET Framework and .NET Standard don't have Deconstructor methods for KeyValuePair
+                foreach (var kvp1 in packagesWithKnownVulnerabilities.OrderBy(p => p.Key.Id))
+                {
+                    PackageIdentity package = kvp1.Key;
+                    Dictionary<PackageVulnerabilityInfo, List<string>> vulnerabilities = kvp1.Value;
+                    foreach (var kvp2 in vulnerabilities.OrderBy(v => v.Key.Url.OriginalString))
+                    {
+                        PackageVulnerabilityInfo vulnerability = kvp2.Key;
+                        List<string> affectedGraphs = kvp2.Value;
+                        (string severityLabel, NuGetLogCode logCode) = GetSeverityLabelAndCode(vulnerability.Severity);
+                        string message = string.Format(Strings.Warning_PackageWithKnownVulnerability,
+                            package.Id,
+                            package.Version.ToNormalizedString(),
+                            severityLabel,
+                            vulnerability.Url);
+                        RestoreLogMessage restoreLogMessage =
+                            RestoreLogMessage.CreateWarning(logCode,
+                            message,
+                            package.Id,
+                            affectedGraphs.ToArray());
+                        restoreLogMessage.ProjectPath = _projectFullPath;
+                        _logger.Log(restoreLogMessage);
+                    }
+                }
+            }
+        }
+
+        private static List<PackageVulnerabilityInfo>? GetKnownVulnerabilities(
+            string name,
+            NuGetVersion version,
+            IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>? knownVulnerabilities)
+        {
+            HashSet<PackageVulnerabilityInfo>? vulnerabilities = null;
+
+            if (knownVulnerabilities == null) return null;
+
+            foreach (var file in knownVulnerabilities)
+            {
+                if (file.TryGetValue(name, out var packageVulnerabilities))
+                {
+                    foreach (var vulnInfo in packageVulnerabilities)
+                    {
+                        if (vulnInfo.Versions.Satisfies(version))
+                        {
+                            if (vulnerabilities == null)
+                            {
+                                vulnerabilities = new();
+                            }
+                            vulnerabilities.Add(vulnInfo);
+                        }
+                    }
+                }
+            }
+
+            return vulnerabilities != null ? vulnerabilities.ToList() : null;
+        }
+
+        private static (string severityLabel, NuGetLogCode code) GetSeverityLabelAndCode(int severity)
+        {
+            switch (severity)
+            {
+                case 1:
+                    return (Strings.Vulnerability_Severity_1, NuGetLogCode.NU1901);
+                case 2:
+                    return (Strings.Vulnerability_Severity_2, NuGetLogCode.NU1902);
+                case 3:
+                    return (Strings.Vulnerability_Severity_3, NuGetLogCode.NU1903);
+                case 4:
+                    return (Strings.Vulnerability_Severity_1, NuGetLogCode.NU1901);
+                default:
+                    return (Strings.Vulnerability_Severity_unknown, NuGetLogCode.NU1900);
+            }
+        }
+
+        private Dictionary<PackageIdentity, Dictionary<PackageVulnerabilityInfo, List<string>>>? FindPackagesWithKnownVulnerabilities(
+            IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities)
+        {
+            // multi-targeting projects often use the same package across multiple TFMs, so group to reduce output spam.
+            Dictionary<PackageIdentity, Dictionary<PackageVulnerabilityInfo, List<string>>>? result = null;
+
+            int minSeverity = ParseAuditLevel();
+
+            foreach (var graph in _targetGraphs)
+            {
+                foreach (LibraryIdentity package in graph.Flattened.Select(i => i.Key).Where(p => p.Type == "package"))
+                {
+                    var fromFile = GetKnownVulnerabilities(package.Name, package.Version, knownVulnerabilities);
+
+                    if (fromFile?.Count() > 0)
+                    {
+                        PackageIdentity packageIdentity = new(package.Name, package.Version);
+
+                        foreach (PackageVulnerabilityInfo knownVulnerability in fromFile)
+                        {
+                            if (knownVulnerability.Severity < minSeverity)
+                            {
+                                continue;
+                            }
+
+                            if (result == null)
+                            {
+                                result = new();
+                            }
+
+                            if (!result.TryGetValue(packageIdentity, out Dictionary<PackageVulnerabilityInfo, List<string>>? knownPackageVulnerabilities))
+                            {
+                                knownPackageVulnerabilities = new();
+                                result.Add(packageIdentity, knownPackageVulnerabilities);
+                            }
+
+                            if (!knownPackageVulnerabilities.TryGetValue(knownVulnerability, out List<string>? affectedGraphs))
+                            {
+                                affectedGraphs = new();
+                                knownPackageVulnerabilities.Add(knownVulnerability, affectedGraphs);
+                            }
+
+                            // Multiple package sources might list the same known vulnerability, so de-duple those too.
+                            if (!affectedGraphs.Contains(graph.TargetGraphName))
+                            {
+                                affectedGraphs.Add(graph.TargetGraphName);
+                            }
+                        }
+                    }
+                }
+            }
+            return result;
+        }
+
+        private async Task<GetVulnerabilityInfoResult?> GetAllVulnerabilityDataAsync(CancellationToken cancellationToken)
+        {
+            var sources = new List<SourceRepository>(_remoteProviders.Count);
+            sources.AddRange(_remoteProviders.Select(p => p.SourceRepository).Where(s => s is not null));
+
+            var results = new Task<GetVulnerabilityInfoResult?>[sources.Count];
+            for (int i = 0; i < sources.Count; i++)
+            {
+                SourceRepository source = sources[i];
+                results[i] = GetVulnerabilityInfoAsync(source, _logger, cancellationToken);
+            }
+
+            await Task.WhenAll(results);
+            if (cancellationToken.IsCancellationRequested)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            List<Exception>? errors = null;
+            List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>? knownVulnerabilities = null;
+            foreach (var resultTask in results)
+            {
+                var result = await resultTask;
+                if (result is null) continue;
+
+                if (result.KnownVulnerabilities != null)
+                {
+                    if (knownVulnerabilities == null)
+                    {
+                        knownVulnerabilities = new();
+                    }
+
+                    knownVulnerabilities.AddRange(result.KnownVulnerabilities);
+                }
+
+                if (result.Exceptions != null)
+                {
+                    if (errors == null)
+                    {
+                        errors = new();
+                    }
+
+                    errors.AddRange(result.Exceptions.InnerExceptions);
+                }
+            }
+
+            GetVulnerabilityInfoResult? final =
+                knownVulnerabilities != null || errors != null
+                ? new(knownVulnerabilities, errors != null ? new AggregateException(errors) : null)
+                : null;
+            return final;
+
+            static async Task<GetVulnerabilityInfoResult?> GetVulnerabilityInfoAsync(SourceRepository source, ILogger logger, CancellationToken cancellationToken)
+            {
+                IVulnerabilityInfoResource? vulnerabilityInfoResource = await source.GetResourceAsync<IVulnerabilityInfoResource>(cancellationToken);
+                if (vulnerabilityInfoResource == null)
+                {
+                    return null;
+                }
+
+                using SourceCacheContext cacheContext = new();
+                GetVulnerabilityInfoResult result = await vulnerabilityInfoResource.GetVulnerabilityInfoAsync(cacheContext, logger, cancellationToken);
+                return result;
+            }
+        }
+
+        private int ParseAuditLevel()
+        {
+            string? auditLevel = _restoreAuditProperties.AuditLevel;
+
+            if (auditLevel == null)
+            {
+                return 1;
+            }
+
+            if (string.Equals("low", auditLevel, StringComparison.OrdinalIgnoreCase))
+            {
+                return 1;
+            }
+            if (string.Equals("moderate", auditLevel, StringComparison.OrdinalIgnoreCase))
+            {
+                return 2;
+            }
+            if (string.Equals("high", auditLevel, StringComparison.OrdinalIgnoreCase))
+            {
+                return 3;
+            }
+            if (string.Equals("critical", auditLevel, StringComparison.OrdinalIgnoreCase))
+            {
+                return 4;
+            }
+
+            string messageText = string.Format(Strings.Error_InvalidNuGetAuditLevelValue, auditLevel, "low, moderate, high, critical");
+            RestoreLogMessage message = RestoreLogMessage.CreateError(NuGetLogCode.NU1014, messageText);
+            message.ProjectPath = _projectFullPath;
+            _logger.Log(message);
+            return 1;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -896,13 +897,19 @@ namespace NuGet.Commands
 
         private static RestoreAuditProperties GetRestoreAuditProperties(IMSBuildItem specItem)
         {
-            var result = new RestoreAuditProperties()
-            {
-                EnableAudit = specItem.GetProperty("NuGetAudit"),
-                AuditLevel = specItem.GetProperty("NuGetAuditLevel")
-            };
+            string enableAudit = specItem.GetProperty("NuGetAudit");
+            string auditLevel = specItem.GetProperty("NuGetAuditLevel");
 
-            return result;
+            if (enableAudit != null || auditLevel != null)
+            {
+                return new RestoreAuditProperties()
+                {
+                    EnableAudit = enableAudit,
+                    AuditLevel = auditLevel
+                };
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -898,7 +898,7 @@ namespace NuGet.Commands
         {
             var result = new RestoreAuditProperties()
             {
-                EnableAudit = StringComparer.InvariantCultureIgnoreCase.Equals(specItem.GetProperty("NuGetAudit"), "enable"),
+                EnableAudit = specItem.GetProperty("NuGetAudit"),
                 AuditLevel = specItem.GetProperty("NuGetAuditLevel")
             };
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -265,6 +265,9 @@ namespace NuGet.Commands
 
                     // Packages lock file properties
                     result.RestoreMetadata.RestoreLockProperties = GetRestoreLockProperites(specItem);
+
+                    // NuGet audit properties
+                    result.RestoreMetadata.RestoreAuditProperties = GetRestoreAuditProperties(specItem);
                 }
 
                 if (restoreType == ProjectStyle.PackagesConfig)
@@ -889,6 +892,17 @@ namespace NuGet.Commands
                 specItem.GetProperty("RestorePackagesWithLockFile"),
                 specItem.GetProperty("NuGetLockFilePath"),
                 IsPropertyTrue(specItem, "RestoreLockedMode"));
+        }
+
+        private static RestoreAuditProperties GetRestoreAuditProperties(IMSBuildItem specItem)
+        {
+            var result = new RestoreAuditProperties()
+            {
+                EnableAudit = StringComparer.InvariantCultureIgnoreCase.Equals(specItem.GetProperty("NuGetAudit"), "enable"),
+                AuditLevel = specItem.GetProperty("NuGetAuditLevel")
+            };
+
+            return result;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/VulnerabilityInformationProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/VulnerabilityInformationProvider.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Model;
+
+namespace NuGet.Commands
+{
+    internal sealed class VulnerabilityInformationProvider : IVulnerabilityInformationProvider
+    {
+        private SourceRepository _source;
+        private ILogger _logger;
+
+        private readonly AsyncLazy<GetVulnerabilityInfoResult?> _vulnerabilityInfo;
+
+        public VulnerabilityInformationProvider(SourceRepository source, ILogger logger)
+        {
+            _source = source;
+            _logger = logger;
+
+            _vulnerabilityInfo = new AsyncLazy<GetVulnerabilityInfoResult?>(GetVulnerabilityInfoAsync);
+        }
+
+        public async Task<GetVulnerabilityInfoResult?> GetVulnerabilityInformationAsync(CancellationToken cancellationToken)
+        {
+            GetVulnerabilityInfoResult? result = await _vulnerabilityInfo;
+            return result;
+        }
+
+        private async Task<GetVulnerabilityInfoResult?> GetVulnerabilityInfoAsync()
+        {
+            IVulnerabilityInfoResource vulnerabilityInfoResource =
+                await _source.GetResourceAsync<IVulnerabilityInfoResource>(CancellationToken.None);
+            if (vulnerabilityInfoResource is null)
+            {
+                return null;
+            }
+
+            using SourceCacheContext cacheContext = new();
+            GetVulnerabilityInfoResult result = await vulnerabilityInfoResource.GetVulnerabilityInfoAsync(cacheContext, _logger, CancellationToken.None);
+            return result;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -889,6 +889,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error occurred while getting package vulnerability data: {0}.
+        /// </summary>
+        internal static string Error_VulnerabilityDataFetch {
+            get {
+                return ResourceManager.GetString("Error_VulnerabilityDataFetch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to output resolved nuspec file because it would overwrite the original at &apos;{0}&apos;.
         /// </summary>
         internal static string Error_WriteResolvedNuSpecOverwriteOriginal {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -2339,6 +2339,51 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to low.
+        /// </summary>
+        internal static string Vulnerability_Severity_1 {
+            get {
+                return ResourceManager.GetString("Vulnerability_Severity_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to moderate.
+        /// </summary>
+        internal static string Vulnerability_Severity_2 {
+            get {
+                return ResourceManager.GetString("Vulnerability_Severity_2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to high.
+        /// </summary>
+        internal static string Vulnerability_Severity_3 {
+            get {
+                return ResourceManager.GetString("Vulnerability_Severity_3", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to critical.
+        /// </summary>
+        internal static string Vulnerability_Severity_4 {
+            get {
+                return ResourceManager.GetString("Vulnerability_Severity_4", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to unknown.
+        /// </summary>
+        internal static string Vulnerability_Severity_unknown {
+            get {
+                return ResourceManager.GetString("Vulnerability_Severity_unknown", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There are {0} package sources defined in your configuration. When using central package management, please map your package sources with package source mapping (https://aka.ms/nuget-package-source-mapping) or specify a single package source. The following sources are defined: {1}.
         /// </summary>
         internal static string Warning_CentralPackageVersions_MultipleSourcesWithoutPackageSourceMapping {
@@ -2399,6 +2444,15 @@ namespace NuGet.Commands {
         internal static string Warning_MinVersionNonInclusive {
             get {
                 return ResourceManager.GetString("Warning_MinVersionNonInclusive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package &apos;{0}&apos; {1} has a known {2} severity vulnerability, {3}..
+        /// </summary>
+        internal static string Warning_PackageWithKnownVulnerability {
+            get {
+                return ResourceManager.GetString("Warning_PackageWithKnownVulnerability", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -475,6 +475,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid NuGetAuditLevel value &apos;{0}&apos;. Expected values: {1}.
+        /// </summary>
+        internal static string Error_InvalidNuGetAuditLevelValue {
+            get {
+                return ResourceManager.GetString("Error_InvalidNuGetAuditLevelValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid project-package combination for {0} {1}. DotnetToolReference project style can only contain references of the DotnetTool type.
         /// </summary>
         internal static string Error_InvalidProjectPackageCombo {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1068,4 +1068,10 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
 {2} - severity, for example low, moder, high, or critical
 {3} - URL for more info on the known vulnerability</comment>
   </data>
+  <data name="Error_InvalidNuGetAuditLevelValue" xml:space="preserve">
+    <value>Invalid NuGetAuditLevel value '{0}'. Expected values: {1}</value>
+    <comment>Don't translate 'NuGetAuditLevel'
+{0} - is the value from the customer's project file
+{1} is the list of valid values "low, moderate, high, critical" (these should not be translated either)</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1074,4 +1074,8 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
 {0} - is the value from the customer's project file
 {1} is the list of valid values "low, moderate, high, critical" (these should not be translated either)</comment>
   </data>
+  <data name="Error_VulnerabilityDataFetch" xml:space="preserve">
+    <value>Error occurred while getting package vulnerability data: {0}</value>
+    <comment>{0} is an error message</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1065,7 +1065,7 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
     <value>Package '{0}' {1} has a known {2} severity vulnerability, {3}.</value>
     <comment>{0} - package id
 {1} - package version
-{2} - severity, for example low, moder, high, or critical
+{2} - severity, for example low, moderate, high, or critical
 {3} - URL for more info on the known vulnerability</comment>
   </data>
   <data name="Error_InvalidNuGetAuditLevelValue" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1041,4 +1041,31 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
     <value>Warning As Error: {0}</value>
     <comment>{0} is a warning message</comment>
   </data>
+  <data name="Vulnerability_Severity_1" xml:space="preserve">
+    <value>low</value>
+    <comment>As in "This package has a low severity vulnerability"</comment>
+  </data>
+  <data name="Vulnerability_Severity_2" xml:space="preserve">
+    <value>moderate</value>
+    <comment>As in "This package has a moderate severity vulnerability"</comment>
+  </data>
+  <data name="Vulnerability_Severity_3" xml:space="preserve">
+    <value>high</value>
+    <comment>As in "This package has a high severity vulnerability"</comment>
+  </data>
+  <data name="Vulnerability_Severity_4" xml:space="preserve">
+    <value>critical</value>
+    <comment>As in "This package has a critical severity vulnerability"</comment>
+  </data>
+  <data name="Vulnerability_Severity_unknown" xml:space="preserve">
+    <value>unknown</value>
+    <comment>As in "This package has a unknown severity vulnerability"</comment>
+  </data>
+  <data name="Warning_PackageWithKnownVulnerability" xml:space="preserve">
+    <value>Package '{0}' {1} has a known {2} severity vulnerability, {3}.</value>
+    <comment>{0} - package id
+{1} - package version
+{2} - severity, for example low, moder, high, or critical
+{3} - URL for more info on the known vulnerability</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -337,6 +337,31 @@ namespace NuGet.Common
         NU1803 = 1803,
 
         /// <summary>
+        /// Unknown package vulnerability issue
+        /// </summary>
+        NU1900 = 1900,
+
+        /// <summary>
+        /// Package with known low severity vulnerability
+        /// </summary>
+        NU1901 = 1901,
+
+        /// <summary>
+        /// Package with known low severity vulnerability
+        /// </summary>
+        NU1902 = 1902,
+
+        /// <summary>
+        /// Package with known low severity vulnerability
+        /// </summary>
+        NU1903 = 1903,
+
+        /// <summary>
+        /// Package with known low severity vulnerability
+        /// </summary>
+        NU1904 = 1904,
+
+        /// <summary>
         /// Undefined signature error
         /// </summary>
         NU3000 = 3000,

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -122,6 +122,11 @@ namespace NuGet.Common
         NU1013 = 1013,
 
         /// <summary>
+        /// NuGetAuditLevel input errors
+        /// </summary>
+        NU1014 = 1014,
+
+        /// <summary>
         /// Unable to resolve package, generic message for unknown type constraints.
         /// </summary>
         NU1100 = 1100,

--- a/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+NuGet.Common.NuGetLogCode.NU1014 = 1014 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1900 = 1900 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1901 = 1901 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1902 = 1902 -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
@@ -1,2 +1,7 @@
 #nullable enable
+NuGet.Common.NuGetLogCode.NU1900 = 1900 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1901 = 1901 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1902 = 1902 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1903 = 1903 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1904 = 1904 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU3042 = 3042 -> NuGet.Common.NuGetLogCode

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/IRemoteDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/IRemoteDependencyProvider.cs
@@ -32,6 +32,12 @@ namespace NuGet.DependencyResolver
         PackageSource Source { get; }
 
         /// <summary>
+        /// Gets the source repository.
+        /// </summary>
+        /// <remarks>Optional. This will be <c>null</c> for project providers.</remarks>
+        SourceRepository SourceRepository { get; }
+
+        /// <summary>
         /// Asynchronously discovers all versions of a package from a source and selects the best match.
         /// </summary>
         /// <remarks>This does not download the package.</remarks>

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
@@ -50,6 +50,8 @@ namespace NuGet.DependencyResolver
         /// <remarks>Optional. This will be <c>null</c> for project providers.</remarks>
         public PackageSource Source { get; private set; }
 
+        public SourceRepository SourceRepository { get; private set; }
+
         /// <summary>
         /// Asynchronously discovers all versions of a package from a source and selects the best match.
         /// </summary>

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~NuGet.DependencyResolver.IRemoteDependencyProvider.SourceRepository.get -> NuGet.Protocol.Core.Types.SourceRepository
+~NuGet.DependencyResolver.LocalDependencyProvider.SourceRepository.get -> NuGet.Protocol.Core.Types.SourceRepository

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
@@ -55,5 +55,7 @@ namespace NuGet.ProjectManagement
         public const string CentralPackageVersionOverrideEnabled = nameof(CentralPackageVersionOverrideEnabled);
         public const string AssemblyName = nameof(AssemblyName);
         public const string CentralPackageTransitivePinningEnabled = nameof(CentralPackageTransitivePinningEnabled);
+        public const string NuGetAudit = nameof(NuGetAudit);
+        public const string NuGetAuditLevel = nameof(NuGetAuditLevel);
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~const NuGet.ProjectManagement.ProjectBuildProperties.NuGetAudit = "NuGetAudit" -> string
+~const NuGet.ProjectManagement.ProjectBuildProperties.NuGetAuditLevel = "NuGetAuditLevel" -> string

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -1046,7 +1046,7 @@ namespace NuGet.ProjectModel
                             switch (auditPropertyName)
                             {
                                 case "enableAudit":
-                                    auditProperties.EnableAudit = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);
+                                    auditProperties.EnableAudit = jsonReader.ReadNextTokenAsString();
                                     break;
 
                                 case "auditLevel":

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -925,6 +925,7 @@ namespace NuGet.ProjectModel
             List<ProjectRestoreMetadataFrameworkInfo> targetFrameworks = null;
             var validateRuntimeAssets = false;
             WarningProperties warningProperties = null;
+            RestoreAuditProperties auditProperties = new RestoreAuditProperties();
 
             jsonReader.ReadObject(propertyName =>
             {
@@ -1038,6 +1039,23 @@ namespace NuGet.ProjectModel
 
                         restoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile, nuGetLockFilePath, restoreLockedMode);
                         break;
+
+                    case "restoreAuditProperties":
+                        jsonReader.ReadObject(auditPropertyName =>
+                        {
+                            switch (auditPropertyName)
+                            {
+                                case "enableAudit":
+                                    auditProperties.EnableAudit = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);
+                                    break;
+
+                                case "auditLevel":
+                                    auditProperties.AuditLevel = jsonReader.ReadNextTokenAsString();
+                                    break;
+                            }
+                        });
+                        break;
+
 
                     case "skipContentFileWrite":
                         skipContentFileWrite = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -1063,7 +1063,6 @@ namespace NuGet.ProjectModel
                         };
                         break;
 
-
                     case "skipContentFileWrite":
                         skipContentFileWrite = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);
                         break;

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -1122,6 +1122,7 @@ namespace NuGet.ProjectModel
             msbuildMetadata.CentralPackageVersionsEnabled = centralPackageVersionsManagementEnabled;
             msbuildMetadata.CentralPackageVersionOverrideDisabled = centralPackageVersionOverrideDisabled;
             msbuildMetadata.CentralPackageTransitivePinningEnabled = CentralPackageTransitivePinningEnabled;
+            msbuildMetadata.RestoreAuditProperties = auditProperties;
 
             if (configFilePaths != null)
             {

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -925,7 +925,7 @@ namespace NuGet.ProjectModel
             List<ProjectRestoreMetadataFrameworkInfo> targetFrameworks = null;
             var validateRuntimeAssets = false;
             WarningProperties warningProperties = null;
-            RestoreAuditProperties auditProperties = new RestoreAuditProperties();
+            RestoreAuditProperties auditProperties = null;
 
             jsonReader.ReadObject(propertyName =>
             {
@@ -1041,19 +1041,26 @@ namespace NuGet.ProjectModel
                         break;
 
                     case "restoreAuditProperties":
+                        string enableAudit = null, auditLevel = null;
                         jsonReader.ReadObject(auditPropertyName =>
                         {
+
                             switch (auditPropertyName)
                             {
                                 case "enableAudit":
-                                    auditProperties.EnableAudit = jsonReader.ReadNextTokenAsString();
+                                    enableAudit = jsonReader.ReadNextTokenAsString();
                                     break;
 
                                 case "auditLevel":
-                                    auditProperties.AuditLevel = jsonReader.ReadNextTokenAsString();
+                                    auditLevel = jsonReader.ReadNextTokenAsString();
                                     break;
                             }
                         });
+                        auditProperties = new RestoreAuditProperties()
+                        {
+                            EnableAudit = enableAudit,
+                            AuditLevel = auditLevel
+                        };
                         break;
 
 

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -158,10 +158,7 @@ namespace NuGet.ProjectModel
             WriteMetadataTargetFrameworks(writer, msbuildMetadata);
             SetWarningProperties(writer, msbuildMetadata);
 
-            // write NuGet lock file msbuild properties
             WriteNuGetLockFileProperties(writer, msbuildMetadata);
-
-            // write NuGetAudit properties
             WriteNuGetAuditProperties(writer, msbuildMetadata.RestoreAuditProperties);
 
             if (msbuildMetadata is PackagesConfigProjectRestoreMetadata pcMsbuildMetadata)
@@ -203,7 +200,7 @@ namespace NuGet.ProjectModel
 
         private static void WriteNuGetAuditProperties(IObjectWriter writer, RestoreAuditProperties auditProperties)
         {
-            if (auditProperties == null) { return; }
+            if (auditProperties == null) return;
 
             writer.WriteObjectStart("restoreAuditProperties");
 

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -207,11 +207,7 @@ namespace NuGet.ProjectModel
 
             writer.WriteObjectStart("restoreAuditProperties");
 
-            if (auditProperties.EnableAudit.HasValue)
-            {
-                SetValueIfTrue(writer, "enableAudit", auditProperties.EnableAudit.Value);
-            }
-
+            SetValueIfNotNull(writer, "enableAudit", auditProperties.EnableAudit);
             SetValueIfNotNull(writer, "auditLevel", auditProperties.AuditLevel);
 
             writer.WriteObjectEnd();

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -9,9 +9,7 @@ using Newtonsoft.Json;
 using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
-using NuGet.Packaging;
 using NuGet.RuntimeModel;
-using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.ProjectModel
@@ -163,6 +161,9 @@ namespace NuGet.ProjectModel
             // write NuGet lock file msbuild properties
             WriteNuGetLockFileProperties(writer, msbuildMetadata);
 
+            // write NuGetAudit properties
+            WriteNuGetAuditProperties(writer, msbuildMetadata.RestoreAuditProperties);
+
             if (msbuildMetadata is PackagesConfigProjectRestoreMetadata pcMsbuildMetadata)
             {
                 SetValue(writer, "packagesConfigPath", pcMsbuildMetadata.PackagesConfigPath);
@@ -198,6 +199,22 @@ namespace NuGet.ProjectModel
 
                 writer.WriteObjectEnd();
             }
+        }
+
+        private static void WriteNuGetAuditProperties(IObjectWriter writer, RestoreAuditProperties auditProperties)
+        {
+            if (auditProperties == null) { return; }
+
+            writer.WriteObjectStart("restoreAuditProperties");
+
+            if (auditProperties.EnableAudit.HasValue)
+            {
+                SetValueIfTrue(writer, "enableAudit", auditProperties.EnableAudit.Value);
+            }
+
+            SetValueIfNotNull(writer, "auditLevel", auditProperties.AuditLevel);
+
+            writer.WriteObjectEnd();
         }
 
         private static void WriteMetadataTargetFrameworks(IObjectWriter writer, ProjectRestoreMetadata msbuildMetadata)

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -129,7 +129,7 @@ namespace NuGet.ProjectModel
 
         public bool CentralPackageTransitivePinningEnabled { get; set; }
 
-        public RestoreAuditProperties RestoreAuditProperties { get; set; } = new RestoreAuditProperties();
+        public RestoreAuditProperties RestoreAuditProperties { get; set; }
 
         public override int GetHashCode()
         {
@@ -266,7 +266,7 @@ namespace NuGet.ProjectModel
             clone.CentralPackageVersionsEnabled = CentralPackageVersionsEnabled;
             clone.CentralPackageVersionOverrideDisabled = CentralPackageVersionOverrideDisabled;
             clone.CentralPackageTransitivePinningEnabled = CentralPackageTransitivePinningEnabled;
-            clone.RestoreAuditProperties = RestoreAuditProperties.Clone();
+            clone.RestoreAuditProperties = RestoreAuditProperties?.Clone();
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -125,6 +125,8 @@ namespace NuGet.ProjectModel
 
         public bool CentralPackageTransitivePinningEnabled { get; set; }
 
+        public RestoreAuditProperties RestoreAuditProperties { get; set; }
+
         public override int GetHashCode()
         {
             var hashCode = new HashCodeCombiner();
@@ -180,6 +182,7 @@ namespace NuGet.ProjectModel
             hashCode.AddObject(CentralPackageVersionsEnabled);
             hashCode.AddObject(CentralPackageVersionOverrideDisabled);
             hashCode.AddObject(CentralPackageTransitivePinningEnabled);
+            hashCode.AddObject(RestoreAuditProperties);
 
             return hashCode.CombinedHash;
         }
@@ -223,7 +226,8 @@ namespace NuGet.ProjectModel
                    EqualityUtility.EqualsWithNullCheck(RestoreLockProperties, other.RestoreLockProperties) &&
                    EqualityUtility.EqualsWithNullCheck(CentralPackageVersionsEnabled, other.CentralPackageVersionsEnabled) &&
                    EqualityUtility.EqualsWithNullCheck(CentralPackageVersionOverrideDisabled, other.CentralPackageVersionOverrideDisabled) &&
-                   EqualityUtility.EqualsWithNullCheck(CentralPackageTransitivePinningEnabled, other.CentralPackageTransitivePinningEnabled);
+                   EqualityUtility.EqualsWithNullCheck(CentralPackageTransitivePinningEnabled, other.CentralPackageTransitivePinningEnabled) &&
+                   RestoreAuditProperties == other.RestoreAuditProperties;
         }
 
         public virtual ProjectRestoreMetadata Clone()
@@ -258,6 +262,7 @@ namespace NuGet.ProjectModel
             clone.CentralPackageVersionsEnabled = CentralPackageVersionsEnabled;
             clone.CentralPackageVersionOverrideDisabled = CentralPackageVersionOverrideDisabled;
             clone.CentralPackageTransitivePinningEnabled = CentralPackageTransitivePinningEnabled;
+            clone.RestoreAuditProperties = RestoreAuditProperties?.Clone();
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -12,10 +12,6 @@ namespace NuGet.ProjectModel
 {
     public class ProjectRestoreMetadata : IEquatable<ProjectRestoreMetadata>
     {
-        public ProjectRestoreMetadata()
-        {
-        }
-
         /// <summary>
         /// Restore behavior type.
         /// </summary>

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -12,6 +12,10 @@ namespace NuGet.ProjectModel
 {
     public class ProjectRestoreMetadata : IEquatable<ProjectRestoreMetadata>
     {
+        public ProjectRestoreMetadata()
+        {
+        }
+
         /// <summary>
         /// Restore behavior type.
         /// </summary>
@@ -125,7 +129,7 @@ namespace NuGet.ProjectModel
 
         public bool CentralPackageTransitivePinningEnabled { get; set; }
 
-        public RestoreAuditProperties RestoreAuditProperties { get; set; }
+        public RestoreAuditProperties RestoreAuditProperties { get; set; } = new RestoreAuditProperties();
 
         public override int GetHashCode()
         {
@@ -262,7 +266,7 @@ namespace NuGet.ProjectModel
             clone.CentralPackageVersionsEnabled = CentralPackageVersionsEnabled;
             clone.CentralPackageVersionOverrideDisabled = CentralPackageVersionOverrideDisabled;
             clone.CentralPackageTransitivePinningEnabled = CentralPackageTransitivePinningEnabled;
-            clone.RestoreAuditProperties = RestoreAuditProperties?.Clone();
+            clone.RestoreAuditProperties = RestoreAuditProperties.Clone();
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
@@ -2,7 +2,7 @@
 NuGet.ProjectModel.RestoreAuditProperties
 NuGet.ProjectModel.RestoreAuditProperties.AuditLevel.get -> string?
 NuGet.ProjectModel.RestoreAuditProperties.AuditLevel.set -> void
-NuGet.ProjectModel.RestoreAuditProperties.EnableAudit.get -> bool?
+NuGet.ProjectModel.RestoreAuditProperties.EnableAudit.get -> string?
 NuGet.ProjectModel.RestoreAuditProperties.EnableAudit.set -> void
 NuGet.ProjectModel.RestoreAuditProperties.Equals(NuGet.ProjectModel.RestoreAuditProperties? other) -> bool
 NuGet.ProjectModel.RestoreAuditProperties.RestoreAuditProperties() -> void

--- a/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
@@ -1,1 +1,14 @@
 #nullable enable
+NuGet.ProjectModel.RestoreAuditProperties
+NuGet.ProjectModel.RestoreAuditProperties.AuditLevel.get -> string?
+NuGet.ProjectModel.RestoreAuditProperties.AuditLevel.set -> void
+NuGet.ProjectModel.RestoreAuditProperties.EnableAudit.get -> bool?
+NuGet.ProjectModel.RestoreAuditProperties.EnableAudit.set -> void
+NuGet.ProjectModel.RestoreAuditProperties.Equals(NuGet.ProjectModel.RestoreAuditProperties? other) -> bool
+NuGet.ProjectModel.RestoreAuditProperties.RestoreAuditProperties() -> void
+override NuGet.ProjectModel.RestoreAuditProperties.Equals(object? obj) -> bool
+override NuGet.ProjectModel.RestoreAuditProperties.GetHashCode() -> int
+static NuGet.ProjectModel.RestoreAuditProperties.operator !=(NuGet.ProjectModel.RestoreAuditProperties? x, NuGet.ProjectModel.RestoreAuditProperties? y) -> bool
+static NuGet.ProjectModel.RestoreAuditProperties.operator ==(NuGet.ProjectModel.RestoreAuditProperties? x, NuGet.ProjectModel.RestoreAuditProperties? y) -> bool
+~NuGet.ProjectModel.ProjectRestoreMetadata.RestoreAuditProperties.get -> NuGet.ProjectModel.RestoreAuditProperties
+~NuGet.ProjectModel.ProjectRestoreMetadata.RestoreAuditProperties.set -> void

--- a/src/NuGet.Core/NuGet.ProjectModel/RestoreAuditProperties.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/RestoreAuditProperties.cs
@@ -11,10 +11,6 @@ namespace NuGet.ProjectModel
 {
     public class RestoreAuditProperties : IEquatable<RestoreAuditProperties>
     {
-        public RestoreAuditProperties()
-        {
-        }
-
         /// <summary>
         /// Gets or sets a value indicating whether NuGet audit (check packages for known vulnerabilities) is enabled.
         /// </summary>

--- a/src/NuGet.Core/NuGet.ProjectModel/RestoreAuditProperties.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/RestoreAuditProperties.cs
@@ -17,14 +17,14 @@ namespace NuGet.ProjectModel
         public string? EnableAudit { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating the NuGet audit level threshold which which vulnerabilities are reported.
+        /// Gets or sets a value indicating the NuGet audit level threshold with which vulnerabilities are reported.
         /// </summary>
         /// <value>low, moderate, high, critical</value>
         public string? AuditLevel { get; set; }
 
         public bool Equals(RestoreAuditProperties? other)
         {
-            if (other is null) { return false; }
+            if (other is null) return false;
 
             return EnableAudit == other.EnableAudit &&
                 AuditLevel == other.AuditLevel;
@@ -37,8 +37,8 @@ namespace NuGet.ProjectModel
 
         public static bool operator ==(RestoreAuditProperties? x, RestoreAuditProperties? y)
         {
-            if (ReferenceEquals(x, y)) { return true; }
-            if (x is null || y is null) { return false; }
+            if (ReferenceEquals(x, y)) return true;
+            if (x is null || y is null) return false;
 
             return x.Equals(y);
         }
@@ -63,7 +63,6 @@ namespace NuGet.ProjectModel
                 EnableAudit = EnableAudit,
                 AuditLevel = AuditLevel
             };
-            Debug.Assert(clone == this && clone.GetHashCode() == GetHashCode());
             return clone;
         }
     }

--- a/src/NuGet.Core/NuGet.ProjectModel/RestoreAuditProperties.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/RestoreAuditProperties.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Diagnostics;
+using NuGet.Shared;
+
+namespace NuGet.ProjectModel
+{
+    public class RestoreAuditProperties : IEquatable<RestoreAuditProperties>
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether NuGet audit (check packages for known vulnerabilities) is enabled.
+        /// </summary>
+        public bool? EnableAudit { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets a value indicating the NuGet audit level threshold which which vulnerabilities are reported.
+        /// </summary>
+        /// <value>low, moderate, high, critical</value>
+        public string? AuditLevel { get; set; }
+
+        public bool Equals(RestoreAuditProperties? other)
+        {
+            if (other is null) { return false; }
+
+            return EnableAudit == other.EnableAudit &&
+                AuditLevel == other.AuditLevel;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return Equals(obj as RestoreAuditProperties);
+        }
+
+        public static bool operator ==(RestoreAuditProperties? x, RestoreAuditProperties? y)
+        {
+            if (ReferenceEquals(x, y)) { return true; }
+            if (x is null || y is null) { return false; }
+
+            return x.Equals(y);
+        }
+
+        public static bool operator !=(RestoreAuditProperties? x, RestoreAuditProperties? y)
+        {
+            return !(x == y);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCodeCombiner = new HashCodeCombiner();
+            hashCodeCombiner.AddStruct(EnableAudit);
+            hashCodeCombiner.AddObject(AuditLevel);
+            return hashCodeCombiner.CombinedHash;
+        }
+
+        internal RestoreAuditProperties Clone()
+        {
+            var clone = new RestoreAuditProperties()
+            {
+                EnableAudit = EnableAudit,
+                AuditLevel = AuditLevel
+            };
+            Debug.Assert(clone == this && clone.GetHashCode() == GetHashCode());
+            return clone;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/RestoreAuditProperties.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/RestoreAuditProperties.cs
@@ -11,6 +11,10 @@ namespace NuGet.ProjectModel
 {
     public class RestoreAuditProperties : IEquatable<RestoreAuditProperties>
     {
+        public RestoreAuditProperties()
+        {
+        }
+
         /// <summary>
         /// Gets or sets a value indicating whether NuGet audit (check packages for known vulnerabilities) is enabled.
         /// </summary>

--- a/src/NuGet.Core/NuGet.ProjectModel/RestoreAuditProperties.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/RestoreAuditProperties.cs
@@ -14,7 +14,7 @@ namespace NuGet.ProjectModel
         /// <summary>
         /// Gets or sets a value indicating whether NuGet audit (check packages for known vulnerabilities) is enabled.
         /// </summary>
-        public bool? EnableAudit { get; set; } = false;
+        public string? EnableAudit { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating the NuGet audit level threshold which which vulnerabilities are reported.
@@ -51,7 +51,7 @@ namespace NuGet.ProjectModel
         public override int GetHashCode()
         {
             var hashCodeCombiner = new HashCodeCombiner();
-            hashCodeCombiner.AddStruct(EnableAudit);
+            hashCodeCombiner.AddObject(EnableAudit);
             hashCodeCombiner.AddObject(AuditLevel);
             return hashCodeCombiner.CombinedHash;
         }

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/ResolverFacts.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/ResolverFacts.cs
@@ -120,6 +120,8 @@ namespace NuGet.DependencyResolver.Core.Tests
 
             public PackageSource Source => new PackageSource("Test");
 
+            public SourceRepository SourceRepository => throw new NotImplementedException();
+
             public async Task<LibraryIdentity> FindLibraryAsync(
                 LibraryRange libraryRange,
                 NuGetFramework targetFramework,

--- a/test/TestUtilities/Test.Utility/DependencyResolver/DependencyProvider.cs
+++ b/test/TestUtilities/Test.Utility/DependencyResolver/DependencyProvider.cs
@@ -26,6 +26,8 @@ namespace Test.Utility
 
         public PackageSource Source => new PackageSource("Test");
 
+        public SourceRepository SourceRepository => throw new NotImplementedException();
+
         public Task<IPackageDownloader> GetPackageDownloaderAsync(
             PackageIdentity packageIdentity,
             SourceCacheContext cacheContext,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12289

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Spec for feature: https://github.com/NuGet/Home/blob/dev/proposed/2022/vulnerabilities-in-restore.md
  * If you see anything in the implementation that does not follow the spec, please let me know!
* Added VulnerabilityInformationProvider, which caches vulnerability data per-source, so when multiple projects need to load the known vulnerability database in a restore, it's only parsed once
* Added AuditUtility class, which has all the business logic in matching known vulnerabilities to packages used in the project, and generates all the warnings
* Added relevant code to get `NuGetAudit` and `NuGetAuditLevel` MSBuild properties from PackageReference projects on CLI and VS.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: Due to time constraints to meet the next preview ship date, tests were postponed, but will be followed up on: https://github.com/NuGet/Client.Engineering/issues/2253
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled: https://github.com/NuGet/docs.microsoft.com-nuget/issues/3049
  - **OR**
  - [ ] N/A
