### PR TITLE
Be more permissive with explicit type in coding guidelines

### DIFF
--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -48,7 +48,7 @@ The general rule we follow is "use Visual Studio defaults".
 
 1. If a file happens to differ in style from these guidelines (e.g. private members are named `m_member` rather than `_member`), the existing style in that file takes precedence. Changes/refactorings are possible, but depending on the complexity, change frequency of the file, might need to be considered on their own merits in a separate pull request.
 
-1. Don't use `var` when it's not obvious what the variable type is.
+1. Explicitly state the data type, and avoid using `var`, in variable declarations where the type is not obvious.
 For example the following are correct:
 
     ```cs
@@ -66,7 +66,7 @@ For example the following are correct:
     var flavor = fruit.GetFlavor();
     ```
 
-    The following are optional and can either use explicit type or var
+    Using an explicit type or `var` in the following examples are both permissible:
 
     ```cs
     string fruit = "Apple";

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -48,7 +48,7 @@ The general rule we follow is "use Visual Studio defaults".
 
 1. If a file happens to differ in style from these guidelines (e.g. private members are named `m_member` rather than `_member`), the existing style in that file takes precedence. Changes/refactorings are possible, but depending on the complexity, change frequency of the file, might need to be considered on their own merits in a separate pull request.
 
-1. We only use `var` when it's obvious what the variable type is.
+1. Don't use `var` when it's not obvious what the variable type is.
 For example the following are correct:
 
     ```cs
@@ -60,10 +60,15 @@ For example the following are correct:
     var nugetVersion = NuGetVersion.Parse("1.0.0");
     ```
 
-    The following are incorrect:
+    The following is incorrect:
 
     ```cs
     var flavor = fruit.GetFlavor();
+    ```
+
+    The following are optional and can either use explicit type or var
+
+    ```cs
     string fruit = "Apple";
     List<Fruit> fruits = new List<Fruit>();
     ```


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: N/A

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Personally, I don't agree with "don't use var when it's not obvious", but I can understand that some people want more certainly about the data type when reading code than I do.

However, I can't see any benefit to preventing explicit types when it's obvious. For example, `string something = "value"`. Since I don't see any downside, I propose that we officially allow it.

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
