### PR TITLE
Allow FloatRange ctor for AbsoluteLatest without prerelease label

### DIFF
--- a/src/NuGet.Core/NuGet.Versioning/FloatRange.cs
+++ b/src/NuGet.Core/NuGet.Versioning/FloatRange.cs
@@ -22,7 +22,9 @@ namespace NuGet.Versioning
         /// </summary>
         /// <param name="floatBehavior">Section to float.</param>
         public FloatRange(NuGetVersionFloatBehavior floatBehavior)
-            : this(floatBehavior, new NuGetVersion(0, 0, 0), null)
+            : this(floatBehavior,
+                  minVersion: floatBehavior == NuGetVersionFloatBehavior.None ? new NuGetVersion(0, 0, 0) : new NuGetVersion(0, 0, 0, releaseLabel: "0"),
+                  releasePrefix: null)
         {
         }
 
@@ -54,6 +56,11 @@ namespace NuGet.Versioning
             {
                 // use the actual label if one was not given
                 _releasePrefix = minVersion.Release;
+            }
+
+            if (_floatBehavior == NuGetVersionFloatBehavior.AbsoluteLatest && _releasePrefix is null)
+            {
+                _releasePrefix = string.Empty;
             }
 
             if (IncludePrerelease && _releasePrefix == null)

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/FloatingRangeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/FloatingRangeTests.cs
@@ -457,10 +457,14 @@ namespace NuGet.Versioning.Test
             Assert.Equal(NuGetVersionFloatBehavior.PrereleaseMajor, range?.FloatBehavior);
         }
 
-        [Fact]
-        public void FloatingRange_FloatAbsoluteLatest()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void FloatingRange_FloatAbsoluteLatest(bool parse)
         {
-            var range = FloatRange.Parse("*-*");
+            var range = parse
+                ? FloatRange.Parse("*-*")
+                : new FloatRange(NuGetVersionFloatBehavior.AbsoluteLatest);
 
             Assert.Equal("0.0.0-0", range?.MinVersion.ToNormalizedString());
             Assert.Equal(NuGetVersionFloatBehavior.AbsoluteLatest, range?.FloatBehavior);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12618

Regression? yes, but in preview version

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

A few weeks ago I merged a PR adding nullable annotations (and enabling nullable checks) to NuGet.Versioning](https://github.com/NuGet/NuGet.Client/pull/5097). Due to the class' API design, the compiler can't know that the `_releaseLabel` field is not null under certain conditions, so after getting feedback in the PR, I added an additional validation, so I could use `MemberNotNullWhenAttribute`, in order to simplify API usage and keep the compiler's nullable checks happy.

Unfortunately there was an edge case that did not have an existing unit test, but was used by the .NET SDK, which regressed. Once I found the "same" scenario being tested in a unit test with `FloatRange.Parse`, I extended it to also test calling the `FloatRange` constructor directly, so the two should behave the same now.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
