### PR TITLE
Fix dotnet nuget config get all setting item order

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigRunners.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigRunners.cs
@@ -171,20 +171,18 @@ namespace NuGet.CommandLine.XPlat
                     IEnumerable<IGrouping<string, SettingItem>> groupByConfigPathsQuery =
                     from item in items
                     group item by item.ConfigPath into newItemGroup
-                    from itemGroup in newItemGroup
-                    orderby newItemGroup.Key descending
                     select newItemGroup;
 
-                    foreach (IGrouping<string, SettingItem> configPathsGroup in groupByConfigPathsQuery)
+                    foreach (IGrouping<string, SettingItem> configPathsGroup in groupByConfigPathsQuery.Reverse())
                     {
                         logger.LogMinimal($" file: {configPathsGroup.Key}");
-                        LogSectionItems(configPathsGroup, logger);
+                        LogSectionItems(configPathsGroup, logger, showPath);
                         logger.LogMinimal(Environment.NewLine);
                     }
                 }
                 else
                 {
-                    LogSectionItems(items, logger);
+                    LogSectionItems(items, logger, showPath);
                     logger.LogMinimal(Environment.NewLine);
                 }
             }
@@ -195,9 +193,14 @@ namespace NuGet.CommandLine.XPlat
         /// </summary>
         /// <param name="items"></param>
         /// <param name="logger"></param>
-        public static void LogSectionItems(IEnumerable<SettingItem> items, ILogger logger)
+        public static void LogSectionItems(IEnumerable<SettingItem> items, ILogger logger, bool showPath)
         {
-            foreach (SettingItem item in items.Reverse())
+            if (!showPath)
+            {
+                items = items.Reverse();
+            }
+
+            foreach (SettingItem item in items)
             {
                 string setting = $"\t{item.ElementName}";
                 IReadOnlyDictionary<string, string> attributes = item.GetAttributes();

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigRunners.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigRunners.cs
@@ -166,23 +166,28 @@ namespace NuGet.CommandLine.XPlat
                 logger.LogMinimal(section + ":");
                 IReadOnlyCollection<SettingItem> items = settings.GetSection(section)?.Items;
 
-                if (showPath)
-                {
-                    IEnumerable<IGrouping<string, SettingItem>> groupByConfigPathsQuery =
+                IEnumerable<IGrouping<string, SettingItem>> groupByConfigPathsQuery =
                     from item in items
                     group item by item.ConfigPath into newItemGroup
                     select newItemGroup;
 
-                    foreach (IGrouping<string, SettingItem> configPathsGroup in groupByConfigPathsQuery.Reverse())
+                var groupByConfigPathsQueryReverse = groupByConfigPathsQuery.Reverse();
+
+                if (showPath)
+                {
+                    foreach (IGrouping<string, SettingItem> configPathsGroup in groupByConfigPathsQueryReverse)
                     {
                         logger.LogMinimal($" file: {configPathsGroup.Key}");
-                        LogSectionItems(configPathsGroup, logger, showPath);
+                        LogSectionItems(configPathsGroup, logger);
                         logger.LogMinimal(Environment.NewLine);
                     }
                 }
                 else
                 {
-                    LogSectionItems(items, logger, showPath);
+                    foreach (IGrouping<string, SettingItem> configPathsGroup in groupByConfigPathsQueryReverse)
+                    {
+                        LogSectionItems(configPathsGroup, logger);
+                    }
                     logger.LogMinimal(Environment.NewLine);
                 }
             }
@@ -193,13 +198,8 @@ namespace NuGet.CommandLine.XPlat
         /// </summary>
         /// <param name="items"></param>
         /// <param name="logger"></param>
-        public static void LogSectionItems(IEnumerable<SettingItem> items, ILogger logger, bool showPath)
+        public static void LogSectionItems(IEnumerable<SettingItem> items, ILogger logger)
         {
-            if (!showPath)
-            {
-                items = items.Reverse();
-            }
-
             foreach (SettingItem item in items)
             {
                 string setting = $"\t{item.ElementName}";

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigRunners.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigRunners.cs
@@ -171,9 +171,11 @@ namespace NuGet.CommandLine.XPlat
                     IEnumerable<IGrouping<string, SettingItem>> groupByConfigPathsQuery =
                     from item in items
                     group item by item.ConfigPath into newItemGroup
+                    from itemGroup in newItemGroup
+                    orderby newItemGroup.Key descending
                     select newItemGroup;
 
-                    foreach (IGrouping<string, SettingItem> configPathsGroup in groupByConfigPathsQuery.Reverse())
+                    foreach (IGrouping<string, SettingItem> configPathsGroup in groupByConfigPathsQuery)
                     {
                         logger.LogMinimal($" file: {configPathsGroup.Key}");
                         LogSectionItems(configPathsGroup, logger);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigRunners.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigRunners.cs
@@ -173,7 +173,7 @@ namespace NuGet.CommandLine.XPlat
                     group item by item.ConfigPath into newItemGroup
                     select newItemGroup;
 
-                    foreach (IGrouping<string, SettingItem> configPathsGroup in groupByConfigPathsQuery)
+                    foreach (IGrouping<string, SettingItem> configPathsGroup in groupByConfigPathsQuery.Reverse())
                     {
                         logger.LogMinimal($" file: {configPathsGroup.Key}");
                         LogSectionItems(configPathsGroup, logger);
@@ -195,7 +195,7 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="logger"></param>
         public static void LogSectionItems(IEnumerable<SettingItem> items, ILogger logger)
         {
-            foreach (SettingItem item in items)
+            foreach (SettingItem item in items.Reverse())
             {
                 string setting = $"\t{item.ElementName}";
                 IReadOnlyDictionary<string, string> attributes = item.GetAttributes();

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatConfigTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatConfigTests.cs
@@ -169,6 +169,47 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
+        public void ConfigGetCommand_WithAllArg_ShowsSettingsInPriorityOrder()
+        {
+            // Arrange & Act
+            using var testInfo = new TestInfo("NuGet.Config", "subfolder");
+
+            var result = CommandRunner.Run(
+                DotnetCli,
+                Path.Combine(testInfo.WorkingPath, "subfolder"),
+                $"{XplatDll} config get all",
+                waitForExit: true);
+            var firstString = "add key=\"Bar\" value=\"https://bontoso.test/v3/index.json\"";
+            var secondString = "add key=\"Foo\" value=\"https://fontoso.test/v3/index.json\"";
+            var firstStringIndex = result.Output.IndexOf(firstString);
+            var secondStringIndex = result.Output.IndexOf(secondString);
+
+            // Assert
+            Assert.True(firstStringIndex < secondStringIndex);
+        }
+
+        [Fact]
+        public void ConfigGetCommand_WithAllArgAndShowPathOption_ShowsPathsInPriorityOrder()
+        {
+            // Arrange & Act
+            using var testInfo = new TestInfo("NuGet.Config", "subfolder");
+            var workingDirectory = Path.Combine(testInfo.WorkingPath, "subfolder");
+
+            var result = CommandRunner.Run(
+                DotnetCli,
+                workingDirectory,
+                $"{XplatDll} config get all --show-path",
+                waitForExit: true);
+            var firstPath = Path.Combine(workingDirectory, "NuGet.Config");
+            var secondPath = Path.Combine(testInfo.WorkingPath, "NuGet.Config");
+            var firstPathIndex = result.Output.IndexOf(firstPath);
+            var secondPathIndex = result.Output.IndexOf(secondPath);
+
+            // Assert
+            Assert.True(firstPathIndex < secondPathIndex);
+        }
+
+        [Fact]
         public void ConfigGetCommand_UsingHelpOption_DisplaysHelpMessage()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12622

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Currently, `dotnet nuget config get all` orders setting items by config file, with settings from lower priority config files appearing above settings from higher priority config files. This PR reverses that order so setting items in each section are listed in order from highest priority config file to lowest priority config file.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
