### PR TITLE
Remove trailing period from NU190X Audit warnings

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -2493,7 +2493,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package &apos;{0}&apos; {1} has a known {2} severity vulnerability, {3}..
+        ///   Looks up a localized string similar to Package &apos;{0}&apos; {1} has a known {2} severity vulnerability, {3}.
         /// </summary>
         internal static string Warning_PackageWithKnownVulnerability {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1062,7 +1062,7 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
     <comment>As in "This package has a unknown severity vulnerability"</comment>
   </data>
   <data name="Warning_PackageWithKnownVulnerability" xml:space="preserve">
-    <value>Package '{0}' {1} has a known {2} severity vulnerability, {3}.</value>
+    <value>Package '{0}' {1} has a known {2} severity vulnerability, {3}</value>
     <comment>{0} - package id
 {1} - package version
 {2} - severity, for example low, moderate, high, or critical


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12600

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Removed trailing period, so terminals that include it during clicks/selection, don't end up with invalid URLs.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: just an output string change
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
