### PR TITLE
Use default '/' split symbol in ETW events.

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/EtwLogActivity.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/EtwLogActivity.cs
@@ -14,7 +14,7 @@ namespace NuGet.VisualStudio.Telemetry
         {
             if (VsEtwLogging.IsProviderEnabled(VsEtwKeywords.Ide, VsEtwLevel.Information))
             {
-                var fullName = (VSTelemetrySession.VSEventNamePrefix + activityName).ToLowerInvariant().Replace('/', '_');
+                var fullName = (VSTelemetrySession.VSEventNamePrefix + activityName).ToLowerInvariant();
                 _activity = VsEtwLogging.CreateActivity(fullName, VsEtwKeywords.Ide, VsEtwLevel.Information);
             }
         }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/12631

Regression? Last working version: N/A

## Description
Avoid converting event/property names in ETW provider

This is allocating a lot during solution close and other places where lots of events are being produced, which is causing GCs to occur in some runs, introducing noise. The statement that says ETW events can't have '/' seems to be incorrect, as Windows, VS & .NET all include events with '/'. Also stopped converting properties as these are raw strings.

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
