### PR TITLE
Reduce allocations in VirtualFileInfo.Name

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/VirtualFileInfo.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/VirtualFileInfo.cs
@@ -59,11 +59,24 @@ namespace NuGet.Commands
             }
         }
 
+        private string _name;
         public string Name
         {
             get
             {
-                return PhysicalPath.Split('/').LastOrDefault();
+                if (_name == null)
+                {
+                    int lastSlashIndex = PhysicalPath.LastIndexOf('/');
+                    if (lastSlashIndex >= 0)
+                    {
+                        _name = PhysicalPath.Substring(lastSlashIndex + 1);
+                    }
+                    else
+                    {
+                        _name = PhysicalPath;
+                    }
+                }
+                return _name;
             }
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: internal bug 1806171
Fixes: https://github.com/NuGet/Home/issues/12550

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The previous code was doing a one-liner `PhysicalPath.Split('/').LastOrDefault();`. However, this causes the following allocations:

* An array for the `Split` results
* One string per array index (hopefully zero allocation when the array length is 1)
* An enumerator for `LastOrDefault`

Additionally, it wasn't caching the result, and running in the debugger shows that many instances have `Name` called multiple times during execution. Prism was showing this at a top allocation impact in VS.

So, the fix is to find the start index of the required string, which is zero allocation, and then get the substring as the only allocation in the method body. When the `PhysicalPath` doesn't contain any `/` characters, the code is now zero-allocation.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: perf improvement, no functional changes
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
