### PR TITLE
Get NuGetAudit properties in VS without DTE

### DIFF
--- a/build/Shared/vs-threading.MembersRequiringMainThread.txt
+++ b/build/Shared/vs-threading.MembersRequiringMainThread.txt
@@ -11,3 +11,4 @@
 [NuGet.PackageManagement.VisualStudio.EnvDTEProjectUtility]::TryGetFolder
 [NuGet.PackageManagement.VisualStudio.EnvDTEProjectUtility]::TryGetNestedFile
 [NuGet.ProjectManagement.IProjectBuildProperties]::GetPropertyValue
+[NuGet.VisualStudio.IVsProjectBuildProperties]::GetPropertyValue

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/CpsProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/CpsProjectSystemServices.cs
@@ -24,6 +24,7 @@ namespace NuGet.PackageManagement.VisualStudio
             ScriptService = new VsProjectScriptHostService(vsProjectAdapter, scriptExecutor);
         }
 
+        [Obsolete]
         public IProjectBuildProperties BuildProperties => throw new NotSupportedException();
 
         public IProjectSystemCapabilities Capabilities => throw new NotSupportedException();

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsCoreProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsCoreProjectSystemServices.cs
@@ -24,7 +24,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
         #region INuGetProjectServices
 
-        public IProjectBuildProperties BuildProperties => _vsProjectAdapter.BuildProperties;
+        [Obsolete]
+        public IProjectBuildProperties BuildProperties => throw new NotImplementedException();
 
         public IProjectSystemCapabilities Capabilities => this;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
@@ -338,7 +338,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private bool IsCentralPackageManagementVersionsEnabled()
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            return MSBuildStringUtility.IsTrue(_vsProjectAdapter.BuildProperties.GetPropertyValue(ProjectBuildProperties.ManagePackageVersionsCentrally));
+            return MSBuildStringUtility.IsTrue(_vsProjectAdapter.BuildProperties.GetPropertyValueWithDteFallback(ProjectBuildProperties.ManagePackageVersionsCentrally));
         }
 
         private class ProjectReference

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
@@ -105,7 +105,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 return Array.Empty<LibraryDependency>();
             }
 
-            bool isCpvmEnabled = await IsCentralPackageManagementVersionsEnabledAsync();
+            bool isCpvmEnabled = IsCentralPackageManagementVersionsEnabled();
 
             var references = installedPackages
                 .Cast<string>()
@@ -334,9 +334,10 @@ namespace NuGet.PackageManagement.VisualStudio
             _vsProject4.PackageReferences.Remove(packageName);
         }
 
-        private async Task<bool> IsCentralPackageManagementVersionsEnabledAsync()
+        private bool IsCentralPackageManagementVersionsEnabled()
         {
-            return MSBuildStringUtility.IsTrue(await _vsProjectAdapter.BuildProperties.GetPropertyValueAsync(ProjectBuildProperties.ManagePackageVersionsCentrally));
+            ThreadHelper.ThrowIfNotOnUIThread();
+            return MSBuildStringUtility.IsTrue(_vsProjectAdapter.BuildProperties.GetPropertyValue(ProjectBuildProperties.ManagePackageVersionsCentrally));
         }
 
         private class ProjectReference

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
@@ -42,7 +42,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
         #region INuGetProjectServices
 
-        public IProjectBuildProperties BuildProperties => _vsProjectAdapter.BuildProperties;
+        [Obsolete]
+        public IProjectBuildProperties BuildProperties => throw new NotImplementedException();
 
         public IProjectSystemCapabilities Capabilities => this;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs
@@ -2,14 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading.Tasks;
 using EnvDTE;
 using Microsoft;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.PackageManagement.VisualStudio.Telemetry;
-using NuGet.ProjectManagement;
+using NuGet.VisualStudio;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -17,28 +16,24 @@ namespace NuGet.PackageManagement.VisualStudio
     /// Contains the information specific to a Visual Basic or C# project or NetCore project.
     /// </summary>
     internal class VsProjectBuildProperties
-        : IProjectBuildProperties
+        : IVsProjectBuildProperties
     {
         private readonly Lazy<Project> _dteProject;
         private Project _project;
         private readonly IVsBuildPropertyStorage _propertyStorage;
-        private readonly IVsProjectThreadingService _threadingService;
         private readonly IVsProjectBuildPropertiesTelemetry _buildPropertiesTelemetry;
         private readonly string[] _projectTypeGuids;
 
         public VsProjectBuildProperties(
             Project project,
             IVsBuildPropertyStorage propertyStorage,
-            IVsProjectThreadingService threadingService,
             IVsProjectBuildPropertiesTelemetry buildPropertiesTelemetry,
             string[] projectTypeGuids)
         {
             Assumes.Present(project);
-            Assumes.Present(threadingService);
 
             _project = project;
             _propertyStorage = propertyStorage;
-            _threadingService = threadingService;
             _buildPropertiesTelemetry = buildPropertiesTelemetry;
             _projectTypeGuids = projectTypeGuids;
         }
@@ -46,16 +41,13 @@ namespace NuGet.PackageManagement.VisualStudio
         public VsProjectBuildProperties(
             Lazy<Project> project,
             IVsBuildPropertyStorage propertyStorage,
-            IVsProjectThreadingService threadingService,
             IVsProjectBuildPropertiesTelemetry buildPropertiesTelemetry,
             string[] projectTypeGuids)
         {
             Assumes.Present(project);
-            Assumes.Present(threadingService);
 
             _dteProject = project;
             _propertyStorage = propertyStorage;
-            _threadingService = threadingService;
             _buildPropertiesTelemetry = buildPropertiesTelemetry;
             _projectTypeGuids = projectTypeGuids;
         }
@@ -95,12 +87,6 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             return null;
-        }
-
-        public async Task<string> GetPropertyValueAsync(string propertyName)
-        {
-            await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
-            return GetPropertyValue(propertyName);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
@@ -405,7 +405,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                return VsProjectAdapter.BuildProperties.GetPropertyValue(propertyName);
+                return VsProjectAdapter.BuildProperties.GetPropertyValueWithDteFallback(propertyName);
 
             });
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
@@ -76,7 +76,7 @@ namespace NuGet.PackageManagement.VisualStudio
             var buildProperties = vsProject.BuildProperties;
 
             // read MSBuild property RestoreProjectStyle
-            var restoreProjectStyle = buildProperties.GetPropertyValue(ProjectBuildProperties.RestoreProjectStyle);
+            var restoreProjectStyle = buildProperties.GetPropertyValueWithDteFallback(ProjectBuildProperties.RestoreProjectStyle);
 
             // check for RestoreProjectStyle property is set and if not set to PackageReference then return false
             if (!(string.IsNullOrEmpty(restoreProjectStyle) ||

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -259,7 +259,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private static string GetPropertySafe(IVsProjectBuildProperties projectBuildProperties, string propertyName)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            var value = projectBuildProperties.GetPropertyValue(propertyName);
+            var value = projectBuildProperties.GetPropertyValueWithDteFallback(propertyName);
 
             if (string.IsNullOrWhiteSpace(value))
             {
@@ -390,7 +390,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             var projectName = ProjectName ?? ProjectUniqueName;
 
-            string specifiedPackageId = _vsProjectAdapter.BuildProperties.GetPropertyValue(ProjectBuildProperties.PackageId);
+            string specifiedPackageId = _vsProjectAdapter.BuildProperties.GetPropertyValueWithDteFallback(ProjectBuildProperties.PackageId);
 
             if (!string.IsNullOrWhiteSpace(specifiedPackageId))
             {
@@ -398,7 +398,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
             else
             {
-                string specifiedAssemblyName = _vsProjectAdapter.BuildProperties.GetPropertyValue(ProjectBuildProperties.AssemblyName);
+                string specifiedAssemblyName = _vsProjectAdapter.BuildProperties.GetPropertyValueWithDteFallback(ProjectBuildProperties.AssemblyName);
 
                 if (!string.IsNullOrWhiteSpace(specifiedAssemblyName))
                 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -237,7 +237,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            var msbuildProjectExtensionsPath = await _vsProjectAdapter.GetMSBuildProjectExtensionsPathAsync();
+            var msbuildProjectExtensionsPath = _vsProjectAdapter.GetMSBuildProjectExtensionsPath();
 
             if (string.IsNullOrEmpty(msbuildProjectExtensionsPath))
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -256,7 +256,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return msbuildProjectExtensionsPath;
         }
 
-        private static string GetPropertySafe(IProjectBuildProperties projectBuildProperties, string propertyName)
+        private static string GetPropertySafe(IVsProjectBuildProperties projectBuildProperties, string propertyName)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
             var value = projectBuildProperties.GetPropertyValue(propertyName);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProjectProvider.cs
@@ -94,7 +94,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             // Check for RestoreProjectStyle property
-            var restoreProjectStyle = vsProjectAdapter.BuildProperties.GetPropertyValue(
+            var restoreProjectStyle = vsProjectAdapter.BuildProperties.GetPropertyValueWithDteFallback(
                 ProjectBuildProperties.RestoreProjectStyle);
 
             // For legacy csproj, either the RestoreProjectStyle must be set to PackageReference or

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsMSBuildProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsMSBuildProjectSystemServices.cs
@@ -21,7 +21,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
         #region INuGetProjectServices
 
-        public IProjectBuildProperties BuildProperties => _vsProjectAdapter.BuildProperties;
+        [Obsolete]
+        public IProjectBuildProperties BuildProperties => throw new NotImplementedException();
 
         public IProjectSystemCapabilities Capabilities => this;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -44,7 +44,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return Path.Combine(ProjectDirectory, msbuildProjectExtensionsPath);
         }
 
-        public IProjectBuildProperties BuildProperties { get; private set; }
+        public IVsProjectBuildProperties BuildProperties { get; }
 
         public string CustomUniqueName => ProjectNames.CustomUniqueName;
 
@@ -116,7 +116,7 @@ namespace NuGet.PackageManagement.VisualStudio
             string fullProjectPath,
             string projectDirectory,
             Func<IVsHierarchy, EnvDTE.Project> loadDteProject,
-            IProjectBuildProperties buildProperties,
+            IVsProjectBuildProperties buildProperties,
             IVsProjectThreadingService threadingService)
         {
             Assumes.Present(vsHierarchyItem);
@@ -135,7 +135,7 @@ namespace NuGet.PackageManagement.VisualStudio
             ProjectNames projectNames,
             string fullProjectPath,
             Func<IVsHierarchy, EnvDTE.Project> loadDteProject,
-            IProjectBuildProperties buildProperties,
+            IVsProjectBuildProperties buildProperties,
             IVsProjectThreadingService threadingService)
             : this(
                   vsHierarchyItem,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -14,7 +14,6 @@ using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Commands;
 using NuGet.Frameworks;
 using NuGet.ProjectManagement;
-using NuGet.RuntimeModel;
 using NuGet.VisualStudio;
 
 namespace NuGet.PackageManagement.VisualStudio
@@ -32,9 +31,10 @@ namespace NuGet.PackageManagement.VisualStudio
 
         #region Properties
 
-        public async Task<string> GetMSBuildProjectExtensionsPathAsync()
+        public string GetMSBuildProjectExtensionsPath()
         {
-            var msbuildProjectExtensionsPath = await BuildProperties.GetPropertyValueAsync(ProjectBuildProperties.MSBuildProjectExtensionsPath);
+            ThreadHelper.ThrowIfNotOnUIThread();
+            var msbuildProjectExtensionsPath = BuildProperties.GetPropertyValue(ProjectBuildProperties.MSBuildProjectExtensionsPath);
 
             if (string.IsNullOrEmpty(msbuildProjectExtensionsPath))
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -34,7 +34,7 @@ namespace NuGet.PackageManagement.VisualStudio
         public string GetMSBuildProjectExtensionsPath()
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            var msbuildProjectExtensionsPath = BuildProperties.GetPropertyValue(ProjectBuildProperties.MSBuildProjectExtensionsPath);
+            var msbuildProjectExtensionsPath = BuildProperties.GetPropertyValueWithDteFallback(ProjectBuildProperties.MSBuildProjectExtensionsPath);
 
             if (string.IsNullOrEmpty(msbuildProjectExtensionsPath))
             {
@@ -88,11 +88,11 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 ThreadHelper.ThrowIfNotOnUIThread();
 
-                var packageVersion = BuildProperties.GetPropertyValue(ProjectBuildProperties.PackageVersion);
+                var packageVersion = BuildProperties.GetPropertyValueWithDteFallback(ProjectBuildProperties.PackageVersion);
 
                 if (string.IsNullOrEmpty(packageVersion))
                 {
-                    packageVersion = BuildProperties.GetPropertyValue(ProjectBuildProperties.Version);
+                    packageVersion = BuildProperties.GetPropertyValueWithDteFallback(ProjectBuildProperties.Version);
 
                     if (string.IsNullOrEmpty(packageVersion))
                     {
@@ -230,13 +230,13 @@ namespace NuGet.PackageManagement.VisualStudio
             await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             var projectPath = FullName;
-            var platformIdentifier = BuildProperties.GetPropertyValue(
+            var platformIdentifier = BuildProperties.GetPropertyValueWithDteFallback(
                 ProjectBuildProperties.TargetPlatformIdentifier);
-            var platformVersion = BuildProperties.GetPropertyValue(
+            var platformVersion = BuildProperties.GetPropertyValueWithDteFallback(
                 ProjectBuildProperties.TargetPlatformVersion);
-            var platformMinVersion = BuildProperties.GetPropertyValue(
+            var platformMinVersion = BuildProperties.GetPropertyValueWithDteFallback(
                 ProjectBuildProperties.TargetPlatformMinVersion);
-            var targetFrameworkMoniker = BuildProperties.GetPropertyValue(
+            var targetFrameworkMoniker = BuildProperties.GetPropertyValueWithDteFallback(
                 ProjectBuildProperties.TargetFrameworkMoniker);
 
             // Projects supporting TargetFramework and TargetFrameworks are detected before

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapterProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapterProvider.cs
@@ -73,7 +73,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             var buildStorageProperty = vsHierarchyItem.VsHierarchy as IVsBuildPropertyStorage;
             var vsBuildProperties = new VsProjectBuildProperties(
-                dteProject, buildStorageProperty, _threadingService, _buildPropertiesTelemetry, projectTypeGuids);
+                dteProject, buildStorageProperty, _buildPropertiesTelemetry, projectTypeGuids);
 
             var projectNames = await ProjectNames.FromDTEProjectAsync(dteProject, vsSolution);
             var fullProjectPath = dteProject.GetFullProjectPath();
@@ -111,13 +111,13 @@ namespace NuGet.PackageManagement.VisualStudio
             await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             var vsHierarchyItem = VsHierarchyItem.FromVsHierarchy(hierarchy);
-            Func<IVsHierarchy, EnvDTE.Project> loadDteProject = hierarchy => VsHierarchyUtility.GetProjectFromHierarchy(hierarchy);
+            Func<IVsHierarchy, EnvDTE.Project> loadDteProject = VsHierarchyUtility.GetProjectFromHierarchy;
 
             var projectTypeGuids = VsHierarchyUtility.GetProjectTypeGuidsFromHierarchy(hierarchy);
 
             var buildStorageProperty = vsHierarchyItem.VsHierarchy as IVsBuildPropertyStorage;
             var vsBuildProperties = new VsProjectBuildProperties(
-                new Lazy<EnvDTE.Project>(() => loadDteProject(hierarchy)), buildStorageProperty, _threadingService, _buildPropertiesTelemetry, projectTypeGuids);
+                new Lazy<EnvDTE.Project>(() => loadDteProject(hierarchy)), buildStorageProperty, _buildPropertiesTelemetry, projectTypeGuids);
 
             var fullProjectPath = projectTypeGuids.Contains(VsProjectTypes.WebSiteProjectTypeGuid) ?
                 VsHierarchyUtility.GetProjectPathForWebsiteProject(hierarchy)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectJsonNuGetProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectJsonNuGetProject.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft;
-using Microsoft.VisualStudio.Shell;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Frameworks;
@@ -44,7 +43,7 @@ namespace NuGet.PackageManagement.VisualStudio
         protected override async Task<string> GetMSBuildProjectExtensionsPathAsync()
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            var msbuildProjectExtensionsPath = ProjectServices.BuildProperties.GetPropertyValue(ProjectBuildProperties.MSBuildProjectExtensionsPath);
+            var msbuildProjectExtensionsPath = _vsProjectAdapter.BuildProperties.GetPropertyValue(ProjectBuildProperties.MSBuildProjectExtensionsPath);
 
             if (string.IsNullOrEmpty(msbuildProjectExtensionsPath))
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectJsonNuGetProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectJsonNuGetProject.cs
@@ -43,7 +43,7 @@ namespace NuGet.PackageManagement.VisualStudio
         protected override async Task<string> GetMSBuildProjectExtensionsPathAsync()
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            var msbuildProjectExtensionsPath = _vsProjectAdapter.BuildProperties.GetPropertyValue(ProjectBuildProperties.MSBuildProjectExtensionsPath);
+            var msbuildProjectExtensionsPath = _vsProjectAdapter.BuildProperties.GetPropertyValueWithDteFallback(ProjectBuildProperties.MSBuildProjectExtensionsPath);
 
             if (string.IsNullOrEmpty(msbuildProjectExtensionsPath))
             {
@@ -74,7 +74,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     var platformMinVersionString = _vsProjectAdapter
                         .BuildProperties
-                        .GetPropertyValue(ProjectBuildProperties.TargetPlatformMinVersion);
+                        .GetPropertyValueWithDteFallback(ProjectBuildProperties.TargetPlatformMinVersion);
 
                     var platformMinVersion = !string.IsNullOrEmpty(platformMinVersionString)
                         ? new Version(platformMinVersionString)
@@ -82,7 +82,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
                     var targetFrameworkMonikerString = _vsProjectAdapter
                         .BuildProperties
-                        .GetPropertyValue(ProjectBuildProperties.TargetFrameworkMoniker);
+                        .GetPropertyValueWithDteFallback(ProjectBuildProperties.TargetFrameworkMoniker);
 
                     var targetFrameworkMoniker = !string.IsNullOrWhiteSpace(targetFrameworkMonikerString)
                         ? NuGetFramework.Parse(targetFrameworkMonikerString)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectJsonNuGetProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectJsonNuGetProject.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft;
+using Microsoft.VisualStudio.Shell;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Frameworks;
@@ -42,7 +43,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
         protected override async Task<string> GetMSBuildProjectExtensionsPathAsync()
         {
-            var msbuildProjectExtensionsPath = await ProjectServices.BuildProperties.GetPropertyValueAsync(ProjectBuildProperties.MSBuildProjectExtensionsPath);
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            var msbuildProjectExtensionsPath = ProjectServices.BuildProperties.GetPropertyValue(ProjectBuildProperties.MSBuildProjectExtensionsPath);
 
             if (string.IsNullOrEmpty(msbuildProjectExtensionsPath))
             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
@@ -6,7 +6,6 @@ using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Frameworks;
-using NuGet.ProjectManagement;
 
 namespace NuGet.VisualStudio
 {
@@ -20,7 +19,7 @@ namespace NuGet.VisualStudio
         /// </summary>
         string GetMSBuildProjectExtensionsPath();
 
-        IProjectBuildProperties BuildProperties { get; }
+        IVsProjectBuildProperties BuildProperties { get; }
 
         string CustomUniqueName { get; }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Frameworks;
 using NuGet.ProjectManagement;
-using NuGet.RuntimeModel;
 
 namespace NuGet.VisualStudio
 {
@@ -19,7 +18,7 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// MSBuildProjectExtensionsPath project property (e.g. c:\projFoo\obj)
         /// </summary>
-        Task<string> GetMSBuildProjectExtensionsPathAsync();
+        string GetMSBuildProjectExtensionsPath();
 
         IProjectBuildProperties BuildProperties { get; }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectBuildProperties.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectBuildProperties.cs
@@ -5,6 +5,16 @@ namespace NuGet.VisualStudio
 {
     public interface IVsProjectBuildProperties
     {
-        string GetPropertyValue(string name);
+        /// <summary>Get the value of a property.</summary>
+        /// <param name="name">The property name to check.</param>
+        /// <returns>The value of the property, if defined by the project. Otherwise, null</returns>
+        string GetPropertyValue(string propertyName);
+
+        /// <summary>Get the value of a property, and use DTE if IBuildPropertyStorage doesn't return a value</summary>
+        /// <param name="name">The property name to check.</param>
+        /// <returns>The value of the property, if defined by the project. Otherwise, null</returns>
+        /// <remarks>This method should not be used for anything new, as an exception is thrown and caught internally
+        /// when no value is defined, which harms performance.</remarks>
+        string GetPropertyValueWithDteFallback(string propertyName);
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectBuildProperties.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectBuildProperties.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.VisualStudio
+{
+    public interface IVsProjectBuildProperties
+    {
+        string GetPropertyValue(string name);
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/DefaultProjectServices.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/DefaultProjectServices.cs
@@ -18,7 +18,9 @@ namespace NuGet.ProjectManagement
     /// </summary>
     internal sealed class DefaultProjectServices
         : INuGetProjectServices
+#pragma warning disable CS0618 // Type or member is obsolete
         , IProjectBuildProperties
+#pragma warning restore CS0618 // Type or member is obsolete
         , IProjectScriptHostService
         , IProjectSystemCapabilities
         , IProjectSystemReferencesReader
@@ -27,6 +29,7 @@ namespace NuGet.ProjectManagement
     {
         public static INuGetProjectServices Instance { get; } = new DefaultProjectServices();
 
+        [Obsolete]
         public IProjectBuildProperties BuildProperties => this;
         public IProjectSystemCapabilities Capabilities => this;
         public IProjectSystemReferencesReader ReferencesReader => this;

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/INuGetProjectServices.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/INuGetProjectServices.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 
+using System;
+
 namespace NuGet.ProjectManagement
 {
     /// <summary>
@@ -17,6 +19,7 @@ namespace NuGet.ProjectManagement
         /// <summary>
         /// Service to access project's build properties.
         /// </summary>
+        [Obsolete]
         IProjectBuildProperties BuildProperties { get; }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/IProjectBuildProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/IProjectBuildProperties.cs
@@ -10,6 +10,7 @@ namespace NuGet.ProjectManagement
     /// Represents an API providing read-only access to 
     /// project's build properties.
     /// </summary>
+    [Obsolete("This was only used by NuGet's VS extension, so has been moved there")]
     public interface IProjectBuildProperties
     {
         /// <summary>
@@ -27,7 +28,6 @@ namespace NuGet.ProjectManagement
         /// <param name="propertyName">A property name</param>
         /// <returns>Property value or <code>null</code> if not found.</returns>
         /// <remarks>Often times when retrieving properties we are already on the UI thread. In those cases, prefer calling the synchronous version instead to avoid the extra state machine allocations.</remarks>
-        [Obsolete]
         Task<string> GetPropertyValueAsync(string propertyName);
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/IProjectBuildProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/IProjectBuildProperties.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 
 namespace NuGet.ProjectManagement
@@ -26,6 +27,7 @@ namespace NuGet.ProjectManagement
         /// <param name="propertyName">A property name</param>
         /// <returns>Property value or <code>null</code> if not found.</returns>
         /// <remarks>Often times when retrieving properties we are already on the UI thread. In those cases, prefer calling the synchronous version instead to avoid the extra state machine allocations.</remarks>
+        [Obsolete]
         Task<string> GetPropertyValueAsync(string propertyName);
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
@@ -11,7 +11,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
-using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectFactories.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectFactories.cs
@@ -97,8 +97,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var testMSBuildProjectExtensionsPath = Path.Combine(fullPath, "obj");
             Directory.CreateDirectory(testMSBuildProjectExtensionsPath);
             projectAdapter
-                .Setup(x => x.GetMSBuildProjectExtensionsPathAsync())
-                .Returns(Task.FromResult(testMSBuildProjectExtensionsPath));
+                .Setup(x => x.GetMSBuildProjectExtensionsPath())
+                .Returns(testMSBuildProjectExtensionsPath);
 
             return projectAdapter.Object;
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectFactories.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectFactories.cs
@@ -79,11 +79,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
         internal static IVsProjectAdapter CreateProjectAdapter(string fullPath)
         {
-            var projectBuildProperties = new Mock<IProjectBuildProperties>();
+            var projectBuildProperties = new Mock<IVsProjectBuildProperties>();
             return CreateProjectAdapter(fullPath, projectBuildProperties);
         }
 
-        internal static IVsProjectAdapter CreateProjectAdapter(string fullPath, Mock<IProjectBuildProperties> projectBuildProperties)
+        internal static IVsProjectAdapter CreateProjectAdapter(string fullPath, Mock<IVsProjectBuildProperties> projectBuildProperties)
         {
             var projectAdapter = CreateProjectAdapter(projectBuildProperties);
 
@@ -103,7 +103,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             return projectAdapter.Object;
         }
 
-        internal static Mock<IVsProjectAdapter> CreateProjectAdapter(Mock<IProjectBuildProperties> projectBuildProperties)
+        internal static Mock<IVsProjectAdapter> CreateProjectAdapter(Mock<IVsProjectBuildProperties> projectBuildProperties)
         {
             var projectAdapter = new Mock<IVsProjectAdapter>();
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -292,15 +292,15 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
                 projectBuildProperties
-                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestorePackagesPath))))
+                    .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestorePackagesPath))))
                     .Returns(restorePackagesPath);
 
                 projectBuildProperties
-                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreSources))))
+                    .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreSources))))
                     .Returns(sources);
 
                 projectBuildProperties
-                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreFallbackFolders))))
+                    .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreFallbackFolders))))
                     .Returns(fallbackFolders);
 
                 var projectServices = new TestProjectSystemServices();
@@ -356,15 +356,15 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
                 projectBuildProperties
-                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestorePackagesPath))))
+                    .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestorePackagesPath))))
                     .Returns(restorePackagesPath);
 
                 projectBuildProperties
-                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreSources))))
+                    .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreSources))))
                     .Returns(sources);
 
                 projectBuildProperties
-                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreFallbackFolders))))
+                    .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreFallbackFolders))))
                     .Returns(fallbackFolders);
 
                 var projectServices = new TestProjectSystemServices();
@@ -416,7 +416,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
                 projectBuildProperties
-                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.PackageTargetFallback))))
+                    .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.PackageTargetFallback))))
                     .Returns("portable-net45+win8;dnxcore50");
 
                 var testProject = new LegacyPackageReferenceProject(
@@ -762,15 +762,15 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
                 projectBuildProperties
-                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestorePackagesWithLockFile))))
+                    .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestorePackagesWithLockFile))))
                     .Returns(restorePackagesWithLockFile);
 
                 projectBuildProperties
-                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.NuGetLockFilePath))))
+                    .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.NuGetLockFilePath))))
                     .Returns(lockFilePath);
 
                 projectBuildProperties
-                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreLockedMode))))
+                    .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreLockedMode))))
                     .Returns(restoreLockedMode.ToString());
 
                 var projectServices = new TestProjectSystemServices();
@@ -1456,15 +1456,15 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
                 projectBuildProperties
-                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RuntimeIdentifier))))
+                    .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RuntimeIdentifier))))
                     .Returns(runtimeIdentifier);
 
                 projectBuildProperties
-                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RuntimeIdentifiers))))
+                    .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RuntimeIdentifiers))))
                     .Returns(runtimeIdentifiers);
 
                 projectBuildProperties
-                    .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RuntimeSupports))))
+                    .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RuntimeSupports))))
                     .Returns(runtimeSupports);
 
                 var projectServices = new TestProjectSystemServices();
@@ -1528,16 +1528,16 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
             projectBuildProperties
-                .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.NoWarn))))
+                .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.NoWarn))))
                 .Returns("NU1504");
             projectBuildProperties
-               .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.TreatWarningsAsErrors))))
+               .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.TreatWarningsAsErrors))))
                .Returns("true");
             projectBuildProperties
-                .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.WarningsNotAsErrors))))
+                .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.WarningsNotAsErrors))))
                 .Returns("NU1801");
             projectBuildProperties
-                .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.WarningsAsErrors))))
+                .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.WarningsAsErrors))))
                 .Returns("NU1803");
 
             var projectServices = new TestProjectSystemServices();

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -288,7 +288,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Arrange
             using (var testDirectory = TestDirectory.Create())
             {
-                var projectBuildProperties = new Mock<IProjectBuildProperties>();
+                var projectBuildProperties = new Mock<IVsProjectBuildProperties>();
                 var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
                 projectBuildProperties
@@ -352,7 +352,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Arrange
             using (var testDirectory = TestDirectory.Create())
             {
-                var projectBuildProperties = new Mock<IProjectBuildProperties>();
+                var projectBuildProperties = new Mock<IVsProjectBuildProperties>();
                 var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
                 projectBuildProperties
@@ -412,7 +412,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Arrange
             using (var testDirectory = TestDirectory.Create())
             {
-                var projectBuildProperties = new Mock<IProjectBuildProperties>();
+                var projectBuildProperties = new Mock<IVsProjectBuildProperties>();
                 var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
                 projectBuildProperties
@@ -758,7 +758,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Arrange
             using (var testDirectory = TestDirectory.Create())
             {
-                var projectBuildProperties = new Mock<IProjectBuildProperties>();
+                var projectBuildProperties = new Mock<IVsProjectBuildProperties>();
                 var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
                 projectBuildProperties
@@ -1452,7 +1452,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Arrange
             using (var testDirectory = TestDirectory.Create())
             {
-                var projectBuildProperties = new Mock<IProjectBuildProperties>();
+                var projectBuildProperties = new Mock<IVsProjectBuildProperties>();
                 var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
                 projectBuildProperties
@@ -1524,7 +1524,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Arrange
             using var testDirectory = TestDirectory.Create();
 
-            var projectBuildProperties = new Mock<IProjectBuildProperties>();
+            var projectBuildProperties = new Mock<IVsProjectBuildProperties>();
             var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
             projectBuildProperties

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -59,8 +59,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 Directory.CreateDirectory(testMSBuildProjectExtensionsPath);
                 var projectAdapter = Mock.Of<IVsProjectAdapter>();
                 Mock.Get(projectAdapter)
-                    .Setup(x => x.GetMSBuildProjectExtensionsPathAsync())
-                    .Returns(Task.FromResult(testMSBuildProjectExtensionsPath));
+                    .Setup(x => x.GetMSBuildProjectExtensionsPath())
+                    .Returns(testMSBuildProjectExtensionsPath);
 
                 var testProject = new LegacyPackageReferenceProject(
                     projectAdapter,
@@ -76,7 +76,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                 // Verify
                 Mock.Get(projectAdapter)
-                    .Verify(x => x.GetMSBuildProjectExtensionsPathAsync(), Times.AtLeastOnce);
+                    .Verify(x => x.GetMSBuildProjectExtensionsPath(), Times.AtLeastOnce);
             }
         }
 
@@ -113,8 +113,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 Directory.CreateDirectory(testMSBuildProjectExtensionsPath);
                 var projectAdapter = Mock.Of<IVsProjectAdapter>();
                 Mock.Get(projectAdapter)
-                    .Setup(x => x.GetMSBuildProjectExtensionsPathAsync())
-                    .Returns(Task.FromResult(testMSBuildProjectExtensionsPath));
+                    .Setup(x => x.GetMSBuildProjectExtensionsPath())
+                    .Returns(testMSBuildProjectExtensionsPath);
 
                 Mock.Get(projectAdapter)
                     .SetupGet(x => x.FullProjectPath)
@@ -134,7 +134,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                 // Verify
                 Mock.Get(projectAdapter)
-                    .Verify(x => x.GetMSBuildProjectExtensionsPathAsync(), Times.AtLeastOnce);
+                    .Verify(x => x.GetMSBuildProjectExtensionsPath(), Times.AtLeastOnce);
             }
         }
 
@@ -169,8 +169,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 Directory.CreateDirectory(testMSBuildProjectExtensionsPath);
                 var projectAdapter = Mock.Of<IVsProjectAdapter>();
                 Mock.Get(projectAdapter)
-                    .Setup(x => x.GetMSBuildProjectExtensionsPathAsync())
-                    .Returns(Task.FromResult(testMSBuildProjectExtensionsPath));
+                    .Setup(x => x.GetMSBuildProjectExtensionsPath())
+                    .Returns(testMSBuildProjectExtensionsPath);
 
                 Mock.Get(projectAdapter)
                     .SetupGet(x => x.FullProjectPath)
@@ -190,7 +190,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                 // Verify
                 Mock.Get(projectAdapter)
-                    .Verify(x => x.GetMSBuildProjectExtensionsPathAsync(), Times.AtLeastOnce);
+                    .Verify(x => x.GetMSBuildProjectExtensionsPath(), Times.AtLeastOnce);
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
@@ -361,7 +361,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     Assert.True(File.Exists(projectLockFilePath));
 
                     // delete existing restore output files
-                    string msBuildProjectExtensionsPath = await vsProjectAdapter.GetMSBuildProjectExtensionsPathAsync();
+                    string msBuildProjectExtensionsPath = vsProjectAdapter.GetMSBuildProjectExtensionsPath();
                     File.Delete(Path.Combine(msBuildProjectExtensionsPath, "project.assets.json"));
                     File.Delete(Path.Combine(msBuildProjectExtensionsPath, NoOpRestoreUtilities.NoOpCacheFileName));
 
@@ -491,7 +491,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         Assert.False(restoreSummary.NoOpRestore);
                     }
 
-                    string msBuildProjectExtensionsPath = await vsProjectAdapter.GetMSBuildProjectExtensionsPathAsync();
+                    string msBuildProjectExtensionsPath = vsProjectAdapter.GetMSBuildProjectExtensionsPath();
 
                     // Initial asserts
                     Assert.True(File.Exists(projectLockFilePath));
@@ -870,7 +870,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     Assert.True(File.Exists(projectLockFilePath));
 
                     // delete existing restore output files
-                    string msBuildProjectExtensionsPath = await vsProjectAdapter.GetMSBuildProjectExtensionsPathAsync();
+                    string msBuildProjectExtensionsPath = vsProjectAdapter.GetMSBuildProjectExtensionsPath();
                     File.Delete(Path.Combine(msBuildProjectExtensionsPath, "project.assets.json"));
                     File.Delete(Path.Combine(msBuildProjectExtensionsPath, NoOpRestoreUtilities.NoOpCacheFileName));
 
@@ -1005,7 +1005,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     Assert.True(File.Exists(projectLockFilePath));
 
                     // delete existing restore output files
-                    File.Delete(Path.Combine(await vsProjectAdapter.GetMSBuildProjectExtensionsPathAsync(), "project.assets.json"));
+                    File.Delete(Path.Combine(vsProjectAdapter.GetMSBuildProjectExtensionsPath(), "project.assets.json"));
 
                     // clean packages folder
                     Directory.Delete(testSolutionManager.GlobalPackagesFolder, true);
@@ -1157,7 +1157,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                             sourceRepositoryProvider.GetRepositories(), sourceRepositoryProvider.GetRepositories(), CancellationToken.None);
 
                     // Assert
-                    var lockFilePath = Path.Combine(await vsProjectAdapterA.GetMSBuildProjectExtensionsPathAsync(), "project.assets.json");
+                    var lockFilePath = Path.Combine(vsProjectAdapterA.GetMSBuildProjectExtensionsPath(), "project.assets.json");
                     Assert.True(File.Exists(lockFilePath));
 
                 }
@@ -1229,7 +1229,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                             sourceRepositoryProvider.GetRepositories(), sourceRepositoryProvider.GetRepositories(), CancellationToken.None);
 
                     // Assert
-                    var assetsFilePath = Path.Combine(await vsProjectAdapterA.GetMSBuildProjectExtensionsPathAsync(), "project.assets.json");
+                    var assetsFilePath = Path.Combine(vsProjectAdapterA.GetMSBuildProjectExtensionsPath(), "project.assets.json");
                     Assert.True(File.Exists(assetsFilePath));
 
                     var assetsFile = new LockFileFormat().Read(assetsFilePath);
@@ -1350,7 +1350,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         CancellationToken.None);
 
                     // Assert
-                    var assetsFilePath = Path.Combine(await vsProjectAdapterA.GetMSBuildProjectExtensionsPathAsync(), "project.assets.json");
+                    var assetsFilePath = Path.Combine(vsProjectAdapterA.GetMSBuildProjectExtensionsPath(), "project.assets.json");
                     Assert.True(File.Exists(assetsFilePath));
 
                     var assetsFile = new LockFileFormat().Read(assetsFilePath);
@@ -1831,7 +1831,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     Assert.True(File.Exists(projectLockFilePath));
 
-                    string msBuildProjectExtensionsPathA = await vsProjectAdapterA.GetMSBuildProjectExtensionsPathAsync();
+                    string msBuildProjectExtensionsPathA = vsProjectAdapterA.GetMSBuildProjectExtensionsPath();
 
                     var lockFilePath = Path.Combine(msBuildProjectExtensionsPathA, "project.assets.json");
                     Assert.True(File.Exists(lockFilePath));
@@ -2014,8 +2014,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     Assert.Equal(PackageDependencyType.Project, lockFile.Targets[0].Dependencies[1].Type);
 
                     // Act
-                    File.Delete(Path.Combine(await vsProjectAdapterA.GetMSBuildProjectExtensionsPathAsync(), NoOpRestoreUtilities.NoOpCacheFileName));
-                    File.Delete(Path.Combine(await vsProjectAdapterB.GetMSBuildProjectExtensionsPathAsync(), NoOpRestoreUtilities.NoOpCacheFileName));
+                    File.Delete(Path.Combine(vsProjectAdapterA.GetMSBuildProjectExtensionsPath(), NoOpRestoreUtilities.NoOpCacheFileName));
+                    File.Delete(Path.Combine(vsProjectAdapterB.GetMSBuildProjectExtensionsPath(), NoOpRestoreUtilities.NoOpCacheFileName));
 
                     restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
                         testSolutionManager,
@@ -2162,7 +2162,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         Assert.False(restoreSummary.NoOpRestore);
                     }
 
-                    var assetsFilePath = Path.Combine(await vsProjectAdapterA.GetMSBuildProjectExtensionsPathAsync(), "project.assets.json");
+                    var assetsFilePath = Path.Combine(vsProjectAdapterA.GetMSBuildProjectExtensionsPath(), "project.assets.json");
                     Assert.True(File.Exists(assetsFilePath));
 
                     var assetsFile = new LockFileFormat().Read(assetsFilePath);
@@ -2282,7 +2282,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         Assert.False(restoreSummary.NoOpRestore);
                     }
 
-                    var assetsFilePath = Path.Combine(await vsProjectAdapter.GetMSBuildProjectExtensionsPathAsync(), "project.assets.json");
+                    var assetsFilePath = Path.Combine(vsProjectAdapter.GetMSBuildProjectExtensionsPath(), "project.assets.json");
                     Assert.True(File.Exists(assetsFilePath));
 
                     var assetsFile = new LockFileFormat().Read(assetsFilePath);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
@@ -76,9 +76,9 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 .Returns(_restoreLockedMode.ToString());
         }
 
-        public Task<string> GetMSBuildProjectExtensionsPathAsync()
+        public string GetMSBuildProjectExtensionsPath()
         {
-            return Task.FromResult(Path.Combine(ProjectDirectory, "obj"));
+            return Path.Combine(ProjectDirectory, "obj");
         }
 
         public IProjectBuildProperties BuildProperties { get; } = Mock.Of<IProjectBuildProperties>();

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
@@ -52,27 +52,27 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             _CentralPackageTransitivePinningEnabled = CentralPackageTransitivePinningEnabled;
 
             Mock.Get(BuildProperties)
-                .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.ManagePackageVersionsCentrally))))
+                .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.ManagePackageVersionsCentrally))))
                 .Returns(_isCPVMEnabled.ToString());
 
             Mock.Get(BuildProperties)
-                .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.CentralPackageVersionOverrideEnabled))))
+                .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.CentralPackageVersionOverrideEnabled))))
                 .Returns(_isCentralPackageVersionOverrideEnabled ?? string.Empty);
 
             Mock.Get(BuildProperties)
-                .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.CentralPackageTransitivePinningEnabled))))
+                .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.CentralPackageTransitivePinningEnabled))))
                 .Returns(_CentralPackageTransitivePinningEnabled ?? string.Empty);
 
             Mock.Get(BuildProperties)
-                .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.NuGetLockFilePath))))
+                .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.NuGetLockFilePath))))
                 .Returns(_nuGetLockFilePath);
 
             Mock.Get(BuildProperties)
-                .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestorePackagesWithLockFile))))
+                .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestorePackagesWithLockFile))))
                 .Returns(_restorePackagesWithLockFile);
 
             Mock.Get(BuildProperties)
-                .Setup(x => x.GetPropertyValue(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreLockedMode))))
+                .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreLockedMode))))
                 .Returns(_restoreLockedMode.ToString());
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
@@ -81,7 +81,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             return Path.Combine(ProjectDirectory, "obj");
         }
 
-        public IProjectBuildProperties BuildProperties { get; } = Mock.Of<IProjectBuildProperties>();
+        public IVsProjectBuildProperties BuildProperties { get; } = Mock.Of<IVsProjectBuildProperties>();
 
         public string CustomUniqueName => ProjectNames.CustomUniqueName;
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -1952,6 +1952,7 @@ namespace NuGet.Test
 
             public bool IsCacheEnabled { get; set; }
 
+            [Obsolete]
             public IProjectBuildProperties BuildProperties => throw new NotImplementedException();
 
             public IProjectSystemCapabilities Capabilities => throw new NotImplementedException();

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/MSBuildNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/MSBuildNuGetProjectTests.cs
@@ -11,8 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.Frameworks;
-using NuGet.LibraryModel;
-using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
@@ -2031,6 +2029,7 @@ namespace ProjectManagement.Test
         {
             public IDictionary<string, int> ScriptsExecuted { get; } = new Dictionary<string, int>();
 
+            [Obsolete]
             public IProjectBuildProperties BuildProperties => throw new NotImplementedException();
 
             public IProjectSystemCapabilities Capabilities => throw new NotImplementedException();

--- a/test/TestUtilities/Test.Utility/ProjectManagement/TestProjectSystemServices.cs
+++ b/test/TestUtilities/Test.Utility/ProjectManagement/TestProjectSystemServices.cs
@@ -27,6 +27,7 @@ namespace Test.Utility
                 .ReturnsAsync(() => new LibraryDependency[] { });
         }
 
+        [Obsolete]
         public IProjectBuildProperties BuildProperties { get; } = Mock.Of<IProjectBuildProperties>();
 
         public IProjectSystemCapabilities Capabilities { get; } = Mock.Of<IProjectSystemCapabilities>();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12289

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Visual Studio's performance regression testing blocked insertion of https://github.com/NuGet/NuGet.Client/pull/5136, due to exception counts for UWP projects increasing too much. Therefore, in LegacyPackageReferenceProject, get the new NuGetAudit properties via a method that does not fall back to DTE.

It turns out `NuGet.PackageManagement`'s `IProjectBuildProperties` was not used outside of VS extension code, so I marked the interface as obsolete, copied the interface (with a small name change) into our VS code, so changes don't count as public API changes. Honestly, when I look at `ProjectJsonNuGetProject.cs`, there's also no reason for this to be in the package we publish to nuget.org (and therefore it's possible that other `*Project.cs` files might not need to be in the package either), but such changes is outside the scope of this PR, and too much risk. The new interface makes it easy for other new properties in the future to avoid hitting DTE.

Finally, it also removes some unnecessary async code, which will slightly reduce allocations.



## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: Existing tests were updated. Also manually tested in VS with SDK style, and non-SDK style projects, plus UWP project, which technically uses the same project system as non-SDK style .NET projects.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
