### PR TITLE
Specify SelectionCriteria list capacity correctly

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -784,7 +784,7 @@ namespace NuGet.Commands
             NuGetFramework framework,
             string runtimeIdentifier)
         {
-            var managedCriteria = new List<SelectionCriteria>(1);
+            List<SelectionCriteria> managedCriteria;
 
             var fallbackFramework = framework as FallbackFramework;
 
@@ -797,7 +797,10 @@ namespace NuGet.Commands
                     framework,
                     runtimeIdentifier);
 
-                managedCriteria.Add(standardCriteria);
+                managedCriteria = new(capacity: 1)
+                {
+                    standardCriteria
+                };
             }
             else
             {
@@ -807,7 +810,10 @@ namespace NuGet.Commands
                     primaryFramework,
                     runtimeIdentifier);
 
-                managedCriteria.Add(primaryCriteria);
+                managedCriteria = new(capacity: 1 + fallbackFramework.Fallback.Count)
+                {
+                    primaryCriteria
+                };
 
                 // Add each fallback framework in order
                 foreach (var fallback in fallbackFramework.Fallback)


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/12667
Relates to: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1837292

Regression? Last working version:

## Description

Previously the capacity could incorrectly be set to 1. This change ensures the list capacity is always set correctly, which avoids having to grow the backing collection and avoids all redundant allocations in this method.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
