### PR TITLE
Avoid string.Split allocations in LockFileFormat.ReadTargetLibrary

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -509,11 +509,17 @@ namespace NuGet.ProjectModel
         {
             var library = new LockFileTargetLibrary();
 
-            var parts = property.Split(new[] { '/' }, 2);
-            library.Name = parts[0];
-            if (parts.Length == 2)
+#pragma warning disable CA1307 // Specify StringComparison
+            int slashIndex = property.IndexOf('/');
+#pragma warning restore CA1307 // Specify StringComparison
+            if (slashIndex == -1)
             {
-                library.Version = NuGetVersion.Parse(parts[1]);
+                library.Name = property;
+            }
+            else
+            {
+                library.Name = property.Substring(0, slashIndex);
+                library.Version = NuGetVersion.Parse(property.Substring(slashIndex + 1));
             }
 
             var jObject = json as JObject;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug
Fixes: https://github.com/NuGet/Home/issues/12663
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1826489

Regression? Last working version: N/A

## Description

The previous code would allocate a `char[]`, a `string[]` and the returned `string`s.

This new code will only allocate the strings.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
