### PR TITLE
Add AsString() for LibraryDependencyTarget and LibraryIncludeFlags

### DIFF
--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyTargetUtils.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyTargetUtils.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -135,7 +136,7 @@ namespace NuGet.LibraryModel
             return string.Join(",", flagStrings);
         }
 
-        private static readonly Dictionary<LibraryDependencyTarget, string> LibraryDependencyTargetCache = new();
+        private static readonly ConcurrentDictionary<LibraryDependencyTarget, string> LibraryDependencyTargetCache = new();
 
         /// <summary>
         /// Efficiently converts <see cref="LibraryDependencyTarget"/> to it's <see cref="string"/> representation.
@@ -147,7 +148,7 @@ namespace NuGet.LibraryModel
             if (!LibraryDependencyTargetCache.TryGetValue(includeFlags, out string enumAsString))
             {
                 enumAsString = includeFlags.ToString();
-                LibraryDependencyTargetCache[includeFlags] = enumAsString;
+                LibraryDependencyTargetCache.TryAdd(includeFlags, enumAsString);
             }
 
             return enumAsString;

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyTargetUtils.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyTargetUtils.cs
@@ -135,6 +135,24 @@ namespace NuGet.LibraryModel
             return string.Join(",", flagStrings);
         }
 
+        private static readonly Dictionary<LibraryDependencyTarget, string> LibraryDependencyTargetCache = new();
+
+        /// <summary>
+        /// Efficiently converts <see cref="LibraryDependencyTarget"/> to it's <see cref="string"/> representation.
+        /// </summary>
+        /// <param name="includeFlags">The <see cref="LibraryDependencyTarget"/> instance to get the <see cref="string"/> representation for.</param>
+        /// <returns>The <see cref="string"/> representation of <paramref name="includeFlags"/>.</returns>
+        public static string AsString(this LibraryDependencyTarget includeFlags)
+        {
+            if (!LibraryDependencyTargetCache.TryGetValue(includeFlags, out string enumAsString))
+            {
+                enumAsString = includeFlags.ToString();
+                LibraryDependencyTargetCache[includeFlags] = enumAsString;
+            }
+
+            return enumAsString;
+        }
+
         [DebuggerDisplay("{String.Substring(Start, Length)}")]
         private struct StringSegment
         {

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryIncludeFlagUtils.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryIncludeFlagUtils.cs
@@ -118,5 +118,23 @@ namespace NuGet.LibraryModel
 
             return result;
         }
+
+        private static readonly Dictionary<LibraryIncludeFlags, string> LibraryIncludeFlagsCache = new();
+
+        /// <summary>
+        /// Efficiently converts <see cref="LibraryIncludeFlags"/> to it's <see cref="string"/> representation.
+        /// </summary>
+        /// <param name="includeFlags">The <see cref="LibraryIncludeFlags"/> instance to get the <see cref="string"/> representation for.</param>
+        /// <returns>The <see cref="string"/> representation of <paramref name="includeFlags"/>.</returns>
+        public static string AsString(this LibraryIncludeFlags includeFlags)
+        {
+            if (!LibraryIncludeFlagsCache.TryGetValue(includeFlags, out string enumAsString))
+            {
+                enumAsString = includeFlags.ToString();
+                LibraryIncludeFlagsCache[includeFlags] = enumAsString;
+            }
+
+            return enumAsString;
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryIncludeFlagUtils.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryIncludeFlagUtils.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -119,7 +120,7 @@ namespace NuGet.LibraryModel
             return result;
         }
 
-        private static readonly Dictionary<LibraryIncludeFlags, string> LibraryIncludeFlagsCache = new();
+        private static readonly ConcurrentDictionary<LibraryIncludeFlags, string> LibraryIncludeFlagsCache = new();
 
         /// <summary>
         /// Efficiently converts <see cref="LibraryIncludeFlags"/> to it's <see cref="string"/> representation.
@@ -131,7 +132,7 @@ namespace NuGet.LibraryModel
             if (!LibraryIncludeFlagsCache.TryGetValue(includeFlags, out string enumAsString))
             {
                 enumAsString = includeFlags.ToString();
-                LibraryIncludeFlagsCache[includeFlags] = enumAsString;
+                LibraryIncludeFlagsCache.TryAdd(includeFlags, enumAsString);
             }
 
             return enumAsString;

--- a/src/NuGet.Core/NuGet.LibraryModel/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.LibraryModel/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~static NuGet.LibraryModel.LibraryDependencyTargetUtils.AsString(this NuGet.LibraryModel.LibraryDependencyTarget includeFlags) -> string
+~static NuGet.LibraryModel.LibraryIncludeFlagUtils.AsString(this NuGet.LibraryModel.LibraryIncludeFlags includeFlags) -> string

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -431,18 +431,18 @@ namespace NuGet.ProjectModel
 
                     if (dependency.IncludeType != LibraryIncludeFlags.All)
                     {
-                        SetValue(writer, "include", dependency.IncludeType.ToString());
+                        SetValue(writer, "include", dependency.IncludeType.AsString());
                     }
 
                     if (dependency.SuppressParent != LibraryIncludeFlagUtils.DefaultSuppressParent)
                     {
-                        SetValue(writer, "suppressParent", dependency.SuppressParent.ToString());
+                        SetValue(writer, "suppressParent", dependency.SuppressParent.AsString());
                     }
 
                     if (dependency.LibraryRange.TypeConstraint != LibraryDependencyTarget.Reference
                         && dependency.LibraryRange.TypeConstraint != (LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference))
                     {
-                        SetValue(writer, "target", dependency.LibraryRange.TypeConstraint.ToString());
+                        SetValue(writer, "target", dependency.LibraryRange.TypeConstraint.AsString());
                     }
 
                     if (VersionRange.All.Equals(versionRange)


### PR DESCRIPTION
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12638

## Description
This change introduces an `AsString()` extension to handle the string conversion. There is a `Dictionary` backing this method that avoids duplicates of the same string. The full set of potential flags is high, but it's expected that the actual number of distinct strings required at runtime will be significantly lower.

## PR Checklist

- [X] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->
