### PR TITLE
Split hosted build test running up for unit tests, functional tests, and Mono tests

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -66,6 +66,10 @@ parameters:
   displayName: Run tests on Mac
   type: boolean
   default: false
+- name: RunMonoTestsOnMac
+  displayName: Run Mono tests on Mac
+  type: boolean
+  default: true
 
 extends:
   template: templates/pipeline.yml
@@ -83,3 +87,4 @@ extends:
     RunSourceBuild: ${{parameters.RunSourceBuild}}
     RunTestsOnLinux: ${{parameters.RunTestsOnLinux}}
     RunTestsOnMac: ${{parameters.RunTestsOnMac}}
+    RunMonoTestsOnMac: ${{parameters.RunMonoTestsOnMac}}

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -59,6 +59,10 @@ parameters:
   displayName: Run tests on Mac
   type: boolean
   default: true
+- name: RunMonoTestsOnMac
+  displayName: Run Mono tests on Mac
+  type: boolean
+  default: true
 
 extends:
   template: templates/pipeline.yml
@@ -77,3 +81,4 @@ extends:
     RunSourceBuild: ${{parameters.RunSourceBuild}}
     RunTestsOnLinux: ${{parameters.RunTestsOnLinux}}
     RunTestsOnMac: ${{parameters.RunTestsOnMac}}
+    RunMonoTestsOnMac: ${{parameters.RunMonoTestsOnMac}}

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -66,6 +66,10 @@ parameters:
   displayName: Run tests on Mac
   type: boolean
   default: true
+- name: RunMonoTestsOnMac
+  displayName: Run Mono tests on Mac
+  type: boolean
+  default: true
 
 extends:
   template: templates/pipeline.yml
@@ -83,3 +87,4 @@ extends:
     RunSourceBuild: ${{parameters.RunSourceBuild}}
     RunTestsOnLinux: ${{parameters.RunTestsOnLinux}}
     RunTestsOnMac: ${{parameters.RunTestsOnMac}}
+    RunMonoTestsOnMac: ${{parameters.RunMonoTestsOnMac}}

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -180,7 +180,6 @@ steps:
     testResultsFiles: "*.trx"
     testRunTitle: "NuGet.Client Unit Tests On Windows"
     searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
-    mergeTestResults: "true"
     publishRunAttachments: "false"
   condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'))"
 

--- a/eng/pipelines/templates/Functional_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Functional_Tests_On_Windows.yml
@@ -65,7 +65,6 @@ steps:
     testRunner: "VSTest"
     testResultsFiles: "*.trx"
     searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
-    mergeTestResults: "true"
     testRunTitle: "NuGet.Client Functional Tests On Windows"
   condition: "succeededOrFailed()"
 

--- a/eng/pipelines/templates/Tests_On_Linux.yml
+++ b/eng/pipelines/templates/Tests_On_Linux.yml
@@ -25,7 +25,6 @@ steps:
     testResultsFiles: "*.trx"
     testRunTitle: "NuGet.Client $(TestRunDisplayName) On Linux"
     searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
-    mergeTestResults: "true"
   condition: "succeededOrFailed()"
 
 - task: PublishBuildArtifacts@1

--- a/eng/pipelines/templates/Tests_On_Linux.yml
+++ b/eng/pipelines/templates/Tests_On_Linux.yml
@@ -1,19 +1,20 @@
 steps:
 - task: ShellScript@2
-  displayName: "Run Tests (continue on error)"
+  displayName: "Run $(TestRunDisplayName) (continue on error)"
   continueOnError: "true"
   inputs:
     scriptPath: "scripts/funcTests/runFuncTests.sh"
+    args: $(TestRunCommandLineArguments)
     disableAutoCwd: "true"
     cwd: "$(Build.Repository.LocalPath)"
   condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: ShellScript@2
-  displayName: "Run Tests (stop on error)"
+  displayName: "Run $(TestRunDisplayName) (stop on error)"
   continueOnError: "false"
   inputs:
     scriptPath: "scripts/funcTests/runFuncTests.sh"
-    disableAutoCwd: "true"
+    args: $(TestRunCommandLineArguments)
     cwd: "$(Build.Repository.LocalPath)"
   condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
 
@@ -22,7 +23,7 @@ steps:
   inputs:
     testRunner: "VSTest"
     testResultsFiles: "*.trx"
-    testRunTitle: "NuGet.Client Tests On Linux"
+    testRunTitle: "NuGet.Client $(TestRunDisplayName) On Linux"
     searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
     mergeTestResults: "true"
   condition: "succeededOrFailed()"
@@ -41,14 +42,14 @@ steps:
     targetType: "inline"
     script: |
       . $(Build.Repository.LocalPath)/scripts/utils/PostGitCommitStatus.ps1
-      SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(System.AccessToken) -CommitSha $(Build.SourceVersion) -TestName "Tests On Linux"
+      SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(System.AccessToken) -CommitSha $(Build.SourceVersion) -TestName "$(TestRunDisplayName) On Linux"
     failOnStderr: "true"
   condition: "not(eq(variables['ManualGitHubChecks'], 'false'))"
 
 - task: PublishPipelineArtifact@1
   displayName: "Publish binlogs"
   inputs:
-    artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
+    artifactName: binlog - $(TestRunDisplayName) On Linux - Attempt $(System.JobAttempt)
     targetPath: $(Build.StagingDirectory)/binlog
   condition: " or(failed(), eq(variables['System.debug'], 'true')) "
 

--- a/eng/pipelines/templates/Tests_On_Mac.yml
+++ b/eng/pipelines/templates/Tests_On_Mac.yml
@@ -32,7 +32,6 @@ steps:
     testRunner: "VSTest"
     testResultsFiles: "*.trx"
     searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
-    mergeTestResults: "true"
     testRunTitle: "NuGet.Client $(TestRunDisplayName) On Mac"
   condition: "always()"
 

--- a/eng/pipelines/templates/Tests_On_Mac.yml
+++ b/eng/pipelines/templates/Tests_On_Mac.yml
@@ -4,21 +4,24 @@ steps:
   inputs:
     artifactName: "NuGet.CommandLine.Test"
     downloadPath: "$(Build.Repository.LocalPath)/artifacts"
+  condition: "and(succeeded(), eq(variables['TestRunDisplayName'], 'Mono Tests'))"
 
 - task: ShellScript@2
-  displayName: "Run Tests (continue on error)"
+  displayName: "Run $(TestRunDisplayName) (continue on error)"
   continueOnError: "true"
   inputs:
     scriptPath: "scripts/funcTests/runFuncTests.sh"
+    args: $(TestRunCommandLineArguments)
     disableAutoCwd: "true"
     cwd: "$(Build.Repository.LocalPath)"
   condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: ShellScript@2
-  displayName: "Run Tests (stop on error)"
+  displayName: "Run $(TestRunDisplayName) (stop on error)"
   continueOnError: "false"
   inputs:
     scriptPath: "scripts/funcTests/runFuncTests.sh"
+    args: $(TestRunCommandLineArguments)
     disableAutoCwd: "true"
     cwd: "$(Build.Repository.LocalPath)"
   condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
@@ -30,7 +33,7 @@ steps:
     testResultsFiles: "*.trx"
     searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
     mergeTestResults: "true"
-    testRunTitle: "NuGet.Client Tests On Mac"
+    testRunTitle: "NuGet.Client $(TestRunDisplayName) On Mac"
   condition: "always()"
 
 - task: PublishBuildArtifacts@1
@@ -47,14 +50,14 @@ steps:
     targetType: "inline"
     script: |
       . $(Build.Repository.LocalPath)/scripts/utils/PostGitCommitStatus.ps1
-      SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(System.AccessToken) -CommitSha $(Build.SourceVersion) -TestName "Tests On Mac"
+      SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(System.AccessToken) -CommitSha $(Build.SourceVersion) -TestName "$(TestRunDisplayName) On Mac"
     failOnStderr: "true"
   condition: "not(eq(variables['ManualGitHubChecks'], 'false'))"
 
 - task: PublishPipelineArtifact@1
   displayName: "Publish binlogs"
   inputs:
-    artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
+    artifactName: binlog - $(TestRunDisplayName) On Mac - Attempt $(System.JobAttempt)
     targetPath: $(Build.StagingDirectory)/binlog
   condition: " or(failed(), eq(variables['System.debug'], 'true')) "
 

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -70,6 +70,10 @@ parameters:
   displayName: Run tests on Mac
   type: boolean
   default: true
+- name: RunMonoTestsOnMac
+  displayName: Run Mono tests on Mac
+  type: boolean
+  default: false
 
 resources:
   pipelines:
@@ -94,6 +98,7 @@ variables:
   RunSourceBuild: ${{ parameters.RunSourceBuild }}
   RunTestsOnLinux: ${{ parameters.RunTestsOnLinux }}
   RunTestsOnMac: ${{ parameters.RunTestsOnMac }}
+  RunMonoTestsOnMac: ${{ parameters.RunMonoTestsOnMac }}
 
 stages:
 - stage: Initialize
@@ -202,10 +207,12 @@ stages:
     steps:
     - template: Source_Build.yml
 
-- stage: CLI_Func_Tests
+- stage: Tests
+  displayName: "Run Unit and Functional Tests"
   dependsOn: Initialize
   jobs:
   - job: Functional_Tests_On_Windows
+    displayName: "Windows FunctionalTests"
     timeoutInMinutes: 120
     variables:
       BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
@@ -225,6 +232,7 @@ stages:
     - template: Functional_Tests_On_Windows.yml
 
   - job: Tests_On_Linux
+    displayName: "Linux"
     timeoutInMinutes: 45
     variables:
       FULLVSTSBUILDNUMBER: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
@@ -235,10 +243,42 @@ stages:
     condition: "and(succeeded(), ne(variables['RunTestsOnLinux'], 'false'))"
     pool:
       vmImage: ubuntu-latest
+    strategy:
+      matrix:
+        UnitTests:
+          TestRunDisplayName: "Unit Tests"
+          TestRunCommandLineArguments: "--unit-tests"
+        FunctionalTests:
+          TestRunDisplayName: "Functional Tests"
+          TestRunCommandLineArguments: "--functional-tests"
     steps:
-      - template: Tests_On_Linux.yml
+    - template: Tests_On_Linux.yml
+
+  - job: Tests_On_Mac
+    displayName: "Mac"
+    timeoutInMinutes: 45
+    variables:
+      FULLVSTSBUILDNUMBER: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+      MSBUILDDISABLENODEREUSE: 1
+      # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
+      MSBuildEnableWorkloadResolver: false
+      BUILD_NET8: 'false'
+    condition: "and(succeeded(), ne(variables['RunTestsOnMac'], 'false'))"
+    pool:
+      vmImage: macos-latest
+    strategy:
+      matrix:
+        UnitTests:
+          TestRunDisplayName: "Unit Tests"
+          TestRunCommandLineArguments: "--unit-tests"
+        FunctionalTests:
+          TestRunDisplayName: "Functional Tests"
+          TestRunCommandLineArguments: "--functional-tests"
+    steps:
+    - template: Tests_On_Mac.yml
 
   - job: CrossFramework_Tests_On_Windows
+    displayName: "Windows CrossFrameworkTests"
     condition: "and(succeeded(), ne(variables['RunCrossFrameworkTestsOnWindows'], 'false'))"
     timeoutInMinutes: 30
     variables:
@@ -250,18 +290,20 @@ stages:
     - template: CrossFramework_Tests_On_Windows.yml
 
 - stage: MacTests
+  displayName: "Mac Mono Tests"
   dependsOn:
   - Initialize
   - Build_Insertable
   jobs:
-  - job: Tests_On_Mac
-    condition: "and(succeeded(), ne(variables['RunTestsOnMac'], 'false'))"
+  - job: MonoTests_On_Mac
+    condition: "and(succeeded(), ne(variables['RunMonoTestsOnMac'], 'false'))"
     timeoutInMinutes: 90
     variables:
       FULLVSTSBUILDNUMBER: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
       # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
       MSBuildEnableWorkloadResolver: false
-      BUILD_NET8: 'false'
+      TestRunDisplayName: "Mono Tests"
+      TestRunCommandLineArguments: "--mono-tests"
     pool:
       vmImage: macos-latest
     steps:

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+UNIT_TESTS=0
+FUNCTIONAL_TESTS=0
+MONO_TESTS=0
+
+while true ; do
+    case "$1" in
+        -u|--unit-tests) UNIT_TESTS=1 ; shift ;;
+        -f|--functional-tests) FUNCTIONAL_TESTS=1 ; shift ;;
+        -m|--mono-tests) MONO_TESTS=1 ; shift ;;
+        --) shift ; break ;;
+        *) shift ; break ;;
+    esac
+done
+
 # move up to the repo root
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DIR=$SCRIPTDIR/../..
@@ -21,22 +35,25 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-echo "=============== Build and run unit tests started at `date -u +"%Y-%m-%dT%H:%M:%S"` ================="
-echo "dotnet msbuild build/build.proj /restore:false /target:CoreUnitTests /property:Configuration=Release /property:ReleaseLabel=beta /bl:$LOG_DIRECTORY/binlog/03.CoreUnitTests.binlog"
-dotnet msbuild build/build.proj /restore:false /target:CoreUnitTests /property:Configuration=Release /property:ReleaseLabel=beta /bl:$LOG_DIRECTORY/binlog/03.CoreUnitTests.binlog
-UNIT_TEST_RESULT=$?
-echo "=============== Build and run unit tests finished at `date -u +"%Y-%m-%dT%H:%M:%S"`================="
-echo ""
+EXIT_CODE=0
 
-echo "============ Build and run functional tests started at `date -u +"%Y-%m-%dT%H:%M:%S"` =============="
-echo "dotnet msbuild build/build.proj /restore:false /target:CoreFuncTests /property:Configuration=Release /property:ReleaseLabel=beta /bl:$LOG_DIRECTORY/binlog/04.CoreFuncTests.binlog"
-dotnet msbuild build/build.proj /restore:false /target:CoreFuncTests /property:Configuration=Release /property:ReleaseLabel=beta /bl:$LOG_DIRECTORY/binlog/04.CoreFuncTests.binlog
-FUNC_TEST_RESULT=$?
-echo "============== Build and run functional tests finished at `date -u +"%Y-%m-%dT%H:%M:%S"`============"
-echo ""
+if [ "$UNIT_TESTS" == "1" ]; then
+    echo "=============== Build and run unit tests started at `date -u +"%Y-%m-%dT%H:%M:%S"` ================="
+    echo "dotnet msbuild build/build.proj /restore:false /target:CoreUnitTests /property:Configuration=Release /property:ReleaseLabel=beta /bl:$LOG_DIRECTORY/binlog/03.CoreUnitTests.binlog"
+    dotnet msbuild build/build.proj /restore:false /target:CoreUnitTests /property:Configuration=Release /property:ReleaseLabel=beta /bl:$LOG_DIRECTORY/binlog/03.CoreUnitTests.binlog
+    EXIT_CODE=$?
+    echo "=============== Build and run unit tests finished at `date -u +"%Y-%m-%dT%H:%M:%S"`================="
+fi
 
-MONO_TEST_RESULT=-1
-if [ "$CI" == "true" ]; then
+if [ "$FUNCTIONAL_TESTS" == "1" ]; then
+    echo "============ Build and run functional tests started at `date -u +"%Y-%m-%dT%H:%M:%S"` =============="
+    echo "dotnet msbuild build/build.proj /restore:false /target:CoreFuncTests /property:Configuration=Release /property:ReleaseLabel=beta /bl:$LOG_DIRECTORY/binlog/04.CoreFuncTests.binlog"
+    dotnet msbuild build/build.proj /restore:false /target:CoreFuncTests /property:Configuration=Release /property:ReleaseLabel=beta /bl:$LOG_DIRECTORY/binlog/04.CoreFuncTests.binlog
+    EXIT_CODE=$?
+    echo "============== Build and run functional tests finished at `date -u +"%Y-%m-%dT%H:%M:%S"`============"
+fi
+
+if [ "$MONO_TESTS" == "1" ]; then
     # Run mono test
     TestDir="$DIR/artifacts/NuGet.CommandLine.Test/"
     VsTestConsole="$DIR/artifacts/NuGet.CommandLine.Test/vstest/vstest.console.exe"
@@ -55,14 +72,14 @@ if [ "$CI" == "true" ]; then
 			    # We are not testing Mono on linux currently, so comment it out.
 			    #echo "mono $VsTestConsole $TestDir/NuGet.CommandLine.Test.dll --TestCaseFilter:Platform!=Windows&Platform!=Darwin --logger:console;verbosity=$VsTestVerbosity --logger:"trx" --ResultsDirectory:$TestResultsDir"
 			    #mono $VsTestConsole "$TestDir/NuGet.CommandLine.Test.dll" --TestCaseFilter:"Platform!=Windows&Platform!=Darwin" --logger:"console;verbosity=$VsTestVerbosity" --logger:"trx" --ResultsDirectory:"$TestResultsDir"
-			    #MONO_TEST_RESULT=$?
+			    #EXIT_CODE=$?
 			    ;;
 		    Darwin)
                 echo "==================== Run mono tests started at `date -u +"%Y-%m-%dT%H:%M:%S"` ======================"
 			    echo "mono $VsTestConsole $TestDir/NuGet.CommandLine.Test.dll --TestCaseFilter:Platform!=Windows&Platform!=Linux --logger:console;verbosity=$VsTestVerbosity --logger:"trx" --ResultsDirectory:$TestResultsDir"
 			    mono $VsTestConsole "$TestDir/NuGet.CommandLine.Test.dll" --TestCaseFilter:"Platform!=Windows&Platform!=Linux" --logger:"console;verbosity=$VsTestVerbosity" --logger:"trx" --ResultsDirectory:"$TestResultsDir"
-			    MONO_TEST_RESULT=$?
-                echo "================== mono tests finished started at `date -u +"%Y-%m-%dT%H:%M:%S"` ==================="
+			    EXIT_CODE=$?
+                echo "================== mono tests finished at `date -u +"%Y-%m-%dT%H:%M:%S"` ==================="
                 echo ""
 			    ;;
 		    *) ;;
@@ -71,30 +88,10 @@ fi
 
 popd
 
-EXITCODE=0
-
-echo "Test Results:"
-if [ $UNIT_TEST_RESULT -eq 0 ]; then
-    echo "  Unit tests:       Passed"
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "SUCCESS!"
 else
-    EXITCODE=$UNIT_TEST_RESULT
-    echo "  Unit tests:       Failed"
+    echo "FAILED!"
 fi
 
-if [ $FUNC_TEST_RESULT -eq 0 ]; then
-    echo "  Functional tests: Passed"
-else
-    EXITCODE=$FUNC_TEST_RESULT
-    echo "  Functional tests: Failed"
-fi
-
-if [ $MONO_TEST_RESULT -eq -1 ]; then
-    echo "  Mono tests:       Not Run"
-elif [ $MONO_TEST_RESULT -eq 0 ]; then
-    echo "  Mono tests:       Passed"
-else
-    EXITCODE=$MONO_TEST_RESULT
-    echo "  Mono tests:       Failed"
-fi
-
-exit $EXITCODE
+exit $EXIT_CODE

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
 Script to post status of tests for the commit to GitHub
 https://developer.github.com/v3/repos/statuses/
@@ -14,7 +14,7 @@ Function Update-GitCommitStatus {
         [Parameter(Mandatory = $True)]
         [string]$PersonalAccessToken,
         [Parameter(Mandatory = $True)]
-        [ValidateSet( "Build_and_UnitTest_NonRTM", "Build_and_UnitTest_RTM", "Tests On Mac", "Tests On Linux", "Functional_Tests_On_Windows IsDesktop", "Functional_Tests_On_Windows IsCore", "CrossFramework_Tests_On_Windows", "End_To_End_Tests_On_Windows Part1", "End_To_End_Tests_On_Windows Part2", "Apex Tests On Windows", "Rebuild")]
+        [ValidateSet( "Build_and_UnitTest_NonRTM", "Build_and_UnitTest_RTM", "Unit Tests On Mac", "Functional Tests On Mac", "Mono Tests On Mac", "Unit Tests On Linux", "Functional Tests On Linux", "Windows FunctionalTests IsDesktop", "Windows FunctionalTests IsCore", "Windows CrossFrameworkTests", "End_To_End_Tests_On_Windows Part1", "End_To_End_Tests_On_Windows Part2", "Apex Tests On Windows", "Rebuild")]
         [string]$TestName,
         [Parameter(Mandatory = $True)]
         [ValidateSet( "pending", "success", "error", "failure")]
@@ -77,37 +77,43 @@ Function InitializeAllTestsToPending {
     if($env:RunFunctionalTestsOnWindows -eq "true")
     {
         # Setup individual states for the matrixing of jobs in "Functional Tests On Windows".
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional_Tests_On_Windows IsDesktop" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional_Tests_On_Windows IsCore" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Windows FunctionalTests IsDesktop" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Windows FunctionalTests IsCore" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
     }
     else
     {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional_Tests_On_Windows IsDesktop" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional_Tests_On_Windows IsCore" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Windows FunctionalTests IsDesktop" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Windows FunctionalTests IsCore" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
     }
     if($env:RunCrossFrameworkTestsOnWindows -eq "true")
     {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "CrossFramework_Tests_On_Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Windows CrossFrameworkTests" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
     }
     else
     {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "CrossFramework_Tests_On_Windows" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Windows CrossFrameworkTests" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
     }
     if($env:RunTestsOnMac -eq "true")
     {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests On Mac" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Unit Tests On Mac" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional Tests On Mac" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Mono Tests On Mac" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
     }
     else
     {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests On Mac" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Unit Tests On Mac" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional Tests On Mac" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Mono Tests On Mac" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
     }
     if($env:RunTestsOnLinux -eq "true")
     {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests On Linux" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Unit Tests On Linux" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional Tests On Linux" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
     }
     else
     {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests On Linux" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Unit Tests On Linux" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional Tests On Linux" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
     }
     if($env:RunEndToEndTests -eq "true")
     {

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
@@ -11,9 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\NuGet.Core\NuGet.Build.Tasks\NuGet.Build.Tasks.csproj" />
-    <ProjectReference Include="..\..\..\src\NuGet.Core\NuGet.Build.Tasks.Console\NuGet.Build.Tasks.Console.csproj" />
     <ProjectReference Include="..\..\..\src\NuGet.Core\Microsoft.Build.NuGetSdkResolver\Microsoft.Build.NuGetSdkResolver.csproj" />
+    <ProjectReference Include="..\..\..\src\NuGet.Core\NuGet.Build.Tasks.Console\NuGet.Build.Tasks.Console.csproj" />
+    <ProjectReference Include="..\..\..\src\NuGet.Core\NuGet.Build.Tasks.Pack\NuGet.Build.Tasks.Pack.csproj" />
+    <ProjectReference Include="..\..\..\src\NuGet.Core\NuGet.Build.Tasks\NuGet.Build.Tasks.csproj" />
     <ProjectReference Include="..\..\TestUtilities\Test.Utility\Test.Utility.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This splits up the execution of unit tests, functional tests, and Mono tests on Linux and Mac.  This means that the Mac tests start sooner and Mono tests can be made optional.

It also splits up the test runs so its easier to tell if a unit tests or functional test failed which lets us re-run individual unit test runs vs functional test runs in case of a flaky test.

![image](https://user-images.githubusercontent.com/17556515/234933523-9a69e880-6188-4cd5-b5b7-735d7845ff39.png)


## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
