### PR TITLE
Avoid allocating boxed List<T> enumerators

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -194,7 +194,7 @@ namespace NuGet.Commands
             string runtimeIdentifier,
             ContentItemCollection contentItems,
             NuspecReader nuspec,
-            IReadOnlyList<SelectionCriteria> orderedCriteria)
+            List<SelectionCriteria> orderedCriteria)
         {
             // Add framework references for desktop projects.
             AddFrameworkReferences(lockFileLib, framework, nuspec);
@@ -267,7 +267,7 @@ namespace NuGet.Commands
             string libraryName,
             ManagedCodeConventions managedCodeConventions,
             LockFileTargetLibrary lockFileLib,
-            IReadOnlyList<SelectionCriteria> orderedCriteria,
+            List<SelectionCriteria> orderedCriteria,
             ContentItemCollection contentItems)
         {
             // Build Transitive
@@ -305,7 +305,7 @@ namespace NuGet.Commands
             ManagedCodeConventions managedCodeConventions,
             LockFileTargetLibrary lockFileLib,
             ContentItemCollection contentItems,
-            IReadOnlyList<SelectionCriteria> orderedCriteria)
+            List<SelectionCriteria> orderedCriteria)
         {
             var toolsGroup = GetLockFileItems(
                 orderedCriteria,
@@ -675,7 +675,7 @@ namespace NuGet.Commands
         /// </summary>
         /// <remarks>Enumerate this once after calling.</remarks>
         private static IEnumerable<LockFileItem> GetLockFileItems(
-            IReadOnlyList<SelectionCriteria> criteria,
+            List<SelectionCriteria> criteria,
             ContentItemCollection items,
             Action<LockFileItem> additionalAction,
             params PatternSet[] patterns)
@@ -718,7 +718,7 @@ namespace NuGet.Commands
         /// </summary>
         /// <remarks>Enumerate this once after calling.</remarks>
         private static IEnumerable<LockFileItem> GetLockFileItems(
-            IReadOnlyList<SelectionCriteria> criteria,
+            List<SelectionCriteria> criteria,
             ContentItemCollection items,
             params PatternSet[] patterns)
         {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -288,7 +288,7 @@ namespace NuGet.Commands
             return packageFiles;
         }
 
-        private static IEnumerable<string> GetPackageFiles(LocalPackageFileCache packageFileCache, string packageId, NuGetVersion version, IEnumerable<VersionFolderPathResolver> resolvers)
+        private static IEnumerable<string> GetPackageFiles(LocalPackageFileCache packageFileCache, string packageId, NuGetVersion version, List<VersionFolderPathResolver> resolvers)
         {
             foreach (var resolver in resolvers)
             {


### PR DESCRIPTION
## Bug

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1837292
Fixes: https://github.com/NuGet/Home/issues/12684

Regression? Last working version: N/A

## Description

By passing the concrete `List<T>` type to `foreach`, the `struct` enumerator will be used on the stack. If calling through the interface `IEnumerable<T>` instead, the enumerator must be boxed resulting in a heap allocation.

This reduces GC pressure and improves performance.

All these methods are private, so there's nothing gained by using the interface as an abstraction.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
