### PR TITLE
Reduce allocations in PackageSpecReferenceDependencyProvider

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -79,14 +79,12 @@ namespace NuGet.ProjectModel
 
         public Library GetLibrary(LibraryRange libraryRange, NuGetFramework targetFramework)
         {
-            Library library = null;
             var name = libraryRange.Name;
 
-            ExternalProjectReference externalReference = null;
             PackageSpec packageSpec = null;
 
             // This must exist in the external references
-            if (_externalProjectsByUniqueName.TryGetValue(name, out externalReference))
+            if (_externalProjectsByUniqueName.TryGetValue(name, out ExternalProjectReference externalReference))
             {
                 packageSpec = externalReference.PackageSpec;
             }
@@ -127,7 +125,7 @@ namespace NuGet.ProjectModel
                 }
             }
 
-            library = new Library
+            Library library = new Library
             {
                 LibraryRange = libraryRange,
                 Identity = new LibraryIdentity

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -25,35 +25,24 @@ namespace NuGet.ProjectModel
         private readonly Dictionary<string, ExternalProjectReference> _externalProjectsByUniqueName
             = new Dictionary<string, ExternalProjectReference>(StringComparer.OrdinalIgnoreCase);
 
-        private readonly ILogger _logger;
-
         private readonly bool _useLegacyAssetTargetFallbackBehavior;
 
         public PackageSpecReferenceDependencyProvider(
             IEnumerable<ExternalProjectReference> externalProjects,
             ILogger logger) :
             this(externalProjects,
-                logger,
                 environmentVariableReader: EnvironmentVariableWrapper.Instance)
         {
         }
 
         internal PackageSpecReferenceDependencyProvider(
             IEnumerable<ExternalProjectReference> externalProjects,
-            ILogger logger,
             IEnvironmentVariableReader environmentVariableReader)
         {
             if (externalProjects == null)
             {
                 throw new ArgumentNullException(nameof(externalProjects));
             }
-
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            _logger = logger;
 
             foreach (var project in externalProjects)
             {

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -95,8 +95,7 @@ namespace NuGet.ProjectModel
                 return null;
             }
 
-            // create a dictionary of dependencies to make sure that no duplicates exist
-            var dependencies = new List<LibraryDependency>();
+            List<LibraryDependency> dependencies;
 
             var projectStyle = packageSpec?.RestoreMetadata?.ProjectStyle ?? ProjectStyle.Unknown;
 
@@ -104,12 +103,12 @@ namespace NuGet.ProjectModel
             if (projectStyle == ProjectStyle.PackageReference)
             {
                 // NETCore
-                dependencies.AddRange(GetDependenciesFromSpecRestoreMetadata(packageSpec, targetFramework));
+                dependencies = GetDependenciesFromSpecRestoreMetadata(packageSpec, targetFramework);
             }
             else
             {
                 // UWP
-                dependencies.AddRange(GetDependenciesFromExternalReference(externalReference, packageSpec, targetFramework));
+                dependencies = GetDependenciesFromExternalReference(externalReference, packageSpec, targetFramework);
             }
 
             // Remove duplicate dependencies. A reference can exist both in csproj and project.json

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -379,22 +379,6 @@ namespace NuGet.ProjectModel
             return dependencies;
         }
 
-        /// <summary>
-        /// Filter dependencies down to only possible project references and return the names.
-        /// </summary>
-        private IEnumerable<string> GetProjectNames(IEnumerable<LibraryDependency> dependencies)
-        {
-            foreach (var dependency in dependencies)
-            {
-                if (IsProject(dependency))
-                {
-                    yield return dependency.Name;
-                }
-            }
-
-            yield break;
-        }
-
         private bool IsProject(LibraryDependency dependency)
         {
             var type = dependency.LibraryRange.TypeConstraint;

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecReferenceDependencyProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecReferenceDependencyProviderTests.cs
@@ -87,7 +87,7 @@ namespace NuGet.ProjectModel.Test
             var packageSpec = ProjectTestHelpers.GetPackageSpec(rootPath: "C:\\", projectName: "A", framework: net472Framework.GetShortFolderName(), dependencyName: "x");
 
             var envVarWrapper = new TestEnvironmentVariableReader(new Dictionary<string, string> { { "NUGET_USE_LEGACY_ASSET_TARGET_FALLBACK_DEPENDENCY_RESOLUTION", assetTargetFallbackEnvironmentVariableValue } });
-            var dependencyProvider = new PackageSpecReferenceDependencyProvider(new List<ExternalProjectReference>(), NullLogger.Instance, envVarWrapper);
+            var dependencyProvider = new PackageSpecReferenceDependencyProvider(new List<ExternalProjectReference>(), envVarWrapper);
             var assetTargetFallback = new AssetTargetFallbackFramework(net60Framework, new List<NuGetFramework> { net472Framework });
             // Act
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1824278
Fixes: https://github.com/NuGet/Home/issues/12647
 
Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Changes:

1. Avoid cloning collection. Both `GetDependenciesFromSpecRestoreMetadata` and `GetDependenciesFromExternalReference` return a collection that can be used directly. There's no need to copy it into a new list.
1. Remove unused logger field.
1. Remove an unused private method.
1. Remove redundant local variable initialization.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
