### PR TITLE
Reduce allocations in TargetFrameworkInformation.Clone

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
@@ -7,24 +7,23 @@ using System.Linq;
 using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
-using NuGet.Packaging;
 using NuGet.Shared;
 
 namespace NuGet.ProjectModel
 {
     public class TargetFrameworkInformation : IEquatable<TargetFrameworkInformation>
     {
-        public string TargetAlias { get; set; } = string.Empty;
+        public string TargetAlias { get; set; }
 
         public NuGetFramework FrameworkName { get; set; }
 
-        public IList<LibraryDependency> Dependencies { get; set; } = new List<LibraryDependency>();
+        public IList<LibraryDependency> Dependencies { get; set; }
 
         /// <summary>
         /// A fallback PCL framework to use when no compatible items
         /// were found for <see cref="FrameworkName"/>.
         /// </summary>
-        public IList<NuGetFramework> Imports { get; set; } = new List<NuGetFramework>();
+        public IList<NuGetFramework> Imports { get; set; }
 
         /// <summary>
         /// If True AssetTargetFallback behavior will be used for Imports.
@@ -39,22 +38,56 @@ namespace NuGet.ProjectModel
         /// <summary>
         /// List of dependencies that are not part of the graph resolution.
         /// </summary>
-        public IList<DownloadDependency> DownloadDependencies { get; } = new List<DownloadDependency>();
+        public IList<DownloadDependency> DownloadDependencies { get; }
 
         /// <summary>
         /// List of the package versions defined in the Central package versions management file. 
         /// </summary>
-        public IDictionary<string, CentralPackageVersion> CentralPackageVersions { get; } = new Dictionary<string, CentralPackageVersion>(StringComparer.OrdinalIgnoreCase);
+        public IDictionary<string, CentralPackageVersion> CentralPackageVersions { get; }
 
         /// <summary>
         /// A set of unique FrameworkReferences
         /// </summary>
-        public ISet<FrameworkDependency> FrameworkReferences { get; } = new HashSet<FrameworkDependency>();
+        public ISet<FrameworkDependency> FrameworkReferences { get; }
 
         /// <summary>
         /// The project provided runtime.json
         /// </summary>
         public string RuntimeIdentifierGraphPath { get; set; }
+
+        public TargetFrameworkInformation()
+        {
+            TargetAlias = string.Empty;
+            Dependencies = new List<LibraryDependency>();
+            Imports = new List<NuGetFramework>();
+            DownloadDependencies = new List<DownloadDependency>();
+            CentralPackageVersions = new Dictionary<string, CentralPackageVersion>(StringComparer.OrdinalIgnoreCase);
+            FrameworkReferences = new HashSet<FrameworkDependency>();
+        }
+
+        internal TargetFrameworkInformation(TargetFrameworkInformation cloneFrom)
+        {
+            TargetAlias = cloneFrom.TargetAlias;
+            FrameworkName = cloneFrom.FrameworkName;
+            Dependencies = CloneList(cloneFrom.Dependencies, static dep => dep.Clone());
+            Imports = new List<NuGetFramework>(cloneFrom.Imports);
+            AssetTargetFallback = cloneFrom.AssetTargetFallback;
+            Warn = cloneFrom.Warn;
+            DownloadDependencies = CloneList(cloneFrom.DownloadDependencies, static dep => dep.Clone());
+            CentralPackageVersions = new Dictionary<string, CentralPackageVersion>(cloneFrom.CentralPackageVersions, StringComparer.OrdinalIgnoreCase);
+            FrameworkReferences = new HashSet<FrameworkDependency>(cloneFrom.FrameworkReferences);
+            RuntimeIdentifierGraphPath = cloneFrom.RuntimeIdentifierGraphPath;
+
+            static IList<T> CloneList<T>(IList<T> source, Func<T, T> cloneFunc)
+            {
+                var clone = new List<T>(capacity: source.Count);
+                for (int i = 0; i < source.Count; i++)
+                {
+                    clone.Add(cloneFunc(source[i]));
+                }
+                return clone;
+            }
+        }
 
         public override string ToString()
         {
@@ -112,18 +145,7 @@ namespace NuGet.ProjectModel
 
         public TargetFrameworkInformation Clone()
         {
-            var clonedObject = new TargetFrameworkInformation();
-            clonedObject.FrameworkName = FrameworkName;
-            clonedObject.Dependencies = Dependencies.Select(item => item.Clone()).ToList();
-            clonedObject.Imports = new List<NuGetFramework>(Imports);
-            clonedObject.AssetTargetFallback = AssetTargetFallback;
-            clonedObject.Warn = Warn;
-            clonedObject.DownloadDependencies.AddRange(DownloadDependencies.Select(item => item.Clone()));
-            clonedObject.FrameworkReferences.AddRange(FrameworkReferences);
-            clonedObject.RuntimeIdentifierGraphPath = RuntimeIdentifierGraphPath;
-            clonedObject.CentralPackageVersions.AddRange(CentralPackageVersions.ToDictionary(item => item.Key, item => item.Value));
-            clonedObject.TargetAlias = TargetAlias;
-            return clonedObject;
+            return new TargetFrameworkInformation(this);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/TargetFrameworkInformationTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/TargetFrameworkInformationTests.cs
@@ -623,6 +623,8 @@ namespace NuGet.ProjectModel.Test
             {
                 leftSide.Should().NotBe(rightSide);
             }
+
+            AssertClone(expected, leftSide, rightSide);
         }
 
         private static void AssertHashCode(bool expected, TargetFrameworkInformation leftSide, TargetFrameworkInformation rightSide)
@@ -634,6 +636,25 @@ namespace NuGet.ProjectModel.Test
             else
             {
                 leftSide.GetHashCode().Should().NotBe(rightSide.GetHashCode());
+            }
+
+            AssertClone(expected, leftSide, rightSide);
+        }
+
+        private static void AssertClone(bool expected, TargetFrameworkInformation leftSide, TargetFrameworkInformation rightSide)
+        {
+            var leftClone = leftSide.Clone();
+            var rightClone = rightSide.Clone();
+
+            if (expected)
+            {
+                leftClone.GetHashCode().Should().Be(rightClone.GetHashCode());
+                leftClone.Should().Be(rightClone);
+            }
+            else
+            {
+                leftClone.GetHashCode().Should().NotBe(rightClone.GetHashCode());
+                leftClone.Should().NotBe(rightClone);
             }
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes AB#1828412
Fixes AB#1828413
Fixes: https://github.com/NuGet/Home/issues/12648

## Description

The previous clone operation had two allocation-related issues:

1. The property initializers would allocate collections during object contruction, only for them to be replaced during population of the clone.
2. The cloning of properties didn't take advantage of known collection sizes when constructing new collections, leading to both:
   - Temporary containers and extra work during collection resizing.
   - Oversized collections upon construction, where extra unused capacity remains in the collections, wasting space.

This change creates a "clone constructor" which takes responsibility for constructing the clone such that each object is only constructed once, and in an efficient manner. This addresses the above problems.

This method was identified as a top contributor to GC pauses by GCPauseWatson.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
