### PR TITLE
Create scheduled pipeline to run pipeline stages that might not need to run for every build

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -80,5 +80,6 @@ extends:
     RunCrossFrameworkTestsOnWindows: ${{parameters.RunCrossFrameworkTestsOnWindows}}
     RunEndToEndTests: ${{parameters.RunEndToEndTests}}
     RunFunctionalTestsOnWindows: ${{parameters.RunFunctionalTestsOnWindows}}
+    RunSourceBuild: ${{parameters.RunSourceBuild}}
     RunTestsOnLinux: ${{parameters.RunTestsOnLinux}}
     RunTestsOnMac: ${{parameters.RunTestsOnMac}}

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -27,6 +27,13 @@ parameters:
   values:
   - delete
   - stop
+- name: NuGetLocalizationType
+  displayName: Whether to do production-ready localization (Full), or pseudo-localization, aka PLOC, (Pseudo) for testing.
+  type: string
+  default: Full
+  values:
+  - Full
+  - Pseudo
 - name: RunApexTests
   displayName: Run Apex tests
   type: boolean
@@ -34,38 +41,44 @@ parameters:
 - name: RunBuildForPublishing
   displayName: Build bits for publishing
   type: boolean
-  default: true
+  default: false
 - name: RunCrossFrameworkTestsOnWindows
   displayName: Run cross framweork tests on Windows
   type: boolean
-  default: true
+  default: false
 - name: RunEndToEndTests
   displayName: Run end-to-end tests
   type: boolean
-  default: true
+  default: false
 - name: RunFunctionalTestsOnWindows
   displayName: Run functional tests on Windows
   type: boolean
-  default: true
+  default: false
 - name: RunSourceBuild
   displayName: Run source build
   type: boolean
-  default: true
+  default: false
 - name: RunTestsOnLinux
   displayName: Run tests on Linux
   type: boolean
-  default: true
+  default: false
 - name: RunTestsOnMac
   displayName: Run tests on Mac
   type: boolean
-  default: true
+  default: false
 
 extends:
   template: templates/pipeline.yml
   parameters:
-    isOfficialBuild: true
+    ApexAgentCleanup: ${{parameters.ApexAgentCleanup}}
     DartLabEnvironment: ${{parameters.DartLabEnvironment}}
     E2EPart1AgentCleanup: ${{parameters.E2EPart1AgentCleanup}}
     E2EPart2AgentCleanup: ${{parameters.E2EPart2AgentCleanup}}
-    ApexAgentCleanup: ${{parameters.ApexAgentCleanup}}
-    NuGetLocalizationType: Full
+    NuGetLocalizationType: ${{parameters.NuGetLocalizationType}}
+    RunApexTests: ${{parameters.RunApexTests}}
+    RunBuildForPublishing: ${{parameters.RunBuildForPublishing}}
+    RunCrossFrameworkTestsOnWindows: ${{parameters.RunCrossFrameworkTestsOnWindows}}
+    RunEndToEndTests: ${{parameters.RunEndToEndTests}}
+    RunFunctionalTestsOnWindows: ${{parameters.RunFunctionalTestsOnWindows}}
+    RunTestsOnLinux: ${{parameters.RunTestsOnLinux}}
+    RunTestsOnMac: ${{parameters.RunTestsOnMac}}

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -69,3 +69,11 @@ extends:
     E2EPart2AgentCleanup: ${{parameters.E2EPart2AgentCleanup}}
     ApexAgentCleanup: ${{parameters.ApexAgentCleanup}}
     NuGetLocalizationType: Full
+    RunApexTests: ${{parameters.RunApexTests}}
+    RunBuildForPublishing: ${{parameters.RunBuildForPublishing}}
+    RunCrossFrameworkTestsOnWindows: ${{parameters.RunCrossFrameworkTestsOnWindows}}
+    RunEndToEndTests: ${{parameters.RunEndToEndTests}}
+    RunFunctionalTestsOnWindows: ${{parameters.RunFunctionalTestsOnWindows}}
+    RunSourceBuild: ${{parameters.RunSourceBuild}}
+    RunTestsOnLinux: ${{parameters.RunTestsOnLinux}}
+    RunTestsOnMac: ${{parameters.RunTestsOnMac}}

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -76,3 +76,10 @@ extends:
     ApexAgentCleanup: ${{parameters.ApexAgentCleanup}}
     NuGetLocalizationType: ${{parameters.NuGetLocalizationType}}
     RunApexTests: ${{parameters.RunApexTests}}
+    RunBuildForPublishing: ${{parameters.RunBuildForPublishing}}
+    RunCrossFrameworkTestsOnWindows: ${{parameters.RunCrossFrameworkTestsOnWindows}}
+    RunEndToEndTests: ${{parameters.RunEndToEndTests}}
+    RunFunctionalTestsOnWindows: ${{parameters.RunFunctionalTestsOnWindows}}
+    RunSourceBuild: ${{parameters.RunSourceBuild}}
+    RunTestsOnLinux: ${{parameters.RunTestsOnLinux}}
+    RunTestsOnMac: ${{parameters.RunTestsOnMac}}

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -34,6 +34,38 @@ parameters:
   values:
   - Full
   - Pseudo
+- name: RunApexTests
+  displayName: Run Apex tests
+  type: boolean
+  default: true
+- name: RunBuildForPublishing
+  displayName: Build bits for publishing
+  type: boolean
+  default: true
+- name: RunCrossFrameworkTestsOnWindows
+  displayName: Run cross framweork tests on Windows
+  type: boolean
+  default: true
+- name: RunEndToEndTests
+  displayName: Run end-to-end tests
+  type: boolean
+  default: true
+- name: RunFunctionalTestsOnWindows
+  displayName: Run functional tests on Windows
+  type: boolean
+  default: true
+- name: RunSourceBuild
+  displayName: Run source build
+  type: boolean
+  default: true
+- name: RunTestsOnLinux
+  displayName: Run tests on Linux
+  type: boolean
+  default: true
+- name: RunTestsOnMac
+  displayName: Run tests on Mac
+  type: boolean
+  default: true
 
 extends:
   template: templates/pipeline.yml
@@ -43,3 +75,4 @@ extends:
     E2EPart2AgentCleanup: ${{parameters.E2EPart2AgentCleanup}}
     ApexAgentCleanup: ${{parameters.ApexAgentCleanup}}
     NuGetLocalizationType: ${{parameters.NuGetLocalizationType}}
+    RunApexTests: ${{parameters.RunApexTests}}

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -153,183 +153,176 @@ stages:
         BuildRTM: false
         NuGetLocalizationType: ${{ parameters.NuGetLocalizationType }}
 
-- ${{ if eq(parameters.RunBuildForPublishing, true) }}:
-  - stage: Build_For_Publishing
-    displayName: Build NuGet published to nuget.org
-    dependsOn: Initialize
-    jobs:
-    - job: Build_and_UnitTest_RTM
-      timeoutInMinutes: 170
-      variables:
-        BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-        FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-        VsTargetChannel: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
-        VsTargetChannelForTests: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannelForTests']]
-        VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
-        BuildRTM: "true"
-      pool:
-        name: VSEngSS-MicroBuild2022-1ES
-      steps:
-      - template: Build_and_UnitTest.yml
-        parameters:
-          BuildRTM: true
-          NuGetLocalizationType: Full
-    - job: Validate_Publishing_Artifacts
-      displayName: 'Validate Publishing build artifacts'
-      dependsOn: Build_and_UnitTest_RTM
-      timeoutInMinutes: 15
-      pool:
-        vmImage: windows-latest
-      steps:
-      - template: Validate_Build_Output.yml
-        parameters:
-          isOfficialBuild: ${{ parameters.isOfficialBuild }}
+- stage: Build_For_Publishing
+  displayName: Build NuGet published to nuget.org
+  dependsOn: Initialize
+  jobs:
+  - job: Build_and_UnitTest_RTM
+    condition: "and(succeeded(), ne(variables['RunBuildForPublishing'], 'false'))"
+    timeoutInMinutes: 170
+    variables:
+      BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+      FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+      VsTargetChannel: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
+      VsTargetChannelForTests: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannelForTests']]
+      VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
+      BuildRTM: "true"
+    pool:
+      name: VSEngSS-MicroBuild2022-1ES
+    steps:
+    - template: Build_and_UnitTest.yml
+      parameters:
+        BuildRTM: true
+        NuGetLocalizationType: Full
+  - job: Validate_Publishing_Artifacts
+    condition: "and(succeeded(), ne(variables['RunBuildForPublishing'], 'false'))"
+    displayName: 'Validate Publishing build artifacts'
+    dependsOn: Build_and_UnitTest_RTM
+    timeoutInMinutes: 15
+    pool:
+      vmImage: windows-latest
+    steps:
+    - template: Validate_Build_Output.yml
+      parameters:
+        isOfficialBuild: ${{ parameters.isOfficialBuild }}
 
-- ${{ if eq(parameters.RunSourceBuild, true) }}:
-  - stage: Source_Build
-    dependsOn: Initialize
-    jobs:
-    - job: Build_Source_Build
-      timeoutInMinutes: 120
-      variables:
-        BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-        FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-        BuildRTM: "false"
-        DOTNET_NUGET_SIGNATURE_VERIFICATION: true
-      pool:
-        vmImage: ubuntu-latest
-      steps:
-      - template: Source_Build.yml
+- stage: Source_Build
+  dependsOn: Initialize
+  jobs:
+  - job: Build_Source_Build
+    condition: "and(succeeded(), ne(variables['RunSourceBuild'], 'false'))"
+    timeoutInMinutes: 120
+    variables:
+      BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+      FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+      BuildRTM: "false"
+      DOTNET_NUGET_SIGNATURE_VERIFICATION: true
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+    - template: Source_Build.yml
 
-- ${{ if or(eq(parameters.RunFunctionalTestsOnWindows, true), eq(parameters.RunTestsOnLinux, true), eq(parameters.RunCrossFrameworkTestsOnWindows, true)) }}:
-  - stage: CLI_Func_Tests
-    dependsOn: Initialize
-    jobs:
-    - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
-      - job: Functional_Tests_On_Windows
-        timeoutInMinutes: 120
-        variables:
-          BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-          FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-           # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
-          MSBuildEnableWorkloadResolver: false
-        condition: "and(succeeded(),ne(variables['RunFunctionalTestsOnWindows'], 'false')) "
-        pool:
-          name: VSEngSS-MicroBuild2022-1ES
-        strategy:
-          matrix:
-            IsDesktop:
-              SkipCoreAssemblies: "true"
-            IsCore:
-              SkipDesktopAssemblies: "true"
-        steps:
-        - template: Functional_Tests_On_Windows.yml
+- stage: CLI_Func_Tests
+  dependsOn: Initialize
+  jobs:
+  - job: Functional_Tests_On_Windows
+    timeoutInMinutes: 120
+    variables:
+      BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+      FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+       # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
+      MSBuildEnableWorkloadResolver: false
+    condition: "and(succeeded(), ne(variables['RunFunctionalTestsOnWindows'], 'false'))"
+    pool:
+      name: VSEngSS-MicroBuild2022-1ES
+    strategy:
+      matrix:
+        IsDesktop:
+          SkipCoreAssemblies: "true"
+        IsCore:
+          SkipDesktopAssemblies: "true"
+    steps:
+    - template: Functional_Tests_On_Windows.yml
 
-    - ${{ if eq(parameters.RunTestsOnLinux, true) }}:
-      - job: Tests_On_Linux
-        timeoutInMinutes: 45
-        variables:
-          FULLVSTSBUILDNUMBER: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-          MSBUILDDISABLENODEREUSE: 1
-          # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
-          MSBuildEnableWorkloadResolver: false
-          DOTNET_NUGET_SIGNATURE_VERIFICATION: true
-        condition: "and(succeeded(), ne(variables['RunTestsOnLinux'], 'false'))"
-        pool:
-          vmImage: ubuntu-latest
-        steps:
-        - template: Tests_On_Linux.yml
+  - job: Tests_On_Linux
+    timeoutInMinutes: 45
+    variables:
+      FULLVSTSBUILDNUMBER: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+      MSBUILDDISABLENODEREUSE: 1
+      # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
+      MSBuildEnableWorkloadResolver: false
+      DOTNET_NUGET_SIGNATURE_VERIFICATION: true
+    condition: "and(succeeded(), ne(variables['RunTestsOnLinux'], 'false'))"
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+      - template: Tests_On_Linux.yml
 
-    - ${{ if eq(parameters.RunCrossFrameworkTestsOnWindows, true) }}:
-      - job: CrossFramework_Tests_On_Windows
-        timeoutInMinutes: 30
-        variables:
-          BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-          FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-        condition: "and(succeeded(),ne(variables['RunCrossFrameworkTestsOnWindows'], 'false')) "
-        pool:
-          vmImage: windows-latest
-        steps:
-        - template: CrossFramework_Tests_On_Windows.yml
+  - job: CrossFramework_Tests_On_Windows
+    condition: "and(succeeded(), ne(variables['RunCrossFrameworkTestsOnWindows'], 'false'))"
+    timeoutInMinutes: 30
+    variables:
+      BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+      FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+    pool:
+      vmImage: windows-latest
+    steps:
+    - template: CrossFramework_Tests_On_Windows.yml
 
-- ${{ if eq(parameters.RunTestsOnMac, true) }}:
-  - stage: MacTests
+- stage: MacTests
+  dependsOn:
+  - Initialize
+  - Build_Insertable
+  jobs:
+  - job: Tests_On_Mac
+    condition: "and(succeeded(), ne(variables['RunTestsOnMac'], 'false'))"
+    timeoutInMinutes: 90
+    variables:
+      FULLVSTSBUILDNUMBER: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+      # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
+      MSBuildEnableWorkloadResolver: false
+    pool:
+      vmImage: macos-latest
+    steps:
+    - template: Tests_On_Mac.yml
+
+# Dartlab's template defines this in its own stage
+- template: End_To_End_Tests_On_Windows.yml
+  parameters:
+    stageName: VS_EndToEnd_Part1
+    stageDisplayName: Part 1
+    condition: "and(succeeded(), ne(variables['RunEndToEndTests'], 'false'))"
     dependsOn:
     - Initialize
     - Build_Insertable
-    condition: "and(succeeded(), ne(variables['RunTestsOnMac'], 'false'))"
-    jobs:
-    - job: Tests_On_Mac
-      timeoutInMinutes: 90
-      variables:
-        FULLVSTSBUILDNUMBER: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-        # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
-        MSBuildEnableWorkloadResolver: false
-      pool:
-        vmImage: macos-latest
-      steps:
-      - template: Tests_On_Mac.yml
+    testExecutionJobTimeoutInMinutes: 100
+    bootstrapperUrl: $(VsBootstrapperUrl)
+    runSettingsURI:  https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
+    DartLabEnvironment: ${{parameters.DartLabEnvironment}}
+    variables:
+    - name: VsBootstrapperUrl
+      value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
+    - name: GitHubStatusName
+      value: End_To_End_Tests_On_Windows Part1
+    part: "InstallPackageTest.ps1,UninstallPackageTest.ps1,UpdatePackageTest.ps1"
+    testMachineCleanUpStrategy: ${{parameters.E2EPart1AgentCleanup}}
 
 # Dartlab's template defines this in its own stage
-- ${{ if eq(parameters.RunEndToEndTests, true) }}:
-  - template: End_To_End_Tests_On_Windows.yml
-    parameters:
-      stageName: VS_EndToEnd_Part1
-      stageDisplayName: Part 1
-      condition: "and(succeeded(), ne(variables['RunEndToEndTests'], 'false'))"
-      dependsOn:
+- template: End_To_End_Tests_On_Windows.yml
+  parameters:
+    stageName: VS_EndToEnd_Part2
+    stageDisplayName: Part 2
+    condition: "and(succeeded(), ne(variables['RunEndToEndTests'], 'false'))"
+    dependsOn:
+    - Initialize
+    - Build_Insertable
+    testExecutionJobTimeoutInMinutes: 100
+    bootstrapperUrl: $(VsBootstrapperUrl)
+    runSettingsURI:  https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
+    DartLabEnvironment: ${{parameters.DartLabEnvironment}}
+    variables:
+    - name: VsBootstrapperUrl
+      value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
+    - name: GitHubStatusName
+      value: End_To_End_Tests_On_Windows Part2
+    part: "A-TopDownloadedPackages.ps1,BuildIntegratedTest.ps1,ExecuteInitScriptTest.ps1,FindPackageTest.ps1,GetPackageTest.ps1,GetProjectTest.ps1,LegacyPackageRefProjectTest.ps1,NativeProjectTest.ps1,NetCoreProjectTest.ps1,PackTest.ps1,ProjectRetargeting.ps1,ServicesTest.ps1,Settings.ps1,SyncPackageTest.ps1,TabExpansionTest.ps1,UniversalWindowsProjectTest.ps1"
+    testMachineCleanUpStrategy: ${{parameters.E2EPart2AgentCleanup}}
+
+# Dartlab's template defines this in its own stage
+- template: Apex_Tests_On_Windows.yml
+  parameters:
+    condition: "and(succeeded(), ne(variables['RunApexTests'], 'false'))"
+    dependsOn:
       - Initialize
       - Build_Insertable
-      testExecutionJobTimeoutInMinutes: 100
-      bootstrapperUrl: $(VsBootstrapperUrl)
-      runSettingsURI:  https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
-      DartLabEnvironment: ${{parameters.DartLabEnvironment}}
-      variables:
+    variables:
       - name: VsBootstrapperUrl
         value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
       - name: GitHubStatusName
-        value: End_To_End_Tests_On_Windows Part1
-      part: "InstallPackageTest.ps1,UninstallPackageTest.ps1,UpdatePackageTest.ps1"
-      testMachineCleanUpStrategy: ${{parameters.E2EPart1AgentCleanup}}
-
-# Dartlab's template defines this in its own stage
-- ${{ if eq(parameters.RunEndToEndTests, true) }}:
-  - template: End_To_End_Tests_On_Windows.yml
-    parameters:
-      stageName: VS_EndToEnd_Part2
-      stageDisplayName: Part 2
-      condition: "and(succeeded(), ne(variables['RunEndToEndTests'], 'false'))"
-      dependsOn:
-      - Initialize
-      - Build_Insertable
-      testExecutionJobTimeoutInMinutes: 100
-      bootstrapperUrl: $(VsBootstrapperUrl)
-      runSettingsURI:  https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
-      DartLabEnvironment: ${{parameters.DartLabEnvironment}}
-      variables:
-      - name: VsBootstrapperUrl
-        value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
-      - name: GitHubStatusName
-        value: End_To_End_Tests_On_Windows Part2
-      part: "A-TopDownloadedPackages.ps1,BuildIntegratedTest.ps1,ExecuteInitScriptTest.ps1,FindPackageTest.ps1,GetPackageTest.ps1,GetProjectTest.ps1,LegacyPackageRefProjectTest.ps1,NativeProjectTest.ps1,NetCoreProjectTest.ps1,PackTest.ps1,ProjectRetargeting.ps1,ServicesTest.ps1,Settings.ps1,SyncPackageTest.ps1,TabExpansionTest.ps1,UniversalWindowsProjectTest.ps1"
-      testMachineCleanUpStrategy: ${{parameters.E2EPart2AgentCleanup}}
-
-# Dartlab's template defines this in its own stage
-- ${{ if eq(parameters.RunApexTests, true) }}:
-  - template: Apex_Tests_On_Windows.yml
-    parameters:
-      condition: "and(succeeded(), ne(variables['RunApexTests'], 'false'))"
-      dependsOn:
-        - Initialize
-        - Build_Insertable
-      variables:
-        - name: VsBootstrapperUrl
-          value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
-        - name: GitHubStatusName
-          value: Apex Tests On Windows
-      isOfficialBuild: ${{parameters.isOfficialBuild}}
-      runSettingsURI: https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
-      dartLabEnvironment: ${{parameters.DartLabEnvironment}}
-      testExecutionJobTimeoutInMinutes: 150
-      bootstrapperUrl: $(VsBootstrapperUrl)
-      testMachineCleanUpStrategy: ${{parameters.ApexAgentCleanup}}
+        value: Apex Tests On Windows
+    isOfficialBuild: ${{parameters.isOfficialBuild}}
+    runSettingsURI: https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
+    dartLabEnvironment: ${{parameters.DartLabEnvironment}}
+    testExecutionJobTimeoutInMinutes: 150
+    bootstrapperUrl: $(VsBootstrapperUrl)
+    testMachineCleanUpStrategy: ${{parameters.ApexAgentCleanup}}

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -38,6 +38,38 @@ parameters:
   values:
   - Full
   - Pseudo
+- name: RunApexTests
+  displayName: Run Apex tests
+  type: boolean
+  default: true
+- name: RunBuildForPublishing
+  displayName: Build bits for publishing
+  type: boolean
+  default: true
+- name: RunCrossFrameworkTestsOnWindows
+  displayName: Run cross framweork tests on Windows
+  type: boolean
+  default: true
+- name: RunEndToEndTests
+  displayName: Run end-to-end tests
+  type: boolean
+  default: true
+- name: RunFunctionalTestsOnWindows
+  displayName: Run functional tests on Windows
+  type: boolean
+  default: true
+- name: RunSourceBuild
+  displayName: Run source build
+  type: boolean
+  default: true
+- name: RunTestsOnLinux
+  displayName: Run tests on Linux
+  type: boolean
+  default: true
+- name: RunTestsOnMac
+  displayName: Run tests on Mac
+  type: boolean
+  default: true
 
 resources:
   pipelines:
@@ -54,6 +86,14 @@ variables:
   DOTNET_NOLOGO: 1
   Codeql.Enabled: ${{ parameters.isOfficialBuild }}
   Codeql.TSAEnabled: ${{ parameters.isOfficialBuild }}
+  RunApexTests: ${{ parameters.RunApexTests }}
+  RunBuildForPublishing: ${{ parameters.RunBuildForPublishing }}
+  RunCrossFrameworkTestsOnWindows: ${{ parameters.RunCrossFrameworkTestsOnWindows }}
+  RunEndToEndTests: ${{ parameters.RunEndToEndTests }}
+  RunFunctionalTestsOnWindows: ${{ parameters.RunFunctionalTestsOnWindows }}
+  RunSourceBuild: ${{ parameters.RunSourceBuild }}
+  RunTestsOnLinux: ${{ parameters.RunTestsOnLinux }}
+  RunTestsOnMac: ${{ parameters.RunTestsOnMac }}
 
 stages:
 - stage: Initialize
@@ -113,174 +153,183 @@ stages:
         BuildRTM: false
         NuGetLocalizationType: ${{ parameters.NuGetLocalizationType }}
 
-- stage: Build_For_Publishing
-  displayName: Build NuGet published to nuget.org
-  dependsOn: Initialize
-  jobs:
-  - job: Build_and_UnitTest_RTM
-    timeoutInMinutes: 170
-    variables:
-      BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-      FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-      VsTargetChannel: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
-      VsTargetChannelForTests: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannelForTests']]
-      VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
-      BuildRTM: "true"
-    pool:
-      name: VSEngSS-MicroBuild2022-1ES
-    steps:
-    - template: Build_and_UnitTest.yml
-      parameters:
-        BuildRTM: true
-        NuGetLocalizationType: Full
-  - job: Validate_Publishing_Artifacts
-    displayName: 'Validate Publishing build artifacts'
-    dependsOn: Build_and_UnitTest_RTM
-    timeoutInMinutes: 15
-    pool:
-      vmImage: windows-latest
-    steps:
-    - template: Validate_Build_Output.yml
-      parameters:
-        isOfficialBuild: ${{ parameters.isOfficialBuild }}
+- ${{ if eq(parameters.RunBuildForPublishing, true) }}:
+  - stage: Build_For_Publishing
+    displayName: Build NuGet published to nuget.org
+    dependsOn: Initialize
+    jobs:
+    - job: Build_and_UnitTest_RTM
+      timeoutInMinutes: 170
+      variables:
+        BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+        FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+        VsTargetChannel: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
+        VsTargetChannelForTests: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannelForTests']]
+        VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
+        BuildRTM: "true"
+      pool:
+        name: VSEngSS-MicroBuild2022-1ES
+      steps:
+      - template: Build_and_UnitTest.yml
+        parameters:
+          BuildRTM: true
+          NuGetLocalizationType: Full
+    - job: Validate_Publishing_Artifacts
+      displayName: 'Validate Publishing build artifacts'
+      dependsOn: Build_and_UnitTest_RTM
+      timeoutInMinutes: 15
+      pool:
+        vmImage: windows-latest
+      steps:
+      - template: Validate_Build_Output.yml
+        parameters:
+          isOfficialBuild: ${{ parameters.isOfficialBuild }}
 
+- ${{ if eq(parameters.RunSourceBuild, true) }}:
+  - stage: Source_Build
+    dependsOn: Initialize
+    jobs:
+    - job: Build_Source_Build
+      timeoutInMinutes: 120
+      variables:
+        BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+        FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+        BuildRTM: "false"
+        DOTNET_NUGET_SIGNATURE_VERIFICATION: true
+      pool:
+        vmImage: ubuntu-latest
+      steps:
+      - template: Source_Build.yml
 
-- stage: Source_Build
-  dependsOn: Initialize
-  jobs:
-  - job: Build_Source_Build
-    timeoutInMinutes: 120
-    variables:
-      BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-      FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-      BuildRTM: "false"
-      DOTNET_NUGET_SIGNATURE_VERIFICATION: true
-    pool:
-      vmImage: ubuntu-latest
-    steps:
-    - template: Source_Build.yml
+- ${{ if or(eq(parameters.RunFunctionalTestsOnWindows, true), eq(parameters.RunTestsOnLinux, true), eq(parameters.RunCrossFrameworkTestsOnWindows, true)) }}:
+  - stage: CLI_Func_Tests
+    dependsOn: Initialize
+    jobs:
+    - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
+      - job: Functional_Tests_On_Windows
+        timeoutInMinutes: 120
+        variables:
+          BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+          FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+           # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
+          MSBuildEnableWorkloadResolver: false
+        condition: "and(succeeded(),ne(variables['RunFunctionalTestsOnWindows'], 'false')) "
+        pool:
+          name: VSEngSS-MicroBuild2022-1ES
+        strategy:
+          matrix:
+            IsDesktop:
+              SkipCoreAssemblies: "true"
+            IsCore:
+              SkipDesktopAssemblies: "true"
+        steps:
+        - template: Functional_Tests_On_Windows.yml
 
-- stage: CLI_Func_Tests
-  dependsOn: Initialize
-  jobs:
-  - job: Functional_Tests_On_Windows
-    timeoutInMinutes: 120
-    variables:
-      BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-      FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-       # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
-      MSBuildEnableWorkloadResolver: false
-    condition: "and(succeeded(),eq(variables['RunFunctionalTestsOnWindows'], 'true')) "
-    pool:
-      name: VSEngSS-MicroBuild2022-1ES
-    strategy:
-      matrix:
-        IsDesktop:
-          SkipCoreAssemblies: "true"
-        IsCore:
-          SkipDesktopAssemblies: "true"
-    steps:
-    - template: Functional_Tests_On_Windows.yml
+    - ${{ if eq(parameters.RunTestsOnLinux, true) }}:
+      - job: Tests_On_Linux
+        timeoutInMinutes: 45
+        variables:
+          FULLVSTSBUILDNUMBER: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+          MSBUILDDISABLENODEREUSE: 1
+          # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
+          MSBuildEnableWorkloadResolver: false
+          DOTNET_NUGET_SIGNATURE_VERIFICATION: true
+        condition: "and(succeeded(), ne(variables['RunTestsOnLinux'], 'false'))"
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+        - template: Tests_On_Linux.yml
 
-  - job: Tests_On_Linux
-    timeoutInMinutes: 45
-    variables:
-      FULLVSTSBUILDNUMBER: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-      MSBUILDDISABLENODEREUSE: 1
-      # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
-      MSBuildEnableWorkloadResolver: false
-      DOTNET_NUGET_SIGNATURE_VERIFICATION: true
-    condition: "and(succeeded(), eq(variables['RunTestsOnLinux'], 'true'))"
-    pool:
-      vmImage: ubuntu-latest
-    steps:
-    - template: Tests_On_Linux.yml
+    - ${{ if eq(parameters.RunCrossFrameworkTestsOnWindows, true) }}:
+      - job: CrossFramework_Tests_On_Windows
+        timeoutInMinutes: 30
+        variables:
+          BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+          FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+        condition: "and(succeeded(),ne(variables['RunCrossFrameworkTestsOnWindows'], 'false')) "
+        pool:
+          vmImage: windows-latest
+        steps:
+        - template: CrossFramework_Tests_On_Windows.yml
 
-  - job: CrossFramework_Tests_On_Windows
-    timeoutInMinutes: 30
-    variables:
-      BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-      FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-    condition: "and(succeeded(),eq(variables['RunCrossFrameworkTestsOnWindows'], 'true')) "
-    pool:
-      vmImage: windows-latest
-    steps:
-    - template: CrossFramework_Tests_On_Windows.yml
-
-- stage: MacTests
-  dependsOn:
-  - Initialize
-  - Build_Insertable
-  condition: "and(succeeded(), eq(variables['RunTestsOnMac'], 'true'))"
-  jobs:
-  - job: Tests_On_Mac
-    timeoutInMinutes: 90
-    variables:
-      FULLVSTSBUILDNUMBER: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-      # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
-      MSBuildEnableWorkloadResolver: false
-    pool:
-      vmImage: macos-latest
-    steps:
-    - template: Tests_On_Mac.yml
-
-# Dartlab's template defines this in its own stage
-- template: End_To_End_Tests_On_Windows.yml
-  parameters:
-    stageName: VS_EndToEnd_Part1
-    stageDisplayName: Part 1
-    condition: "and(succeeded(), eq(variables['RunEndToEndTests'], 'true'))"
+- ${{ if eq(parameters.RunTestsOnMac, true) }}:
+  - stage: MacTests
     dependsOn:
     - Initialize
     - Build_Insertable
-    testExecutionJobTimeoutInMinutes: 100
-    bootstrapperUrl: $(VsBootstrapperUrl)
-    runSettingsURI:  https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
-    DartLabEnvironment: ${{parameters.DartLabEnvironment}}
-    variables:
-    - name: VsBootstrapperUrl
-      value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
-    - name: GitHubStatusName
-      value: End_To_End_Tests_On_Windows Part1
-    part: "InstallPackageTest.ps1,UninstallPackageTest.ps1,UpdatePackageTest.ps1"
-    testMachineCleanUpStrategy: ${{parameters.E2EPart1AgentCleanup}}
+    condition: "and(succeeded(), ne(variables['RunTestsOnMac'], 'false'))"
+    jobs:
+    - job: Tests_On_Mac
+      timeoutInMinutes: 90
+      variables:
+        FULLVSTSBUILDNUMBER: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+        # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
+        MSBuildEnableWorkloadResolver: false
+      pool:
+        vmImage: macos-latest
+      steps:
+      - template: Tests_On_Mac.yml
 
 # Dartlab's template defines this in its own stage
-- template: End_To_End_Tests_On_Windows.yml
-  parameters:
-    stageName: VS_EndToEnd_Part2
-    stageDisplayName: Part 2
-    condition: "and(succeeded(), eq(variables['RunEndToEndTests'], 'true'))"
-    dependsOn:
-    - Initialize
-    - Build_Insertable
-    testExecutionJobTimeoutInMinutes: 100
-    bootstrapperUrl: $(VsBootstrapperUrl)
-    runSettingsURI:  https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
-    DartLabEnvironment: ${{parameters.DartLabEnvironment}}
-    variables:
-    - name: VsBootstrapperUrl
-      value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
-    - name: GitHubStatusName
-      value: End_To_End_Tests_On_Windows Part2
-    part: "A-TopDownloadedPackages.ps1,BuildIntegratedTest.ps1,ExecuteInitScriptTest.ps1,FindPackageTest.ps1,GetPackageTest.ps1,GetProjectTest.ps1,LegacyPackageRefProjectTest.ps1,NativeProjectTest.ps1,NetCoreProjectTest.ps1,PackTest.ps1,ProjectRetargeting.ps1,ServicesTest.ps1,Settings.ps1,SyncPackageTest.ps1,TabExpansionTest.ps1,UniversalWindowsProjectTest.ps1"
-    testMachineCleanUpStrategy: ${{parameters.E2EPart2AgentCleanup}}
-
-# Dartlab's template defines this in its own stage
-- template: Apex_Tests_On_Windows.yml
-  parameters:
-    condition: "and(succeeded(), eq(variables['RunApexTests'], 'true'))"
-    dependsOn:
+- ${{ if eq(parameters.RunEndToEndTests, true) }}:
+  - template: End_To_End_Tests_On_Windows.yml
+    parameters:
+      stageName: VS_EndToEnd_Part1
+      stageDisplayName: Part 1
+      condition: "and(succeeded(), ne(variables['RunEndToEndTests'], 'false'))"
+      dependsOn:
       - Initialize
       - Build_Insertable
-    variables:
+      testExecutionJobTimeoutInMinutes: 100
+      bootstrapperUrl: $(VsBootstrapperUrl)
+      runSettingsURI:  https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
+      DartLabEnvironment: ${{parameters.DartLabEnvironment}}
+      variables:
       - name: VsBootstrapperUrl
         value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
       - name: GitHubStatusName
-        value: Apex Tests On Windows
-    isOfficialBuild: ${{parameters.isOfficialBuild}}
-    runSettingsURI: https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
-    dartLabEnvironment: ${{parameters.DartLabEnvironment}}
-    testExecutionJobTimeoutInMinutes: 150
-    bootstrapperUrl: $(VsBootstrapperUrl)
-    testMachineCleanUpStrategy: ${{parameters.ApexAgentCleanup}}
+        value: End_To_End_Tests_On_Windows Part1
+      part: "InstallPackageTest.ps1,UninstallPackageTest.ps1,UpdatePackageTest.ps1"
+      testMachineCleanUpStrategy: ${{parameters.E2EPart1AgentCleanup}}
+
+# Dartlab's template defines this in its own stage
+- ${{ if eq(parameters.RunEndToEndTests, true) }}:
+  - template: End_To_End_Tests_On_Windows.yml
+    parameters:
+      stageName: VS_EndToEnd_Part2
+      stageDisplayName: Part 2
+      condition: "and(succeeded(), ne(variables['RunEndToEndTests'], 'false'))"
+      dependsOn:
+      - Initialize
+      - Build_Insertable
+      testExecutionJobTimeoutInMinutes: 100
+      bootstrapperUrl: $(VsBootstrapperUrl)
+      runSettingsURI:  https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
+      DartLabEnvironment: ${{parameters.DartLabEnvironment}}
+      variables:
+      - name: VsBootstrapperUrl
+        value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
+      - name: GitHubStatusName
+        value: End_To_End_Tests_On_Windows Part2
+      part: "A-TopDownloadedPackages.ps1,BuildIntegratedTest.ps1,ExecuteInitScriptTest.ps1,FindPackageTest.ps1,GetPackageTest.ps1,GetProjectTest.ps1,LegacyPackageRefProjectTest.ps1,NativeProjectTest.ps1,NetCoreProjectTest.ps1,PackTest.ps1,ProjectRetargeting.ps1,ServicesTest.ps1,Settings.ps1,SyncPackageTest.ps1,TabExpansionTest.ps1,UniversalWindowsProjectTest.ps1"
+      testMachineCleanUpStrategy: ${{parameters.E2EPart2AgentCleanup}}
+
+# Dartlab's template defines this in its own stage
+- ${{ if eq(parameters.RunApexTests, true) }}:
+  - template: Apex_Tests_On_Windows.yml
+    parameters:
+      condition: "and(succeeded(), ne(variables['RunApexTests'], 'false'))"
+      dependsOn:
+        - Initialize
+        - Build_Insertable
+      variables:
+        - name: VsBootstrapperUrl
+          value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
+        - name: GitHubStatusName
+          value: Apex Tests On Windows
+      isOfficialBuild: ${{parameters.isOfficialBuild}}
+      runSettingsURI: https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
+      dartLabEnvironment: ${{parameters.DartLabEnvironment}}
+      testExecutionJobTimeoutInMinutes: 150
+      bootstrapperUrl: $(VsBootstrapperUrl)
+      testMachineCleanUpStrategy: ${{parameters.ApexAgentCleanup}}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2020

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This adds a new [Continuous Integration pipeline](https://dev.azure.com/devdiv/DevDiv/_build?definitionId=18292&_a=summary) that will run daily and run stages that we can disable for pull request and official builds.

This introduces pipeline parameters which we can now set in the UI with checkboxes rather than true/false values.  The parameters are then set as variables so that runtime logic still has access. Here are the current defaults:
| Pull Requests | Official | Continous Integration |
|---|---|---|
|![image](https://user-images.githubusercontent.com/17556515/234069919-f3efa386-5f29-40ac-b404-a09869bb4baa.png)| ![image](https://user-images.githubusercontent.com/17556515/234069941-a8f76535-3337-4dbb-a1f2-433d2776dcda.png) | ![image](https://user-images.githubusercontent.com/17556515/234069596-a73bd755-36b6-482a-b7b9-fce9bbe90bfc.png) |

We can then turn off Apex tests by default for pull requests build and individuals can schedule builds and uncheck stages that they might not need like they did before.


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
