### PR TITLE
Revert "Workaround: .NET SDK Installs version 8.0.100-preview.3 (#5169)"

### DIFF
--- a/build/DotNetSdkVersions.txt
+++ b/build/DotNetSdkVersions.txt
@@ -1,5 +1,5 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Channel 8.0 -Version 8.0.100-preview.3.23178.7
+-Channel 8.0
 -Channel 7.0
 -Channel 6.0 -Runtime dotnet
 -Channel 5.0

--- a/build/config.props
+++ b/build/config.props
@@ -27,7 +27,7 @@
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <VsTargetBranch>main</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
-    <VsTargetChannelForTests>int.d17.5</VsTargetChannelForTests>
+    <VsTargetChannelForTests>$(VsTargetChannel)</VsTargetChannelForTests>
 
     <!-- NuGet SDK VS package Semantic Version -->
     <NuGetSdkVsSemanticVersion>$(VsTargetMajorVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</NuGetSdkVsSemanticVersion>


### PR DESCRIPTION
This reverts commit 9d95d880fd45c88f5e71c3a3d215514dcbe76a3c.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2291

Regression? Last working version: N/A

## Description
VS version has been updated on CI agent pool. This reverts the workaround that pinned the SDK to .NET 8 preview 3 and pinned the Test VS version to was available on MicroBuild in PR: https://github.com/NuGet/NuGet.Client/pull/5169.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
