### PR TITLE
Add dependencies for PVP flow

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
     <MicrosoftBuildVersion Condition="'$(TargetFramework)' == 'netcoreapp5.0'">16.11.0</MicrosoftBuildVersion>
 
     <!-- Overridden by source build to ensure the same version is used across products, do not remove these properties -->
+    <!-- For each property here, there is an appropriate package dependency in eng/Version.Details.xml -->
     <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion Condition="'$(MicrosoftExtensionsFileProvidersAbstractionsPackageVersion)' == ''">6.0.0</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
     <MicrosoftExtensionsFileSystemGlobbingPackageVersion Condition="'$(MicrosoftExtensionsFileSystemGlobbingPackageVersion)' == ''">6.0.0</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
     <MicrosoftWebXdtPackageVersion Condition="'$(MicrosoftWebXdtPackageVersion)' == ''">3.0.0</MicrosoftWebXdtPackageVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,4 +5,31 @@
     See https://github.com/dotnet/arcade/issues/2396 for details.
     See https://github.com/dotnet/arcade/blob/master/Documentation/DependencyDescriptionFormat.md#details-file for schema.
   -->
+
+  <!--
+    Following dependencies are required for PVP flow.
+    PVP flow infra will automatically bump the version to the latest live one.
+  -->
+  <ProductDependencies>
+    <Dependency Name="Microsoft.Build" Version="17.3.1">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>80f618ad45d38475773fd1a6eaa059f118a0ad5a</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="6.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>8470979eb44c2218025515234d3e01138bd74afb</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>8470979eb44c2218025515234d3e01138bd74afb</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Web.Xdt" Version="3.0.0">
+      <Uri>https://github.com/aspnet/xdt</Uri>
+      <Sha>d4d088b6a9c793525b1a27a119cb66ba4587bb39</Sha>
+    </Dependency>
+    <Dependency Name="System.ComponentModel.Composition" Version="4.5.0">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>30ab651fcb4354552bd4891619a0bdd81e0ebdbf</Sha>
+    </Dependency>
+  </ProductDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,6 +9,9 @@
   <!--
     Following dependencies are required for PVP flow.
     PVP flow infra will automatically bump the version to the latest live one.
+
+    Versions specified here were initially mirrored from repo dependencies, but there is no
+    Arcade flow and versions do not necessarily match what is currently consumed by repo build.
   -->
   <ProductDependencies>
     <Dependency Name="Microsoft.Build" Version="17.3.1">


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12633

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Contributes to https://github.com/dotnet/source-build/issues/3043

PVP flow is a method of flowing dependencies in source build that only overrides versions of packages that the repo has a declared dependency on in Version.Details.xml. This means that the package flow is closer to the Microsoft's way of building .NET.

To enable this for `nuget.client`, we just need to add dependencies on the packages that should be overridden in source build. In this case, it's `Microsoft.Build` packages. We originally thought that these are used as references, and introduced relevant SBRP packages with https://github.com/dotnet/source-build-reference-packages/pull/694. However, runtime packages are needed, and this PR enables the flow of live packages.

To fully enable PVP flow, the repo project in the VMR will need to set `<PackageVersionPropsFlowType>DependenciesOnly</PackageVersionPropsFlowType>` once these changes flow in.