### PR TITLE
Reduce allocations in ContentItemCollection

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemGroup.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemGroup.cs
@@ -15,6 +15,12 @@ namespace NuGet.ContentModel
             Items = new List<ContentItem>();
         }
 
+        internal ContentItemGroup(IDictionary<string, object> properties, IList<ContentItem> items)
+        {
+            Properties = properties;
+            Items = items;
+        }
+
         public IDictionary<string, object> Properties { get; }
 
         public IList<ContentItem> Items { get; }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes: https://github.com/NuGet/Home/issues/12645
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1824305
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1824313
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1837276

Regression? Last working version: N/A

## Description

Changes:

1. Allow `ContentItemGroup` to receive collections as constructor arguments. This allows code that initialises these instances to take full ownership of the construction of those collections, rather than having to call `Add` on its properties in a loop during construction.
1. Clone the property dictionary in a way that allows the new object to be constructed more efficiently, avoiding collection resizes (and the temporary allocations that come with them).
1. Swap heap-allocated `Tuple<>` for stack-allocated `ValueTuple<>`, reducing temporary allocations.
1. Stop allocating an unused `List<ContentItem>` in local variable `groupItems`.
1. Typo and minor formatting.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
