### PR TITLE
Bring vulnerabilites/deprecation data to Browse tab

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -261,7 +261,7 @@ namespace NuGet.PackageManagement.UI
                 var detailedPackageMetadata = new DetailedPackageMetadata(
                     packageSearchMetadata,
                     packageDeprecationMetadata,
-                    packageSearchMetadata.DownloadCount);
+                    searchResultPackage.DownloadCount);
 
                 _metadataDict[detailedPackageMetadata.Version] = detailedPackageMetadata;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
@@ -212,12 +212,12 @@ namespace NuGet.PackageManagement.VisualStudio
             // Transitive packages will have only one version the first time they are loaded, when the package is selected we update the cache with all the versions
             if (backgroundDataCache != null)
             {
-                if (isTransitive &&
-                    (backgroundDataCache.AllVersionsContextInfo.Result == null || backgroundDataCache.AllVersionsContextInfo.Result.Count <= 1))
+                if (isTransitive && (backgroundDataCache.AllVersionsContextInfo.Result == null || backgroundDataCache.AllVersionsContextInfo.Result.Count <= 1)
+                    || backgroundDataCache.AllVersionsContextInfo.Result.First().PackageSearchMetadata == null) // If the item was cached with search API, PackageSearchMetadata could be null. If so, update it with registration api information
                 {
-                    IPackageMetadataProvider transitivePackageMetadataProvider = await GetPackageMetadataProviderAsync(packageSources, projects?.ToList().AsReadOnly(), cancellationToken);
-                    IPackageSearchMetadata transitivePackageMetadata = await transitivePackageMetadataProvider.GetPackageMetadataAsync(identity, includePrerelease, cancellationToken);
-                    backgroundDataCache.UpdateSearchMetadata(transitivePackageMetadata);
+                    IPackageMetadataProvider newPackageMetadataProvider = await GetPackageMetadataProviderAsync(packageSources, projects?.ToList().AsReadOnly(), cancellationToken);
+                    IPackageSearchMetadata newPackageMetadata = await newPackageMetadataProvider.GetPackageMetadataAsync(identity, includePrerelease, cancellationToken);
+                    backgroundDataCache.UpdateSearchMetadata(newPackageMetadata);
                 }
                 return await backgroundDataCache.AllVersionsContextInfo;
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
@@ -212,8 +212,10 @@ namespace NuGet.PackageManagement.VisualStudio
             // Transitive packages will have only one version the first time they are loaded, when the package is selected we update the cache with all the versions
             if (backgroundDataCache != null)
             {
-                if (isTransitive && (backgroundDataCache.AllVersionsContextInfo.Result == null || backgroundDataCache.AllVersionsContextInfo.Result.Count <= 1)
-                    || backgroundDataCache.AllVersionsContextInfo.Result.First().PackageSearchMetadata == null) // If the item was cached with search API, PackageSearchMetadata could be null. If so, update it with registration api information
+                // If the item was cached with search API, PackageSearchMetadata could be null. If so, update it with registration api information
+                if (isTransitive
+                    && !(backgroundDataCache.AllVersionsContextInfo.Result?.Count > 1)
+                    || backgroundDataCache.AllVersionsContextInfo.Result?.First().PackageSearchMetadata == null)
                 {
                     IPackageMetadataProvider newPackageMetadataProvider = await GetPackageMetadataProviderAsync(packageSources, projects?.ToList().AsReadOnly(), cancellationToken);
                     IPackageSearchMetadata newPackageMetadata = await newPackageMetadataProvider.GetPackageMetadataAsync(identity, includePrerelease, cancellationToken);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12623

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
![image](https://github.com/NuGet/NuGet.Client/assets/43253759/39e30726-e03e-4d37-b803-3b4e15c0694b)

This was a problem in the cache, when we do a query for the Browse tab we use a search API that doesn't bring Vulnerabilities/Deprecation data, and when we click a package we query to the registration API that has this information. With this change I'm updating `IPackageSearchMetadata` to the registration API data so when we calculate all the versions we can have this information.


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
