### PR TITLE
Update PublicAPIAnalyzer to 3.3.4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
     <CryptographyPackagesVersion Condition="'$(CryptographyPackagesVersion)' == ''">5.0.0</CryptographyPackagesVersion>
-    <MicrosoftCodeAnalysisPublicApiAnalyzersVersion Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)' == ''">3.0.0</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
+    <MicrosoftCodeAnalysisPublicApiAnalyzersVersion Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)' == ''">3.3.4</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <NewtonsoftJsonPackageVersion Condition="'$(NewtonsoftJsonPackageVersion)' == ''">13.0.1</NewtonsoftJsonPackageVersion>
     <SystemPackagesVersion Condition="'$(SystemPackagesVersion)' == ''">4.3.0</SystemPackagesVersion>
     <VSFrameworkVersion Condition="'$(VSFrameworkVersion)' == ''">17.4.33103.184</VSFrameworkVersion>

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -738,8 +738,8 @@ NuGet.Commands.TrustedSignerActionsProvider
 ~NuGet.Commands.TrustedSignerActionsProvider.SyncTrustedRepositoryAsync(string name, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task
 ~NuGet.Commands.TrustedSignerActionsProvider.TrustedSignerActionsProvider(NuGet.Packaging.Signing.ITrustedSignersProvider trustedSignersProvider, NuGet.Common.ILogger logger) -> void
 NuGet.Commands.TrustedSignersArgs
-~NuGet.Commands.TrustedSignersArgs.Action.get -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
-~NuGet.Commands.TrustedSignersArgs.Action.set -> void
+NuGet.Commands.TrustedSignersArgs.Action.get -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
+NuGet.Commands.TrustedSignersArgs.Action.set -> void
 NuGet.Commands.TrustedSignersArgs.AllowUntrustedRoot.get -> bool
 NuGet.Commands.TrustedSignersArgs.AllowUntrustedRoot.set -> void
 NuGet.Commands.TrustedSignersArgs.Author.get -> bool
@@ -761,10 +761,10 @@ NuGet.Commands.TrustedSignersArgs.Repository.set -> void
 ~NuGet.Commands.TrustedSignersArgs.ServiceIndex.get -> string
 ~NuGet.Commands.TrustedSignersArgs.ServiceIndex.set -> void
 NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
-~NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.Add = 0 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
-~NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.List = 1 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
-~NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.Remove = 2 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
-~NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.Sync = 3 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
+NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.Add = 0 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
+NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.List = 1 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
+NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.Remove = 2 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
+NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.Sync = 3 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
 NuGet.Commands.TrustedSignersArgs.TrustedSignersArgs() -> void
 NuGet.Commands.TrustedSignersCommandRunner
 ~NuGet.Commands.TrustedSignersCommandRunner.ExecuteCommandAsync(NuGet.Commands.TrustedSignersArgs trustedSignersArgs) -> System.Threading.Tasks.Task<int>
@@ -824,9 +824,9 @@ NuGet.Commands.VerifyArgs.LogLevel.set -> void
 ~NuGet.Commands.VerifyArgs.Settings.get -> NuGet.Configuration.ISettings
 ~NuGet.Commands.VerifyArgs.Settings.set -> void
 NuGet.Commands.VerifyArgs.Verification
-~NuGet.Commands.VerifyArgs.Verification.All = 1 -> NuGet.Commands.VerifyArgs.Verification
-~NuGet.Commands.VerifyArgs.Verification.Signatures = 2 -> NuGet.Commands.VerifyArgs.Verification
-~NuGet.Commands.VerifyArgs.Verification.Unknown = 0 -> NuGet.Commands.VerifyArgs.Verification
+NuGet.Commands.VerifyArgs.Verification.All = 1 -> NuGet.Commands.VerifyArgs.Verification
+NuGet.Commands.VerifyArgs.Verification.Signatures = 2 -> NuGet.Commands.VerifyArgs.Verification
+NuGet.Commands.VerifyArgs.Verification.Unknown = 0 -> NuGet.Commands.VerifyArgs.Verification
 ~NuGet.Commands.VerifyArgs.Verifications.get -> System.Collections.Generic.IList<NuGet.Commands.VerifyArgs.Verification>
 ~NuGet.Commands.VerifyArgs.Verifications.set -> void
 NuGet.Commands.VerifyArgs.VerifyArgs() -> void

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Shipped.txt
@@ -737,8 +737,8 @@ NuGet.Commands.TrustedSignerActionsProvider
 ~NuGet.Commands.TrustedSignerActionsProvider.SyncTrustedRepositoryAsync(string name, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task
 ~NuGet.Commands.TrustedSignerActionsProvider.TrustedSignerActionsProvider(NuGet.Packaging.Signing.ITrustedSignersProvider trustedSignersProvider, NuGet.Common.ILogger logger) -> void
 NuGet.Commands.TrustedSignersArgs
-~NuGet.Commands.TrustedSignersArgs.Action.get -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
-~NuGet.Commands.TrustedSignersArgs.Action.set -> void
+NuGet.Commands.TrustedSignersArgs.Action.get -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
+NuGet.Commands.TrustedSignersArgs.Action.set -> void
 NuGet.Commands.TrustedSignersArgs.AllowUntrustedRoot.get -> bool
 NuGet.Commands.TrustedSignersArgs.AllowUntrustedRoot.set -> void
 NuGet.Commands.TrustedSignersArgs.Author.get -> bool
@@ -760,10 +760,10 @@ NuGet.Commands.TrustedSignersArgs.Repository.set -> void
 ~NuGet.Commands.TrustedSignersArgs.ServiceIndex.get -> string
 ~NuGet.Commands.TrustedSignersArgs.ServiceIndex.set -> void
 NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
-~NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.Add = 0 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
-~NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.List = 1 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
-~NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.Remove = 2 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
-~NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.Sync = 3 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
+NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.Add = 0 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
+NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.List = 1 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
+NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.Remove = 2 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
+NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.Sync = 3 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
 NuGet.Commands.TrustedSignersArgs.TrustedSignersArgs() -> void
 NuGet.Commands.TrustedSignersCommandRunner
 ~NuGet.Commands.TrustedSignersCommandRunner.ExecuteCommandAsync(NuGet.Commands.TrustedSignersArgs trustedSignersArgs) -> System.Threading.Tasks.Task<int>
@@ -823,9 +823,9 @@ NuGet.Commands.VerifyArgs.LogLevel.set -> void
 ~NuGet.Commands.VerifyArgs.Settings.get -> NuGet.Configuration.ISettings
 ~NuGet.Commands.VerifyArgs.Settings.set -> void
 NuGet.Commands.VerifyArgs.Verification
-~NuGet.Commands.VerifyArgs.Verification.All = 1 -> NuGet.Commands.VerifyArgs.Verification
-~NuGet.Commands.VerifyArgs.Verification.Signatures = 2 -> NuGet.Commands.VerifyArgs.Verification
-~NuGet.Commands.VerifyArgs.Verification.Unknown = 0 -> NuGet.Commands.VerifyArgs.Verification
+NuGet.Commands.VerifyArgs.Verification.All = 1 -> NuGet.Commands.VerifyArgs.Verification
+NuGet.Commands.VerifyArgs.Verification.Signatures = 2 -> NuGet.Commands.VerifyArgs.Verification
+NuGet.Commands.VerifyArgs.Verification.Unknown = 0 -> NuGet.Commands.VerifyArgs.Verification
 ~NuGet.Commands.VerifyArgs.Verifications.get -> System.Collections.Generic.IList<NuGet.Commands.VerifyArgs.Verification>
 ~NuGet.Commands.VerifyArgs.Verifications.set -> void
 NuGet.Commands.VerifyArgs.VerifyArgs() -> void

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -736,8 +736,8 @@ NuGet.Commands.TrustedSignerActionsProvider
 ~NuGet.Commands.TrustedSignerActionsProvider.SyncTrustedRepositoryAsync(string name, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task
 ~NuGet.Commands.TrustedSignerActionsProvider.TrustedSignerActionsProvider(NuGet.Packaging.Signing.ITrustedSignersProvider trustedSignersProvider, NuGet.Common.ILogger logger) -> void
 NuGet.Commands.TrustedSignersArgs
-~NuGet.Commands.TrustedSignersArgs.Action.get -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
-~NuGet.Commands.TrustedSignersArgs.Action.set -> void
+NuGet.Commands.TrustedSignersArgs.Action.get -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
+NuGet.Commands.TrustedSignersArgs.Action.set -> void
 NuGet.Commands.TrustedSignersArgs.AllowUntrustedRoot.get -> bool
 NuGet.Commands.TrustedSignersArgs.AllowUntrustedRoot.set -> void
 NuGet.Commands.TrustedSignersArgs.Author.get -> bool
@@ -759,10 +759,10 @@ NuGet.Commands.TrustedSignersArgs.Repository.set -> void
 ~NuGet.Commands.TrustedSignersArgs.ServiceIndex.get -> string
 ~NuGet.Commands.TrustedSignersArgs.ServiceIndex.set -> void
 NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
-~NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.Add = 0 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
-~NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.List = 1 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
-~NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.Remove = 2 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
-~NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.Sync = 3 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
+NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.Add = 0 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
+NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.List = 1 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
+NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.Remove = 2 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
+NuGet.Commands.TrustedSignersArgs.TrustedSignersAction.Sync = 3 -> NuGet.Commands.TrustedSignersArgs.TrustedSignersAction
 NuGet.Commands.TrustedSignersArgs.TrustedSignersArgs() -> void
 NuGet.Commands.TrustedSignersCommandRunner
 ~NuGet.Commands.TrustedSignersCommandRunner.ExecuteCommandAsync(NuGet.Commands.TrustedSignersArgs trustedSignersArgs) -> System.Threading.Tasks.Task<int>
@@ -822,9 +822,9 @@ NuGet.Commands.VerifyArgs.LogLevel.set -> void
 ~NuGet.Commands.VerifyArgs.Settings.get -> NuGet.Configuration.ISettings
 ~NuGet.Commands.VerifyArgs.Settings.set -> void
 NuGet.Commands.VerifyArgs.Verification
-~NuGet.Commands.VerifyArgs.Verification.All = 1 -> NuGet.Commands.VerifyArgs.Verification
-~NuGet.Commands.VerifyArgs.Verification.Signatures = 2 -> NuGet.Commands.VerifyArgs.Verification
-~NuGet.Commands.VerifyArgs.Verification.Unknown = 0 -> NuGet.Commands.VerifyArgs.Verification
+NuGet.Commands.VerifyArgs.Verification.All = 1 -> NuGet.Commands.VerifyArgs.Verification
+NuGet.Commands.VerifyArgs.Verification.Signatures = 2 -> NuGet.Commands.VerifyArgs.Verification
+NuGet.Commands.VerifyArgs.Verification.Unknown = 0 -> NuGet.Commands.VerifyArgs.Verification
 ~NuGet.Commands.VerifyArgs.Verifications.get -> System.Collections.Generic.IList<NuGet.Commands.VerifyArgs.Verification>
 ~NuGet.Commands.VerifyArgs.Verifications.set -> void
 NuGet.Commands.VerifyArgs.VerifyArgs() -> void

--- a/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
@@ -7,3 +7,4 @@ NuGet.Common.NuGetLogCode.NU1903 = 1903 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1904 = 1904 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU1905 = 1905 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU3042 = 3042 -> NuGet.Common.NuGetLogCode
+NuGet.Common.PathResolver.SearchPathResult.SearchPathResult() -> void

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/PublicAPI.Shipped.txt
@@ -59,7 +59,7 @@ NuGet.DependencyResolver.IRemoteDependencyProvider
 NuGet.DependencyResolver.IRemoteDependencyProvider.IsHttp.get -> bool
 ~NuGet.DependencyResolver.IRemoteDependencyProvider.Source.get -> NuGet.Configuration.PackageSource
 NuGet.DependencyResolver.LibraryRangeCacheKey
-~NuGet.DependencyResolver.LibraryRangeCacheKey.Equals(NuGet.DependencyResolver.LibraryRangeCacheKey other) -> bool
+NuGet.DependencyResolver.LibraryRangeCacheKey.Equals(NuGet.DependencyResolver.LibraryRangeCacheKey other) -> bool
 ~NuGet.DependencyResolver.LibraryRangeCacheKey.Framework.get -> NuGet.Frameworks.NuGetFramework
 ~NuGet.DependencyResolver.LibraryRangeCacheKey.LibraryRange.get -> NuGet.LibraryModel.LibraryRange
 ~NuGet.DependencyResolver.LibraryRangeCacheKey.LibraryRangeCacheKey(NuGet.LibraryModel.LibraryRange range, NuGet.Frameworks.NuGetFramework framework) -> void

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-NuGet.DependencyResolver.LibraryRangeCacheKey.Equals(NuGet.DependencyResolver.LibraryRangeCacheKey other) -> bool
+NuGet.DependencyResolver.LibraryRangeCacheKey.LibraryRangeCacheKey() -> void
 static NuGet.DependencyResolver.LibraryRangeCacheKey.operator !=(NuGet.DependencyResolver.LibraryRangeCacheKey left, NuGet.DependencyResolver.LibraryRangeCacheKey right) -> bool
 static NuGet.DependencyResolver.LibraryRangeCacheKey.operator ==(NuGet.DependencyResolver.LibraryRangeCacheKey left, NuGet.DependencyResolver.LibraryRangeCacheKey right) -> bool
 ~NuGet.DependencyResolver.IRemoteDependencyProvider.SourceRepository.get -> NuGet.Protocol.Core.Types.SourceRepository

--- a/src/NuGet.Core/NuGet.LibraryModel/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.LibraryModel/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
+NuGet.LibraryModel.LibraryType.LibraryType() -> void
 ~static NuGet.LibraryModel.LibraryDependencyTargetUtils.AsString(this NuGet.LibraryModel.LibraryDependencyTarget includeFlags) -> string
 ~static NuGet.LibraryModel.LibraryIncludeFlagUtils.AsString(this NuGet.LibraryModel.LibraryIncludeFlags includeFlags) -> string

--- a/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+NuGet.ProjectModel.BuildAction.BuildAction() -> void
 NuGet.ProjectModel.RestoreAuditProperties
 NuGet.ProjectModel.RestoreAuditProperties.AuditLevel.get -> string?
 NuGet.ProjectModel.RestoreAuditProperties.AuditLevel.set -> void


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2346

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

A recent community PR changed a public API, but the analyzer interestingly didn't force PublicAPI.*.txt changes, which surprised me. While the update to the analyzer package version doesn't make struct-class changes explicitly obvious, it at least adds additional public api file changes, which helps.

Also, it looks like it fixes a bug regarding nullability and enums.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
