### PR TITLE
Onboard onto Dartlab build-to-build upgrade feature

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -27,7 +27,7 @@
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <VsTargetBranch>main</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
-    <VsTargetChannelForTests>int.d17.5</VsTargetChannelForTests>
+    <VsTargetChannelForTests>int.$(VsTargetBranch)</VsTargetChannelForTests>
 
     <!-- NuGet SDK VS package Semantic Version -->
     <NuGetSdkVsSemanticVersion>$(VsTargetMajorVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</NuGetSdkVsSemanticVersion>

--- a/build/config.props
+++ b/build/config.props
@@ -27,7 +27,7 @@
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <VsTargetBranch>main</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
-    <VsTargetChannelForTests>int.$(VsTargetBranch)</VsTargetChannelForTests>
+    <VsTargetChannelForTests>int.d17.5</VsTargetChannelForTests>
 
     <!-- NuGet SDK VS package Semantic Version -->
     <NuGetSdkVsSemanticVersion>$(VsTargetMajorVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</NuGetSdkVsSemanticVersion>

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -37,8 +37,8 @@ stages:
           value: ${{parameters.bootstrapperUrl}}
         - ${{parameters.variables}}
       runSettingsURI: ${{parameters.runSettingsURI}}
-      visualStudioBootstrapperURI: $(bootstrapperUrl)
-      baseVisualStudioBootstrapperURI: $(bootstrapperUrl)
+      visualStudioBootstrapperURI: $(bootstrapperUrl)      
+      baseVisualStudioBootstrapperURI: https://vsdrop.corp.microsoft.com/file/v1/$(VisualStudio.BaseBuild.ProductsDropName);${{parameters.visualStudioBootstrapperDropPath}}
       candidateBaselineBuilds: $(BaselineBuildCommitIds)
       testLabPoolName: VS-Platform
       dartLabEnvironment: ${{parameters.DartLabEnvironment}}

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -35,7 +35,8 @@ stages:
       variables:
         - name: bootstrapperUrl
           value: ${{parameters.bootstrapperUrl}}
-        - ${{parameters.variables}}
+        - ${{if gt(length(parameters.variables), 0)}}:
+          - ${{parameters.variables}}
       runSettingsURI: ${{parameters.runSettingsURI}}
       visualStudioBootstrapperURI: $(bootstrapperUrl)      
       baseVisualStudioBootstrapperURI: https://vsdrop.corp.microsoft.com/file/v1/$(VisualStudio.BaseBuild.ProductsDropName);bootstrappers/Enterprise/vs_enterprise.exe

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -71,16 +71,12 @@ stages:
               Write-Host "Getting Baseline build commit ids for build: '$(BaselineBuildID)'"
               
               $artifactName = 'BuildArtifacts'
-              $baselineBuildsFile: $(Agent.TempDirectory)\BaselineBuilds.json
+              $baselineBuildsFile = $(Agent.TempDirectory)\BaselineBuilds.json
 
-              $artifact = Get-BuildArtifact -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' - 
-              BuildID $(BaselineBuildID)  -ArtifactName $artifactName -OAuthAccessToken (ConvertTo-SecureString 
-              '$(System.AccessToken)' -AsPlainText -Force)
+              $artifact = Get-BuildArtifact -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID)  -ArtifactName $artifactName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
               $containerName = $artifact.Resource.Data -Split '/' | Select-Object -Last 1
               $fileName = Join-Path $containerName 'BaselineBuilds.json'
-              $jsonString = Read-BuildArtifactFile -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' 
-              -BuildID $bootstrapperBuildID  -ArtifactName $artifactName -FileName $fileName -OAuthAccessToken 
-              (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
+              $jsonString = Read-BuildArtifactFile -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID) -ArtifactName $artifactName -FileName $fileName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
 
               $jsonString | Out-File -FilePath $baselineBuildsFile
 

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -37,7 +37,7 @@ stages:
           value: ${{parameters.bootstrapperUrl}}
         - ${{parameters.variables}}
       runSettingsURI: ${{parameters.runSettingsURI}}
-      visualStudioBootstrapperURI: $(bootstrapperUrl)
+      baseVisualStudioBootstrapperURI: $(bootstrapperUrl)
       testLabPoolName: VS-Platform
       dartLabEnvironment: ${{parameters.DartLabEnvironment}}
       visualStudioSigning: Test

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -26,7 +26,7 @@ parameters:
     type: string
 
 stages:
-  - template: stages\visual-studio\single-runsettings.yml@DartLabTemplates
+  - template: stages\visual-studio\build-to-build-upgrade\single-runsettings.yml@DartLabTemplates
     parameters:
       name: VS_Apex_Tests
       displayName: Apex Tests On Windows

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -62,6 +62,7 @@ stages:
             continueOnError: true
             filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
             arguments: -ClientSecret (ConvertTo-SecureString '$(CloudBuild-ClientSecret)' -AsPlainText -Force) -ClientID '$(CloudBuild-ClientID)' -SessionID '${{ parameters.QBuildSessionId }}' -OutVariableName 'BaselineBuildID'
+        
         - task: PowerShell@1
           displayName: "Get Baseline build commit ids"
           name: "getbaselinebuildcommitids"

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -51,7 +51,7 @@ stages:
       testMachineCleanUpStrategy: ${{parameters.testMachineCleanUpStrategy}}
       testAgentElevated: true
       preTestMachineConfigurationStepList:
-      - template: \steps\powershell\execute-script.yml
+      - template: \steps\powershell\execute-script.yml@DartLabTemplates
         parameters:
           displayName: Get Baseline Build ID using CloudBuild Session ID
           continueOnError: true

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -71,7 +71,7 @@ stages:
               Write-Host "Getting Baseline build commit ids for build: '$(BaselineBuildID)'"
               
               $artifactName = 'BuildArtifacts'
-              $baselineBuildsFile = $(Agent.TempDirectory)\BaselineBuilds.json
+              $baselineBuildsFile = Join-Path $(Agent.TempDirectory) "BaselineBuilds.json"
 
               $artifact = Get-BuildArtifact -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID)  -ArtifactName $artifactName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
               $containerName = $artifact.Resource.Data -Split '/' | Select-Object -Last 1

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -90,7 +90,7 @@ stages:
           continueOnError: true
           inputs:
             filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildID.ps1
-            arguments: -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -InstanceURL '$(System.CollectionUri)' -RepositoryName '$(Build.Repository.Name)' -ProjectName '$(System.TeamProject)' -CommitIDs $(BaselineBuildCommitIds) -BuildDefinitionIDs 10289 -OutVariableName 'VisualStudio.BaseBuild.ID'
+            arguments: -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -InstanceURL '$(System.CollectionUri)' -RepositoryName 'VS' -ProjectName '$(System.TeamProject)' -CommitIDs $(BaselineBuildCommitIds) -BuildDefinitionIDs 10289 -OutVariableName 'VisualStudio.BaseBuild.ID'
         - task: PowerShell@2
           name: SetVisualStudioBaseBuildProductsDropName
           displayName: Set 'VisualStudio.BaseBuild.ProductsDropName'

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -53,41 +53,41 @@ stages:
       testMachineCleanUpStrategy: ${{parameters.testMachineCleanUpStrategy}}
       testAgentElevated: true
       preTestMachineConfigurationStepList:
-      - template: \steps\powershell\execute-script.yml@DartLabTemplates
-        parameters:
-          displayName: Get Baseline Build ID using CloudBuild Session ID
+        - template: \steps\powershell\execute-script.yml@DartLabTemplates
+          parameters:
+            displayName: Get Baseline Build ID using CloudBuild Session ID
+            continueOnError: true
+            filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
+            arguments: -ClientSecret '$(CloudBuild-ClientSecret)' -ClientID '$(CloudBuild-ClientID)' -SessionID '${{parameters.QBuildSessionId}}' -OutVariableName 'BaselineBuildID'
+        
+        - task: PowerShell@1
+          displayName: "Get Baseline build commit ids"
+          name: "getbaselinebuildcommitids"
           continueOnError: true
-          filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
-          arguments: -ClientSecret '$(CloudBuild-ClientSecret)' -ClientID '$(CloudBuild-ClientID)' -SessionID '${{parameters.QBuildSessionId}}' -OutVariableName 'BaselineBuildID'
-      
-      - task: PowerShell@1
-        displayName: "Get Baseline build commit ids"
-        name: "getbaselinebuildcommitids"
-        continueOnError: true
-        inputs:
-          scriptType: "inlineScript"
-          inlineScript: |
-            try {
-            Write-Host "Getting Baseline build commit ids for build: '$(BaselineBuildID)'"
-            
-            $artifactName = 'BuildArtifacts'
-            $baselineBuildsFile: $(Agent.TempDirectory)\BaselineBuilds.json
+          inputs:
+            scriptType: "inlineScript"
+            inlineScript: |
+              try {
+              Write-Host "Getting Baseline build commit ids for build: '$(BaselineBuildID)'"
+              
+              $artifactName = 'BuildArtifacts'
+              $baselineBuildsFile: $(Agent.TempDirectory)\BaselineBuilds.json
 
-            $artifact = Get-BuildArtifact -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' - 
-            BuildID $(BaselineBuildID)  -ArtifactName $artifactName -OAuthAccessToken (ConvertTo-SecureString 
-            '$(System.AccessToken)' -AsPlainText -Force)
-            $containerName = $artifact.Resource.Data -Split '/' | Select-Object -Last 1
-            $fileName = Join-Path $containerName 'BaselineBuilds.json'
-            $jsonString = Read-BuildArtifactFile -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' 
-            -BuildID $bootstrapperBuildID  -ArtifactName $artifactName -FileName $fileName -OAuthAccessToken 
-            (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
+              $artifact = Get-BuildArtifact -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' - 
+              BuildID $(BaselineBuildID)  -ArtifactName $artifactName -OAuthAccessToken (ConvertTo-SecureString 
+              '$(System.AccessToken)' -AsPlainText -Force)
+              $containerName = $artifact.Resource.Data -Split '/' | Select-Object -Last 1
+              $fileName = Join-Path $containerName 'BaselineBuilds.json'
+              $jsonString = Read-BuildArtifactFile -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' 
+              -BuildID $bootstrapperBuildID  -ArtifactName $artifactName -FileName $fileName -OAuthAccessToken 
+              (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
 
-            $jsonString | Out-File -FilePath $baselineBuildsFile
+              $jsonString | Out-File -FilePath $baselineBuildsFile
 
-            $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildCommitIDs.ps1 -BuildJson $baselineBuildsFile -OutVariableName "BaselineBuildCommitIds"
-            } catch {
-              Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
-            }      
+              $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildCommitIDs.ps1 -BuildJson $baselineBuildsFile -OutVariableName "BaselineBuildCommitIds"
+              } catch {
+                Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
+              }      
       preDeployAndRunTestsStepList:
         - task: PowerShell@1
           displayName: "Print Environment Variables"

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -38,7 +38,7 @@ stages:
         - ${{parameters.variables}}
       runSettingsURI: ${{parameters.runSettingsURI}}
       visualStudioBootstrapperURI: $(bootstrapperUrl)      
-      baseVisualStudioBootstrapperURI: https://vsdrop.corp.microsoft.com/file/v1/$(VisualStudio.BaseBuild.ProductsDropName);${{parameters.visualStudioBootstrapperDropPath}}
+      baseVisualStudioBootstrapperURI: https://vsdrop.corp.microsoft.com/file/v1/$(VisualStudio.BaseBuild.ProductsDropName);bootstrappers/Enterprise/vs_enterprise.exe
       candidateBaselineBuilds: $(BaselineBuildCommitIds)
       testLabPoolName: VS-Platform
       dartLabEnvironment: ${{parameters.DartLabEnvironment}}
@@ -87,7 +87,31 @@ stages:
               $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildCommitIDs.ps1 -BuildJson $baselineBuildsFile -OutVariableName "BaselineBuildCommitIds"
               } catch {
                 Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
-              }      
+              }
+
+        - task: PowerShell@2
+          name: SetVisualStudioBaseBuildID
+          displayName: Set 'VisualStudio.BaseBuild.ID'
+          continueOnError: true
+          inputs:
+            filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildID.ps1
+            arguments: -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -InstanceURL '$(System.CollectionUri)' -RepositoryName '$(Build.Repository.Name)' -ProjectName '$(System.TeamProject)' -CommitIDs $(BaselineBuildCommitIds) -BuildDefinitionIDs 10289 -OutVariableName 'VisualStudio.BaseBuild.ID'
+        
+        - task: PowerShell@2
+          name: SetVisualStudioBaseBuildProductsDropName
+          displayName: Set 'VisualStudio.BaseBuild.ProductsDropName'
+          condition: ne(variables['VisualStudio.BaseBuild.ID'], '')
+          inputs:
+            filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
+            arguments: -AccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -DropNamePrefix 'Products' -AccountURL '$(System.CollectionUri)' -ProjectName '$(System.TeamProject)' -BuildID $(VisualStudio.BaseBuild.ID) -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'
+        
+        - task: PowerShell@2
+          name: SetBaseProductsDropNameToTarget
+          displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build
+          condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
+          inputs:
+            filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
+            arguments: -DropNamePrefix 'Products' -VstsDropUrlsJson '$(Pipeline.Workspace)\${{parameters.cloudBuildResourceName}}\BuildArtifacts\VstsDropUrls.json' -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'              
       preDeployAndRunTestsStepList:
         - task: PowerShell@1
           displayName: "Print Environment Variables"

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -59,7 +59,7 @@ stages:
             displayName: Get Baseline Build ID using CloudBuild Session ID
             continueOnError: true
             filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
-            arguments: -ClientSecret (ConvertTo-SecureString '$(CloudBuild-ClientSecret)' -AsPlainText -Force) -ClientID (ConvertTo-SecureString '$(CloudBuild-ClientID)' -AsPlainText -Force) -SessionID '$(setcloudbuildsessionid.QBuildSessionId)' -OutVariableName 'BaselineBuildID'
+            arguments: -ClientSecret (ConvertTo-SecureString '$(CloudBuild-ClientSecret)' -AsPlainText -Force) -ClientID '$(CloudBuild-ClientID)' -SessionID '$(setcloudbuildsessionid.QBuildSessionId)' -OutVariableName 'BaselineBuildID'
         - task: PowerShell@1
           displayName: "Get Baseline build commit ids"
           name: "getbaselinebuildcommitids"

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -59,7 +59,7 @@ stages:
             displayName: Get Baseline Build ID using CloudBuild Session ID
             continueOnError: true
             filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
-            arguments: -ClientSecret '$(CloudBuild-ClientSecret)' -ClientID '$(CloudBuild-ClientID)' -SessionID '${{parameters.QBuildSessionId}}' -OutVariableName 'BaselineBuildID'
+            arguments: -ClientSecret (ConvertTo-SecureString '$(CloudBuild-ClientSecret)' -AsPlainText -Force) -ClientID (ConvertTo-SecureString '$(CloudBuild-ClientID)' -AsPlainText -Force) -SessionID '$(setcloudbuildsessionid.QBuildSessionId)' -OutVariableName 'BaselineBuildID'
         - task: PowerShell@1
           displayName: "Get Baseline build commit ids"
           name: "getbaselinebuildcommitids"

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -22,6 +22,8 @@ parameters:
   - name: isOfficialBuild
     type: boolean
     default: false
+  - name: QBuildSessionId
+    type: string
 
 stages:
   - template: stages\visual-studio\single-runsettings.yml@DartLabTemplates
@@ -48,6 +50,43 @@ stages:
       testExecutionJobTimeoutInMinutes: ${{parameters.testExecutionJobTimeoutInMinutes}}
       testMachineCleanUpStrategy: ${{parameters.testMachineCleanUpStrategy}}
       testAgentElevated: true
+      preTestMachineConfigurationStepList:
+      - template: \steps\powershell\execute-script.yml
+        parameters:
+          displayName: Get Baseline Build ID using CloudBuild Session ID
+          continueOnError: true
+          filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
+          arguments: -ClientSecret '$(CloudBuild-ClientSecret)' -ClientID '$(CloudBuild-ClientID)' -SessionID '${{parameters.QBuildSessionId}}' -OutVariableName 'BaselineBuildID'
+      
+      - task: PowerShell@1
+        displayName: "Get Baseline build commit ids"
+        name: "getbaselinebuildcommitids"
+        continueOnError: true
+        inputs:
+          scriptType: "inlineScript"
+          inlineScript: |
+            try {
+            Write-Host "Getting Baseline build commit ids for build: '$(BaselineBuildID)'"
+            
+            $artifactName = 'BuildArtifacts'
+            $baselineBuildsFile: $(Agent.TempDirectory)\BaselineBuilds.json
+
+            $artifact = Get-BuildArtifact -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' - 
+            BuildID $(BaselineBuildID)  -ArtifactName $artifactName -OAuthAccessToken (ConvertTo-SecureString 
+            '$(System.AccessToken)' -AsPlainText -Force)
+            $containerName = $artifact.Resource.Data -Split '/' | Select-Object -Last 1
+            $fileName = Join-Path $containerName 'BaselineBuilds.json'
+            $jsonString = Read-BuildArtifactFile -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' 
+            -BuildID $bootstrapperBuildID  -ArtifactName $artifactName -FileName $fileName -OAuthAccessToken 
+            (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
+
+            $jsonString | Out-File -FilePath $baselineBuildsFile
+
+            $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildCommitIDs.ps1 -BuildJson $baselineBuildsFile -OutVariableName "BaselineBuildCommitIds"
+            } catch {
+              Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
+            }
+      candidateBaselineBuilds: $(BaselineBuildCommitIds)
       preDeployAndRunTestsStepList:
         - task: PowerShell@1
           displayName: "Print Environment Variables"

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -3,6 +3,8 @@ parameters:
     type: object
   - name: bootstrapperUrl
     type: string
+  - name: baseBuildDrop
+    type: string
   - name: runSettingsURI
     type: string
   - name: DartLabEnvironment
@@ -39,7 +41,7 @@ stages:
           - ${{parameters.variables}}
       runSettingsURI: ${{parameters.runSettingsURI}}
       visualStudioBootstrapperURI: $(bootstrapperUrl)      
-      baseVisualStudioBootstrapperURI: https://vsdrop.corp.microsoft.com/file/v1/$(VisualStudio.BaseBuild.ProductsDropName);bootstrappers/Enterprise/vs_enterprise.exe
+      baseVisualStudioBootstrapperURI: ${{parameters.baseBuildDrop}};bootstrappers/Enterprise/vs_enterprise.exe
       candidateBaselineBuilds: $(BaselineBuildCommitIds)
       testLabPoolName: VS-Platform
       dartLabEnvironment: ${{parameters.DartLabEnvironment}}
@@ -83,28 +85,7 @@ stages:
               $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildCommitIDs.ps1 -BuildJson $baselineBuildsFile -OutVariableName "BaselineBuildCommitIds"
               } catch {
                 Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
-              }
-        - task: PowerShell@2
-          name: SetVisualStudioBaseBuildID
-          displayName: Set 'VisualStudio.BaseBuild.ID'
-          continueOnError: true
-          inputs:
-            filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildID.ps1
-            arguments: -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -InstanceURL '$(System.CollectionUri)' -RepositoryName 'VS' -ProjectName '$(System.TeamProject)' -CommitIDs $(BaselineBuildCommitIds) -BuildDefinitionIDs 10289 -OutVariableName 'VisualStudio.BaseBuild.ID'
-        - task: PowerShell@2
-          name: SetVisualStudioBaseBuildProductsDropName
-          displayName: Set 'VisualStudio.BaseBuild.ProductsDropName'
-          condition: ne(variables['VisualStudio.BaseBuild.ID'], '')
-          inputs:
-            filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
-            arguments: -AccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -DropNamePrefix 'Products' -AccountURL '$(System.CollectionUri)' -ProjectName '$(System.TeamProject)' -BuildID $(VisualStudio.BaseBuild.ID) -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'
-        - task: PowerShell@2
-          name: SetBaseProductsDropNameToTarget
-          displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build
-          condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
-          inputs:
-            filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
-            arguments: -DropNamePrefix 'Products' -VstsDropUrlsJson '$(Pipeline.Workspace)\VisualStudioBuildUnderTest\BuildArtifacts\VstsDropUrls.json' -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'              
+              }            
       preDeployAndRunTestsStepList:
         - task: PowerShell@1
           displayName: "Print Environment Variables"

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -111,7 +111,7 @@ stages:
           condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
           inputs:
             filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
-            arguments: -DropNamePrefix 'Products' -VstsDropUrlsJson '$(Pipeline.Workspace)\${{parameters.cloudBuildResourceName}}\BuildArtifacts\VstsDropUrls.json' -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'              
+            arguments: -DropNamePrefix 'Products' -VstsDropUrlsJson '$(Pipeline.Workspace)\VisualStudioBuildUnderTest\BuildArtifacts\VstsDropUrls.json' -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'              
       preDeployAndRunTestsStepList:
         - task: PowerShell@1
           displayName: "Print Environment Variables"

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -59,7 +59,7 @@ stages:
             displayName: Get Baseline Build ID using CloudBuild Session ID
             continueOnError: true
             filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
-            arguments: -ClientSecret (ConvertTo-SecureString '$(CloudBuild-ClientSecret)' -AsPlainText -Force) -ClientID '$(CloudBuild-ClientID)' -SessionID '$(setcloudbuildsessionid.QBuildSessionId)' -OutVariableName 'BaselineBuildID'
+            arguments: -ClientSecret (ConvertTo-SecureString '$(CloudBuild-ClientSecret)' -AsPlainText -Force) -ClientID '$(CloudBuild-ClientID)' -SessionID '${{ parameters.QBuildSessionId }}' -OutVariableName 'BaselineBuildID'
         - task: PowerShell@1
           displayName: "Get Baseline build commit ids"
           name: "getbaselinebuildcommitids"

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -37,6 +37,7 @@ stages:
           value: ${{parameters.bootstrapperUrl}}
         - ${{parameters.variables}}
       runSettingsURI: ${{parameters.runSettingsURI}}
+      visualStudioBootstrapperURI: $(bootstrapperUrl)
       baseVisualStudioBootstrapperURI: $(bootstrapperUrl)
       testLabPoolName: VS-Platform
       dartLabEnvironment: ${{parameters.DartLabEnvironment}}

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -59,7 +59,6 @@ stages:
             continueOnError: true
             filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
             arguments: -ClientSecret '$(CloudBuild-ClientSecret)' -ClientID '$(CloudBuild-ClientID)' -SessionID '${{parameters.QBuildSessionId}}' -OutVariableName 'BaselineBuildID'
-        
         - task: PowerShell@1
           displayName: "Get Baseline build commit ids"
           name: "getbaselinebuildcommitids"
@@ -88,7 +87,6 @@ stages:
               } catch {
                 Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
               }
-
         - task: PowerShell@2
           name: SetVisualStudioBaseBuildID
           displayName: Set 'VisualStudio.BaseBuild.ID'
@@ -96,7 +94,6 @@ stages:
           inputs:
             filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildID.ps1
             arguments: -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -InstanceURL '$(System.CollectionUri)' -RepositoryName '$(Build.Repository.Name)' -ProjectName '$(System.TeamProject)' -CommitIDs $(BaselineBuildCommitIds) -BuildDefinitionIDs 10289 -OutVariableName 'VisualStudio.BaseBuild.ID'
-        
         - task: PowerShell@2
           name: SetVisualStudioBaseBuildProductsDropName
           displayName: Set 'VisualStudio.BaseBuild.ProductsDropName'
@@ -104,7 +101,6 @@ stages:
           inputs:
             filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
             arguments: -AccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -DropNamePrefix 'Products' -AccountURL '$(System.CollectionUri)' -ProjectName '$(System.TeamProject)' -BuildID $(VisualStudio.BaseBuild.ID) -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'
-        
         - task: PowerShell@2
           name: SetBaseProductsDropNameToTarget
           displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -39,6 +39,7 @@ stages:
       runSettingsURI: ${{parameters.runSettingsURI}}
       visualStudioBootstrapperURI: $(bootstrapperUrl)
       baseVisualStudioBootstrapperURI: $(bootstrapperUrl)
+      candidateBaselineBuilds: $(BaselineBuildCommitIds)
       testLabPoolName: VS-Platform
       dartLabEnvironment: ${{parameters.DartLabEnvironment}}
       visualStudioSigning: Test
@@ -86,8 +87,7 @@ stages:
             $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildCommitIDs.ps1 -BuildJson $baselineBuildsFile -OutVariableName "BaselineBuildCommitIds"
             } catch {
               Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
-            }
-      candidateBaselineBuilds: $(BaselineBuildCommitIds)
+            }      
       preDeployAndRunTestsStepList:
         - task: PowerShell@1
           displayName: "Print Environment Variables"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -371,6 +371,22 @@ steps:
         Write-Host "##vso[task.LogIssue type=error;]Unable to set CloudBuild Session ID: $_"
       }
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  
+- task: PowerShell@1
+  displayName: "Set Base Build Drop variable for tests"
+  name: "setbasebuilddrop"
+  continueOnError: true
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      try {
+        $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
+        $buildDrop = $json[0].BuildDrop;
+        Write-Host "Base Build Drop: $buildDrop"
+        Write-Host "##vso[task.setvariable variable=BaseBuildDrop;isOutput=true]$buildDrop"
+      } catch {
+        Write-Host "##vso[task.LogIssue type=error;]Unable to set Base Build Drop: $_"
+      }
 
 - task: MSBuild@1
   displayName: 'Generate .runsettings files'

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -354,6 +354,23 @@ steps:
         exit 1
       }
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  
+- task: PowerShell@1
+  displayName: "Set CloudBuild Session ID variable for tests"
+  name: "setcloudbuildsessionid"
+  continueOnError: true
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      try {
+        $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
+        $qBuildSessionId = $json[0].QBuildSessionId;
+        Write-Host "CloudBuild Session ID: `$qBuildSessionId`"
+        Write-Host "##vso[task.setvariable variable=QBuildSessionId ;isOutput=true]$qBuildSessionId"
+      } catch {
+        Write-Host "##vso[task.LogIssue type=error;]Unable to set CloudBuild Session ID: $_"
+      }
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1
   displayName: 'Generate .runsettings files'

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -365,7 +365,7 @@ steps:
       try {
         $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
         $qBuildSessionId = $json[0].QBuildSessionId;
-        Write-Host "CloudBuild Session ID: `$qBuildSessionId`"
+        Write-Host "CloudBuild Session ID: $qBuildSessionId"
         Write-Host "##vso[task.setvariable variable=QBuildSessionId ;isOutput=true]$qBuildSessionId"
       } catch {
         Write-Host "##vso[task.LogIssue type=error;]Unable to set CloudBuild Session ID: $_"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -366,7 +366,7 @@ steps:
         $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
         $qBuildSessionId = $json[0].QBuildSessionId;
         Write-Host "CloudBuild Session ID: $qBuildSessionId"
-        Write-Host "##vso[task.setvariable variable=QBuildSessionId ;isOutput=true]$qBuildSessionId"
+        Write-Host "##vso[task.setvariable variable=QBuildSessionId;isOutput=true]$qBuildSessionId"
       } catch {
         Write-Host "##vso[task.LogIssue type=error;]Unable to set CloudBuild Session ID: $_"
       }

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -387,6 +387,7 @@ steps:
       } catch {
         Write-Host "##vso[task.LogIssue type=error;]Unable to set Base Build Drop: $_"
       }
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1
   displayName: 'Generate .runsettings files'

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -29,7 +29,7 @@ parameters:
   type: string
 
 stages:
-- template: stages\visual-studio\visual-studio/build-to-build-upgrade\agent.yml@DartLabTemplates
+- template: stages\visual-studio\build-to-build-upgrade\agent.yml@DartLabTemplates
   parameters:
     name: ${{parameters.stageName}}
     displayName: 'E2E Tests ${{parameters.stageDisplayName}}'

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -59,6 +59,11 @@ stages:
     visualStudioSigning: Test
     testMachineCleanUpStrategy: ${{parameters.testMachineCleanUpStrategy}}
     preTestMachineConfigurationStepList:
+    - task: PowerShell@2
+      displayName: Set 'VisualStudio.InstallationUnderTest.SetupParameters'
+      inputs:
+        filePath: $(DartLab.Path)\Scripts\VisualStudio\Installation\Get-VisualStudioSetupParameters.ps1
+        arguments: -RunSettingsURI '$(runSettingsURI)' -InstallPath 'C:\Test\VisualStudio' -NoRestart -Quiet -Wait -OutVariableName 'VisualStudio.InstallationUnderTest.SetupParameters'
     - template: \steps\powershell\execute-script.yml@DartLabTemplates
       parameters:
         displayName: Get Baseline Build ID using CloudBuild Session ID
@@ -110,11 +115,6 @@ stages:
       inputs:
         filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
         arguments: -DropNamePrefix 'Products' -VstsDropUrlsJson '$(Pipeline.Workspace)\VisualStudioBuildUnderTest\BuildArtifacts\VstsDropUrls.json' -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName' 
-    - task: PowerShell@2
-      displayName: Set 'VisualStudio.InstallationUnderTest.SetupParameters'
-      inputs:
-        filePath: $(DartLab.Path)\Scripts\VisualStudio\Installation\Get-VisualStudioSetupParameters.ps1
-        arguments: -RunSettingsURI '$(runSettingsURI)' -InstallPath 'C:\Test\VisualStudio' -NoRestart -Quiet -Wait -OutVariableName 'VisualStudio.InstallationUnderTest.SetupParameters'
     deployAndRunTestsStepList:
     - task: PowerShell@1
       displayName: "Define variables"

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -64,6 +64,57 @@ stages:
       inputs:
         filePath: $(DartLab.Path)\Scripts\VisualStudio\Installation\Get-VisualStudioSetupParameters.ps1
         arguments: -RunSettingsURI '$(runSettingsURI)' -InstallPath 'C:\Test\VisualStudio' -NoRestart -Quiet -Wait -OutVariableName 'VisualStudio.InstallationUnderTest.SetupParameters'
+    - template: \steps\powershell\execute-script.yml@DartLabTemplates
+      parameters:
+        displayName: Get Baseline Build ID using CloudBuild Session ID
+        continueOnError: true
+        filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
+        arguments: -ClientSecret (ConvertTo-SecureString '$(CloudBuild-ClientSecret)' -AsPlainText -Force) -ClientID '$(CloudBuild-ClientID)' -SessionID '${{ parameters.QBuildSessionId }}' -OutVariableName 'BaselineBuildID'
+    - task: PowerShell@1
+      displayName: "Get Baseline build commit ids"
+      name: "getbaselinebuildcommitids"
+      continueOnError: true
+      inputs:
+        scriptType: "inlineScript"
+        inlineScript: |
+          try {
+          Write-Host "Getting Baseline build commit ids for build: '$(BaselineBuildID)'"
+          
+          $artifactName = 'BuildArtifacts'
+          $baselineBuildsFile = Join-Path $(Agent.TempDirectory) "BaselineBuilds.json"
+
+          $artifact = Get-BuildArtifact -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID)  -ArtifactName $artifactName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
+          $containerName = $artifact.Resource.Data -Split '/' | Select-Object -Last 1
+          $fileName = Join-Path $containerName 'BaselineBuilds.json'
+          $jsonString = Read-BuildArtifactFile -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID) -ArtifactName $artifactName -FileName $fileName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
+
+          $jsonString | Out-File -FilePath $baselineBuildsFile
+
+          $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildCommitIDs.ps1 -BuildJson $baselineBuildsFile -OutVariableName "BaselineBuildCommitIds"
+          } catch {
+            Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
+          }
+    - task: PowerShell@2
+      name: SetVisualStudioBaseBuildID
+      displayName: Set 'VisualStudio.BaseBuild.ID'
+      continueOnError: true
+      inputs:
+        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildID.ps1
+        arguments: -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -InstanceURL '$(System.CollectionUri)' -RepositoryName 'VS' -ProjectName '$(System.TeamProject)' -CommitIDs $(BaselineBuildCommitIds) -BuildDefinitionIDs 10289 -OutVariableName 'VisualStudio.BaseBuild.ID'
+    - task: PowerShell@2
+      name: SetVisualStudioBaseBuildProductsDropName
+      displayName: Set 'VisualStudio.BaseBuild.ProductsDropName'
+      condition: ne(variables['VisualStudio.BaseBuild.ID'], '')
+      inputs:
+        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
+        arguments: -AccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -DropNamePrefix 'Products' -AccountURL '$(System.CollectionUri)' -ProjectName '$(System.TeamProject)' -BuildID $(VisualStudio.BaseBuild.ID) -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'
+    - task: PowerShell@2
+      name: SetBaseProductsDropNameToTarget
+      displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build
+      condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
+      inputs:
+        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
+        arguments: -DropNamePrefix 'Products' -VstsDropUrlsJson '$(Pipeline.Workspace)\VisualStudioBuildUnderTest\BuildArtifacts\VstsDropUrls.json' -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName' 
     deployAndRunTestsStepList:
     - task: PowerShell@1
       displayName: "Define variables"

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -59,63 +59,62 @@ stages:
     visualStudioSigning: Test
     testMachineCleanUpStrategy: ${{parameters.testMachineCleanUpStrategy}}
     preTestMachineConfigurationStepList:
-      - template: \steps\powershell\execute-script.yml@DartLabTemplates
-        parameters:
-          displayName: Get Baseline Build ID using CloudBuild Session ID
-          continueOnError: true
-          filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
-          arguments: -ClientSecret (ConvertTo-SecureString '$(CloudBuild-ClientSecret)' -AsPlainText -Force) -ClientID '$(CloudBuild-ClientID)' -SessionID '${{ parameters.QBuildSessionId }}' -OutVariableName 'BaselineBuildID'
-      - task: PowerShell@1
-        displayName: "Get Baseline build commit ids"
-        name: "getbaselinebuildcommitids"
+    - template: \steps\powershell\execute-script.yml@DartLabTemplates
+      parameters:
+        displayName: Get Baseline Build ID using CloudBuild Session ID
         continueOnError: true
-        inputs:
-          scriptType: "inlineScript"
-          inlineScript: |
-            try {
-            Write-Host "Getting Baseline build commit ids for build: '$(BaselineBuildID)'"
-            
-            $artifactName = 'BuildArtifacts'
-            $baselineBuildsFile = Join-Path $(Agent.TempDirectory) "BaselineBuilds.json"
+        filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
+        arguments: -ClientSecret (ConvertTo-SecureString '$(CloudBuild-ClientSecret)' -AsPlainText -Force) -ClientID '$(CloudBuild-ClientID)' -SessionID '${{ parameters.QBuildSessionId }}' -OutVariableName 'BaselineBuildID'
+    - task: PowerShell@1
+      displayName: "Get Baseline build commit ids"
+      name: "getbaselinebuildcommitids"
+      continueOnError: true
+      inputs:
+        scriptType: "inlineScript"
+        inlineScript: |
+          try {
+          Write-Host "Getting Baseline build commit ids for build: '$(BaselineBuildID)'"
+          
+          $artifactName = 'BuildArtifacts'
+          $baselineBuildsFile = Join-Path $(Agent.TempDirectory) "BaselineBuilds.json"
 
-            $artifact = Get-BuildArtifact -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID)  -ArtifactName $artifactName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
-            $containerName = $artifact.Resource.Data -Split '/' | Select-Object -Last 1
-            $fileName = Join-Path $containerName 'BaselineBuilds.json'
-            $jsonString = Read-BuildArtifactFile -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID) -ArtifactName $artifactName -FileName $fileName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
+          $artifact = Get-BuildArtifact -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID)  -ArtifactName $artifactName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
+          $containerName = $artifact.Resource.Data -Split '/' | Select-Object -Last 1
+          $fileName = Join-Path $containerName 'BaselineBuilds.json'
+          $jsonString = Read-BuildArtifactFile -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID) -ArtifactName $artifactName -FileName $fileName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
 
-            $jsonString | Out-File -FilePath $baselineBuildsFile
+          $jsonString | Out-File -FilePath $baselineBuildsFile
 
-            $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildCommitIDs.ps1 -BuildJson $baselineBuildsFile -OutVariableName "BaselineBuildCommitIds"
-            } catch {
-              Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
-            }
-      - task: PowerShell@2
-        name: SetVisualStudioBaseBuildID
-        displayName: Set 'VisualStudio.BaseBuild.ID'
-        continueOnError: true
-        inputs:
-          filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildID.ps1
-          arguments: -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -InstanceURL '$(System.CollectionUri)' -RepositoryName 'VS' -ProjectName '$(System.TeamProject)' -CommitIDs $(BaselineBuildCommitIds) -BuildDefinitionIDs 10289 -OutVariableName 'VisualStudio.BaseBuild.ID'
-      - task: PowerShell@2
-        name: SetVisualStudioBaseBuildProductsDropName
-        displayName: Set 'VisualStudio.BaseBuild.ProductsDropName'
-        condition: ne(variables['VisualStudio.BaseBuild.ID'], '')
-        inputs:
-          filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
-          arguments: -AccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -DropNamePrefix 'Products' -AccountURL '$(System.CollectionUri)' -ProjectName '$(System.TeamProject)' -BuildID $(VisualStudio.BaseBuild.ID) -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'
-      - task: PowerShell@2
-        name: SetBaseProductsDropNameToTarget
-        displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build
-        condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
-        inputs:
-          filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
-          arguments: -DropNamePrefix 'Products' -VstsDropUrlsJson '$(Pipeline.Workspace)\VisualStudioBuildUnderTest\BuildArtifacts\VstsDropUrls.json' -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName' 
-      - task: PowerShell@2
-        displayName: Set 'VisualStudio.InstallationUnderTest.SetupParameters'
-        inputs:
-          filePath: $(DartLab.Path)\Scripts\VisualStudio\Installation\Get-VisualStudioSetupParameters.ps1
-          arguments: -RunSettingsURI '$(runSettingsURI)' -InstallPath 'C:\Test\VisualStudio' -NoRestart -Quiet -Wait -OutVariableName 'VisualStudio.InstallationUnderTest.SetupParameters'
-
+          $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildCommitIDs.ps1 -BuildJson $baselineBuildsFile -OutVariableName "BaselineBuildCommitIds"
+          } catch {
+            Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
+          }
+    - task: PowerShell@2
+      name: SetVisualStudioBaseBuildID
+      displayName: Set 'VisualStudio.BaseBuild.ID'
+      continueOnError: true
+      inputs:
+        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildID.ps1
+        arguments: -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -InstanceURL '$(System.CollectionUri)' -RepositoryName 'VS' -ProjectName '$(System.TeamProject)' -CommitIDs $(BaselineBuildCommitIds) -BuildDefinitionIDs 10289 -OutVariableName 'VisualStudio.BaseBuild.ID'
+    - task: PowerShell@2
+      name: SetVisualStudioBaseBuildProductsDropName
+      displayName: Set 'VisualStudio.BaseBuild.ProductsDropName'
+      condition: ne(variables['VisualStudio.BaseBuild.ID'], '')
+      inputs:
+        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
+        arguments: -AccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -DropNamePrefix 'Products' -AccountURL '$(System.CollectionUri)' -ProjectName '$(System.TeamProject)' -BuildID $(VisualStudio.BaseBuild.ID) -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'
+    - task: PowerShell@2
+      name: SetBaseProductsDropNameToTarget
+      displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build
+      condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
+      inputs:
+        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
+        arguments: -DropNamePrefix 'Products' -VstsDropUrlsJson '$(Pipeline.Workspace)\VisualStudioBuildUnderTest\BuildArtifacts\VstsDropUrls.json' -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName' 
+    - task: PowerShell@2
+      displayName: Set 'VisualStudio.InstallationUnderTest.SetupParameters'
+      inputs:
+        filePath: $(DartLab.Path)\Scripts\VisualStudio\Installation\Get-VisualStudioSetupParameters.ps1
+        arguments: -RunSettingsURI '$(runSettingsURI)' -InstallPath 'C:\Test\VisualStudio' -NoRestart -Quiet -Wait -OutVariableName 'VisualStudio.InstallationUnderTest.SetupParameters'
     deployAndRunTestsStepList:
     - task: PowerShell@1
       displayName: "Define variables"

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -25,9 +25,11 @@ parameters:
   values:
   - delete
   - stop
+- name: QBuildSessionId
+  type: string
 
 stages:
-- template: stages\visual-studio\agent.yml@DartLabTemplates
+- template: stages\visual-studio\visual-studio/build-to-build-upgrade\agent.yml@DartLabTemplates
   parameters:
     name: ${{parameters.stageName}}
     displayName: 'E2E Tests ${{parameters.stageDisplayName}}'
@@ -46,7 +48,10 @@ stages:
       value: ${{parameters.runSettingsURI}}
     - name: Part
       value: ${{parameters.part}}
-    - ${{parameters.variables}}
+    - ${{if gt(length(parameters.variables), 0)}}:
+        - ${{parameters.variables}}
+    baseVisualStudioBootstrapperURI: https://vsdrop.corp.microsoft.com/file/v1/$(VisualStudio.BaseBuild.ProductsDropName);bootstrappers/Enterprise/vs_enterprise.exe
+    candidateBaselineBuilds: $(BaselineBuildCommitIds)
     visualStudioBootstrapperURI: $(bootstrapperUrl)
     visualStudioInstallationParameters: $(VisualStudio.InstallationUnderTest.SetupParameters)
     testLabPoolName: VS-Platform
@@ -54,11 +59,62 @@ stages:
     visualStudioSigning: Test
     testMachineCleanUpStrategy: ${{parameters.testMachineCleanUpStrategy}}
     preTestMachineConfigurationStepList:
-    - task: PowerShell@2
-      displayName: Set 'VisualStudio.InstallationUnderTest.SetupParameters'
-      inputs:
-        filePath: $(DartLab.Path)\Scripts\VisualStudio\Installation\Get-VisualStudioSetupParameters.ps1
-        arguments: -RunSettingsURI '$(runSettingsURI)' -InstallPath 'C:\Test\VisualStudio' -NoRestart -Quiet -Wait -OutVariableName 'VisualStudio.InstallationUnderTest.SetupParameters'
+      - template: \steps\powershell\execute-script.yml@DartLabTemplates
+        parameters:
+          displayName: Get Baseline Build ID using CloudBuild Session ID
+          continueOnError: true
+          filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
+          arguments: -ClientSecret (ConvertTo-SecureString '$(CloudBuild-ClientSecret)' -AsPlainText -Force) -ClientID '$(CloudBuild-ClientID)' -SessionID '${{ parameters.QBuildSessionId }}' -OutVariableName 'BaselineBuildID'
+      - task: PowerShell@1
+        displayName: "Get Baseline build commit ids"
+        name: "getbaselinebuildcommitids"
+        continueOnError: true
+        inputs:
+          scriptType: "inlineScript"
+          inlineScript: |
+            try {
+            Write-Host "Getting Baseline build commit ids for build: '$(BaselineBuildID)'"
+            
+            $artifactName = 'BuildArtifacts'
+            $baselineBuildsFile = Join-Path $(Agent.TempDirectory) "BaselineBuilds.json"
+
+            $artifact = Get-BuildArtifact -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID)  -ArtifactName $artifactName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
+            $containerName = $artifact.Resource.Data -Split '/' | Select-Object -Last 1
+            $fileName = Join-Path $containerName 'BaselineBuilds.json'
+            $jsonString = Read-BuildArtifactFile -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID) -ArtifactName $artifactName -FileName $fileName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
+
+            $jsonString | Out-File -FilePath $baselineBuildsFile
+
+            $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildCommitIDs.ps1 -BuildJson $baselineBuildsFile -OutVariableName "BaselineBuildCommitIds"
+            } catch {
+              Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
+            }
+      - task: PowerShell@2
+        name: SetVisualStudioBaseBuildID
+        displayName: Set 'VisualStudio.BaseBuild.ID'
+        continueOnError: true
+        inputs:
+          filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildID.ps1
+          arguments: -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -InstanceURL '$(System.CollectionUri)' -RepositoryName 'VS' -ProjectName '$(System.TeamProject)' -CommitIDs $(BaselineBuildCommitIds) -BuildDefinitionIDs 10289 -OutVariableName 'VisualStudio.BaseBuild.ID'
+      - task: PowerShell@2
+        name: SetVisualStudioBaseBuildProductsDropName
+        displayName: Set 'VisualStudio.BaseBuild.ProductsDropName'
+        condition: ne(variables['VisualStudio.BaseBuild.ID'], '')
+        inputs:
+          filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
+          arguments: -AccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -DropNamePrefix 'Products' -AccountURL '$(System.CollectionUri)' -ProjectName '$(System.TeamProject)' -BuildID $(VisualStudio.BaseBuild.ID) -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'
+      - task: PowerShell@2
+        name: SetBaseProductsDropNameToTarget
+        displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build
+        condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
+        inputs:
+          filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
+          arguments: -DropNamePrefix 'Products' -VstsDropUrlsJson '$(Pipeline.Workspace)\VisualStudioBuildUnderTest\BuildArtifacts\VstsDropUrls.json' -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName' 
+      - task: PowerShell@2
+        displayName: Set 'VisualStudio.InstallationUnderTest.SetupParameters'
+        inputs:
+          filePath: $(DartLab.Path)\Scripts\VisualStudio\Installation\Get-VisualStudioSetupParameters.ps1
+          arguments: -RunSettingsURI '$(runSettingsURI)' -InstallPath 'C:\Test\VisualStudio' -NoRestart -Quiet -Wait -OutVariableName 'VisualStudio.InstallationUnderTest.SetupParameters'
 
     deployAndRunTestsStepList:
     - task: PowerShell@1

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -59,135 +59,140 @@ stages:
     visualStudioSigning: Test
     testMachineCleanUpStrategy: ${{parameters.testMachineCleanUpStrategy}}
     preTestMachineConfigurationStepList:
-    - task: PowerShell@2
-      displayName: Set 'VisualStudio.InstallationUnderTest.SetupParameters'
-      inputs:
-        filePath: $(DartLab.Path)\Scripts\VisualStudio\Installation\Get-VisualStudioSetupParameters.ps1
-        arguments: -RunSettingsURI '$(runSettingsURI)' -InstallPath 'C:\Test\VisualStudio' -NoRestart -Quiet -Wait -OutVariableName 'VisualStudio.InstallationUnderTest.SetupParameters'
-    - template: \steps\powershell\execute-script.yml@DartLabTemplates
-      parameters:
-        displayName: Get Baseline Build ID using CloudBuild Session ID
+      - task: PowerShell@2
+        displayName: Set 'VisualStudio.InstallationUnderTest.SetupParameters'
+        inputs:
+          filePath: $(DartLab.Path)\Scripts\VisualStudio\Installation\Get-VisualStudioSetupParameters.ps1
+          arguments: -RunSettingsURI '$(runSettingsURI)' -InstallPath 'C:\Test\VisualStudio' -NoRestart -Quiet -Wait -OutVariableName 'VisualStudio.InstallationUnderTest.SetupParameters'
+      
+      - template: \steps\powershell\execute-script.yml@DartLabTemplates
+        parameters:
+          displayName: Get Baseline Build ID using CloudBuild Session ID
+          continueOnError: true
+          filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
+          arguments: -ClientSecret (ConvertTo-SecureString '$(CloudBuild-ClientSecret)' -AsPlainText -Force) -ClientID '$(CloudBuild-ClientID)' -SessionID '${{ parameters.QBuildSessionId }}' -OutVariableName 'BaselineBuildID'
+      
+      - task: PowerShell@1
+        displayName: "Get Baseline build commit ids"
+        name: "getbaselinebuildcommitids"
         continueOnError: true
-        filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
-        arguments: -ClientSecret (ConvertTo-SecureString '$(CloudBuild-ClientSecret)' -AsPlainText -Force) -ClientID '$(CloudBuild-ClientID)' -SessionID '${{ parameters.QBuildSessionId }}' -OutVariableName 'BaselineBuildID'
-    - task: PowerShell@1
-      displayName: "Get Baseline build commit ids"
-      name: "getbaselinebuildcommitids"
-      continueOnError: true
-      inputs:
-        scriptType: "inlineScript"
-        inlineScript: |
-          try {
-          Write-Host "Getting Baseline build commit ids for build: '$(BaselineBuildID)'"
-          
-          $artifactName = 'BuildArtifacts'
-          $baselineBuildsFile = Join-Path $(Agent.TempDirectory) "BaselineBuilds.json"
+        inputs:
+          scriptType: "inlineScript"
+          inlineScript: |
+            try {
+            Write-Host "Getting Baseline build commit ids for build: '$(BaselineBuildID)'"
+            
+            $artifactName = 'BuildArtifacts'
+            $baselineBuildsFile = Join-Path $(Agent.TempDirectory) "BaselineBuilds.json"
 
-          $artifact = Get-BuildArtifact -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID)  -ArtifactName $artifactName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
-          $containerName = $artifact.Resource.Data -Split '/' | Select-Object -Last 1
-          $fileName = Join-Path $containerName 'BaselineBuilds.json'
-          $jsonString = Read-BuildArtifactFile -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID) -ArtifactName $artifactName -FileName $fileName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
+            $artifact = Get-BuildArtifact -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID)  -ArtifactName $artifactName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
+            $containerName = $artifact.Resource.Data -Split '/' | Select-Object -Last 1
+            $fileName = Join-Path $containerName 'BaselineBuilds.json'
+            $jsonString = Read-BuildArtifactFile -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID) -ArtifactName $artifactName -FileName $fileName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
 
-          $jsonString | Out-File -FilePath $baselineBuildsFile
+            $jsonString | Out-File -FilePath $baselineBuildsFile
 
-          $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildCommitIDs.ps1 -BuildJson $baselineBuildsFile -OutVariableName "BaselineBuildCommitIds"
-          } catch {
-            Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
-          }
-    - task: PowerShell@2
-      name: SetVisualStudioBaseBuildID
-      displayName: Set 'VisualStudio.BaseBuild.ID'
-      continueOnError: true
-      inputs:
-        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildID.ps1
-        arguments: -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -InstanceURL '$(System.CollectionUri)' -RepositoryName 'VS' -ProjectName '$(System.TeamProject)' -CommitIDs $(BaselineBuildCommitIds) -BuildDefinitionIDs 10289 -OutVariableName 'VisualStudio.BaseBuild.ID'
-    - task: PowerShell@2
-      name: SetVisualStudioBaseBuildProductsDropName
-      displayName: Set 'VisualStudio.BaseBuild.ProductsDropName'
-      condition: ne(variables['VisualStudio.BaseBuild.ID'], '')
-      inputs:
-        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
-        arguments: -AccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -DropNamePrefix 'Products' -AccountURL '$(System.CollectionUri)' -ProjectName '$(System.TeamProject)' -BuildID $(VisualStudio.BaseBuild.ID) -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'
-    - task: PowerShell@2
-      name: SetBaseProductsDropNameToTarget
-      displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build
-      condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
-      inputs:
-        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
-        arguments: -DropNamePrefix 'Products' -VstsDropUrlsJson '$(Pipeline.Workspace)\VisualStudioBuildUnderTest\BuildArtifacts\VstsDropUrls.json' -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName' 
-    deployAndRunTestsStepList:
-    - task: PowerShell@1
-      displayName: "Define variables"
-      inputs:
-        scriptType: "inlineScript"
-        inlineScript: |
-          $EndToEndTestCommandToRunPart = '"' + "Run-Test -Exclude '${env:PART}' -Verbose *>&1 | Tee-Object $(System.DefaultWorkingDirectory)\artifacts\EndToEnd\FullLog_$(Build.BuildNumber).txt" +'"'
-          Write-Host "##vso[task.setvariable variable=EndToEndTestCommandToRunPart]$EndToEndTestCommandToRunPart"
+            $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildCommitIDs.ps1 -BuildJson $baselineBuildsFile -OutVariableName "BaselineBuildCommitIds"
+            } catch {
+              Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
+            }
+      
+      - task: PowerShell@2
+        name: SetVisualStudioBaseBuildID
+        displayName: Set 'VisualStudio.BaseBuild.ID'
+        continueOnError: true
+        inputs:
+          filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildID.ps1
+          arguments: -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -InstanceURL '$(System.CollectionUri)' -RepositoryName 'VS' -ProjectName '$(System.TeamProject)' -CommitIDs $(BaselineBuildCommitIds) -BuildDefinitionIDs 10289 -OutVariableName 'VisualStudio.BaseBuild.ID'
+      
+      - task: PowerShell@2
+        name: SetVisualStudioBaseBuildProductsDropName
+        displayName: Set 'VisualStudio.BaseBuild.ProductsDropName'
+        condition: ne(variables['VisualStudio.BaseBuild.ID'], '')
+        inputs:
+          filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
+          arguments: -AccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -DropNamePrefix 'Products' -AccountURL '$(System.CollectionUri)' -ProjectName '$(System.TeamProject)' -BuildID $(VisualStudio.BaseBuild.ID) -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'
+      
+      - task: PowerShell@2
+        name: SetBaseProductsDropNameToTarget
+        displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build
+        condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
+        inputs:
+          filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
+          arguments: -DropNamePrefix 'Products' -VstsDropUrlsJson '$(Pipeline.Workspace)\VisualStudioBuildUnderTest\BuildArtifacts\VstsDropUrls.json' -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName' 
+      deployAndRunTestsStepList:
+        - task: PowerShell@1
+          displayName: "Define variables"
+          inputs:
+            scriptType: "inlineScript"
+            inlineScript: |
+              $EndToEndTestCommandToRunPart = '"' + "Run-Test -Exclude '${env:PART}' -Verbose *>&1 | Tee-Object $(System.DefaultWorkingDirectory)\artifacts\EndToEnd\FullLog_$(Build.BuildNumber).txt" +'"'
+              Write-Host "##vso[task.setvariable variable=EndToEndTestCommandToRunPart]$EndToEndTestCommandToRunPart"
 
-    - task: PowerShell@1
-      displayName: "Print Environment Variables"
-      inputs:
-        scriptType: "inlineScript"
-        inlineScript: |
-          Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
+        - task: PowerShell@1
+          displayName: "Print Environment Variables"
+          inputs:
+            scriptType: "inlineScript"
+            inlineScript: |
+              Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
 
-    - task: DownloadBuildArtifacts@0
-      displayName: "Download Build artifacts"
-      inputs:
-        artifactName: "VS15"
-        downloadPath: "$(Build.Repository.LocalPath)/artifacts"
+        - task: DownloadBuildArtifacts@0
+          displayName: "Download Build artifacts"
+          inputs:
+            artifactName: "VS15"
+            downloadPath: "$(Build.Repository.LocalPath)/artifacts"
 
-    - powershell: |
-        $zipPath = "$(Build.Repository.Localpath)/artifacts/VS15/EndToEnd.zip"
-        $dest = "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/"
-        Write-Output "Extracting '$zipPath' to '$dest'"
-        Expand-Archive -Path "$zipPath" -DestinationPath "$dest"
-        $nugetExePath = "$(Build.Repository.Localpath)/artifacts/VS15/NuGet.exe"
-        Write-Output "Copying '$nugetExePath' to '$dest'"
-        Copy-Item -Path "$nugetExePath" -Destination "$dest"
-      displayName: "Extract EndToEnd.zip"
+        - powershell: |
+            $zipPath = "$(Build.Repository.Localpath)/artifacts/VS15/EndToEnd.zip"
+            $dest = "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/"
+            Write-Output "Extracting '$zipPath' to '$dest'"
+            Expand-Archive -Path "$zipPath" -DestinationPath "$dest"
+            $nugetExePath = "$(Build.Repository.Localpath)/artifacts/VS15/NuGet.exe"
+            Write-Output "Copying '$nugetExePath' to '$dest'"
+            Copy-Item -Path "$nugetExePath" -Destination "$dest"
+          displayName: "Extract EndToEnd.zip"
 
-    - task: PowerShell@1
-      displayName: "SetupFunctionalTests.ps1"
-      inputs:
-        scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/SetupFunctionalTests.ps1"
+        - task: PowerShell@1
+          displayName: "SetupFunctionalTests.ps1"
+          inputs:
+            scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/SetupFunctionalTests.ps1"
 
-    - task: PowerShell@1
-      displayName: "RunFunctionalTests.ps1 (stop on error)"
-      timeoutInMinutes: 75
-      continueOnError: "false"
-      inputs:
-        scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/RunFunctionalTests.ps1"
-        arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber)"
-      condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
+        - task: PowerShell@1
+          displayName: "RunFunctionalTests.ps1 (stop on error)"
+          timeoutInMinutes: 75
+          continueOnError: "false"
+          inputs:
+            scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/RunFunctionalTests.ps1"
+            arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber)"
+          condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
 
-    - task: PowerShell@1
-      displayName: "RunFunctionalTests.ps1 (continue on error)"
-      timeoutInMinutes: 75
-      continueOnError: "true"
-      inputs:
-        scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/RunFunctionalTests.ps1"
-        arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber)"
-      condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
+        - task: PowerShell@1
+          displayName: "RunFunctionalTests.ps1 (continue on error)"
+          timeoutInMinutes: 75
+          continueOnError: "true"
+          inputs:
+            scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/RunFunctionalTests.ps1"
+            arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber)"
+          condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
-    - task: PublishTestResults@2
-      displayName: "Publish Test Results"
-      inputs:
-        testRunner: "JUnit"
-        testResultsFiles: "*.xml"
-        searchFolder: "$(System.DefaultWorkingDirectory)\\testresults"
-        mergeTestResults: "true"
-        testRunTitle: "NuGet.Client EndToEnd Tests On Windows"
-      condition: "succeededOrFailed()"
+        - task: PublishTestResults@2
+          displayName: "Publish Test Results"
+          inputs:
+            testRunner: "JUnit"
+            testResultsFiles: "*.xml"
+            searchFolder: "$(System.DefaultWorkingDirectory)\\testresults"
+            mergeTestResults: "true"
+            testRunTitle: "NuGet.Client EndToEnd Tests On Windows"
+          condition: "succeededOrFailed()"
 
-    - task: ComponentGovernanceComponentDetection@0
-      displayName: 'Component Detection'
+        - task: ComponentGovernanceComponentDetection@0
+          displayName: 'Component Detection'
 
-    - task: PowerShell@1
-      displayName: "Initialize Git Commit Status on GitHub"
-      inputs:
-        scriptType: "inlineScript"
-        inlineScript: |
-          . $(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\PostGitCommitStatus.ps1
-          SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(System.AccessToken) -CommitSha $(Build.SourceVersion) -TestName "$(GitHubStatusName)"
-      condition: "not(eq(variables['ManualGitHubChecks'], 'false'))"
+        - task: PowerShell@1
+          displayName: "Initialize Git Commit Status on GitHub"
+          inputs:
+            scriptType: "inlineScript"
+            inlineScript: |
+              . $(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\PostGitCommitStatus.ps1
+              SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(System.AccessToken) -CommitSha $(Build.SourceVersion) -TestName "$(GitHubStatusName)"
+          condition: "not(eq(variables['ManualGitHubChecks'], 'false'))"

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -52,7 +52,7 @@ stages:
       value: ${{parameters.part}}
     - ${{if gt(length(parameters.variables), 0)}}:
       - ${{parameters.variables}}
-    baseVisualStudioBootstrapperURI: https://vsdrop.corp.microsoft.com/file/v1/$(VisualStudio.BaseBuild.ProductsDropName);bootstrappers/Enterprise/vs_enterprise.exe
+    baseVisualStudioBootstrapperURI: ${{parameters.baseBuildDrop}};bootstrappers/Enterprise/vs_enterprise.exe
     candidateBaselineBuilds: $(BaselineBuildCommitIds)
     visualStudioBootstrapperURI: $(bootstrapperUrl)
     visualStudioInstallationParameters: $(VisualStudio.InstallationUnderTest.SetupParameters)

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -9,6 +9,8 @@ parameters:
   type: object
 - name: bootstrapperUrl
   type: string
+- name: baseBuildDrop
+  type: string
 - name: runSettingsURI
   type: string
 - name: DartLabEnvironment
@@ -96,30 +98,6 @@ stages:
           } catch {
             Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
           }
-    
-    - task: PowerShell@2
-      name: SetVisualStudioBaseBuildID
-      displayName: Set 'VisualStudio.BaseBuild.ID'
-      continueOnError: true
-      inputs:
-        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildID.ps1
-        arguments: -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -InstanceURL '$(System.CollectionUri)' -RepositoryName 'VS' -ProjectName '$(System.TeamProject)' -CommitIDs $(BaselineBuildCommitIds) -BuildDefinitionIDs 10289 -OutVariableName 'VisualStudio.BaseBuild.ID'
-    
-    - task: PowerShell@2
-      name: SetVisualStudioBaseBuildProductsDropName
-      displayName: Set 'VisualStudio.BaseBuild.ProductsDropName'
-      condition: ne(variables['VisualStudio.BaseBuild.ID'], '')
-      inputs:
-        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
-        arguments: -AccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -DropNamePrefix 'Products' -AccountURL '$(System.CollectionUri)' -ProjectName '$(System.TeamProject)' -BuildID $(VisualStudio.BaseBuild.ID) -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'
-    
-    - task: PowerShell@2
-      name: SetBaseProductsDropNameToTarget
-      displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build
-      condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
-      inputs:
-        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
-        arguments: -DropNamePrefix 'Products' -VstsDropUrlsJson '$(Pipeline.Workspace)\VisualStudioBuildUnderTest\BuildArtifacts\VstsDropUrls.json' -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName' 
     deployAndRunTestsStepList:
     - task: PowerShell@1
       displayName: "Define variables"

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -49,7 +49,7 @@ stages:
     - name: Part
       value: ${{parameters.part}}
     - ${{if gt(length(parameters.variables), 0)}}:
-        - ${{parameters.variables}}
+      - ${{parameters.variables}}
     baseVisualStudioBootstrapperURI: https://vsdrop.corp.microsoft.com/file/v1/$(VisualStudio.BaseBuild.ProductsDropName);bootstrappers/Enterprise/vs_enterprise.exe
     candidateBaselineBuilds: $(BaselineBuildCommitIds)
     visualStudioBootstrapperURI: $(bootstrapperUrl)

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -120,79 +120,79 @@ stages:
         inputs:
           filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
           arguments: -DropNamePrefix 'Products' -VstsDropUrlsJson '$(Pipeline.Workspace)\VisualStudioBuildUnderTest\BuildArtifacts\VstsDropUrls.json' -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName' 
-      deployAndRunTestsStepList:
-        - task: PowerShell@1
-          displayName: "Define variables"
-          inputs:
-            scriptType: "inlineScript"
-            inlineScript: |
-              $EndToEndTestCommandToRunPart = '"' + "Run-Test -Exclude '${env:PART}' -Verbose *>&1 | Tee-Object $(System.DefaultWorkingDirectory)\artifacts\EndToEnd\FullLog_$(Build.BuildNumber).txt" +'"'
-              Write-Host "##vso[task.setvariable variable=EndToEndTestCommandToRunPart]$EndToEndTestCommandToRunPart"
+    deployAndRunTestsStepList:
+      - task: PowerShell@1
+        displayName: "Define variables"
+        inputs:
+          scriptType: "inlineScript"
+          inlineScript: |
+            $EndToEndTestCommandToRunPart = '"' + "Run-Test -Exclude '${env:PART}' -Verbose *>&1 | Tee-Object $(System.DefaultWorkingDirectory)\artifacts\EndToEnd\FullLog_$(Build.BuildNumber).txt" +'"'
+            Write-Host "##vso[task.setvariable variable=EndToEndTestCommandToRunPart]$EndToEndTestCommandToRunPart"
 
-        - task: PowerShell@1
-          displayName: "Print Environment Variables"
-          inputs:
-            scriptType: "inlineScript"
-            inlineScript: |
-              Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
+      - task: PowerShell@1
+        displayName: "Print Environment Variables"
+        inputs:
+          scriptType: "inlineScript"
+          inlineScript: |
+            Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
 
-        - task: DownloadBuildArtifacts@0
-          displayName: "Download Build artifacts"
-          inputs:
-            artifactName: "VS15"
-            downloadPath: "$(Build.Repository.LocalPath)/artifacts"
+      - task: DownloadBuildArtifacts@0
+        displayName: "Download Build artifacts"
+        inputs:
+          artifactName: "VS15"
+          downloadPath: "$(Build.Repository.LocalPath)/artifacts"
 
-        - powershell: |
-            $zipPath = "$(Build.Repository.Localpath)/artifacts/VS15/EndToEnd.zip"
-            $dest = "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/"
-            Write-Output "Extracting '$zipPath' to '$dest'"
-            Expand-Archive -Path "$zipPath" -DestinationPath "$dest"
-            $nugetExePath = "$(Build.Repository.Localpath)/artifacts/VS15/NuGet.exe"
-            Write-Output "Copying '$nugetExePath' to '$dest'"
-            Copy-Item -Path "$nugetExePath" -Destination "$dest"
-          displayName: "Extract EndToEnd.zip"
+      - powershell: |
+          $zipPath = "$(Build.Repository.Localpath)/artifacts/VS15/EndToEnd.zip"
+          $dest = "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/"
+          Write-Output "Extracting '$zipPath' to '$dest'"
+          Expand-Archive -Path "$zipPath" -DestinationPath "$dest"
+          $nugetExePath = "$(Build.Repository.Localpath)/artifacts/VS15/NuGet.exe"
+          Write-Output "Copying '$nugetExePath' to '$dest'"
+          Copy-Item -Path "$nugetExePath" -Destination "$dest"
+        displayName: "Extract EndToEnd.zip"
 
-        - task: PowerShell@1
-          displayName: "SetupFunctionalTests.ps1"
-          inputs:
-            scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/SetupFunctionalTests.ps1"
+      - task: PowerShell@1
+        displayName: "SetupFunctionalTests.ps1"
+        inputs:
+          scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/SetupFunctionalTests.ps1"
 
-        - task: PowerShell@1
-          displayName: "RunFunctionalTests.ps1 (stop on error)"
-          timeoutInMinutes: 75
-          continueOnError: "false"
-          inputs:
-            scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/RunFunctionalTests.ps1"
-            arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber)"
-          condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
+      - task: PowerShell@1
+        displayName: "RunFunctionalTests.ps1 (stop on error)"
+        timeoutInMinutes: 75
+        continueOnError: "false"
+        inputs:
+          scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/RunFunctionalTests.ps1"
+          arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber)"
+        condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
 
-        - task: PowerShell@1
-          displayName: "RunFunctionalTests.ps1 (continue on error)"
-          timeoutInMinutes: 75
-          continueOnError: "true"
-          inputs:
-            scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/RunFunctionalTests.ps1"
-            arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber)"
-          condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
+      - task: PowerShell@1
+        displayName: "RunFunctionalTests.ps1 (continue on error)"
+        timeoutInMinutes: 75
+        continueOnError: "true"
+        inputs:
+          scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/RunFunctionalTests.ps1"
+          arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber)"
+        condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
-        - task: PublishTestResults@2
-          displayName: "Publish Test Results"
-          inputs:
-            testRunner: "JUnit"
-            testResultsFiles: "*.xml"
-            searchFolder: "$(System.DefaultWorkingDirectory)\\testresults"
-            mergeTestResults: "true"
-            testRunTitle: "NuGet.Client EndToEnd Tests On Windows"
-          condition: "succeededOrFailed()"
+      - task: PublishTestResults@2
+        displayName: "Publish Test Results"
+        inputs:
+          testRunner: "JUnit"
+          testResultsFiles: "*.xml"
+          searchFolder: "$(System.DefaultWorkingDirectory)\\testresults"
+          mergeTestResults: "true"
+          testRunTitle: "NuGet.Client EndToEnd Tests On Windows"
+        condition: "succeededOrFailed()"
 
-        - task: ComponentGovernanceComponentDetection@0
-          displayName: 'Component Detection'
+      - task: ComponentGovernanceComponentDetection@0
+        displayName: 'Component Detection'
 
-        - task: PowerShell@1
-          displayName: "Initialize Git Commit Status on GitHub"
-          inputs:
-            scriptType: "inlineScript"
-            inlineScript: |
-              . $(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\PostGitCommitStatus.ps1
-              SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(System.AccessToken) -CommitSha $(Build.SourceVersion) -TestName "$(GitHubStatusName)"
-          condition: "not(eq(variables['ManualGitHubChecks'], 'false'))"
+      - task: PowerShell@1
+        displayName: "Initialize Git Commit Status on GitHub"
+        inputs:
+          scriptType: "inlineScript"
+          inlineScript: |
+            . $(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\PostGitCommitStatus.ps1
+            SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(System.AccessToken) -CommitSha $(Build.SourceVersion) -TestName "$(GitHubStatusName)"
+        condition: "not(eq(variables['ManualGitHubChecks'], 'false'))"

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -64,57 +64,6 @@ stages:
       inputs:
         filePath: $(DartLab.Path)\Scripts\VisualStudio\Installation\Get-VisualStudioSetupParameters.ps1
         arguments: -RunSettingsURI '$(runSettingsURI)' -InstallPath 'C:\Test\VisualStudio' -NoRestart -Quiet -Wait -OutVariableName 'VisualStudio.InstallationUnderTest.SetupParameters'
-    - template: \steps\powershell\execute-script.yml@DartLabTemplates
-      parameters:
-        displayName: Get Baseline Build ID using CloudBuild Session ID
-        continueOnError: true
-        filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
-        arguments: -ClientSecret (ConvertTo-SecureString '$(CloudBuild-ClientSecret)' -AsPlainText -Force) -ClientID '$(CloudBuild-ClientID)' -SessionID '${{ parameters.QBuildSessionId }}' -OutVariableName 'BaselineBuildID'
-    - task: PowerShell@1
-      displayName: "Get Baseline build commit ids"
-      name: "getbaselinebuildcommitids"
-      continueOnError: true
-      inputs:
-        scriptType: "inlineScript"
-        inlineScript: |
-          try {
-          Write-Host "Getting Baseline build commit ids for build: '$(BaselineBuildID)'"
-          
-          $artifactName = 'BuildArtifacts'
-          $baselineBuildsFile = Join-Path $(Agent.TempDirectory) "BaselineBuilds.json"
-
-          $artifact = Get-BuildArtifact -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID)  -ArtifactName $artifactName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
-          $containerName = $artifact.Resource.Data -Split '/' | Select-Object -Last 1
-          $fileName = Join-Path $containerName 'BaselineBuilds.json'
-          $jsonString = Read-BuildArtifactFile -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID) -ArtifactName $artifactName -FileName $fileName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
-
-          $jsonString | Out-File -FilePath $baselineBuildsFile
-
-          $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildCommitIDs.ps1 -BuildJson $baselineBuildsFile -OutVariableName "BaselineBuildCommitIds"
-          } catch {
-            Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
-          }
-    - task: PowerShell@2
-      name: SetVisualStudioBaseBuildID
-      displayName: Set 'VisualStudio.BaseBuild.ID'
-      continueOnError: true
-      inputs:
-        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildID.ps1
-        arguments: -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -InstanceURL '$(System.CollectionUri)' -RepositoryName 'VS' -ProjectName '$(System.TeamProject)' -CommitIDs $(BaselineBuildCommitIds) -BuildDefinitionIDs 10289 -OutVariableName 'VisualStudio.BaseBuild.ID'
-    - task: PowerShell@2
-      name: SetVisualStudioBaseBuildProductsDropName
-      displayName: Set 'VisualStudio.BaseBuild.ProductsDropName'
-      condition: ne(variables['VisualStudio.BaseBuild.ID'], '')
-      inputs:
-        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
-        arguments: -AccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -DropNamePrefix 'Products' -AccountURL '$(System.CollectionUri)' -ProjectName '$(System.TeamProject)' -BuildID $(VisualStudio.BaseBuild.ID) -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'
-    - task: PowerShell@2
-      name: SetBaseProductsDropNameToTarget
-      displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build
-      condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
-      inputs:
-        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
-        arguments: -DropNamePrefix 'Products' -VstsDropUrlsJson '$(Pipeline.Workspace)\VisualStudioBuildUnderTest\BuildArtifacts\VstsDropUrls.json' -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName' 
     deployAndRunTestsStepList:
     - task: PowerShell@1
       displayName: "Define variables"

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -59,140 +59,140 @@ stages:
     visualStudioSigning: Test
     testMachineCleanUpStrategy: ${{parameters.testMachineCleanUpStrategy}}
     preTestMachineConfigurationStepList:
-      - task: PowerShell@2
-        displayName: Set 'VisualStudio.InstallationUnderTest.SetupParameters'
-        inputs:
-          filePath: $(DartLab.Path)\Scripts\VisualStudio\Installation\Get-VisualStudioSetupParameters.ps1
-          arguments: -RunSettingsURI '$(runSettingsURI)' -InstallPath 'C:\Test\VisualStudio' -NoRestart -Quiet -Wait -OutVariableName 'VisualStudio.InstallationUnderTest.SetupParameters'
-      
-      - template: \steps\powershell\execute-script.yml@DartLabTemplates
-        parameters:
-          displayName: Get Baseline Build ID using CloudBuild Session ID
-          continueOnError: true
-          filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
-          arguments: -ClientSecret (ConvertTo-SecureString '$(CloudBuild-ClientSecret)' -AsPlainText -Force) -ClientID '$(CloudBuild-ClientID)' -SessionID '${{ parameters.QBuildSessionId }}' -OutVariableName 'BaselineBuildID'
-      
-      - task: PowerShell@1
-        displayName: "Get Baseline build commit ids"
-        name: "getbaselinebuildcommitids"
+    - task: PowerShell@2
+      displayName: Set 'VisualStudio.InstallationUnderTest.SetupParameters'
+      inputs:
+        filePath: $(DartLab.Path)\Scripts\VisualStudio\Installation\Get-VisualStudioSetupParameters.ps1
+        arguments: -RunSettingsURI '$(runSettingsURI)' -InstallPath 'C:\Test\VisualStudio' -NoRestart -Quiet -Wait -OutVariableName 'VisualStudio.InstallationUnderTest.SetupParameters'
+    
+    - template: \steps\powershell\execute-script.yml@DartLabTemplates
+      parameters:
+        displayName: Get Baseline Build ID using CloudBuild Session ID
         continueOnError: true
-        inputs:
-          scriptType: "inlineScript"
-          inlineScript: |
-            try {
-            Write-Host "Getting Baseline build commit ids for build: '$(BaselineBuildID)'"
-            
-            $artifactName = 'BuildArtifacts'
-            $baselineBuildsFile = Join-Path $(Agent.TempDirectory) "BaselineBuilds.json"
+        filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
+        arguments: -ClientSecret (ConvertTo-SecureString '$(CloudBuild-ClientSecret)' -AsPlainText -Force) -ClientID '$(CloudBuild-ClientID)' -SessionID '${{ parameters.QBuildSessionId }}' -OutVariableName 'BaselineBuildID'
+    
+    - task: PowerShell@1
+      displayName: "Get Baseline build commit ids"
+      name: "getbaselinebuildcommitids"
+      continueOnError: true
+      inputs:
+        scriptType: "inlineScript"
+        inlineScript: |
+          try {
+          Write-Host "Getting Baseline build commit ids for build: '$(BaselineBuildID)'"
+          
+          $artifactName = 'BuildArtifacts'
+          $baselineBuildsFile = Join-Path $(Agent.TempDirectory) "BaselineBuilds.json"
 
-            $artifact = Get-BuildArtifact -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID)  -ArtifactName $artifactName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
-            $containerName = $artifact.Resource.Data -Split '/' | Select-Object -Last 1
-            $fileName = Join-Path $containerName 'BaselineBuilds.json'
-            $jsonString = Read-BuildArtifactFile -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID) -ArtifactName $artifactName -FileName $fileName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
+          $artifact = Get-BuildArtifact -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID)  -ArtifactName $artifactName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
+          $containerName = $artifact.Resource.Data -Split '/' | Select-Object -Last 1
+          $fileName = Join-Path $containerName 'BaselineBuilds.json'
+          $jsonString = Read-BuildArtifactFile -InstanceURL 'https://dev.azure.com/devdiv' -ProjectName 'DevDiv' -BuildID $(BaselineBuildID) -ArtifactName $artifactName -FileName $fileName -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force)
 
-            $jsonString | Out-File -FilePath $baselineBuildsFile
+          $jsonString | Out-File -FilePath $baselineBuildsFile
 
-            $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildCommitIDs.ps1 -BuildJson $baselineBuildsFile -OutVariableName "BaselineBuildCommitIds"
-            } catch {
-              Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
-            }
-      
-      - task: PowerShell@2
-        name: SetVisualStudioBaseBuildID
-        displayName: Set 'VisualStudio.BaseBuild.ID'
-        continueOnError: true
-        inputs:
-          filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildID.ps1
-          arguments: -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -InstanceURL '$(System.CollectionUri)' -RepositoryName 'VS' -ProjectName '$(System.TeamProject)' -CommitIDs $(BaselineBuildCommitIds) -BuildDefinitionIDs 10289 -OutVariableName 'VisualStudio.BaseBuild.ID'
-      
-      - task: PowerShell@2
-        name: SetVisualStudioBaseBuildProductsDropName
-        displayName: Set 'VisualStudio.BaseBuild.ProductsDropName'
-        condition: ne(variables['VisualStudio.BaseBuild.ID'], '')
-        inputs:
-          filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
-          arguments: -AccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -DropNamePrefix 'Products' -AccountURL '$(System.CollectionUri)' -ProjectName '$(System.TeamProject)' -BuildID $(VisualStudio.BaseBuild.ID) -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'
-      
-      - task: PowerShell@2
-        name: SetBaseProductsDropNameToTarget
-        displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build
-        condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
-        inputs:
-          filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
-          arguments: -DropNamePrefix 'Products' -VstsDropUrlsJson '$(Pipeline.Workspace)\VisualStudioBuildUnderTest\BuildArtifacts\VstsDropUrls.json' -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName' 
+          $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildCommitIDs.ps1 -BuildJson $baselineBuildsFile -OutVariableName "BaselineBuildCommitIds"
+          } catch {
+            Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
+          }
+    
+    - task: PowerShell@2
+      name: SetVisualStudioBaseBuildID
+      displayName: Set 'VisualStudio.BaseBuild.ID'
+      continueOnError: true
+      inputs:
+        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildID.ps1
+        arguments: -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -InstanceURL '$(System.CollectionUri)' -RepositoryName 'VS' -ProjectName '$(System.TeamProject)' -CommitIDs $(BaselineBuildCommitIds) -BuildDefinitionIDs 10289 -OutVariableName 'VisualStudio.BaseBuild.ID'
+    
+    - task: PowerShell@2
+      name: SetVisualStudioBaseBuildProductsDropName
+      displayName: Set 'VisualStudio.BaseBuild.ProductsDropName'
+      condition: ne(variables['VisualStudio.BaseBuild.ID'], '')
+      inputs:
+        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
+        arguments: -AccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -DropNamePrefix 'Products' -AccountURL '$(System.CollectionUri)' -ProjectName '$(System.TeamProject)' -BuildID $(VisualStudio.BaseBuild.ID) -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'
+    
+    - task: PowerShell@2
+      name: SetBaseProductsDropNameToTarget
+      displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build
+      condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
+      inputs:
+        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
+        arguments: -DropNamePrefix 'Products' -VstsDropUrlsJson '$(Pipeline.Workspace)\VisualStudioBuildUnderTest\BuildArtifacts\VstsDropUrls.json' -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName' 
     deployAndRunTestsStepList:
-      - task: PowerShell@1
-        displayName: "Define variables"
-        inputs:
-          scriptType: "inlineScript"
-          inlineScript: |
-            $EndToEndTestCommandToRunPart = '"' + "Run-Test -Exclude '${env:PART}' -Verbose *>&1 | Tee-Object $(System.DefaultWorkingDirectory)\artifacts\EndToEnd\FullLog_$(Build.BuildNumber).txt" +'"'
-            Write-Host "##vso[task.setvariable variable=EndToEndTestCommandToRunPart]$EndToEndTestCommandToRunPart"
+    - task: PowerShell@1
+      displayName: "Define variables"
+      inputs:
+        scriptType: "inlineScript"
+        inlineScript: |
+          $EndToEndTestCommandToRunPart = '"' + "Run-Test -Exclude '${env:PART}' -Verbose *>&1 | Tee-Object $(System.DefaultWorkingDirectory)\artifacts\EndToEnd\FullLog_$(Build.BuildNumber).txt" +'"'
+          Write-Host "##vso[task.setvariable variable=EndToEndTestCommandToRunPart]$EndToEndTestCommandToRunPart"
 
-      - task: PowerShell@1
-        displayName: "Print Environment Variables"
-        inputs:
-          scriptType: "inlineScript"
-          inlineScript: |
-            Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
+    - task: PowerShell@1
+      displayName: "Print Environment Variables"
+      inputs:
+        scriptType: "inlineScript"
+        inlineScript: |
+          Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
 
-      - task: DownloadBuildArtifacts@0
-        displayName: "Download Build artifacts"
-        inputs:
-          artifactName: "VS15"
-          downloadPath: "$(Build.Repository.LocalPath)/artifacts"
+    - task: DownloadBuildArtifacts@0
+      displayName: "Download Build artifacts"
+      inputs:
+        artifactName: "VS15"
+        downloadPath: "$(Build.Repository.LocalPath)/artifacts"
 
-      - powershell: |
-          $zipPath = "$(Build.Repository.Localpath)/artifacts/VS15/EndToEnd.zip"
-          $dest = "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/"
-          Write-Output "Extracting '$zipPath' to '$dest'"
-          Expand-Archive -Path "$zipPath" -DestinationPath "$dest"
-          $nugetExePath = "$(Build.Repository.Localpath)/artifacts/VS15/NuGet.exe"
-          Write-Output "Copying '$nugetExePath' to '$dest'"
-          Copy-Item -Path "$nugetExePath" -Destination "$dest"
-        displayName: "Extract EndToEnd.zip"
+    - powershell: |
+        $zipPath = "$(Build.Repository.Localpath)/artifacts/VS15/EndToEnd.zip"
+        $dest = "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/"
+        Write-Output "Extracting '$zipPath' to '$dest'"
+        Expand-Archive -Path "$zipPath" -DestinationPath "$dest"
+        $nugetExePath = "$(Build.Repository.Localpath)/artifacts/VS15/NuGet.exe"
+        Write-Output "Copying '$nugetExePath' to '$dest'"
+        Copy-Item -Path "$nugetExePath" -Destination "$dest"
+      displayName: "Extract EndToEnd.zip"
 
-      - task: PowerShell@1
-        displayName: "SetupFunctionalTests.ps1"
-        inputs:
-          scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/SetupFunctionalTests.ps1"
+    - task: PowerShell@1
+      displayName: "SetupFunctionalTests.ps1"
+      inputs:
+        scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/SetupFunctionalTests.ps1"
 
-      - task: PowerShell@1
-        displayName: "RunFunctionalTests.ps1 (stop on error)"
-        timeoutInMinutes: 75
-        continueOnError: "false"
-        inputs:
-          scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/RunFunctionalTests.ps1"
-          arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber)"
-        condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
+    - task: PowerShell@1
+      displayName: "RunFunctionalTests.ps1 (stop on error)"
+      timeoutInMinutes: 75
+      continueOnError: "false"
+      inputs:
+        scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/RunFunctionalTests.ps1"
+        arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber)"
+      condition: "and(succeeded(), not(eq(variables['IsOfficialBuild'], 'true')))"
 
-      - task: PowerShell@1
-        displayName: "RunFunctionalTests.ps1 (continue on error)"
-        timeoutInMinutes: 75
-        continueOnError: "true"
-        inputs:
-          scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/RunFunctionalTests.ps1"
-          arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber)"
-        condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
+    - task: PowerShell@1
+      displayName: "RunFunctionalTests.ps1 (continue on error)"
+      timeoutInMinutes: 75
+      continueOnError: "true"
+      inputs:
+        scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/RunFunctionalTests.ps1"
+        arguments: "-PMCCommand $(EndToEndTestCommandToRunPart) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber)"
+      condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
-      - task: PublishTestResults@2
-        displayName: "Publish Test Results"
-        inputs:
-          testRunner: "JUnit"
-          testResultsFiles: "*.xml"
-          searchFolder: "$(System.DefaultWorkingDirectory)\\testresults"
-          mergeTestResults: "true"
-          testRunTitle: "NuGet.Client EndToEnd Tests On Windows"
-        condition: "succeededOrFailed()"
+    - task: PublishTestResults@2
+      displayName: "Publish Test Results"
+      inputs:
+        testRunner: "JUnit"
+        testResultsFiles: "*.xml"
+        searchFolder: "$(System.DefaultWorkingDirectory)\\testresults"
+        mergeTestResults: "true"
+        testRunTitle: "NuGet.Client EndToEnd Tests On Windows"
+      condition: "succeededOrFailed()"
 
-      - task: ComponentGovernanceComponentDetection@0
-        displayName: 'Component Detection'
+    - task: ComponentGovernanceComponentDetection@0
+      displayName: 'Component Detection'
 
-      - task: PowerShell@1
-        displayName: "Initialize Git Commit Status on GitHub"
-        inputs:
-          scriptType: "inlineScript"
-          inlineScript: |
-            . $(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\PostGitCommitStatus.ps1
-            SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(System.AccessToken) -CommitSha $(Build.SourceVersion) -TestName "$(GitHubStatusName)"
-        condition: "not(eq(variables['ManualGitHubChecks'], 'false'))"
+    - task: PowerShell@1
+      displayName: "Initialize Git Commit Status on GitHub"
+      inputs:
+        scriptType: "inlineScript"
+        inlineScript: |
+          . $(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\PostGitCommitStatus.ps1
+          SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(System.AccessToken) -CommitSha $(Build.SourceVersion) -TestName "$(GitHubStatusName)"
+      condition: "not(eq(variables['ManualGitHubChecks'], 'false'))"

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -124,7 +124,6 @@ stages:
     - template: Initialize_Build.yml
 
 - stage: StaticSourceAnalysis
-  condition: false
   displayName: Static Source Analysis
   dependsOn: []
   jobs:
@@ -163,7 +162,6 @@ stages:
 - stage: Build_For_Publishing
   displayName: Build NuGet published to nuget.org
   dependsOn: Initialize
-  condition: false
   jobs:
   - job: Build_and_UnitTest_RTM
     condition: "and(succeeded(), ne(variables['RunBuildForPublishing'], 'false'))"
@@ -196,7 +194,6 @@ stages:
 
 - stage: Source_Build
   dependsOn: Initialize
-  condition: false
   jobs:
   - job: Build_Source_Build
     condition: "and(succeeded(), ne(variables['RunSourceBuild'], 'false'))"
@@ -213,7 +210,6 @@ stages:
 
 - stage: Tests
   displayName: "Run Unit and Functional Tests"
-  condition: false
   dependsOn: Initialize
   jobs:
   - job: Functional_Tests_On_Windows
@@ -320,7 +316,7 @@ stages:
   parameters:
     stageName: VS_EndToEnd_Part1
     stageDisplayName: Part 1
-    condition: false
+    condition: "and(succeeded(), ne(variables['RunEndToEndTests'], 'false'))"
     dependsOn:
     - Initialize
     - Build_Insertable
@@ -341,7 +337,7 @@ stages:
   parameters:
     stageName: VS_EndToEnd_Part2
     stageDisplayName: Part 2
-    condition: false
+    condition: "and(succeeded(), ne(variables['RunEndToEndTests'], 'false'))"
     dependsOn:
     - Initialize
     - Build_Insertable

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -351,8 +351,8 @@ stages:
       value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['setcloudbuildsessionid.QBuildSessionId']]
     - name: GitHubStatusName
       value: End_To_End_Tests_On_Windows Part2
-    part: "A-TopDownloadedPackages.ps1,BuildIntegratedTest.ps1,ExecuteInitScriptTest.ps1,FindPackageTest.ps1,GetPackageTest.ps1,GetProjectTest.ps1,LegacyPackageRefProjectTest.ps1,NativeProjectTest.ps1,NetCoreProjectTest.ps1,PackTest.ps1,ProjectRetargeting.ps1,ServicesTest.ps1,Settings.ps1,SyncPackageTest.ps1,TabExpansionTest.ps1,UniversalWindowsProjectTest.ps1"
     QBuildSessionId: $(QBuildSessionId)
+    part: "A-TopDownloadedPackages.ps1,BuildIntegratedTest.ps1,ExecuteInitScriptTest.ps1,FindPackageTest.ps1,GetPackageTest.ps1,GetProjectTest.ps1,LegacyPackageRefProjectTest.ps1,NativeProjectTest.ps1,NetCoreProjectTest.ps1,PackTest.ps1,ProjectRetargeting.ps1,ServicesTest.ps1,Settings.ps1,SyncPackageTest.ps1,TabExpansionTest.ps1,UniversalWindowsProjectTest.ps1"
     testMachineCleanUpStrategy: ${{parameters.E2EPart2AgentCleanup}}
 
 # Dartlab's template defines this in its own stage

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -368,6 +368,8 @@ stages:
     variables:
       - name: VsBootstrapperUrl
         value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
+      - name: VsBaseBuildDrop
+        value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['setbasebuilddrop.BaseBuildDrop']]
       - name: QBuildSessionId
         value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['setcloudbuildsessionid.QBuildSessionId']]
       - name: GitHubStatusName
@@ -377,5 +379,6 @@ stages:
     dartLabEnvironment: ${{parameters.DartLabEnvironment}}
     testExecutionJobTimeoutInMinutes: 150
     bootstrapperUrl: $(VsBootstrapperUrl)
+    baseBuildDrop: $(VsBaseBuildDrop)
     QBuildSessionId: $(QBuildSessionId)
     testMachineCleanUpStrategy: ${{parameters.ApexAgentCleanup}}

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -347,6 +347,8 @@ stages:
     variables:
     - name: VsBootstrapperUrl
       value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
+    - name: QBuildSessionId
+      value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['setcloudbuildsessionid.QBuildSessionId']]
     - name: GitHubStatusName
       value: End_To_End_Tests_On_Windows Part2
     part: "A-TopDownloadedPackages.ps1,BuildIntegratedTest.ps1,ExecuteInitScriptTest.ps1,FindPackageTest.ps1,GetPackageTest.ps1,GetProjectTest.ps1,LegacyPackageRefProjectTest.ps1,NativeProjectTest.ps1,NetCoreProjectTest.ps1,PackTest.ps1,ProjectRetargeting.ps1,ServicesTest.ps1,Settings.ps1,SyncPackageTest.ps1,TabExpansionTest.ps1,UniversalWindowsProjectTest.ps1"

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -296,6 +296,7 @@ stages:
 
 - stage: MacTests
   displayName: "Mac Mono Tests"
+  condition: false
   dependsOn:
   - Initialize
   - Build_Insertable

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -124,6 +124,7 @@ stages:
     - template: Initialize_Build.yml
 
 - stage: StaticSourceAnalysis
+  condition: false
   displayName: Static Source Analysis
   dependsOn: []
   jobs:
@@ -162,6 +163,7 @@ stages:
 - stage: Build_For_Publishing
   displayName: Build NuGet published to nuget.org
   dependsOn: Initialize
+  condition: false
   jobs:
   - job: Build_and_UnitTest_RTM
     condition: "and(succeeded(), ne(variables['RunBuildForPublishing'], 'false'))"
@@ -194,6 +196,7 @@ stages:
 
 - stage: Source_Build
   dependsOn: Initialize
+  condition: false
   jobs:
   - job: Build_Source_Build
     condition: "and(succeeded(), ne(variables['RunSourceBuild'], 'false'))"
@@ -210,6 +213,7 @@ stages:
 
 - stage: Tests
   displayName: "Run Unit and Functional Tests"
+  condition: false
   dependsOn: Initialize
   jobs:
   - job: Functional_Tests_On_Windows
@@ -315,7 +319,7 @@ stages:
   parameters:
     stageName: VS_EndToEnd_Part1
     stageDisplayName: Part 1
-    condition: "and(succeeded(), ne(variables['RunEndToEndTests'], 'false'))"
+    condition: false
     dependsOn:
     - Initialize
     - Build_Insertable
@@ -336,7 +340,7 @@ stages:
   parameters:
     stageName: VS_EndToEnd_Part2
     stageDisplayName: Part 2
-    condition: "and(succeeded(), ne(variables['RunEndToEndTests'], 'false'))"
+    condition: false
     dependsOn:
     - Initialize
     - Build_Insertable

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -362,6 +362,8 @@ stages:
     variables:
       - name: VsBootstrapperUrl
         value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
+      - name: QBuildSessionId
+        value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['setcloudbuildsessionid.QBuildSessionId']]
       - name: GitHubStatusName
         value: Apex Tests On Windows
     isOfficialBuild: ${{parameters.isOfficialBuild}}
@@ -369,4 +371,5 @@ stages:
     dartLabEnvironment: ${{parameters.DartLabEnvironment}}
     testExecutionJobTimeoutInMinutes: 150
     bootstrapperUrl: $(VsBootstrapperUrl)
+    QBuildSessionId: $(QBuildSessionId)
     testMachineCleanUpStrategy: ${{parameters.ApexAgentCleanup}}

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -321,6 +321,7 @@ stages:
     - Build_Insertable
     testExecutionJobTimeoutInMinutes: 100
     bootstrapperUrl: $(VsBootstrapperUrl)
+    baseBuildDrop: $(VsBaseBuildDrop)
     runSettingsURI:  https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
     DartLabEnvironment: ${{parameters.DartLabEnvironment}}
     variables:
@@ -347,6 +348,7 @@ stages:
     - Build_Insertable
     testExecutionJobTimeoutInMinutes: 100
     bootstrapperUrl: $(VsBootstrapperUrl)
+    baseBuildDrop: $(VsBaseBuildDrop)
     runSettingsURI:  https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
     DartLabEnvironment: ${{parameters.DartLabEnvironment}}
     variables:

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -352,6 +352,7 @@ stages:
     - name: GitHubStatusName
       value: End_To_End_Tests_On_Windows Part2
     part: "A-TopDownloadedPackages.ps1,BuildIntegratedTest.ps1,ExecuteInitScriptTest.ps1,FindPackageTest.ps1,GetPackageTest.ps1,GetProjectTest.ps1,LegacyPackageRefProjectTest.ps1,NativeProjectTest.ps1,NetCoreProjectTest.ps1,PackTest.ps1,ProjectRetargeting.ps1,ServicesTest.ps1,Settings.ps1,SyncPackageTest.ps1,TabExpansionTest.ps1,UniversalWindowsProjectTest.ps1"
+    QBuildSessionId: $(QBuildSessionId)
     testMachineCleanUpStrategy: ${{parameters.E2EPart2AgentCleanup}}
 
 # Dartlab's template defines this in its own stage

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -326,6 +326,8 @@ stages:
     variables:
     - name: VsBootstrapperUrl
       value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
+    - name: VsBaseBuildDrop
+      value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['setbasebuilddrop.BaseBuildDrop']]
     - name: QBuildSessionId
       value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['setcloudbuildsessionid.QBuildSessionId']]
     - name: GitHubStatusName
@@ -350,6 +352,8 @@ stages:
     variables:
     - name: VsBootstrapperUrl
       value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
+    - name: VsBaseBuildDrop
+      value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['setbasebuilddrop.BaseBuildDrop']]
     - name: QBuildSessionId
       value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['setcloudbuildsessionid.QBuildSessionId']]
     - name: GitHubStatusName

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -292,7 +292,6 @@ stages:
 
 - stage: MacTests
   displayName: "Mac Mono Tests"
-  condition: false
   dependsOn:
   - Initialize
   - Build_Insertable

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -326,8 +326,11 @@ stages:
     variables:
     - name: VsBootstrapperUrl
       value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
+    - name: QBuildSessionId
+      value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['setcloudbuildsessionid.QBuildSessionId']]
     - name: GitHubStatusName
       value: End_To_End_Tests_On_Windows Part1
+    QBuildSessionId: $(QBuildSessionId)
     part: "InstallPackageTest.ps1,UninstallPackageTest.ps1,UpdatePackageTest.ps1"
     testMachineCleanUpStrategy: ${{parameters.E2EPart1AgentCleanup}}
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1584

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

I followed the instructions in our [internal wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/34040/Component-Repository) to start using the build-to-build upgrade feature. According to the information I found, instead of setting up a new machine from scratch, this feature allows me to use an existing machine from our pool that meets the required criteria. When we deploy the machine, this feature updates Visual Studio to the necessary version instead of installing it again, which saves time for running tests.

I want to give a shout-out to @vishavpandhi for helping me throughout the onboarding process. I learned that the build-to-build upgrade feature only works when we're testing on the `int.main` VS branch. However, if we need to go back to the previous release version because of a problem caused by another team, DartLab will install Visual Studio from scratch.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A