### PR TITLE
Show Vulnerable label in versions combobox

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/DisplayVersion.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/DisplayVersion.cs
@@ -49,6 +49,20 @@ namespace NuGet.PackageManagement.UI
             bool autoReferenced = false,
             bool isDeprecated = false,
             string versionFormat = "N")
+            : this(range, version, additionalInfo, isValidVersion, isCurrentInstalled, autoReferenced, isDeprecated, isVulnerable: false, versionFormat)
+        {
+        }
+
+        public DisplayVersion(
+            VersionRange range,
+            NuGetVersion version,
+            string additionalInfo,
+            bool isValidVersion = true,
+            bool isCurrentInstalled = false,
+            bool autoReferenced = false,
+            bool isDeprecated = false,
+            bool isVulnerable = false,
+            string versionFormat = "N")
         {
             if (versionFormat == null)
             {
@@ -65,6 +79,7 @@ namespace NuGet.PackageManagement.UI
             IsCurrentInstalled = isCurrentInstalled;
             AutoReferenced = autoReferenced;
             IsDeprecated = isDeprecated;
+            IsVulnerable = isVulnerable;
 
             // Display a single version if the range is locked
             if (range.OriginalString == null && range.HasLowerAndUpperBounds && range.MinVersion == range.MaxVersion)
@@ -83,12 +98,27 @@ namespace NuGet.PackageManagement.UI
                     AdditionalInfo + " " + Range.OriginalString;
             }
 
-            if (IsDeprecated)
+            if (IsDeprecated && IsVulnerable)
+            {
+                _toString += string.Format(
+                    CultureInfo.CurrentCulture,
+                    "    ({0}, {1})",
+                    Resources.Label_Vulnerable,
+                    Resources.Label_Deprecated);
+            }
+            else if (IsDeprecated)
             {
                 _toString += string.Format(
                     CultureInfo.CurrentCulture,
                     "    ({0})",
                     Resources.Label_Deprecated);
+            }
+            else if (IsVulnerable)
+            {
+                _toString += string.Format(
+                    CultureInfo.CurrentCulture,
+                    "    ({0})",
+                    Resources.Label_Vulnerable);
             }
         }
 
@@ -104,6 +134,8 @@ namespace NuGet.PackageManagement.UI
 
         public bool IsDeprecated { get; set; }
 
+        public bool IsVulnerable { get; set; }
+
         public override string ToString()
         {
             return _toString;
@@ -115,7 +147,8 @@ namespace NuGet.PackageManagement.UI
             return other != null
                 && other.Version == Version
                 && string.Equals(other.AdditionalInfo, AdditionalInfo, StringComparison.Ordinal)
-                && IsDeprecated == other.IsDeprecated;
+                && IsDeprecated == other.IsDeprecated
+                && IsVulnerable == other.IsVulnerable;
         }
 
         public override int GetHashCode()

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/DisplayVersion.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/DisplayVersion.cs
@@ -36,20 +36,7 @@ namespace NuGet.PackageManagement.UI
             bool autoReferenced = false,
             bool isDeprecated = false,
             string versionFormat = "N")
-            : this(range, version: null, additionalInfo, isValidVersion, isCurrentInstalled, autoReferenced, isDeprecated, versionFormat)
-        {
-        }
-
-        public DisplayVersion(
-            VersionRange range,
-            NuGetVersion version,
-            string additionalInfo,
-            bool isValidVersion = true,
-            bool isCurrentInstalled = false,
-            bool autoReferenced = false,
-            bool isDeprecated = false,
-            string versionFormat = "N")
-            : this(range, version, additionalInfo, isValidVersion, isCurrentInstalled, autoReferenced, isDeprecated, isVulnerable: false, versionFormat)
+            : this(range, version: null, additionalInfo, isValidVersion, isCurrentInstalled, autoReferenced, isDeprecated, isVulnerable: false, versionFormat)
         {
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -36,7 +36,7 @@ namespace NuGet.PackageManagement.UI
 
         // all versions of the _searchResultPackage
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1051:DoNotDeclareVisibleInstanceFields")]
-        protected List<(NuGetVersion version, bool isDeprecated)> _allPackageVersions;
+        protected List<(NuGetVersion version, bool isDeprecated, bool isVulnerable)> _allPackageVersions;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1051:DoNotDeclareVisibleInstanceFields")]
         protected PackageItemViewModel _searchResultPackage;
@@ -219,9 +219,9 @@ namespace NuGet.PackageManagement.UI
             }
 
             // Show the current package version as the only package in the list at first just in case fetching the versions takes a while.
-            _allPackageVersions = new List<(NuGetVersion version, bool isDeprecated)>()
+            _allPackageVersions = new List<(NuGetVersion version, bool isDeprecated, bool isVulnerable)>()
             {
-                (searchResultPackage.Version, false)
+                (searchResultPackage.Version, false, false)
             };
 
             await CreateVersionsAsync(CancellationToken.None);
@@ -269,15 +269,17 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private (NuGetVersion version, bool isDeprecated) GetVersion(VersionInfoContextInfo versionInfo)
+        private (NuGetVersion version, bool isDeprecated, bool isVulnerable) GetVersion(VersionInfoContextInfo versionInfo)
         {
             var isDeprecated = false;
+            var isVulnerable = false;
             if (versionInfo.PackageSearchMetadata != null)
             {
                 isDeprecated = versionInfo.PackageDeprecationMetadata != null;
+                isVulnerable = versionInfo.PackageSearchMetadata.Vulnerabilities != null;
             }
 
-            return (versionInfo.Version, isDeprecated);
+            return (versionInfo.Version, isDeprecated, isVulnerable);
         }
 
         protected virtual void DependencyBehavior_SelectedChanged(object sender, EventArgs e)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -205,14 +205,14 @@ namespace NuGet.PackageManagement.UI
             }
 
             _versions.Clear();
-            List<(NuGetVersion version, bool isDeprecated)> allVersions = _allPackageVersions?.Where(v => v.version != null).OrderByDescending(v => v.version).ToList();
+            List<(NuGetVersion version, bool isDeprecated, bool isVulnerable)> allVersions = _allPackageVersions?.Where(v => v.version != null).OrderByDescending(v => v.version).ToList();
 
             // null, if no version constraint defined in package.config
             VersionRange allowedVersions = await GetAllowedVersionsAsync(cancellationToken);
             var allVersionsAllowed = allVersions.Where(v => allowedVersions.Satisfies(v.version)).ToArray();
 
             var blockedVersions = new List<NuGetVersion>(allVersions.Count);
-            foreach ((NuGetVersion version, bool isDeprecated) in allVersions)
+            foreach ((NuGetVersion version, bool isDeprecated, bool isVulnerable) in allVersions)
             {
                 if (!allVersionsAllowed.Any(a => a.version.Version.Equals(version.Version)))
                 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1294,6 +1294,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Vulnerable.
+        /// </summary>
+        public static string Label_Vulnerable {
+            get {
+                return ResourceManager.GetString("Label_Vulnerable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Loading license file....
         /// </summary>
         public static string LicenseFile_Loading {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -990,4 +990,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Text_PackageMappingsDisabled" xml:space="preserve">
     <value>Package source mapping is off.</value>
   </data>
+  <data name="Label_Vulnerable" xml:space="preserve">
+    <value>Vulnerable</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
@@ -3,13 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
-using Microsoft.TeamFoundation.Common;
 using NuGet.Versioning;
 
 namespace NuGet.PackageManagement.UI
@@ -170,7 +168,7 @@ namespace NuGet.PackageManagement.UI
                                 bool isBestOption = rangeBestVersion.ToString() == _versions.Items[_versions.SelectedIndex].ToString();
                                 if (isBestOption)
                                 {
-                                    PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRequestedVersionRange, rangeBestVersion, additionalInfo: null);
+                                    PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRequestedVersionRange, rangeBestVersion, additionalInfo: null, isVulnerable: false);
                                     _versions.Text = comboboxText;
                                 }
                                 else
@@ -253,7 +251,7 @@ namespace NuGet.PackageManagement.UI
                 if (currentItem != null && (comboboxText == _versions.Items[i].ToString() || _versions.Items[i].ToString() == matchVersion?.ToString()))
                 {
                     _versions.SelectedIndex = i; // This is the "select" effect in the dropdown
-                    PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRange, matchVersion, additionalInfo: null);
+                    PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRange, matchVersion, additionalInfo: null, isVulnerable: currentItem.IsVulnerable);
                 }
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11127

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Added a label to the versions combobox to show when a package is Vulnerable or Vulnerable and deprecated. (Deprecated label already exists).

![image](https://github.com/NuGet/NuGet.Client/assets/43253759/a19cc17a-67f1-4c61-bacc-a6ee9b46e7c5)

![image](https://github.com/NuGet/NuGet.Client/assets/43253759/d17b647d-ed16-4661-b999-18670004f6d9)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Adding tests was getting too complicated and I think this is a simple UI change that can be validated manually.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
