### PR TITLE
Show an Icon for Package Source Mapping Status in the Details Pane

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageSourceMappingActionViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageSourceMappingActionViewModel.cs
@@ -5,6 +5,8 @@
 
 using System;
 using System.Linq;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
 
 namespace NuGet.PackageManagement.UI.ViewModels
 {
@@ -35,6 +37,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
 
                 RaisePropertyChanged(nameof(IsPackageMapped));
                 RaisePropertyChanged(nameof(MappingStatus));
+                RaisePropertyChanged(nameof(MappingStatusIcon));
             }
         }
 
@@ -71,11 +74,31 @@ namespace NuGet.PackageManagement.UI.ViewModels
             }
         }
 
+        public ImageMoniker MappingStatusIcon
+        {
+            get
+            {
+                if (!IsPackageSourceMappingEnabled)
+                {
+                    return KnownMonikers.StatusInformation;
+                }
+                if (IsPackageMapped)
+                {
+                    return KnownMonikers.StatusOK;
+                }
+                else
+                {
+                    return KnownMonikers.StatusOffline;
+                }
+            }
+        }
+
         public void SettingsChanged()
         {
             RaisePropertyChanged(nameof(IsPackageSourceMappingEnabled));
             RaisePropertyChanged(nameof(IsPackageMapped));
             RaisePropertyChanged(nameof(MappingStatus));
+            RaisePropertyChanged(nameof(MappingStatusIcon));
         }
 
         public static PackageSourceMappingActionViewModel Create(INuGetUI uiController)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageSourceMappingActionViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageSourceMappingActionViewModel.cs
@@ -88,7 +88,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
                 }
                 else
                 {
-                    return KnownMonikers.StatusOffline;
+                    return KnownMonikers.StatusError;
                 }
             }
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageSourceMappingActionControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageSourceMappingActionControl.xaml
@@ -2,7 +2,8 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
              xmlns:nuget="clr-namespace:NuGet.PackageManagement.UI"
              mc:Ignorable="d"
              Margin="0,9,0,0"
@@ -16,14 +17,20 @@
     </ResourceDictionary>
   </UserControl.Resources>
   <Grid>
-    <TextBlock Margin="0,0,9,0" TextWrapping="Wrap">
-      <Run Text="{Binding MappingStatus, Mode=OneWay}" />
-      <Control Margin="6,0,0,0" IsTabStop="False" />
-      <Hyperlink Click="SettingsButtonClicked"
-                 Style="{StaticResource HyperlinkStyleNoUri}"
-                 AutomationProperties.Name="{x:Static nuget:Resources.Hyperlink_PackageSourceMappingSettings}">
-        <TextBlock TextWrapping="Wrap" Text="{x:Static nuget:Resources.Hyperlink_PackageSourceMappingSettings}" />
-      </Hyperlink>
-    </TextBlock>
+    <StackPanel Orientation="Horizontal">
+      <imaging:CrispImage
+        Margin="0,0,2,0"
+        AutomationProperties.Name="{Binding MappingStatus, Mode=OneWay}"
+        Moniker="{Binding MappingStatusIcon, Mode=OneWay}" />
+      <TextBlock x:Name="_textStatus" Margin="0,0,9,0" TextWrapping="Wrap">
+        <Run Text="{Binding MappingStatus, Mode=OneWay}" />
+        <Control Margin="6,0,0,0" IsTabStop="False" />
+        <Hyperlink Click="SettingsButtonClicked"
+                   Style="{StaticResource HyperlinkStyleNoUri}"
+                   AutomationProperties.Name="{x:Static nuget:Resources.Hyperlink_PackageSourceMappingSettings}">
+          <TextBlock TextWrapping="Wrap" Text="{x:Static nuget:Resources.Hyperlink_PackageSourceMappingSettings}" />
+        </Hyperlink>
+      </TextBlock>
+    </StackPanel>
   </Grid>
 </UserControl>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageSourceMappingActionViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageSourceMappingActionViewModelTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using Microsoft.VisualStudio.Imaging;
 using Moq;
 using NuGet.Configuration;
 using NuGet.PackageManagement.UI.ViewModels;
@@ -32,6 +33,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             Assert.Equal(false, target.IsPackageSourceMappingEnabled);
             Assert.Equal(false, target.IsPackageMapped);
             Assert.Equal(Resources.Text_PackageMappingsDisabled, target.MappingStatus);
+            Assert.Equal(KnownMonikers.StatusInformation, target.MappingStatusIcon);
             Assert.Null(target.PackageId);
         }
 
@@ -57,6 +59,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             Assert.Equal(true, target.IsPackageSourceMappingEnabled);
             Assert.Equal(false, target.IsPackageMapped);
             Assert.Equal(Resources.Text_PackageMappingsNotFound, target.MappingStatus);
+            Assert.Equal(KnownMonikers.StatusOffline, target.MappingStatusIcon);
             Assert.Null(target.PackageId);
         }
 
@@ -83,6 +86,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             Assert.Equal(true, target.IsPackageSourceMappingEnabled);
             Assert.Equal(true, target.IsPackageMapped);
             Assert.Equal(Resources.Text_PackageMappingsFound, target.MappingStatus);
+            Assert.Equal(KnownMonikers.StatusOK, target.MappingStatusIcon);
             Assert.Equal(packageId, target.PackageId);
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageSourceMappingActionViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageSourceMappingActionViewModelTests.cs
@@ -59,7 +59,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             Assert.Equal(true, target.IsPackageSourceMappingEnabled);
             Assert.Equal(false, target.IsPackageMapped);
             Assert.Equal(Resources.Text_PackageMappingsNotFound, target.MappingStatus);
-            Assert.Equal(KnownMonikers.StatusOffline, target.MappingStatusIcon);
+            Assert.Equal(KnownMonikers.StatusError, target.MappingStatusIcon);
             Assert.Null(target.PackageId);
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12609

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Adds an icon beside the Package Source Mapping status in the Details pane.

![image](https://github.com/NuGet/NuGet.Client/assets/49205731/88f1b8eb-cf80-4ad2-9e47-8fc0d5a22ace)
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/904ce1a6-5c83-4c7b-9ac5-82ac375c751f)
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/2b63bbda-128f-4727-aa35-25e8e11780b2)


Tested with Narrator and Accessibility Insights. When Narrator drills-in to the Icon, it will read the same text beside the icon, plus the word "Image" since that's the control type (our other icons also do this).

![image](https://github.com/NuGet/NuGet.Client/assets/49205731/bc5ed73d-3b25-48e7-9e64-e26f2372dcab)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled - part of https://github.com/NuGet/docs.microsoft.com-nuget/issues/3063
  - **OR**
  - [ ] N/A
