### PR TITLE
Avoid allocating StringBuilder in some cases

### DIFF
--- a/build/Shared/StringBuilderPool.cs
+++ b/build/Shared/StringBuilderPool.cs
@@ -3,8 +3,6 @@
 
 #nullable enable
 
-using System;
-using System.Collections.Generic;
 using System.Text;
 
 namespace NuGet
@@ -45,7 +43,7 @@ namespace NuGet
         /// </returns>
         /// <remarks>
         /// This buffer is loaned to the caller and should be returned to the same pool via
-        /// <see cref="Return"/> so that it may be reused in subsequent usage of <see cref="Rent"/>.
+        /// <see cref="ToStringAndReturn"/> so that it may be reused in subsequent usage of <see cref="Rent"/>.
         /// It is not a fatal error to not return a rented string builder, but failure to do so may lead to
         /// decreased application performance, as the pool may need to create a new instance to replace
         /// the one lost.
@@ -62,7 +60,7 @@ namespace NuGet
 
         /// <summary>
         /// Returns to the pool an array that was previously obtained via <see cref="Rent"/> on the same
-        /// <see cref="StringBuilderPool"/> instance.
+        /// <see cref="StringBuilderPool"/> instance, returning the built string.
         /// </summary>
         /// <param name="builder">
         /// The <see cref="StringBuilder"/> previously obtained from <see cref="Rent"/> to return to the pool.
@@ -70,17 +68,22 @@ namespace NuGet
         /// <remarks>
         /// Once a <see cref="StringBuilder"/> has been returned to the pool, the caller gives up all ownership
         /// of the instance and must not use it. The reference returned from a given call to <see cref="Rent"/>
-        /// must only be returned via <see cref="Return"/> once.  The default <see cref="StringBuilderPool"/>
+        /// must only be returned via <see cref="ToStringAndReturn"/> once.  The default <see cref="StringBuilderPool"/>
         /// may hold onto the returned instance in order to rent it again, or it may release the returned instance
         /// if it's determined that the pool already has enough instances stored.
         /// </remarks>
-        public void Return(StringBuilder builder)
+        /// <returns>The string, built from <paramref name="builder"/>.</returns>
+        public string ToStringAndReturn(StringBuilder builder)
         {
+            string result = builder.ToString();
+
             if (builder.Capacity <= MaxPoolSize)
             {
                 builder.Clear();
                 _pool.Free(builder);
             }
+
+            return result;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
@@ -265,11 +265,7 @@ namespace NuGet.Common
                 path.Append(path2Segments[len2 - 1]);
             }
 
-            var relativePath = path.ToString();
-
-            StringBuilderPool.Shared.Return(path);
-
-            return relativePath;
+            return StringBuilderPool.Shared.ToStringAndReturn(path);
         }
 
         public static string GetAbsolutePath(string basePath, string relativePath)

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
@@ -72,7 +72,8 @@ namespace NuGet.LibraryModel
                 return null;
             }
 
-            var sb = new StringBuilder();
+            StringBuilder sb = StringBuilderPool.Shared.Rent(256);
+
             sb.Append(Name);
 
             if (VersionRange.HasLowerBound)
@@ -102,7 +103,11 @@ namespace NuGet.LibraryModel
                 sb.Append(VersionRange.MaxVersion.ToNormalizedString());
             }
 
-            return sb.ToString();
+            var result = sb.ToString();
+
+            StringBuilderPool.Shared.Return(sb);
+
+            return result;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
@@ -88,7 +88,7 @@ namespace NuGet.LibraryModel
 
                 if (VersionRange.IsFloating)
                 {
-                    sb.Append(VersionRange.Float.ToString());
+                    VersionRange.Float.ToString(sb);
                 }
                 else
                 {

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
@@ -67,41 +67,43 @@ namespace NuGet.LibraryModel
 
         public string ToLockFileDependencyGroupString()
         {
+            if (VersionRange is null)
+            {
+                return null;
+            }
+
             var sb = new StringBuilder();
             sb.Append(Name);
 
-            if (VersionRange != null)
+            if (VersionRange.HasLowerBound)
             {
-                if (VersionRange.HasLowerBound)
+                sb.Append(" ");
+
+                if (VersionRange.IsMinInclusive)
                 {
-                    sb.Append(" ");
-
-                    if (VersionRange.IsMinInclusive)
-                    {
-                        sb.Append(">= ");
-                    }
-                    else
-                    {
-                        sb.Append("> ");
-                    }
-
-                    if (VersionRange.IsFloating)
-                    {
-                        sb.Append(VersionRange.Float.ToString());
-                    }
-                    else
-                    {
-                        sb.Append(VersionRange.MinVersion.ToNormalizedString());
-                    }
+                    sb.Append(">= ");
+                }
+                else
+                {
+                    sb.Append("> ");
                 }
 
-                if (VersionRange.HasUpperBound)
+                if (VersionRange.IsFloating)
                 {
-                    sb.Append(" ");
-
-                    sb.Append(VersionRange.IsMaxInclusive ? "<= " : "< ");
-                    sb.Append(VersionRange.MaxVersion.ToNormalizedString());
+                    sb.Append(VersionRange.Float.ToString());
                 }
+                else
+                {
+                    sb.Append(VersionRange.MinVersion.ToNormalizedString());
+                }
+            }
+
+            if (VersionRange.HasUpperBound)
+            {
+                sb.Append(" ");
+
+                sb.Append(VersionRange.IsMaxInclusive ? "<= " : "< ");
+                sb.Append(VersionRange.MaxVersion.ToNormalizedString());
             }
 
             return sb.ToString();

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
@@ -103,11 +103,7 @@ namespace NuGet.LibraryModel
                 sb.Append(VersionRange.MaxVersion.ToNormalizedString());
             }
 
-            var result = sb.ToString();
-
-            StringBuilderPool.Shared.Return(sb);
-
-            return result;
+            return StringBuilderPool.Shared.ToStringAndReturn(sb);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
@@ -77,15 +77,13 @@ namespace NuGet.LibraryModel
 
             if (VersionRange.HasLowerBound)
             {
-                sb.Append(" ");
-
                 if (VersionRange.IsMinInclusive)
                 {
-                    sb.Append(">= ");
+                    sb.Append(" >= ");
                 }
                 else
                 {
-                    sb.Append("> ");
+                    sb.Append(" > ");
                 }
 
                 if (VersionRange.IsFloating)
@@ -100,9 +98,7 @@ namespace NuGet.LibraryModel
 
             if (VersionRange.HasUpperBound)
             {
-                sb.Append(" ");
-
-                sb.Append(VersionRange.IsMaxInclusive ? "<= " : "< ");
+                sb.Append(VersionRange.IsMaxInclusive ? " <= " : " < ");
                 sb.Append(VersionRange.MaxVersion.ToNormalizedString());
             }
 

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
@@ -582,9 +582,8 @@ namespace NuGet.Protocol
             builder.Append('.');
             builder.Append(normalizedVersionString);
             builder.Append(".nupkg");
-            string contentUri = builder.ToString();
 
-            StringBuilderPool.Shared.Return(builder);
+            string contentUri = StringBuilderPool.Shared.ToStringAndReturn(builder);
 
             return new PackageInfo
             {

--- a/src/NuGet.Core/NuGet.Versioning/FloatRange.cs
+++ b/src/NuGet.Core/NuGet.Versioning/FloatRange.cs
@@ -381,47 +381,11 @@ namespace NuGet.Versioning
         /// </summary>
         public override string ToString()
         {
-            var result = string.Empty;
-            switch (_floatBehavior)
-            {
-                case NuGetVersionFloatBehavior.None:
-                    result = MinVersion.ToNormalizedString();
-                    break;
-                case NuGetVersionFloatBehavior.Prerelease:
-                    result = string.Format(VersionFormatter.Instance, "{0:V}-{1}*", MinVersion, _releasePrefix);
-                    break;
-                case NuGetVersionFloatBehavior.Revision:
-                    result = string.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}.*", MinVersion.Major, MinVersion.Minor, MinVersion.Patch);
-                    break;
-                case NuGetVersionFloatBehavior.Patch:
-                    result = string.Format(CultureInfo.InvariantCulture, "{0}.{1}.*", MinVersion.Major, MinVersion.Minor);
-                    break;
-                case NuGetVersionFloatBehavior.Minor:
-                    result = string.Format(CultureInfo.InvariantCulture, "{0}.*", MinVersion.Major);
-                    break;
-                case NuGetVersionFloatBehavior.Major:
-                    result = "*";
-                    break;
-                case NuGetVersionFloatBehavior.PrereleaseRevision:
-                    result = string.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}.*-{3}*", MinVersion.Major, MinVersion.Minor, MinVersion.Patch, _releasePrefix);
-                    break;
-                case NuGetVersionFloatBehavior.PrereleasePatch:
-                    result = string.Format(CultureInfo.InvariantCulture, "{0}.{1}.*-{2}*", MinVersion.Major, MinVersion.Minor, _releasePrefix);
-                    break;
-                case NuGetVersionFloatBehavior.PrereleaseMinor:
-                    result = string.Format(CultureInfo.InvariantCulture, "{0}.*-{1}*", MinVersion.Major, _releasePrefix);
-                    break;
-                case NuGetVersionFloatBehavior.PrereleaseMajor:
-                    result = string.Format(CultureInfo.InvariantCulture, "*-{1}*", MinVersion.Major, _releasePrefix);
-                    break;
-                case NuGetVersionFloatBehavior.AbsoluteLatest:
-                    result = "*-*";
-                    break;
-                default:
-                    break;
-            }
+            StringBuilder sb = StringBuilderPool.Shared.Rent(256);
 
-            return result;
+            ToString(sb);
+
+            return StringBuilderPool.Shared.ToStringAndReturn(sb);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Versioning/FloatRange.cs
+++ b/src/NuGet.Core/NuGet.Versioning/FloatRange.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Text;
 using NuGet.Shared;
 
 namespace NuGet.Versioning
@@ -421,6 +422,51 @@ namespace NuGet.Versioning
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Create a floating version string in the format: 1.0.0-alpha-*
+        /// </summary>
+        public void ToString(StringBuilder sb)
+        {
+            switch (_floatBehavior)
+            {
+                case NuGetVersionFloatBehavior.None:
+                    sb.Append(MinVersion.ToNormalizedString());
+                    break;
+                case NuGetVersionFloatBehavior.Prerelease:
+                    sb.AppendFormat(VersionFormatter.Instance, "{0:V}-{1}*", MinVersion, _releasePrefix);
+                    break;
+                case NuGetVersionFloatBehavior.Revision:
+                    sb.AppendFormat(CultureInfo.InvariantCulture, "{0}.{1}.{2}.*", MinVersion.Major, MinVersion.Minor, MinVersion.Patch);
+                    break;
+                case NuGetVersionFloatBehavior.Patch:
+                    sb.AppendFormat(CultureInfo.InvariantCulture, "{0}.{1}.*", MinVersion.Major, MinVersion.Minor);
+                    break;
+                case NuGetVersionFloatBehavior.Minor:
+                    sb.AppendFormat(CultureInfo.InvariantCulture, "{0}.*", MinVersion.Major);
+                    break;
+                case NuGetVersionFloatBehavior.Major:
+                    sb.Append('*');
+                    break;
+                case NuGetVersionFloatBehavior.PrereleaseRevision:
+                    sb.AppendFormat(CultureInfo.InvariantCulture, "{0}.{1}.{2}.*-{3}*", MinVersion.Major, MinVersion.Minor, MinVersion.Patch, _releasePrefix);
+                    break;
+                case NuGetVersionFloatBehavior.PrereleasePatch:
+                    sb.AppendFormat(CultureInfo.InvariantCulture, "{0}.{1}.*-{2}*", MinVersion.Major, MinVersion.Minor, _releasePrefix);
+                    break;
+                case NuGetVersionFloatBehavior.PrereleaseMinor:
+                    sb.AppendFormat(CultureInfo.InvariantCulture, "{0}.*-{1}*", MinVersion.Major, _releasePrefix);
+                    break;
+                case NuGetVersionFloatBehavior.PrereleaseMajor:
+                    sb.AppendFormat(CultureInfo.InvariantCulture, "*-{1}*", MinVersion.Major, _releasePrefix);
+                    break;
+                case NuGetVersionFloatBehavior.AbsoluteLatest:
+                    sb.Append("*-*");
+                    break;
+                default:
+                    break;
+            }
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Versioning/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Versioning/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 NuGet.Versioning.FloatRange.IncludePrerelease.get -> bool
+NuGet.Versioning.FloatRange.ToString(System.Text.StringBuilder! sb) -> void
 NuGet.Versioning.VersionRange.HasLowerAndUpperBounds.get -> bool
 NuGet.Versioning.VersionRange.HasLowerBound.get -> bool
 NuGet.Versioning.VersionRange.HasUpperBound.get -> bool

--- a/src/NuGet.Core/NuGet.Versioning/VersionFormatter.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionFormatter.cs
@@ -48,12 +48,7 @@ namespace NuGet.Versioning
                 Format(builder, c, version);
             }
 
-            string formattedString = builder.ToString();
-
-            StringBuilderPool.Shared.Return(builder);
-
-            return formattedString;
-
+            return StringBuilderPool.Shared.ToStringAndReturn(builder);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Versioning/VersionRangeFormatter.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRangeFormatter.cs
@@ -49,29 +49,22 @@ namespace NuGet.Versioning
             else
             {
                 var sb = StringBuilderPool.Shared.Rent(format.Length);
-                try
+
+                for (var i = 0; i < format.Length; i++)
                 {
-                    for (var i = 0; i < format.Length; i++)
+                    var s = Format(format[i], range);
+
+                    if (s == null)
                     {
-                        var s = Format(format[i], range);
-
-                        if (s == null)
-                        {
-                            sb.Append(format[i]);
-                        }
-                        else
-                        {
-                            sb.Append(s);
-                        }
+                        sb.Append(format[i]);
                     }
+                    else
+                    {
+                        sb.Append(s);
+                    }
+                }
 
-                    string formatted = sb.ToString();
-                    return formatted;
-                }
-                finally
-                {
-                    StringBuilderPool.Shared.Return(sb);
-                }
+                return StringBuilderPool.Shared.ToStringAndReturn(sb);
             }
         }
 
@@ -185,11 +178,7 @@ namespace NuGet.Versioning
 
             sb.Append(range.HasUpperBound && range.IsMaxInclusive ? ']' : ')');
 
-            string result = sb.ToString();
-
-            StringBuilderPool.Shared.Return(sb);
-
-            return result;
+            return StringBuilderPool.Shared.ToStringAndReturn(sb);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Versioning/VersionRangeFormatter.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRangeFormatter.cs
@@ -160,7 +160,7 @@ namespace NuGet.Versioning
         /// </summary>
         private string GetNormalizedString(VersionRange range)
         {
-            var sb = new StringBuilder();
+            StringBuilder sb = StringBuilderPool.Shared.Rent(256);
 
             sb.Append(range.HasLowerBound && range.IsMinInclusive ? '[' : '(');
 
@@ -185,7 +185,11 @@ namespace NuGet.Versioning
 
             sb.Append(range.HasUpperBound && range.IsMaxInclusive ? ']' : ')');
 
-            return sb.ToString();
+            string result = sb.ToString();
+
+            StringBuilderPool.Shared.Return(sb);
+
+            return result;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Versioning/VersionRangeFormatter.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRangeFormatter.cs
@@ -168,7 +168,7 @@ namespace NuGet.Versioning
             {
                 if (range.IsFloating)
                 {
-                    sb.Append(range.Float.ToString());
+                    range.Float.ToString(sb);
                 }
                 else
                 {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/12664

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1826374/
Potentially contributes to: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1828422

Regression? Last working version: N/A

## Description

- When `VersionRange` is `null`, `ToLockFileDependencyGroupString` can return the `Name` property unmodified, without copying via a StringBuilder.
- Make fewer `StringBuilder.Append` calls.
- `FloatRange.ToString` can append to an existing `StringBuilder` rather than allocating a temporary string, then appending that.
- Pool more `StringBuilder` objects.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
