### PR TITLE
Add nullable annotations to NuGet.Frameworks

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/NuGetFrameworkFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/NuGetFrameworkFormatter.cs
@@ -43,7 +43,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                 }
             }
 
-            return NuGetFramework.ParseComponents(frameworkName, platformName);
+            return NuGetFramework.ParseComponents(frameworkName!, platformName);
         }
 
         protected override void SerializeCore(ref MessagePackWriter writer, NuGetFramework value, MessagePackSerializerOptions options)

--- a/src/NuGet.Core/NuGet.Frameworks/AssetTargetFallbackFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/AssetTargetFallbackFramework.cs
@@ -2,15 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using NuGet.Shared;
 
-#if IS_NET40_CLIENT
-using FallbackList = System.Collections.Generic.IList<NuGet.Frameworks.NuGetFramework>;
-#else
 using FallbackList = System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.NuGetFramework>;
-#endif
 
 namespace NuGet.Frameworks
 {
@@ -20,28 +15,17 @@ namespace NuGet.Frameworks
     /// </summary>
     public class AssetTargetFallbackFramework : NuGetFramework, IEquatable<AssetTargetFallbackFramework>
     {
-        private readonly FallbackList _fallback;
         private int? _hashCode;
-        private NuGetFramework _rootFramework;
 
         /// <summary>
         /// List framework to fall back to.
         /// </summary>
-        public FallbackList Fallback
-        {
-            get { return _fallback; }
-        }
+        public FallbackList Fallback { get; }
 
         /// <summary>
         /// Root project framework.
         /// </summary>
-        public NuGetFramework RootFramework
-        {
-            get
-            {
-                return _rootFramework;
-            }
-        }
+        public NuGetFramework RootFramework { get; }
 
         public AssetTargetFallbackFramework(NuGetFramework framework, FallbackList fallbackFrameworks)
             : base(ValidateFrameworkArgument(framework))
@@ -56,14 +40,14 @@ namespace NuGet.Frameworks
                 throw new ArgumentException("Empty fallbackFrameworks is invalid", nameof(fallbackFrameworks));
             }
 
-            _fallback = fallbackFrameworks;
-            _rootFramework = framework;
+            Fallback = fallbackFrameworks;
+            RootFramework = framework;
         }
 
 
         private static NuGetFramework ValidateFrameworkArgument(NuGetFramework framework)
         {
-            if (framework == null)
+            if (framework is null)
             {
                 throw new ArgumentNullException(nameof(framework));
             }
@@ -75,10 +59,10 @@ namespace NuGet.Frameworks
         /// </summary>
         public FallbackFramework AsFallbackFramework()
         {
-            return new FallbackFramework(_rootFramework, _fallback);
+            return new FallbackFramework(RootFramework, Fallback);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as AssetTargetFallbackFramework);
         }
@@ -105,7 +89,7 @@ namespace NuGet.Frameworks
             return _hashCode.Value;
         }
 
-        public bool Equals(AssetTargetFallbackFramework other)
+        public bool Equals(AssetTargetFallbackFramework? other)
         {
             if (other == null)
             {

--- a/src/NuGet.Core/NuGet.Frameworks/CompatibilityCacheKey.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/CompatibilityCacheKey.cs
@@ -53,7 +53,7 @@ namespace NuGet.Frameworks
             return _hashCode;
         }
 
-        public bool Equals(CompatibilityCacheKey other)
+        public bool Equals(CompatibilityCacheKey? other)
         {
             if (other == null)
             {
@@ -69,7 +69,7 @@ namespace NuGet.Frameworks
                 && Candidate.Equals(other.Candidate);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as CompatibilityCacheKey);
         }

--- a/src/NuGet.Core/NuGet.Frameworks/CompatibilityListProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/CompatibilityListProvider.cs
@@ -15,13 +15,15 @@ namespace NuGet.Frameworks
 
         public CompatibilityListProvider(IFrameworkNameProvider nameProvider, IFrameworkCompatibilityProvider compatibilityProvider)
         {
-            _nameProvider = nameProvider;
-            _compatibilityProvider = compatibilityProvider;
+            _nameProvider = nameProvider ?? throw new ArgumentNullException(nameof(nameProvider));
+            _compatibilityProvider = compatibilityProvider ?? throw new ArgumentNullException(nameof(compatibilityProvider));
             _reducer = new FrameworkReducer(_nameProvider, _compatibilityProvider);
         }
 
         public IEnumerable<NuGetFramework> GetFrameworksSupporting(NuGetFramework target)
         {
+            if (target == null) throw new ArgumentNullException(nameof(target));
+
             var remaining = _nameProvider
                 .GetCompatibleCandidates()
                 .Where(candidate => _compatibilityProvider.IsCompatible(candidate, target));
@@ -45,7 +47,7 @@ namespace NuGet.Frameworks
                 .Concat(lookup[true]);
         }
 
-        private static IFrameworkCompatibilityListProvider _default;
+        private static IFrameworkCompatibilityListProvider? _default;
 
         public static IFrameworkCompatibilityListProvider Default
         {

--- a/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
@@ -122,7 +122,7 @@ namespace NuGet.Frameworks
             if (target.IsPCL)
             {
                 // do not include optional frameworks here since we might be unable to tell what is optional on the other framework
-                if (!_mappings.TryGetPortableFrameworks(target.Profile, false, out targetFrameworks))
+                if (!_mappings.TryGetPortableFrameworks(target.Profile, includeOptional: false, out targetFrameworks))
                 {
                     targetFrameworks = Array.Empty<NuGetFramework>();
                 }
@@ -135,7 +135,7 @@ namespace NuGet.Frameworks
             if (candidate.IsPCL)
             {
                 // include optional frameworks here, the larger the list the more compatible it is
-                if (!_mappings.TryGetPortableFrameworks(candidate.Profile, true, out candidateFrameworks))
+                if (!_mappings.TryGetPortableFrameworks(candidate.Profile, includeOptional: true, out candidateFrameworks))
                 {
                     candidateFrameworks = Array.Empty<NuGetFramework>();
                 }

--- a/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
@@ -17,7 +17,7 @@ namespace NuGet.Frameworks
 
         public CompatibilityProvider(IFrameworkNameProvider mappings)
         {
-            _mappings = mappings;
+            _mappings = mappings ?? throw new ArgumentNullException(nameof(mappings));
             _expander = new FrameworkExpander(mappings);
             _cache = new ConcurrentDictionary<CompatibilityCacheKey, bool>();
         }
@@ -30,15 +30,8 @@ namespace NuGet.Frameworks
         /// <returns>True if framework supports other</returns>
         public bool IsCompatible(NuGetFramework target, NuGetFramework candidate)
         {
-            if (target == null)
-            {
-                throw new ArgumentNullException(nameof(target));
-            }
-
-            if (candidate == null)
-            {
-                throw new ArgumentNullException(nameof(candidate));
-            }
+            if (target == null) throw new ArgumentNullException(nameof(target));
+            if (candidate == null) throw new ArgumentNullException(nameof(candidate));
 
             // check the cache for a solution
             var cacheKey = new CompatibilityCacheKey(target, candidate);
@@ -123,13 +116,16 @@ namespace NuGet.Frameworks
                 return IsCompatibleWithTarget(target, candidate);
             }
 
-            IEnumerable<NuGetFramework> targetFrameworks;
-            IEnumerable<NuGetFramework> candidateFrameworks;
+            IEnumerable<NuGetFramework>? targetFrameworks;
+            IEnumerable<NuGetFramework>? candidateFrameworks;
 
             if (target.IsPCL)
             {
                 // do not include optional frameworks here since we might be unable to tell what is optional on the other framework
-                _mappings.TryGetPortableFrameworks(target.Profile, false, out targetFrameworks);
+                if (!_mappings.TryGetPortableFrameworks(target.Profile, false, out targetFrameworks))
+                {
+                    targetFrameworks = Array.Empty<NuGetFramework>();
+                }
             }
             else
             {
@@ -139,7 +135,10 @@ namespace NuGet.Frameworks
             if (candidate.IsPCL)
             {
                 // include optional frameworks here, the larger the list the more compatible it is
-                _mappings.TryGetPortableFrameworks(candidate.Profile, true, out candidateFrameworks);
+                if (!_mappings.TryGetPortableFrameworks(candidate.Profile, true, out candidateFrameworks))
+                {
+                    candidateFrameworks = Array.Empty<NuGetFramework>();
+                }
             }
             else
             {
@@ -241,9 +240,7 @@ namespace NuGet.Frameworks
             {
                 var frameworkToExpand = toExpand.Pop();
 
-                IEnumerable<NuGetFramework> compatibleFrameworks = null;
-
-                if (_mappings.TryGetEquivalentFrameworks(frameworkToExpand, out compatibleFrameworks))
+                if (_mappings.TryGetEquivalentFrameworks(frameworkToExpand, out IEnumerable<NuGetFramework>? compatibleFrameworks))
                 {
                     foreach (var curFramework in compatibleFrameworks)
                     {

--- a/src/NuGet.Core/NuGet.Frameworks/CompatibilityTable.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/CompatibilityTable.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace NuGet.Frameworks
@@ -25,6 +27,10 @@ namespace NuGet.Frameworks
 
         public CompatibilityTable(IEnumerable<NuGetFramework> frameworks, IFrameworkNameProvider mappings, IFrameworkCompatibilityProvider compat)
         {
+            if (frameworks is null) throw new ArgumentNullException(nameof(frameworks));
+            if (mappings is null) throw new ArgumentNullException(nameof(mappings));
+            if (compat is null) throw new ArgumentNullException(nameof(compat));
+
             _compat = compat;
             _mappings = mappings;
             _table = GetTable(frameworks, _compat);
@@ -44,6 +50,8 @@ namespace NuGet.Frameworks
         /// </summary>
         public IEnumerable<NuGetFramework> GetNearest(NuGetFramework framework)
         {
+            if (framework is null) throw new ArgumentNullException(nameof(framework));
+
             // start with everything compatible with the framework
             var allCompatible = _table.Keys.Where(f => _compat.IsCompatible(framework, f));
 
@@ -53,10 +61,9 @@ namespace NuGet.Frameworks
         /// <summary>
         /// Returns the list of all frameworks compatible with the given framework
         /// </summary>
-        public bool TryGetCompatible(NuGetFramework framework, out IEnumerable<NuGetFramework> compatible)
+        public bool TryGetCompatible(NuGetFramework framework, [NotNullWhen(true)] out IEnumerable<NuGetFramework>? compatible)
         {
-            HashSet<NuGetFramework> frameworks = null;
-            if (_table.TryGetValue(framework, out frameworks))
+            if (_table.TryGetValue(framework, out HashSet<NuGetFramework>? frameworks))
             {
                 compatible = new HashSet<NuGetFramework>(frameworks);
                 return true;

--- a/src/NuGet.Core/NuGet.Frameworks/DefaultCompatibilityProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/DefaultCompatibilityProvider.cs
@@ -10,7 +10,7 @@ namespace NuGet.Frameworks
         {
         }
 
-        private static IFrameworkCompatibilityProvider _instance;
+        private static IFrameworkCompatibilityProvider? _instance;
 
         public static IFrameworkCompatibilityProvider Instance
         {

--- a/src/NuGet.Core/NuGet.Frameworks/DualCompatibilityFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/DualCompatibilityFramework.cs
@@ -24,7 +24,7 @@ namespace NuGet.Frameworks
         public NuGetFramework SecondaryFramework { get; }
 
         private int? _hashCode;
-        private FallbackFramework _fallbackFramework;
+        private FallbackFramework? _fallbackFramework;
 
         /// <summary>
         /// Multiple compatbility 
@@ -66,12 +66,12 @@ namespace NuGet.Frameworks
             return framework;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as DualCompatibilityFramework);
         }
 
-        public bool Equals(DualCompatibilityFramework other)
+        public bool Equals(DualCompatibilityFramework? other)
         {
             if (other == null)
             {

--- a/src/NuGet.Core/NuGet.Frameworks/FallbackFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FallbackFramework.cs
@@ -2,15 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using NuGet.Shared;
 
-#if IS_NET40_CLIENT
-using FallbackList = System.Collections.Generic.IList<NuGet.Frameworks.NuGetFramework>;
-#else
 using FallbackList = System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.NuGetFramework>;
-#endif
 
 namespace NuGet.Frameworks
 {
@@ -19,12 +14,8 @@ namespace NuGet.Frameworks
         /// <summary>
         /// List framework to fall back to.
         /// </summary>
-        public FallbackList Fallback
-        {
-            get { return _fallback; }
-        }
+        public FallbackList Fallback { get; }
 
-        private readonly FallbackList _fallback;
         private int? _hashCode;
 
         public FallbackFramework(NuGetFramework framework, FallbackList fallbackFrameworks)
@@ -45,10 +36,10 @@ namespace NuGet.Frameworks
                 throw new ArgumentException("Empty fallbackFrameworks is invalid", nameof(fallbackFrameworks));
             }
 
-            _fallback = fallbackFrameworks;
+            Fallback = fallbackFrameworks;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as FallbackFramework);
         }
@@ -72,7 +63,7 @@ namespace NuGet.Frameworks
             return _hashCode.Value;
         }
 
-        public bool Equals(FallbackFramework other)
+        public bool Equals(FallbackFramework? other)
         {
             if (other == null)
             {

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkExpander.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkExpander.cs
@@ -20,7 +20,7 @@ namespace NuGet.Frameworks
 
         public FrameworkExpander(IFrameworkNameProvider mappings)
         {
-            _mappings = mappings;
+            _mappings = mappings ?? throw new ArgumentNullException(nameof(mappings));
         }
 
         /// <summary>
@@ -28,6 +28,8 @@ namespace NuGet.Frameworks
         /// </summary>
         public IEnumerable<NuGetFramework> Expand(NuGetFramework framework)
         {
+            if (framework == null) throw new ArgumentNullException(nameof(framework));
+
             var seen = new HashSet<NuGetFramework>() { framework };
             var toExpand = new Stack<NuGetFramework>();
             toExpand.Push(framework);
@@ -52,10 +54,8 @@ namespace NuGet.Frameworks
             // but NOT to dotnet (which is deprecated).
             if (framework.IsPCL)
             {
-                int profileNumber;
-                IEnumerable<FrameworkRange> ranges;
-                if (_mappings.TryGetPortableProfileNumber(framework.Profile, out profileNumber)
-                    && _mappings.TryGetPortableCompatibilityMappings(profileNumber, out ranges))
+                if (_mappings.TryGetPortableProfileNumber(framework.Profile, out int profileNumber)
+                    && _mappings.TryGetPortableCompatibilityMappings(profileNumber, out IEnumerable<FrameworkRange>? ranges))
                 {
                     foreach (var range in ranges)
                     {
@@ -76,8 +76,7 @@ namespace NuGet.Frameworks
         private IEnumerable<NuGetFramework> ExpandInternal(NuGetFramework framework)
         {
             // check the framework directly, this includes profiles which the range doesn't return
-            IEnumerable<NuGetFramework> directlyEquivalent = null;
-            if (_mappings.TryGetEquivalentFrameworks(framework, out directlyEquivalent))
+            if (_mappings.TryGetEquivalentFrameworks(framework, out IEnumerable<NuGetFramework>? directlyEquivalent))
             {
                 foreach (var eqFw in directlyEquivalent)
                 {
@@ -90,8 +89,7 @@ namespace NuGet.Frameworks
                 new NuGetFramework(framework.Framework, new Version(0, 0), framework.Profile),
                 framework);
 
-            IEnumerable<NuGetFramework> equivalent = null;
-            if (_mappings.TryGetEquivalentFrameworks(frameworkRange, out equivalent))
+            if (_mappings.TryGetEquivalentFrameworks(frameworkRange, out IEnumerable<NuGetFramework>? equivalent))
             {
                 foreach (var eqFw in equivalent)
                 {
@@ -102,8 +100,7 @@ namespace NuGet.Frameworks
             // find all possible sub set frameworks if no profile is used
             if (!framework.HasProfile)
             {
-                IEnumerable<string> subSetFrameworks = null;
-                if (_mappings.TryGetSubSetFrameworks(framework.Framework, out subSetFrameworks))
+                if (_mappings.TryGetSubSetFrameworks(framework.Framework, out IEnumerable<string>? subSetFrameworks))
                 {
                     foreach (var subFramework in subSetFrameworks)
                     {
@@ -114,8 +111,7 @@ namespace NuGet.Frameworks
             }
 
             // explicit compatiblity mappings
-            IEnumerable<FrameworkRange> ranges = null;
-            if (_mappings.TryGetCompatibilityMappings(framework, out ranges))
+            if (_mappings.TryGetCompatibilityMappings(framework, out IEnumerable<FrameworkRange>? ranges))
             {
                 foreach (var range in ranges)
                 {

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkExtensions.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkExtensions.cs
@@ -21,7 +21,7 @@ namespace NuGet.Frameworks
         /// <summary>
         /// Return the item with the target framework nearest the project framework
         /// </summary>
-        public static T GetNearest<T>(this IEnumerable<T> items, NuGetFramework projectFramework) where T : class, IFrameworkSpecific
+        public static T? GetNearest<T>(this IEnumerable<T> items, NuGetFramework projectFramework) where T : class, IFrameworkSpecific
         {
             return NuGetFrameworkUtility.GetNearest(items, projectFramework, e => e.TargetFramework);
         }

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkNameHelpers.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkNameHelpers.cs
@@ -14,14 +14,14 @@ namespace NuGet.Frameworks
             return String.Format(CultureInfo.InvariantCulture, "Profile{0}", profileNumber);
         }
 
-        public static string GetFolderName(string identifierShortName, string versionString, string profileShortName)
+        public static string GetFolderName(string identifierShortName, string versionString, string? profileShortName)
         {
             return String.Format(CultureInfo.InvariantCulture, "{0}{1}{2}{3}", identifierShortName, versionString, String.IsNullOrEmpty(profileShortName) ? string.Empty : "-", profileShortName);
         }
 
         public static string GetVersionString(Version version)
         {
-            string versionString = null;
+            string? versionString = null;
 
             if (version != null)
             {
@@ -38,12 +38,12 @@ namespace NuGet.Frameworks
                 }
             }
 
-            return versionString;
+            return versionString!;
         }
 
-        public static Version GetVersion(string versionString)
+        public static Version GetVersion(string? versionString)
         {
-            Version version = null;
+            Version version;
 
             if (string.IsNullOrEmpty(versionString))
             {
@@ -51,7 +51,7 @@ namespace NuGet.Frameworks
             }
             else
             {
-                if (versionString.IndexOf('.') > -1)
+                if (versionString!.IndexOf('.') > -1)
                 {
                     // parse the version as a normal dot delimited version
                     _ = Version.TryParse(versionString, out version);

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkNameHelpers.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkNameHelpers.cs
@@ -54,7 +54,7 @@ namespace NuGet.Frameworks
                 if (versionString!.IndexOf('.') > -1)
                 {
                     // parse the version as a normal dot delimited version
-                    _ = Version.TryParse(versionString, out version);
+                    version = Version.Parse(versionString);
                 }
                 else
                 {
@@ -67,7 +67,7 @@ namespace NuGet.Frameworks
                     // take only the first 4 digits and add dots
                     // 451 -> 4.5.1
                     // 81233 -> 8123
-                    _ = Version.TryParse(string.Join(".", versionString.ToCharArray().Take(4)), out version);
+                    version = Version.Parse(string.Join(".", versionString.ToCharArray().Take(4)));
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkNameHelpers.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkNameHelpers.cs
@@ -43,18 +43,16 @@ namespace NuGet.Frameworks
 
         public static Version GetVersion(string? versionString)
         {
-            Version version;
-
             if (string.IsNullOrEmpty(versionString))
             {
-                version = FrameworkConstants.EmptyVersion;
+                return FrameworkConstants.EmptyVersion;
             }
             else
             {
                 if (versionString!.IndexOf('.') > -1)
                 {
                     // parse the version as a normal dot delimited version
-                    version = Version.Parse(versionString);
+                    return Version.Parse(versionString);
                 }
                 else
                 {
@@ -67,11 +65,9 @@ namespace NuGet.Frameworks
                     // take only the first 4 digits and add dots
                     // 451 -> 4.5.1
                     // 81233 -> 8123
-                    version = Version.Parse(string.Join(".", versionString.ToCharArray().Take(4)));
+                    return Version.Parse(string.Join(".", versionString.ToCharArray().Take(4)));
                 }
             }
-
-            return version;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 
@@ -61,7 +62,7 @@ namespace NuGet.Frameworks
         private readonly List<NuGetFramework> _netStandardVersions;
         private readonly List<NuGetFramework> _compatibleCandidates;
 
-        public FrameworkNameProvider(IEnumerable<IFrameworkMappings> mappings, IEnumerable<IPortableFrameworkMappings> portableMappings)
+        public FrameworkNameProvider(IEnumerable<IFrameworkMappings>? mappings, IEnumerable<IPortableFrameworkMappings>? portableMappings)
         {
             _identifierSynonyms = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             _identifierToShortName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -93,7 +94,7 @@ namespace NuGet.Frameworks
         /// <summary>
         /// Converts a key using the mappings, or if the key is already converted, finds the normalized form.
         /// </summary>
-        private static bool TryConvertOrNormalize(string key, IDictionary<string, string> mappings, IDictionary<string, string> reverse, out string value)
+        private static bool TryConvertOrNormalize(string key, IDictionary<string, string> mappings, IDictionary<string, string> reverse, [NotNullWhen(true)] out string? value)
         {
             if (mappings.TryGetValue(key, out value))
             {
@@ -109,27 +110,27 @@ namespace NuGet.Frameworks
             return false;
         }
 
-        public bool TryGetIdentifier(string framework, out string identifier)
+        public bool TryGetIdentifier(string framework, [NotNullWhen(true)] out string? identifier)
         {
             return TryConvertOrNormalize(framework, _identifierSynonyms, _identifierToShortName, out identifier);
         }
 
-        public bool TryGetProfile(string frameworkIdentifier, string profileShortName, out string profile)
+        public bool TryGetProfile(string frameworkIdentifier, string profileShortName, [NotNullWhen(true)] out string? profile)
         {
             return TryConvertOrNormalize(profileShortName, _profileShortToLong, _profilesToShortName, out profile);
         }
 
-        public bool TryGetShortIdentifier(string identifier, out string identifierShortName)
+        public bool TryGetShortIdentifier(string identifier, [NotNullWhen(true)] out string? identifierShortName)
         {
             return TryConvertOrNormalize(identifier, _identifierToShortName, _identifierShortToLong, out identifierShortName);
         }
 
-        public bool TryGetShortProfile(string frameworkIdentifier, string profile, out string profileShortName)
+        public bool TryGetShortProfile(string frameworkIdentifier, string profile, [NotNullWhen(true)] out string? profileShortName)
         {
             return TryConvertOrNormalize(profile, _profilesToShortName, _profileShortToLong, out profileShortName);
         }
 
-        public bool TryGetVersion(string versionString, out Version version)
+        public bool TryGetVersion(string versionString, [NotNullWhen(true)] out Version? version)
         {
             version = null;
 
@@ -162,7 +163,7 @@ namespace NuGet.Frameworks
             return false;
         }
 
-        public bool TryGetPlatformVersion(string versionString, out Version version)
+        public bool TryGetPlatformVersion(string versionString, [NotNullWhen(true)] out Version? version)
         {
             version = null;
 
@@ -347,8 +348,7 @@ namespace NuGet.Frameworks
             {
                 var current = toProcess.Pop();
 
-                HashSet<NuGetFramework> currentEquivalent = null;
-                if (_equivalentFrameworks.TryGetValue(current, out currentEquivalent))
+                if (_equivalentFrameworks.TryGetValue(current, out HashSet<NuGetFramework>? currentEquivalent))
                 {
                     foreach (var equalFramework in currentEquivalent)
                     {
@@ -369,7 +369,7 @@ namespace NuGet.Frameworks
         {
             if (frameworks.Count > 0)
             {
-                NuGetFramework current = null;
+                NuGetFramework? current = null;
                 var remaining = frameworks.Count == 1 ? null : new HashSet<NuGetFramework>();
 
                 var isFirst = true;
@@ -382,16 +382,15 @@ namespace NuGet.Frameworks
                         continue;
                     }
 
-                    remaining.Add(fw);
+                    remaining!.Add(fw);
                 }
 
                 var equalFrameworks = new HashSet<NuGetFramework>();
                 // include ourselves
-                equalFrameworks.Add(current);
+                equalFrameworks.Add(current!);
 
                 // find all equivalent frameworks for the current one
-                HashSet<NuGetFramework> curFrameworks = null;
-                if (_equivalentFrameworks.TryGetValue(current, out curFrameworks))
+                if (_equivalentFrameworks.TryGetValue(current!, out HashSet<NuGetFramework>? curFrameworks))
                 {
                     UnionWith(equalFrameworks, curFrameworks);
                 }
@@ -421,9 +420,7 @@ namespace NuGet.Frameworks
 
         private HashSet<NuGetFramework> GetOptionalFrameworks(int profile)
         {
-            HashSet<NuGetFramework> frameworks = null;
-
-            if (_portableOptionalFrameworks.TryGetValue(profile, out frameworks))
+            if (_portableOptionalFrameworks.TryGetValue(profile, out HashSet<NuGetFramework>? frameworks))
             {
                 return frameworks;
             }
@@ -431,16 +428,15 @@ namespace NuGet.Frameworks
             return EmptyFrameworkSet;
         }
 
-        public bool TryGetPortableFrameworks(int profile, out IEnumerable<NuGetFramework> frameworks)
+        public bool TryGetPortableFrameworks(int profile, [NotNullWhen(true)] out IEnumerable<NuGetFramework>? frameworks)
         {
             return TryGetPortableFrameworks(profile, true, out frameworks);
         }
 
-        public bool TryGetPortableFrameworks(int profile, bool includeOptional, out IEnumerable<NuGetFramework> frameworks)
+        public bool TryGetPortableFrameworks(int profile, bool includeOptional, [NotNullWhen(true)] out IEnumerable<NuGetFramework>? frameworks)
         {
             var result = new HashSet<NuGetFramework>();
-            HashSet<NuGetFramework> tmpFrameworks = null;
-            if (_portableFrameworks.TryGetValue(profile, out tmpFrameworks))
+            if (_portableFrameworks.TryGetValue(profile, out HashSet<NuGetFramework>? tmpFrameworks))
             {
                 foreach (var fw in tmpFrameworks)
                 {
@@ -450,8 +446,7 @@ namespace NuGet.Frameworks
 
             if (includeOptional)
             {
-                HashSet<NuGetFramework> optional = null;
-                if (_portableOptionalFrameworks.TryGetValue(profile, out optional))
+                if (_portableOptionalFrameworks.TryGetValue(profile, out HashSet<NuGetFramework>? optional))
                 {
                     foreach (var fw in optional)
                     {
@@ -464,7 +459,7 @@ namespace NuGet.Frameworks
             return result.Count > 0;
         }
 
-        public bool TryGetPortableFrameworks(string shortPortableProfiles, out IEnumerable<NuGetFramework> frameworks)
+        public bool TryGetPortableFrameworks(string shortPortableProfiles, [NotNullWhen(true)] out IEnumerable<NuGetFramework>? frameworks)
         {
             if (shortPortableProfiles == null)
             {
@@ -494,10 +489,9 @@ namespace NuGet.Frameworks
             return result.Count > 0;
         }
 
-        public bool TryGetPortableCompatibilityMappings(int profile, out IEnumerable<FrameworkRange> supportedFrameworkRanges)
+        public bool TryGetPortableCompatibilityMappings(int profile, [NotNullWhen(true)] out IEnumerable<FrameworkRange>? supportedFrameworkRanges)
         {
-            HashSet<FrameworkRange> entries;
-            if (_portableCompatibilityMappings.TryGetValue(profile, out entries))
+            if (_portableCompatibilityMappings.TryGetValue(profile, out HashSet<FrameworkRange>? entries))
             {
                 supportedFrameworkRanges = entries;
                 return supportedFrameworkRanges.Any();
@@ -520,7 +514,7 @@ namespace NuGet.Frameworks
             return false;
         }
 
-        public bool TryGetPortableFrameworks(string profile, bool includeOptional, out IEnumerable<NuGetFramework> frameworks)
+        public bool TryGetPortableFrameworks(string profile, bool includeOptional, [NotNullWhen(true)] out IEnumerable<NuGetFramework>? frameworks)
         {
             // attempt to parse the profile for a number
             int profileNum;
@@ -539,13 +533,12 @@ namespace NuGet.Frameworks
             return TryGetPortableFrameworks(profile, out frameworks);
         }
 
-        public bool TryGetEquivalentFrameworks(NuGetFramework framework, out IEnumerable<NuGetFramework> frameworks)
+        public bool TryGetEquivalentFrameworks(NuGetFramework framework, [NotNullWhen(true)] out IEnumerable<NuGetFramework>? frameworks)
         {
             var result = new HashSet<NuGetFramework>();
 
             // add in all framework aliases
-            HashSet<NuGetFramework> eqFrameworks = null;
-            if (_equivalentFrameworks.TryGetValue(framework, out eqFrameworks))
+            if (_equivalentFrameworks.TryGetValue(framework, out HashSet<NuGetFramework>? eqFrameworks))
             {
                 foreach (var eqFw in eqFrameworks)
                 {
@@ -559,11 +552,9 @@ namespace NuGet.Frameworks
             // add in all profile aliases
             foreach (var fw in baseFrameworks)
             {
-                Dictionary<string, HashSet<string>> eqProfiles = null;
-                if (_equivalentProfiles.TryGetValue(fw.Framework, out eqProfiles))
+                if (_equivalentProfiles.TryGetValue(fw.Framework, out Dictionary<string, HashSet<string>>? eqProfiles))
                 {
-                    HashSet<string> matchingProfiles = null;
-                    if (eqProfiles.TryGetValue(fw.Profile, out matchingProfiles))
+                    if (eqProfiles.TryGetValue(fw.Profile, out HashSet<string>? matchingProfiles))
                     {
                         foreach (var eqProfile in matchingProfiles)
                         {
@@ -580,7 +571,7 @@ namespace NuGet.Frameworks
             return result.Count > 0;
         }
 
-        public bool TryGetEquivalentFrameworks(FrameworkRange range, out IEnumerable<NuGetFramework> frameworks)
+        public bool TryGetEquivalentFrameworks(FrameworkRange range, [NotNullWhen(true)] out IEnumerable<NuGetFramework>? frameworks)
         {
             if (range == null)
             {
@@ -598,8 +589,7 @@ namespace NuGet.Frameworks
 
             foreach (var framework in relevant)
             {
-                IEnumerable<NuGetFramework> values = null;
-                if (TryGetEquivalentFrameworks(framework, out values))
+                if (TryGetEquivalentFrameworks(framework, out IEnumerable<NuGetFramework>? values))
                 {
                     foreach (var val in values)
                     {
@@ -612,7 +602,7 @@ namespace NuGet.Frameworks
             return results.Count > 0;
         }
 
-        private void InitMappings(IEnumerable<IFrameworkMappings> mappings)
+        private void InitMappings(IEnumerable<IFrameworkMappings>? mappings)
         {
             if (mappings != null)
             {
@@ -651,7 +641,7 @@ namespace NuGet.Frameworks
             }
         }
 
-        private void InitPortableMappings(IEnumerable<IPortableFrameworkMappings> portableMappings)
+        private void InitPortableMappings(IEnumerable<IPortableFrameworkMappings>? portableMappings)
         {
             if (portableMappings != null)
             {
@@ -712,8 +702,7 @@ namespace NuGet.Frameworks
             {
                 foreach (var mapping in mappings)
                 {
-                    HashSet<OneWayCompatibilityMappingEntry> entries;
-                    if (!_compatibilityMappings.TryGetValue(mapping.TargetFrameworkRange.Min.Framework, out entries))
+                    if (!_compatibilityMappings.TryGetValue(mapping.TargetFrameworkRange.Min.Framework, out HashSet<OneWayCompatibilityMappingEntry>? entries))
                     {
                         entries = new HashSet<OneWayCompatibilityMappingEntry>(OneWayCompatibilityMappingEntry.Comparer);
                         _compatibilityMappings.Add(mapping.TargetFrameworkRange.Min.Framework, entries);
@@ -730,8 +719,7 @@ namespace NuGet.Frameworks
             {
                 foreach (var mapping in mappings)
                 {
-                    HashSet<string> subSets = null;
-                    if (!_subSetFrameworks.TryGetValue(mapping.Value, out subSets))
+                    if (!_subSetFrameworks.TryGetValue(mapping.Value, out HashSet<string>? subSets))
                     {
                         subSets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                         _subSetFrameworks.Add(mapping.Value, subSets);
@@ -756,24 +744,19 @@ namespace NuGet.Frameworks
                     var profile1 = profileMapping.Mapping.Key;
                     var profile2 = profileMapping.Mapping.Value;
 
-                    Dictionary<string, HashSet<string>> profileMappings = null;
-
-                    if (!_equivalentProfiles.TryGetValue(frameworkIdentifier, out profileMappings))
+                    if (!_equivalentProfiles.TryGetValue(frameworkIdentifier, out Dictionary<string, HashSet<string>>? profileMappings))
                     {
                         profileMappings = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
                         _equivalentProfiles.Add(frameworkIdentifier, profileMappings);
                     }
 
-                    HashSet<string> innerMappings1 = null;
-                    HashSet<string> innerMappings2 = null;
-
-                    if (!profileMappings.TryGetValue(profile1, out innerMappings1))
+                    if (!profileMappings.TryGetValue(profile1, out HashSet<string>? innerMappings1))
                     {
                         innerMappings1 = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                         profileMappings.Add(profile1, innerMappings1);
                     }
 
-                    if (!profileMappings.TryGetValue(profile2, out innerMappings2))
+                    if (!profileMappings.TryGetValue(profile2, out HashSet<string>? innerMappings2))
                     {
                         innerMappings2 = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                         profileMappings.Add(profile2, innerMappings2);
@@ -808,8 +791,7 @@ namespace NuGet.Frameworks
                             continue;
                         }
 
-                        HashSet<NuGetFramework> eqFrameworks;
-                        if (!_equivalentFrameworks.TryGetValue(next, out eqFrameworks))
+                        if (!_equivalentFrameworks.TryGetValue(next, out HashSet<NuGetFramework>? eqFrameworks))
                         {
                             // initialize set
                             eqFrameworks = new HashSet<NuGetFramework>();
@@ -895,9 +877,7 @@ namespace NuGet.Frameworks
             {
                 foreach (var pair in mappings)
                 {
-                    HashSet<NuGetFramework> frameworks = null;
-
-                    if (!_portableFrameworks.TryGetValue(pair.Key, out frameworks))
+                    if (!_portableFrameworks.TryGetValue(pair.Key, out HashSet<NuGetFramework>? frameworks))
                     {
                         frameworks = new HashSet<NuGetFramework>();
                         _portableFrameworks.Add(pair.Key, frameworks);
@@ -918,9 +898,7 @@ namespace NuGet.Frameworks
             {
                 foreach (var pair in mappings)
                 {
-                    HashSet<NuGetFramework> frameworks = null;
-
-                    if (!_portableOptionalFrameworks.TryGetValue(pair.Key, out frameworks))
+                    if (!_portableOptionalFrameworks.TryGetValue(pair.Key, out HashSet<NuGetFramework>? frameworks))
                     {
                         frameworks = new HashSet<NuGetFramework>();
                         _portableOptionalFrameworks.Add(pair.Key, frameworks);
@@ -940,8 +918,7 @@ namespace NuGet.Frameworks
             {
                 foreach (var mapping in mappings)
                 {
-                    HashSet<FrameworkRange> entries;
-                    if (!_portableCompatibilityMappings.TryGetValue(mapping.Key, out entries))
+                    if (!_portableCompatibilityMappings.TryGetValue(mapping.Key, out HashSet<FrameworkRange>? entries))
                     {
                         entries = new HashSet<FrameworkRange>(new FrameworkRangeComparer());
                         _portableCompatibilityMappings.Add(mapping.Key, entries);
@@ -967,10 +944,9 @@ namespace NuGet.Frameworks
             }
         }
 
-        public bool TryGetCompatibilityMappings(NuGetFramework framework, out IEnumerable<FrameworkRange> supportedFrameworkRanges)
+        public bool TryGetCompatibilityMappings(NuGetFramework framework, [NotNullWhen(true)] out IEnumerable<FrameworkRange>? supportedFrameworkRanges)
         {
-            HashSet<OneWayCompatibilityMappingEntry> entries;
-            if (_compatibilityMappings.TryGetValue(framework.Framework, out entries))
+            if (_compatibilityMappings.TryGetValue(framework.Framework, out HashSet<OneWayCompatibilityMappingEntry>? entries))
             {
                 supportedFrameworkRanges = entries.Where(m => m.TargetFrameworkRange.Satisfies(framework)).Select(m => m.SupportedFrameworkRange);
                 return supportedFrameworkRanges.Any();
@@ -980,10 +956,9 @@ namespace NuGet.Frameworks
             return false;
         }
 
-        public bool TryGetSubSetFrameworks(string frameworkIdentifier, out IEnumerable<string> subSetFrameworks)
+        public bool TryGetSubSetFrameworks(string frameworkIdentifier, [NotNullWhen(true)] out IEnumerable<string>? subSetFrameworks)
         {
-            HashSet<string> values = null;
-            if (_subSetFrameworks.TryGetValue(frameworkIdentifier, out values))
+            if (_subSetFrameworks.TryGetValue(frameworkIdentifier, out HashSet<string>? values))
             {
                 subSetFrameworks = values;
                 return true;
@@ -993,8 +968,12 @@ namespace NuGet.Frameworks
             return false;
         }
 
-        public int CompareFrameworks(NuGetFramework x, NuGetFramework y)
+        public int CompareFrameworks(NuGetFramework? x, NuGetFramework? y)
         {
+            if (x is null && y is null) return 0;
+            if (x is null) return -1;
+            if (y is null) return 1;
+
             // For the purposes of this compare do not treat netcore50 as packages based
             var xPackagesBased = x.IsPackageBased && !NuGetFrameworkUtility.IsNetCore50AndUp(x);
             var yPackagesBased = y.IsPackageBased && !NuGetFrameworkUtility.IsNetCore50AndUp(y);
@@ -1010,13 +989,17 @@ namespace NuGet.Frameworks
             return CompareUsingPrecedence(x, y, precedence);
         }
 
-        public int CompareEquivalentFrameworks(NuGetFramework x, NuGetFramework y)
+        public int CompareEquivalentFrameworks(NuGetFramework? x, NuGetFramework? y)
         {
             return CompareUsingPrecedence(x, y, _equivalentFrameworkPrecedence);
         }
 
-        private static int CompareUsingPrecedence(NuGetFramework x, NuGetFramework y, Dictionary<string, int> precedence)
+        private static int CompareUsingPrecedence(NuGetFramework? x, NuGetFramework? y, Dictionary<string, int> precedence)
         {
+            if (x is null && y is null) return 0;
+            if (x is null) return -1;
+            if (y is null) return 1;
+
             if (StringComparer.OrdinalIgnoreCase.Equals(x.Framework, y.Framework))
             {
                 return 0;
@@ -1040,10 +1023,8 @@ namespace NuGet.Frameworks
 
         public NuGetFramework GetShortNameReplacement(NuGetFramework framework)
         {
-            NuGetFramework result;
-
             // Replace the framework name if a rewrite exists
-            if (!_shortNameRewrites.TryGetValue(framework, out result))
+            if (!_shortNameRewrites.TryGetValue(framework, out NuGetFramework? result))
             {
                 result = framework;
             }
@@ -1053,10 +1034,8 @@ namespace NuGet.Frameworks
 
         public NuGetFramework GetFullNameReplacement(NuGetFramework framework)
         {
-            NuGetFramework result;
-
             // Replace the framework name if a rewrite exists
-            if (!_fullNameRewrites.TryGetValue(framework, out result))
+            if (!_fullNameRewrites.TryGetValue(framework, out NuGetFramework? result))
             {
                 result = framework;
             }
@@ -1135,8 +1114,7 @@ namespace NuGet.Frameworks
                     continue;
                 }
 
-                HashSet<string> subset;
-                if (_subSetFrameworks.TryGetValue(framework.Framework, out subset))
+                if (_subSetFrameworks.TryGetValue(framework.Framework, out HashSet<string>? subset))
                 {
                     foreach (var subFramework in subset)
                     {
@@ -1144,8 +1122,7 @@ namespace NuGet.Frameworks
                     }
                 }
 
-                HashSet<string> superset;
-                if (superSetFrameworks.TryGetValue(framework.Framework, out superset))
+                if (superSetFrameworks.TryGetValue(framework.Framework, out HashSet<string>? superset))
                 {
                     foreach (var superFramework in superset)
                     {

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkRange.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkRange.cs
@@ -11,8 +11,6 @@ namespace NuGet.Frameworks
     /// </summary>
     public class FrameworkRange : IEquatable<FrameworkRange>
     {
-        private readonly NuGetFramework _minFramework;
-        private readonly NuGetFramework _maxFramework;
         private readonly bool _includeMin;
         private readonly bool _includeMax;
 
@@ -24,23 +22,16 @@ namespace NuGet.Frameworks
 
         public FrameworkRange(NuGetFramework min, NuGetFramework max, bool includeMin, bool includeMax)
         {
-            if (min == null)
-            {
-                throw new ArgumentNullException(nameof(min));
-            }
-
-            if (max == null)
-            {
-                throw new ArgumentNullException(nameof(max));
-            }
+            if (min == null) throw new ArgumentNullException(nameof(min));
+            if (max == null) throw new ArgumentNullException(nameof(max));
 
             if (!SameExceptForVersion(min, max))
             {
                 throw new FrameworkException(Strings.FrameworkMismatch);
             }
 
-            _minFramework = min;
-            _maxFramework = max;
+            Min = min;
+            Max = max;
             _includeMin = includeMin;
             _includeMax = includeMax;
         }
@@ -48,18 +39,12 @@ namespace NuGet.Frameworks
         /// <summary>
         /// Minimum Framework
         /// </summary>
-        public NuGetFramework Min
-        {
-            get { return _minFramework; }
-        }
+        public NuGetFramework Min { get; }
 
         /// <summary>
         /// Maximum Framework
         /// </summary>
-        public NuGetFramework Max
-        {
-            get { return _maxFramework; }
-        }
+        public NuGetFramework Max { get; }
 
         /// <summary>
         /// Minimum version inclusiveness.
@@ -86,19 +71,16 @@ namespace NuGet.Frameworks
         /// <summary>
         /// Framework Identifier of both the Min and Max
         /// </summary>
-        public string FrameworkIdentifier
-        {
-            get { return Min.Framework; }
-        }
+        public string FrameworkIdentifier => Min.Framework;
 
         /// <summary>
         /// True if the framework version falls between the min and max
         /// </summary>
         public bool Satisfies(NuGetFramework framework)
         {
-            return SameExceptForVersion(_minFramework, framework)
-                && (_includeMin ? _minFramework.Version <= framework.Version : _minFramework.Version < framework.Version)
-                && (_includeMax ? _maxFramework.Version >= framework.Version : _maxFramework.Version > framework.Version);
+            return SameExceptForVersion(Min, framework)
+                && (_includeMin ? Min.Version <= framework.Version : Min.Version < framework.Version)
+                && (_includeMax ? Max.Version >= framework.Version : Max.Version > framework.Version);
         }
 
         private static bool SameExceptForVersion(NuGetFramework x, NuGetFramework y)
@@ -109,16 +91,16 @@ namespace NuGet.Frameworks
 
         public override string ToString()
         {
-            return String.Format(CultureInfo.InvariantCulture, "[{0}, {1}]", Min.ToString(), Max.ToString());
+            return string.Format(CultureInfo.InvariantCulture, "[{0}, {1}]", Min.ToString(), Max.ToString());
         }
 
-        public bool Equals(FrameworkRange other)
+        public bool Equals(FrameworkRange? other)
         {
             var comparer = new FrameworkRangeComparer();
             return comparer.Equals(this, other);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as FrameworkRange;
 

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkRuntimePair.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkRuntimePair.cs
@@ -9,40 +9,27 @@ namespace NuGet.Frameworks
 {
     public class FrameworkRuntimePair : IEquatable<FrameworkRuntimePair>, IComparable<FrameworkRuntimePair>
     {
-        public NuGetFramework Framework
+        public NuGetFramework Framework { get; }
+
+        public string RuntimeIdentifier { get; }
+
+        public string Name { get; }
+
+        public FrameworkRuntimePair(NuGetFramework framework, string? runtimeIdentifier)
         {
-            get { return _framework; }
+            Framework = framework ?? throw new ArgumentNullException(nameof(framework));
+            RuntimeIdentifier = runtimeIdentifier ?? string.Empty;
+            Name = GetName(framework, runtimeIdentifier);
         }
 
-        public string RuntimeIdentifier
-        {
-            get { return _runtimeIdentifier; }
-        }
-
-        public string Name
-        {
-            get { return _name; }
-        }
-
-        private readonly NuGetFramework _framework;
-        private readonly string _runtimeIdentifier;
-        private readonly string _name;
-
-        public FrameworkRuntimePair(NuGetFramework framework, string runtimeIdentifier)
-        {
-            _framework = framework;
-            _runtimeIdentifier = runtimeIdentifier ?? string.Empty;
-            _name = GetName(framework, runtimeIdentifier);
-        }
-
-        public bool Equals(FrameworkRuntimePair other)
+        public bool Equals(FrameworkRuntimePair? other)
         {
             return other != null &&
                 Equals(Framework, other.Framework) &&
                 string.Equals(RuntimeIdentifier, other.RuntimeIdentifier, StringComparison.Ordinal);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as FrameworkRuntimePair);
         }
@@ -66,8 +53,10 @@ namespace NuGet.Frameworks
             return new FrameworkRuntimePair(Framework, RuntimeIdentifier);
         }
 
-        public int CompareTo(FrameworkRuntimePair other)
+        public int CompareTo(FrameworkRuntimePair? other)
         {
+            if (other == null) return 1;
+
             var fxCompare = string.Compare(Framework.GetShortFolderName(), other.Framework.GetShortFolderName(), StringComparison.Ordinal);
             if (fxCompare != 0)
             {
@@ -76,8 +65,10 @@ namespace NuGet.Frameworks
             return string.Compare(RuntimeIdentifier, other.RuntimeIdentifier, StringComparison.Ordinal);
         }
 
-        public static string GetName(NuGetFramework framework, string runtimeIdentifier)
+        public static string GetName(NuGetFramework framework, string? runtimeIdentifier)
         {
+            if (framework is null) throw new ArgumentNullException(nameof(framework));
+
             if (string.IsNullOrEmpty(runtimeIdentifier))
             {
                 return framework.ToString();
@@ -92,8 +83,10 @@ namespace NuGet.Frameworks
             }
         }
 
-        public static string GetTargetGraphName(NuGetFramework framework, string runtimeIdentifier)
+        public static string GetTargetGraphName(NuGetFramework framework, string? runtimeIdentifier)
         {
+            if (framework is null) throw new ArgumentNullException(nameof(framework));
+
             if (string.IsNullOrEmpty(runtimeIdentifier))
             {
                 return framework.ToString();

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkSpecificMapping.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkSpecificMapping.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace NuGet.Frameworks
@@ -10,9 +11,6 @@ namespace NuGet.Frameworks
     /// </summary>
     public class FrameworkSpecificMapping
     {
-        private readonly string _frameworkIdentifier;
-        private readonly KeyValuePair<string, string> _mapping;
-
         public FrameworkSpecificMapping(string frameworkIdentifier, string key, string value)
             : this(frameworkIdentifier, new KeyValuePair<string, string>(key, value))
         {
@@ -20,18 +18,12 @@ namespace NuGet.Frameworks
 
         public FrameworkSpecificMapping(string frameworkIdentifier, KeyValuePair<string, string> mapping)
         {
-            _frameworkIdentifier = frameworkIdentifier;
-            _mapping = mapping;
+            FrameworkIdentifier = frameworkIdentifier ?? throw new ArgumentNullException(nameof(frameworkIdentifier));
+            Mapping = mapping;
         }
 
-        public string FrameworkIdentifier
-        {
-            get { return _frameworkIdentifier; }
-        }
+        public string FrameworkIdentifier { get; }
 
-        public KeyValuePair<string, string> Mapping
-        {
-            get { return _mapping; }
-        }
+        public KeyValuePair<string, string> Mapping { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
@@ -7,6 +7,7 @@
     <Shipping>true</Shipping>
     <IncludeInVSIX>true</IncludeInVSIX>
     <XPLATProject>true</XPLATProject>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
@@ -42,13 +42,8 @@ namespace NuGet.Frameworks
         /// Creates a new NuGetFramework instance, with an optional profile (only available for netframework)
         /// </summary>
         public NuGetFramework(string frameworkIdentifier, Version frameworkVersion, string? frameworkProfile)
-            : this(frameworkIdentifier, frameworkVersion, profile: ProcessProfile(frameworkProfile), platform: string.Empty, platformVersion: FrameworkConstants.EmptyVersion)
+            : this(frameworkIdentifier, frameworkVersion, profile: frameworkProfile ?? string.Empty, platform: string.Empty, platformVersion: FrameworkConstants.EmptyVersion)
         {
-        }
-
-        private static string ProcessProfile(string? profile)
-        {
-            return profile ?? string.Empty;
         }
 
         /// <summary>
@@ -239,13 +234,13 @@ namespace NuGet.Frameworks
                     sb.Append("-");
 
                     if (framework.HasProfile
-                        && mappings.TryGetPortableFrameworks(framework.Profile, false, out IEnumerable<NuGetFramework>? frameworks)
+                        && mappings.TryGetPortableFrameworks(framework.Profile, includeOptional: false, out IEnumerable<NuGetFramework>? frameworks)
                         && frameworks.Any())
                     {
                         var required = new HashSet<NuGetFramework>(frameworks, Comparer);
 
                         // Normalize by removing all optional frameworks
-                        mappings.TryGetPortableFrameworks(framework.Profile, false, out frameworks);
+                        mappings.TryGetPortableFrameworks(framework.Profile, includeOptional: false, out frameworks);
 
                         // sort the PCL frameworks by alphabetical order
                         var sortedFrameworks = required.Select(e => e.GetShortFolderName(mappings)).OrderBy(e => e, StringComparer.OrdinalIgnoreCase);

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
@@ -17,8 +17,8 @@ namespace NuGet.Frameworks
         private readonly string _frameworkIdentifier;
         private readonly Version _frameworkVersion;
         private readonly string _frameworkProfile;
-        private string _targetFrameworkMoniker;
-        private string _targetPlatformMoniker;
+        private string? _targetFrameworkMoniker;
+        private string? _targetPlatformMoniker;
         private int? _hashCode;
 
         public NuGetFramework(NuGetFramework framework)
@@ -41,12 +41,12 @@ namespace NuGet.Frameworks
         /// <summary>
         /// Creates a new NuGetFramework instance, with an optional profile (only available for netframework)
         /// </summary>
-        public NuGetFramework(string frameworkIdentifier, Version frameworkVersion, string frameworkProfile)
+        public NuGetFramework(string frameworkIdentifier, Version frameworkVersion, string? frameworkProfile)
             : this(frameworkIdentifier, frameworkVersion, profile: ProcessProfile(frameworkProfile), platform: string.Empty, platformVersion: FrameworkConstants.EmptyVersion)
         {
         }
 
-        private static string ProcessProfile(string profile)
+        private static string ProcessProfile(string? profile)
         {
             return profile ?? string.Empty;
         }
@@ -61,25 +61,10 @@ namespace NuGet.Frameworks
 
         internal NuGetFramework(string frameworkIdentifier, Version frameworkVersion, string profile, string platform, Version platformVersion)
         {
-            if (frameworkIdentifier == null)
-            {
-                throw new ArgumentNullException(nameof(frameworkIdentifier));
-            }
-
-            if (frameworkVersion == null)
-            {
-                throw new ArgumentNullException(nameof(frameworkVersion));
-            }
-
-            if (platform == null)
-            {
-                throw new ArgumentNullException(nameof(platform));
-            }
-
-            if (platformVersion == null)
-            {
-                throw new ArgumentNullException(nameof(platformVersion));
-            }
+            if (frameworkIdentifier == null) throw new ArgumentNullException(nameof(frameworkIdentifier));
+            if (frameworkVersion == null) throw new ArgumentNullException(nameof(frameworkVersion));
+            if (platform == null) throw new ArgumentNullException(nameof(platform));
+            if (platformVersion == null) throw new ArgumentNullException(nameof(platformVersion));
 
             _frameworkIdentifier = frameworkIdentifier;
             _frameworkVersion = NormalizeVersion(frameworkVersion);
@@ -93,36 +78,22 @@ namespace NuGet.Frameworks
         /// <summary>
         /// Target framework
         /// </summary>
-        public string Framework
-        {
-            get { return _frameworkIdentifier; }
-        }
+        public string Framework => _frameworkIdentifier;
 
         /// <summary>
         /// Target framework version
         /// </summary>
-        public Version Version
-        {
-            get { return _frameworkVersion; }
-        }
+        public Version Version => _frameworkVersion;
 
         /// <summary>
         /// Framework Platform (net5.0+)
         /// </summary>
-        public string Platform
-        {
-            get;
-            private set;
-        }
+        public string Platform { get; }
 
         /// <summary>
         /// Framework Platform Version (net5.0+)
         /// </summary>
-        public Version PlatformVersion
-        {
-            get;
-            private set;
-        }
+        public Version PlatformVersion { get; }
 
         /// <summary>
         /// True if the platform is non-empty
@@ -143,10 +114,7 @@ namespace NuGet.Frameworks
         /// <summary>
         /// Target framework profile
         /// </summary>
-        public string Profile
-        {
-            get { return _frameworkProfile; }
-        }
+        public string Profile => _frameworkProfile;
 
         /// <summary>The TargetFrameworkMoniker identifier of the current NuGetFramework.</summary>
         /// <remarks>Formatted to a System.Versioning.FrameworkName</remarks>
@@ -270,9 +238,8 @@ namespace NuGet.Frameworks
                 {
                     sb.Append("-");
 
-                    IEnumerable<NuGetFramework> frameworks = null;
                     if (framework.HasProfile
-                        && mappings.TryGetPortableFrameworks(framework.Profile, false, out frameworks)
+                        && mappings.TryGetPortableFrameworks(framework.Profile, false, out IEnumerable<NuGetFramework>? frameworks)
                         && frameworks.Any())
                     {
                         var required = new HashSet<NuGetFramework>(frameworks, Comparer);
@@ -457,17 +424,23 @@ namespace NuGet.Frameworks
                 : DotNetFrameworkName;
         }
 
-        public bool Equals(NuGetFramework other)
+        public bool Equals(NuGetFramework? other)
         {
+#pragma warning disable CS8604 // Possible null reference argument.
+            // Nullable annotations were added to the BCL for IEqualityComparer in .NET 5
             return Comparer.Equals(this, other);
+#pragma warning restore CS8604 // Possible null reference argument.
         }
 
-        public static bool operator ==(NuGetFramework left, NuGetFramework right)
+        public static bool operator ==(NuGetFramework? left, NuGetFramework? right)
         {
+#pragma warning disable CS8604 // Possible null reference argument.
+            // Nullable annotations were added to the BCL for IEqualityComparer in .NET 5
             return Comparer.Equals(left, right);
+#pragma warning restore CS8604 // Possible null reference argument.
         }
 
-        public static bool operator !=(NuGetFramework left, NuGetFramework right)
+        public static bool operator !=(NuGetFramework? left, NuGetFramework? right)
         {
             return !(left == right);
         }
@@ -482,7 +455,7 @@ namespace NuGet.Frameworks
             return _hashCode.Value;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as NuGetFramework;
 

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
@@ -136,9 +136,11 @@ namespace NuGet.Frameworks
             return result;
         }
 
+        private static readonly char[] CommaSeparator = new char[] { ',' };
+
         private static string[] GetParts(string targetPlatformMoniker)
         {
-            return targetPlatformMoniker.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray();
+            return targetPlatformMoniker.Split(CommaSeparator, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray();
         }
 
         /// <summary>
@@ -149,7 +151,7 @@ namespace NuGet.Frameworks
             if (frameworkName == null) throw new ArgumentNullException(nameof(frameworkName));
             if (mappings == null) throw new ArgumentNullException(nameof(mappings));
 
-            string[] parts = frameworkName.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray();
+            string[] parts = frameworkName.Split(CommaSeparator, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray();
 
             // if the first part is a special framework, ignore the rest
             if (!TryParseSpecialFramework(parts[0], out NuGetFramework? result))

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkUtility.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkUtility.cs
@@ -15,7 +15,7 @@ namespace NuGet.Frameworks
         /// <param name="items">framework specific groups or items</param>
         /// <param name="framework">project target framework</param>
         /// <param name="selector">retrieves the framework from the group</param>
-        public static T GetNearest<T>(IEnumerable<T> items, NuGetFramework framework, Func<T, NuGetFramework> selector) where T : class
+        public static T? GetNearest<T>(IEnumerable<T> items, NuGetFramework framework, Func<T, NuGetFramework> selector) where T : class
         {
             return GetNearest<T>(items, framework, DefaultFrameworkNameProvider.Instance, DefaultCompatibilityProvider.Instance, selector);
         }
@@ -27,26 +27,15 @@ namespace NuGet.Frameworks
         /// <param name="framework">project target framework</param>
         /// <param name="selector">retrieves the framework from the group</param>
         /// <param name="frameworkMappings">framework mappings</param>
-        public static T GetNearest<T>(IEnumerable<T> items,
+        public static T? GetNearest<T>(IEnumerable<T> items,
             NuGetFramework framework,
             IFrameworkNameProvider frameworkMappings,
             IFrameworkCompatibilityProvider compatibilityProvider,
             Func<T, NuGetFramework> selector) where T : class
         {
-            if (framework == null)
-            {
-                throw new ArgumentNullException(nameof(framework));
-            }
-
-            if (frameworkMappings == null)
-            {
-                throw new ArgumentNullException(nameof(frameworkMappings));
-            }
-
-            if (compatibilityProvider == null)
-            {
-                throw new ArgumentNullException(nameof(compatibilityProvider));
-            }
+            if (framework == null) throw new ArgumentNullException(nameof(framework));
+            if (frameworkMappings == null) throw new ArgumentNullException(nameof(frameworkMappings));
+            if (compatibilityProvider == null) throw new ArgumentNullException(nameof(compatibilityProvider));
 
             if (items != null)
             {
@@ -67,7 +56,7 @@ namespace NuGet.Frameworks
         /// </summary>
         /// <param name="items">framework specific groups or items</param>
         /// <param name="framework">project target framework</param>
-        public static T GetNearest<T>(IEnumerable<T> items, NuGetFramework framework) where T : IFrameworkSpecific
+        public static T? GetNearest<T>(IEnumerable<T> items, NuGetFramework framework) where T : IFrameworkSpecific
         {
             return GetNearest<T>(items, framework, DefaultFrameworkNameProvider.Instance, DefaultCompatibilityProvider.Instance);
         }
@@ -77,25 +66,14 @@ namespace NuGet.Frameworks
         /// </summary>
         /// <param name="items">framework specific groups or items</param>
         /// <param name="framework">project target framework</param>
-        public static T GetNearest<T>(IEnumerable<T> items,
+        public static T? GetNearest<T>(IEnumerable<T> items,
                                         NuGetFramework framework,
                                         IFrameworkNameProvider frameworkMappings,
                                         IFrameworkCompatibilityProvider compatibilityProvider) where T : IFrameworkSpecific
         {
-            if (framework == null)
-            {
-                throw new ArgumentNullException(nameof(framework));
-            }
-
-            if (frameworkMappings == null)
-            {
-                throw new ArgumentNullException(nameof(frameworkMappings));
-            }
-
-            if (compatibilityProvider == null)
-            {
-                throw new ArgumentNullException(nameof(compatibilityProvider));
-            }
+            if (framework == null) throw new ArgumentNullException(nameof(framework));
+            if (frameworkMappings == null) throw new ArgumentNullException(nameof(frameworkMappings));
+            if (compatibilityProvider == null) throw new ArgumentNullException(nameof(compatibilityProvider));
 
             if (items != null)
             {
@@ -116,6 +94,9 @@ namespace NuGet.Frameworks
         /// </summary>
         public static bool IsCompatibleWithFallbackCheck(NuGetFramework projectFramework, NuGetFramework candidate)
         {
+            if (projectFramework is null) throw new ArgumentNullException(nameof(projectFramework));
+            if (candidate is null) throw new ArgumentNullException(nameof(candidate));
+
             var compatible = DefaultCompatibilityProvider.Instance.IsCompatible(projectFramework, candidate);
 
             if (!compatible)

--- a/src/NuGet.Core/NuGet.Frameworks/OneWayCompatibilityMappingEntry.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/OneWayCompatibilityMappingEntry.cs
@@ -44,7 +44,7 @@ namespace NuGet.Frameworks
             get { return new CompatibilityMappingComparer(); }
         }
 
-        public bool Equals(OneWayCompatibilityMappingEntry other)
+        public bool Equals(OneWayCompatibilityMappingEntry? other)
         {
             return Comparer.Equals(this, other);
         }

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI.Shipped.txt
@@ -1,194 +1,194 @@
 #nullable enable
 NuGet.Frameworks.AssetTargetFallbackFramework
-~NuGet.Frameworks.AssetTargetFallbackFramework.AsFallbackFramework() -> NuGet.Frameworks.FallbackFramework
-~NuGet.Frameworks.AssetTargetFallbackFramework.AssetTargetFallbackFramework(NuGet.Frameworks.NuGetFramework framework, System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.NuGetFramework> fallbackFrameworks) -> void
-~NuGet.Frameworks.AssetTargetFallbackFramework.Equals(NuGet.Frameworks.AssetTargetFallbackFramework other) -> bool
-~NuGet.Frameworks.AssetTargetFallbackFramework.Fallback.get -> System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.NuGetFramework>
-~NuGet.Frameworks.AssetTargetFallbackFramework.RootFramework.get -> NuGet.Frameworks.NuGetFramework
+NuGet.Frameworks.AssetTargetFallbackFramework.AsFallbackFramework() -> NuGet.Frameworks.FallbackFramework!
+NuGet.Frameworks.AssetTargetFallbackFramework.AssetTargetFallbackFramework(NuGet.Frameworks.NuGetFramework! framework, System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.NuGetFramework!>! fallbackFrameworks) -> void
+NuGet.Frameworks.AssetTargetFallbackFramework.Equals(NuGet.Frameworks.AssetTargetFallbackFramework? other) -> bool
+NuGet.Frameworks.AssetTargetFallbackFramework.Fallback.get -> System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.NuGetFramework!>!
+NuGet.Frameworks.AssetTargetFallbackFramework.RootFramework.get -> NuGet.Frameworks.NuGetFramework!
 NuGet.Frameworks.CompatibilityListProvider
-~NuGet.Frameworks.CompatibilityListProvider.CompatibilityListProvider(NuGet.Frameworks.IFrameworkNameProvider nameProvider, NuGet.Frameworks.IFrameworkCompatibilityProvider compatibilityProvider) -> void
-~NuGet.Frameworks.CompatibilityListProvider.GetFrameworksSupporting(NuGet.Frameworks.NuGetFramework target) -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework>
+NuGet.Frameworks.CompatibilityListProvider.CompatibilityListProvider(NuGet.Frameworks.IFrameworkNameProvider! nameProvider, NuGet.Frameworks.IFrameworkCompatibilityProvider! compatibilityProvider) -> void
+NuGet.Frameworks.CompatibilityListProvider.GetFrameworksSupporting(NuGet.Frameworks.NuGetFramework! target) -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>!
 NuGet.Frameworks.CompatibilityMappingComparer
 NuGet.Frameworks.CompatibilityMappingComparer.CompatibilityMappingComparer() -> void
-~NuGet.Frameworks.CompatibilityMappingComparer.Equals(NuGet.Frameworks.OneWayCompatibilityMappingEntry x, NuGet.Frameworks.OneWayCompatibilityMappingEntry y) -> bool
-~NuGet.Frameworks.CompatibilityMappingComparer.GetHashCode(NuGet.Frameworks.OneWayCompatibilityMappingEntry obj) -> int
+NuGet.Frameworks.CompatibilityMappingComparer.Equals(NuGet.Frameworks.OneWayCompatibilityMappingEntry? x, NuGet.Frameworks.OneWayCompatibilityMappingEntry? y) -> bool
+NuGet.Frameworks.CompatibilityMappingComparer.GetHashCode(NuGet.Frameworks.OneWayCompatibilityMappingEntry! obj) -> int
 NuGet.Frameworks.CompatibilityProvider
-~NuGet.Frameworks.CompatibilityProvider.CompatibilityProvider(NuGet.Frameworks.IFrameworkNameProvider mappings) -> void
-~NuGet.Frameworks.CompatibilityProvider.IsCompatible(NuGet.Frameworks.NuGetFramework target, NuGet.Frameworks.NuGetFramework candidate) -> bool
+NuGet.Frameworks.CompatibilityProvider.CompatibilityProvider(NuGet.Frameworks.IFrameworkNameProvider! mappings) -> void
+NuGet.Frameworks.CompatibilityProvider.IsCompatible(NuGet.Frameworks.NuGetFramework! target, NuGet.Frameworks.NuGetFramework! candidate) -> bool
 NuGet.Frameworks.CompatibilityTable
-~NuGet.Frameworks.CompatibilityTable.CompatibilityTable(System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> frameworks) -> void
-~NuGet.Frameworks.CompatibilityTable.CompatibilityTable(System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> frameworks, NuGet.Frameworks.IFrameworkNameProvider mappings, NuGet.Frameworks.IFrameworkCompatibilityProvider compat) -> void
-~NuGet.Frameworks.CompatibilityTable.GetNearest(NuGet.Frameworks.NuGetFramework framework) -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework>
-~NuGet.Frameworks.CompatibilityTable.HasFramework(NuGet.Frameworks.NuGetFramework framework) -> bool
-~NuGet.Frameworks.CompatibilityTable.TryGetCompatible(NuGet.Frameworks.NuGetFramework framework, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> compatible) -> bool
+NuGet.Frameworks.CompatibilityTable.CompatibilityTable(System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>! frameworks) -> void
+NuGet.Frameworks.CompatibilityTable.CompatibilityTable(System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>! frameworks, NuGet.Frameworks.IFrameworkNameProvider! mappings, NuGet.Frameworks.IFrameworkCompatibilityProvider! compat) -> void
+NuGet.Frameworks.CompatibilityTable.GetNearest(NuGet.Frameworks.NuGetFramework! framework) -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>!
+NuGet.Frameworks.CompatibilityTable.HasFramework(NuGet.Frameworks.NuGetFramework! framework) -> bool
+NuGet.Frameworks.CompatibilityTable.TryGetCompatible(NuGet.Frameworks.NuGetFramework! framework, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>? compatible) -> bool
 NuGet.Frameworks.DefaultCompatibilityProvider
 NuGet.Frameworks.DefaultCompatibilityProvider.DefaultCompatibilityProvider() -> void
 NuGet.Frameworks.DefaultFrameworkMappings
-~NuGet.Frameworks.DefaultFrameworkMappings.CompatibilityMappings.get -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.OneWayCompatibilityMappingEntry>
+NuGet.Frameworks.DefaultFrameworkMappings.CompatibilityMappings.get -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.OneWayCompatibilityMappingEntry!>!
 NuGet.Frameworks.DefaultFrameworkMappings.DefaultFrameworkMappings() -> void
-~NuGet.Frameworks.DefaultFrameworkMappings.EquivalentFrameworkPrecedence.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Frameworks.DefaultFrameworkMappings.EquivalentFrameworks.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<NuGet.Frameworks.NuGetFramework, NuGet.Frameworks.NuGetFramework>>
-~NuGet.Frameworks.DefaultFrameworkMappings.EquivalentProfiles.get -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.FrameworkSpecificMapping>
-~NuGet.Frameworks.DefaultFrameworkMappings.FullNameReplacements.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<NuGet.Frameworks.NuGetFramework, NuGet.Frameworks.NuGetFramework>>
-~NuGet.Frameworks.DefaultFrameworkMappings.IdentifierShortNames.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>
-~NuGet.Frameworks.DefaultFrameworkMappings.IdentifierSynonyms.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>
-~NuGet.Frameworks.DefaultFrameworkMappings.NonPackageBasedFrameworkPrecedence.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Frameworks.DefaultFrameworkMappings.PackageBasedFrameworkPrecedence.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Frameworks.DefaultFrameworkMappings.ProfileShortNames.get -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.FrameworkSpecificMapping>
-~NuGet.Frameworks.DefaultFrameworkMappings.ShortNameReplacements.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<NuGet.Frameworks.NuGetFramework, NuGet.Frameworks.NuGetFramework>>
-~NuGet.Frameworks.DefaultFrameworkMappings.SubSetFrameworks.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>
+NuGet.Frameworks.DefaultFrameworkMappings.EquivalentFrameworkPrecedence.get -> System.Collections.Generic.IEnumerable<string!>!
+NuGet.Frameworks.DefaultFrameworkMappings.EquivalentFrameworks.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<NuGet.Frameworks.NuGetFramework!, NuGet.Frameworks.NuGetFramework!>>!
+NuGet.Frameworks.DefaultFrameworkMappings.EquivalentProfiles.get -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.FrameworkSpecificMapping!>!
+NuGet.Frameworks.DefaultFrameworkMappings.FullNameReplacements.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<NuGet.Frameworks.NuGetFramework!, NuGet.Frameworks.NuGetFramework!>>!
+NuGet.Frameworks.DefaultFrameworkMappings.IdentifierShortNames.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, string!>>!
+NuGet.Frameworks.DefaultFrameworkMappings.IdentifierSynonyms.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, string!>>!
+NuGet.Frameworks.DefaultFrameworkMappings.NonPackageBasedFrameworkPrecedence.get -> System.Collections.Generic.IEnumerable<string!>!
+NuGet.Frameworks.DefaultFrameworkMappings.PackageBasedFrameworkPrecedence.get -> System.Collections.Generic.IEnumerable<string!>!
+NuGet.Frameworks.DefaultFrameworkMappings.ProfileShortNames.get -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.FrameworkSpecificMapping!>!
+NuGet.Frameworks.DefaultFrameworkMappings.ShortNameReplacements.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<NuGet.Frameworks.NuGetFramework!, NuGet.Frameworks.NuGetFramework!>>!
+NuGet.Frameworks.DefaultFrameworkMappings.SubSetFrameworks.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, string!>>!
 NuGet.Frameworks.DefaultFrameworkNameProvider
 NuGet.Frameworks.DefaultFrameworkNameProvider.DefaultFrameworkNameProvider() -> void
 NuGet.Frameworks.DefaultPortableFrameworkMappings
-~NuGet.Frameworks.DefaultPortableFrameworkMappings.CompatibilityMappings.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, NuGet.Frameworks.FrameworkRange>>
+NuGet.Frameworks.DefaultPortableFrameworkMappings.CompatibilityMappings.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, NuGet.Frameworks.FrameworkRange!>>!
 NuGet.Frameworks.DefaultPortableFrameworkMappings.DefaultPortableFrameworkMappings() -> void
-~NuGet.Frameworks.DefaultPortableFrameworkMappings.ProfileFrameworks.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, NuGet.Frameworks.NuGetFramework[]>>
-~NuGet.Frameworks.DefaultPortableFrameworkMappings.ProfileOptionalFrameworks.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, NuGet.Frameworks.NuGetFramework[]>>
+NuGet.Frameworks.DefaultPortableFrameworkMappings.ProfileFrameworks.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, NuGet.Frameworks.NuGetFramework![]!>>!
+NuGet.Frameworks.DefaultPortableFrameworkMappings.ProfileOptionalFrameworks.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, NuGet.Frameworks.NuGetFramework![]!>>!
 NuGet.Frameworks.DualCompatibilityFramework
-~NuGet.Frameworks.DualCompatibilityFramework.AsFallbackFramework() -> NuGet.Frameworks.FallbackFramework
-~NuGet.Frameworks.DualCompatibilityFramework.DualCompatibilityFramework(NuGet.Frameworks.NuGetFramework framework, NuGet.Frameworks.NuGetFramework secondaryFramework) -> void
-~NuGet.Frameworks.DualCompatibilityFramework.Equals(NuGet.Frameworks.DualCompatibilityFramework other) -> bool
-~NuGet.Frameworks.DualCompatibilityFramework.RootFramework.get -> NuGet.Frameworks.NuGetFramework
-~NuGet.Frameworks.DualCompatibilityFramework.SecondaryFramework.get -> NuGet.Frameworks.NuGetFramework
+NuGet.Frameworks.DualCompatibilityFramework.AsFallbackFramework() -> NuGet.Frameworks.FallbackFramework!
+NuGet.Frameworks.DualCompatibilityFramework.DualCompatibilityFramework(NuGet.Frameworks.NuGetFramework! framework, NuGet.Frameworks.NuGetFramework! secondaryFramework) -> void
+NuGet.Frameworks.DualCompatibilityFramework.Equals(NuGet.Frameworks.DualCompatibilityFramework? other) -> bool
+NuGet.Frameworks.DualCompatibilityFramework.RootFramework.get -> NuGet.Frameworks.NuGetFramework!
+NuGet.Frameworks.DualCompatibilityFramework.SecondaryFramework.get -> NuGet.Frameworks.NuGetFramework!
 NuGet.Frameworks.FallbackFramework
-~NuGet.Frameworks.FallbackFramework.Equals(NuGet.Frameworks.FallbackFramework other) -> bool
-~NuGet.Frameworks.FallbackFramework.Fallback.get -> System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.NuGetFramework>
-~NuGet.Frameworks.FallbackFramework.FallbackFramework(NuGet.Frameworks.NuGetFramework framework, System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.NuGetFramework> fallbackFrameworks) -> void
+NuGet.Frameworks.FallbackFramework.Equals(NuGet.Frameworks.FallbackFramework? other) -> bool
+NuGet.Frameworks.FallbackFramework.Fallback.get -> System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.NuGetFramework!>!
+NuGet.Frameworks.FallbackFramework.FallbackFramework(NuGet.Frameworks.NuGetFramework! framework, System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.NuGetFramework!>! fallbackFrameworks) -> void
 NuGet.Frameworks.FrameworkConstants
 NuGet.Frameworks.FrameworkConstants.CommonFrameworks
 NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers
 NuGet.Frameworks.FrameworkConstants.PlatformIdentifiers
 NuGet.Frameworks.FrameworkConstants.SpecialIdentifiers
 NuGet.Frameworks.FrameworkException
-~NuGet.Frameworks.FrameworkException.FrameworkException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~NuGet.Frameworks.FrameworkException.FrameworkException(string message) -> void
+NuGet.Frameworks.FrameworkException.FrameworkException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+NuGet.Frameworks.FrameworkException.FrameworkException(string! message) -> void
 NuGet.Frameworks.FrameworkExpander
-~NuGet.Frameworks.FrameworkExpander.Expand(NuGet.Frameworks.NuGetFramework framework) -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework>
+NuGet.Frameworks.FrameworkExpander.Expand(NuGet.Frameworks.NuGetFramework! framework) -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>!
 NuGet.Frameworks.FrameworkExpander.FrameworkExpander() -> void
-~NuGet.Frameworks.FrameworkExpander.FrameworkExpander(NuGet.Frameworks.IFrameworkNameProvider mappings) -> void
+NuGet.Frameworks.FrameworkExpander.FrameworkExpander(NuGet.Frameworks.IFrameworkNameProvider! mappings) -> void
 NuGet.Frameworks.FrameworkNameHelpers
 NuGet.Frameworks.FrameworkNameProvider
-~NuGet.Frameworks.FrameworkNameProvider.AddFrameworkPrecedenceMappings(System.Collections.Generic.IDictionary<string, int> destination, System.Collections.Generic.IEnumerable<string> mappings) -> void
-~NuGet.Frameworks.FrameworkNameProvider.CompareEquivalentFrameworks(NuGet.Frameworks.NuGetFramework x, NuGet.Frameworks.NuGetFramework y) -> int
-~NuGet.Frameworks.FrameworkNameProvider.CompareFrameworks(NuGet.Frameworks.NuGetFramework x, NuGet.Frameworks.NuGetFramework y) -> int
-~NuGet.Frameworks.FrameworkNameProvider.FrameworkNameProvider(System.Collections.Generic.IEnumerable<NuGet.Frameworks.IFrameworkMappings> mappings, System.Collections.Generic.IEnumerable<NuGet.Frameworks.IPortableFrameworkMappings> portableMappings) -> void
-~NuGet.Frameworks.FrameworkNameProvider.GetCompatibleCandidates() -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework>
-~NuGet.Frameworks.FrameworkNameProvider.GetFullNameReplacement(NuGet.Frameworks.NuGetFramework framework) -> NuGet.Frameworks.NuGetFramework
-~NuGet.Frameworks.FrameworkNameProvider.GetNetStandardVersions() -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework>
-~NuGet.Frameworks.FrameworkNameProvider.GetShortNameReplacement(NuGet.Frameworks.NuGetFramework framework) -> NuGet.Frameworks.NuGetFramework
-~NuGet.Frameworks.FrameworkNameProvider.GetVersionString(string framework, System.Version version) -> string
-~NuGet.Frameworks.FrameworkNameProvider.TryGetCompatibilityMappings(NuGet.Frameworks.NuGetFramework framework, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.FrameworkRange> supportedFrameworkRanges) -> bool
-~NuGet.Frameworks.FrameworkNameProvider.TryGetEquivalentFrameworks(NuGet.Frameworks.FrameworkRange range, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> frameworks) -> bool
-~NuGet.Frameworks.FrameworkNameProvider.TryGetEquivalentFrameworks(NuGet.Frameworks.NuGetFramework framework, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> frameworks) -> bool
-~NuGet.Frameworks.FrameworkNameProvider.TryGetIdentifier(string framework, out string identifier) -> bool
-~NuGet.Frameworks.FrameworkNameProvider.TryGetPlatformVersion(string versionString, out System.Version version) -> bool
-~NuGet.Frameworks.FrameworkNameProvider.TryGetPortableCompatibilityMappings(int profile, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.FrameworkRange> supportedFrameworkRanges) -> bool
-~NuGet.Frameworks.FrameworkNameProvider.TryGetPortableFrameworks(int profile, bool includeOptional, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> frameworks) -> bool
-~NuGet.Frameworks.FrameworkNameProvider.TryGetPortableFrameworks(int profile, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> frameworks) -> bool
-~NuGet.Frameworks.FrameworkNameProvider.TryGetPortableFrameworks(string profile, bool includeOptional, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> frameworks) -> bool
-~NuGet.Frameworks.FrameworkNameProvider.TryGetPortableFrameworks(string shortPortableProfiles, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> frameworks) -> bool
-~NuGet.Frameworks.FrameworkNameProvider.TryGetPortableProfile(System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> supportedFrameworks, out int profileNumber) -> bool
-~NuGet.Frameworks.FrameworkNameProvider.TryGetPortableProfileNumber(string profile, out int profileNumber) -> bool
-~NuGet.Frameworks.FrameworkNameProvider.TryGetProfile(string frameworkIdentifier, string profileShortName, out string profile) -> bool
-~NuGet.Frameworks.FrameworkNameProvider.TryGetShortIdentifier(string identifier, out string identifierShortName) -> bool
-~NuGet.Frameworks.FrameworkNameProvider.TryGetShortProfile(string frameworkIdentifier, string profile, out string profileShortName) -> bool
-~NuGet.Frameworks.FrameworkNameProvider.TryGetSubSetFrameworks(string frameworkIdentifier, out System.Collections.Generic.IEnumerable<string> subSetFrameworks) -> bool
-~NuGet.Frameworks.FrameworkNameProvider.TryGetVersion(string versionString, out System.Version version) -> bool
+NuGet.Frameworks.FrameworkNameProvider.AddFrameworkPrecedenceMappings(System.Collections.Generic.IDictionary<string!, int>! destination, System.Collections.Generic.IEnumerable<string!>! mappings) -> void
+NuGet.Frameworks.FrameworkNameProvider.CompareEquivalentFrameworks(NuGet.Frameworks.NuGetFramework? x, NuGet.Frameworks.NuGetFramework? y) -> int
+NuGet.Frameworks.FrameworkNameProvider.CompareFrameworks(NuGet.Frameworks.NuGetFramework? x, NuGet.Frameworks.NuGetFramework? y) -> int
+NuGet.Frameworks.FrameworkNameProvider.FrameworkNameProvider(System.Collections.Generic.IEnumerable<NuGet.Frameworks.IFrameworkMappings!>? mappings, System.Collections.Generic.IEnumerable<NuGet.Frameworks.IPortableFrameworkMappings!>? portableMappings) -> void
+NuGet.Frameworks.FrameworkNameProvider.GetCompatibleCandidates() -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>!
+NuGet.Frameworks.FrameworkNameProvider.GetFullNameReplacement(NuGet.Frameworks.NuGetFramework! framework) -> NuGet.Frameworks.NuGetFramework!
+NuGet.Frameworks.FrameworkNameProvider.GetNetStandardVersions() -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>!
+NuGet.Frameworks.FrameworkNameProvider.GetShortNameReplacement(NuGet.Frameworks.NuGetFramework! framework) -> NuGet.Frameworks.NuGetFramework!
+NuGet.Frameworks.FrameworkNameProvider.GetVersionString(string! framework, System.Version! version) -> string!
+NuGet.Frameworks.FrameworkNameProvider.TryGetCompatibilityMappings(NuGet.Frameworks.NuGetFramework! framework, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.FrameworkRange!>? supportedFrameworkRanges) -> bool
+NuGet.Frameworks.FrameworkNameProvider.TryGetEquivalentFrameworks(NuGet.Frameworks.FrameworkRange! range, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>? frameworks) -> bool
+NuGet.Frameworks.FrameworkNameProvider.TryGetEquivalentFrameworks(NuGet.Frameworks.NuGetFramework! framework, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>? frameworks) -> bool
+NuGet.Frameworks.FrameworkNameProvider.TryGetIdentifier(string! framework, out string? identifier) -> bool
+NuGet.Frameworks.FrameworkNameProvider.TryGetPlatformVersion(string! versionString, out System.Version? version) -> bool
+NuGet.Frameworks.FrameworkNameProvider.TryGetPortableCompatibilityMappings(int profile, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.FrameworkRange!>? supportedFrameworkRanges) -> bool
+NuGet.Frameworks.FrameworkNameProvider.TryGetPortableFrameworks(int profile, bool includeOptional, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>? frameworks) -> bool
+NuGet.Frameworks.FrameworkNameProvider.TryGetPortableFrameworks(int profile, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>? frameworks) -> bool
+NuGet.Frameworks.FrameworkNameProvider.TryGetPortableFrameworks(string! profile, bool includeOptional, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>? frameworks) -> bool
+NuGet.Frameworks.FrameworkNameProvider.TryGetPortableFrameworks(string! shortPortableProfiles, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>? frameworks) -> bool
+NuGet.Frameworks.FrameworkNameProvider.TryGetPortableProfile(System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>! supportedFrameworks, out int profileNumber) -> bool
+NuGet.Frameworks.FrameworkNameProvider.TryGetPortableProfileNumber(string! profile, out int profileNumber) -> bool
+NuGet.Frameworks.FrameworkNameProvider.TryGetProfile(string! frameworkIdentifier, string! profileShortName, out string? profile) -> bool
+NuGet.Frameworks.FrameworkNameProvider.TryGetShortIdentifier(string! identifier, out string? identifierShortName) -> bool
+NuGet.Frameworks.FrameworkNameProvider.TryGetShortProfile(string! frameworkIdentifier, string! profile, out string? profileShortName) -> bool
+NuGet.Frameworks.FrameworkNameProvider.TryGetSubSetFrameworks(string! frameworkIdentifier, out System.Collections.Generic.IEnumerable<string!>? subSetFrameworks) -> bool
+NuGet.Frameworks.FrameworkNameProvider.TryGetVersion(string! versionString, out System.Version? version) -> bool
 NuGet.Frameworks.FrameworkPrecedenceSorter
-~NuGet.Frameworks.FrameworkPrecedenceSorter.Compare(NuGet.Frameworks.NuGetFramework x, NuGet.Frameworks.NuGetFramework y) -> int
-~NuGet.Frameworks.FrameworkPrecedenceSorter.FrameworkPrecedenceSorter(NuGet.Frameworks.IFrameworkNameProvider mappings, bool allEquivalent) -> void
+NuGet.Frameworks.FrameworkPrecedenceSorter.Compare(NuGet.Frameworks.NuGetFramework? x, NuGet.Frameworks.NuGetFramework? y) -> int
+NuGet.Frameworks.FrameworkPrecedenceSorter.FrameworkPrecedenceSorter(NuGet.Frameworks.IFrameworkNameProvider! mappings, bool allEquivalent) -> void
 NuGet.Frameworks.FrameworkRange
-~NuGet.Frameworks.FrameworkRange.Equals(NuGet.Frameworks.FrameworkRange other) -> bool
-~NuGet.Frameworks.FrameworkRange.FrameworkIdentifier.get -> string
-~NuGet.Frameworks.FrameworkRange.FrameworkRange(NuGet.Frameworks.NuGetFramework min, NuGet.Frameworks.NuGetFramework max) -> void
-~NuGet.Frameworks.FrameworkRange.FrameworkRange(NuGet.Frameworks.NuGetFramework min, NuGet.Frameworks.NuGetFramework max, bool includeMin, bool includeMax) -> void
+NuGet.Frameworks.FrameworkRange.Equals(NuGet.Frameworks.FrameworkRange? other) -> bool
+NuGet.Frameworks.FrameworkRange.FrameworkIdentifier.get -> string!
+NuGet.Frameworks.FrameworkRange.FrameworkRange(NuGet.Frameworks.NuGetFramework! min, NuGet.Frameworks.NuGetFramework! max) -> void
+NuGet.Frameworks.FrameworkRange.FrameworkRange(NuGet.Frameworks.NuGetFramework! min, NuGet.Frameworks.NuGetFramework! max, bool includeMin, bool includeMax) -> void
 NuGet.Frameworks.FrameworkRange.IncludeMax.get -> bool
 NuGet.Frameworks.FrameworkRange.IncludeMin.get -> bool
-~NuGet.Frameworks.FrameworkRange.Max.get -> NuGet.Frameworks.NuGetFramework
-~NuGet.Frameworks.FrameworkRange.Min.get -> NuGet.Frameworks.NuGetFramework
-~NuGet.Frameworks.FrameworkRange.Satisfies(NuGet.Frameworks.NuGetFramework framework) -> bool
+NuGet.Frameworks.FrameworkRange.Max.get -> NuGet.Frameworks.NuGetFramework!
+NuGet.Frameworks.FrameworkRange.Min.get -> NuGet.Frameworks.NuGetFramework!
+NuGet.Frameworks.FrameworkRange.Satisfies(NuGet.Frameworks.NuGetFramework! framework) -> bool
 NuGet.Frameworks.FrameworkRangeComparer
-~NuGet.Frameworks.FrameworkRangeComparer.Equals(NuGet.Frameworks.FrameworkRange x, NuGet.Frameworks.FrameworkRange y) -> bool
+NuGet.Frameworks.FrameworkRangeComparer.Equals(NuGet.Frameworks.FrameworkRange? x, NuGet.Frameworks.FrameworkRange? y) -> bool
 NuGet.Frameworks.FrameworkRangeComparer.FrameworkRangeComparer() -> void
-~NuGet.Frameworks.FrameworkRangeComparer.GetHashCode(NuGet.Frameworks.FrameworkRange obj) -> int
+NuGet.Frameworks.FrameworkRangeComparer.GetHashCode(NuGet.Frameworks.FrameworkRange! obj) -> int
 NuGet.Frameworks.FrameworkReducer
 NuGet.Frameworks.FrameworkReducer.FrameworkReducer() -> void
-~NuGet.Frameworks.FrameworkReducer.FrameworkReducer(NuGet.Frameworks.IFrameworkNameProvider mappings, NuGet.Frameworks.IFrameworkCompatibilityProvider compat) -> void
-~NuGet.Frameworks.FrameworkReducer.GetNearest(NuGet.Frameworks.NuGetFramework framework, System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> possibleFrameworks) -> NuGet.Frameworks.NuGetFramework
-~NuGet.Frameworks.FrameworkReducer.ReduceDownwards(System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> frameworks) -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework>
-~NuGet.Frameworks.FrameworkReducer.ReduceEquivalent(System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> frameworks) -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework>
-~NuGet.Frameworks.FrameworkReducer.ReduceUpwards(System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> frameworks) -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework>
+NuGet.Frameworks.FrameworkReducer.FrameworkReducer(NuGet.Frameworks.IFrameworkNameProvider! mappings, NuGet.Frameworks.IFrameworkCompatibilityProvider! compat) -> void
+NuGet.Frameworks.FrameworkReducer.GetNearest(NuGet.Frameworks.NuGetFramework! framework, System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>! possibleFrameworks) -> NuGet.Frameworks.NuGetFramework?
+NuGet.Frameworks.FrameworkReducer.ReduceDownwards(System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>! frameworks) -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>!
+NuGet.Frameworks.FrameworkReducer.ReduceEquivalent(System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>! frameworks) -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>!
+NuGet.Frameworks.FrameworkReducer.ReduceUpwards(System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>! frameworks) -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>!
 NuGet.Frameworks.FrameworkRuntimePair
-~NuGet.Frameworks.FrameworkRuntimePair.Clone() -> NuGet.Frameworks.FrameworkRuntimePair
-~NuGet.Frameworks.FrameworkRuntimePair.CompareTo(NuGet.Frameworks.FrameworkRuntimePair other) -> int
-~NuGet.Frameworks.FrameworkRuntimePair.Equals(NuGet.Frameworks.FrameworkRuntimePair other) -> bool
-~NuGet.Frameworks.FrameworkRuntimePair.Framework.get -> NuGet.Frameworks.NuGetFramework
-~NuGet.Frameworks.FrameworkRuntimePair.FrameworkRuntimePair(NuGet.Frameworks.NuGetFramework framework, string runtimeIdentifier) -> void
-~NuGet.Frameworks.FrameworkRuntimePair.Name.get -> string
-~NuGet.Frameworks.FrameworkRuntimePair.RuntimeIdentifier.get -> string
+NuGet.Frameworks.FrameworkRuntimePair.Clone() -> NuGet.Frameworks.FrameworkRuntimePair!
+NuGet.Frameworks.FrameworkRuntimePair.CompareTo(NuGet.Frameworks.FrameworkRuntimePair? other) -> int
+NuGet.Frameworks.FrameworkRuntimePair.Equals(NuGet.Frameworks.FrameworkRuntimePair? other) -> bool
+NuGet.Frameworks.FrameworkRuntimePair.Framework.get -> NuGet.Frameworks.NuGetFramework!
+NuGet.Frameworks.FrameworkRuntimePair.FrameworkRuntimePair(NuGet.Frameworks.NuGetFramework! framework, string? runtimeIdentifier) -> void
+NuGet.Frameworks.FrameworkRuntimePair.Name.get -> string!
+NuGet.Frameworks.FrameworkRuntimePair.RuntimeIdentifier.get -> string!
 NuGet.Frameworks.FrameworkSpecificMapping
-~NuGet.Frameworks.FrameworkSpecificMapping.FrameworkIdentifier.get -> string
-~NuGet.Frameworks.FrameworkSpecificMapping.FrameworkSpecificMapping(string frameworkIdentifier, System.Collections.Generic.KeyValuePair<string, string> mapping) -> void
-~NuGet.Frameworks.FrameworkSpecificMapping.FrameworkSpecificMapping(string frameworkIdentifier, string key, string value) -> void
-~NuGet.Frameworks.FrameworkSpecificMapping.Mapping.get -> System.Collections.Generic.KeyValuePair<string, string>
+NuGet.Frameworks.FrameworkSpecificMapping.FrameworkIdentifier.get -> string!
+NuGet.Frameworks.FrameworkSpecificMapping.FrameworkSpecificMapping(string! frameworkIdentifier, System.Collections.Generic.KeyValuePair<string!, string!> mapping) -> void
+NuGet.Frameworks.FrameworkSpecificMapping.FrameworkSpecificMapping(string! frameworkIdentifier, string! key, string! value) -> void
+NuGet.Frameworks.FrameworkSpecificMapping.Mapping.get -> System.Collections.Generic.KeyValuePair<string!, string!>
 NuGet.Frameworks.IFrameworkCompatibilityListProvider
-~NuGet.Frameworks.IFrameworkCompatibilityListProvider.GetFrameworksSupporting(NuGet.Frameworks.NuGetFramework target) -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework>
+NuGet.Frameworks.IFrameworkCompatibilityListProvider.GetFrameworksSupporting(NuGet.Frameworks.NuGetFramework! target) -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>!
 NuGet.Frameworks.IFrameworkCompatibilityProvider
-~NuGet.Frameworks.IFrameworkCompatibilityProvider.IsCompatible(NuGet.Frameworks.NuGetFramework framework, NuGet.Frameworks.NuGetFramework other) -> bool
+NuGet.Frameworks.IFrameworkCompatibilityProvider.IsCompatible(NuGet.Frameworks.NuGetFramework! framework, NuGet.Frameworks.NuGetFramework! other) -> bool
 NuGet.Frameworks.IFrameworkMappings
-~NuGet.Frameworks.IFrameworkMappings.CompatibilityMappings.get -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.OneWayCompatibilityMappingEntry>
-~NuGet.Frameworks.IFrameworkMappings.EquivalentFrameworkPrecedence.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Frameworks.IFrameworkMappings.EquivalentFrameworks.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<NuGet.Frameworks.NuGetFramework, NuGet.Frameworks.NuGetFramework>>
-~NuGet.Frameworks.IFrameworkMappings.EquivalentProfiles.get -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.FrameworkSpecificMapping>
-~NuGet.Frameworks.IFrameworkMappings.FullNameReplacements.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<NuGet.Frameworks.NuGetFramework, NuGet.Frameworks.NuGetFramework>>
-~NuGet.Frameworks.IFrameworkMappings.IdentifierShortNames.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>
-~NuGet.Frameworks.IFrameworkMappings.IdentifierSynonyms.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>
-~NuGet.Frameworks.IFrameworkMappings.NonPackageBasedFrameworkPrecedence.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Frameworks.IFrameworkMappings.PackageBasedFrameworkPrecedence.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Frameworks.IFrameworkMappings.ProfileShortNames.get -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.FrameworkSpecificMapping>
-~NuGet.Frameworks.IFrameworkMappings.ShortNameReplacements.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<NuGet.Frameworks.NuGetFramework, NuGet.Frameworks.NuGetFramework>>
-~NuGet.Frameworks.IFrameworkMappings.SubSetFrameworks.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>
+NuGet.Frameworks.IFrameworkMappings.CompatibilityMappings.get -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.OneWayCompatibilityMappingEntry!>!
+NuGet.Frameworks.IFrameworkMappings.EquivalentFrameworkPrecedence.get -> System.Collections.Generic.IEnumerable<string!>!
+NuGet.Frameworks.IFrameworkMappings.EquivalentFrameworks.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<NuGet.Frameworks.NuGetFramework!, NuGet.Frameworks.NuGetFramework!>>!
+NuGet.Frameworks.IFrameworkMappings.EquivalentProfiles.get -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.FrameworkSpecificMapping!>!
+NuGet.Frameworks.IFrameworkMappings.FullNameReplacements.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<NuGet.Frameworks.NuGetFramework!, NuGet.Frameworks.NuGetFramework!>>!
+NuGet.Frameworks.IFrameworkMappings.IdentifierShortNames.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, string!>>!
+NuGet.Frameworks.IFrameworkMappings.IdentifierSynonyms.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, string!>>!
+NuGet.Frameworks.IFrameworkMappings.NonPackageBasedFrameworkPrecedence.get -> System.Collections.Generic.IEnumerable<string!>!
+NuGet.Frameworks.IFrameworkMappings.PackageBasedFrameworkPrecedence.get -> System.Collections.Generic.IEnumerable<string!>!
+NuGet.Frameworks.IFrameworkMappings.ProfileShortNames.get -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.FrameworkSpecificMapping!>!
+NuGet.Frameworks.IFrameworkMappings.ShortNameReplacements.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<NuGet.Frameworks.NuGetFramework!, NuGet.Frameworks.NuGetFramework!>>!
+NuGet.Frameworks.IFrameworkMappings.SubSetFrameworks.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, string!>>!
 NuGet.Frameworks.IFrameworkNameProvider
-~NuGet.Frameworks.IFrameworkNameProvider.CompareEquivalentFrameworks(NuGet.Frameworks.NuGetFramework x, NuGet.Frameworks.NuGetFramework y) -> int
-~NuGet.Frameworks.IFrameworkNameProvider.CompareFrameworks(NuGet.Frameworks.NuGetFramework x, NuGet.Frameworks.NuGetFramework y) -> int
-~NuGet.Frameworks.IFrameworkNameProvider.GetCompatibleCandidates() -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework>
-~NuGet.Frameworks.IFrameworkNameProvider.GetFullNameReplacement(NuGet.Frameworks.NuGetFramework framework) -> NuGet.Frameworks.NuGetFramework
-~NuGet.Frameworks.IFrameworkNameProvider.GetNetStandardVersions() -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework>
-~NuGet.Frameworks.IFrameworkNameProvider.GetShortNameReplacement(NuGet.Frameworks.NuGetFramework framework) -> NuGet.Frameworks.NuGetFramework
-~NuGet.Frameworks.IFrameworkNameProvider.GetVersionString(string framework, System.Version version) -> string
-~NuGet.Frameworks.IFrameworkNameProvider.TryGetCompatibilityMappings(NuGet.Frameworks.NuGetFramework framework, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.FrameworkRange> supportedFrameworkRanges) -> bool
-~NuGet.Frameworks.IFrameworkNameProvider.TryGetEquivalentFrameworks(NuGet.Frameworks.FrameworkRange range, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> frameworks) -> bool
-~NuGet.Frameworks.IFrameworkNameProvider.TryGetEquivalentFrameworks(NuGet.Frameworks.NuGetFramework framework, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> frameworks) -> bool
-~NuGet.Frameworks.IFrameworkNameProvider.TryGetIdentifier(string identifierShortName, out string identifier) -> bool
-~NuGet.Frameworks.IFrameworkNameProvider.TryGetPlatformVersion(string versionString, out System.Version version) -> bool
-~NuGet.Frameworks.IFrameworkNameProvider.TryGetPortableCompatibilityMappings(int profile, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.FrameworkRange> supportedFrameworkRanges) -> bool
-~NuGet.Frameworks.IFrameworkNameProvider.TryGetPortableFrameworks(int profile, bool includeOptional, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> frameworks) -> bool
-~NuGet.Frameworks.IFrameworkNameProvider.TryGetPortableFrameworks(int profile, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> frameworks) -> bool
-~NuGet.Frameworks.IFrameworkNameProvider.TryGetPortableFrameworks(string profile, bool includeOptional, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> frameworks) -> bool
-~NuGet.Frameworks.IFrameworkNameProvider.TryGetPortableFrameworks(string shortPortableProfiles, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> frameworks) -> bool
-~NuGet.Frameworks.IFrameworkNameProvider.TryGetPortableProfile(System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> supportedFrameworks, out int profileNumber) -> bool
-~NuGet.Frameworks.IFrameworkNameProvider.TryGetPortableProfileNumber(string profile, out int profileNumber) -> bool
-~NuGet.Frameworks.IFrameworkNameProvider.TryGetProfile(string frameworkIdentifier, string profileShortName, out string profile) -> bool
-~NuGet.Frameworks.IFrameworkNameProvider.TryGetShortIdentifier(string identifier, out string identifierShortName) -> bool
-~NuGet.Frameworks.IFrameworkNameProvider.TryGetShortProfile(string frameworkIdentifier, string profile, out string profileShortName) -> bool
-~NuGet.Frameworks.IFrameworkNameProvider.TryGetSubSetFrameworks(string frameworkIdentifier, out System.Collections.Generic.IEnumerable<string> subSetFrameworkIdentifiers) -> bool
-~NuGet.Frameworks.IFrameworkNameProvider.TryGetVersion(string versionString, out System.Version version) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.CompareEquivalentFrameworks(NuGet.Frameworks.NuGetFramework? x, NuGet.Frameworks.NuGetFramework? y) -> int
+NuGet.Frameworks.IFrameworkNameProvider.CompareFrameworks(NuGet.Frameworks.NuGetFramework? x, NuGet.Frameworks.NuGetFramework? y) -> int
+NuGet.Frameworks.IFrameworkNameProvider.GetCompatibleCandidates() -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>!
+NuGet.Frameworks.IFrameworkNameProvider.GetFullNameReplacement(NuGet.Frameworks.NuGetFramework! framework) -> NuGet.Frameworks.NuGetFramework!
+NuGet.Frameworks.IFrameworkNameProvider.GetNetStandardVersions() -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>!
+NuGet.Frameworks.IFrameworkNameProvider.GetShortNameReplacement(NuGet.Frameworks.NuGetFramework! framework) -> NuGet.Frameworks.NuGetFramework!
+NuGet.Frameworks.IFrameworkNameProvider.GetVersionString(string! framework, System.Version! version) -> string!
+NuGet.Frameworks.IFrameworkNameProvider.TryGetCompatibilityMappings(NuGet.Frameworks.NuGetFramework! framework, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.FrameworkRange!>? supportedFrameworkRanges) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetEquivalentFrameworks(NuGet.Frameworks.FrameworkRange! range, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>? frameworks) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetEquivalentFrameworks(NuGet.Frameworks.NuGetFramework! framework, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>? frameworks) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetIdentifier(string! identifierShortName, out string? identifier) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetPlatformVersion(string! versionString, out System.Version? version) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetPortableCompatibilityMappings(int profile, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.FrameworkRange!>? supportedFrameworkRanges) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetPortableFrameworks(int profile, bool includeOptional, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>? frameworks) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetPortableFrameworks(int profile, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>? frameworks) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetPortableFrameworks(string! profile, bool includeOptional, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>? frameworks) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetPortableFrameworks(string! shortPortableProfiles, out System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>? frameworks) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetPortableProfile(System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>! supportedFrameworks, out int profileNumber) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetPortableProfileNumber(string! profile, out int profileNumber) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetProfile(string! frameworkIdentifier, string! profileShortName, out string? profile) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetShortIdentifier(string! identifier, out string? identifierShortName) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetShortProfile(string! frameworkIdentifier, string! profile, out string? profileShortName) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetSubSetFrameworks(string! frameworkIdentifier, out System.Collections.Generic.IEnumerable<string!>? subSetFrameworkIdentifiers) -> bool
+NuGet.Frameworks.IFrameworkNameProvider.TryGetVersion(string! versionString, out System.Version? version) -> bool
 NuGet.Frameworks.IFrameworkSpecific
-~NuGet.Frameworks.IFrameworkSpecific.TargetFramework.get -> NuGet.Frameworks.NuGetFramework
+NuGet.Frameworks.IFrameworkSpecific.TargetFramework.get -> NuGet.Frameworks.NuGetFramework!
 NuGet.Frameworks.IFrameworkTargetable
-~NuGet.Frameworks.IFrameworkTargetable.SupportedFrameworks.get -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework>
+NuGet.Frameworks.IFrameworkTargetable.SupportedFrameworks.get -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>!
 NuGet.Frameworks.IPortableFrameworkMappings
-~NuGet.Frameworks.IPortableFrameworkMappings.CompatibilityMappings.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, NuGet.Frameworks.FrameworkRange>>
-~NuGet.Frameworks.IPortableFrameworkMappings.ProfileFrameworks.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, NuGet.Frameworks.NuGetFramework[]>>
-~NuGet.Frameworks.IPortableFrameworkMappings.ProfileOptionalFrameworks.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, NuGet.Frameworks.NuGetFramework[]>>
+NuGet.Frameworks.IPortableFrameworkMappings.CompatibilityMappings.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, NuGet.Frameworks.FrameworkRange!>>!
+NuGet.Frameworks.IPortableFrameworkMappings.ProfileFrameworks.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, NuGet.Frameworks.NuGetFramework![]!>>!
+NuGet.Frameworks.IPortableFrameworkMappings.ProfileOptionalFrameworks.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, NuGet.Frameworks.NuGetFramework![]!>>!
 NuGet.Frameworks.NuGetFramework
 NuGet.Frameworks.NuGetFramework.AllFrameworkVersions.get -> bool
-~NuGet.Frameworks.NuGetFramework.DotNetFrameworkName.get -> string
-~NuGet.Frameworks.NuGetFramework.DotNetPlatformName.get -> string
-~NuGet.Frameworks.NuGetFramework.Equals(NuGet.Frameworks.NuGetFramework other) -> bool
-~NuGet.Frameworks.NuGetFramework.Framework.get -> string
-~NuGet.Frameworks.NuGetFramework.GetDotNetFrameworkName(NuGet.Frameworks.IFrameworkNameProvider mappings) -> string
-~NuGet.Frameworks.NuGetFramework.GetShortFolderName() -> string
+NuGet.Frameworks.NuGetFramework.DotNetFrameworkName.get -> string!
+NuGet.Frameworks.NuGetFramework.DotNetPlatformName.get -> string!
+NuGet.Frameworks.NuGetFramework.Equals(NuGet.Frameworks.NuGetFramework? other) -> bool
+NuGet.Frameworks.NuGetFramework.Framework.get -> string!
+NuGet.Frameworks.NuGetFramework.GetDotNetFrameworkName(NuGet.Frameworks.IFrameworkNameProvider! mappings) -> string!
+NuGet.Frameworks.NuGetFramework.GetShortFolderName() -> string!
 NuGet.Frameworks.NuGetFramework.HasPlatform.get -> bool
 NuGet.Frameworks.NuGetFramework.HasProfile.get -> bool
 NuGet.Frameworks.NuGetFramework.IsAgnostic.get -> bool
@@ -197,199 +197,199 @@ NuGet.Frameworks.NuGetFramework.IsPCL.get -> bool
 NuGet.Frameworks.NuGetFramework.IsPackageBased.get -> bool
 NuGet.Frameworks.NuGetFramework.IsSpecificFramework.get -> bool
 NuGet.Frameworks.NuGetFramework.IsUnsupported.get -> bool
-~NuGet.Frameworks.NuGetFramework.NuGetFramework(NuGet.Frameworks.NuGetFramework framework) -> void
-~NuGet.Frameworks.NuGetFramework.NuGetFramework(string framework) -> void
-~NuGet.Frameworks.NuGetFramework.NuGetFramework(string framework, System.Version version) -> void
-~NuGet.Frameworks.NuGetFramework.NuGetFramework(string frameworkIdentifier, System.Version frameworkVersion, string frameworkProfile) -> void
-~NuGet.Frameworks.NuGetFramework.NuGetFramework(string frameworkIdentifier, System.Version frameworkVersion, string platform, System.Version platformVersion) -> void
-~NuGet.Frameworks.NuGetFramework.Platform.get -> string
-~NuGet.Frameworks.NuGetFramework.PlatformVersion.get -> System.Version
-~NuGet.Frameworks.NuGetFramework.Profile.get -> string
-~NuGet.Frameworks.NuGetFramework.Version.get -> System.Version
+NuGet.Frameworks.NuGetFramework.NuGetFramework(NuGet.Frameworks.NuGetFramework! framework) -> void
+NuGet.Frameworks.NuGetFramework.NuGetFramework(string! framework) -> void
+NuGet.Frameworks.NuGetFramework.NuGetFramework(string! framework, System.Version! version) -> void
+NuGet.Frameworks.NuGetFramework.NuGetFramework(string! frameworkIdentifier, System.Version! frameworkVersion, string? frameworkProfile) -> void
+NuGet.Frameworks.NuGetFramework.NuGetFramework(string! frameworkIdentifier, System.Version! frameworkVersion, string! platform, System.Version! platformVersion) -> void
+NuGet.Frameworks.NuGetFramework.Platform.get -> string!
+NuGet.Frameworks.NuGetFramework.PlatformVersion.get -> System.Version!
+NuGet.Frameworks.NuGetFramework.Profile.get -> string!
+NuGet.Frameworks.NuGetFramework.Version.get -> System.Version!
 NuGet.Frameworks.NuGetFrameworkExtensions
 NuGet.Frameworks.NuGetFrameworkFullComparer
-~NuGet.Frameworks.NuGetFrameworkFullComparer.Equals(NuGet.Frameworks.NuGetFramework x, NuGet.Frameworks.NuGetFramework y) -> bool
-~NuGet.Frameworks.NuGetFrameworkFullComparer.GetHashCode(NuGet.Frameworks.NuGetFramework obj) -> int
+NuGet.Frameworks.NuGetFrameworkFullComparer.Equals(NuGet.Frameworks.NuGetFramework? x, NuGet.Frameworks.NuGetFramework? y) -> bool
+NuGet.Frameworks.NuGetFrameworkFullComparer.GetHashCode(NuGet.Frameworks.NuGetFramework! obj) -> int
 NuGet.Frameworks.NuGetFrameworkFullComparer.NuGetFrameworkFullComparer() -> void
 NuGet.Frameworks.NuGetFrameworkNameComparer
-~NuGet.Frameworks.NuGetFrameworkNameComparer.Equals(NuGet.Frameworks.NuGetFramework x, NuGet.Frameworks.NuGetFramework y) -> bool
-~NuGet.Frameworks.NuGetFrameworkNameComparer.GetHashCode(NuGet.Frameworks.NuGetFramework obj) -> int
+NuGet.Frameworks.NuGetFrameworkNameComparer.Equals(NuGet.Frameworks.NuGetFramework? x, NuGet.Frameworks.NuGetFramework? y) -> bool
+NuGet.Frameworks.NuGetFrameworkNameComparer.GetHashCode(NuGet.Frameworks.NuGetFramework! obj) -> int
 NuGet.Frameworks.NuGetFrameworkNameComparer.NuGetFrameworkNameComparer() -> void
 NuGet.Frameworks.NuGetFrameworkSorter
-~NuGet.Frameworks.NuGetFrameworkSorter.Compare(NuGet.Frameworks.NuGetFramework x, NuGet.Frameworks.NuGetFramework y) -> int
+NuGet.Frameworks.NuGetFrameworkSorter.Compare(NuGet.Frameworks.NuGetFramework? x, NuGet.Frameworks.NuGetFramework? y) -> int
 NuGet.Frameworks.NuGetFrameworkSorter.NuGetFrameworkSorter() -> void
 NuGet.Frameworks.NuGetFrameworkUtility
 NuGet.Frameworks.OneWayCompatibilityMappingEntry
-~NuGet.Frameworks.OneWayCompatibilityMappingEntry.Equals(NuGet.Frameworks.OneWayCompatibilityMappingEntry other) -> bool
-~NuGet.Frameworks.OneWayCompatibilityMappingEntry.OneWayCompatibilityMappingEntry(NuGet.Frameworks.FrameworkRange targetFramework, NuGet.Frameworks.FrameworkRange supportedFramework) -> void
-~NuGet.Frameworks.OneWayCompatibilityMappingEntry.SupportedFrameworkRange.get -> NuGet.Frameworks.FrameworkRange
-~NuGet.Frameworks.OneWayCompatibilityMappingEntry.TargetFrameworkRange.get -> NuGet.Frameworks.FrameworkRange
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.AspNet = "ASP.NET" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.AspNetCore = "ASP.NETCore" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.Dnx = "DNX" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.DnxCore = "DNXCore" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.DotNet = "dotnet" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.MonoAndroid = "MonoAndroid" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.MonoMac = "MonoMac" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.MonoTouch = "MonoTouch" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.NanoFramework = ".NETnanoFramework" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.Native = "native" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.Net = ".NETFramework" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.NetCore = ".NETCore" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.NetCoreApp = ".NETCoreApp" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.NetMicro = ".NETMicroFramework" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.NetPlatform = ".NETPlatform" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.NetStandard = ".NETStandard" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.NetStandardApp = ".NETStandardApp" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.Portable = ".NETPortable" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.Silverlight = "Silverlight" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.Tizen = "Tizen" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.UAP = "UAP" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.WinRT = "WinRT" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.Windows = "Windows" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.WindowsPhone = "WindowsPhone" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.WindowsPhoneApp = "WindowsPhoneApp" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.XamarinIOs = "Xamarin.iOS" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.XamarinMac = "Xamarin.Mac" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.XamarinPlayStation3 = "Xamarin.PlayStation3" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.XamarinPlayStation4 = "Xamarin.PlayStation4" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.XamarinPlayStationVita = "Xamarin.PlayStationVita" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.XamarinTVOS = "Xamarin.TVOS" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.XamarinWatchOS = "Xamarin.WatchOS" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.XamarinXbox360 = "Xamarin.Xbox360" -> string
-~const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.XamarinXboxOne = "Xamarin.XboxOne" -> string
-~const NuGet.Frameworks.FrameworkConstants.PlatformIdentifiers.Windows = "Windows" -> string
-~const NuGet.Frameworks.FrameworkConstants.PlatformIdentifiers.WindowsPhone = "WindowsPhone" -> string
-~const NuGet.Frameworks.FrameworkConstants.SpecialIdentifiers.Agnostic = "Agnostic" -> string
-~const NuGet.Frameworks.FrameworkConstants.SpecialIdentifiers.Any = "Any" -> string
-~const NuGet.Frameworks.FrameworkConstants.SpecialIdentifiers.Unsupported = "Unsupported" -> string
-~override NuGet.Frameworks.AssetTargetFallbackFramework.Equals(object obj) -> bool
+NuGet.Frameworks.OneWayCompatibilityMappingEntry.Equals(NuGet.Frameworks.OneWayCompatibilityMappingEntry? other) -> bool
+NuGet.Frameworks.OneWayCompatibilityMappingEntry.OneWayCompatibilityMappingEntry(NuGet.Frameworks.FrameworkRange! targetFramework, NuGet.Frameworks.FrameworkRange! supportedFramework) -> void
+NuGet.Frameworks.OneWayCompatibilityMappingEntry.SupportedFrameworkRange.get -> NuGet.Frameworks.FrameworkRange!
+NuGet.Frameworks.OneWayCompatibilityMappingEntry.TargetFrameworkRange.get -> NuGet.Frameworks.FrameworkRange!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.AspNet = "ASP.NET" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.AspNetCore = "ASP.NETCore" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.Dnx = "DNX" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.DnxCore = "DNXCore" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.DotNet = "dotnet" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.MonoAndroid = "MonoAndroid" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.MonoMac = "MonoMac" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.MonoTouch = "MonoTouch" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.NanoFramework = ".NETnanoFramework" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.Native = "native" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.Net = ".NETFramework" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.NetCore = ".NETCore" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.NetCoreApp = ".NETCoreApp" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.NetMicro = ".NETMicroFramework" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.NetPlatform = ".NETPlatform" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.NetStandard = ".NETStandard" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.NetStandardApp = ".NETStandardApp" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.Portable = ".NETPortable" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.Silverlight = "Silverlight" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.Tizen = "Tizen" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.UAP = "UAP" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.WinRT = "WinRT" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.Windows = "Windows" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.WindowsPhone = "WindowsPhone" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.WindowsPhoneApp = "WindowsPhoneApp" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.XamarinIOs = "Xamarin.iOS" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.XamarinMac = "Xamarin.Mac" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.XamarinPlayStation3 = "Xamarin.PlayStation3" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.XamarinPlayStation4 = "Xamarin.PlayStation4" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.XamarinPlayStationVita = "Xamarin.PlayStationVita" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.XamarinTVOS = "Xamarin.TVOS" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.XamarinWatchOS = "Xamarin.WatchOS" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.XamarinXbox360 = "Xamarin.Xbox360" -> string!
+const NuGet.Frameworks.FrameworkConstants.FrameworkIdentifiers.XamarinXboxOne = "Xamarin.XboxOne" -> string!
+const NuGet.Frameworks.FrameworkConstants.PlatformIdentifiers.Windows = "Windows" -> string!
+const NuGet.Frameworks.FrameworkConstants.PlatformIdentifiers.WindowsPhone = "WindowsPhone" -> string!
+const NuGet.Frameworks.FrameworkConstants.SpecialIdentifiers.Agnostic = "Agnostic" -> string!
+const NuGet.Frameworks.FrameworkConstants.SpecialIdentifiers.Any = "Any" -> string!
+const NuGet.Frameworks.FrameworkConstants.SpecialIdentifiers.Unsupported = "Unsupported" -> string!
+override NuGet.Frameworks.AssetTargetFallbackFramework.Equals(object? obj) -> bool
 override NuGet.Frameworks.AssetTargetFallbackFramework.GetHashCode() -> int
-~override NuGet.Frameworks.DualCompatibilityFramework.Equals(object obj) -> bool
+override NuGet.Frameworks.DualCompatibilityFramework.Equals(object? obj) -> bool
 override NuGet.Frameworks.DualCompatibilityFramework.GetHashCode() -> int
-~override NuGet.Frameworks.FallbackFramework.Equals(object obj) -> bool
+override NuGet.Frameworks.FallbackFramework.Equals(object? obj) -> bool
 override NuGet.Frameworks.FallbackFramework.GetHashCode() -> int
-~override NuGet.Frameworks.FrameworkRange.Equals(object obj) -> bool
+override NuGet.Frameworks.FrameworkRange.Equals(object? obj) -> bool
 override NuGet.Frameworks.FrameworkRange.GetHashCode() -> int
-~override NuGet.Frameworks.FrameworkRange.ToString() -> string
-~override NuGet.Frameworks.FrameworkRuntimePair.Equals(object obj) -> bool
+override NuGet.Frameworks.FrameworkRange.ToString() -> string!
+override NuGet.Frameworks.FrameworkRuntimePair.Equals(object? obj) -> bool
 override NuGet.Frameworks.FrameworkRuntimePair.GetHashCode() -> int
-~override NuGet.Frameworks.FrameworkRuntimePair.ToString() -> string
-~override NuGet.Frameworks.NuGetFramework.Equals(object obj) -> bool
+override NuGet.Frameworks.FrameworkRuntimePair.ToString() -> string!
+override NuGet.Frameworks.NuGetFramework.Equals(object? obj) -> bool
 override NuGet.Frameworks.NuGetFramework.GetHashCode() -> int
-~override NuGet.Frameworks.NuGetFramework.ToString() -> string
-~override NuGet.Frameworks.OneWayCompatibilityMappingEntry.ToString() -> string
-~static NuGet.Frameworks.CompatibilityListProvider.Default.get -> NuGet.Frameworks.IFrameworkCompatibilityListProvider
-~static NuGet.Frameworks.DefaultCompatibilityProvider.Instance.get -> NuGet.Frameworks.IFrameworkCompatibilityProvider
-~static NuGet.Frameworks.DefaultFrameworkMappings.Instance.get -> NuGet.Frameworks.IFrameworkMappings
-~static NuGet.Frameworks.DefaultFrameworkNameProvider.Instance.get -> NuGet.Frameworks.IFrameworkNameProvider
-~static NuGet.Frameworks.DefaultPortableFrameworkMappings.Instance.get -> NuGet.Frameworks.IPortableFrameworkMappings
-~static NuGet.Frameworks.FrameworkNameHelpers.GetFolderName(string identifierShortName, string versionString, string profileShortName) -> string
-~static NuGet.Frameworks.FrameworkNameHelpers.GetPortableProfileNumberString(int profileNumber) -> string
-~static NuGet.Frameworks.FrameworkNameHelpers.GetVersion(string versionString) -> System.Version
-~static NuGet.Frameworks.FrameworkNameHelpers.GetVersionString(System.Version version) -> string
-~static NuGet.Frameworks.FrameworkRuntimePair.GetName(NuGet.Frameworks.NuGetFramework framework, string runtimeIdentifier) -> string
-~static NuGet.Frameworks.FrameworkRuntimePair.GetTargetGraphName(NuGet.Frameworks.NuGetFramework framework, string runtimeIdentifier) -> string
-~static NuGet.Frameworks.NuGetFramework.Parse(string folderName) -> NuGet.Frameworks.NuGetFramework
-~static NuGet.Frameworks.NuGetFramework.Parse(string folderName, NuGet.Frameworks.IFrameworkNameProvider mappings) -> NuGet.Frameworks.NuGetFramework
-~static NuGet.Frameworks.NuGetFramework.ParseComponents(string targetFrameworkMoniker, string targetPlatformMoniker) -> NuGet.Frameworks.NuGetFramework
-~static NuGet.Frameworks.NuGetFramework.ParseFolder(string folderName) -> NuGet.Frameworks.NuGetFramework
-~static NuGet.Frameworks.NuGetFramework.ParseFolder(string folderName, NuGet.Frameworks.IFrameworkNameProvider mappings) -> NuGet.Frameworks.NuGetFramework
-~static NuGet.Frameworks.NuGetFramework.ParseFrameworkName(string frameworkName, NuGet.Frameworks.IFrameworkNameProvider mappings) -> NuGet.Frameworks.NuGetFramework
-~static NuGet.Frameworks.NuGetFramework.operator !=(NuGet.Frameworks.NuGetFramework left, NuGet.Frameworks.NuGetFramework right) -> bool
-~static NuGet.Frameworks.NuGetFramework.operator ==(NuGet.Frameworks.NuGetFramework left, NuGet.Frameworks.NuGetFramework right) -> bool
-~static NuGet.Frameworks.NuGetFrameworkExtensions.GetNearest<T>(this System.Collections.Generic.IEnumerable<T> items, NuGet.Frameworks.NuGetFramework projectFramework) -> T
-~static NuGet.Frameworks.NuGetFrameworkExtensions.IsDesktop(this NuGet.Frameworks.NuGetFramework framework) -> bool
-~static NuGet.Frameworks.NuGetFrameworkUtility.GetNearest<T>(System.Collections.Generic.IEnumerable<T> items, NuGet.Frameworks.NuGetFramework framework) -> T
-~static NuGet.Frameworks.NuGetFrameworkUtility.GetNearest<T>(System.Collections.Generic.IEnumerable<T> items, NuGet.Frameworks.NuGetFramework framework, NuGet.Frameworks.IFrameworkNameProvider frameworkMappings, NuGet.Frameworks.IFrameworkCompatibilityProvider compatibilityProvider) -> T
-~static NuGet.Frameworks.NuGetFrameworkUtility.GetNearest<T>(System.Collections.Generic.IEnumerable<T> items, NuGet.Frameworks.NuGetFramework framework, NuGet.Frameworks.IFrameworkNameProvider frameworkMappings, NuGet.Frameworks.IFrameworkCompatibilityProvider compatibilityProvider, System.Func<T, NuGet.Frameworks.NuGetFramework> selector) -> T
-~static NuGet.Frameworks.NuGetFrameworkUtility.GetNearest<T>(System.Collections.Generic.IEnumerable<T> items, NuGet.Frameworks.NuGetFramework framework, System.Func<T, NuGet.Frameworks.NuGetFramework> selector) -> T
-~static NuGet.Frameworks.NuGetFrameworkUtility.IsCompatibleWithFallbackCheck(NuGet.Frameworks.NuGetFramework projectFramework, NuGet.Frameworks.NuGetFramework candidate) -> bool
-~static NuGet.Frameworks.NuGetFrameworkUtility.IsNetCore50AndUp(NuGet.Frameworks.NuGetFramework framework) -> bool
-~static NuGet.Frameworks.OneWayCompatibilityMappingEntry.Comparer.get -> NuGet.Frameworks.CompatibilityMappingComparer
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.AspNet -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.AspNet50 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.AspNetCore -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.AspNetCore50 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Dnx -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Dnx45 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Dnx451 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Dnx452 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DnxCore -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DnxCore50 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DotNet -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DotNet50 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DotNet51 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DotNet52 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DotNet53 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DotNet54 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DotNet55 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DotNet56 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Native -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net11 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net2 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net35 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net4 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net403 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net45 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net451 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net452 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net46 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net461 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net462 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net463 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net47 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net471 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net472 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net50 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net70 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCore45 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCore451 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCore50 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCoreApp10 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCoreApp11 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCoreApp20 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCoreApp21 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCoreApp22 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCoreApp30 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCoreApp31 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard10 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard11 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard12 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard13 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard14 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard15 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard16 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard17 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard20 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard21 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandardApp15 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.SL4 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.SL5 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Tizen3 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Tizen4 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Tizen6 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.UAP10 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.WP7 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.WP75 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.WP8 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.WP81 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.WPA81 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Win10 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Win8 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Win81 -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.FrameworkConstants.DotNetAll -> NuGet.Frameworks.FrameworkRange
-~static readonly NuGet.Frameworks.FrameworkConstants.EmptyVersion -> System.Version
-~static readonly NuGet.Frameworks.FrameworkConstants.MaxVersion -> System.Version
-~static readonly NuGet.Frameworks.FrameworkConstants.Version10 -> System.Version
-~static readonly NuGet.Frameworks.FrameworkConstants.Version5 -> System.Version
-~static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version
-~static readonly NuGet.Frameworks.FrameworkConstants.Version7 -> System.Version
-~static readonly NuGet.Frameworks.NuGetFramework.AgnosticFramework -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.NuGetFramework.AnyFramework -> NuGet.Frameworks.NuGetFramework
-~static readonly NuGet.Frameworks.NuGetFramework.Comparer -> System.Collections.Generic.IEqualityComparer<NuGet.Frameworks.NuGetFramework>
-~static readonly NuGet.Frameworks.NuGetFramework.FrameworkNameComparer -> System.Collections.Generic.IEqualityComparer<NuGet.Frameworks.NuGetFramework>
-~static readonly NuGet.Frameworks.NuGetFramework.UnsupportedFramework -> NuGet.Frameworks.NuGetFramework
-~virtual NuGet.Frameworks.NuGetFramework.GetShortFolderName(NuGet.Frameworks.IFrameworkNameProvider mappings) -> string
+override NuGet.Frameworks.NuGetFramework.ToString() -> string!
+override NuGet.Frameworks.OneWayCompatibilityMappingEntry.ToString() -> string!
+static NuGet.Frameworks.CompatibilityListProvider.Default.get -> NuGet.Frameworks.IFrameworkCompatibilityListProvider!
+static NuGet.Frameworks.DefaultCompatibilityProvider.Instance.get -> NuGet.Frameworks.IFrameworkCompatibilityProvider!
+static NuGet.Frameworks.DefaultFrameworkMappings.Instance.get -> NuGet.Frameworks.IFrameworkMappings!
+static NuGet.Frameworks.DefaultFrameworkNameProvider.Instance.get -> NuGet.Frameworks.IFrameworkNameProvider!
+static NuGet.Frameworks.DefaultPortableFrameworkMappings.Instance.get -> NuGet.Frameworks.IPortableFrameworkMappings!
+static NuGet.Frameworks.FrameworkNameHelpers.GetFolderName(string! identifierShortName, string! versionString, string? profileShortName) -> string!
+static NuGet.Frameworks.FrameworkNameHelpers.GetPortableProfileNumberString(int profileNumber) -> string!
+static NuGet.Frameworks.FrameworkNameHelpers.GetVersion(string? versionString) -> System.Version!
+static NuGet.Frameworks.FrameworkNameHelpers.GetVersionString(System.Version! version) -> string!
+static NuGet.Frameworks.FrameworkRuntimePair.GetName(NuGet.Frameworks.NuGetFramework! framework, string? runtimeIdentifier) -> string!
+static NuGet.Frameworks.FrameworkRuntimePair.GetTargetGraphName(NuGet.Frameworks.NuGetFramework! framework, string? runtimeIdentifier) -> string!
+static NuGet.Frameworks.NuGetFramework.Parse(string! folderName) -> NuGet.Frameworks.NuGetFramework!
+static NuGet.Frameworks.NuGetFramework.Parse(string! folderName, NuGet.Frameworks.IFrameworkNameProvider! mappings) -> NuGet.Frameworks.NuGetFramework!
+static NuGet.Frameworks.NuGetFramework.ParseComponents(string! targetFrameworkMoniker, string? targetPlatformMoniker) -> NuGet.Frameworks.NuGetFramework!
+static NuGet.Frameworks.NuGetFramework.ParseFolder(string! folderName) -> NuGet.Frameworks.NuGetFramework!
+static NuGet.Frameworks.NuGetFramework.ParseFolder(string! folderName, NuGet.Frameworks.IFrameworkNameProvider! mappings) -> NuGet.Frameworks.NuGetFramework!
+static NuGet.Frameworks.NuGetFramework.ParseFrameworkName(string! frameworkName, NuGet.Frameworks.IFrameworkNameProvider! mappings) -> NuGet.Frameworks.NuGetFramework!
+static NuGet.Frameworks.NuGetFramework.operator !=(NuGet.Frameworks.NuGetFramework? left, NuGet.Frameworks.NuGetFramework? right) -> bool
+static NuGet.Frameworks.NuGetFramework.operator ==(NuGet.Frameworks.NuGetFramework? left, NuGet.Frameworks.NuGetFramework? right) -> bool
+static NuGet.Frameworks.NuGetFrameworkExtensions.GetNearest<T>(this System.Collections.Generic.IEnumerable<T!>! items, NuGet.Frameworks.NuGetFramework! projectFramework) -> T?
+static NuGet.Frameworks.NuGetFrameworkExtensions.IsDesktop(this NuGet.Frameworks.NuGetFramework! framework) -> bool
+static NuGet.Frameworks.NuGetFrameworkUtility.GetNearest<T>(System.Collections.Generic.IEnumerable<T>! items, NuGet.Frameworks.NuGetFramework! framework) -> T?
+static NuGet.Frameworks.NuGetFrameworkUtility.GetNearest<T>(System.Collections.Generic.IEnumerable<T>! items, NuGet.Frameworks.NuGetFramework! framework, NuGet.Frameworks.IFrameworkNameProvider! frameworkMappings, NuGet.Frameworks.IFrameworkCompatibilityProvider! compatibilityProvider) -> T?
+static NuGet.Frameworks.NuGetFrameworkUtility.GetNearest<T>(System.Collections.Generic.IEnumerable<T!>! items, NuGet.Frameworks.NuGetFramework! framework, NuGet.Frameworks.IFrameworkNameProvider! frameworkMappings, NuGet.Frameworks.IFrameworkCompatibilityProvider! compatibilityProvider, System.Func<T!, NuGet.Frameworks.NuGetFramework!>! selector) -> T?
+static NuGet.Frameworks.NuGetFrameworkUtility.GetNearest<T>(System.Collections.Generic.IEnumerable<T!>! items, NuGet.Frameworks.NuGetFramework! framework, System.Func<T!, NuGet.Frameworks.NuGetFramework!>! selector) -> T?
+static NuGet.Frameworks.NuGetFrameworkUtility.IsCompatibleWithFallbackCheck(NuGet.Frameworks.NuGetFramework! projectFramework, NuGet.Frameworks.NuGetFramework! candidate) -> bool
+static NuGet.Frameworks.NuGetFrameworkUtility.IsNetCore50AndUp(NuGet.Frameworks.NuGetFramework! framework) -> bool
+static NuGet.Frameworks.OneWayCompatibilityMappingEntry.Comparer.get -> NuGet.Frameworks.CompatibilityMappingComparer!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.AspNet -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.AspNet50 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.AspNetCore -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.AspNetCore50 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Dnx -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Dnx45 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Dnx451 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Dnx452 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DnxCore -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DnxCore50 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DotNet -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DotNet50 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DotNet51 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DotNet52 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DotNet53 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DotNet54 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DotNet55 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.DotNet56 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Native -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net11 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net2 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net35 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net4 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net403 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net45 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net451 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net452 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net46 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net461 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net462 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net463 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net47 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net471 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net472 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net50 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net60 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net70 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCore45 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCore451 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCore50 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCoreApp10 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCoreApp11 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCoreApp20 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCoreApp21 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCoreApp22 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCoreApp30 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCoreApp31 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard10 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard11 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard12 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard13 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard14 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard15 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard16 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard17 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard20 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard21 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandardApp15 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.SL4 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.SL5 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Tizen3 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Tizen4 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Tizen6 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.UAP10 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.WP7 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.WP75 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.WP8 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.WP81 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.WPA81 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Win10 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Win8 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Win81 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.DotNetAll -> NuGet.Frameworks.FrameworkRange!
+static readonly NuGet.Frameworks.FrameworkConstants.EmptyVersion -> System.Version!
+static readonly NuGet.Frameworks.FrameworkConstants.MaxVersion -> System.Version!
+static readonly NuGet.Frameworks.FrameworkConstants.Version10 -> System.Version!
+static readonly NuGet.Frameworks.FrameworkConstants.Version5 -> System.Version!
+static readonly NuGet.Frameworks.FrameworkConstants.Version6 -> System.Version!
+static readonly NuGet.Frameworks.FrameworkConstants.Version7 -> System.Version!
+static readonly NuGet.Frameworks.NuGetFramework.AgnosticFramework -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.NuGetFramework.AnyFramework -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.NuGetFramework.Comparer -> System.Collections.Generic.IEqualityComparer<NuGet.Frameworks.NuGetFramework!>!
+static readonly NuGet.Frameworks.NuGetFramework.FrameworkNameComparer -> System.Collections.Generic.IEqualityComparer<NuGet.Frameworks.NuGetFramework!>!
+static readonly NuGet.Frameworks.NuGetFramework.UnsupportedFramework -> NuGet.Frameworks.NuGetFramework!
+virtual NuGet.Frameworks.NuGetFramework.GetShortFolderName(NuGet.Frameworks.IFrameworkNameProvider! mappings) -> string!

--- a/src/NuGet.Core/NuGet.Frameworks/comparers/CompatibilityMappingComparer.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/comparers/CompatibilityMappingComparer.cs
@@ -8,7 +8,7 @@ namespace NuGet.Frameworks
 {
     public class CompatibilityMappingComparer : IEqualityComparer<OneWayCompatibilityMappingEntry>
     {
-        public bool Equals(OneWayCompatibilityMappingEntry x, OneWayCompatibilityMappingEntry y)
+        public bool Equals(OneWayCompatibilityMappingEntry? x, OneWayCompatibilityMappingEntry? y)
         {
             if (ReferenceEquals(x, y))
             {

--- a/src/NuGet.Core/NuGet.Frameworks/comparers/FrameworkPrecedenceSorter.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/comparers/FrameworkPrecedenceSorter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace NuGet.Frameworks
@@ -15,11 +16,11 @@ namespace NuGet.Frameworks
 
         public FrameworkPrecedenceSorter(IFrameworkNameProvider mappings, bool allEquivalent)
         {
-            _mappings = mappings;
+            _mappings = mappings ?? throw new ArgumentNullException(nameof(mappings));
             _allEquivalent = allEquivalent;
         }
 
-        public int Compare(NuGetFramework x, NuGetFramework y)
+        public int Compare(NuGetFramework? x, NuGetFramework? y)
         {
             return _allEquivalent ? _mappings.CompareEquivalentFrameworks(x, y) : _mappings.CompareFrameworks(x, y);
         }

--- a/src/NuGet.Core/NuGet.Frameworks/comparers/FrameworkRangeComparer.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/comparers/FrameworkRangeComparer.cs
@@ -13,7 +13,7 @@ namespace NuGet.Frameworks
         {
         }
 
-        public bool Equals(FrameworkRange x, FrameworkRange y)
+        public bool Equals(FrameworkRange? x, FrameworkRange? y)
         {
             if (ReferenceEquals(x, y))
             {

--- a/src/NuGet.Core/NuGet.Frameworks/comparers/NuGetFrameworkFullComparer.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/comparers/NuGetFrameworkFullComparer.cs
@@ -12,7 +12,7 @@ namespace NuGet.Frameworks
     /// </summary>
     public class NuGetFrameworkFullComparer : IEqualityComparer<NuGetFramework>
     {
-        public bool Equals(NuGetFramework x, NuGetFramework y)
+        public bool Equals(NuGetFramework? x, NuGetFramework? y)
         {
             if (ReferenceEquals(x, y))
             {

--- a/src/NuGet.Core/NuGet.Frameworks/comparers/NuGetFrameworkNameComparer.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/comparers/NuGetFrameworkNameComparer.cs
@@ -11,7 +11,7 @@ namespace NuGet.Frameworks
     /// </summary>
     public class NuGetFrameworkNameComparer : IEqualityComparer<NuGetFramework>
     {
-        public bool Equals(NuGetFramework x, NuGetFramework y)
+        public bool Equals(NuGetFramework? x, NuGetFramework? y)
         {
             if (ReferenceEquals(x, y))
             {

--- a/src/NuGet.Core/NuGet.Frameworks/comparers/NuGetFrameworkSorter.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/comparers/NuGetFrameworkSorter.cs
@@ -17,7 +17,7 @@ namespace NuGet.Frameworks
         {
         }
 
-        public int Compare(NuGetFramework x, NuGetFramework y)
+        public int Compare(NuGetFramework? x, NuGetFramework? y)
         {
             if (ReferenceEquals(x, y))
             {

--- a/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkNameProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkNameProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NuGet.Frameworks
 {
@@ -11,33 +12,33 @@ namespace NuGet.Frameworks
         /// <summary>
         /// Returns the official framework identifier for an alias or short name.
         /// </summary>
-        bool TryGetIdentifier(string identifierShortName, out string identifier);
+        bool TryGetIdentifier(string identifierShortName, [NotNullWhen(true)] out string? identifier);
 
         /// <summary>
         /// Gives the short name used for folders in NuGet
         /// </summary>
-        bool TryGetShortIdentifier(string identifier, out string identifierShortName);
+        bool TryGetShortIdentifier(string identifier, [NotNullWhen(true)] out string? identifierShortName);
 
         /// <summary>
         /// Get the official profile name from the short name.
         /// </summary>
-        bool TryGetProfile(string frameworkIdentifier, string profileShortName, out string profile);
+        bool TryGetProfile(string frameworkIdentifier, string profileShortName, [NotNullWhen(true)] out string? profile);
 
         /// <summary>
         /// Returns the shortened version of the profile name.
         /// </summary>
-        bool TryGetShortProfile(string frameworkIdentifier, string profile, out string profileShortName);
+        bool TryGetShortProfile(string frameworkIdentifier, string profile, [NotNullWhen(true)] out string? profileShortName);
 
         /// <summary>
         /// Parses a version string using single digit rules if no dots exist
         /// </summary>
-        bool TryGetVersion(string versionString, out Version version);
+        bool TryGetVersion(string versionString, [NotNullWhen(true)] out Version? version);
 
         /// <summary>
         /// Parses a version string. If no dots exist, all digits are treated
         /// as semver-major, instead of inserting dots.
         /// </summary>
-        bool TryGetPlatformVersion(string versionString, out Version version);
+        bool TryGetPlatformVersion(string versionString, [NotNullWhen(true)] out Version? version);
 
         /// <summary>
         /// Returns a shortened version. If all digits are single digits no dots will be used.
@@ -57,55 +58,55 @@ namespace NuGet.Frameworks
         /// <summary>
         /// Returns the frameworks based on a portable profile number.
         /// </summary>
-        bool TryGetPortableFrameworks(int profile, out IEnumerable<NuGetFramework> frameworks);
+        bool TryGetPortableFrameworks(int profile, [NotNullWhen(true)] out IEnumerable<NuGetFramework>? frameworks);
 
         /// <summary>
         /// Returns the frameworks based on a portable profile number.
         /// </summary>
-        bool TryGetPortableFrameworks(int profile, bool includeOptional, out IEnumerable<NuGetFramework> frameworks);
+        bool TryGetPortableFrameworks(int profile, bool includeOptional, [NotNullWhen(true)] out IEnumerable<NuGetFramework>? frameworks);
 
         /// <summary>
         /// Returns the frameworks based on a profile string.
         /// Profile can be either the number in format: Profile=7, or the shortened NuGet version: net45+win8
         /// </summary>
-        bool TryGetPortableFrameworks(string profile, bool includeOptional, out IEnumerable<NuGetFramework> frameworks);
+        bool TryGetPortableFrameworks(string profile, bool includeOptional, [NotNullWhen(true)] out IEnumerable<NuGetFramework>? frameworks);
 
         /// <summary>
         /// Parses a shortened portable framework profile list.
         /// Ex: net45+win8
         /// </summary>
-        bool TryGetPortableFrameworks(string shortPortableProfiles, out IEnumerable<NuGetFramework> frameworks);
+        bool TryGetPortableFrameworks(string shortPortableProfiles, [NotNullWhen(true)] out IEnumerable<NuGetFramework>? frameworks);
 
         /// <summary>
         /// Returns ranges of frameworks that are known to be supported by the given portable profile number.
         /// Ex: Profile7 -> netstandard1.1
         /// </summary>
-        bool TryGetPortableCompatibilityMappings(int profile, out IEnumerable<FrameworkRange> supportedFrameworkRanges);
+        bool TryGetPortableCompatibilityMappings(int profile, [NotNullWhen(true)] out IEnumerable<FrameworkRange>? supportedFrameworkRanges);
 
         /// <summary>
         /// Returns a list of all possible substitutions where the framework name
         /// have equivalents.
         /// Ex: sl3 -> wp8
         /// </summary>
-        bool TryGetEquivalentFrameworks(NuGetFramework framework, out IEnumerable<NuGetFramework> frameworks);
+        bool TryGetEquivalentFrameworks(NuGetFramework framework, [NotNullWhen(true)] out IEnumerable<NuGetFramework>? frameworks);
 
         /// <summary>
         /// Gives all substitutions for a framework range.
         /// </summary>
-        bool TryGetEquivalentFrameworks(FrameworkRange range, out IEnumerable<NuGetFramework> frameworks);
+        bool TryGetEquivalentFrameworks(FrameworkRange range, [NotNullWhen(true)] out IEnumerable<NuGetFramework>? frameworks);
 
         /// <summary>
         /// Returns ranges of frameworks that are known to be supported by the given framework.
         /// Ex: net45 -> native
         /// </summary>
-        bool TryGetCompatibilityMappings(NuGetFramework framework, out IEnumerable<FrameworkRange> supportedFrameworkRanges);
+        bool TryGetCompatibilityMappings(NuGetFramework framework, [NotNullWhen(true)] out IEnumerable<FrameworkRange>? supportedFrameworkRanges);
 
         /// <summary>
         /// Returns all sub sets of the given framework.
         /// Ex: .NETFramework -> .NETCore
         /// These will have the same version, but a different framework
         /// </summary>
-        bool TryGetSubSetFrameworks(string frameworkIdentifier, out IEnumerable<string> subSetFrameworkIdentifiers);
+        bool TryGetSubSetFrameworks(string frameworkIdentifier, [NotNullWhen(true)] out IEnumerable<string>? subSetFrameworkIdentifiers);
 
         /// <summary>
         /// The ascending order of frameworks should be based on the following ordered groups:
@@ -121,7 +122,7 @@ namespace NuGet.Frameworks
         /// </summary>
         /// <remarks>netcore50 is a special case since netcore451 is not packages based, but netcore50 is.
         /// This sort will treat all versions of netcore as non-packages based.</remarks>
-        int CompareFrameworks(NuGetFramework x, NuGetFramework y);
+        int CompareFrameworks(NuGetFramework? x, NuGetFramework? y);
 
         /// <summary>
         /// Used to pick between two equivalent frameworks. This is meant to favor the more human-readable
@@ -129,7 +130,7 @@ namespace NuGet.Frameworks
         /// equivalent (e.g. with
         /// <see cref="TryGetEquivalentFrameworks(NuGetFramework, out IEnumerable{NuGetFramework})"/>).
         /// </summary>
-        int CompareEquivalentFrameworks(NuGetFramework x, NuGetFramework y);
+        int CompareEquivalentFrameworks(NuGetFramework? x, NuGetFramework? y);
 
         /// <summary>
         /// Returns folder short names rewrites.

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/AssetTargetFallbackTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/AssetTargetFallbackTests.cs
@@ -15,13 +15,13 @@ namespace NuGet.Frameworks.Test
         [Fact]
         public void Constructor_WithNullFramework_Throws()
         {
-            Assert.Throws<ArgumentNullException>(() => new AssetTargetFallbackFramework(framework: null, fallbackFrameworks: SampleFrameworkList));
+            Assert.Throws<ArgumentNullException>(() => new AssetTargetFallbackFramework(framework: null!, fallbackFrameworks: SampleFrameworkList));
         }
 
         [Fact]
         public void Constructor_WithNullFallbacks_Throws()
         {
-            Assert.Throws<ArgumentNullException>(() => new AssetTargetFallbackFramework(framework: NuGetFramework.AnyFramework, fallbackFrameworks: null));
+            Assert.Throws<ArgumentNullException>(() => new AssetTargetFallbackFramework(framework: NuGetFramework.AnyFramework, fallbackFrameworks: null!));
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTableTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTableTests.cs
@@ -21,8 +21,7 @@ namespace NuGet.Test
 
             CompatibilityTable table = new CompatibilityTable(all);
 
-            IEnumerable<NuGetFramework> compatible = null;
-            table.TryGetCompatible(win81, out compatible);
+            table.TryGetCompatible(win81, out IEnumerable<NuGetFramework>? compatible);
 
             var results = compatible.ToArray();
 
@@ -44,8 +43,7 @@ namespace NuGet.Test
 
             CompatibilityTable table = new CompatibilityTable(all);
 
-            IEnumerable<NuGetFramework> compatible = null;
-            table.TryGetCompatible(win9, out compatible);
+            table.TryGetCompatible(win9, out IEnumerable<NuGetFramework>? compatible);
 
             var results = compatible.ToArray();
 
@@ -68,8 +66,7 @@ namespace NuGet.Test
 
             CompatibilityTable table = new CompatibilityTable(all);
 
-            IEnumerable<NuGetFramework> compatible = null;
-            table.TryGetCompatible(net40, out compatible);
+            table.TryGetCompatible(net40, out IEnumerable<NuGetFramework>? compatible);
 
             Assert.Equal(2, compatible.Count());
             Assert.Equal(net35, compatible.First());
@@ -88,8 +85,7 @@ namespace NuGet.Test
 
             CompatibilityTable table = new CompatibilityTable(all);
 
-            IEnumerable<NuGetFramework> compatible = null;
-            table.TryGetCompatible(wp8, out compatible);
+            table.TryGetCompatible(wp8, out IEnumerable<NuGetFramework>? compatible);
 
             Assert.Equal(wp8, compatible.Single());
         }

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/DualCompatibilityFrameworkTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/DualCompatibilityFrameworkTests.cs
@@ -14,13 +14,13 @@ namespace NuGet.Frameworks.Test
         [Fact]
         public void Constructor_WithNullFramework_Throws()
         {
-            Assert.Throws<ArgumentNullException>(() => new DualCompatibilityFramework(framework: null, secondaryFramework: NuGetFramework.AnyFramework));
+            Assert.Throws<ArgumentNullException>(() => new DualCompatibilityFramework(framework: null!, secondaryFramework: NuGetFramework.AnyFramework));
         }
 
         [Fact]
         public void Constructor_WithNullSecondary_Throws()
         {
-            Assert.Throws<ArgumentNullException>(() => new DualCompatibilityFramework(framework: NuGetFramework.AnyFramework, secondaryFramework: null));
+            Assert.Throws<ArgumentNullException>(() => new DualCompatibilityFramework(framework: NuGetFramework.AnyFramework, secondaryFramework: null!));
         }
 
         [Theory]

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkNameProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkNameProviderTests.cs
@@ -146,10 +146,9 @@ namespace NuGet.Test
             var provider = DefaultFrameworkNameProvider.Instance;
 
             NuGetFramework input = new NuGetFramework("Windows", new Version(8, 0));
-            IEnumerable<NuGetFramework> frameworks = null;
-            provider.TryGetEquivalentFrameworks(input, out frameworks);
+            provider.TryGetEquivalentFrameworks(input, out IEnumerable<NuGetFramework>? frameworks);
 
-            var set = new HashSet<NuGetFramework>(frameworks, NuGetFramework.Comparer);
+            var set = new HashSet<NuGetFramework>(frameworks!, NuGetFramework.Comparer);
 
             Assert.False(set.Contains(input));
         }
@@ -160,8 +159,7 @@ namespace NuGet.Test
             var provider = DefaultFrameworkNameProvider.Instance;
 
             NuGetFramework input = new NuGetFramework("Windows", new Version(8, 0));
-            IEnumerable<NuGetFramework> frameworks = null;
-            provider.TryGetEquivalentFrameworks(input, out frameworks);
+            provider.TryGetEquivalentFrameworks(input, out IEnumerable<NuGetFramework>? frameworks);
 
             var results = frameworks
                 .OrderBy(f => f, new NuGetFrameworkSorter())
@@ -182,8 +180,7 @@ namespace NuGet.Test
             var provider = DefaultFrameworkNameProvider.Instance;
 
             NuGetFramework input = new NuGetFramework("MyFramework", new Version(9, 0));
-            IEnumerable<NuGetFramework> frameworks = null;
-            bool found = provider.TryGetEquivalentFrameworks(input, out frameworks);
+            bool found = provider.TryGetEquivalentFrameworks(input, out _);
 
             Assert.False(found);
         }
@@ -195,8 +192,7 @@ namespace NuGet.Test
         {
             var provider = DefaultFrameworkNameProvider.Instance;
 
-            string identifier = null;
-            bool found = provider.TryGetIdentifier(input, out identifier);
+            bool found = provider.TryGetIdentifier(input, out _);
 
             Assert.False(found);
         }
@@ -209,8 +205,7 @@ namespace NuGet.Test
         {
             var provider = DefaultFrameworkNameProvider.Instance;
 
-            string identifier = null;
-            provider.TryGetIdentifier(input, out identifier);
+            provider.TryGetIdentifier(input, out string? identifier);
 
             Assert.Equal(expected, identifier);
         }
@@ -221,7 +216,7 @@ namespace NuGet.Test
             // Arrange
             var target = DefaultFrameworkNameProvider.Instance;
             var input = "net45+win8+net-cf+net46";
-            IEnumerable<NuGetFramework> frameworks;
+            IEnumerable<NuGetFramework>? frameworks;
 
             // Act & Assert
             var actual = Assert.Throws<ArgumentException>(
@@ -251,10 +246,9 @@ namespace NuGet.Test
         {
             var provider = DefaultFrameworkNameProvider.Instance;
 
-            Version version = null;
-            provider.TryGetVersion(versionString, out version);
+            provider.TryGetVersion(versionString, out Version? version);
 
-            string actual = provider.GetVersionString("Windows", version);
+            string actual = provider.GetVersionString("Windows", version!);
 
             Assert.Equal(expected, actual);
         }

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkReducerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkReducerTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using NuGet.Frameworks;
 using Xunit;
@@ -214,7 +213,7 @@ namespace NuGet.Test
             var result = reducer.GetNearest(project, frameworks);
 
             // Assert
-            Assert.Equal(expectedFramework, result.GetShortFolderName());
+            Assert.Equal(expectedFramework, result!.GetShortFolderName());
         }
 
         [Fact]
@@ -373,7 +372,7 @@ namespace NuGet.Test
             var result = reducer.GetNearest(project, frameworks);
 
             // Assert
-            Assert.Equal(expectedFramework, result.GetShortFolderName());
+            Assert.Equal(expectedFramework, result!.GetShortFolderName());
         }
 
         [Fact]
@@ -1067,7 +1066,7 @@ namespace NuGet.Test
 
             var result = reducer.GetNearest(projectFramework, frameworks);
 
-            Assert.Equal("net40", result.GetShortFolderName());
+            Assert.Equal("net40", result!.GetShortFolderName());
         }
 
         [Theory]

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGet.Frameworks.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGet.Frameworks.Test.csproj
@@ -4,6 +4,7 @@
     <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Frameworks.</Description>
     <UserSecretsId>f889ae50-c1f1-4c63-beae-292414bb3939</UserSecretsId>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkTests.cs
@@ -134,8 +134,8 @@ namespace NuGet.Test
         public void EqualityOperator_ReturnTrueIfBothFrameworksAreNull()
         {
             // Arrange
-            NuGetFramework framework1 = null;
-            NuGetFramework framework2 = null;
+            NuGetFramework? framework1 = null;
+            NuGetFramework? framework2 = null;
 
             // Act and Assert
             Assert.True(framework1 == framework2);
@@ -159,8 +159,8 @@ namespace NuGet.Test
         public void InequalityOperator_ReturnFalseIfBothFrameworksAreNull()
         {
             // Arrange
-            NuGetFramework framework1 = null;
-            NuGetFramework framework2 = null;
+            NuGetFramework? framework1 = null;
+            NuGetFramework? framework2 = null;
 
             // Act and Assert
             Assert.False(framework1 != framework2);
@@ -217,7 +217,7 @@ namespace NuGet.Test
         {
             // Arrange
             var framework1 = NuGetFramework.Parse(frameworkName);
-            NuGetFramework framework2 = null;
+            NuGetFramework? framework2 = null;
 
             // Act and Assert
             Assert.False(framework1 == framework2);
@@ -243,7 +243,7 @@ namespace NuGet.Test
         {
             // Arrange
             var framework1 = NuGetFramework.Parse(frameworkName);
-            NuGetFramework framework2 = null;
+            NuGetFramework? framework2 = null;
 
             // Act and Assert
             Assert.True(framework1 != framework2);

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkUtilityTests.cs
@@ -31,11 +31,11 @@ namespace NuGet.Frameworks.Test
         {
             // Arrange
             var project = NuGetFramework.Parse("net45");
-            List<FrameworkSpecificGroup> items = null;
+            List<FrameworkSpecificGroup>? items = null;
 
             // Act
-            var nearestWithSelector = NuGetFrameworkUtility.GetNearest<FrameworkSpecificGroup>(items, project, (item) => item.TargetFramework);
-            var nearest = NuGetFrameworkUtility.GetNearest<FrameworkSpecificGroup>(items, project);
+            var nearestWithSelector = NuGetFrameworkUtility.GetNearest<FrameworkSpecificGroup>(items!, project, (item) => item.TargetFramework);
+            var nearest = NuGetFrameworkUtility.GetNearest<FrameworkSpecificGroup>(items!, project);
 
             // Assert
             Assert.Null(nearest);
@@ -58,8 +58,8 @@ namespace NuGet.Frameworks.Test
             var nearest = NuGetFrameworkUtility.GetNearest<FrameworkSpecificGroup>(items, project);
 
             // Assert
-            Assert.Equal("net45", nearestWithSelector.TargetFramework.GetShortFolderName());
-            Assert.Equal("net45", nearest.TargetFramework.GetShortFolderName());
+            Assert.Equal("net45", nearestWithSelector!.TargetFramework.GetShortFolderName());
+            Assert.Equal("net45", nearest!.TargetFramework.GetShortFolderName());
         }
 
 
@@ -77,8 +77,8 @@ namespace NuGet.Frameworks.Test
             var nearest = NuGetFrameworkUtility.GetNearest<FrameworkSpecificGroup>(items, project);
 
             // Assert
-            Assert.Equal("any", nearestWithSelector.TargetFramework.GetShortFolderName());
-            Assert.Equal("any", nearest.TargetFramework.GetShortFolderName());
+            Assert.Equal("any", nearestWithSelector!.TargetFramework.GetShortFolderName());
+            Assert.Equal("any", nearest!.TargetFramework.GetShortFolderName());
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12570

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Add nullable annotations to NuGet.Frameworks and its test project
* Found two places where `#if NET40_CLIENT` was used. Delete it, since we stopped building for .NET 4.0 a while ago
* Some minor code cleanup in some places (for example, use auto-props)
* Added null checks and throw `ArgumentNullException` on some public APIs where nulls are not expected/allowed, but wasn't previously being enforced (would have thrown `NullReferenceException`, so not has a better error experience).
* I think only 1 bug was found and fixed. See comments below.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: PR goal is to annotate nullability. Product behaviour, and therefore tests, shouldn't be affected.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
