### PR TITLE
Convert LibraryRangeCacheKey to a struct

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/LibraryRangeCacheKey.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/LibraryRangeCacheKey.cs
@@ -10,9 +10,9 @@ using NuGet.Shared;
 namespace NuGet.DependencyResolver
 {
     /// <summary>
-    /// Helper class to hold a library range and framework.
+    /// Helper type to hold a library range and framework.
     /// </summary>
-    public class LibraryRangeCacheKey : IEquatable<LibraryRangeCacheKey>
+    public readonly struct LibraryRangeCacheKey : IEquatable<LibraryRangeCacheKey>
     {
         public LibraryRangeCacheKey(LibraryRange range, NuGetFramework framework)
         {
@@ -32,7 +32,7 @@ namespace NuGet.DependencyResolver
 
         public override bool Equals(object obj)
         {
-            return Equals(obj as LibraryRangeCacheKey);
+            return obj is LibraryRangeCacheKey key && Equals(key);
         }
 
         public override int GetHashCode()
@@ -42,16 +42,6 @@ namespace NuGet.DependencyResolver
 
         public bool Equals(LibraryRangeCacheKey other)
         {
-            if (Object.ReferenceEquals(this, other))
-            {
-                return true;
-            }
-
-            if (Object.ReferenceEquals(null, other))
-            {
-                return false;
-            }
-
             return LibraryRange.Equals(other.LibraryRange)
                 && Framework.Equals(other.Framework);
         }
@@ -59,6 +49,16 @@ namespace NuGet.DependencyResolver
         public override string ToString()
         {
             return string.Format(CultureInfo.InvariantCulture, "{0} {1}", LibraryRange, Framework);
+        }
+
+        public static bool operator ==(LibraryRangeCacheKey left, LibraryRangeCacheKey right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(LibraryRangeCacheKey left, LibraryRangeCacheKey right)
+        {
+            return !(left == right);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/PublicAPI.Unshipped.txt
@@ -1,3 +1,6 @@
 #nullable enable
+NuGet.DependencyResolver.LibraryRangeCacheKey.Equals(NuGet.DependencyResolver.LibraryRangeCacheKey other) -> bool
+static NuGet.DependencyResolver.LibraryRangeCacheKey.operator !=(NuGet.DependencyResolver.LibraryRangeCacheKey left, NuGet.DependencyResolver.LibraryRangeCacheKey right) -> bool
+static NuGet.DependencyResolver.LibraryRangeCacheKey.operator ==(NuGet.DependencyResolver.LibraryRangeCacheKey left, NuGet.DependencyResolver.LibraryRangeCacheKey right) -> bool
 ~NuGet.DependencyResolver.IRemoteDependencyProvider.SourceRepository.get -> NuGet.Protocol.Core.Types.SourceRepository
 ~NuGet.DependencyResolver.LocalDependencyProvider.SourceRepository.get -> NuGet.Protocol.Core.Types.SourceRepository


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1824495
Fixes: https://github.com/NuGet/Home/issues/12646

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

`LibraryRangeCacheKey ` is showing up in customer traces captured during GC pauses as contributing to many of those pauses. It can comfortably be a struct, avoiding the additional heap allocation.

This is a binary change to public API (unlikely to be a source change).

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
