### PR TITLE
Run .NET integration and cross framework tests on .NET7 and .NET 8

### DIFF
--- a/build/DotNetSdkVersions.txt
+++ b/build/DotNetSdkVersions.txt
@@ -1,4 +1,5 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
+-Channel 8.0
 -Channel 7.0
 -Channel 6.0 -Runtime dotnet
 -Channel 5.0

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -15,7 +15,7 @@
     <NETFXTargetFramework>net472</NETFXTargetFramework>
     <NETCoreTargetFramework>netcoreapp3.1</NETCoreTargetFramework>
     <NETCoreTargetFramework Condition="'$(DotNetBuildFromSource)' == 'true'">net7.0</NETCoreTargetFramework>
-    <NETCoreTestTargetFramework>net6.0</NETCoreTestTargetFramework>
+    <NETCoreTestTargetFrameworks>net7.0;net8.0</NETCoreTestTargetFrameworks>
     <NetStandardVersion>netstandard2.0</NetStandardVersion>
     <TargetFrameworksExe>$(NETFXTargetFramework);$(NETCoreTargetFramework)</TargetFrameworksExe>
     <TargetFrameworksExe Condition="'$(IsXPlat)' == 'true'">$(NETCoreTargetFramework)</TargetFrameworksExe>
@@ -29,7 +29,7 @@
     <TargetFrameworksLibrary Condition="'$(DotNetBuildFromSource)' == 'true'">$(NETCoreTargetFramework);$(NetStandardVersion)</TargetFrameworksLibrary>
     <TargetFrameworksLibraryForSigning>$(TargetFrameworksLibrary);netcoreapp5.0</TargetFrameworksLibraryForSigning>
     <TargetFrameworksLibraryForSigning Condition="'$(DotNetBuildFromSource)' == 'true'">$(TargetFrameworksLibrary);net7.0</TargetFrameworksLibraryForSigning>
-    <TargetFrameworksLibraryForCrossVerificationTests>$(NETFXTargetFramework);net7.0</TargetFrameworksLibraryForCrossVerificationTests>
+    <TargetFrameworksLibraryForCrossVerificationTests>$(NETFXTargetFramework);$(NETCoreTestTargetFrameworks)</TargetFrameworksLibraryForCrossVerificationTests>
     <RepositoryRootDirectory>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\</RepositoryRootDirectory>
     <BuildCommonDirectory>$(RepositoryRootDirectory)build\</BuildCommonDirectory>
     <SolutionFile>$(RepositoryRootDirectory)$(RepositoryName).sln</SolutionFile>

--- a/eng/pipelines/templates/CrossFramework_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/CrossFramework_Tests_On_Windows.yml
@@ -36,42 +36,34 @@ steps:
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/restore:false /target:BuildNoVSIX /property:BuildRTM=false /property:BuildNumber=$(BuildNumber) /binarylogger:$(Build.StagingDirectory)\\binlog\\02.Build.binlog"
 
-- task: PowerShell@1
-  displayName: "Run Cross Verify Tests (continue on error)"
-  continueOnError: "true"
+- task: DotNetCoreCLI@2
+  displayName: "Run Cross Verify Tests (.NET Framework)"
+  continueOnError: ${{ eq(variables['IsOfficialBuild'], 'true') }}
   inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      dotnet test --no-build --configuration Release `
-      $(Build.Repository.LocalPath)\test\NuGet.Core.FuncTests\NuGet.Signing.CrossFramework.Test\NuGet.Signing.CrossFramework.Test.csproj `
-      --logger:"trx;LogFileName=$(Build.Repository.LocalPath)\\build\\TestResults\CrossVerifyTests-vsts.trx" `
-      --logger:"console;verbosity=detailed" `
-      --settings:$(Build.Repository.LocalPath)\build\xunit.runsettings
-  condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
+    command: 'test'
+    projects: '$(Build.Repository.LocalPath)\test\NuGet.Core.FuncTests\NuGet.Signing.CrossFramework.Test\NuGet.Signing.CrossFramework.Test.csproj'
+    arguments: '--no-restore --no-build --framework net472 --settings:$(Build.Repository.LocalPath)\build\xunit.runsettings /noautorsp /property:Configuration=$(BuildConfiguration) "/binarylogger:$(Build.StagingDirectory)\\binlog\\03.Test-net472.binlog"'
+    testRunTitle: 'NuGet.Client Cross Verify Tests On Windows (.NET Framework)'
 
-- task: PowerShell@1
-  displayName: "Run Cross Verify Tests (stop on error)"
-  continueOnError: "false"
+- task: DotNetCoreCLI@2
+  displayName: "Run Cross Verify Tests (.NET 7.0)"
+  continueOnError: ${{ eq(variables['IsOfficialBuild'], 'true') }}
   inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      dotnet test --no-build --configuration Release `
-      $(Build.Repository.LocalPath)\test\NuGet.Core.FuncTests\NuGet.Signing.CrossFramework.Test\NuGet.Signing.CrossFramework.Test.csproj `
-      --logger:"trx;LogFileName=$(Build.Repository.LocalPath)\\build\\TestResults\CrossVerifyTests-vsts.trx" `
-      --logger:"console;verbosity=detailed" `
-      --settings:$(Build.Repository.LocalPath)\build\xunit.runsettings
-  condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
+    command: 'test'
+    projects: '$(Build.Repository.LocalPath)\test\NuGet.Core.FuncTests\NuGet.Signing.CrossFramework.Test\NuGet.Signing.CrossFramework.Test.csproj'
+    arguments: '--no-restore --no-build --framework net7.0 --settings:$(Build.Repository.LocalPath)\build\xunit.runsettings /noautorsp /property:Configuration=$(BuildConfiguration) "/binarylogger:$(Build.StagingDirectory)\\binlog\\03.Test-net7.0.binlog"'
+    testRunTitle: 'NuGet.Client Cross Verify Tests On Windows (.NET 7.0)'
+    condition: "succeededOrFailed()"
 
-- task: PublishTestResults@2
-  displayName: "Publish Test Results"
-  continueOnError: "true"
+- task: DotNetCoreCLI@2
+  displayName: "Run Cross Verify Tests (.NET 8.0)"
+  continueOnError: ${{ eq(variables['IsOfficialBuild'], 'true') }}
   inputs:
-    testRunner: "VSTest"
-    testResultsFiles: "*.trx"
-    searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
-    mergeTestResults: "true"
-    testRunTitle: "NuGet.Client Cross Verify Tests On Windows"
-  condition: "succeededOrFailed()"
+    command: 'test'
+    projects: '$(Build.Repository.LocalPath)\test\NuGet.Core.FuncTests\NuGet.Signing.CrossFramework.Test\NuGet.Signing.CrossFramework.Test.csproj'
+    arguments: '--no-restore --no-build --framework net8.0 --settings:$(Build.Repository.LocalPath)\build\xunit.runsettings /noautorsp /property:Configuration=$(BuildConfiguration) "/binarylogger:$(Build.StagingDirectory)\\binlog\\03.Test-net8.0.binlog"'
+    testRunTitle: 'NuGet.Client Cross Verify Tests On Windows (.NET 8.0)'
+    condition: "succeededOrFailed()"
 
 - task: PublishBuildArtifacts@1
   displayName: "Publish Test Freeze Dump"

--- a/global.json
+++ b/global.json
@@ -6,4 +6,7 @@
   // version.  We also don't want to introduce MS.DN.Arcade.SDK into the non-source-build build.
   // eng/source-build/global.json has the entry for the Arcade version we need for
   // Arcade-powered source-build.
+  "sdk": {
+    "allowPrerelease": true
+  }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -10029,7 +10029,7 @@ namespace NuGet.CommandLine.Test
                 var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
                     "proj",
                     pathContext.SolutionRoot,
-                    "net7.0-windows");
+                    "net8.0-windows");
 
                 project.AddPackageToAllFrameworks(packageX);
                 solution.Projects.Add(project);
@@ -10048,7 +10048,7 @@ namespace NuGet.CommandLine.Test
 
                 var propsItemGroups = propsXML.Root.Elements().Where(e => e.Name.LocalName == "ItemGroup").ToList();
 
-                Assert.Contains("'$(TargetFramework)' == 'net7.0-windows' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Contains("'$(TargetFramework)' == 'net8.0-windows' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
             }
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Constants.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Constants.cs
@@ -8,7 +8,13 @@ namespace Dotnet.Integration.Test
 {
     internal static class Constants
     {
+#if NET8_0
+        internal static readonly NuGetFramework DefaultTargetFramework = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new Version(8, 0, 0, 0));
+#elif NET7_0
         internal static readonly NuGetFramework DefaultTargetFramework = FrameworkConstants.CommonFrameworks.Net70;
+#else
+        // Unknown target framework, update this list to support it
+#endif
 
         internal static readonly Uri DotNetPackageSource = new("https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet7/nuget/v3/index.json");
     }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NETCoreTestTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>$(NETCoreTestTargetFrameworks)</TargetFrameworks>
     <Description>Integration tests for NuGet-powered dotnet CLI commands such as pack/restore/list package and dotnet nuget.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -29,7 +29,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_V3LocalSourceFeed_WithRelativePath_NoVersionSpecified_Success()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext())
             {
                 var projectName = "projectA";
                 var targetFrameworks = "net5.0";
@@ -74,7 +74,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_V3LocalSourceFeed_WithRelativePath_NoVersionSpecified_Fail()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext())
             {
                 var projectName = "projectA";
                 var targetFrameworks = "net5.0";
@@ -107,7 +107,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_V3LocalSourceFeed_WithRelativePath_VersionSpecified_Success()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext())
             {
                 var projectName = "projectA";
                 var targetFrameworks = "net5.0";
@@ -152,7 +152,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_V3LocalSourceFeed_WithRelativePath_VersionSpecified_Fail()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext())
             {
                 var projectName = "projectA";
                 var targetFrameworks = "net5.0";
@@ -185,7 +185,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_V3LocalSourceFeed_WithDefaultSolutiuonSource_NoVersionSpecified_Success()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext(addTemplateFeed: false))
             {
                 var projectName = "projectA";
                 var targetFrameworks = "net5.0";
@@ -214,9 +214,9 @@ namespace Dotnet.Integration.Test
 
                 // Make sure source is replaced in generated dgSpec file.
                 PackageSpec packageSpec = projectA.AssetsFile.PackageSpec;
-                string[] sources = packageSpec.RestoreMetadata.Sources.Select(s => s.Name).ToArray();
-                Assert.Equal(sources.Count(), 1);
-                Assert.Equal(sources[0], pathContext.PackageSource);
+                
+                packageSpec.RestoreMetadata.Sources.Select(s => s.Name).Should().ContainSingle()
+                    .Which.Should().Be(pathContext.PackageSource);
 
                 var ridlessTarget = projectA.AssetsFile.Targets.Where(e => string.IsNullOrEmpty(e.RuntimeIdentifier)).Single();
                 // Should resolve to specified package.
@@ -229,7 +229,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WhenPackageSourceMappingConfiguredAndNoMatchingSourceFound_Fails()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution, and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -290,7 +290,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WhenPackageSourceMappingConfiguredInstallsPackagesFromExpectedSources_Success()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution, and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -354,7 +354,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WhenPackageSourceMappingConfiguredInstallsPackagesFromSourcesUriOption_Success()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution, and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -420,7 +420,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WhenPackageSourceMappingConfiguredCanotInstallsPackagesFromSourcesUriOption_Fails()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution, and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -485,7 +485,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WhenPackageSourceMappingConfiguredInstallsPackagesFromRestoreSources_Success()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution, and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -554,7 +554,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WhenPackageSourceMappingConfiguredCanotInstallsPackagesFromRestoreSources_Fails()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution, and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -693,7 +693,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WithCPM_WhenPackageVersionDoesNotExistAndVersionCLIArgNotPassed_Success()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution, and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -742,7 +742,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WithCPM_WhenPackageVersionDoesNotExistAndVersionCLIArgPassed_Success()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution, and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -791,7 +791,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WithCPM_WhenPackageVersionExistsAndVersionCLIArgNotPassed_NoOp()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -843,7 +843,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WithCPM_WhenPackageVersionExistsAndVersionCLIArgPassed_Success()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -894,7 +894,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WithCPM_WhenMultipleItemGroupsExist_Success()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -951,7 +951,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WithCPM_WithPackageReference_NoVersionOverride_NoPackageVersion_NoVersionCLI_Errors()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -1014,7 +1014,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WithCPM_WithPackageReference_NoVersionOverride_NoPackageVersion_WithVersionCLI_Errors()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -1077,7 +1077,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WithCPM_WithPackageReference_NoVersionOverride_WithPackageVersion_NoVersionCLI_NoOps()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -1143,7 +1143,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WithCPM_WithPackageReference_NoVersionOverride_WithPackageVersion_WithVersionCLI_Success()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -1205,7 +1205,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WithCPM_WithPackageReference_WithVersionOverride_NoPackageVersion_NoVersionCLI_NoOps()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -1268,7 +1268,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WithCPM_WithPackageReference_WithVersionOverride_NoPackageVersion_WithVersionCLI_Success()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -1330,7 +1330,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WithCPM_WithPackageReference_WithVersionOverride_WithPackageVersion_NoVersionCLI_NoOps()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -1396,7 +1396,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WithCPM_WithPackageReference_WithVersionOverride_WithPackageVersion_WithVersionCLI_Success()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -1461,7 +1461,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WithCPM_WithPackageReference_EmptyVersionOverride_WithPackageVersion_WithVersionCLI_IgnoreEmptyVersionOverride_Success()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -1528,7 +1528,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WithCPM_WrongPackageReference_WithVersionOverride_WithPackageVersion_WithVersionCLI_WrongConfiguration_Error()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -1590,7 +1590,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WithCPM_WithPackageReference_WithVersionOverride_WrongPackageVersion_WithVersionCLI_WrongConfiguration_Error()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -1653,7 +1653,7 @@ namespace Dotnet.Integration.Test
         [Fact]
         public async Task AddPkg_WithCPM_WithPackageReference_DisabledVersionOverride_WrongPackageVersion_WithVersionCLI_WrongConfiguration_Error()
         {
-            using var pathContext = new SimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
 
             // Set up solution and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -38,7 +38,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public void DotnetRestore_SolutionRestoreVerifySolutionDirPassedToProjects()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 _msbuildFixture.CreateDotnetNewProject(pathContext.SolutionRoot, "proj");
 
@@ -93,7 +93,7 @@ EndGlobal";
         [Fact]
         public void DotnetRestore_WithAuthorSignedPackage_Succeeds()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var packageFile = new FileInfo(Path.Combine(pathContext.PackageSource, "TestPackage.AuthorSigned.1.0.0.nupkg"));
                 var package = SigningTestUtility.GetResourceBytes(packageFile.Name);
@@ -188,7 +188,7 @@ EndGlobal";
         [Fact]
         public async Task DotnetRestore_UpdateLastAccessTime()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var packageX = new SimpleTestPackageContext()
                 {
@@ -261,7 +261,7 @@ EndGlobal";
         [PlatformFact(Platform.Windows, Platform.Linux)]
         public async Task DotnetRestore_WithUnSignedPackageAndSignatureValidationModeAsRequired_FailsAsync()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 //Setup packages and feed
                 var packageX = new SimpleTestPackageContext()
@@ -333,7 +333,7 @@ EndGlobal";
         [PlatformFact(Platform.Darwin)]
         public async Task DotnetRestore_WithUnSignedPackageAndSignatureValidationModeAsRequired_SucceedAsync()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 //Setup packages and feed
                 var packageX = new SimpleTestPackageContext()
@@ -408,7 +408,7 @@ EndGlobal";
         [InlineData("true")]
         public async Task DotnetRestore_WithUnSignedPackageAndSignatureValidationModeAsRequired_WithEnvVarTrue_Fails(string envVarValue)
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 //Arrange
                 var envVarName = SignatureVerificationEnvironmentVariable;
@@ -489,7 +489,7 @@ EndGlobal";
         [PlatformFact(Platform.Darwin, SkipPlatform = Platform.Darwin)]
         public async Task DotnetRestore_WithUnSignedPackageAndSignatureValidationModeAsRequired_WithEnvVarNameCaseSensitive_Succeed()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 //Arrange
                 var envVarName = SignatureVerificationEnvironmentVariableTypo;
@@ -572,7 +572,7 @@ EndGlobal";
         [PlatformFact(Platform.Linux, Platform.Darwin, SkipPlatform = Platform.Darwin)]
         public async Task DotnetRestore_WithUnSignedPackageAndSignatureValidationModeAsRequired_WithEnvVarValueCaseInsensitive_Fails()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 //Arrange
                 var envVarName = SignatureVerificationEnvironmentVariable;
@@ -653,7 +653,7 @@ EndGlobal";
         [PlatformFact(Platform.Windows)]
         public void DotnetRestore_WithAuthorSignedPackageAndSignatureValidationModeAsRequired_Succeeds()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var packageFile = new FileInfo(Path.Combine(pathContext.PackageSource, "TestPackage.AuthorSigned.1.0.0.nupkg"));
                 var package = SigningTestUtility.GetResourceBytes(packageFile.Name);
@@ -740,7 +740,7 @@ EndGlobal";
         [InlineData(false)]
         public async Task DotnetRestore_OneLinePerRestore(bool useStaticGraphRestore)
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var testDirectory = pathContext.SolutionRoot;
                 var pkgX = new SimpleTestPackageContext("x", "1.0.0");
@@ -819,7 +819,7 @@ EndGlobal";
         [PlatformFact(Platform.Windows)]
         public async Task DotnetRestore_ProjectMovedDoesNotRunRestore()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var tfm = "net472";
                 var testDirectory = pathContext.SolutionRoot;
@@ -878,7 +878,7 @@ EndGlobal";
         [PlatformFact(Platform.Windows)]
         public void DotnetRestore_PackageDownloadSupported_IsSet()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 _msbuildFixture.CreateDotnetNewProject(pathContext.SolutionRoot, "proj");
 
@@ -905,7 +905,7 @@ EndGlobal";
         [PlatformFact(Platform.Windows)]
         public async Task DotnetRestore_LockedMode_NewProjectOutOfBox()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
 
                 // Set up solution, and project
@@ -972,7 +972,7 @@ EndGlobal";
         [PlatformFact(Platform.Windows)]
         public void DotnetRestore_LockedMode_Net7WithAndWithoutPlatform()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 // Arrange
                 string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
@@ -1009,7 +1009,7 @@ EndGlobal";
         public async Task DotnetRestore_VerifyPerProjectConfigSourcesAreUsedForChildProjectsWithoutSolutionAsync()
         {
             // Arrange
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
                 var projects = new Dictionary<string, SimpleTestProjectContext>();
@@ -1109,7 +1109,7 @@ EndGlobal";
         public async Task DotnetRestore_VerifyPerProjectConfigSourcesAreUsedForChildProjectsWithSolutionAsync()
         {
             // Arrange
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var projects = new Dictionary<string, SimpleTestProjectContext>();
                 var sources = new List<string>();
@@ -1208,7 +1208,7 @@ EndGlobal";
         [PlatformFact(Platform.Windows)]
         public async Task DotnetRestore_PackageReferenceWithAliases_ReflectedInTheAssetsFile()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 // Set up solution, and project
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -1256,7 +1256,7 @@ EndGlobal";
         [PlatformFact(Platform.Windows)]
         public async Task DotnetRestore_MultiTargettingWithAliases_Succeeds()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var testDirectory = pathContext.SolutionRoot;
                 var pkgX = new SimpleTestPackageContext("x", "1.0.0");
@@ -1317,7 +1317,7 @@ EndGlobal";
         [Fact]
         public async Task DotnetRestore_WithTargetFrameworksProperty_StaticGraphAndRegularRestore_AreEquivalent()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var testDirectory = pathContext.SolutionRoot;
                 var pkgX = new SimpleTestPackageContext("x", "1.0.0");
@@ -1367,7 +1367,7 @@ EndGlobal";
         [Fact]
         public void GenerateRestoreGraphFile_StandardAndStaticGraphRestore_AreEquivalent()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var testDirectory = pathContext.SolutionRoot;
                 var projectName1 = "ClassLibrary";
@@ -1402,7 +1402,7 @@ EndGlobal";
         [InlineData("netcoreapp2.1;netcoreapp3.0;netcoreapp3.1", false)]
         public async Task DotnetRestore_MultiTargettingProject_WithDifferentPackageReferences_ForceDoesNotRewriteAssetsFile(string targetFrameworks, bool useStaticGraphRestore)
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var projectName = "ClassLibrary1";
                 var testDirectory = pathContext.SolutionRoot;
@@ -1465,7 +1465,7 @@ EndGlobal";
         [InlineData("netcoreapp3.0;netcoreapp2.1;netcoreapp3.1", false)]
         public async Task DotnetRestore_MultiTargettingProject_WithDifferentProjectReferences_ForceDoesNotRewriteAssetsFile(string targetFrameworks, bool useStaticGraphRestore)
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var projectName = "ClassLibrary1";
                 var testDirectory = pathContext.SolutionRoot;
@@ -1544,7 +1544,7 @@ EndGlobal";
         [Fact]
         public void CollectFrameworkReferences_WithTransitiveFrameworkReferences_ExcludesTransitiveFrameworkReferences()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 // Arrange
                 // Library project with Framework Reference
@@ -1623,7 +1623,7 @@ EndGlobal";
         public void Dotnet_New_Template_Restore_Success(string template)
         {
             // Arrange
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var projectName = new DirectoryInfo(pathContext.SolutionRoot).Name;
                 var solutionDirectory = pathContext.SolutionRoot;
@@ -1643,7 +1643,7 @@ EndGlobal";
         [PlatformFact(Platform.Windows)]
         public async Task DotnetRestore_SameNameSameKeyProjectPackageReferencing_Succeeds()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 // Set up solution, and project
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -1721,7 +1721,7 @@ EndGlobal";
         [InlineData("PackageDownload", "NU1505")]
         public async Task DotnetRestore_WithDuplicateItem_WarnsWithLogCode(string itemName, string logCode)
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var projectName = "ClassLibrary1";
                 var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
@@ -1766,7 +1766,7 @@ EndGlobal";
         [Fact]
         public async Task DotnetRestore_WithDuplicatePackageVersion_WarnsWithNU1506()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var projectName = "ClassLibrary1";
                 var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
@@ -1818,7 +1818,7 @@ EndGlobal";
         [InlineData("PackageDownload", "NU1505")]
         public async Task DotnetRestore_WithDuplicateItem_WithTreatWarningsAsErrors_ErrorsWithLogCode(string itemName, string logCode)
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var projectName = "ClassLibrary1";
                 var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
@@ -1869,7 +1869,7 @@ EndGlobal";
         [Fact]
         public async Task WhenPackageSourceMappingConfiguredInstallsPackageReferencesAndDownloadsFromExpectedSources_Success()
         {
-            using var pathContext = _msbuildFixture.CreateSimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext();
 
             // Set up solution, and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -1948,7 +1948,7 @@ EndGlobal";
         [Fact]
         public async Task WhenPackageSourceMappingConfiguredAndNoMatchingSourceFound_Fails()
         {
-            using var pathContext = _msbuildFixture.CreateSimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext();
 
             // Set up solution, and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -2025,7 +2025,7 @@ EndGlobal";
         [Fact]
         public async Task DotnetRestore_PackageSourceMappingFilter_WithAllSourceOptions_Succeed()
         {
-            using var pathContext = _msbuildFixture.CreateSimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext();
 
             // Set up solution, and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -2109,7 +2109,7 @@ EndGlobal";
         [Fact]
         public async Task DotnetRestore_PackageSourceMappingFilter_WithNotEnoughSourceOptions_Fails()
         {
-            using var pathContext = _msbuildFixture.CreateSimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext();
 
             // Set up solution, and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -2179,7 +2179,7 @@ EndGlobal";
         [Fact]
         public async Task WhenPackageSourceMappingIsEnabled_InstallsPackagesFromRestoreSources_Success()
         {
-            using var pathContext = _msbuildFixture.CreateSimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext();
 
             // Set up solution, and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -2249,7 +2249,7 @@ EndGlobal";
         [Fact]
         public async Task WhenPackageSourceMappingIsEnabled_CannotInstallsPackagesFromRestoreSources_Fails()
         {
-            using var pathContext = _msbuildFixture.CreateSimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext();
 
             // Set up solution, and project
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
@@ -2321,7 +2321,7 @@ EndGlobal";
 
         public async Task DotnetRestore_WithDuplicatePackageVersion_WithTreatWarningsAsErrors_ErrorsWithNU1506()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var projectName = "ClassLibrary1";
                 var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
@@ -2376,7 +2376,7 @@ EndGlobal";
         [Fact]
         public async Task DotnetRestore_WithDuplicatePackageReference_RespectsContinueOnError()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var projectName = "ClassLibrary1";
                 var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
@@ -2422,7 +2422,7 @@ EndGlobal";
         [Fact]
         public async Task WhenPackageReferrenceHasRelatedFiles_RelatedPropertyIsApplied_Success()
         {
-            using var pathContext = _msbuildFixture.CreateSimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext();
 
             // Set up solution, and project
             // projectA -> projectB -> packageX -> packageY
@@ -2519,7 +2519,7 @@ EndGlobal";
         [Fact]
         public async Task DotnetRestore_CentralPackageVersionManagement_NoOps()
         {
-            using (var pathContext = _msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var testDirectory = pathContext.SolutionRoot;
                 var pkgX = new SimpleTestPackageContext("x", "1.0.0");
@@ -2590,7 +2590,7 @@ EndGlobal";
         public async Task DotnetRestore_WithMultiTargetingProject_WhenTargetFrameworkIsSpecifiedOnTheCommandline_RestoresForSingleFramework(bool useStaticGraphEvaluation)
         {
             // Arrange
-            using var pathContext = _msbuildFixture.CreateSimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext();
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, new SimpleTestPackageContext("x", "1.0.0"));
             string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
             string projectFileContents =
@@ -2629,7 +2629,7 @@ EndGlobal";
         public async Task DotnetRestore_WithMultiTargetingProject_WhenTargetFrameworkIsSpecifiedOnTheCommandline_AndPerFrameworkProjectReferencesAreUsed_RestoresForSingleFramework(bool useStaticGraphEvaluation)
         {
             // Arrange
-            using var pathContext = _msbuildFixture.CreateSimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext();
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, new SimpleTestPackageContext("x", "1.0.0"));
             var projectAWorkingDirectory = Path.Combine(pathContext.SolutionRoot, "a");
             var projectBWorkingDirectory = Path.Combine(pathContext.SolutionRoot, "b");
@@ -2680,7 +2680,7 @@ EndGlobal";
         public async Task DotnetRestore_WithMultiTargettingProject_WhenTargetFrameworkIsSpecifiedOnTheCommandline_PerFrameworkProjectReferencesAreUsed_RestoresForSingleFramework(bool useStaticGraphEvaluation)
         {
             // Arrange
-            using var pathContext = _msbuildFixture.CreateSimpleTestPathContext();
+            using SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext();
             var additionalSource = Path.Combine(pathContext.SolutionRoot, "additionalSource");
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(additionalSource, new SimpleTestPackageContext("x", "1.0.0"));
             string tfm = Constants.DefaultTargetFramework.GetShortFolderName();

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSourcesTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSourcesTests.cs
@@ -24,7 +24,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public void Sources_WhenAddingSource_GotAdded()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext())
             {
                 var workingPath = pathContext.WorkingDirectory;
                 var settings = pathContext.Settings;
@@ -57,7 +57,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public void Sources_WhenAddingSourceWithCredentials_CredentialsWereAddedAndEncrypted()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext())
             {
                 var workingPath = pathContext.WorkingDirectory;
                 var settings = pathContext.Settings;
@@ -108,7 +108,7 @@ namespace Dotnet.Integration.Test
         [InlineData("https://source.test", false)]
         public void Sources_WarnWhenAdding(string source, bool shouldWarn)
         {
-            using (SimpleTestPathContext pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext())
             {
                 TestDirectory workingPath = pathContext.WorkingDirectory;
                 SimpleTestSettingsContext settings = pathContext.Settings;
@@ -383,7 +383,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public void Sources_WhenAddingSourceWithCredentialsInClearText_CredentialsWereAddedAndNotEncrypted()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext())
             {
                 var workingPath = pathContext.WorkingDirectory;
                 var settings = pathContext.Settings;
@@ -652,7 +652,7 @@ namespace Dotnet.Integration.Test
         [Fact(Skip = "cutting verbosity Quiet for now. #6374 covers fixing it for `dotnet add package` too.")]
         public void TestVerbosityQuiet_DoesNotShowInfoMessages()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext())
             {
                 var workingPath = pathContext.WorkingDirectory;
                 var settings = pathContext.Settings;
@@ -690,7 +690,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows, Skip = "https://github.com/NuGet/Home/issues/12503")]
         public void List_Sources_LocalizatedPackagesourceKeys_ConsideredDiffererent()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext())
             {
                 var workingPath = pathContext.WorkingDirectory;
                 var settings = pathContext.Settings;

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
@@ -29,7 +29,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public void DotnetToolTests_NoPackageReferenceToolRestore_ThrowsError()
         {
-            using (var testDirectory = _msbuildFixture.CreateTestDirectory())
+            using (TestDirectory testDirectory = _msbuildFixture.CreateTestDirectory())
             {
                 var tfm = "netcoreapp2.0";
                 var projectName = "ToolRestoreProject";
@@ -50,7 +50,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public void DotnetToolTests_RegularDependencyPackageWithDependenciesToolRestore_ThrowsError()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
@@ -75,7 +75,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_BasicDotnetToolRestore_SucceedsAsync()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
@@ -118,7 +118,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_MismatchedRID_FailsAsync()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
@@ -153,7 +153,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_BasicDotnetToolRestore_WithJsonCompatibleAssets_SucceedsAsync()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
@@ -200,7 +200,7 @@ namespace Dotnet.Integration.Test
         [InlineData("netcoreapp2.0", "any", "win-x86")]
         public async Task DotnetToolTests_PackageWithRuntimeJson_RuntimeIdentifierAny_SucceedsAsync(string tfm, string packageRID, string projectRID)
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 string testDirectory = pathContext.WorkingDirectory;
                 var projectName = "ToolRestoreProject";
@@ -243,7 +243,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_RegularDependencyAndToolPackageWithDependenciesToolRestore_ThrowsErrorAsync()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
@@ -288,7 +288,7 @@ namespace Dotnet.Integration.Test
         [InlineData("netcoreapp1.0", "any", "win7-x64")]
         public async Task DotnetToolTests_ToolWithPlatformPackage_SucceedsAsync(string tfm, string packageRid, string projectRid)
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 string testDirectory = pathContext.WorkingDirectory;
                 var projectName = "ToolRestoreProject";
@@ -343,7 +343,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_ToolPackageWithIncompatibleToolsAssets_FailsAsync()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
@@ -381,7 +381,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_ToolsPackageWithExtraPackageTypes_FailsAsync()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
@@ -415,7 +415,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_BasicDotnetToolRestoreWithNestedValues_SucceedsAsync()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
@@ -460,7 +460,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_AutoreferencedDependencyAndToolPackagToolRestore_SucceedsAsync()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
@@ -512,7 +512,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_AutoreferencedDependencyRegularDependencyAndToolPackagToolRestore_ThrowsAsync()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
@@ -563,7 +563,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_ToolPackageAndPlatformsPackageAnyRID_SucceedsAsync()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";
@@ -616,7 +616,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_IncompatibleAutorefPackageAndToolsPackageAsync()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp1.0";
@@ -675,7 +675,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_ToolRestoreWithFallback_SucceedsAsync()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 string testDirectory = pathContext.WorkingDirectory;
                 var actualTfm = "netcoreapp2.0";
@@ -732,7 +732,7 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows)]
         public async Task DotnetToolTests_ToolRestoreWithRuntimeIdentiferGraphPath_SucceedsAsync()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 string testDirectory = pathContext.WorkingDirectory;
                 var tfm = "netcoreapp2.0";

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetVerifyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetVerifyTests.cs
@@ -159,7 +159,7 @@ namespace Dotnet.Integration.Test
             // Arrange
             IX509StoreCertificate storeCertificate = _signFixture.DefaultCertificate;
 
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var nupkg = new SimpleTestPackageContext("A", "1.0.0");
                 string testDirectory = pathContext.WorkingDirectory;
@@ -203,7 +203,7 @@ namespace Dotnet.Integration.Test
             // Arrange
             IX509StoreCertificate storeCertificate = _signFixture.DefaultCertificate;
 
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var nupkg = new SimpleTestPackageContext("A", "1.0.0");
                 string testDirectory = pathContext.WorkingDirectory;
@@ -248,7 +248,7 @@ namespace Dotnet.Integration.Test
             IX509StoreCertificate storeCertificate = _signFixture.UntrustedSelfIssuedCertificateInCertificateStore;
 
             // Arrange
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var nupkg = new SimpleTestPackageContext("A", "1.0.0");
                 string testDirectory = pathContext.WorkingDirectory;
@@ -302,7 +302,7 @@ namespace Dotnet.Integration.Test
             IX509StoreCertificate storeCertificate = _signFixture.UntrustedSelfIssuedCertificateInCertificateStore;
 
             // Arrange
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var nupkg = new SimpleTestPackageContext("A", "1.0.0");
                 string testDirectory = pathContext.WorkingDirectory;
@@ -348,7 +348,7 @@ namespace Dotnet.Integration.Test
             IX509StoreCertificate storeCertificate = _signFixture.UntrustedSelfIssuedCertificateInCertificateStore;
 
             // Arrange
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var nupkg = new SimpleTestPackageContext("A", "1.0.0");
                 string testDirectory = pathContext.WorkingDirectory;
@@ -394,7 +394,7 @@ namespace Dotnet.Integration.Test
             IX509StoreCertificate storeCertificate = _signFixture.UntrustedSelfIssuedCertificateInCertificateStore;
 
             // Arrange
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var nupkg = new SimpleTestPackageContext("A", "1.0.0");
                 await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.WorkingDirectory, nupkg);
@@ -444,7 +444,7 @@ namespace Dotnet.Integration.Test
             IX509StoreCertificate storeCertificate = _signFixture.UntrustedSelfIssuedCertificateInCertificateStore;
 
             // Arrange
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var nupkg = new SimpleTestPackageContext("A", "1.0.0");
                 await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.WorkingDirectory, nupkg);
@@ -495,7 +495,7 @@ namespace Dotnet.Integration.Test
             // Arrange
             IX509StoreCertificate storeCertificate = _signFixture.DefaultCertificate;
 
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var package = new SimpleTestPackageContext();
                 string certFingerprint = SignatureTestUtility.GetFingerprint(storeCertificate.Certificate, HashAlgorithmName.SHA256);
@@ -550,7 +550,7 @@ namespace Dotnet.Integration.Test
             // Arrange
             IX509StoreCertificate storeCertificate = _signFixture.DefaultCertificate;
 
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var package = new SimpleTestPackageContext();
                 string certFingerprint = SignatureTestUtility.GetFingerprint(storeCertificate.Certificate, HashAlgorithmName.SHA256);
@@ -600,7 +600,7 @@ namespace Dotnet.Integration.Test
             IX509StoreCertificate storeCertificate = _signFixture.UntrustedSelfIssuedCertificateInCertificateStore;
 
             // Arrange
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var nupkg = new SimpleTestPackageContext("A", "1.0.0");
 
@@ -644,7 +644,7 @@ namespace Dotnet.Integration.Test
             IX509StoreCertificate storeCertificate = _signFixture.UntrustedSelfIssuedCertificateInCertificateStore;
 
             // Arrange
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = _msbuildFixture.CreateSimpleTestPathContext())
             {
                 var nupkg = new SimpleTestPackageContext("A", "1.0.0");
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -140,7 +140,7 @@ namespace Dotnet.Integration.Test
         public void PackCommand_NewSolution_OutputInDefaultPaths()
         {
             // Arrange
-            using (var testDirectory = TestDirectory.Create())
+            using (var testDirectory = msbuildFixture.CreateTestDirectory())
             {
                 var solutionName = "Solution1";
                 var projectName = "ClassLibrary1";
@@ -550,7 +550,7 @@ namespace Dotnet.Integration.Test
         public async Task PackCommand_PackProject_PackageReferenceAllStableFloatingVersionRange_UsesRestoredVersionInNuspecAsync()
         {
             // Arrange
-            using (var pathContext = msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = msbuildFixture.CreateSimpleTestPathContext())
             {
                 var projectName = "ClassLibrary1";
                 var availableVersions = "1.0.0;2.0.0";
@@ -634,7 +634,7 @@ namespace Dotnet.Integration.Test
         public void PackCommand_PackProject_SupportMultipleFrameworks()
         {
             // Arrange
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = msbuildFixture.CreateSimpleTestPathContext())
             {
                 SimpleTestSettingsContext settings = pathContext.Settings;
                 settings.AddNetStandardFeeds();
@@ -725,7 +725,7 @@ namespace Dotnet.Integration.Test
         public void PackProject_DependenciesWithContentFiles_NupkgExcludesContentFilesFromDependencies()
         {
             // Arrange
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = msbuildFixture.CreateSimpleTestPathContext())
             {
                 string testDirectory = pathContext.WorkingDirectory;
                 // layout
@@ -2151,7 +2151,7 @@ namespace Dotnet.Integration.Test
         [InlineData("netstandard1.4;net451;netcoreapp1.0")]
         public void PackCommand_MultipleFrameworks_GeneratesPackageOnBuild(string frameworks)
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = msbuildFixture.CreateSimpleTestPathContext())
             {
                 SimpleTestSettingsContext settings = pathContext.Settings;
                 settings.AddNetStandardFeeds();
@@ -3880,7 +3880,7 @@ namespace ClassLibrary
         public void PackCommand_ManualAddPackage_DevelopmentDependency()
         {
             // Arrange
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = msbuildFixture.CreateSimpleTestPathContext())
             {
                 SimpleTestSettingsContext settings = pathContext.Settings;
                 settings.AddNetStandardFeeds();
@@ -5739,7 +5739,7 @@ namespace ClassLibrary
         public async Task PackCommand_PrereleaseDependency_SucceedAndLogsWarning()
         {
             // Arrange
-            using (var pathContext = msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = msbuildFixture.CreateSimpleTestPathContext())
             {
                 var prereleaseDependencyName = "PreReleasePackageA";
                 var prereleaseDependencyVersion = "6.0.0-preview.3";
@@ -5781,7 +5781,7 @@ namespace ClassLibrary
         [Fact]
         public async Task PackCommand_PrereleaseDependency_WarningSuppressed_Succeed()
         {
-            using (var pathContext = msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = msbuildFixture.CreateSimpleTestPathContext())
             {
                 var prereleaseDependencyName = "PreReleasePackageA";
                 var prereleaseDependencyVersion = "6.0.0-preview.3";
@@ -5844,7 +5844,7 @@ namespace ClassLibrary
         [Fact]
         public async Task PackCommand_PrereleaseDependencies_PartialWarningSuppressed_SucceedAndLogsWarning()
         {
-            using (var pathContext = msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = msbuildFixture.CreateSimpleTestPathContext())
             {
                 var prereleaseDependencyAName = "PreReleasePackageA";
                 var prereleaseDependencyAVersion = "4.8.0-beta00011";
@@ -5896,7 +5896,7 @@ namespace ClassLibrary
         [Fact]
         public async Task PackCommand_PrereleaseDependency_ProjectLevelWarningSuppressed_Succeed()
         {
-            using (var pathContext = msbuildFixture.CreateSimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = msbuildFixture.CreateSimpleTestPathContext())
             {
                 var prereleaseDependencyAName = "PreReleasePackageA";
                 var prereleaseDependencyAVersion = "4.8.0-beta00011";
@@ -5962,7 +5962,7 @@ namespace ClassLibrary
         [Fact]
         public async Task PackCommand_MultiTfm_PrereleaseDependency_TreatWarningsAsErrors_FailsAndLogsWarning()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = msbuildFixture.CreateSimpleTestPathContext())
             {
                 SimpleTestSettingsContext settings = pathContext.Settings;
                 settings.AddNetStandardFeeds();
@@ -6022,7 +6022,7 @@ namespace ClassLibrary
         [Fact]
         public async Task PackCommand_MultiTfm_PrereleaseDependency_WarningIsSuppressed_Succeeds()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = msbuildFixture.CreateSimpleTestPathContext())
             {
                 SimpleTestSettingsContext settings = pathContext.Settings;
                 settings.AddNetStandardFeeds();
@@ -6105,7 +6105,7 @@ namespace ClassLibrary
         [Fact]
         public async Task PackCommand_MultiTfm_PrereleaseDependency_ProjectLevelWarningSuppressed_Succeed()
         {
-            using (var pathContext = new SimpleTestPathContext())
+            using (SimpleTestPathContext pathContext = msbuildFixture.CreateSimpleTestPathContext())
             {
                 SimpleTestSettingsContext settings = pathContext.Settings;
                 settings.AddNetStandardFeeds();

--- a/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
@@ -64,8 +64,6 @@ namespace NuGet.Test.Utility
 
         private static void CopyLatestCliToTestDirectory(string destinationDir)
         {
-            WriteGlobalJson(destinationDir);
-
             var sdkPath = Path.Combine(SdkDirSource, SdkVersion + Path.DirectorySeparatorChar);
             var fallbackFolderPath = Path.Combine(SdkDirSource, "NuGetFallbackFolder");
 
@@ -331,7 +329,12 @@ project TFMs found: {string.Join(", ", compiledTfms.Keys.Select(k => k.ToString(
 
         public static void WriteGlobalJson(string path)
         {
-            string globalJsonText = $"{{\"sdk\": {{\"version\": \"{SdkVersion}\"}}}}";
+            string globalJsonText = $@"{{
+  ""sdk"": {{
+    ""version"": ""{SdkVersion}"",
+    ""allowPrerelease"": true
+  }}
+}}";
             var globalJsonPath = Path.Combine(path, "global.json");
             File.WriteAllText(globalJsonPath, globalJsonText);
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2171

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This enables .NET 8 in our build pipeline and configures the .NET integration tests and cross framework tests to run against .NET 7 and .NET 8

The cross framework tests run each framework under a different test run so they show up separately in AzDevOps:
![image](https://user-images.githubusercontent.com/17556515/233140319-540dd9eb-1eb3-4614-b051-2910328b5d08.png)

The cross framework tests take a little longer to run but does not make the overall build time any longer since the end-to-end tests still take longer.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
