### PR TITLE
Add apex test -- Search Package in Browse/Installed/Updates tab from PMUI

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/ApexTestUIProject.cs
+++ b/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/ApexTestUIProject.cs
@@ -56,7 +56,7 @@ namespace NuGet.PackageManagement.UI.TestContract
             UIInvoke(() => _packageManagerControl.Search(searchText));
         }
 
-        public bool SearchPackageVerification(string tabName, string packageId, string packageVersion = null)
+        public bool VerifyFirstPackageOnTab(string tabName, string packageId, string packageVersion = null)
         {
             var result = _packageManagerControl.PackageList.PackageItems.FirstOrDefault();
             if (tabName == "Browse")

--- a/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/ApexTestUIProject.cs
+++ b/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/ApexTestUIProject.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
@@ -55,6 +54,19 @@ namespace NuGet.PackageManagement.UI.TestContract
         public void Search(string searchText)
         {
             UIInvoke(() => _packageManagerControl.Search(searchText));
+        }
+
+        public bool SearchPackageVerification(string tabName, string packageId, string packageVersion = null)
+        {
+            var result = _packageManagerControl.PackageList.PackageItems.FirstOrDefault();
+            if (tabName == "Browse")
+            {
+                return result.Id == packageId;
+            }
+            else
+            {
+                return result.Id == packageId && result.Version == NuGetVersion.Parse(packageVersion);
+            }
         }
 
         public void InstallPackage(string packageId, string version)

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetUIProjectTestExtension.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetUIProjectTestExtension.cs
@@ -34,7 +34,7 @@ namespace NuGet.Tests.Apex
 
         public void AssertSearchedPackageItem(string tabName, string packageId, string packageVersion = null)
         {
-            var searchPackageResult = _uiproject.SearchPackageVerification(tabName, packageId, packageVersion);
+            var searchPackageResult = _uiproject.VerifyFirstPackageOnTab(tabName, packageId, packageVersion);
             searchPackageResult.Should().BeTrue($"searching for the package {packageId} in the {tabName} tab failed");
         }
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetUIProjectTestExtension.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetUIProjectTestExtension.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using FluentAssertions;
 using Microsoft.Test.Apex.Services;
 using NuGet.PackageManagement.UI;
 using NuGet.PackageManagement.UI.TestContract;
@@ -29,6 +30,12 @@ namespace NuGet.Tests.Apex
         public bool SearchPackageFromUI(string searchText)
         {
             return _uiproject.WaitForSearchComplete(() => _uiproject.Search(searchText), _timeout);
+        }
+
+        public void AssertSearchedPackageItem(string tabName, string packageId, string packageVersion = null)
+        {
+            var searchPackageResult = _uiproject.SearchPackageVerification(tabName, packageId, packageVersion);
+            searchPackageResult.Should().BeTrue($"searching for the package {packageId} in the {tabName} tab failed");
         }
 
         public bool InstallPackageFromUI(string packageId, string version)

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -834,7 +834,7 @@ namespace NuGet.Tests.Apex
 
         [NuGetWpfTheory]
         [MemberData(nameof(GetIOSTemplates))]
-        public async Task UninstallPackagForIOSProjectInPMC(ProjectTemplate projectTemplate)
+        public async Task UninstallPackageForIOSProjectInPMC(ProjectTemplate projectTemplate)
         {
             EnsureVisualStudioHost();
             using (var simpleTestPathContext = new SimpleTestPathContext())

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -448,5 +448,99 @@ namespace NuGet.Tests.Apex
             // Assert
             CommonUtility.AssertPackageNotInPackagesConfig(VisualStudio, project, "log4net", XunitLogger);
         }
+
+        [StaFact]
+        public async Task SearchPackageInBrowseTabFromUI()
+        {
+            // Arrange
+            var tabName = "Browse";
+            await CommonUtility.CreatePackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1);
+
+            NuGetApexTestService nugetTestService = GetNuGetTestService();
+
+            SolutionService solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
+            ProjectTestExtension project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V48, "TestProject");
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            // Act
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, XunitLogger);
+
+            NuGetUIProjectTestExtension uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.SwitchTabToBrowse();
+            uiwindow.SearchPackageFromUI(TestPackageName);
+
+            // Assert
+            VisualStudio.AssertNoErrors();
+            uiwindow.AssertSearchedPackageItem(tabName, TestPackageName);
+        }
+
+        [StaFact]
+        public async Task SearchPackageInInstalledTabFromUI()
+        {
+            // Arrange
+            var TestPackageName2 = "Contoso.B";
+            var tabName = "Installed";
+            await CommonUtility.CreatePackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1);
+            await CommonUtility.CreatePackageInSourceAsync(_pathContext.PackageSource, TestPackageName2, TestPackageVersionV1);
+            CommonUtility.CreatePackage(TestPackageName2, TestPackageVersionV1);
+
+            NuGetApexTestService nugetTestService = GetNuGetTestService();
+
+            SolutionService solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
+            ProjectTestExtension project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V48, "TestProject");
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            // Act
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, XunitLogger);
+
+            NuGetUIProjectTestExtension uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI(TestPackageName, TestPackageVersionV1);
+            uiwindow.InstallPackageFromUI(TestPackageName2, TestPackageVersionV1);
+            uiwindow.SearchPackageFromUI(TestPackageName);
+
+            // Assert
+            VisualStudio.AssertNoErrors();
+            uiwindow.AssertSearchedPackageItem(tabName, TestPackageName, TestPackageVersionV1);
+
+            // Act
+            uiwindow.SearchPackageFromUI(TestPackageName2);
+
+            // Assert
+            VisualStudio.AssertNoErrors();
+            uiwindow.AssertSearchedPackageItem(tabName, TestPackageName2, TestPackageVersionV1);
+        }
+
+        [StaFact]
+        public async Task SearchPackageInUpdatesTabFromUI()
+        {
+            //Arrange
+            var tabName = "Updates";
+            await CommonUtility.CreatePackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1);
+            await CommonUtility.CreatePackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV2);
+
+            NuGetApexTestService nugetTestService = GetNuGetTestService();
+
+            SolutionService solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
+            ProjectTestExtension project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V48, "TestProject");
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            // Act
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, XunitLogger);
+
+            NuGetUIProjectTestExtension uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI(TestPackageName, TestPackageVersionV1);
+            uiwindow.SearchPackageFromUI(TestPackageName);
+            uiwindow.SwitchTabToUpdate();
+
+            // Assert
+            VisualStudio.AssertNoErrors();
+            uiwindow.AssertSearchedPackageItem(tabName, TestPackageName, TestPackageVersionV1);
+        }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -533,7 +533,7 @@ namespace NuGet.Tests.Apex
             
             // Assert
             VisualStudio.AssertNoErrors();
-            uiwindow.AssertSearchedPackageItem(tabName, TestPackageName, TestPackageVersionV1);
+            uiwindow.AssertSearchedPackageItem(tabName, TestPackageName, TestPackageVersionV2);
         }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -505,13 +505,6 @@ namespace NuGet.Tests.Apex
             // Assert
             VisualStudio.AssertNoErrors();
             uiwindow.AssertSearchedPackageItem(tabName, TestPackageName, TestPackageVersionV1);
-
-            // Act
-            uiwindow.SearchPackageFromUI(TestPackageName2);
-
-            // Assert
-            VisualStudio.AssertNoErrors();
-            uiwindow.AssertSearchedPackageItem(tabName, TestPackageName2, TestPackageVersionV1);
         }
 
         [StaFact]
@@ -535,9 +528,9 @@ namespace NuGet.Tests.Apex
 
             NuGetUIProjectTestExtension uiwindow = nugetTestService.GetUIWindowfromProject(project);
             uiwindow.InstallPackageFromUI(TestPackageName, TestPackageVersionV1);
-            uiwindow.SearchPackageFromUI(TestPackageName);
             uiwindow.SwitchTabToUpdate();
-
+            uiwindow.SearchPackageFromUI(TestPackageName);
+            
             // Assert
             VisualStudio.AssertNoErrors();
             uiwindow.AssertSearchedPackageItem(tabName, TestPackageName, TestPackageVersionV1);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug
Fixes: https://github.com/NuGet/Client.Engineering/issues/2345

Regression? Last working version: N/A
## Description
1. Add apex test -- Search Package in Browse/Installed/Updates tab from PMUI to verify that the packages searched for appear in the list of the corresponding tab when searching for packages.
2. Remove unnecessary using directive from "test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/ApexTestUIProject.cs"
3. Fix Misspelled words in “test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs”
## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added
   - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
