### PR TITLE
Fix issue with solution filters not restoring when in different folder than referenced solution

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/ProjectInSolution.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/ProjectInSolution.cs
@@ -28,6 +28,7 @@ namespace NuGet.Common
         {
             RelativePath = relativePath;
             IsSolutionFolder = isSolutionFolder;
+            AbsolutePath = absolutePath;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/ProjectInSolution.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/ProjectInSolution.cs
@@ -15,11 +15,16 @@ namespace NuGet.Common
         public string RelativePath { get; private set; }
 
         /// <summary>
+        /// The absolute path to the project.
+        /// </summary>
+        public string AbsolutePath { get; private set; }
+
+        /// <summary>
         /// Indicates if the project is a solution folder.
         /// </summary>
         public bool IsSolutionFolder { get; private set; }
 
-        public ProjectInSolution(string relativePath, bool isSolutionFolder)
+        public ProjectInSolution(string relativePath, string absolutePath, bool isSolutionFolder)
         {
             RelativePath = relativePath;
             IsSolutionFolder = isSolutionFolder;

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Solution.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Solution.cs
@@ -87,6 +87,8 @@ namespace NuGet.Common
                 }
             }
 
+            var solutionDirectory = Path.GetDirectoryName(solutionFileName);
+
             // load projects
             var projectInSolutionType = msbuildAssembly.GetType(
                 "Microsoft.Build.Construction.ProjectInSolution",
@@ -103,7 +105,8 @@ namespace NuGet.Common
                 var projectType = projectTypeProperty.GetValue(proj, index: null).ToString();
                 var isSolutionFolder = projectType.Equals("SolutionFolder", StringComparison.OrdinalIgnoreCase);
                 var relativePath = (string)relativePathProperty.GetValue(proj, index: null);
-                projects.Add(new ProjectInSolution(relativePath, isSolutionFolder));
+                var absolutePath = Path.Combine(solutionDirectory, relativePath);
+                projects.Add(new ProjectInSolution(relativePath, absolutePath, isSolutionFolder));
             }
             Projects = projects;
         }
@@ -136,7 +139,9 @@ namespace NuGet.Common
                     if (projectShouldBuild)
                     {
                         var relativePath = project.RelativePath.Replace('\\', Path.DirectorySeparatorChar);
-                        projects.Add(new ProjectInSolution(relativePath, isSolutionFolder));
+                        var absolutePath = project.AbsolutePath;
+
+                        projects.Add(new ProjectInSolution(relativePath, absolutePath, isSolutionFolder));
                     }
                 }
                 catch (TargetInvocationException ex)

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -173,7 +173,7 @@ namespace NuGet.CommandLine
 
                     if (process.ExitCode != 0 || !finished)
                     {
-                        // If a problem occurred log all msbuild output as an error 
+                        // If a problem occurred log all msbuild output as an error
                         // so that the user can see it.
                         // By default this runs with /v:q which means that only
                         // errors and warnings will be in the output.
@@ -182,7 +182,7 @@ namespace NuGet.CommandLine
 
                     // MSBuild writes errors to the output stream, parsing the console output to find
                     // the errors would be error prone so here we log all output combined with any
-                    // errors on the error stream (haven't seen the error stream used to date) 
+                    // errors on the error stream (haven't seen the error stream used to date)
                     // to give the user the complete info.
                     await console.LogAsync(logLevel, output.ToString() + errors.ToString());
 
@@ -437,9 +437,8 @@ namespace NuGet.CommandLine
             try
             {
                 var solution = new Solution(solutionFile, msbuildPath);
-                var solutionDirectory = Path.GetDirectoryName(solutionFile);
                 return solution.Projects.Where(project => !project.IsSolutionFolder)
-                    .Select(project => CombinePathWithVerboseError(solutionDirectory, project.RelativePath));
+                    .Select(project => project.AbsolutePath);
             }
             catch (Exception ex)
             {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -381,14 +381,14 @@ namespace NuGet.CommandLine.Test
 
                 // Act
                 var r = CommandRunner.Run(nugetexe,
-                    workingPath, "restore " + Path.Combine(workingPath, "filter", "a.proj2.slnf") + " -Source " + repositoryPath,
+                    workingPath, "restore " + Path.Combine(workingPath, "filter", "filterinsubfolder.slnf") + " -Source " + repositoryPath,
                     waitForExit: true);
 
                 // Assert
                 Assert.True(_successCode == r.ExitCode, r.Output + " " + r.Errors);
                 var packageFileA = Path.Combine(pathContext.PackagesV2, "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(pathContext.PackagesV2, "packageB.2.2.0", "packageB.2.2.0.nupkg");
-                Assert.False(File.Exists(packageFileA));
+                Assert.True(File.Exists(packageFileA));
                 Assert.True(File.Exists(packageFileB));
             }
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -373,6 +373,24 @@ namespace NuGet.CommandLine.Test
                 Assert.False(File.Exists(packageFileA));
                 Assert.True(File.Exists(packageFileB));
             }
+
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var workingPath = pathContext.WorkingDirectory;
+                var repositoryPath = Util.CreateBasicTwoProjectSolutionWithSolutionFilters(workingPath, "packages.config", "packages.config");
+
+                // Act
+                var r = CommandRunner.Run(nugetexe,
+                    workingPath, "restore " + Path.Combine(workingPath, "filter", "a.proj2.slnf") + " -Source " + repositoryPath,
+                    waitForExit: true);
+
+                // Assert
+                Assert.True(_successCode == r.ExitCode, r.Output + " " + r.Errors);
+                var packageFileA = Path.Combine(pathContext.PackagesV2, "packageA.1.1.0", "packageA.1.1.0.nupkg");
+                var packageFileB = Path.Combine(pathContext.PackagesV2, "packageB.2.2.0", "packageB.2.2.0.nupkg");
+                Assert.False(File.Exists(packageFileA));
+                Assert.True(File.Exists(packageFileB));
+            }
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -954,6 +954,9 @@ EndProject");
         public static string CreateBasicTwoProjectSolutionWithSolutionFilters(TestDirectory workingPath, string proj1ConfigFileName, string proj2ConfigFileName, bool redirectGlobalPackagesFolder = true)
         {
             var repositoryPath = CreateBasicTwoProjectSolution(workingPath, proj1ConfigFileName, proj2ConfigFileName, redirectGlobalPackagesFolder);
+            var filterInSubfolderPath = Path.Combine(workingPath, "filter");
+
+            Directory.CreateDirectory(filterInSubfolderPath);
 
             CreateFile(workingPath, "a.proj1.slnf", @"{
   ""solution"": {
@@ -972,6 +975,18 @@ EndProject");
     ]
   }
 }");
+
+
+            CreateFile(filterInSubfolderPath, "filterinsubfolder.slnf",  @"{
+  ""solution"": {
+    ""path"": ""..\\a.sln"",
+    ""projects"": [
+      ""proj1\\proj1.csproj"",
+      ""proj2\\proj2.csproj"",
+    ]
+  }
+}");
+
 
             return repositoryPath;
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12562

Regression? Last working version: n/a

## Description

This is a bug fix that allows restoration of nuget packages for solution filters in directories other than the referenced solution file.  A repo of the issue can be found in this Git repository: https://github.com/jerhon/nuget-slnf-bug

This changes the paths used to restore projects to be determined by the AbsolutePath reported by the MSBuild SDK on the ProjectFile rather than doing path math on the directory of the passed in file and the relative path reported by MSBuild.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
