### PR TITLE
Avoid allocations while parsing NuGetVersion from strings

### DIFF
--- a/src/NuGet.Core/NuGet.Versioning/NuGetVersionFactory.cs
+++ b/src/NuGet.Core/NuGet.Versioning/NuGetVersionFactory.cs
@@ -164,8 +164,8 @@ namespace NuGet.Versioning
 
                 long returnValue = 0;
 
-                // Parse the values in reverse and assign a tens place to them.
-                // When parsing "123456", this method adds 6 + 50 + 400 + 3000 + 20000 + 100000
+                // Parse the values digit by digit and multiplies by 10 to make space for the next digit.
+                // When parsing "123456", this method becomes 1 -> 10 + 2 -> 120 + 3 -> 1230 + 4 -> 12340 + 5 -> 123450 + 6 -> 123456
                 for (int i = start; i < end; i++)
                 {
                     // negative numbers are invalid for version strings so we only need to check for digits

--- a/src/NuGet.Core/NuGet.Versioning/NuGetVersionFactory.cs
+++ b/src/NuGet.Core/NuGet.Versioning/NuGetVersionFactory.cs
@@ -149,10 +149,10 @@ namespace NuGet.Versioning
                     end = s.Length;
                 }
 
-                return TryParseInt(s, start, end - 1, out versionNumber);
+                return TryParseInt(s, start, end, out versionNumber);
             }
 
-            // start and end are inclusive bounds for the section of string to parse
+            // start is inclusive bound and end is exclusive for the section of string to parse
             static bool TryParseInt(string s, int start, int end, out int value)
             {
                 // invalid section specified
@@ -163,11 +163,10 @@ namespace NuGet.Versioning
                 }
 
                 long returnValue = 0;
-                int multiplier = 1;
 
                 // Parse the values in reverse and assign a tens place to them.
                 // When parsing "123456", this method adds 6 + 50 + 400 + 3000 + 20000 + 100000
-                for (int i = end; i >= start; i--)
+                for (int i = start; i < end; i++)
                 {
                     // negative numbers are invalid for version strings so we only need to check for digits
                     char current = s[i];
@@ -179,8 +178,7 @@ namespace NuGet.Versioning
 
                     // subtract off ASCII value of '0' from our current character to get the digit's value
                     // e.g. '3' - '0' == 51 - 58 == 3
-                    returnValue += (current - '0') * multiplier;
-                    multiplier *= 10;
+                    returnValue = returnValue * 10 + (current - '0');
 
                     // Check for overflow. We can't get outside the bounds of long before exceeding int.MaxValue
                     // Intentionally avoid usage of 'checked' statement to avoid exception

--- a/src/NuGet.Core/NuGet.Versioning/NuGetVersionFactory.cs
+++ b/src/NuGet.Core/NuGet.Versioning/NuGetVersionFactory.cs
@@ -155,6 +155,13 @@ namespace NuGet.Versioning
             // start and end are inclusive bounds for the section of string to parse
             static bool TryParseInt(string s, int start, int end, out int value)
             {
+                // invalid section specified
+                if (start >= end)
+                {
+                    value = 0;
+                    return false;
+                }
+
                 long returnValue = 0;
                 int multiplier = 1;
 

--- a/src/NuGet.Core/NuGet.Versioning/NuGetVersionFactory.cs
+++ b/src/NuGet.Core/NuGet.Versioning/NuGetVersionFactory.cs
@@ -104,7 +104,7 @@ namespace NuGet.Versioning
             }
         }
 
-        public static bool TryGetNormalizedVersion(string str, [NotNullWhen(true)] out Version? version)
+        private static bool TryGetNormalizedVersion(string str, [NotNullWhen(true)] out Version? version)
         {
             if (string.IsNullOrWhiteSpace(str))
             {
@@ -183,7 +183,6 @@ namespace NuGet.Versioning
                         intermediateVersionNumber = intermediateVersionNumber * 10 + currentChar - '0';
 
                         // Check for overflow. We can't get outside the bounds of intermediateVersionNumber, a long, before exceeding int.MaxValue
-                        // since we're
                         // Intentionally avoid usage of 'checked' statement to avoid exception
                         if (intermediateVersionNumber > int.MaxValue)
                         {

--- a/src/NuGet.Core/NuGet.Versioning/NuGetVersionFactory.cs
+++ b/src/NuGet.Core/NuGet.Versioning/NuGetVersionFactory.cs
@@ -106,7 +106,7 @@ namespace NuGet.Versioning
 
         private static bool TryGetNormalizedVersion(string str, [NotNullWhen(true)] out Version? version)
         {
-            if (GetNextSection(str, 0, out int endIndex, out int major))
+            if (!string.IsNullOrEmpty(str) && GetNextSection(str, 0, out int endIndex, out int major))
             {
                 int build = 0;
                 int revision = 0;

--- a/src/NuGet.Core/NuGet.Versioning/NuGetVersionFactory.cs
+++ b/src/NuGet.Core/NuGet.Versioning/NuGetVersionFactory.cs
@@ -143,28 +143,35 @@ namespace NuGet.Versioning
                 }
 
                 end = s.IndexOf('.', start);
-                string versionSection;
 
                 if (end == -1)
                 {
                     end = s.Length;
-                    versionSection = s.Substring(start);
                 }
-                else
+
+                return TryParseInt(s, start, end - 1, out versionNumber);
+            }
+
+            // start and end are inclusive bounds for the section of string to parse
+            static bool TryParseInt(string s, int start, int end, out int value)
+            {
+                value = 0;
+                int multiplier = 1;
+                for (int i = end; i >= start; i--)
                 {
-                    versionSection = s.Substring(start, end - start);
+                    // negative numbers are invalid for version strings so we only need to check for digits
+                    char current = s[i];
+                    if (current < '0' || current > '9')
+                    {
+                        value = 0;
+                        return false;
+                    }
+
+                    value += (current - '0') * multiplier;
+                    multiplier *= 10;
                 }
 
-                bool parseResult = int.TryParse(versionSection, out versionNumber);
-                if (versionNumber < 0)
-                {
-                    // negative numbers are invalid for version strings
-                    versionNumber = 0;
-
-                    return false;
-                }
-
-                return parseResult;
+                return true;
             }
         }
 

--- a/src/NuGet.Core/NuGet.Versioning/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Versioning/PublicAPI.Unshipped.txt
@@ -7,3 +7,4 @@ NuGet.Versioning.VersionRange.IsMaxInclusive.get -> bool
 NuGet.Versioning.VersionRange.IsMinInclusive.get -> bool
 NuGet.Versioning.VersionRange.MaxVersion.get -> NuGet.Versioning.NuGetVersion?
 NuGet.Versioning.VersionRange.MinVersion.get -> NuGet.Versioning.NuGetVersion?
+static NuGet.Versioning.NuGetVersion.TryGetNormalizedVersion(string! str, out System.Version? version) -> bool

--- a/src/NuGet.Core/NuGet.Versioning/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Versioning/PublicAPI.Unshipped.txt
@@ -7,4 +7,3 @@ NuGet.Versioning.VersionRange.IsMaxInclusive.get -> bool
 NuGet.Versioning.VersionRange.IsMinInclusive.get -> bool
 NuGet.Versioning.VersionRange.MaxVersion.get -> NuGet.Versioning.NuGetVersion?
 NuGet.Versioning.VersionRange.MinVersion.get -> NuGet.Versioning.NuGetVersion?
-static NuGet.Versioning.NuGetVersion.TryGetNormalizedVersion(string! str, out System.Version? version) -> bool


### PR DESCRIPTION
## Description
The code that parses NuGetVersion from strings [indirectly uses .NET's Version.TryParse](https://github.com/NuGet/NuGet.Client/blob/a6fff16af6f44927a83851448a99beb1d2801600/src/NuGet.Clients/NuGet.VisualStudio/LegacyTypes/SemanticVersion.cs#L179) to parse the version portion of the string. This can be avoided to save lots of allocations in hot paths.

Fixes: NuGet/Home#12630

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
