### PR TITLE
VersionRangeFormatter should use StringBuilderPool

### DIFF
--- a/src/NuGet.Core/NuGet.Versioning/VersionRangeFormatter.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRangeFormatter.cs
@@ -48,24 +48,30 @@ namespace NuGet.Versioning
             }
             else
             {
-                var sb = new StringBuilder(format.Length);
-
-                for (var i = 0; i < format.Length; i++)
+                var sb = StringBuilderPool.Shared.Rent(format.Length);
+                try
                 {
-                    var s = Format(format[i], range);
+                    for (var i = 0; i < format.Length; i++)
+                    {
+                        var s = Format(format[i], range);
 
-                    if (s == null)
-                    {
-                        sb.Append(format[i]);
+                        if (s == null)
+                        {
+                            sb.Append(format[i]);
+                        }
+                        else
+                        {
+                            sb.Append(s);
+                        }
                     }
-                    else
-                    {
-                        sb.Append(s);
-                    }
+
+                    string formatted = sb.ToString();
+                    return formatted;
                 }
-
-                string formatted = sb.ToString();
-                return formatted;
+                finally
+                {
+                    StringBuilderPool.Shared.Return(sb);
+                }
             }
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: internal ticket 1805843
Fixes: https://github.com/NuGet/Home/issues/12551

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Prism allocation view lists VersionRangeFormatter's allocation of StringBuilders as highly impactful in VS 17.6. Use the string builder pool instead to minimize allocations.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: perf improvement
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
