### PR TITLE
Only allow certain packages in source build

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -182,7 +182,7 @@
 
       <_sourceBuildUnexpectedPackage Include="@(PackageReference)" Exclude="@(_allowBuildFromSourcePackage)" />
     </ItemGroup>
-    <Error Text="Found @(_sourceBuildUnexpectedPackage-&gt;Count()) not on DotNetBuildFromSource allow list: '@(_sourceBuildUnexpectedPackage)'" Condition=" '@(_sourceBuildUnexpectedPackage)' != '' " />
+    <Error Text="Found @(_sourceBuildUnexpectedPackage-&gt;Count()) PackageReferences not on DotNetBuildFromSource allow list: '@(_sourceBuildUnexpectedPackage)'" Condition=" '@(_sourceBuildUnexpectedPackage)' != '' " />
   </Target>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -155,23 +155,30 @@
   </ItemGroup>
 
   <!-- DotNetBuildFromSource can only use packages that are open source -->
-  <Target Name="CheckSourceBuildPackageReferences" AfterTargets="Restore" Condition=" '$(DotNetBuildFromSource)' == 'true' ">
+  <Target Name="CheckSourceBuildPackageReferences" AfterTargets="CollectPackageReferences" Condition=" '$(DotNetBuildFromSource)' == 'true' ">
     <ItemGroup>
+      <_allowBuildFromSourcePackage Remove="@(_allowBuildFromSourcePackage)" />
+      <_sourceBuildUnexpectedPackage Remove="@(_sourceBuildUnexpectedPackage)" />
+
+      <_allowBuildFromSourcePackage Include="@(PackageReference)" Condition=" '%(PackageReference.IsImplicitlyDefined)' == 'true' " />
+
       <_allowBuildFromSourcePackage Include="Microsoft.Build.Framework" />
       <_allowBuildFromSourcePackage Include="Microsoft.Build.Tasks.Core" />
       <_allowBuildFromSourcePackage Include="Microsoft.Build.Utilities.Core" />
       <_allowBuildFromSourcePackage Include="Microsoft.Build" />
+      <_allowBuildFromSourcePackage Include="Microsoft.CSharp" />
       <_allowBuildFromSourcePackage Include="Microsoft.Extensions.CommandLineUtils.Sources" />
       <_allowBuildFromSourcePackage Include="Microsoft.Extensions.FileProviders.Abstractions" />
       <_allowBuildFromSourcePackage Include="Microsoft.Extensions.FileSystemGlobbing" />
       <_allowBuildFromSourcePackage Include="Microsoft.SourceLink.AzureRepos.Git" />
       <_allowBuildFromSourcePackage Include="Microsoft.SourceLink.GitHub" />
-      <_allowBuildFromSourcePackage Include="NETStandard.Library" />
+      <_allowBuildFromSourcePackage Include="Microsoft.Web.Xdt" />
       <_allowBuildFromSourcePackage Include="Newtonsoft.Json" />
-      <_allowBuildFromSourcePackage Include="System.Cryptography.ProtectedData" />
+      <_allowBuildFromSourcePackage Include="System.ComponentModel.Composition" />
       <_allowBuildFromSourcePackage Include="System.Diagnostics.Debug" />
       <_allowBuildFromSourcePackage Include="System.Security.Cryptography.Cng" />
       <_allowBuildFromSourcePackage Include="System.Security.Cryptography.Pkcs" />
+      <_allowBuildFromSourcePackage Include="System.Security.Cryptography.ProtectedData" />
 
       <_sourceBuildUnexpectedPackage Include="@(PackageReference)" Exclude="@(_allowBuildFromSourcePackage)" />
     </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -126,7 +126,7 @@
 
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" Condition="'$(Shipping)' == 'true' AND '$(IsXPlat)' != 'true'" />
-    <GlobalPackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" version="1.0.0" />
+    <GlobalPackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" version="1.0.0" Condition=" '$(DotNetBuildFromSource)' != 'true' " />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(UsePublicApiAnalyzer)' == 'true' ">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -153,4 +153,29 @@
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.3" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)build\BannedSymbols.txt" Condition="'$(TestProject)' != 'true'" />
   </ItemGroup>
+
+  <!-- DotNetBuildFromSource can only use packages that are open source -->
+  <Target Name="CheckSourceBuildPackageReferences" AfterTargets="Restore" Condition=" '$(DotNetBuildFromSource)' == 'true' ">
+    <ItemGroup>
+      <_allowBuildFromSourcePackage Include="Microsoft.Build.Framework" />
+      <_allowBuildFromSourcePackage Include="Microsoft.Build.Tasks.Core" />
+      <_allowBuildFromSourcePackage Include="Microsoft.Build.Utilities.Core" />
+      <_allowBuildFromSourcePackage Include="Microsoft.Build" />
+      <_allowBuildFromSourcePackage Include="Microsoft.Extensions.CommandLineUtils.Sources" />
+      <_allowBuildFromSourcePackage Include="Microsoft.Extensions.FileProviders.Abstractions" />
+      <_allowBuildFromSourcePackage Include="Microsoft.Extensions.FileSystemGlobbing" />
+      <_allowBuildFromSourcePackage Include="Microsoft.SourceLink.AzureRepos.Git" />
+      <_allowBuildFromSourcePackage Include="Microsoft.SourceLink.GitHub" />
+      <_allowBuildFromSourcePackage Include="NETStandard.Library" />
+      <_allowBuildFromSourcePackage Include="Newtonsoft.Json" />
+      <_allowBuildFromSourcePackage Include="System.Cryptography.ProtectedData" />
+      <_allowBuildFromSourcePackage Include="System.Diagnostics.Debug" />
+      <_allowBuildFromSourcePackage Include="System.Security.Cryptography.Cng" />
+      <_allowBuildFromSourcePackage Include="System.Security.Cryptography.Pkcs" />
+
+      <_sourceBuildUnexpectedPackage Include="@(PackageReference)" Exclude="@(_allowBuildFromSourcePackage)" />
+    </ItemGroup>
+    <Error Text="Found @(_sourceBuildUnexpectedPackage-&gt;Count()) not on DotNetBuildFromSource allow list: '@(_sourceBuildUnexpectedPackage)'" Condition=" '@(_sourceBuildUnexpectedPackage)' != '' " />
+  </Target>
+
 </Project>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ILMerge" PrivateAssets="All" />
+    <PackageReference Include="ILMerge" PrivateAssets="All" Condition=" '$(DotNetBuildFromSource)' != 'true' " />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(IsCore)' == 'true' ">


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12604
Fixes: https://github.com/NuGet/Home/issues/12603

Regression? yes Last working version: before https://github.com/NuGet/NuGet.Client/pull/5164

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Add ` '$(DotNetBuildFromSource)' != 'true' ` conditions on two packages
* Add target that runs after restore that validates package references in source build are on allow list, to hopefully prevent something like this happening again.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
