### PR TITLE
Warn no vuln data only when explicit opt-in

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -61,8 +61,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GetReferenceNearestTargetFrameworkTaskSupportsTargetPlatformParameter>true</GetReferenceNearestTargetFrameworkTaskSupportsTargetPlatformParameter>
     <!-- Flag if the Central package file is enabled -->
     <_CentralPackageVersionsEnabled Condition="'$(ManagePackageVersionsCentrally)' == 'true' AND '$(CentralPackageVersionsFileImported)' == 'true'">true</_CentralPackageVersionsEnabled>
-    <!-- NuGetAudit is enabled by default when using the .NET 8 SDK or above -->
-    <NuGetAudit Condition=" '$(NuGetAudit)' == '' AND $([MSBuild]::VersionGreaterThanOrEquals($([MSBuild]::ValueOrDefault('$(NETCoreSdkVersion)', '0.0')), '8.0'))">true</NuGetAudit>
+    <!-- NuGetAudit is enabled by default when using the .NET 8 SDK or above. Customers should set 'true', so we'll use 'default' to signal implicit opt-in -->
+    <NuGetAudit Condition=" '$(NuGetAudit)' == '' AND $([MSBuild]::VersionGreaterThanOrEquals($([MSBuild]::ValueOrDefault('$(NETCoreSdkVersion)', '0.0')), '8.0'))">default</NuGetAudit>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -277,12 +277,12 @@ namespace NuGet.Commands
                     });
                 }
 
-                string enableAudit = _request.Project.RestoreMetadata?.RestoreAuditProperties?.EnableAudit;
-                if (string.Equals(enableAudit, bool.TrueString, StringComparison.InvariantCultureIgnoreCase)
-                    || string.Equals(enableAudit, "enable", StringComparison.InvariantCultureIgnoreCase))
+                AuditUtility.EnabledValue enableAudit = AuditUtility.ParseEnableValue(_request.Project.RestoreMetadata?.RestoreAuditProperties?.EnableAudit);
+                if (enableAudit == AuditUtility.EnabledValue.ImplicitOptIn || enableAudit == AuditUtility.EnabledValue.ExplicitOptIn)
                 {
                     telemetry.StartIntervalMeasure();
                     var audit = new AuditUtility(
+                        enableAudit,
                         _request.Project.RestoreMetadata.RestoreAuditProperties,
                         _request.Project.FilePath,
                         graphs,

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/ProjectPropertyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/ProjectPropertyTests.cs
@@ -27,14 +27,8 @@ namespace Dotnet.Integration.Test
             var projectFileContents = @"<Project Sdk=""Microsoft.NET.Sdk"">
     <Target Name=""ValidateNuGetAuditValue"">
         <Message Importance=""high"" Text=""NuGetAudit: '$(NuGetAudit)'"" />
-        <Error Text=""ExpectEnabled was not set"" Condition="" '$(ExpectEnabled)' != 'true' AND '$(ExpectEnabled)' != 'false' "" />
+        <Error Text=""NuGetAudit ('$(NuGetAudit)') does not have expected value ('$(ExpectedValue)')"" Condition="" '$(ExpectedValue)' != '$(NuGetAudit)' "" />
         <Message Importance=""high"" Text=""SdkVersion: $(NETCoreSdkVersion) "" />
-    </Target>
-    <Target Name=""ValidateEnabled"" Condition="" '$(ExpectEnabled)' == 'true' "" AfterTargets=""ValidateNuGetAuditValue"">
-        <Error Text=""NuGetAudit property should be set to true by default"" Condition="" '$(NuGetAudit)' != 'true' "" />
-    </Target>
-    <Target Name=""ValidateNotSet"" Condition="" '$(ExpectEnabled)' != 'true' "" AfterTargets=""ValidateNuGetAuditValue"">
-        <Error Text=""NuGetAudit property should not be set"" Condition="" '$(NuGetAudit)' != '' "" />
     </Target>
 </Project>";
             File.WriteAllText(projectFilePath, projectFileContents);
@@ -44,13 +38,13 @@ namespace Dotnet.Integration.Test
             // Therefore, we can depend on this file's compile time TFM to tell us if we're testing the .NET 7 or 8 SDK.
             string expected =
 #if NET8_0_OR_GREATER
-                "true";
+                "default";
 #else
-                "false";
+                "";
 #endif
 
             // Act
-            var result = _msbuildFixture.RunDotnet(testDirectory.Path, $"msbuild -t:ValidateNuGetAuditValue -p:ExpectEnabled={expected}");
+            var result = _msbuildFixture.RunDotnet(testDirectory.Path, $"msbuild -t:ValidateNuGetAuditValue -p:ExpectedValue={expected}");
 
             // Assert
             result.Success.Should().BeTrue(result.AllOutput);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12610

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

NU1905, which warns when NuGetAudit is enabled, but no sources have vulnerability data, should only be output when the feature is explicitly enabled. This means people who use upstreaming NuGet feeds, or only private feeds, do not get the warning when the feature is enabled by default.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
