### PR TITLE
Run CI build with cert chain retries

### DIFF
--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -88,6 +88,7 @@ resources:
 
 variables:
   DOTNET_NOLOGO: 1
+  NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY: 3,1000
   Codeql.Enabled: ${{ parameters.isOfficialBuild }}
   Codeql.TSAEnabled: ${{ parameters.isOfficialBuild }}
   RunApexTests: ${{ parameters.RunApexTests }}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2335 

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

We've been experiencing a number of "The repository primary signature validity period has expired." failures during restore on CI. Timestamped signatures are supposed to prevent expired certificates from causing this error, but the error can still happen if the timestamp isn't signed properly, or if the timestamp signature is invalid. On Windows, sometimes the RPC server returns "too busy" errors, and none of the higher level APIs retry. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
