### PR TITLE
Don't allocate as many Task instances

### DIFF
--- a/build/Shared/TaskResult.cs
+++ b/build/Shared/TaskResult.cs
@@ -23,6 +23,14 @@ internal static class TaskResult
     public static Task<bool> False { get; } = Task.FromResult(false);
 
     /// <summary>
+    /// Returns a <see cref="Task{TResult}"/> that's completed successfully with the result of <paramref name="b"/>.
+    /// </summary>
+    public static Task<bool> Boolean(bool b)
+    {
+        return b ? True : False;
+    }
+
+    /// <summary>
     /// Returns a <see cref="Task{TResult}"/> of type <typeparamref name="T" /> that's completed successfully with the result of <see langword="null"/>.
     /// </summary>
     public static Task<T?> Null<T>() where T : class => NullTaskResult<T>.Instance;

--- a/build/Shared/TaskResult.cs
+++ b/build/Shared/TaskResult.cs
@@ -31,6 +31,29 @@ internal static class TaskResult
     }
 
     /// <summary>
+    /// Gets a <see cref="Task{TResult}"/> that's completed successfully with the result of <see langword="true"/>.
+    /// </summary>
+    public static Task<int> Zero { get; } = Task.FromResult(0);
+
+    /// <summary>
+    /// Gets a <see cref="Task{TResult}"/> that's completed successfully with the result of <see langword="false"/>.
+    /// </summary>
+    public static Task<int> One { get; } = Task.FromResult(1);
+
+    /// <summary>
+    /// Returns a <see cref="Task{TResult}"/> that's completed successfully with the result of <paramref name="i"/>.
+    /// </summary>
+    public static Task<int> Integer(int i)
+    {
+        return i switch
+        {
+            0 => Zero,
+            1 => One,
+            _ => Task.FromResult(i)
+        };
+    }
+
+    /// <summary>
     /// Returns a <see cref="Task{TResult}"/> of type <typeparamref name="T" /> that's completed successfully with the result of <see langword="null"/>.
     /// </summary>
     public static Task<T?> Null<T>() where T : class => NullTaskResult<T>.Instance;

--- a/build/Shared/TaskResult.cs
+++ b/build/Shared/TaskResult.cs
@@ -1,0 +1,54 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NuGet;
+
+#nullable enable
+
+internal static class TaskResult
+{
+    /// <summary>
+    /// Gets a <see cref="Task{TResult}"/> that's completed successfully with the result of <see langword="true"/>.
+    /// </summary>
+    public static Task<bool> True { get; } = Task.FromResult(true);
+
+    /// <summary>
+    /// Gets a <see cref="Task{TResult}"/> that's completed successfully with the result of <see langword="false"/>.
+    /// </summary>
+    public static Task<bool> False { get; } = Task.FromResult(false);
+
+    /// <summary>
+    /// Returns a <see cref="Task{TResult}"/> of type <typeparamref name="T" /> that's completed successfully with the result of <see langword="null"/>.
+    /// </summary>
+    public static Task<T?> Null<T>() where T : class => NullTaskResult<T>.Instance;
+
+    private static class NullTaskResult<T> where T : class
+    {
+        public static readonly Task<T?> Instance = Task.FromResult<T?>(null);
+    }
+
+    /// <summary>
+    /// Returns a <see cref="Task{TResult}"/> whose value is an empty enumerable of type <typeparamref name="T" />.
+    /// </summary>
+    public static Task<IEnumerable<T>> EmptyEnumerable<T>() => EmptyEnumerableTaskResult<T>.Instance;
+
+    private static class EmptyEnumerableTaskResult<T>
+    {
+        public static readonly Task<IEnumerable<T>> Instance = Task.FromResult(Enumerable.Empty<T>());
+    }
+
+    /// <summary>
+    /// Returns a <see cref="Task{TResult}"/> whose value is an empty array with element type <typeparamref name="T" />.
+    /// </summary>
+    public static Task<T[]> EmptyArray<T>() => EmptyArrayTaskResult<T>.Instance;
+
+    private static class EmptyArrayTaskResult<T>
+    {
+        public static readonly Task<T[]> Instance = Task.FromResult(Array.Empty<T>());
+    }
+}

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -233,7 +233,7 @@ namespace NuGet.CommandLine
         public virtual Task ExecuteCommandAsync()
         {
             ExecuteCommand();
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public virtual void ExecuteCommand()

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/LocalsCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/LocalsCommand.cs
@@ -38,7 +38,7 @@ namespace NuGet.CommandLine.Commands
                 // immediately show usage help for this command instead.
                 HelpCommand.ViewHelpForCommand(CommandAttribute.CommandName);
 
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             }
 
             if (LocalsCommandRunner == null)
@@ -47,7 +47,7 @@ namespace NuGet.CommandLine.Commands
             }
             var localsArgs = new LocalsArgs(Arguments, Settings, Console.LogInformation, Console.LogError, Clear, List);
             LocalsCommandRunner.ExecuteCommand(localsArgs);
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/VerifyCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/VerifyCommand.cs
@@ -67,7 +67,7 @@ namespace NuGet.CommandLine
             {
                 throw new ExitCodeException(1);
             }
-            return Task.FromResult(result);
+            return Task.CompletedTask;
         }
 
         private IList<Verification> GetVerificationTypes()

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
@@ -440,7 +440,7 @@ namespace NuGet.CommandLine
         {
             Log(message);
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         private static LogLevel GetVerbosityLevel(Verbosity level)

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/InstallCommandProject.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/InstallCommandProject.cs
@@ -83,7 +83,7 @@ namespace NuGet.CommandLine
             }
 
             // For SxS scenarios PackageManagement should not read these references, this would cause uninstalls.
-            return Task.FromResult(Enumerable.Empty<PackageReference>());
+            return TaskResult.EmptyEnumerable<PackageReference>();
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -111,7 +111,7 @@ namespace NuGet.Common
         public Task AddFrameworkReferenceAsync(string name, string packageId)
         {
             // No-op
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public void AddImport(string targetFullPath, ImportLocation location)
@@ -182,13 +182,13 @@ namespace NuGet.Common
                 new[] { new KeyValuePair<string, string>("HintPath", relativePath),
                         new KeyValuePair<string, string>("Private", "True")});
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public Task BeginProcessingAsync()
         {
             // No-op outside of visual studio, this is implemented in other project systems, like vsmsbuild & website.
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public void RegisterProcessedFiles(IEnumerable<string> files)
@@ -199,7 +199,7 @@ namespace NuGet.Common
         public Task EndProcessingAsync()
         {
             // No-op outside of visual studio, this is implemented in other project systems, like vsmsbuild & website.
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public void DeleteDirectory(string path, bool recursive)
@@ -319,7 +319,7 @@ namespace NuGet.Common
                 Project.RemoveItem(assemblyReference);
             }
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public string ResolvePath(string path)

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -265,7 +265,7 @@ namespace NuGet.Common
 
         public Task<bool> ReferenceExistsAsync(string name)
         {
-            return Task.FromResult(GetReference(name) != null);
+            return TaskResult.Boolean(GetReference(name) != null);
         }
 
         public void RemoveFile(string path)

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
@@ -81,7 +81,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                     WaitAndLogPackageActions();
                     UnsubscribeFromProgressEvents();
 
-                    return Task.FromResult(true);
+                    return TaskResult.True;
                 }, Token);
             });
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UninstallPackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UninstallPackageCommand.cs
@@ -80,7 +80,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                     WaitAndLogPackageActions();
                     UnsubscribeFromProgressEvents();
 
-                    return Task.FromResult(true);
+                    return TaskResult.True;
                 }, Token);
             });
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
@@ -131,7 +131,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                     WaitAndLogPackageActions();
                     UnsubscribeFromProgressEvents();
 
-                    return Task.FromResult(true);
+                    return TaskResult.True;
                 }, Token);
             });
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/NativeProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/NativeProjectSystem.cs
@@ -42,7 +42,7 @@ namespace NuGet.PackageManagement.VisualStudio
         public override Task<bool> ReferenceExistsAsync(string name)
         {
             // We disable assembly reference for native projects
-            return Task.FromResult(true);
+            return TaskResult.True;
         }
 
         public override Task RemoveReferenceAsync(string name)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/WebSiteProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/WebSiteProjectSystem.cs
@@ -190,7 +190,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public override Task BeginProcessingAsync()
         {
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public override void RegisterProcessedFiles(IEnumerable<string> files)
@@ -222,7 +222,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             _excludedCodeFiles.Clear();
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/WixProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/WixProjectSystem.cs
@@ -61,7 +61,7 @@ namespace NuGet.PackageManagement.VisualStudio
         public override Task<bool> ReferenceExistsAsync(string name)
         {
             // References aren't allowed for WiX projects
-            return Task.FromResult(true);
+            return TaskResult.True;
         }
 
         public override bool IsSupportedFile(string path)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
@@ -90,7 +90,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
                 else
                 {
-                    return Task.FromResult<string>(null);
+                    return TaskResult.Null<string>();
                 }
             }
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -272,7 +272,7 @@ namespace NuGet.SolutionRestoreManager
                     () => new BlockingCollection<SolutionRestoreRequest>(RequestQueueLimit));
 
                 _pendingRestore = new BackgroundRestoreOperation();
-                _activeRestoreTask = Task.FromResult(true);
+                _activeRestoreTask = TaskResult.True;
                 _restoreJobContext = new SolutionRestoreJobContext();
 
                 // Set to signaled, restore is no longer busy

--- a/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildLogger.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildLogger.cs
@@ -194,7 +194,7 @@ namespace NuGet.Build
         {
             Log(message);
 
-            return System.Threading.Tasks.Task.FromResult(0);
+            return System.Threading.Tasks.Task.CompletedTask;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs
@@ -32,7 +32,7 @@ namespace NuGet.CommandLine.XPlat
             // Remove reference from the project
             var result = msBuild.RemovePackageReference(packageReferenceArgs.ProjectPath, libraryDependency);
 
-            return Task.FromResult(result);
+            return TaskResult.Integer(result);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/CommandOutputLogger.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/CommandOutputLogger.cs
@@ -125,7 +125,7 @@ namespace NuGet.CommandLine.XPlat
         {
             Log(message);
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/PackCollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCollectorLogger.cs
@@ -72,7 +72,7 @@ namespace NuGet.Commands
                 }
             }
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         private bool IsWarningSuppressed(ILogMessage message)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/RestoreCollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/RestoreCollectorLogger.cs
@@ -175,7 +175,7 @@ namespace NuGet.Commands
                 }
             }
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public override void Log(ILogMessage message)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphFileRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphFileRequestProvider.cs
@@ -41,7 +41,7 @@ namespace NuGet.Commands
             // True if .dg file
             var result = (File.Exists(path) && path.EndsWith(".dg", StringComparison.OrdinalIgnoreCase));
 
-            return Task.FromResult(result);
+            return TaskResult.Boolean(result);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Logging/LegacyLoggerAdapter.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/LegacyLoggerAdapter.cs
@@ -58,7 +58,7 @@ namespace NuGet.Common
         {
             Log(level, data);
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public virtual void Log(ILogMessage message)

--- a/src/NuGet.Core/NuGet.Common/Logging/LoggerBase.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/LoggerBase.cs
@@ -37,7 +37,7 @@ namespace NuGet.Common
                 return LogAsync(new LogMessage(level, data));
             }
 
-            return Task.FromResult(true);
+            return TaskResult.True;
         }
 
         public virtual void LogDebug(string data)

--- a/src/NuGet.Core/NuGet.Common/Logging/NullLogger.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/NullLogger.cs
@@ -27,9 +27,9 @@ namespace NuGet.Common
 
         public override void Log(LogLevel level, string data) { }
 
-        public override Task LogAsync(ILogMessage message) { return Task.FromResult(0); }
+        public override Task LogAsync(ILogMessage message) { return Task.CompletedTask; }
 
-        public override Task LogAsync(LogLevel level, string data) { return Task.FromResult(0); }
+        public override Task LogAsync(LogLevel level, string data) { return Task.CompletedTask; }
 
     }
 }

--- a/src/NuGet.Core/NuGet.Common/PathUtil/FileUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/FileUtility.cs
@@ -42,7 +42,7 @@ namespace NuGet.Common
                 {
                     Delete(filePath);
 
-                    return Task.FromResult(0);
+                    return TaskResult.Zero;
                 },
                 // Do not allow this to be cancelled
                 CancellationToken.None);
@@ -70,7 +70,7 @@ namespace NuGet.Common
                 {
                     Replace(writeSourceFile, destFilePath);
 
-                    return Task.FromResult(0);
+                    return TaskResult.Zero;
                 },
                 // Do not allow this to be cancelled
                 CancellationToken.None);

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
@@ -89,7 +89,7 @@ namespace NuGet.DependencyResolver
 
             if (library == null)
             {
-                return Task.FromResult<LibraryIdentity>(null);
+                return TaskResult.Null<LibraryIdentity>();
             }
 
             return Task.FromResult(library.Identity);

--- a/src/NuGet.Core/NuGet.PackageManagement/LoggerAdapter.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/LoggerAdapter.cs
@@ -62,7 +62,7 @@ namespace NuGet.ProjectManagement
         public override Task LogAsync(ILogMessage message)
         {
             ProjectLogger.Log(message);
-            return Task.FromResult(0);
+            return TaskResult.Zero;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -3545,7 +3545,7 @@ namespace NuGet.PackageManagement
                 }
             }
 
-            return Task.FromResult(false);
+            return TaskResult.False;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/ProjectContextLogger.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/ProjectContextLogger.cs
@@ -32,7 +32,7 @@ namespace NuGet.PackageManagement
                 _projectContext.Log(message);
             }
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/DefaultProjectServices.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/DefaultProjectServices.cs
@@ -59,7 +59,7 @@ namespace NuGet.ProjectManagement
             Common.ILogger _,
             CancellationToken __)
         {
-            return Task.FromResult(Enumerable.Empty<ProjectRestoreReference>());
+            return TaskResult.EmptyEnumerable<ProjectRestoreReference>();
         }
 
         public string GetPropertyValue(string propertyName)

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/DefaultProjectServices.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/DefaultProjectServices.cs
@@ -85,7 +85,7 @@ namespace NuGet.ProjectManagement
         public Task SaveProjectAsync(CancellationToken _)
         {
             // do nothing
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public Task ExecutePackageScriptAsync(
@@ -97,7 +97,7 @@ namespace NuGet.ProjectManagement
             CancellationToken _)
         {
             // No-op
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public Task<bool> ExecutePackageInitScriptAsync(

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/DefaultProjectServices.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/DefaultProjectServices.cs
@@ -69,7 +69,7 @@ namespace NuGet.ProjectManagement
 
         public Task<string> GetPropertyValueAsync(string propertyName)
         {
-            return Task.FromResult<string>(null);
+            return TaskResult.Null<string>();
         }
 
         public T GetGlobalService<T>() where T : class

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/DefaultProjectServices.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/DefaultProjectServices.cs
@@ -108,7 +108,7 @@ namespace NuGet.ProjectManagement
             CancellationToken _)
         {
             // No-op
-            return Task.FromResult(false);
+            return TaskResult.False;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/FolderNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/FolderNuGetProject.cs
@@ -89,7 +89,7 @@ namespace NuGet.ProjectManagement
         /// <see cref="IEnumerable{PackageReference}" />.</returns>
         public override Task<IEnumerable<PackageReference>> GetInstalledPackagesAsync(CancellationToken token)
         {
-            return Task.FromResult(Enumerable.Empty<PackageReference>());
+            return TaskResult.EmptyEnumerable<PackageReference>();
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/FolderNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/FolderNuGetProject.cs
@@ -241,7 +241,7 @@ namespace NuGet.ProjectManagement
             CancellationToken token)
         {
             // Do nothing. Return true
-            return Task.FromResult(true);
+            return TaskResult.True;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/NuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/NuGetProject.cs
@@ -58,13 +58,13 @@ namespace NuGet.ProjectManagement
         public virtual Task PreProcessAsync(INuGetProjectContext nuGetProjectContext, CancellationToken token)
         {
             // Do Nothing by default
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public virtual Task PostProcessAsync(INuGetProjectContext nuGetProjectContext, CancellationToken token)
         {
             // Do Nothing by default
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public T GetMetadata<T>(string key)

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/PackagesConfigNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/PackagesConfigNuGetProject.cs
@@ -198,7 +198,7 @@ namespace NuGet.ProjectManagement
             if (packageReference == null)
             {
                 nuGetProjectContext.Log(MessageLevel.Warning, Strings.PackageDoesNotExisttInPackagesConfig, packageIdentity, Path.GetFileName(FullPath));
-                return Task.FromResult(false);
+                return TaskResult.False;
             }
 
             try
@@ -231,7 +231,7 @@ namespace NuGet.ProjectManagement
             }
 
             nuGetProjectContext.Log(MessageLevel.Info, Strings.RemovedPackageFromPackagesConfig, packageIdentity, Path.GetFileName(FullPath));
-            return Task.FromResult(true);
+            return TaskResult.True;
         }
 
         public override Task<IEnumerable<PackageReference>> GetInstalledPackagesAsync(CancellationToken token)

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
@@ -130,7 +130,7 @@ namespace NuGet.ProjectManagement.Projects
         protected virtual Task UpdateInternalTargetFrameworkAsync()
         {
             // Extending class will implement the functionality
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public override async Task<IEnumerable<PackageReference>> GetInstalledPackagesAsync(CancellationToken token)

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
@@ -158,7 +158,7 @@ namespace NuGet.ProjectManagement.Projects
         protected virtual Task<string> GetMSBuildProjectExtensionsPathAsync()
         {
             // Extending class will implement the functionality.
-            return Task.FromResult((string)null);
+            return TaskResult.Null<string>();
         }
 
         public override async Task<IReadOnlyList<PackageSpec>> GetPackageSpecsAsync(DependencyGraphCacheContext context)
@@ -382,7 +382,7 @@ namespace NuGet.ProjectManagement.Projects
         // Overriding class wil implement the method
         public override Task<string> GetCacheFilePathAsync()
         {
-            return Task.FromResult((string)null);
+            return TaskResult.Null<string>();
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/LocalPackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/LocalPackageArchiveDownloader.cs
@@ -108,7 +108,7 @@ namespace NuGet.Packaging
             _logger = logger;
             _packageReader = new Lazy<PackageArchiveReader>(GetPackageReader);
             _sourceStream = new Lazy<FileStream>(GetSourceStream);
-            _handleExceptionAsync = exception => Task.FromResult(false);
+            _handleExceptionAsync = exception => TaskResult.False;
             Source = source;
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -437,7 +437,7 @@ namespace NuGet.Packaging
 
             return Task.FromResult(_isSigned.Value);
 #else
-            return Task.FromResult(false);
+            return TaskResult.False;
 #endif
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -236,7 +236,7 @@ namespace NuGet.Packaging
 
         public override Task<bool> IsSignedAsync(CancellationToken token)
         {
-            return Task.FromResult(false);
+            return TaskResult.False;
         }
 
         public override Task ValidateIntegrityAsync(SignatureContent signatureContent, CancellationToken token)

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -231,7 +231,7 @@ namespace NuGet.Packaging
 
         public override Task<PrimarySignature> GetPrimarySignatureAsync(CancellationToken token)
         {
-            return Task.FromResult<PrimarySignature>(null);
+            return TaskResult.Null<PrimarySignature>();
         }
 
         public override Task<bool> IsSignedAsync(CancellationToken token)

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
@@ -300,7 +300,7 @@ namespace NuGet.Protocol
                 {
                     if (stream == null)
                     {
-                        return Task.FromResult<JObject>(null);
+                        return TaskResult.Null<JObject>();
                     }
 
                     return stream.AsJObjectAsync(token);

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/NullThrottle.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/NullThrottle.cs
@@ -11,7 +11,6 @@ namespace NuGet.Protocol
     /// </summary>
     public class NullThrottle : IThrottle
     {
-        private static readonly Task _completedTask = Task.FromResult(true);
         private static readonly NullThrottle _instance = new NullThrottle();
 
         public static NullThrottle Instance
@@ -24,7 +23,7 @@ namespace NuGet.Protocol
 
         public Task WaitAsync()
         {
-            return _completedTask;
+            return Task.CompletedTask;
         }
 
         public void Release()

--- a/src/NuGet.Core/NuGet.Protocol/LocalPackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalPackageArchiveDownloader.cs
@@ -109,7 +109,7 @@ namespace NuGet.Protocol
             _logger = logger;
             _packageReader = new Lazy<PackageArchiveReader>(GetPackageReader);
             _sourceStream = new Lazy<FileStream>(GetSourceStream);
-            _handleExceptionAsync = exception => Task.FromResult(false);
+            _handleExceptionAsync = exception => TaskResult.False;
             Source = source;
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
@@ -90,7 +90,7 @@ namespace NuGet.Protocol
         }
 
         /// <inheritdoc cref="IPackageSearchMetadata.GetVersionsAsync" />
-        public Task<IEnumerable<VersionInfo>> GetVersionsAsync() => Task.FromResult(Enumerable.Empty<VersionInfo>());
+        public Task<IEnumerable<VersionInfo>> GetVersionsAsync() => TaskResult.EmptyEnumerable<VersionInfo>();
 
         /// <summary>
         /// Convert a string to a URI safely. This will return null if there are errors.

--- a/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
@@ -117,7 +117,7 @@ namespace NuGet.Protocol
         public LicenseMetadata LicenseMetadata => _nuspec.GetLicenseMetadata();
 
         /// <inheritdoc cref="IPackageSearchMetadata.GetDeprecationMetadataAsync" />
-        public Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() => Task.FromResult<PackageDeprecationMetadata>(null);
+        public Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() => TaskResult.Null<PackageDeprecationMetadata>();
 
         /// <inheritdoc cref="IPackageSearchMetadata.Vulnerabilities" />
         public IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities => null;

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
@@ -132,7 +132,7 @@ namespace NuGet.Protocol
         public NuGetVersion Version { get; private set; }
 
         /// <inheritdoc cref="IPackageSearchMetadata.GetVersionsAsync" />
-        public Task<IEnumerable<VersionInfo>> GetVersionsAsync() => Task.FromResult(Enumerable.Empty<VersionInfo>());
+        public Task<IEnumerable<VersionInfo>> GetVersionsAsync() => TaskResult.EmptyEnumerable<VersionInfo>();
 
         private static Uri GetUriSafe(string url)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
@@ -142,7 +142,7 @@ namespace NuGet.Protocol
         }
 
         /// <inheritdoc cref="IPackageSearchMetadata.GetDeprecationMetadataAsync" />
-        public Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() => Task.FromResult<PackageDeprecationMetadata>(null);
+        public Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() => TaskResult.Null<PackageDeprecationMetadata>();
 
         /// <inheritdoc cref="IPackageSearchMetadata.Vulnerabilities" />
         public IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get; } = null; // Vulnerability metadata is not added to nuget.org's v2 feed.

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Connection.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Connection.cs
@@ -279,7 +279,7 @@ namespace NuGet.Protocol.Plugins
             if (State == ConnectionState.Closing ||
                 State == ConnectionState.Closed)
             {
-                return Task.FromResult<TInbound>(null);
+                return TaskResult.Null<TInbound>();
             }
 
             if (_state < (int)ConnectionState.Connecting)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/MessageDispatcher.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/MessageDispatcher.cs
@@ -288,7 +288,7 @@ namespace NuGet.Protocol.Plugins
 
             if (connection == null)
             {
-                return Task.FromResult<TInbound>(null);
+                return TaskResult.Null<TInbound>();
             }
 
             return DispatchWithNewContextAsync<TOutbound, TInbound>(

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/MessageDispatcher.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/MessageDispatcher.cs
@@ -189,7 +189,7 @@ namespace NuGet.Protocol.Plugins
 
             if (connection == null)
             {
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             }
 
             return DispatchCancelAsync(connection, request, cancellationToken);
@@ -219,7 +219,7 @@ namespace NuGet.Protocol.Plugins
 
             if (connection == null)
             {
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             }
 
             return DispatchFaultAsync(connection, request, fault, cancellationToken);
@@ -255,7 +255,7 @@ namespace NuGet.Protocol.Plugins
 
             if (connection == null)
             {
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             }
 
             return DispatchProgressAsync(connection, request, progress, cancellationToken);
@@ -334,7 +334,7 @@ namespace NuGet.Protocol.Plugins
 
             if (connection == null)
             {
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             }
 
             return DispatchAsync(connection, MessageType.Response, request, responsePayload, cancellationToken);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
@@ -244,7 +244,7 @@ namespace NuGet.Protocol.Plugins
                                     {
                                         await cacheEntry.UpdateCacheFileAsync();
 
-                                        return Task.FromResult<object>(null);
+                                        return TaskResult.Null<object>();
                                     },
                                     token: cancellationToken),
                                 cancellationToken);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageDownloader.cs
@@ -107,7 +107,7 @@ namespace NuGet.Protocol.Plugins
             _packageIdentity = packageIdentity;
             _packageReader = packageReader;
             _packageSourceRepository = packageSourceRepository;
-            _handleExceptionAsync = exception => Task.FromResult(false);
+            _handleExceptionAsync = exception => TaskResult.False;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -1127,7 +1127,7 @@ namespace NuGet.Protocol.Plugins
 
         public override Task<bool> IsSignedAsync(CancellationToken token)
         {
-            return Task.FromResult(false);
+            return TaskResult.False;
         }
 
         public override Task ValidateIntegrityAsync(SignatureContent signatureContent, CancellationToken token)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -1122,7 +1122,7 @@ namespace NuGet.Protocol.Plugins
 
         public override Task<PrimarySignature> GetPrimarySignatureAsync(CancellationToken token)
         {
-            return Task.FromResult<PrimarySignature>(null);
+            return TaskResult.Null<PrimarySignature>();
         }
 
         public override Task<bool> IsSignedAsync(CancellationToken token)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/CloseRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/CloseRequestHandler.cs
@@ -82,7 +82,7 @@ namespace NuGet.Protocol.Plugins
 
             _plugin.Close();
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Sender.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Sender.cs
@@ -143,7 +143,7 @@ namespace NuGet.Protocol.Plugins
                 }
             }
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         private void ThrowIfDisposed()

--- a/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
@@ -114,7 +114,7 @@ namespace NuGet.Protocol
             _cacheContext = cacheContext;
             _logger = logger;
             _packageReader = new Lazy<PackageArchiveReader>(GetPackageReader);
-            _handleExceptionAsync = exception => Task.FromResult(false);
+            _handleExceptionAsync = exception => TaskResult.False;
             Source = source;
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -413,7 +413,7 @@ namespace NuGet.Protocol.Core.Types
                                     bool logOccurred = DetectAndLogSkippedErrorOccurrence(responseStatusCode, source, pathToPackage, response.ReasonPhrase, logger);
                                     showPushCommandPackagePushed = !logOccurred;
 
-                                    return Task.FromResult(0);
+                                    return TaskResult.Zero;
                                 },
                                 logger,
                                 token);
@@ -455,7 +455,7 @@ namespace NuGet.Protocol.Core.Types
                         bool logOccurred = DetectAndLogSkippedErrorOccurrence(responseStatusCode, source, pathToPackage, response.ReasonPhrase, logger);
                         showPushCommandPackagePushed = !logOccurred;
 
-                        return Task.FromResult(0);
+                        return TaskResult.Zero;
                     },
                     logger,
                     token);
@@ -724,7 +724,7 @@ namespace NuGet.Protocol.Core.Types
                 {
                     response.EnsureSuccessStatusCode();
 
-                    return Task.FromResult(0);
+                    return TaskResult.Zero;
                 },
                 logger,
                 token);

--- a/src/NuGet.Core/NuGet.Protocol/Utility/FindPackagesByIdNupkgDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/FindPackagesByIdNupkgDownloader.cs
@@ -77,7 +77,7 @@ namespace NuGet.Protocol
                 {
                     reader = PackageUtilities.OpenNuspecFromNupkg(identity.Id, stream, logger);
 
-                    return Task.FromResult(true);
+                    return TaskResult.True;
                 },
                 cacheContext,
                 logger,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Xamls/InfiniteScrollListTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Xamls/InfiniteScrollListTests.cs
@@ -179,7 +179,7 @@ namespace NuGet.PackageManagement.UI.Test
                     It.IsNotNull<SearchResultContextInfo>(),
                     It.IsNotNull<IProgress<IItemLoaderState>>(),
                     It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(0));
+                .Returns(Task.CompletedTask);
 
             var loadingStatus = LoadingStatus.Loading;
             var loadingStatusCallCount = 0;
@@ -216,7 +216,7 @@ namespace NuGet.PackageManagement.UI.Test
             loader.Setup(x => x.UpdateStateAsync(
                     It.IsNotNull<IProgress<IItemLoaderState>>(),
                     It.IsAny<CancellationToken>()))
-                .Returns(() => Task.FromResult(0));
+                .Returns(() => Task.CompletedTask);
 
             var logger = new Mock<INuGetUILogger>();
             var searchResultTask = Task.FromResult(new SearchResultContextInfo());
@@ -291,7 +291,7 @@ namespace NuGet.PackageManagement.UI.Test
                     It.IsNotNull<SearchResultContextInfo>(),
                     It.IsNotNull<IProgress<IItemLoaderState>>(),
                     It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(0))
+                .Returns(Task.CompletedTask)
                 .Callback(() =>
                 {
                     currentStatus = searchItems.Length > 0 ? LoadingStatus.Ready : LoadingStatus.NoItemsFound;
@@ -299,7 +299,7 @@ namespace NuGet.PackageManagement.UI.Test
             loaderMock.Setup(x => x.UpdateStateAsync(
                     It.IsNotNull<IProgress<IItemLoaderState>>(),
                     It.IsAny<CancellationToken>()))
-                .Returns(() => Task.FromResult(0));
+                .Returns(() => Task.CompletedTask);
             loaderMock.Setup(x => x.GetCurrent())
                 .Returns(() => searchItems.Select(x => new PackageItemViewModel(searchService.Object)));
 

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/ResponseSender.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/ResponseSender.cs
@@ -60,7 +60,7 @@ namespace NuGet.Protocol.FuncTest
                 }
             }
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         internal Task SendAsync<TPayload>(MessageType type, MessageMethod method, TPayload payload)
@@ -75,7 +75,7 @@ namespace NuGet.Protocol.FuncTest
 
             _responses.Add(response);
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         private static string Serialize(object value)

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/ConcurrencyUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/ConcurrencyUtilitiesTests.cs
@@ -144,13 +144,13 @@ namespace NuGet.Core.FuncTest
             {
                 action1HitSem.Set();
                 action1Sem.Wait();
-                return Task.FromResult(true);
+                return TaskResult.True;
             };
 
             Func<CancellationToken, Task<bool>> action2 = (ct) =>
             {
                 action2Sem.Set();
-                return Task.FromResult(true);
+                return TaskResult.True;
             };
 
             // Act
@@ -196,13 +196,13 @@ namespace NuGet.Core.FuncTest
             {
                 action1HitSem.Set();
                 action1Sem.Wait();
-                return Task.FromResult(true);
+                return TaskResult.True;
             };
 
             Func<CancellationToken, Task<bool>> action2 = (ct) =>
             {
                 action2Sem.Set();
-                return Task.FromResult(true);
+                return TaskResult.True;
             };
 
             // Act

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -1999,7 +1999,7 @@ namespace NuGet.Test
             public Task<bool> ExecutePackageInitScriptAsync(PackageIdentity packageIdentity, string packageInstallPath, INuGetProjectContext projectContext, bool throwOnFailure, CancellationToken token)
             {
                 ExecuteInitScriptAsyncCalls.Add(packageIdentity);
-                return Task.FromResult(true);
+                return TaskResult.True;
             }
 
             public Task<IEnumerable<LibraryDependency>> GetPackageReferencesAsync(NuGetFramework targetFramework, CancellationToken token)

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/MSBuildNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/MSBuildNuGetProjectTests.cs
@@ -2067,7 +2067,7 @@ namespace ProjectManagement.Test
                 }
 
                 ScriptsExecuted[scriptRelativePath]++;
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             }
 
             public Task<bool> ExecutePackageInitScriptAsync(PackageIdentity packageIdentity, string packageInstallPath, INuGetProjectContext projectContext, bool throwOnFailure, CancellationToken token)

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/TestNuGetProject.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/TestNuGetProject.cs
@@ -54,7 +54,7 @@ namespace NuGet.Test
             INuGetProjectContext nuGetProjectContext,
             CancellationToken token)
         {
-            return Task.FromResult(true);
+            return TaskResult.True;
         }
 
         public override Task<bool> UninstallPackageAsync(PackageIdentity packageIdentity, INuGetProjectContext nuGetProjectContext, CancellationToken token)

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
@@ -255,7 +255,7 @@ namespace NuGet.Protocol.Tests
 
             public override Task<PrimarySignature> GetPrimarySignatureAsync(CancellationToken token)
             {
-                return Task.FromResult<PrimarySignature>(null);
+                return TaskResult.Null<PrimarySignature>();
             }
 
             public override Stream GetStream(string path)

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
@@ -265,7 +265,7 @@ namespace NuGet.Protocol.Tests
 
             public override Task<bool> IsSignedAsync(CancellationToken token)
             {
-                return Task.FromResult(false);
+                return TaskResult.False;
             }
 
             public override Task ValidateIntegrityAsync(SignatureContent signatureContent, CancellationToken token)

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceTests.cs
@@ -41,7 +41,7 @@ namespace NuGet.Protocol.Tests
                 // Act
                 await tc.HttpSource.GetAsync(
                     new HttpSourceCachedRequest(tc.Url, tc.CacheKey, tc.CacheContext),
-                    result => Task.FromResult(true),
+                    result => TaskResult.True,
                     tc.Logger,
                     token: CancellationToken.None);
 
@@ -87,7 +87,7 @@ namespace NuGet.Protocol.Tests
                 // Act
                 await tc.HttpSource.ProcessStreamAsync(
                     new HttpSourceRequest(tc.Url, tc.Logger),
-                    stream => Task.FromResult(true),
+                    stream => TaskResult.True,
                     tc.Logger,
                     token: CancellationToken.None);
 
@@ -108,7 +108,7 @@ namespace NuGet.Protocol.Tests
                 // Act
                 await tc.HttpSource.ProcessResponseAsync(
                     new HttpSourceRequest(tc.Url, tc.Logger),
-                    stream => Task.FromResult(true),
+                    stream => TaskResult.True,
                     tc.Logger,
                     token: CancellationToken.None);
 
@@ -372,7 +372,7 @@ namespace NuGet.Protocol.Tests
                     {
                         EnsureValidContents = tc.GetStreamValidator(validCache: true, validNetwork: false)
                     },
-                    result => Task.FromResult(true),
+                    result => TaskResult.True,
                     tc.Logger,
                     CancellationToken.None));
 
@@ -469,7 +469,7 @@ namespace NuGet.Protocol.Tests
                     {
                         return tc.HttpSource.ProcessStreamAsync(
                             new HttpSourceRequest(tc.Url, tc.Logger),
-                            stream => Task.FromResult(true),
+                            stream => TaskResult.True,
                             tc.Logger,
                             token: CancellationToken.None);
                     }));

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalPackageArchiveDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalPackageArchiveDownloaderTests.cs
@@ -162,7 +162,7 @@ namespace NuGet.Protocol.Tests
                     FileAccess.Write,
                     FileShare.None))
                 {
-                    test.Downloader.SetExceptionHandler(exception => Task.FromResult(true));
+                    test.Downloader.SetExceptionHandler(exception => TaskResult.True);
 
                     var wasCopied = await test.Downloader.CopyNupkgFileToAsync(
                         destinationFilePath,

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/AutomaticProgressReporterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/AutomaticProgressReporterTests.cs
@@ -182,7 +182,7 @@ namespace NuGet.Protocol.Plugins.Tests
                             SentEvent.Set();
                         }
                     })
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 Request = MessageUtilities.Create(
                     requestId: "a",

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/InboundRequestContextTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/InboundRequestContextTests.cs
@@ -126,7 +126,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         x => x.SendAsync(
                             It.Is<Message>(m => m.Type == MessageType.Cancel),
                             It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 var requestHandler = new Mock<IRequestHandler>(MockBehavior.Strict);
 
@@ -140,7 +140,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         {
                             handledEvent.Set();
                         })
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 var request = MessageUtilities.Create(
                     test.RequestId,
@@ -221,7 +221,7 @@ namespace NuGet.Protocol.Plugins.Tests
 
                             sentEvent.Set();
                         })
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 test.Context.BeginFaultAsync(
                     new Message(
@@ -319,7 +319,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         {
                             handledEvent.Set();
                         })
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 test.Context.BeginResponseAsync(
                     new Message(
@@ -365,7 +365,7 @@ namespace NuGet.Protocol.Plugins.Tests
 
                             sentEvent.Set();
                         })
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 test.Context.BeginResponseAsync(
                     new Message(

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/MessageDispatcherTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/MessageDispatcherTests.cs
@@ -85,7 +85,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         {
                             sentEvent.Set();
                         })
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 dispatcher.SetConnection(connection.Object);
 
@@ -131,7 +131,7 @@ namespace NuGet.Protocol.Plugins.Tests
 
                         blockingEvent.Set();
 
-                        return Task.FromResult(0);
+                        return Task.CompletedTask;
                     };
 
                 connection.Raise(x => x.MessageReceived += null, new MessageEventArgs(request));
@@ -174,7 +174,7 @@ namespace NuGet.Protocol.Plugins.Tests
 
                     blockingEvent.Set();
 
-                    return Task.FromResult(0);
+                    return Task.CompletedTask;
                 };
 
                 connection.Raise(x => x.MessageReceived += null, new MessageEventArgs(request));
@@ -836,7 +836,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         {
                             sentEvent.Set();
                         })
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 dispatcher.SetConnection(connection.Object);
 
@@ -883,7 +883,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         {
                             sentEvent.Set();
                         })
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 dispatcher.SetConnection(connection.Object);
 
@@ -929,7 +929,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         {
                             sentEvent.Set();
                         })
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 dispatcher.SetConnection(connection.Object);
 
@@ -1001,7 +1001,7 @@ namespace NuGet.Protocol.Plugins.Tests
 
                         respondingEvent.Wait(cancellationToken);
 
-                        return Task.FromResult(0);
+                        return Task.CompletedTask;
                     }
                 };
 
@@ -1033,7 +1033,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         {
                             sentEvent.Set();
                         })
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 dispatcher.SetConnection(connection.Object);
 
@@ -1078,7 +1078,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 {
                     responseReceived = true;
                     blockingEvent.Set();
-                    return Task.FromResult(0);
+                    return Task.CompletedTask;
                 };
 
                 connection.Raise(x => x.MessageReceived += null, new MessageEventArgs(request));
@@ -1161,7 +1161,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         break;
                 }
 
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             }
 
             public Task<TInbound> SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(MessageMethod method, TOutbound payload, CancellationToken cancellationToken)

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/OutboundRequestContextTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/OutboundRequestContextTests.cs
@@ -97,7 +97,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         {
                             cancelEvent.Set();
                         })
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 test.CancellationTokenSource.Cancel();
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginMulticlientUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginMulticlientUtilitiesTests.cs
@@ -25,7 +25,7 @@ namespace NuGet.Protocol.Plugins.Tests
             var exception = await Assert.ThrowsAsync<ArgumentException>(
                 () => _utilities.DoOncePerPluginLifetimeAsync(
                     key,
-                    () => Task.FromResult(0),
+                    () => Task.CompletedTask,
                     CancellationToken.None));
 
             Assert.Equal("key", exception.ParamName);
@@ -49,7 +49,7 @@ namespace NuGet.Protocol.Plugins.Tests
             await Assert.ThrowsAsync<OperationCanceledException>(
                 () => _utilities.DoOncePerPluginLifetimeAsync(
                     key: "a",
-                    taskFunc: () => Task.FromResult(0),
+                    taskFunc: () => Task.CompletedTask,
                     cancellationToken: new CancellationToken(canceled: true)));
         }
 
@@ -63,7 +63,7 @@ namespace NuGet.Protocol.Plugins.Tests
                     taskFunc: () =>
                     {
                         wasExecuted = true;
-                        return Task.FromResult(0);
+                        return Task.CompletedTask;
                     },
                     cancellationToken: CancellationToken.None);
 
@@ -76,7 +76,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 taskFunc: () =>
                 {
                     wasExecuted = true;
-                    return Task.FromResult(0);
+                    return Task.CompletedTask;
                 },
                 cancellationToken: CancellationToken.None);
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginPackageDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginPackageDownloaderTests.cs
@@ -220,7 +220,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 test.Plugin.SetupGet(x => x.Connection)
                     .Returns(connection.Object);
 
-                test.Downloader.SetExceptionHandler(exception => Task.FromResult(true));
+                test.Downloader.SetExceptionHandler(exception => TaskResult.True);
 
                 var wasCopied = await test.Downloader.CopyNupkgFileToAsync(
                     destinationFilePath,

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginResourceTests.cs
@@ -136,7 +136,7 @@ namespace NuGet.Protocol.Plugins.Tests
                     It.IsNotNull<string>(),
                     It.IsNotNull<Func<Task>>(),
                     It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(0));
+                .Returns(Task.CompletedTask);
 
             var pluginCreationResults = new List<PluginCreationResult>()
                 {
@@ -205,7 +205,7 @@ namespace NuGet.Protocol.Plugins.Tests
                     It.IsNotNull<string>(),
                     It.IsNotNull<Func<Task>>(),
                     It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(0));
+                .Returns(Task.CompletedTask);
 
             var pluginCreationResults = new List<PluginCreationResult>()
                 {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/GetCredentialsRequestHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/GetCredentialsRequestHandlerTests.cs
@@ -168,7 +168,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         It.Is<GetCredentialsResponse>(r => r.ResponseCode == MessageResponseCode.NotFound
                             && r.Username == null && r.Password == null),
                         It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 await provider.HandleResponseAsync(
                     Mock.Of<IConnection>(),
@@ -210,7 +210,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         It.Is<GetCredentialsResponse>(r => r.ResponseCode == MessageResponseCode.NotFound
                             && r.Username == null && r.Password == null),
                         It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 await provider.HandleResponseAsync(
                     Mock.Of<IConnection>(),
@@ -248,7 +248,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         It.Is<GetCredentialsResponse>(r => r.ResponseCode == MessageResponseCode.Success
                             && r.Username == "a" && r.Password == "b"),
                         It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 await provider.HandleResponseAsync(
                     Mock.Of<IConnection>(),
@@ -295,7 +295,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         It.Is<GetCredentialsResponse>(r => r.ResponseCode == MessageResponseCode.Success
                             && r.Username == "a" && r.Password == "b"),
                         It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 await provider.HandleResponseAsync(
                     Mock.Of<IConnection>(),
@@ -327,7 +327,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         It.Is<GetCredentialsResponse>(r => r.ResponseCode == MessageResponseCode.NotFound
                             && r.Username == null && r.Password == null),
                         It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 await provider.HandleResponseAsync(
                     Mock.Of<IConnection>(),
@@ -373,7 +373,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         It.Is<GetCredentialsResponse>(r => r.ResponseCode == MessageResponseCode.NotFound
                             && r.Username == null && r.Password == null),
                         It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 await provider.HandleResponseAsync(
                     Mock.Of<IConnection>(),
@@ -424,7 +424,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         It.Is<GetCredentialsResponse>(r => r.ResponseCode == MessageResponseCode.Success
                             && r.Username == "a" && r.Password == "b"),
                         It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 await provider.HandleResponseAsync(
                     Mock.Of<IConnection>(),
@@ -456,7 +456,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         It.Is<GetCredentialsResponse>(r => r.ResponseCode == MessageResponseCode.NotFound
                             && r.Username == null && r.Password == null),
                         It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 await provider.HandleResponseAsync(
                     Mock.Of<IConnection>(),
@@ -502,7 +502,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         It.Is<GetCredentialsResponse>(r => r.ResponseCode == MessageResponseCode.NotFound
                             && r.Username == null && r.Password == null),
                         It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 await provider.HandleResponseAsync(
                     Mock.Of<IConnection>(),
@@ -534,7 +534,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         It.Is<GetCredentialsResponse>(r => r.ResponseCode == MessageResponseCode.NotFound
                             && r.Username == null && r.Password == null),
                         It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 await provider.HandleResponseAsync(
                     Mock.Of<IConnection>(),

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/GetServiceIndexRequestHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/GetServiceIndexRequestHandlerTests.cs
@@ -157,7 +157,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         It.Is<Message>(r => r == request),
                         It.Is<GetServiceIndexResponse>(r => r.ResponseCode == MessageResponseCode.NotFound),
                         It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 await provider.HandleResponseAsync(
                     Mock.Of<IConnection>(),
@@ -183,7 +183,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         It.Is<Message>(r => r == request),
                         It.Is<GetServiceIndexResponse>(r => r.ResponseCode == MessageResponseCode.NotFound),
                         It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 await provider.HandleResponseAsync(
                     Mock.Of<IConnection>(),
@@ -214,7 +214,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         It.Is<Message>(r => r == request),
                         It.Is<GetServiceIndexResponse>(r => r.ResponseCode == MessageResponseCode.NotFound),
                         It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 await provider.HandleResponseAsync(
                     Mock.Of<IConnection>(),
@@ -263,7 +263,7 @@ namespace NuGet.Protocol.Plugins.Tests
                         It.Is<GetServiceIndexResponse>(r => r.ResponseCode == MessageResponseCode.Success
                             && r.ServiceIndex.ToString(Formatting.None) == serviceIndex.ToString(Formatting.None)),
                         It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.CompletedTask);
 
                 await provider.HandleResponseAsync(
                     Mock.Of<IConnection>(),

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/LogRequestHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/LogRequestHandlerTests.cs
@@ -189,7 +189,7 @@ namespace NuGet.Protocol.Plugins.Tests
                     It.IsNotNull<Message>(),
                     It.IsNotNull<LogResponse>(),
                     It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(0));
+                .Returns(Task.CompletedTask);
 
             await test.Handler.HandleResponseAsync(
                 Mock.Of<IConnection>(),
@@ -250,7 +250,7 @@ namespace NuGet.Protocol.Plugins.Tests
                     It.Is<Message>(message => message == request),
                     It.Is<LogResponse>(response => response.ResponseCode == responseCode),
                     It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(0));
+                .Returns(Task.CompletedTask);
 
             if (expectLog)
             {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/MonitorNuGetProcessExitRequestHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/MonitorNuGetProcessExitRequestHandlerTests.cs
@@ -111,7 +111,7 @@ namespace NuGet.Protocol.Plugins.Tests
                     It.Is<Message>(r => r == request),
                     It.Is<MonitorNuGetProcessExitResponse>(r => r.ResponseCode == MessageResponseCode.NotFound),
                     It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(0));
+                .Returns(Task.CompletedTask);
 
             await _handler.HandleResponseAsync(
                 Mock.Of<IConnection>(),
@@ -130,7 +130,7 @@ namespace NuGet.Protocol.Plugins.Tests
                     It.Is<Message>(r => r == request),
                     It.Is<MonitorNuGetProcessExitResponse>(r => r.ResponseCode == MessageResponseCode.Success),
                     It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(0));
+                .Returns(Task.CompletedTask);
 
             await _handler.HandleResponseAsync(
                 Mock.Of<IConnection>(),

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemotePackageArchiveDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemotePackageArchiveDownloaderTests.cs
@@ -257,7 +257,7 @@ namespace NuGet.Protocol.Tests
 
                 var destinationFilePath = Path.Combine(test.TestDirectory.Path, "a");
 
-                test.Downloader.SetExceptionHandler(exception => Task.FromResult(true));
+                test.Downloader.SetExceptionHandler(exception => TaskResult.True);
 
                 var wasCopied = await test.Downloader.CopyNupkgFileToAsync(
                     destinationFilePath,

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceTests.cs
@@ -596,7 +596,7 @@ namespace NuGet.Protocol.Tests
         private static HttpSource CreateDummyHttpSource()
         {
             var packageSource = new PackageSource("https://unit.test");
-            Task<HttpHandlerResource> messageHandlerFactory() => Task.FromResult<HttpHandlerResource>(null);
+            Task<HttpHandlerResource> messageHandlerFactory() => TaskResult.Null<HttpHandlerResource>();
 
             return new HttpSource(packageSource, messageHandlerFactory, Mock.Of<IThrottle>());
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV2FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV2FindPackageByIdResourceTests.cs
@@ -683,7 +683,7 @@ namespace NuGet.Protocol.Tests
         private static HttpSource CreateDummyHttpSource()
         {
             var packageSource = new PackageSource("https://unit.test");
-            Task<HttpHandlerResource> messageHandlerFactory() => Task.FromResult<HttpHandlerResource>(null);
+            Task<HttpHandlerResource> messageHandlerFactory() => TaskResult.Null<HttpHandlerResource>();
 
             return new HttpSource(packageSource, messageHandlerFactory, Mock.Of<IThrottle>());
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV3FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV3FindPackageByIdResourceTests.cs
@@ -550,7 +550,7 @@ namespace NuGet.Protocol.Tests
         private static HttpSource CreateDummyHttpSource()
         {
             var packageSource = new PackageSource("https://unit.test");
-            Task<HttpHandlerResource> messageHandlerFactory() => Task.FromResult<HttpHandlerResource>(null);
+            Task<HttpHandlerResource> messageHandlerFactory() => TaskResult.Null<HttpHandlerResource>();
 
             return new HttpSource(packageSource, messageHandlerFactory, Mock.Of<IThrottle>());
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Utility/TimeoutUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Utility/TimeoutUtilityTests.cs
@@ -89,7 +89,7 @@ namespace NuGet.Protocol.Tests
             Func<CancellationToken, Task> actionAsync = token =>
             {
                 timeoutToken = token;
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             };
 
             // Act

--- a/test/TestExtensions/TestablePlugin/ResponseReceiver.cs
+++ b/test/TestExtensions/TestablePlugin/ResponseReceiver.cs
@@ -49,7 +49,7 @@ namespace NuGet.Test.TestExtensions.TestablePlugin
                 }
             }
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
+++ b/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
@@ -172,7 +172,6 @@ namespace Test.Utility
 
         public Task<bool> DoesNuGetSupportsAnyProjectAsync()
         {
-            // NOTE cannot use TaskResult.True here because of IVT diamond. This is only test code.
             return Task.FromResult(true);
         }
 

--- a/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
+++ b/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
@@ -172,6 +172,7 @@ namespace Test.Utility
 
         public Task<bool> DoesNuGetSupportsAnyProjectAsync()
         {
+            // NOTE cannot use TaskResult.True here because of IVT diamond. This is only test code.
             return Task.FromResult(true);
         }
 

--- a/test/TestUtilities/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
+++ b/test/TestUtilities/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
@@ -178,7 +178,7 @@ namespace Test.Utility
 
         public Task BeginProcessingAsync()
         {
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public void RegisterProcessedFiles(IEnumerable<string> files)
@@ -200,7 +200,7 @@ namespace Test.Utility
             ProcessedFiles = FilesInProcessing;
             FilesInProcessing = null;
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public void DeleteDirectory(string path, bool recursive)

--- a/test/TestUtilities/Test.Utility/ProjectManagement/TestNuGetProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/ProjectManagement/TestNuGetProjectContext.cs
@@ -114,7 +114,7 @@ namespace Test.Utility
         public override Task OpenFile(string fullPath)
         {
             FilesOpened.Add(fullPath);
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/Signing/SignatureTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SignatureTestUtility.cs
@@ -162,7 +162,7 @@ namespace Test.Utility.Signing
             reader.BaseStream.Seek(offset: metadata.EndOfCentralDirectory, origin: SeekOrigin.Begin);
             SignedPackageArchiveIOUtility.ReadAndWriteUntilPosition(reader, writer, reader.BaseStream.Length);
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         private static List<CentralDirectoryHeaderMetadata> ShiftMetadata(

--- a/test/TestUtilities/Test.Utility/TestLogger.cs
+++ b/test/TestUtilities/Test.Utility/TestLogger.cs
@@ -166,7 +166,7 @@ namespace NuGet.Test.Utility
         {
             Log(level, data);
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public void Log(ILogMessage message)

--- a/test/TestUtilities/Test.Utility/XunitLogger.cs
+++ b/test/TestUtilities/Test.Utility/XunitLogger.cs
@@ -35,6 +35,8 @@ namespace Test.Utility
         public override Task LogAsync(ILogMessage message)
         {
             Log(message);
+
+            // NOTE cannot use TaskResult.True here because of IVT diamond. This is only test code.
             return Task.FromResult(true);
         }
     }

--- a/test/TestUtilities/Test.Utility/XunitLogger.cs
+++ b/test/TestUtilities/Test.Utility/XunitLogger.cs
@@ -36,7 +36,6 @@ namespace Test.Utility
         {
             Log(message);
 
-            // NOTE cannot use TaskResult.True here because of IVT diamond. This is only test code.
             return Task.FromResult(true);
         }
     }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/12659

Regression? Last working version:

## Description

When a `Task` completes successfully, it's `Task` object may be reused.

Currently NuGet.Client allocates a lot of `Task` objects in places where singletons could be used.

This PR addresses that, reducing allocations overall and reducing the overhead of async code.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
