### PR TITLE
Add two Apex test cases to install latest package in PMC

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -305,7 +305,6 @@ namespace NuGet.Tests.Apex
                     uiwindow.InstallPackageFromUI(packageName, packageVersion1);
                     testContext.SolutionService.Build();
                     testContext.NuGetApexTestService.WaitForAutoRestore();
-                    uiwindow.SwitchTabToUpdate();
 
                     uiwindow.UpdatePackageFromUI(packageName, packageVersion2);
                     testContext.SolutionService.Build();
@@ -343,7 +342,6 @@ namespace NuGet.Tests.Apex
                     uiwindow.InstallPackageFromUI(packageName, packageVersion);
                     testContext.SolutionService.Build();
                     testContext.NuGetApexTestService.WaitForAutoRestore();
-                    uiwindow.SwitchTabToInstalled();
 
                     uiwindow.UninstallPackageFromUI(packageName);
                     testContext.SolutionService.Build();


### PR DESCRIPTION
## Bug
https://github.com/NuGet/Client.Engineering/issues/2285

## Description
We want to add two Apex test cases into "C:\NuGet\NuGet.Client\test\NuGet.Tests.Apex\NuGet.Tests.Apex\NuGetEndToEndTests\NuGetConsoleTestCase.cs" for intalling latest package in PMC within two types of projects: WCFServiceApplication (.NET Framework) & NetStandardClassLibrary.

1. We test the same scenario with two different projects: WCFServiceApplication (.NET Framework) & NetStandardClassLibrary.
2. We created a package with two different versions and typed a command "Install-package [packageName]" to verify if NuGet can install the latest version.
3. BTW, we deleted two unnecessary lines from "...\NetCoreProjectTestCase.cs" to improve the efficiency of running the cases.
## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added
