### PR TITLE
Use Microsoft.IO.Redist on .NET Framework

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,6 +54,7 @@
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="$(MicrosoftExtensionsFileProvidersAbstractionsPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(MicrosoftExtensionsFileSystemGlobbingPackageVersion)" />
     <PackageVersion Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="$(VSFrameworkVersion)" />
+    <PackageVersion Include="Microsoft.IO.Redist" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Net.Compilers.netcore" Version="3.0.0-dev-61717-03" />
     <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />

--- a/NuGet.sln
+++ b/NuGet.sln
@@ -11,6 +11,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4A4623E9-CE1F-4DF2-A4C2-513CE8377D2A}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		Directory.Packages.props = Directory.Packages.props
 		build\NuGet.ruleset = build\NuGet.ruleset
 	EndProjectSection
 EndProject

--- a/src/NuGet.Core/NuGet.Common/NuGet.Common.csproj
+++ b/src/NuGet.Core/NuGet.Common/NuGet.Common.csproj
@@ -25,6 +25,10 @@
     <ProjectReference Include="..\NuGet.Frameworks\NuGet.Frameworks.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <PackageReference Include="Microsoft.IO.Redist" />
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Update="Strings.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
@@ -178,7 +178,11 @@ namespace NuGet.Common
         /// </summary>
         public static string GetRelativePath(string path1, string path2)
         {
+#if NETFRAMEWORK
+            return Microsoft.IO.Path.GetRelativePath(relativeTo: path1, path2);
+#else
             return GetRelativePath(path1, path2, Path.DirectorySeparatorChar);
+#endif
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/ArrayPool.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ArrayPool.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if NETSTANDARD2_0
 
 using NuGet;
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Buffers;
 using System.IO;
 using System.IO.MemoryMappedFiles;
 using NuGet.Common;
@@ -24,7 +23,7 @@ namespace NuGet.Packaging
 
 #if NETFRAMEWORK || NETSTANDARD2_0
             const int bufferSize = 81920; // Same as Stream.CopyTo
-            byte[] buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+            byte[] buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(bufferSize);
 
             int bytesRead;
             while ((bytesRead = inputStream.Read(buffer, offset: 0, buffer.Length)) != 0)
@@ -32,7 +31,7 @@ namespace NuGet.Packaging
                 outputStream.Write(buffer, offset: 0, bytesRead);
             }
 
-            ArrayPool<byte>.Shared.Return(buffer);
+            System.Buffers.ArrayPool<byte>.Shared.Return(buffer);
 #else
             inputStream.CopyTo(outputStream);
 #endif

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/PathUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/PathUtilityTests.cs
@@ -9,7 +9,7 @@ namespace NuGet.Common.Test
     public class PathUtilityTests
     {
         [PlatformFact(Platform.Windows)]
-        public void PathUtility_RelativePathDifferenctRootCase()
+        public void PathUtility_RelativePathDifferentRootCase()
         {
             // Arrange & Act
             var path1 = @"C:\foo\";


### PR DESCRIPTION
## Bug

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1826488
Fixes: https://github.com/NuGet/Client.Engineering/issues/2315

Regression? Last working version: N/A

## Description

This package providers lower allocation versions of several Path and Directory methods, including overloads that accept `ReadOnlySpan<char>` in many cases.

This change uses `Microsoft.IO.Path.GetRelativePath` in the `PathUtility.GetRelativePath` method on .NET Framework to help reduce allocations in Visual Studio.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
