### PR TITLE
Show diagnostic beneath unresolved package/project reference in Solution Explorer

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/AssetsFileTopLevelDependenciesCollectionSourceProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/AssetsFileTopLevelDependenciesCollectionSourceProvider.cs
@@ -26,7 +26,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
     /// <remarks>
     /// Templates out common code with a bunch of protected methods to override for specific item types.
     /// </remarks>
-    internal abstract class AssetsFileTopLevelDependenciesCollectionSourceProvider<TIdentity, TItem> : DependenciesAttachedCollectionSourceProviderBase
+    internal abstract class AssetsFileTopLevelDependenciesCollectionSourceProvider<TItem> : DependenciesAttachedCollectionSourceProviderBase
         where TItem : class, IRelatableItem
     {
         protected AssetsFileTopLevelDependenciesCollectionSourceProvider(ProjectTreeFlags flags)
@@ -34,9 +34,9 @@ namespace NuGet.VisualStudio.SolutionExplorer
         {
         }
 
-        protected abstract bool TryGetIdentity(Properties properties, out TIdentity identity);
+        protected abstract bool TryGetLibraryName(Properties properties, [NotNullWhen(returnValue: true)] out string? libraryName);
 
-        protected abstract bool TryGetLibrary(AssetsFileTarget target, TIdentity identity, [NotNullWhen(returnValue: true)] out AssetsFileTargetLibrary? library);
+        protected abstract bool TryGetLibrary(AssetsFileTarget target, string libraryName, [NotNullWhen(returnValue: true)] out AssetsFileTargetLibrary? library);
 
         protected abstract TItem CreateItem(AssetsFileTarget targetData, AssetsFileTargetLibrary library);
 
@@ -51,7 +51,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            TIdentity identity;
+            string? libraryName;
 
             if (!ErrorHandler.Succeeded(hierarchyItem.HierarchyIdentity.Hierarchy.GetProperty(
                 hierarchyItem.HierarchyIdentity.ItemID, (int)__VSHPROPID.VSHPROPID_ExtObject, out object projectItemObject)))
@@ -63,7 +63,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
             {
                 Properties? properties = (projectItemObject as ProjectItem)?.Properties;
 
-                if (properties == null || !TryGetIdentity(properties, out identity))
+                if (properties == null || !TryGetLibraryName(properties, out libraryName))
                 {
                     containsCollectionSource = null;
                     return false;
@@ -99,7 +99,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
                     AssetsFileDependenciesSnapshot snapshot = versionedValue.Value;
                     if (snapshot.TryGetTarget(target, out AssetsFileTarget? targetData))
                     {
-                        if (TryGetLibrary(targetData, identity, out AssetsFileTargetLibrary? library))
+                        if (TryGetLibrary(targetData, libraryName, out AssetsFileTargetLibrary? library))
                         {
                             if (item == null)
                             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageAssemblyItem.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageAssemblyItem.cs
@@ -67,7 +67,9 @@ namespace NuGet.VisualStudio.SolutionExplorer
             {
                 get
                 {
-                    return _item.Target.TryResolvePackagePath(_item.Library.Name, _item.Library.Version, out string? fullPath)
+                    return
+                        _item.Library.Version is not null &&
+                        _item.Target.TryResolvePackagePath(_item.Library.Name, _item.Library.Version, out string? fullPath)
                         ? System.IO.Path.GetFullPath(System.IO.Path.Combine(fullPath, _item.Path))
                         : null;
                 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageBuildFileItem.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageBuildFileItem.cs
@@ -40,7 +40,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
             _fileOpener = fileOpener;
         }
 
-        public string? FullPath => Target.TryResolvePackagePath(Library.Name, Library.Version, out string? fullPath)
+        public string? FullPath => Library.Version is not null && Target.TryResolvePackagePath(Library.Name, Library.Version, out string? fullPath)
             ? System.IO.Path.GetFullPath(System.IO.Path.Combine(fullPath, Path))
             : null;
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageDocumentItem.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageDocumentItem.cs
@@ -68,7 +68,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
             return result;
         }
 
-        public string? FullPath => Target.TryResolvePackagePath(Library.Name, Library.Version, out string? fullPath)
+        public string? FullPath => Library.Version is not null && Target.TryResolvePackagePath(Library.Name, Library.Version, out string? fullPath)
             ? System.IO.Path.GetFullPath(System.IO.Path.Combine(fullPath, Path))
             : null;
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageReferenceItem.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Items/PackageReferenceItem.cs
@@ -44,7 +44,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
             return true;
         }
 
-        private static string GetCaption(AssetsFileTargetLibrary library) => $"{library.Name} ({library.Version})";
+        private static string GetCaption(AssetsFileTargetLibrary library) => library.Version is not null ? $"{library.Name} ({library.Version})" : library.Name;
 
         public override object Identity => Library.Name;
 
@@ -71,7 +71,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
 
             public BrowseObject(PackageReferenceItem item) => _item = item;
 
-            public override string GetComponentName() => $"{_item.Library.Name} ({_item.Library.Version})";
+            public override string GetComponentName() => _item.Library.Version is not null ? $"{_item.Library.Name} ({_item.Library.Version})" : _item.Library.Name;
 
             public override string GetClassName() => VsResources.PackageReferenceBrowseObjectClassName;
 
@@ -81,11 +81,11 @@ namespace NuGet.VisualStudio.SolutionExplorer
 
             [BrowseObjectDisplayName(nameof(VsResources.PackageReferenceVersionDisplayName))]
             [BrowseObjectDescription(nameof(VsResources.PackageReferenceVersionDescription))]
-            public string Version => _item.Library.Version;
+            public string? Version => _item.Library.Version;
 
             [BrowseObjectDisplayName(nameof(VsResources.PackageReferencePathDisplayName))]
             [BrowseObjectDescription(nameof(VsResources.PackageReferencePathDescription))]
-            public string? Path => _item.Target.TryResolvePackagePath(_item.Library.Name, _item.Library.Version, out string? fullPath) ? fullPath : null;
+            public string? Path => _item.Library.Version is not null && _item.Target.TryResolvePackagePath(_item.Library.Name, _item.Library.Version, out string? fullPath) ? fullPath : null;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileDependenciesSnapshot.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileDependenciesSnapshot.cs
@@ -90,13 +90,15 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
 
                 previous.DataByTarget.TryGetValue(lockFileTarget.Name, out AssetsFileTarget? previousTarget);
 
+                ImmutableArray<AssetsFileLogMessage> logMessages = ParseLogMessages(lockFile, previousTarget, lockFileTarget.Name);
+
                 dataByTarget.Add(
                     lockFileTarget.Name,
                     new AssetsFileTarget(
                         this,
                         lockFileTarget.Name,
-                        ParseLogMessages(lockFile, previousTarget, lockFileTarget.Name),
-                        ParseLibraries(lockFile, lockFileTarget)));
+                        logMessages,
+                        ParseLibraries(lockFile, lockFileTarget, logMessages)));
             }
 
             DataByTarget = dataByTarget.ToImmutable();
@@ -123,14 +125,14 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
 
                     j++;
 
-                    if (j < previousLogs.Length && previousLogs[j].Equals(logMessage))
+                    if (j < previousLogs.Length && previousLogs[j].Equals(logMessage, lockFile.PackageSpec.FilePath))
                     {
                         // Unchanged, so use previous value
                         builder.Add(previousLogs[j]);
                     }
                     else
                     {
-                        builder.Add(new AssetsFileLogMessage(logMessage));
+                        builder.Add(new AssetsFileLogMessage(lockFile.PackageSpec.FilePath, logMessage));
                     }
                 }
 
@@ -138,7 +140,7 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
             }
         }
 
-        internal static ImmutableDictionary<string, AssetsFileTargetLibrary> ParseLibraries(LockFile lockFile, LockFileTarget lockFileTarget)
+        internal static ImmutableDictionary<string, AssetsFileTargetLibrary> ParseLibraries(LockFile lockFile, LockFileTarget lockFileTarget, ImmutableArray<AssetsFileLogMessage> logMessages)
         {
             ImmutableDictionary<string, AssetsFileTargetLibrary>.Builder builder = ImmutableDictionary.CreateBuilder<string, AssetsFileTargetLibrary>(StringComparer.OrdinalIgnoreCase);
 
@@ -147,6 +149,19 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
                 if (AssetsFileTargetLibrary.TryCreate(lockFile, lockFileLibrary, out AssetsFileTargetLibrary? library))
                 {
                     builder.Add(library.Name, library);
+                }
+            }
+
+            // If a non-existent library is referenced, it will have an error log message, but no entry in "libraries".
+            // We want to show a diagnostic node beneath such nodes in the tree, so need to create a dummy library entry,
+            // otherwise there's nothing to attach that diagnostic to.
+            foreach (AssetsFileLogMessage message in logMessages)
+            {
+                string libraryName = message.LibraryName;
+
+                if (!builder.ContainsKey(libraryName))
+                {
+                    builder.Add(libraryName, AssetsFileTargetLibrary.CreatePlaceholder(libraryName));
                 }
             }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileLibraryType.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileLibraryType.cs
@@ -11,6 +11,22 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
     internal enum AssetsFileLibraryType : byte
     {
         Package,
-        Project
+
+        Project,
+
+        /// <summary>
+        /// When it is unknown whether the library represents a package or a project.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This occurs, for example, when a referenced item is not found. It will be present in the lock file's
+        /// messages, but not elsewhere in the lock file.
+        /// </para>
+        /// <para>
+        /// This enum member exists only to support attaching diagnostic items to their package or project reference
+        /// node in the tree.
+        /// </para>
+        /// </remarks>
+        Unknown
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileTarget.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileTarget.cs
@@ -145,14 +145,12 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
             return true;
         }
 
-        public bool TryGetPackage(string packageId, string version, [NotNullWhen(returnValue: true)] out AssetsFileTargetLibrary? assetsFileLibrary)
+        public bool TryGetPackage(string packageId, [NotNullWhen(returnValue: true)] out AssetsFileTargetLibrary? assetsFileLibrary)
         {
             Requires.NotNull(packageId, nameof(packageId));
-            Requires.NotNull(version, nameof(version));
 
             if (LibraryByName.TryGetValue(packageId, out assetsFileLibrary) &&
-                assetsFileLibrary.Type is AssetsFileLibraryType.Package or AssetsFileLibraryType.Unknown &&
-                (assetsFileLibrary.Version == version || assetsFileLibrary.Version is null))
+                assetsFileLibrary.Type is AssetsFileLibraryType.Package or AssetsFileLibraryType.Unknown)
             {
                 return true;
             }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileTarget.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileTarget.cs
@@ -151,8 +151,8 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
             Requires.NotNull(version, nameof(version));
 
             if (LibraryByName.TryGetValue(packageId, out assetsFileLibrary) &&
-                assetsFileLibrary.Type == AssetsFileLibraryType.Package &&
-                assetsFileLibrary.Version == version)
+                assetsFileLibrary.Type is AssetsFileLibraryType.Package or AssetsFileLibraryType.Unknown &&
+                (assetsFileLibrary.Version == version || assetsFileLibrary.Version is null))
             {
                 return true;
             }
@@ -166,7 +166,7 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
             Requires.NotNull(projectId, nameof(projectId));
 
             if (LibraryByName.TryGetValue(projectId, out assetsFileLibrary) &&
-                assetsFileLibrary.Type == AssetsFileLibraryType.Project)
+                assetsFileLibrary.Type is AssetsFileLibraryType.Project or AssetsFileLibraryType.Unknown)
             {
                 return true;
             }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileTargetLibrary.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileTargetLibrary.cs
@@ -39,6 +39,33 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
             return true;
         }
 
+        /// <summary>
+        /// Creates a dummy placeholder for a library in cases where we only know the name of the library.
+        /// </summary>
+        /// <remarks>
+        /// This is useful, for example, when a referenced package does not exist. It will not have an entry in "libraries",
+        /// yet we want to model its presence in our snapshot so that we can display diagnostic nodes to it. For such libraries,
+        /// the version is unknown, which we represent with a <see langword="null"/> value.
+        /// </remarks>
+        public static AssetsFileTargetLibrary CreatePlaceholder(string name)
+        {
+            return new AssetsFileTargetLibrary(name);
+        }
+
+        private AssetsFileTargetLibrary(string name)
+        {
+            Name = name;
+            Version = null;
+            Type = AssetsFileLibraryType.Unknown;
+            Dependencies = ImmutableArray<string>.Empty;
+            FrameworkAssemblies = ImmutableArray<string>.Empty;
+            CompileTimeAssemblies = ImmutableArray<string>.Empty;
+            ContentFiles = ImmutableArray<AssetsFileTargetLibraryContentFile>.Empty;
+            BuildFiles = ImmutableArray<string>.Empty;
+            BuildMultiTargetingFiles = ImmutableArray<string>.Empty;
+            DocumentationFiles = ImmutableArray<string>.Empty;
+        }
+
         private AssetsFileTargetLibrary(LockFileLibrary? library, LockFileTargetLibrary targetLibrary, AssetsFileLibraryType type)
         {
             Name = targetLibrary.Name;
@@ -103,7 +130,15 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
         }
 
         public string Name { get; }
-        public string Version { get; }
+
+        /// <summary>
+        /// Gets the version of the library, or <see langword="null"/> if it is unknown.
+        /// </summary>
+        /// <remarks>
+        /// The version can be unknown for packages that fail to resolve at all, for example when the package
+        /// name is not found. For resolved packages however, this value will always be present.
+        /// </remarks>
+        public string? Version { get; }
         public AssetsFileLibraryType Type { get; }
         public ImmutableArray<string> Dependencies { get; }
         public ImmutableArray<string> FrameworkAssemblies { get; }
@@ -113,6 +148,6 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
         public ImmutableArray<string> BuildMultiTargetingFiles { get; }
         public ImmutableArray<string> DocumentationFiles { get; }
 
-        public override string ToString() => $"{Type} {Name} ({Version}) {Dependencies.Length} {(Dependencies.Length == 1 ? "dependency" : "dependencies")}";
+        public override string ToString() => $"{Type} {Name} ({Version ?? "Unknown"}) {Dependencies.Length} {(Dependencies.Length == 1 ? "dependency" : "dependencies")}";
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/PackageReferenceAttachedCollectionSourceProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/PackageReferenceAttachedCollectionSourceProvider.cs
@@ -18,25 +18,23 @@ namespace NuGet.VisualStudio.SolutionExplorer
     [Export(typeof(IAttachedCollectionSourceProvider))]
     [Name(nameof(PackageReferenceAttachedCollectionSourceProvider))]
     [Order(Before = HierarchyItemsProviderNames.Contains)]
-    internal sealed class PackageReferenceAttachedCollectionSourceProvider : AssetsFileTopLevelDependenciesCollectionSourceProvider<(string Name, string Version), PackageReferenceItem>
+    internal sealed class PackageReferenceAttachedCollectionSourceProvider : AssetsFileTopLevelDependenciesCollectionSourceProvider<PackageReferenceItem>
     {
         public PackageReferenceAttachedCollectionSourceProvider()
             : base(DependencyTreeFlags.PackageDependency)
         {
         }
 
-        protected override bool TryGetIdentity(Properties properties, out (string Name, string Version) identity)
+        protected override bool TryGetLibraryName(Properties properties, [NotNullWhen(returnValue: true)] out string? libraryName)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
             try
             {
                 if (properties.Item("Name")?.Value is string name &&
-                    properties.Item("Version")?.Value is string version &&
-                    !string.IsNullOrEmpty(name) &&
-                    !string.IsNullOrEmpty(version))
+                    !string.IsNullOrEmpty(name))
                 {
-                    identity = (name, version);
+                    libraryName = name;
                     return true;
                 }
             }
@@ -46,13 +44,13 @@ namespace NuGet.VisualStudio.SolutionExplorer
                 // "Could not find project item with item type 'PackageReference' and include value '...'.
             }
 
-            identity = default;
+            libraryName = null;
             return false;
         }
 
-        protected override bool TryGetLibrary(AssetsFileTarget target, (string Name, string Version) identity, [NotNullWhen(returnValue: true)] out AssetsFileTargetLibrary? library)
+        protected override bool TryGetLibrary(AssetsFileTarget target, string libraryName, [NotNullWhen(returnValue: true)] out AssetsFileTargetLibrary? library)
         {
-            return target.TryGetPackage(identity.Name, identity.Version, out library);
+            return target.TryGetPackage(libraryName, out library);
         }
 
         protected override PackageReferenceItem CreateItem(AssetsFileTarget targetData, AssetsFileTargetLibrary library)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/ProjectReferenceAttachedCollectionSourceProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/ProjectReferenceAttachedCollectionSourceProvider.cs
@@ -18,22 +18,22 @@ namespace NuGet.VisualStudio.SolutionExplorer
     [Export(typeof(IAttachedCollectionSourceProvider))]
     [Name(nameof(ProjectReferenceAttachedCollectionSourceProvider))]
     [Order(Before = HierarchyItemsProviderNames.Contains)]
-    internal sealed class ProjectReferenceAttachedCollectionSourceProvider : AssetsFileTopLevelDependenciesCollectionSourceProvider<string, ProjectReferenceItem>
+    internal sealed class ProjectReferenceAttachedCollectionSourceProvider : AssetsFileTopLevelDependenciesCollectionSourceProvider<ProjectReferenceItem>
     {
         public ProjectReferenceAttachedCollectionSourceProvider()
             : base(DependencyTreeFlags.ProjectDependency)
         {
         }
 
-        protected override bool TryGetIdentity(Properties properties, out string identity)
+        protected override bool TryGetLibraryName(Properties properties, [NotNullWhen(returnValue: true)] out string libraryName)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
             try
             {
-                if (properties.Item("Identity")?.Value is string identityString)
+                if (properties.Item("Identity")?.Value is string identity)
                 {
-                    identity = identityString;
+                    libraryName = identity;
                     return true;
                 }
             }
@@ -43,13 +43,13 @@ namespace NuGet.VisualStudio.SolutionExplorer
                 // "Could not find project item with item type 'ProjectReference' and include value '...'.
             }
 
-            identity = null!;
+            libraryName = null!;
             return false;
         }
 
-        protected override bool TryGetLibrary(AssetsFileTarget target, string identity, [NotNullWhen(returnValue: true)] out AssetsFileTargetLibrary? library)
+        protected override bool TryGetLibrary(AssetsFileTarget target, string libraryName, [NotNullWhen(returnValue: true)] out AssetsFileTargetLibrary? library)
         {
-            return target.TryGetProject(identity, out library);
+            return target.TryGetProject(libraryName, out library);
         }
 
         protected override ProjectReferenceItem CreateItem(AssetsFileTarget targetData, AssetsFileTargetLibrary library)

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
@@ -59,7 +59,7 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
             var lockFileFormat = new LockFileFormat();
             var lockFile = lockFileFormat.Parse(lockFileContent, "In Memory");
 
-            var dependencies = AssetsFileDependenciesSnapshot.ParseLibraries(lockFile, lockFile.Targets.First());
+            var dependencies = AssetsFileDependenciesSnapshot.ParseLibraries(lockFile, lockFile.Targets.First(), ImmutableArray<AssetsFileLogMessage>.Empty);
 
             Assert.Equal(1, dependencies.Count);
             Assert.True(dependencies.ContainsKey("system.runtime"));
@@ -86,7 +86,7 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
                 }
             };
 
-            var exception = Assert.Throws<ArgumentException>(() => AssetsFileDependenciesSnapshot.ParseLibraries(new LockFile(), lockFileTarget));
+            var exception = Assert.Throws<ArgumentException>(() => AssetsFileDependenciesSnapshot.ParseLibraries(new LockFile(), lockFileTarget, ImmutableArray<AssetsFileLogMessage>.Empty));
 
             Assert.Contains("PackageA", exception.Message);
         }
@@ -124,7 +124,7 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
                 }
             };
 
-            ImmutableDictionary<string, AssetsFileTargetLibrary> dependencies = AssetsFileDependenciesSnapshot.ParseLibraries(new LockFile(), lockFileTarget);
+            ImmutableDictionary<string, AssetsFileTargetLibrary> dependencies = AssetsFileDependenciesSnapshot.ParseLibraries(new LockFile(), lockFileTarget, ImmutableArray<AssetsFileLogMessage>.Empty);
 
             Assert.Equal(lockFileTarget.Libraries.Count, dependencies.Count);
             Assert.All<LockFileTargetLibrary>(lockFileTarget.Libraries,

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using NuGet.ProjectModel;
@@ -17,72 +16,76 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
         [Fact]
         public void ParseLibraries_IgnoreCaseInDependenciesTree_Succeeds()
         {
-            // Arrange
-            var lockFileContent = @"{
-  ""version"": 3,
-  ""targets"": {
-    ""net5.0"": {
-      ""System.Runtime/4.0.20-beta-22927"": {
-        ""type"": ""package"",
-        ""dependencies"": {
-          ""Frob"": ""4.0.20""
-        },
-        ""compile"": {
-          ""ref/dotnet/System.Runtime.dll"": {}
-        }
-      }
-    }
-  },
-  ""libraries"": {
-    ""System.Runtime/4.0.20-beta-22927"": {
-      ""sha512"": ""sup3rs3cur3"",
-      ""type"": ""package"",
-      ""files"": [
-        ""System.Runtime.nuspec""
-      ]
-    }
-  },
-  ""projectFileDependencyGroups"": {
-    """": [
-      ""System.Runtime [4.0.10-beta-*, )""
-    ],
-    ""net5.0"": []
-  },
-  ""logs"": [
-    {
-      ""code"": ""NU1000"",
-      ""level"": ""Error"",
-      ""message"": ""test log message""
-    }
-  ]
-}";
-            var lockFileFormat = new LockFileFormat();
-            var lockFile = lockFileFormat.Parse(lockFileContent, "In Memory");
+            var lockFileContent = """
+                {
+                  "version": 3,
+                  "targets": {
+                    "net5.0": {
+                      "System.Runtime/4.0.20-beta-22927": {
+                        "type": "package",
+                        "dependencies": {
+                          "Frob": "4.0.20"
+                        },
+                        "compile": {
+                          "ref/dotnet/System.Runtime.dll": {}
+                        }
+                      }
+                    }
+                  },
+                  "libraries": {
+                    "System.Runtime/4.0.20-beta-22927": {
+                      "sha512": "sup3rs3cur3",
+                      "type": "package",
+                      "files": [
+                        "System.Runtime.nuspec"
+                      ]
+                    }
+                  },
+                  "projectFileDependencyGroups": {
+                    "": [
+                      "System.Runtime [4.0.10-beta-*, )"
+                    ],
+                    "net5.0": []
+                  },
+                  "logs": [
+                    {
+                      "code": "NU1000",
+                      "level": "Error",
+                      "message": "test log message"
+                    }
+                  ]
+                }
+                """;
+
+            var lockFilePath = """C:\repo\obj\project.assets.json""";
+
+            var lockFile = new LockFileFormat().Parse(lockFileContent, lockFilePath);
 
             var dependencies = AssetsFileDependenciesSnapshot.ParseLibraries(lockFile, lockFile.Targets.First(), ImmutableArray<AssetsFileLogMessage>.Empty);
 
-            Assert.Equal(1, dependencies.Count);
-            Assert.True(dependencies.ContainsKey("system.runtime"));
+            var dependency = Assert.Single(dependencies);
+            Assert.Equal("System.Runtime", dependency.Key);
         }
 
         [Fact]
         public void ParseLibraries_LockFileTargetLibrariesWithDifferentCase_Throws()
         {
-            // Arrange
-            var lockFileTarget = new LockFileTarget();
-            lockFileTarget.Libraries = new List<LockFileTargetLibrary>
+            var lockFileTarget = new LockFileTarget
             {
-                new LockFileTargetLibrary()
+                Libraries = new LockFileTargetLibrary[]
                 {
-                    Name = "packageA",
-                    Type = "package",
-                    Version = NuGetVersion.Parse("1.0.0")
-                },
-                new LockFileTargetLibrary()
-                {
-                    Name = "PackageA",
-                    Type = "package",
-                    Version = NuGetVersion.Parse("1.0.0")
+                    new()
+                    {
+                        Name = "packageA",
+                        Type = "package",
+                        Version = NuGetVersion.Parse("1.0.0")
+                    },
+                    new()
+                    {
+                        Name = "PackageA",
+                        Type = "package",
+                        Version = NuGetVersion.Parse("1.0.0")
+                    }
                 }
             };
 
@@ -94,40 +97,41 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
         [Fact]
         public void ParseLibraries_LockFileTargetLibrariesMatchesDependencies_Succeeds()
         {
-            // Arrange
-            var lockFileTarget = new LockFileTarget();
-            lockFileTarget.Libraries = new List<LockFileTargetLibrary>
+            var lockFileTarget = new LockFileTarget
             {
-                new LockFileTargetLibrary()
+                Libraries = new LockFileTargetLibrary[]
                 {
-                    Name = "packageA",
-                    Type = "package",
-                    Version = NuGetVersion.Parse("1.0.0")
-                },
-                new LockFileTargetLibrary()
-                {
-                    Name = "packageB",
-                    Type = "package",
-                    Version = NuGetVersion.Parse("1.0.0")
-                },
-                new LockFileTargetLibrary()
-                {
-                    Name = "projectA",
-                    Type = "project",
-                    Version = NuGetVersion.Parse("1.0.0")
-                },
-                new LockFileTargetLibrary()
-                {
-                    Name = "projectB",
-                    Type = "project",
-                    Version = NuGetVersion.Parse("1.0.0")
+                    new()
+                    {
+                        Name = "packageA",
+                        Type = "package",
+                        Version = NuGetVersion.Parse("1.0.0")
+                    },
+                    new()
+                    {
+                        Name = "packageB",
+                        Type = "package",
+                        Version = NuGetVersion.Parse("1.0.0")
+                    },
+                    new()
+                    {
+                        Name = "projectA",
+                        Type = "project",
+                        Version = NuGetVersion.Parse("1.0.0")
+                    },
+                    new()
+                    {
+                        Name = "projectB",
+                        Type = "project",
+                        Version = NuGetVersion.Parse("1.0.0")
+                    }
                 }
             };
 
             ImmutableDictionary<string, AssetsFileTargetLibrary> dependencies = AssetsFileDependenciesSnapshot.ParseLibraries(new LockFile(), lockFileTarget, ImmutableArray<AssetsFileLogMessage>.Empty);
 
             Assert.Equal(lockFileTarget.Libraries.Count, dependencies.Count);
-            Assert.All<LockFileTargetLibrary>(lockFileTarget.Libraries,
+            Assert.All(lockFileTarget.Libraries,
                 source =>
                 {
                     Assert.True(dependencies.ContainsKey(source.Name));
@@ -136,8 +140,7 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
                     Assert.Equal(source.Name, target.Name);
                     Assert.Equal(source.Version.ToNormalizedString(), target.Version);
 
-                    AssetsFileLibraryType sourceType;
-                    Assert.True(Enum.TryParse<AssetsFileLibraryType>(source.Type, ignoreCase: true, out sourceType));
+                    Assert.True(Enum.TryParse(source.Type, ignoreCase: true, out AssetsFileLibraryType sourceType));
                     Assert.Equal(sourceType, target.Type);
                 });
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes https://github.com/dotnet/project-system/issues/8947
Fixes https://github.com/dotnet/project-system/issues/8998

Regression? Last working version: No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Previously, if a project referenced a non-existent package or project, the dependency would appear with a yellow triangle without any further explanation.

A log message would be present in the `project.assets.json` file, however we would not attach it to the tree.

This is because unresolved packages/projects such as these do not have entries in the `libraries` section of the lock file. This meant that we would not create an `IRelatableItem` for the library, and would then not be able to attach child nodes (such as diagnostics).

This change ensures that libaries mentioned in log messages have at least a dummy entry in the `LibraryByName` collection, so that tree construction completes successfully.

Another required change here was the normalization of unresolved project paths. In some instances these were identified with the relative path used in the project file (such as `..\OtherProject\OtherProject.csproj`), yet in the log messages the identity would be the full path. To fix this issue and allow diagnostics to be attached to unresolved project references, absolute library IDs are made relative to the project file during snapshot construction. It's possible to author a project file for which this would not work correctly, but that seems unlikely to occur very often in practice.

## Before

![image](https://user-images.githubusercontent.com/350947/233948333-055dc9fd-96bd-4bad-a5c1-05c0c0d6c63c.png)

## After

![image](https://user-images.githubusercontent.com/350947/233948561-936c2c3d-6382-4879-a770-1b30cfa67733.png)

When one of the diagnostic nodes is focussed, the _Properties_ window shows more information.

![image](https://user-images.githubusercontent.com/350947/233948779-dbbce24d-964c-4250-8388-5ce2e302127a.png)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
