### PR TITLE
Workaround: .NET SDK Installs version 8.0.100-preview.3

### DIFF
--- a/build/DotNetSdkVersions.txt
+++ b/build/DotNetSdkVersions.txt
@@ -1,5 +1,5 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Channel 8.0 -Version 8.0.100-preview.3
+-Channel 8.0 -Version 8.0.100-preview.4.23260.5
 -Channel 7.0
 -Channel 6.0 -Runtime dotnet
 -Channel 5.0

--- a/build/DotNetSdkVersions.txt
+++ b/build/DotNetSdkVersions.txt
@@ -1,5 +1,5 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Channel 8.0 -Version 8.0.100-preview.4.23260.5
+-Channel 8.0 -Version 8.0.100-preview.3.23178.7
 -Channel 7.0
 -Channel 6.0 -Runtime dotnet
 -Channel 5.0

--- a/build/DotNetSdkVersions.txt
+++ b/build/DotNetSdkVersions.txt
@@ -1,5 +1,5 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Channel 8.0
+-Channel 8.0 -Version 8.0.100-preview.3
 -Channel 7.0
 -Channel 6.0 -Runtime dotnet
 -Channel 5.0

--- a/build/config.props
+++ b/build/config.props
@@ -27,7 +27,7 @@
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <VsTargetBranch>main</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
-    <VsTargetChannelForTests>$(VsTargetChannel)</VsTargetChannelForTests>
+    <VsTargetChannelForTests>int.d17.5</VsTargetChannelForTests>
 
     <!-- NuGet SDK VS package Semantic Version -->
     <NuGetSdkVsSemanticVersion>$(VsTargetMajorVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</NuGetSdkVsSemanticVersion>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2290

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Pin the SDK to a .NET 8 preview 3 version.
Pin the Test VS version to what's currently available on MicroBuild.

HotSeat will keep track of solutions like MicroBuild updating VS on our CI agents, which means we can undo this workaround.
Tracking the reversal in: https://github.com/NuGet/Client.Engineering/issues/2291

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled https://github.com/NuGet/Client.Engineering/issues/2291
  - **OR**
  - [ ] N/A
