### PR TITLE
Use PreAuthenticate=true in NuGet.Protocol

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
@@ -53,7 +53,8 @@ namespace NuGet.Protocol
             var clientHandler = new HttpClientHandler
             {
                 Proxy = proxy,
-                AutomaticDecompression = (DecompressionMethods.GZip | DecompressionMethods.Deflate)
+                AutomaticDecompression = (DecompressionMethods.GZip | DecompressionMethods.Deflate),
+                PreAuthenticate = true
             };
 
 #if IS_DESKTOP

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
@@ -145,10 +145,10 @@ namespace NuGet.Protocol.FuncTest
                 _httpListener = listener;
                 _baseUrl = baseUrl;
 
-                listener.BeginGetContext(EndGetContext, listener);
+                listener.BeginGetContext(HandleHttpRequest, listener);
             }
 
-            public void EndGetContext(IAsyncResult result)
+            public void HandleHttpRequest(IAsyncResult result)
             {
                 HttpListener httpListener = (HttpListener)result.AsyncState!;
                 if (httpListener.IsListening)
@@ -190,7 +190,7 @@ namespace NuGet.Protocol.FuncTest
 
                     try
                     {
-                        httpListener.BeginGetContext(EndGetContext, httpListener);
+                        httpListener.BeginGetContext(HandleHttpRequest, httpListener);
                     }
                     catch (ObjectDisposedException)
                     {

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
@@ -186,7 +186,14 @@ namespace NuGet.Protocol.FuncTest
 
                     context?.Response.Close();
 
-                    httpListener.BeginGetContext(EndGetContext, httpListener);
+                    try
+                    {
+                        httpListener.BeginGetContext(EndGetContext, httpListener);
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // .NET 5 throws here, whereas .NET Framework triggers the callback where we can check IsListening == false
+                    }
                 }
             }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
@@ -179,9 +179,15 @@ namespace NuGet.Protocol.FuncTest
 
                         string? authorization = context.Request.Headers["Authorization"];
 
-                        context.Response.StatusCode = string.IsNullOrEmpty(authorization)
-                            ? 401
-                            : 200;
+                        if (authorization == null)
+                        {
+                            context.Response.StatusCode = 401;
+                            context.Response.Headers.Add("WWW-Authenticate", "Basic");
+                        }
+                        else
+                        {
+                            context.Response.StatusCode = 200;
+                        }
 
                         _output.WriteLine($"Got request for {context.Request.Url}. Auth: {authorization}");
 

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
@@ -1,0 +1,182 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Server;
+using Xunit;
+
+namespace NuGet.Protocol.FuncTest
+{
+    public class AuthenticationHandlerTests
+    {
+        [Fact]
+        public async Task OnlyOneRequestWithoutAuthorizationHeader()
+        {
+            // Arrange
+            var portReserver = new PortReserver();
+            await portReserver.ExecuteAsync(async (port, cancellationToken) =>
+            {
+                var server = new RequestCollectingServer();
+                server.Start(port);
+                try
+                {
+                    var packageSource = new PackageSource(server.BaseUrl + "v3/index.json", "test");
+                    packageSource.Credentials = new PackageSourceCredential(packageSource.Name, "user", "pass", true, "basic");
+                    var repository = Repository.Factory.GetCoreV3(packageSource);
+
+                    var httpSourceResource = await repository.GetResourceAsync<HttpSourceResource>();
+                    var source = httpSourceResource.HttpSource;
+
+                    using (var sourceCacheContext = new SourceCacheContext()
+                    {
+                        DirectDownload = true,
+                        NoCache = true,
+                    })
+                    {
+                        Mock<ILogger> logger = new();
+                        HttpSourceCacheContext httpSourceCacheContext = HttpSourceCacheContext.Create(sourceCacheContext, isFirstAttempt: true);
+
+                        // Act
+                        var request = new HttpSourceCachedRequest(server.BaseUrl + "1", "1", httpSourceCacheContext);
+                        _ = await source.GetAsync(request, ProcessResponse, logger.Object, cancellationToken);
+
+                        request = new HttpSourceCachedRequest(server.BaseUrl + "2", "2", httpSourceCacheContext);
+                        _ = await source.GetAsync(request, ProcessResponse, logger.Object, cancellationToken);
+                    }
+                }
+                finally
+                {
+                    server.Stop();
+                }
+
+                // Assert
+                Assert.Equal(
+                    1,
+                    server.Requests.Count(RequestWithoutAuthorizationheader));
+                Assert.Equal(
+                    2,
+                    server.Requests.Select(r => r.RawUrl).Distinct().Count());
+
+                // ExecuteAsync returns Task<T>, so need to return something to give it a <T>.
+                return (object?)null;
+            },
+            CancellationToken.None);
+
+            static bool RequestWithoutAuthorizationheader(HttpListenerRequest request)
+            {
+                string? value = request.Headers["Authorization"];
+                return string.IsNullOrEmpty(value);
+            }
+        }
+
+        private static Task<string> ProcessResponse(HttpSourceResult result)
+        {
+            return Task.FromResult(string.Empty);
+        }
+
+        private class RequestCollectingServer
+        {
+            private string? _baseUrl;
+            private HttpListener? _httpListener;
+            private List<HttpListenerRequest> _requests = new();
+            private Thread? _serverThread;
+
+            public string BaseUrl
+            {
+                get
+                {
+                    if (_baseUrl == null)
+                    {
+                        throw new InvalidOperationException("Start must be called first");
+                    }
+                    return _baseUrl;
+                }
+            }
+
+            public IReadOnlyList<HttpListenerRequest> Requests
+            {
+                get
+                {
+                    return _requests;
+                }
+            }
+
+            public void Start(int port)
+            {
+                if (_httpListener != null)
+                {
+                    throw new InvalidOperationException("Already started");
+                }
+
+                string baseUrl = $"http://localhost:{port}/";
+                var listener = new HttpListener();
+                listener.Prefixes.Add(baseUrl);
+                listener.AuthenticationSchemes = AuthenticationSchemes.Basic | AuthenticationSchemes.Anonymous;
+                listener.Start();
+                _httpListener = listener;
+                _baseUrl = baseUrl;
+
+                _serverThread = new Thread(ProcessRequests);
+                _serverThread.Start();
+            }
+
+            public void Stop()
+            {
+                if (_httpListener == null)
+                {
+                    throw new InvalidOperationException("Not started");
+                }
+
+                var listener = _httpListener;
+                _httpListener = null;
+                _baseUrl = null;
+
+                listener.Close();
+
+                _serverThread?.Join();
+                _serverThread = null;
+            }
+
+            private void ProcessRequests()
+            {
+                if (_httpListener == null)
+                {
+                    throw new InvalidOperationException("_httpListener must be created");
+                }
+
+                try
+                {
+                    while (true)
+                    {
+                        HttpListenerContext context = _httpListener.GetContext();
+
+                        _requests.Add(context.Request);
+
+                        string? authorization = context.Request.Headers["Authorization"];
+
+                        context.Response.StatusCode = string.IsNullOrEmpty(authorization)
+                            ? 401
+                            : 200;
+
+                        context.Response.Close();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    string msg = ex.Message;
+                }
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
@@ -100,7 +100,6 @@ namespace NuGet.Protocol.FuncTest
             private string? _baseUrl;
             private HttpListener? _httpListener;
             private List<HttpListenerRequest> _requests = new();
-            private Thread? _serverThread;
             private ITestOutputHelper _output;
 
             public RequestCollectingServer(ITestOutputHelper output)
@@ -210,9 +209,6 @@ namespace NuGet.Protocol.FuncTest
 
                 listener.Stop();
                 listener.Close();
-
-                _serverThread?.Join();
-                _serverThread = null;
             }
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12514

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Set `HttpClientHandler.PreAuthenticate` to true. As long as a private NuGet feed puts all resources under sub-directories where the service index is (docs issue created to create server implementation guidelines), then as long as NuGet makes an HTTP request for the service index, then all other URLs will be pre-authenticated.

There are more edge cases (like expiring tokens), but see the [epic for reducing HTTP 401's](https://github.com/NuGet/Home/issues/12517) for other follow up issues. This PR will still provide significant benefit for many scenarios, even if there are some gaps.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled: https://github.com/NuGet/docs.microsoft.com-nuget/issues/3059
  - **OR**
  - [ ] N/A
