### PR TITLE
Disable Install/Update button in Project level when using VersionOverride

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -320,6 +320,7 @@ namespace NuGet.PackageManagement.UI
         {
             base.OnSelectedVersionChanged();
             OnPropertyChanged(nameof(IsInstallorUpdateButtonEnabled));
+            OnPropertyChanged(nameof(ShowVersionOverrideTooltip));
             OnPropertyChanged(nameof(IsSelectedVersionInstalled));
             OnPropertyChanged(nameof(IsInstalledVersionTopLevel));
         }
@@ -341,6 +342,14 @@ namespace NuGet.PackageManagement.UI
             get
             {
                 return SelectedVersion != null && !IsSelectedVersionInstalled && !InstalledVersionIsAutoReferenced && VersionOverride == null;
+            }
+        }
+
+        public bool ShowVersionOverrideTooltip
+        {
+            get
+            {
+                return !IsInstallorUpdateButtonEnabled && VersionOverride != null;
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -39,6 +39,7 @@ namespace NuGet.PackageManagement.UI
         {
             // Set InstalledVersion before fetching versions list.
             PackageLevel = searchResultPackage.PackageLevel;
+            VersionOverride = searchResultPackage.VersionOverride;
             InstalledVersion = searchResultPackage.InstalledVersion;
             InstalledVersionRange = searchResultPackage.AllowedVersions;
 
@@ -303,6 +304,18 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
+        private VersionRange _versionOverride;
+
+        public VersionRange VersionOverride
+        {
+            get => _versionOverride;
+            private set
+            {
+                _versionOverride = value;
+                OnPropertyChanged(nameof(VersionOverride));
+            }
+        }
+
         public override void OnSelectedVersionChanged()
         {
             base.OnSelectedVersionChanged();
@@ -327,7 +340,7 @@ namespace NuGet.PackageManagement.UI
         {
             get
             {
-                return SelectedVersion != null && !IsSelectedVersionInstalled && !InstalledVersionIsAutoReferenced;
+                return SelectedVersion != null && !IsSelectedVersionInstalled && !InstalledVersionIsAutoReferenced && VersionOverride == null;
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -261,16 +261,23 @@ namespace NuGet.PackageManagement.UI
             foreach (PackageSearchMetadataContextInfo metadata in _state.Results.PackageSearchItems)
             {
                 VersionRange allowedVersions = VersionRange.All;
+                VersionRange versionOverride = null;
 
                 // get the allowed version range and pass it to package item view model to choose the latest version based on that
                 if (_packageReferences != null)
                 {
                     IEnumerable<IPackageReferenceContextInfo> matchedPackageReferences = _packageReferences.Where(r => StringComparer.OrdinalIgnoreCase.Equals(r.Identity.Id, metadata.Identity.Id));
                     VersionRange[] allowedVersionsRange = matchedPackageReferences.Select(r => r.AllowedVersions).Where(v => v != null).ToArray();
+                    VersionRange[] versionOverrides = matchedPackageReferences.Select(r => r.VersionOverride).Where(v => v != null).ToArray();
 
                     if (allowedVersionsRange.Length > 0)
                     {
                         allowedVersions = allowedVersionsRange[0];
+                    }
+
+                    if (versionOverrides.Length > 0)
+                    {
+                        versionOverride = versionOverrides[0];
                     }
                 }
 
@@ -291,6 +298,7 @@ namespace NuGet.PackageManagement.UI
                     DownloadCount = metadata.DownloadCount,
                     Summary = metadata.Summary,
                     AllowedVersions = allowedVersions,
+                    VersionOverride = versionOverride,
                     PrefixReserved = metadata.PrefixReserved && !IsMultiSource,
                     Recommended = metadata.IsRecommended,
                     RecommenderVersion = metadata.RecommenderVersion,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -2187,6 +2187,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Dependency version defined by VersionOverride, modify project file to change package version..
+        /// </summary>
+        public static string UpdateButton_VersionOverride_Tooltip {
+            get {
+                return ResourceManager.GetString("UpdateButton_VersionOverride_Tooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to NuGet migrate failed to install packages as PackageReference. Changed files are backed up at {0}.
         /// </summary>
         public static string Upgrade_InstallFailed {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -975,4 +975,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="VSOptions_Label_PackagePattern" xml:space="preserve">
     <value>Package pattern:</value>
   </data>
+  <data name="UpdateButton_VersionOverride_Tooltip" xml:space="preserve">
+    <value>Dependency version defined by VersionOverride, modify project file to change package version.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -57,6 +57,8 @@ namespace NuGet.PackageManagement.UI
 
         public VersionRange AllowedVersions { get; set; }
 
+        public VersionRange VersionOverride { get; set; }
+
         public IReadOnlyCollection<PackageSourceContextInfo> Sources { get; set; }
 
         public bool IncludePrerelease { get; set; }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
@@ -156,6 +156,9 @@
       HorizontalAlignment="Left"
       AutomationProperties.AutomationId="Project_Button_Update"
       Click="InstallButton_Clicked"
+      ToolTipService.ShowOnDisabled="True" 
+      ToolTipService.IsEnabled="{Binding ShowVersionOverrideTooltip, Mode=OneWay}" 
+      ToolTip="{x:Static local:Resources.UpdateButton_VersionOverride_Tooltip}"
       Visibility="{Binding IsInstalledVersionTopLevel, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"
       IsEnabled="{Binding IsInstallorUpdateButtonEnabled, Mode=OneWay}"
       Content="{x:Static local:Resources.Button_Update}" />

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/IPackageReferenceContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/IPackageReferenceContextInfo.cs
@@ -15,5 +15,6 @@ namespace NuGet.VisualStudio.Internal.Contracts
         bool IsAutoReferenced { get; }
         bool IsUserInstalled { get; }
         bool IsDevelopmentDependency { get; }
+        VersionRange? VersionOverride { get; }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageReferenceContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageReferenceContextInfo.cs
@@ -36,7 +36,8 @@ namespace NuGet.VisualStudio.Internal.Contracts
                 IsAutoReferenced = (packageReference as BuildIntegratedPackageReference)?.Dependency?.AutoReferenced == true,
                 AllowedVersions = packageReference.AllowedVersions,
                 IsUserInstalled = packageReference.IsUserInstalled,
-                IsDevelopmentDependency = packageReference.IsDevelopmentDependency
+                IsDevelopmentDependency = packageReference.IsDevelopmentDependency,
+                VersionOverride = (packageReference as BuildIntegratedPackageReference)?.Dependency?.VersionOverride
             };
 
             return packageReferenceContextInfo;
@@ -48,5 +49,6 @@ namespace NuGet.VisualStudio.Internal.Contracts
         public bool IsAutoReferenced { get; internal set; }
         public bool IsUserInstalled { get; internal set; }
         public bool IsDevelopmentDependency { get; internal set; }
+        public VersionRange? VersionOverride { get; internal set; }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/TransitivePackageReferenceContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/TransitivePackageReferenceContextInfo.cs
@@ -78,5 +78,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         public bool IsUserInstalled { get; internal set; }
 
         public bool IsDevelopmentDependency { get; internal set; }
+
+        public VersionRange? VersionOverride { get; internal set; }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/PublicAPI.Unshipped.txt
@@ -1,2 +1,5 @@
 #nullable enable
 NuGet.VisualStudio.Internal.Contracts.INuGetProjectManagerService.IsCentralPackageManagementEnabledAsync(string! projectId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<bool>
+NuGet.VisualStudio.Internal.Contracts.IPackageReferenceContextInfo.VersionOverride.get -> NuGet.Versioning.VersionRange?
+NuGet.VisualStudio.Internal.Contracts.PackageReferenceContextInfo.VersionOverride.get -> NuGet.Versioning.VersionRange?
+NuGet.VisualStudio.Internal.Contracts.TransitivePackageReferenceContextInfo.VersionOverride.get -> NuGet.Versioning.VersionRange?


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug 

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12230

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Disable the Install/Update button in Project level PM UI when the Package Version is set by a VersionOverride.
![image](https://user-images.githubusercontent.com/43253759/233681751-195d5aa8-2427-4f33-b3c8-4ccf14e937ac.png)

![image](https://user-images.githubusercontent.com/43253759/233682326-1638780f-280a-47bd-a872-296e7f292299.png)

![image](https://user-images.githubusercontent.com/43253759/235506072-1f534701-1a71-4779-9d9b-ab7bda5d9378.png)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Tested manually in PM UI
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
