### PR TITLE
Exclude WPF projects from source-build

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,3 +1,4 @@
 <Project>
   <Import Project="build\common.targets" Condition="'$(IsCrossTargetingBuild)' == 'true' And '$(_WasCommonPropsImported)' != 'true'" />
+  <Import Project="eng\source-build\ExcludeFromSourceBuild.AfterCommonTargets.targets" Condition="'$(DotNetBuildFromSource)' == 'true'" />
 </Project>

--- a/eng/source-build/ExcludeFromSourceBuild.AfterCommonTargets.targets
+++ b/eng/source-build/ExcludeFromSourceBuild.AfterCommonTargets.targets
@@ -1,0 +1,21 @@
+<Project>
+  <!--
+    If a project specifies ExcludeFromSourceBuild=true during a source build suppress all targets and emulate a no-op
+    (empty common targets like Restore, Build, Pack, etc.).
+    Inspired by https://github.com/dotnet/arcade/blob/d9275ca3f692b5f97702bb6717a3bf78afedbf38/src/Microsoft.DotNet.Arcade.Sdk/tools/ExcludeFromBuild.BeforeCommonTargets.targets
+  -->
+  <PropertyGroup>
+    <_SuppressAllTargets>false</_SuppressAllTargets>
+    <_SuppressAllTargets Condition="'$(DotNetBuildFromSource)' == 'true' and '$(ExcludeFromSourceBuild)' == 'true'">true</_SuppressAllTargets>
+    <!-- If excluding, then disable a restore warning, which will fire on newer SDKs, as well as set the NuGetRestoreTargets property to empty,
+         which will avoid importing the restore targets inside the .NET SDK. If the restore targets exist, then static graph restore will attempt tpo
+         execute. -->
+    <DisableWarnForInvalidRestoreProjects Condition="'$(_SuppressAllTargets)' == 'true'">true</DisableWarnForInvalidRestoreProjects>
+    <NuGetRestoreTargets Condition="'$(_SuppressAllTargets)' == 'true'">$(MSBuildThisFileDirectory)NoRestore.targets</NuGetRestoreTargets>
+    <!-- When a project is using the .NET SDK, but with the "UseWpf" property, there will be an attempt to import the windows desktop SDK targets.
+         These are not available in certain circumstances, like linux source build. -->
+    <ImportWindowsDesktopTargets Condition="'$(_SuppressAllTargets)' == 'true'">false</ImportWindowsDesktopTargets>
+  </PropertyGroup>
+
+  <Import Project="Noop.proj" Condition="'$(_SuppressAllTargets)' == 'true'" />
+</Project>

--- a/eng/source-build/Noop.proj
+++ b/eng/source-build/Noop.proj
@@ -1,0 +1,6 @@
+<Project>
+  <Target Name="Restore" />
+  <Target Name="Build" />
+  <Target Name="Pack" />
+  <Target Name="Test" />
+</Project>

--- a/src/NuGet.Clients/NuGet.Console/NuGet.Console.csproj
+++ b/src/NuGet.Clients/NuGet.Console/NuGet.Console.csproj
@@ -8,6 +8,7 @@
     <Description>Package Manager PowerShell Console implementation.</Description>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
     <UseWpf>true</UseWpf>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -11,6 +11,7 @@
     <UseWinForms>true</UseWinForms>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/dotnet/source-build/issues/3467

Regression? Last working version: Break caused by https://github.com/NuGet/NuGet.Client/pull/5167

## Description

The changes in https://github.com/NuGet/NuGet.Client/pull/5167 updated projects to use SDK-style projects which caused them to be recognized by .NET's source-build infrastructure. Source-build attempted to build these projects and some of them ended up failing because they are defined as WPF projects which uses the Windows Desktop SDK. That fails in source-build because it only supports targeting for Linux.

This is fixed by updating the build system to exclude these two WPF projects from source-build. This follows the same pattern that is used by other .NET repos which are based on Arcade. But since the NuGet.Client repo doesn't use Arcade, a custom solution had to be implemented. Much of this implementation was taken directly from Arcade and adjusted to work in this repo. First, the relevant WPF-based projects are updated to set `ExcludeFromSourceBuild` to `true`. The build logic then works by checking whether .NET source-build is enabled (`DotNetBuildFromSource`) and whether the project is excluded from source-build. If so, it overrides all the necessary MSBuild targets of the project so that it results in a no-op. This effectively causes the projects to be skipped from source-build.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
