### PR TITLE
Replace Assembly.GetExecutingAssembly() with reliable method

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -9,7 +9,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Credentials;
@@ -164,8 +163,8 @@ namespace NuGet.CommandLine
         {
             if (ShouldOutputNuGetVersion)
             {
-                var assemblyName = Assembly.GetExecutingAssembly().GetName();
-                var assemblyLocation = Assembly.GetExecutingAssembly().Location;
+                var assemblyName = typeof(Command).Assembly.GetName();
+                var assemblyLocation = typeof(Command).Assembly.Location;
                 var version = System.Diagnostics.FileVersionInfo.GetVersionInfo(assemblyLocation).FileVersion;
                 var message = string.Format(
                     CultureInfo.CurrentCulture,

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/HelpCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/HelpCommand.cs
@@ -40,7 +40,7 @@ namespace NuGet.CommandLine
         public HelpCommand(ICommandManager commandManager)
         {
             _commandManager = commandManager;
-            _commandExe = Assembly.GetExecutingAssembly().GetName().Name;
+            _commandExe = typeof(HelpCommand).Assembly.GetName().Name;
         }
 
         public override void ExecuteCommand()

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Pack/AssemblyMetadataExtractor.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Pack/AssemblyMetadataExtractor.cs
@@ -23,7 +23,7 @@ namespace NuGet.CommandLine
 
         private static T CreateInstance<T>(AppDomain domain)
         {
-            string assemblyLocation = Assembly.GetExecutingAssembly().Location;
+            string assemblyLocation = typeof(AssemblyMetadataExtractor).Assembly.Location;
 
             try
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Common/CommonResources.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Common/CommonResources.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;
 
@@ -33,7 +32,7 @@ namespace NuGet
                 if (ReferenceEquals(resourceMan, null))
                 {
                     // Find the CommonResources.resources file's full resource name in this assembly
-                    string commonResourcesName = Assembly.GetExecutingAssembly().GetManifestResourceNames().First(s => s.EndsWith("CommonResources.resources", StringComparison.OrdinalIgnoreCase));
+                    string commonResourcesName = typeof(CommonResources).Assembly.GetManifestResourceNames().First(s => s.EndsWith("CommonResources.resources", StringComparison.OrdinalIgnoreCase));
 
                     // Trim off the ".resources"
                     commonResourcesName = commonResourcesName.Substring(0, commonResourcesName.Length - 10);

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/PSTypeWrapper.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/PSTypeWrapper.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Management.Automation;
 using System.Reflection;
-using LocalResources = NuGet.PackageManagement.PowerShellCmdlets.Resources;
 
 namespace NuGetConsole.Host.PowerShell.Implementation
 {
@@ -46,7 +45,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             {
                 if (_addWrapperMembersScript == null)
                 {
-                    string extensionRoot = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                    string extensionRoot = Path.GetDirectoryName(typeof(PSTypeWrapper).Assembly.Location);
                     string scriptPath = Path.Combine(extensionRoot, "Modules", "NuGet", "Add-WrapperMembers.ps1");
                     string scriptContents = File.ReadAllText(scriptPath);
                     _addWrapperMembersScript = ScriptBlock.Create(scriptContents);

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/RunspaceManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/RunspaceManager.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
-using System.Reflection;
 using EnvDTE;
 using EnvDTE80;
 using Microsoft.PowerShell;
@@ -109,7 +108,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
         private static void LoadModules(RunspaceDispatcher runspace)
         {
             // We store our PS module file at <extension root>\Modules\NuGet\NuGet.psd1
-            string extensionRoot = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string extensionRoot = Path.GetDirectoryName(typeof(RunspaceManager).Assembly.Location);
             string modulePath = Path.Combine(extensionRoot, "Modules", "NuGet", "NuGet.psd1");
             runspace.ImportModule(modulePath);
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UpgradeLogger.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UpgradeLogger.cs
@@ -6,7 +6,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Reflection;
 using System.Xml;
 using System.Xml.Xsl;
 using NuGet.Common;
@@ -149,7 +148,7 @@ namespace NuGet.PackageManagement.UI
         internal void Flush()
         {
 
-            using (var xsltStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(XsltManifestResourceName))
+            using (var xsltStream = typeof(UpgradeLogger).Assembly.GetManifestResourceStream(XsltManifestResourceName))
             {
                 Debug.Assert(xsltStream != null, $"Resource {XsltManifestResourceName} could not be loaded.");
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/CommonResources.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/CommonResources.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;
 
@@ -33,7 +32,7 @@ namespace NuGet
                 if (ReferenceEquals(resourceMan, null))
                 {
                     // Find the CommonResources.resources file's full resource name in this assembly
-                    string commonResourcesName = Assembly.GetExecutingAssembly().GetManifestResourceNames().First(s => s.EndsWith("CommonResources.resources", StringComparison.OrdinalIgnoreCase));
+                    string commonResourcesName = typeof(CommonResources).Assembly.GetManifestResourceNames().First(s => s.EndsWith("CommonResources.resources", StringComparison.OrdinalIgnoreCase));
 
                     // Trim off the ".resources"
                     commonResourcesName = commonResourcesName.Substring(0, commonResourcesName.Length - 10);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/CommonResources.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/CommonResources.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;
 
@@ -33,7 +32,7 @@ namespace NuGet.VisualStudio
                 if (ReferenceEquals(resourceMan, null))
                 {
                     // Find the CommonResources.resources file's full resource name in this assembly
-                    string commonResourcesName = Assembly.GetExecutingAssembly().GetManifestResourceNames().First(s => s.EndsWith("CommonResources.resources", StringComparison.OrdinalIgnoreCase));
+                    string commonResourcesName = typeof(CommonResources).Assembly.GetManifestResourceNames().First(s => s.EndsWith("CommonResources.resources", StringComparison.OrdinalIgnoreCase));
 
                     // Trim off the ".resources"
                     commonResourcesName = commonResourcesName.Substring(0, commonResourcesName.Length - 10);

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/Program.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/Program.cs
@@ -63,7 +63,7 @@ namespace NuGet.Build.Tasks.Console
                     // It also can be different per instance of Visual Studio so when running unit tests it always needs to match that instance of MSBuild
                     // The code below runs this EXE in an AppDomain as if its MSBuild.exe so the assembly search location is next to MSBuild.exe and all binding redirects are used
                     // allowing this process to evaluate MSBuild projects as if it is MSBuild.exe
-                    var thisAssembly = Assembly.GetExecutingAssembly();
+                    Assembly thisAssembly = typeof(Program).Assembly;
 
                     AppDomain appDomain = AppDomain.CreateDomain(
                         thisAssembly.FullName,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12650

Regression? Last working version:

## Description
In case code inlining happens then Assembly.GetExecutingAssembly().Location may point to wrong location.
So we need to replace with typeof(T).Assembly.Location for reliability. This concern came up during review of another internal repo.
I'm only doing for product code, not for tests.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
