### PR TITLE
Use VS Styles for `TreeViewItem` Header controls

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
@@ -186,9 +186,6 @@
     <Setter Property="FocusVisualStyle" Value="{StaticResource ControlsFocusVisualStyle}" />
   </Style>
 
-  <Style x:Key="{x:Type TreeView}" TargetType="{x:Type TreeView}" BasedOn="{StaticResource {x:Static vs:VsResourceKeys.ThemedDialogTreeViewStyleKey}}"/>
-  <Style x:Key="{x:Type TreeViewItem}" TargetType="{x:Type TreeViewItem}" BasedOn="{StaticResource {x:Static vs:VsResourceKeys.ThemedDialogTreeViewItemStyleKey}}"/>
-
   <Style x:Key="{x:Type CheckBox}" TargetType="{x:Type CheckBox}" BasedOn="{StaticResource {x:Type CheckBox}}">
     <Setter Property="FocusVisualStyle" Value="{DynamicResource ControlsFocusVisualStyle}"/>
     <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}"/>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
@@ -186,6 +186,9 @@
     <Setter Property="FocusVisualStyle" Value="{StaticResource ControlsFocusVisualStyle}" />
   </Style>
 
+  <Style x:Key="{x:Type TreeView}" TargetType="{x:Type TreeView}" BasedOn="{StaticResource {x:Static vs:VsResourceKeys.ThemedDialogTreeViewStyleKey}}"/>
+  <Style x:Key="{x:Type TreeViewItem}" TargetType="{x:Type TreeViewItem}" BasedOn="{StaticResource {x:Static vs:VsResourceKeys.ThemedDialogTreeViewItemStyleKey}}"/>
+
   <Style x:Key="{x:Type CheckBox}" TargetType="{x:Type CheckBox}" BasedOn="{StaticResource {x:Type CheckBox}}">
     <Setter Property="FocusVisualStyle" Value="{DynamicResource ControlsFocusVisualStyle}"/>
     <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}"/>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -368,16 +368,6 @@
         <DataTemplate DataType="{x:Type nuget:PackageDependencyMetadata}">
           <TextBlock Text="{Binding}" ToolTip="{Binding}" />
         </DataTemplate>
-        <!--
-          Override the background and foreground brushes that TreeViewItems use for highlighting the item
-          when in the selected state and point to VS themed colors instead of using the defaults.
-        -->
-        <SolidColorBrush
-          x:Key="{x:Static SystemColors.HighlightBrushKey}"
-          Color="{DynamicResource {x:Static nuget:Brushes.ListItemBackgroundSelectedColorKey}}" />
-        <SolidColorBrush
-          x:Key="{x:Static SystemColors.HighlightTextBrushKey}"
-          Color="{DynamicResource {x:Static nuget:Brushes.ListItemTextSelectedColorKey}}" />
       </TreeView.Resources>
       <TreeViewItem Header="{x:Static nuget:Resources.Label_Dependencies}"
                     ItemsSource="{Binding Path=DependencySets}"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2310

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- Remove custom styling for `TreeViewItem` header controls which are used in the `Dependencies` node in the Details Pane of PM UI.

- `4.498:1` is considered acceptable for the `5.0:1` standard according to our accessibility SME.
It is the same value called out by AccessibilityInsights when analyzing the Properties pane in Solution Explorer:

![image](https://github.com/NuGet/NuGet.Client/assets/49205731/89f693ec-ab78-45e6-9935-88a60ed1b421)


## Results from AccessibilityInsights after this PR

### Blue theme 
Highlight vs. Foreground (`4.498:1` is `~5.0:1`)
Highlight vs. Background (`4.498:1` is >`3.5:1`) -- same as foreground which is #FFFFFF
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/c5b03d92-4aa9-457a-b36b-86af8fdcc209)

### Dark theme
Highlight vs. Foreground (`4.498:1` is `~5.0:1`)
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/21be61f3-18dc-4e78-a8b9-1d86cae5ac89)

Highlight vs. Background (`3.663:1` is >`3.5:1`)
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/757cc9d2-4edd-4db7-8e79-abec813c1247)

### Light theme
Highlight vs. Foreground (`4.498:1` is `~5.0:1`)
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/3010cb7d-4110-4e17-90cc-cb07f944caf6)

Highlight vs. Background (`3.887:1` is >`3.5:1`)
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/6e065c0c-0aaf-4517-b61b-bf16b730022c)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - AccessibilityInsights screenshots above
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
