### PR TITLE
Warn when Audit enabled, but no vulnerability data is found

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -2484,6 +2484,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to NuGetAudit is enabled, but no package sources contain known vulnerability data..
+        /// </summary>
+        internal static string Warning_NoVulnerabilityData {
+            get {
+                return ResourceManager.GetString("Warning_NoVulnerabilityData", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Package &apos;{0}&apos; {1} has a known {2} severity vulnerability, {3}..
         /// </summary>
         internal static string Warning_PackageWithKnownVulnerability {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1088,4 +1088,8 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
 {0} - is the value from the customer's project file
 {1} is the list of valid values "direct, all"</comment>
   </data>
+  <data name="Warning_NoVulnerabilityData" xml:space="preserve">
+    <value>NuGetAudit is enabled, but no package sources contain known vulnerability data.</value>
+    <comment>Do not translate NuGetAudit</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -367,6 +367,11 @@ namespace NuGet.Common
         NU1904 = 1904,
 
         /// <summary>
+        /// NuGetAudit enabled, but no vulnerability data found
+        /// </summary>
+        NU1905 = 1905,
+
+        /// <summary>
         /// Undefined signature error
         /// </summary>
         NU3000 = 3000,

--- a/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
@@ -5,4 +5,5 @@ NuGet.Common.NuGetLogCode.NU1901 = 1901 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1902 = 1902 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1903 = 1903 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1904 = 1904 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1905 = 1905 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU3042 = 3042 -> NuGet.Common.NuGetLogCode


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12610

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Warn when NuGetAudit is enabled, but none of the package sources provided any known vulnerability data to check against.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: https://github.com/NuGet/Client.Engineering/issues/2253
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled: https://github.com/NuGet/docs.microsoft.com-nuget/issues/3049
  - **OR**
  - [ ] N/A
