### PR TITLE
Enable NuGetAudit by default on .NET 8 and higher

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -62,7 +62,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Flag if the Central package file is enabled -->
     <_CentralPackageVersionsEnabled Condition="'$(ManagePackageVersionsCentrally)' == 'true' AND '$(CentralPackageVersionsFileImported)' == 'true'">true</_CentralPackageVersionsEnabled>
     <!-- NuGetAudit is enabled by default when using the .NET 8 SDK or above -->
-    <NuGetAudit Condition=" '$(NuGetAudit)' != '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '8.0'))">true</NuGetAudit>
+    <NuGetAudit Condition=" '$(NuGetAudit)' == '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '8.0'))">true</NuGetAudit>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -62,7 +62,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Flag if the Central package file is enabled -->
     <_CentralPackageVersionsEnabled Condition="'$(ManagePackageVersionsCentrally)' == 'true' AND '$(CentralPackageVersionsFileImported)' == 'true'">true</_CentralPackageVersionsEnabled>
     <!-- NuGetAudit is enabled by default when using the .NET 8 SDK or above -->
-    <NuGetAudit Condition=" '$(NuGetAudit)' == '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '8.0'))">true</NuGetAudit>
+    <NuGetAudit Condition=" '$(NuGetAudit)' == '' AND $([MSBuild]::VersionGreaterThanOrEquals($([MSBuild]::ValueOrDefault('$(NETCoreSdkVersion)', '0.0')), '8.0'))">true</NuGetAudit>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -61,6 +61,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GetReferenceNearestTargetFrameworkTaskSupportsTargetPlatformParameter>true</GetReferenceNearestTargetFrameworkTaskSupportsTargetPlatformParameter>
     <!-- Flag if the Central package file is enabled -->
     <_CentralPackageVersionsEnabled Condition="'$(ManagePackageVersionsCentrally)' == 'true' AND '$(CentralPackageVersionsFileImported)' == 'true'">true</_CentralPackageVersionsEnabled>
+    <!-- NuGetAudit is enabled by default when using the .NET 8 SDK or above -->
+    <NuGetAudit Condition=" '$(NuGetAudit)' != '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '8.0'))">true</NuGetAudit>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/ProjectPropertyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/ProjectPropertyTests.cs
@@ -27,8 +27,14 @@ namespace Dotnet.Integration.Test
             var projectFileContents = @"<Project Sdk=""Microsoft.NET.Sdk"">
     <Target Name=""ValidateNuGetAuditValue"">
         <Message Importance=""high"" Text=""NuGetAudit: '$(NuGetAudit)'"" />
-        <Error Text=""NuGetAudit property should be set to true by default"" Condition=""'$(NuGetAuditExpected)' == 'true' AND '$(NuGetAudit)' != 'true'"" />
-        <Error Text=""NuGetAudit property should not be set to true by default"" Condition=""'$(NuGetAuditExpected)' != 'true' AND '$(NuGetAudit)' == 'true'"" />
+        <Error Text=""ExpectEnabled was not set"" Condition="" '$(ExpectEnabled)' != 'true' AND '$(ExpectEnabled)' != 'false' "" />
+        <Message Importance=""high"" Text=""SdkVersion: $(NETCoreSdkVersion) "" />
+    </Target>
+    <Target Name=""ValidateEnabled"" Condition="" '$(ExpectEnabled)' == 'true' "" AfterTargets=""ValidateNuGetAuditValue"">
+        <Error Text=""NuGetAudit property should be set to true by default"" Condition="" '$(NuGetAudit)' != 'true' "" />
+    </Target>
+    <Target Name=""ValidateNotSet"" Condition="" '$(ExpectEnabled)' != 'true' "" AfterTargets=""ValidateNuGetAuditValue"">
+        <Error Text=""NuGetAudit property should not be set"" Condition="" '$(NuGetAudit)' != '' "" />
     </Target>
 </Project>";
             File.WriteAllText(projectFilePath, projectFileContents);
@@ -44,7 +50,7 @@ namespace Dotnet.Integration.Test
 #endif
 
             // Act
-            var result = _msbuildFixture.RunDotnet(testDirectory.Path, $"msbuild -t:ValidateNuGetAuditValue -p:NuGetAuditExpected={expected}");
+            var result = _msbuildFixture.RunDotnet(testDirectory.Path, $"msbuild -t:ValidateNuGetAuditValue -p:ExpectEnabled={expected}");
 
             // Assert
             result.Success.Should().BeTrue(result.AllOutput);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/ProjectPropertyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/ProjectPropertyTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using FluentAssertions;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace Dotnet.Integration.Test
+{
+    [Collection(DotnetIntegrationCollection.Name)]
+    public class ProjectPropertyTests
+    {
+        private MsbuildIntegrationTestFixture _msbuildFixture;
+
+        public ProjectPropertyTests(MsbuildIntegrationTestFixture fixture)
+        {
+            _msbuildFixture = fixture;
+        }
+
+        [Fact]
+        public void NuGetAudit_EnabledByDefaultOnNet8AndHigher()
+        {
+            // Arrange
+            using TestDirectory testDirectory = TestDirectory.Create();
+            string projectFilePath = Path.Combine(testDirectory.Path, "test.csproj");
+            var projectFileContents = @"<Project Sdk=""Microsoft.NET.Sdk"">
+    <Target Name=""ValidateNuGetAuditValue"">
+        <Message Importance=""high"" Text=""NuGetAudit: '$(NuGetAudit)'"" />
+        <Error Text=""NuGetAudit property should be set to true by default"" Condition=""'$(NuGetAuditExpected)' == 'true' AND '$(NuGetAudit)' != 'true'"" />
+        <Error Text=""NuGetAudit property should not be set to true by default"" Condition=""'$(NuGetAuditExpected)' != 'true' AND '$(NuGetAudit)' == 'true'"" />
+    </Target>
+</Project>";
+            File.WriteAllText(projectFilePath, projectFileContents);
+
+            // Dotnet.Integration.Tests works by finding the test assembly compile TFM, then finding the SDK that maches the TFM's major version.
+            // (see TestDotnetCliUtility.GetSdkToTestByAssemblyPath).
+            // Therefore, we can depend on this file's compile time TFM to tell us if we're testing the .NET 7 or 8 SDK.
+            string expected =
+#if NET8_0_OR_GREATER
+                "true";
+#else
+                "false";
+#endif
+
+            // Act
+            var result = _msbuildFixture.RunDotnet(testDirectory.Path, $"msbuild -t:ValidateNuGetAuditValue -p:NuGetAuditExpected={expected}");
+
+            // Assert
+            result.Success.Should().BeTrue(result.AllOutput);
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12568

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Enable NuGetAudit by default when customers are using the .NET 8 SDK or higher.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
