### PR TITLE
[release-4.9.x] Install root cert of repository timestamp as a workaround for intermittent restore failure on Windows

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -8,7 +8,7 @@ steps:
       gci env:* | sort-object name
 
 - task: PowerShell@1
-  displayName: "Install Repository Timestamp Certificate"
+  displayName: "Install Repository Timestamp Certificate" #This is a workaround for the intermittent restore failure(NuGet/Home/issues/11099)
   inputs:
     scriptType: "inlineScript"
     inlineScript: |

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -1,4 +1,4 @@
-steps:  
+steps:
 - task: PowerShell@1
   displayName: "Update Build Number"
   inputs:
@@ -6,6 +6,50 @@ steps:
     inlineScript: |
       Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
       gci env:* | sort-object name
+
+- task: PowerShell@1
+  displayName: "Install Repository Timestamp Certificate"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      # CN=Symantec SHA256 TimeStamping Signer - G3
+      # SHA-256 fingerprint:  C474CE76007D02394E0DA5E4DE7C14C680F9E282013CFEF653EF5DB71FDF61F8
+      [string] $certificateBase64 = 'MIIFSzCCBDOgAwIBAgIQe9Tlr7rMBz+hASMEIkFNEjANBgkqhkiG9w0BAQsFADB3MQswCQYDVQQGEwJVUzEdMBsGA1UEChMUU3ltYW50ZWMgQ29ycG9yYXRpb24xHzAdBgNVBAsTFlN5bWFudGVjIFRydXN0IE5ldHdvcmsxKDAmBgNVBAMTH1N5bWFudGVjIFNIQTI1NiBUaW1lU3RhbXBpbmcgQ0EwHhcNMTcxMjIzMDAwMDAwWhcNMjkwMzIyMjM1OTU5WjCBgDELMAkGA1UEBhMCVVMxHTAbBgNVBAoTFFN5bWFudGVjIENvcnBvcmF0aW9uMR8wHQYDVQQLExZTeW1hbnRlYyBUcnVzdCBOZXR3b3JrMTEwLwYDVQQDEyhTeW1hbnRlYyBTSEEyNTYgVGltZVN0YW1waW5nIFNpZ25lciAtIEczMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArw6Kqvjcv2l7VBdxRwm9jTyB+HQVd2eQnP3eTgKeS3b25TY+ZdUkIG0w+d0dg+k/J0ozTm0WiuSNQI0iqr6nCxvSB7Y8tRokKPgbclE9yAmIJgg6+fpDI3VHcAyzX1uPCB1ySFdlTa8CPED39N0yOJM/5Sym81kjy4DeE035EMmqChhsVWFX0fECLMS1q/JsI9KfDQ8ZbK2FYmn9ToXBilIxq1vYyXRS41dsIr9Vf2/KBqs/SrcidmXs7DbylpWBJiz9u5iqATjTryVAmwlT8ClXhVhe6oVIQSGH5d600yaye0BTWHmOUjEGTZQDRcTOPAPstwDyOiLFtG/l77CKmwIDAQABo4IBxzCCAcMwDAYDVR0TAQH/BAIwADBmBgNVHSAEXzBdMFsGC2CGSAGG+EUBBxcDMEwwIwYIKwYBBQUHAgEWF2h0dHBzOi8vZC5zeW1jYi5jb20vY3BzMCUGCCsGAQUFBwICMBkaF2h0dHBzOi8vZC5zeW1jYi5jb20vcnBhMEAGA1UdHwQ5MDcwNaAzoDGGL2h0dHA6Ly90cy1jcmwud3Muc3ltYW50ZWMuY29tL3NoYTI1Ni10c3MtY2EuY3JsMBYGA1UdJQEB/wQMMAoGCCsGAQUFBwMIMA4GA1UdDwEB/wQEAwIHgDB3BggrBgEFBQcBAQRrMGkwKgYIKwYBBQUHMAGGHmh0dHA6Ly90cy1vY3NwLndzLnN5bWFudGVjLmNvbTA7BggrBgEFBQcwAoYvaHR0cDovL3RzLWFpYS53cy5zeW1hbnRlYy5jb20vc2hhMjU2LXRzcy1jYS5jZXIwKAYDVR0RBCEwH6QdMBsxGTAXBgNVBAMTEFRpbWVTdGFtcC0yMDQ4LTYwHQYDVR0OBBYEFKUTAamfhcwbbhYeXzsxqnk2AHsdMB8GA1UdIwQYMBaAFK9j1sqjToVy4Ke8QfMpojh/gHViMA0GCSqGSIb3DQEBCwUAA4IBAQBGnq/wuKJfoplIz6gnSyHNsrmmcnBjL+NVKXs5Rk7nfmUGWIu8V4qSDQjYELo2JPoKe/s702K/SpQV5oLbilRt/yj+Z89xP+YzCdmiWRD0Hkr+Zcze1GvjUil1AEorpczLm+ipTfe0F1mSQcO3P4bm9sB/RDxGXBda46Q71Wkm1SF94YBnfmKst04uFZrlnCOvWxHqcalB+Q15OKmhDc+0sdo+mnrHIsV0zd9HCYbE/JElshuW6YUI6N3qdGBuYKVWeg3IRFjc5vlIFJ7lv94AvXexmBRyFCTfxxEsHwA/w0sUxmcczB4Go5BfXFSLPuMzW4IPxbeGAk5xn+lmRT92'
+      [byte[]] $certificateBytes = [System.Convert]::FromBase64String($certificateBase64)
+      $certificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($certificateBytes)
+      $oid = [System.Security.Cryptography.Oid]::new("1.3.6.1.5.5.7.3.8")
+      Function Build-Chain([System.Security.Cryptography.X509Certificates.X509Certificate2] $certificate)
+      {
+          $chain = [System.Security.Cryptography.X509Certificates.X509Chain]::new()
+          Try
+          {
+              $chain.ChainPolicy.ApplicationPolicy.Add($oid)
+              $chain.Build($certificate)
+              ForEach ($status In $chain.ChainStatus)
+              {
+                  If ($status.Status -eq [System.Security.Cryptography.X509Certificates.X509ChainStatusFlags]::UntrustedRoot)
+                  {
+                      Return $False
+                  }
+              }
+              Return $True
+          }
+          Finally
+          {
+              $chain.Dispose()
+          }
+      }
+      Try
+      {
+          While (!(Build-Chain $certificate))
+          {
+              Start-Sleep -Seconds 5
+          }
+      }
+      Finally
+      {
+          $certificate.Dispose()
+      }
 
 - task: NuGetToolInstaller@0
   displayName: "Use NuGet 4.6.2"

--- a/eng/pipelines/templates/Functional_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Functional_Tests_On_Windows.yml
@@ -25,7 +25,7 @@ steps:
     arguments: "-Force -CI"
 
 - task: PowerShell@1
-  displayName: "Install Repository Timestamp Certificate"
+  displayName: "Install Repository Timestamp Certificate" #This is a workaround for the intermittent restore failure(NuGet/Home/issues/11099)
   inputs:
     scriptType: "inlineScript"
     inlineScript: |

--- a/eng/pipelines/templates/Functional_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Functional_Tests_On_Windows.yml
@@ -24,6 +24,50 @@ steps:
     scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
     arguments: "-Force -CI"
 
+- task: PowerShell@1
+  displayName: "Install Repository Timestamp Certificate"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      # CN=Symantec SHA256 TimeStamping Signer - G3
+      # SHA-256 fingerprint:  C474CE76007D02394E0DA5E4DE7C14C680F9E282013CFEF653EF5DB71FDF61F8
+      [string] $certificateBase64 = 'MIIFSzCCBDOgAwIBAgIQe9Tlr7rMBz+hASMEIkFNEjANBgkqhkiG9w0BAQsFADB3MQswCQYDVQQGEwJVUzEdMBsGA1UEChMUU3ltYW50ZWMgQ29ycG9yYXRpb24xHzAdBgNVBAsTFlN5bWFudGVjIFRydXN0IE5ldHdvcmsxKDAmBgNVBAMTH1N5bWFudGVjIFNIQTI1NiBUaW1lU3RhbXBpbmcgQ0EwHhcNMTcxMjIzMDAwMDAwWhcNMjkwMzIyMjM1OTU5WjCBgDELMAkGA1UEBhMCVVMxHTAbBgNVBAoTFFN5bWFudGVjIENvcnBvcmF0aW9uMR8wHQYDVQQLExZTeW1hbnRlYyBUcnVzdCBOZXR3b3JrMTEwLwYDVQQDEyhTeW1hbnRlYyBTSEEyNTYgVGltZVN0YW1waW5nIFNpZ25lciAtIEczMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArw6Kqvjcv2l7VBdxRwm9jTyB+HQVd2eQnP3eTgKeS3b25TY+ZdUkIG0w+d0dg+k/J0ozTm0WiuSNQI0iqr6nCxvSB7Y8tRokKPgbclE9yAmIJgg6+fpDI3VHcAyzX1uPCB1ySFdlTa8CPED39N0yOJM/5Sym81kjy4DeE035EMmqChhsVWFX0fECLMS1q/JsI9KfDQ8ZbK2FYmn9ToXBilIxq1vYyXRS41dsIr9Vf2/KBqs/SrcidmXs7DbylpWBJiz9u5iqATjTryVAmwlT8ClXhVhe6oVIQSGH5d600yaye0BTWHmOUjEGTZQDRcTOPAPstwDyOiLFtG/l77CKmwIDAQABo4IBxzCCAcMwDAYDVR0TAQH/BAIwADBmBgNVHSAEXzBdMFsGC2CGSAGG+EUBBxcDMEwwIwYIKwYBBQUHAgEWF2h0dHBzOi8vZC5zeW1jYi5jb20vY3BzMCUGCCsGAQUFBwICMBkaF2h0dHBzOi8vZC5zeW1jYi5jb20vcnBhMEAGA1UdHwQ5MDcwNaAzoDGGL2h0dHA6Ly90cy1jcmwud3Muc3ltYW50ZWMuY29tL3NoYTI1Ni10c3MtY2EuY3JsMBYGA1UdJQEB/wQMMAoGCCsGAQUFBwMIMA4GA1UdDwEB/wQEAwIHgDB3BggrBgEFBQcBAQRrMGkwKgYIKwYBBQUHMAGGHmh0dHA6Ly90cy1vY3NwLndzLnN5bWFudGVjLmNvbTA7BggrBgEFBQcwAoYvaHR0cDovL3RzLWFpYS53cy5zeW1hbnRlYy5jb20vc2hhMjU2LXRzcy1jYS5jZXIwKAYDVR0RBCEwH6QdMBsxGTAXBgNVBAMTEFRpbWVTdGFtcC0yMDQ4LTYwHQYDVR0OBBYEFKUTAamfhcwbbhYeXzsxqnk2AHsdMB8GA1UdIwQYMBaAFK9j1sqjToVy4Ke8QfMpojh/gHViMA0GCSqGSIb3DQEBCwUAA4IBAQBGnq/wuKJfoplIz6gnSyHNsrmmcnBjL+NVKXs5Rk7nfmUGWIu8V4qSDQjYELo2JPoKe/s702K/SpQV5oLbilRt/yj+Z89xP+YzCdmiWRD0Hkr+Zcze1GvjUil1AEorpczLm+ipTfe0F1mSQcO3P4bm9sB/RDxGXBda46Q71Wkm1SF94YBnfmKst04uFZrlnCOvWxHqcalB+Q15OKmhDc+0sdo+mnrHIsV0zd9HCYbE/JElshuW6YUI6N3qdGBuYKVWeg3IRFjc5vlIFJ7lv94AvXexmBRyFCTfxxEsHwA/w0sUxmcczB4Go5BfXFSLPuMzW4IPxbeGAk5xn+lmRT92'
+      [byte[]] $certificateBytes = [System.Convert]::FromBase64String($certificateBase64)
+      $certificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($certificateBytes)
+      $oid = [System.Security.Cryptography.Oid]::new("1.3.6.1.5.5.7.3.8")
+      Function Build-Chain([System.Security.Cryptography.X509Certificates.X509Certificate2] $certificate)
+      {
+          $chain = [System.Security.Cryptography.X509Certificates.X509Chain]::new()
+          Try
+          {
+              $chain.ChainPolicy.ApplicationPolicy.Add($oid)
+              $chain.Build($certificate)
+              ForEach ($status In $chain.ChainStatus)
+              {
+                  If ($status.Status -eq [System.Security.Cryptography.X509Certificates.X509ChainStatusFlags]::UntrustedRoot)
+                  {
+                      Return $False
+                  }
+              }
+              Return $True
+          }
+          Finally
+          {
+              $chain.Dispose()
+          }
+      }
+      Try
+      {
+          While (!(Build-Chain $certificate))
+          {
+              Start-Sleep -Seconds 5
+          }
+      }
+      Finally
+      {
+          $certificate.Dispose()
+      }
+
 - task: MSBuild@1
   displayName: "Restore for VS2017"
   inputs:


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:https://github.com/NuGet/Client.Engineering/issues/2254

Regression? Last working version:

## Context
This is the same with https://github.com/NuGet/Home/issues/11099
And it's fixed in PR https://github.com/NuGet/NuGet.Client/pull/4259 for NuGet version 6.0 and later.
But since this is the release-4.9.x branch, we run the builds for this branch on VS2017 agent pool and there is no version 6.0 tooling available, so we have to use other workaround to fix this.
Thanks for @dtivel 's help for providing this workaround!

## Description
Install the timestamp certificate on repository signature before running restore as an workaround.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
