### PR TITLE
Enable source-build pre-built detection

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,5 +1,99 @@
 <UsageData>
   <IgnorePatterns>
-    <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
+    <!--
+      To ensure that source-building .NET is successful, prebuilt package detection is enabled
+      in all contributing repos.
+
+      This repo doesn't use Arcade infra and does not support dependency flow.
+      As a result, prebuilt detection and resolution is handled differently.
+
+      Repo owners or contributors:
+      If you get an error in source-build leg pointing at new prebuilt package being detected, 
+      resolve the prebuilt issue before merging your PR.
+      If that is not possible, do the following:
+        - contact source-build team
+        - add required UsagePattern entry as provided by source-build team
+        - create an issue in this repo, to address new prebuilt package.
+    -->
+
+    <!--
+      Packages not owned by .NET - exclusion of specifc package version.
+    -->
+    <UsagePattern IdentityGlob="Microsoft.VisualStudioEng.MicroBuild.Core/1.0.0" />
+    <UsagePattern IdentityGlob="Newtonsoft.Json/13.0.1" />
+    <UsagePattern IdentityGlob="System.Windows.Extensions/6.0.0" />
+
+    <!--
+      Packages owned by .NET - exclusion of all versions.
+    -->
+    <UsagePattern IdentityGlob="Microsoft.Build/*" />
+    <UsagePattern IdentityGlob="Microsoft.Build.Framework/*" />
+    <UsagePattern IdentityGlob="Microsoft.Build.Tasks.Core/*" />
+    <UsagePattern IdentityGlob="Microsoft.Build.Tasks.Git/*" />
+    <UsagePattern IdentityGlob="Microsoft.Build.Utilities.Core/*" />
+    <UsagePattern IdentityGlob="Microsoft.CSharp/*" />
+    <UsagePattern IdentityGlob="Microsoft.DotNet.Arcade.Sdk/*" />
+    <UsagePattern IdentityGlob="Microsoft.DotNet.SourceBuild.Tasks/*" />
+    <UsagePattern IdentityGlob="Microsoft.Extensions.CommandLineUtils.Sources/*" />
+    <UsagePattern IdentityGlob="Microsoft.Extensions.FileProviders.Abstractions/*" />
+    <UsagePattern IdentityGlob="Microsoft.Extensions.FileSystemGlobbing/*" />
+    <UsagePattern IdentityGlob="Microsoft.Extensions.Primitives/*" />
+    <UsagePattern IdentityGlob="Microsoft.NET.StringTools/*" />
+    <UsagePattern IdentityGlob="Microsoft.NETCore.Platforms/*" />
+    <UsagePattern IdentityGlob="Microsoft.NETCore.Targets/*" />
+    <UsagePattern IdentityGlob="Microsoft.SourceLink.AzureRepos.Git/*2" />
+    <UsagePattern IdentityGlob="Microsoft.SourceLink.Common/*" />
+    <UsagePattern IdentityGlob="Microsoft.SourceLink.GitHub/*" />
+    <UsagePattern IdentityGlob="Microsoft.Web.Xdt/*" />
+    <UsagePattern IdentityGlob="Microsoft.Win32.Registry/*" />
+    <UsagePattern IdentityGlob="Microsoft.Win32.SystemEvents/*" />
+    <UsagePattern IdentityGlob="NETStandard.Library/*" />
+    <UsagePattern IdentityGlob="System.Buffers/*" />
+    <UsagePattern IdentityGlob="System.CodeDom/*" />
+    <UsagePattern IdentityGlob="System.Collections/*" />
+    <UsagePattern IdentityGlob="System.Collections.Immutable/*" />
+    <UsagePattern IdentityGlob="System.ComponentModel.Composition/*" />
+    <UsagePattern IdentityGlob="System.Configuration.ConfigurationManager/*" />
+    <UsagePattern IdentityGlob="System.Diagnostics.Debug/*" />
+    <UsagePattern IdentityGlob="System.Drawing.Common/*" />
+    <UsagePattern IdentityGlob="System.Dynamic.Runtime/*" />
+    <UsagePattern IdentityGlob="System.Formats.Asn1/*" />
+    <UsagePattern IdentityGlob="System.Globalization/*" />
+    <UsagePattern IdentityGlob="System.IO/*" />
+    <UsagePattern IdentityGlob="System.Linq/*" />
+    <UsagePattern IdentityGlob="System.Linq.Expressions/*" />
+    <UsagePattern IdentityGlob="System.Memory/*" />
+    <UsagePattern IdentityGlob="System.Numerics.Vectors/*" />
+    <UsagePattern IdentityGlob="System.ObjectModel/*" />
+    <UsagePattern IdentityGlob="System.Reflection/*" />
+    <UsagePattern IdentityGlob="System.Reflection.Emit/*" />
+    <UsagePattern IdentityGlob="System.Reflection.Emit.ILGeneration/*" />
+    <UsagePattern IdentityGlob="System.Reflection.Emit.Lightweight/*" />
+    <UsagePattern IdentityGlob="System.Reflection.Extensions/*" />
+    <UsagePattern IdentityGlob="System.Reflection.Metadata/*" />
+    <UsagePattern IdentityGlob="System.Reflection.MetadataLoadContext/*" />
+    <UsagePattern IdentityGlob="System.Reflection.Primitives/*" />
+    <UsagePattern IdentityGlob="System.Reflection.TypeExtensions/*" />
+    <UsagePattern IdentityGlob="System.Resources.Extensions/*" />
+    <UsagePattern IdentityGlob="System.Resources.ResourceManager/*" />
+    <UsagePattern IdentityGlob="System.Runtime/*" />
+    <UsagePattern IdentityGlob="System.Runtime.CompilerServices.Unsafe/*" />
+    <UsagePattern IdentityGlob="System.Runtime.Extensions/*" />
+    <UsagePattern IdentityGlob="System.Runtime.Handles/*" />
+    <UsagePattern IdentityGlob="System.Runtime.InteropServices/*" />
+    <UsagePattern IdentityGlob="System.Security.AccessControl/*" />
+    <UsagePattern IdentityGlob="System.Security.Cryptography.Cng/*" />
+    <UsagePattern IdentityGlob="System.Security.Cryptography.Pkcs/*" />
+    <UsagePattern IdentityGlob="System.Security.Cryptography.ProtectedData/*" />
+    <UsagePattern IdentityGlob="System.Security.Cryptography.Xml/*" />
+    <UsagePattern IdentityGlob="System.Security.Permissions/*" />
+    <UsagePattern IdentityGlob="System.Security.Principal.Windows/*" />
+    <UsagePattern IdentityGlob="System.Text.Encoding/*" />
+    <UsagePattern IdentityGlob="System.Text.Encoding.CodePages/*" />
+    <UsagePattern IdentityGlob="System.Text.Encodings.Web/*" />
+    <UsagePattern IdentityGlob="System.Text.Json/*" />
+    <UsagePattern IdentityGlob="System.Threading/*" />
+    <UsagePattern IdentityGlob="System.Threading.Tasks/*" />
+    <UsagePattern IdentityGlob="System.Threading.Tasks.Dataflow/*" />
   </IgnorePatterns>
 </UsageData>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -17,7 +17,7 @@
     -->
 
     <!--
-      Packages not owned by .NET - exclusion of specifc package version.
+      Packages not owned by .NET - exclusion of specific package version.
     -->
     <UsagePattern IdentityGlob="Newtonsoft.Json/13.0.1" />
     <UsagePattern IdentityGlob="System.Windows.Extensions/6.0.0" />

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -10,10 +10,7 @@
       Repo owners or contributors:
       If you get an error in source-build leg pointing at new prebuilt package being detected,
       resolve the prebuilt issue before merging your PR.
-      If that is not possible, do the following:
-        - contact source-build team
-        - add required UsagePattern entry as provided by source-build team
-        - create an issue in this repo, to address new prebuilt package.
+      If that is not possible, contact the source-build team: @dotnet/source-build-internal.
     -->
 
     <!--

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -8,7 +8,7 @@
       As a result, prebuilt detection and resolution is handled differently.
 
       Repo owners or contributors:
-      If you get an error in source-build leg pointing at new prebuilt package being detected, 
+      If you get an error in source-build leg pointing at new prebuilt package being detected,
       resolve the prebuilt issue before merging your PR.
       If that is not possible, do the following:
         - contact source-build team
@@ -19,7 +19,6 @@
     <!--
       Packages not owned by .NET - exclusion of specifc package version.
     -->
-    <UsagePattern IdentityGlob="Microsoft.VisualStudioEng.MicroBuild.Core/1.0.0" />
     <UsagePattern IdentityGlob="Newtonsoft.Json/13.0.1" />
     <UsagePattern IdentityGlob="System.Windows.Extensions/6.0.0" />
 

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,5 +1,5 @@
 <UsageData>
   <IgnorePatterns>
-    <UsagePattern IdentityGlob="*/*" />
+    <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
   </IgnorePatterns>
 </UsageData>

--- a/eng/source-build/build.sh
+++ b/eng/source-build/build.sh
@@ -83,4 +83,5 @@ fi
 
 ReadGlobalVersion Microsoft.DotNet.Arcade.Sdk
 export ARCADE_VERSION=$_ReadGlobalVersion
+export NUGET_PACKAGES=$scriptroot/../../artifacts/source-build/self/package-cache/
 "$DOTNET" msbuild "$scriptroot/source-build.proj" /p:Configuration=$configuration /p:DotNetBuildFromSource=true /p:ArcadeBuildFromSource=true "/p:RepoRoot=$scriptroot/../../" "/bl:$scriptroot/../../artifacts/source-build/self/log/source-build.binlog" $args

--- a/eng/source-build/build.sh
+++ b/eng/source-build/build.sh
@@ -83,5 +83,9 @@ fi
 
 ReadGlobalVersion Microsoft.DotNet.Arcade.Sdk
 export ARCADE_VERSION=$_ReadGlobalVersion
-export NUGET_PACKAGES=$scriptroot/../../artifacts/source-build/self/package-cache/
+
+if [ -z "$DotNetBuildFromSourceFlavor" ] || [ "$DotNetBuildFromSourceFlavor" != "Product" ]; then
+  export NUGET_PACKAGES=$scriptroot/../../artifacts/source-build/self/package-cache/
+fi
+
 "$DOTNET" msbuild "$scriptroot/source-build.proj" /p:Configuration=$configuration /p:DotNetBuildFromSource=true /p:ArcadeBuildFromSource=true "/p:RepoRoot=$scriptroot/../../" "/bl:$scriptroot/../../artifacts/source-build/self/log/source-build.binlog" $args

--- a/eng/source-build/source-build.proj
+++ b/eng/source-build/source-build.proj
@@ -20,15 +20,28 @@
   <Target Name="SourceBuildPostBuild" DependsOnTargets="SourceBuildInnerBuild">
     <Message Text="Running source-build PostBuild target" Importance="High" />
 
+    <ItemGroup>
+      <_CommonProperties Include="_NETCORE_ENGINEERING_TELEMETRY=AfterSourceBuild" />
+      <_CommonProperties Include="ArcadeBuildFromSource=true"/>
+    </ItemGroup>
+
     <MSbuild Projects="$(ArcadeDir)/Build.proj"
-             Properties="_NETCORE_ENGINEERING_TELEMETRY=AfterSourceBuild;ArcadeBuildFromSource=true;Restore=true;Build=false;Pack=false;Publish=false;Rebuild=false;Test=false;IntegrationTest=false;PerformanceTest=false;PreventPrebuiltBuild=false;BaseInnerSourceBuildCommand=echo skipping internal build with args: "
+             Properties="@(_CommonProperties);Restore=true;Build=false;Pack=false;Publish=false;Rebuild=false;Test=false;IntegrationTest=false;PerformanceTest=false;PreventPrebuiltBuild=false;BaseInnerSourceBuildCommand=echo skipping internal build with args: "
              Targets="Execute"
             />
 
     <Message Text="Finished restoring Arcade" Importance="High" />
 
+    <ItemGroup>
+      <_AfterSourceBuildProperties Include="CurrentRepoSourceBuildArtifactsPackagesDir=$(ProjectRoot)artifacts/nupkgs/" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(DotNetBuildFromSourceFlavor)' != 'Product'">
+      <_AfterSourceBuildProperties Include="FailOnPrebuiltBaselineError=true" />
+    </ItemGroup>
+
     <MSbuild Projects="$(ArcadeDir)/SourceBuild/AfterSourceBuild.proj"
-             Properties="_NETCORE_ENGINEERING_TELEMETRY=AfterSourceBuild;ArcadeBuildFromSource=true;CurrentRepoSourceBuildArtifactsPackagesDir=$(ProjectRoot)artifacts/nupkgs/;FailOnPrebuiltBaselineError=true"
+             Properties="@(_CommonProperties);@(_AfterSourceBuildProperties)"
             />
 
   </Target>

--- a/eng/source-build/source-build.proj
+++ b/eng/source-build/source-build.proj
@@ -28,7 +28,7 @@
     <Message Text="Finished restoring Arcade" Importance="High" />
 
     <MSbuild Projects="$(ArcadeDir)/SourceBuild/AfterSourceBuild.proj"
-             Properties="_NETCORE_ENGINEERING_TELEMETRY=AfterSourceBuild;ArcadeBuildFromSource=true;CurrentRepoSourceBuildArtifactsPackagesDir=$(ProjectRoot)artifacts/nupkgs/"
+             Properties="_NETCORE_ENGINEERING_TELEMETRY=AfterSourceBuild;ArcadeBuildFromSource=true;CurrentRepoSourceBuildArtifactsPackagesDir=$(ProjectRoot)artifacts/nupkgs/;FailOnPrebuiltBaselineError=true"
             />
 
   </Target>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/12598

Regression? No

## Description

Enables prebuilt detection, that causes build failure for any new prebuilts not in baseline.

Since it's not possible to flow dependencies, i.e. SBRP intermediate package, all prebuilts have to be listed in prebuilt baseline: https://github.com/NuGet/NuGet.Client/blob/dev/eng/SourceBuildPrebuiltBaseline.xml

All .NET packages are excluded with `*` version, to avoid unnecessary changes in the future - i.e.:
`<UsagePattern IdentityGlob="System.Buffers/*" />`

All instances of other packages are excluded with specific version, to ensure that version update triggers proper prebuilt update process, i.e.:
`<UsagePattern IdentityGlob="Newtonsoft.Json/13.0.1" />`