### PR TITLE
Enable non-allocating enumeration via collection interfaces

### DIFF
--- a/build/Shared/NoAllocEnumerateExtensions.cs
+++ b/build/Shared/NoAllocEnumerateExtensions.cs
@@ -1,0 +1,407 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet;
+
+internal static class NoAllocEnumerateExtensions
+{
+    #region IList
+
+    /// <summary>
+    /// Avoids allocating an enumerator when enumerating an <see cref="IList{T}"/> where the concrete type
+    /// has a well known struct enumerator, such as for <see cref="List{T}"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Several collection types (e.g. <see cref="List{T}"/>) provide a struct-based enumerator type
+    /// (e.g. <see cref="List{T}.Enumerator"/>) which the compiler can use in <see langword="foreach" /> statements.
+    /// When using a struct-based enumerator, no heap allocation occurs during such enumeration.
+    /// This is in contrast to the interface-based enumerator <see cref="IEnumerator{T}"/> which will
+    /// always be allocated on the heap.
+    /// </para>
+    /// <para>
+    /// This method returns a custom struct enumerator that will avoid any heap allocation if <paramref name="list"/>
+    /// (which is declared via interface <see cref="IList{T}"/>) is actually of known concrete type that
+    /// provides its own struct enumerator. If so, it delegates to that type's enumerator without any boxing
+    /// or other heap allocation.
+    /// </para>
+    /// <para>
+    /// If <paramref name="list"/> is not of a known concrete type, the returned enumerator falls back to the
+    /// interface-based enumerator, which will be allocated on the heap. Benchmarking shows the overhead in
+    /// such cases is low enough to be within the measurement error, meaning this is an inexpensive optimization
+    /// that won't regress behavior and with low downside for cases where it cannot apply an optimization.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// <![CDATA[IList<string> list = ...;
+    ///
+    /// foreach (string item in list.NoAllocEnumerate())
+    /// {
+    ///     // ...
+    /// }]]>
+    /// </code>
+    /// </example>
+    public static OptimisticallyNonAllocatingListEnumerable<T> NoAllocEnumerate<T>(this IList<T> list)
+        where T : notnull
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        return new(list);
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
+
+    /// <summary>
+    /// Provides a struct-based enumerator for use with <see cref="IList{T}"/>.
+    /// Do not use this type directly. Use <see cref="NoAllocEnumerate{T}(IList{T})"/> instead.
+    /// </summary>
+    public readonly ref struct OptimisticallyNonAllocatingListEnumerable<T>
+        where T : notnull
+    {
+        private readonly IList<T> _list;
+
+        [Obsolete("Do not construct directly. Use internal static method NoAllocEnumerateExtensions.NoAllocEnumerate instead.")]
+        internal OptimisticallyNonAllocatingListEnumerable(IList<T> list) => _list = list;
+
+        public Enumerator GetEnumerator() => new(_list);
+
+        /// <summary>
+        /// A struct-based enumerator for use with <see cref="IList{T}"/>.
+        /// Do not use this type directly. Use <see cref="NoAllocEnumerate{T}(IList{T})"/> instead.
+        /// </summary>
+        public struct Enumerator : IDisposable
+        {
+            private readonly int _enumeratorType;
+            private readonly IEnumerator<T>? _fallbackEnumerator;
+            private List<T>.Enumerator _concreteEnumerator;
+
+            internal Enumerator(IList<T> list)
+            {
+                _concreteEnumerator = default;
+                _fallbackEnumerator = null;
+
+                if (list.Count == 0)
+                {
+                    // The collection is empty, just return false from MoveNext.
+                    _enumeratorType = 100;
+                }
+                else if (list is List<T> concrete)
+                {
+                    _enumeratorType = 0;
+                    _concreteEnumerator = concrete.GetEnumerator();
+                }
+                else
+                {
+                    _enumeratorType = 99;
+                    _fallbackEnumerator = list.GetEnumerator();
+                }
+            }
+
+            public T Current
+            {
+                get
+                {
+                    return _enumeratorType switch
+                    {
+                        0 => _concreteEnumerator.Current,
+                        99 => _fallbackEnumerator!.Current,
+                        _ => default!,
+                    };
+                }
+            }
+
+            public bool MoveNext()
+            {
+                return _enumeratorType switch
+                {
+                    0 => _concreteEnumerator.MoveNext(),
+                    99 => _fallbackEnumerator!.MoveNext(),
+                    _ => false,
+                };
+            }
+
+            public void Dispose()
+            {
+                switch (_enumeratorType)
+                {
+                    case 0:
+                        _concreteEnumerator.Dispose();
+                        break;
+                    case 99:
+                        _fallbackEnumerator!.Dispose();
+                        break;
+                }
+            }
+        }
+    }
+
+    #endregion
+
+    #region IEnumerable
+
+    /// <summary>
+    /// Avoids allocating an enumerator when enumerating an <see cref="IEnumerable{T}"/> where the concrete type
+    /// has a well known struct enumerator, such as for <see cref="List{T}"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Several collection types (e.g. <see cref="List{T}"/>) provide a struct-based enumerator type
+    /// (e.g. <see cref="List{T}.Enumerator"/>) which the compiler can use in <see langword="foreach" /> statements.
+    /// When using a struct-based enumerator, no heap allocation occurs during such enumeration.
+    /// This is in contrast to the interface-based enumerator <see cref="IEnumerator{T}"/> which will
+    /// always be allocated on the heap.
+    /// </para>
+    /// <para>
+    /// This method returns a custom struct enumerator that will avoid any heap allocation if <paramref name="source"/>
+    /// (which is declared via interface <see cref="IEnumerable{T}"/>) is actually of known concrete type that
+    /// provides its own struct enumerator. If so, it delegates to that type's enumerator without any boxing
+    /// or other heap allocation.
+    /// </para>
+    /// <para>
+    /// If <paramref name="source"/> is not of a known concrete type, the returned enumerator falls back to the
+    /// interface-based enumerator, which will be allocated on the heap. Benchmarking shows the overhead in
+    /// such cases is low enough to be within the measurement error, meaning this is an inexpensive optimization
+    /// that won't regress behavior and with low downside for cases where it cannot apply an optimization.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// <![CDATA[IEnumerable<string> source = ...;
+    ///
+    /// foreach (string item in source.NoAllocEnumerate())
+    /// {
+    ///     // ...
+    /// }]]>
+    /// </code>
+    /// </example>
+    public static OptimisticallyNonAllocatingEnumerable<T> NoAllocEnumerate<T>(this IEnumerable<T> source)
+        where T : notnull
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        return new(source);
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
+
+    /// <summary>
+    /// Provides a struct-based enumerator for use with <see cref="IEnumerable{T}"/>.
+    /// Do not use this type directly. Use <see cref="NoAllocEnumerate{T}(IEnumerable{T})"/> instead.
+    /// </summary>
+    public readonly ref struct OptimisticallyNonAllocatingEnumerable<T>
+        where T : notnull
+    {
+        private readonly IEnumerable<T> _source;
+
+        [Obsolete("Do not construct directly. Use internal static method NoAllocEnumerateExtensions.NoAllocEnumerate instead.")]
+        internal OptimisticallyNonAllocatingEnumerable(IEnumerable<T> source) => _source = source;
+
+        public Enumerator GetEnumerator() => new(_source);
+
+        /// <summary>
+        /// A struct-based enumerator for use with <see cref="IEnumerable{T}"/>.
+        /// Do not use this type directly. Use <see cref="NoAllocEnumerate{T}(IEnumerable{T})"/> instead.
+        /// </summary>
+        public struct Enumerator : IDisposable
+        {
+            private readonly int _enumeratorType;
+            private readonly IEnumerator<T>? _fallbackEnumerator;
+            private List<T>.Enumerator _concreteEnumerator;
+
+            internal Enumerator(IEnumerable<T> source)
+            {
+                _concreteEnumerator = default;
+                _fallbackEnumerator = null;
+
+                if (source is ICollection<T> { Count: 0 } or IReadOnlyCollection<T> { Count: 0 })
+                {
+                    // The collection is empty, just return false from MoveNext.
+                    _enumeratorType = 100;
+                }
+                else if (source is List<T> concrete)
+                {
+                    _enumeratorType = 0;
+                    _concreteEnumerator = concrete.GetEnumerator();
+                }
+                else
+                {
+                    _enumeratorType = 99;
+                    _fallbackEnumerator = source.GetEnumerator();
+                }
+            }
+
+            public T Current
+            {
+                get
+                {
+                    return _enumeratorType switch
+                    {
+                        0 => _concreteEnumerator.Current,
+                        99 => _fallbackEnumerator!.Current,
+                        _ => default!,
+                    };
+                }
+            }
+
+            public bool MoveNext()
+            {
+                return _enumeratorType switch
+                {
+                    0 => _concreteEnumerator.MoveNext(),
+                    99 => _fallbackEnumerator!.MoveNext(),
+                    _ => false,
+                };
+            }
+
+            public void Dispose()
+            {
+                switch (_enumeratorType)
+                {
+                    case 0:
+                        _concreteEnumerator.Dispose();
+                        break;
+                    case 99:
+                        _fallbackEnumerator!.Dispose();
+                        break;
+                }
+            }
+        }
+    }
+
+    #endregion
+
+    #region IDictionary
+
+    /// <summary>
+    /// Avoids allocating an enumerator when enumerating an <see cref="IDictionary{TKey,TValue}"/> where the concrete type
+    /// has a well known struct enumerator, such as for <see cref="Dictionary{TKey,TValue}"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Several collection types (e.g. <see cref="Dictionary{TKey,TValue}"/>) provide a struct-based enumerator type
+    /// (e.g. <see cref="Dictionary{TKey,TValue}.Enumerator"/>) which the compiler can use in <see langword="foreach" /> statements.
+    /// When using a struct-based enumerator, no heap allocation occurs during such enumeration.
+    /// This is in contrast to the interface-based enumerator <see cref="IEnumerator{T}"/> which will
+    /// always be allocated on the heap.
+    /// </para>
+    /// <para>
+    /// This method returns a custom struct enumerator that will avoid any heap allocation if <paramref name="dictionary"/>
+    /// (which is declared via interface <see cref="IEnumerable{T}"/>) is actually of known concrete type that
+    /// provides its own struct enumerator. If so, it delegates to that type's enumerator without any boxing
+    /// or other heap allocation.
+    /// </para>
+    /// <para>
+    /// If <paramref name="dictionary"/> is not of a known concrete type, the returned enumerator falls back to the
+    /// interface-based enumerator, which will be allocated on the heap. Benchmarking shows the overhead in
+    /// such cases is low enough to be within the measurement error, meaning this is an inexpensive optimization
+    /// that won't regress behavior and with low downside for cases where it cannot apply an optimization.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// <![CDATA[IDictionary<string, string> dictionary = ...;
+    ///
+    /// foreach ((string key, string value) in dictionary.NoAllocEnumerate())
+    /// {
+    ///     // ...
+    /// }]]>
+    /// </code>
+    /// </example>
+    public static OptimisticallyNonAllocatingDictionaryEnumerable<TKey, TValue> NoAllocEnumerate<TKey, TValue>(this IDictionary<TKey, TValue> dictionary)
+        where TKey : notnull
+        where TValue : notnull
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        return new(dictionary);
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
+
+    /// <summary>
+    /// Provides a struct-based enumerator for use with <see cref="IDictionary{TKey,TValue}"/>.
+    /// Do not use this type directly. Use <see cref="NoAllocEnumerate{TKey, TValue}(IDictionary{TKey, TValue})"/> instead.
+    /// </summary>
+    public readonly ref struct OptimisticallyNonAllocatingDictionaryEnumerable<TKey, TValue>
+        where TKey : notnull
+        where TValue : notnull
+    {
+        private readonly IDictionary<TKey, TValue> _dictionary;
+
+        [Obsolete("Do not construct directly. Use internal static method NoAllocEnumerateExtensions.NoAllocEnumerate instead.")]
+        internal OptimisticallyNonAllocatingDictionaryEnumerable(IDictionary<TKey, TValue> dictionary) => _dictionary = dictionary;
+
+        public Enumerator GetEnumerator() => new(_dictionary);
+
+        /// <summary>
+        /// A struct-based enumerator for use with <see cref="IEnumerable{T}"/>.
+        /// Do not use this type directly. Use <see cref="NoAllocEnumerate{TKey, TValue}(IDictionary{TKey, TValue})"/> instead.
+        /// </summary>
+        public struct Enumerator : IDisposable
+        {
+            private readonly int _enumeratorType;
+            private readonly IEnumerator<KeyValuePair<TKey, TValue>>? _fallbackEnumerator;
+            private Dictionary<TKey, TValue>.Enumerator _concreteEnumerator;
+
+            internal Enumerator(IDictionary<TKey, TValue> dictionary)
+            {
+                _concreteEnumerator = default;
+                _fallbackEnumerator = null;
+
+                if (dictionary.Count == 0)
+                {
+                    // The collection is empty, just return false from MoveNext.
+                    _enumeratorType = 100;
+                }
+                else if (dictionary is Dictionary<TKey, TValue> concrete)
+                {
+                    _enumeratorType = 0;
+                    _concreteEnumerator = concrete.GetEnumerator();
+                }
+                else
+                {
+                    _enumeratorType = 99;
+                    _fallbackEnumerator = dictionary.GetEnumerator();
+                }
+            }
+
+            public KeyValuePair<TKey, TValue> Current
+            {
+                get
+                {
+                    return _enumeratorType switch
+                    {
+                        0 => _concreteEnumerator.Current,
+                        99 => _fallbackEnumerator!.Current,
+                        _ => default!,
+                    };
+                }
+            }
+
+            public bool MoveNext()
+            {
+                return _enumeratorType switch
+                {
+                    0 => _concreteEnumerator.MoveNext(),
+                    99 => _fallbackEnumerator!.MoveNext(),
+                    _ => false,
+                };
+            }
+
+            public void Dispose()
+            {
+                switch (_enumeratorType)
+                {
+                    case 0:
+                        _concreteEnumerator.Dispose();
+                        break;
+                    case 99:
+                        _fallbackEnumerator!.Dispose();
+                        break;
+                }
+            }
+        }
+    }
+
+    #endregion
+}

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/ContentFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/ContentFileUtils.cs
@@ -88,7 +88,7 @@ namespace NuGet.Commands
             {
                 var codeLanguage = group.Properties[ManagedCodeConventions.PropertyNames.CodeLanguage] as string;
 
-                foreach (var item in group.Items)
+                foreach (var item in group.Items.NoAllocEnumerate())
                 {
                     if (!entryMappings.ContainsKey(item.Path))
                     {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -689,7 +689,7 @@ namespace NuGet.Commands
 
                 if (group != null)
                 {
-                    foreach (var item in group.Items)
+                    foreach (var item in group.Items.NoAllocEnumerate())
                     {
                         var newItem = new LockFileItem(item.Path);
                         object locale;
@@ -975,7 +975,7 @@ namespace NuGet.Commands
                 var rid = (string)group.Properties[ManagedCodeConventions.PropertyNames.RuntimeIdentifier];
 
                 // Create lock file entries for each assembly.
-                foreach (var item in group.Items)
+                foreach (var item in group.Items.NoAllocEnumerate())
                 {
                     results.Add(new LockFileRuntimeTarget(item.Path)
                     {

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -838,7 +838,7 @@ namespace NuGet.Packaging
                 ContentExtractor.GetContentForPattern(collection, pattern, targetedItemGroups);
                 foreach (ContentItemGroup group in targetedItemGroups)
                 {
-                    foreach (ContentItem item in group.Items)
+                    foreach (ContentItem item in group.Items.NoAllocEnumerate())
                     {
                         var framework = (NuGetFramework)item.Properties["tfm"];
                         if (framework == null)

--- a/src/NuGet.Core/NuGet.Packaging/Rules/InvalidUndottedFrameworkRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/InvalidUndottedFrameworkRule.cs
@@ -227,7 +227,7 @@ namespace NuGet.Packaging.Rules
                 ContentExtractor.GetContentForPattern(collection, pattern, targetedItemGroups);
                 foreach (ContentItemGroup group in targetedItemGroups)
                 {
-                    foreach (ContentItem item in group.Items)
+                    foreach (ContentItem item in group.Items.NoAllocEnumerate())
                     {
                         var exists = item.Properties.TryGetValue("tfm_raw", out var frameworkRaw);
                         string frameworkString = (string)frameworkRaw;

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/NoAllocEnumerateExtensionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/NoAllocEnumerateExtensionsTests.cs
@@ -1,0 +1,226 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Xunit;
+
+namespace NuGet.Common.Test;
+
+public class NoAllocEnumerateExtensionsTests
+{
+    #region IEnumerable
+
+    [Fact]
+    public void NoAllocEnumerate_IEnumerable_List()
+    {
+        ValidateIEnumerable(new List<int> { 0, 1, 2, 3 });
+    }
+
+    [Fact]
+    public void NoAllocEnumerate_IEnumerable_ImmutableList()
+    {
+        ValidateIEnumerable(ImmutableList.Create(0, 1, 2, 3));
+    }
+
+    [Fact]
+    public void NoAllocEnumerate_IEnumerable_ImmutableArray()
+    {
+        ValidateIEnumerable(ImmutableArray.Create(0, 1, 2, 3));
+    }
+
+    [Fact]
+    public void NoAllocEnumerate_IEnumerable_Fallback()
+    {
+        int[] array = { 0, 1, 2, 3 };
+
+        var mock = new Mock<IEnumerable<int>>(MockBehavior.Strict);
+
+        mock.Setup(o => o.GetEnumerator())
+            .Returns(((IEnumerable<int>)array).GetEnumerator());
+
+        ValidateIEnumerable(mock.Object);
+
+        mock.Verify();
+    }
+
+    [Fact]
+    public void NoAllocEnumerate_IEnumerable_ICollection_OptimizedForEmpty()
+    {
+        var mock = new Mock<ICollection<int>>(MockBehavior.Strict);
+
+        mock.SetupGet(o => o.Count).Returns(0);
+
+        // NOTE because the source is empty, GetEnumerator should not be called at all.
+
+        foreach (int i in mock.Object.NoAllocEnumerate())
+        {
+
+        }
+
+        mock.Verify();
+    }
+
+    private static void ValidateIEnumerable(IEnumerable<int> collection)
+    {
+        List<int> actual = new();
+
+        foreach (var item in collection.NoAllocEnumerate())
+        {
+            actual.Add(item);
+        }
+
+        Assert.Equal(4, actual.Count);
+        Assert.Equal(0, actual[0]);
+        Assert.Equal(1, actual[1]);
+        Assert.Equal(2, actual[2]);
+        Assert.Equal(3, actual[3]);
+    }
+
+    #endregion
+
+    #region IList
+
+    [Fact]
+    public void NoAllocEnumerate_IList_List()
+    {
+        ValidateIList(new List<int> { 0, 1, 2, 3 });
+    }
+
+    [Fact]
+    public void NoAllocEnumerate_IList_ImmutableList()
+    {
+        ValidateIList(ImmutableList.Create(0, 1, 2, 3));
+    }
+
+    [Fact]
+    public void NoAllocEnumerate_IList_ImmutableArray()
+    {
+        ValidateIList(ImmutableArray.Create(0, 1, 2, 3));
+    }
+
+    [Fact]
+    public void NoAllocEnumerate_IList_Fallback()
+    {
+        int[] array = { 0, 1, 2, 3 };
+
+        Mock<IList<int>> mock = new(MockBehavior.Strict);
+
+        mock.SetupGet(o => o.Count)
+            .Returns(array.Length);
+        mock.Setup(o => o.GetEnumerator())
+            .Returns(((IEnumerable<int>)array).GetEnumerator());
+
+        ValidateIList(mock.Object);
+
+        mock.Verify();
+    }
+
+    [Fact]
+    public void NoAllocEnumerate_IList_OptimizedForEmpty()
+    {
+        Mock<IList<int>> mock = new(MockBehavior.Strict);
+
+        mock.SetupGet(o => o.Count).Returns(0);
+
+        // NOTE because the source is empty, GetEnumerator should not be called at all.
+
+        foreach (int i in mock.Object.NoAllocEnumerate())
+        {
+
+        }
+
+        mock.Verify();
+    }
+
+    private static void ValidateIList(IList<int> collection)
+    {
+        List<int> actual = new();
+
+        foreach (var item in collection.NoAllocEnumerate())
+        {
+            actual.Add(item);
+        }
+
+        Assert.Equal(4, actual.Count);
+        Assert.Equal(0, actual[0]);
+        Assert.Equal(1, actual[1]);
+        Assert.Equal(2, actual[2]);
+        Assert.Equal(3, actual[3]);
+    }
+
+    #endregion
+
+    #region IDictionary
+
+    [Fact]
+    public void NoAllocEnumerate_IDictionary_Dictionary()
+    {
+        ValidateIDictionary(new Dictionary<int, int>() { [0] = 0, [1] = 1, [2] = 2, [3] = 3 });
+    }
+
+    [Fact]
+    public void NoAllocEnumerate_IDictionary_ImmutableDictionary()
+    {
+        ValidateIDictionary(ImmutableDictionary<int, int>.Empty.Add(0, 0).Add(1, 1).Add(2, 2).Add(3, 3));
+    }
+
+    [Fact]
+    public void NoAllocEnumerate_IDictionary_Fallback()
+    {
+        KeyValuePair<int, int>[] array =
+        {
+            new KeyValuePair<int, int>(0, 0),
+            new KeyValuePair<int, int>(1, 1),
+            new KeyValuePair<int, int>(2, 2),
+            new KeyValuePair<int, int>(3, 3)
+        };
+
+        Mock<IDictionary<int, int>> mock = new(MockBehavior.Strict);
+
+        mock.SetupGet(o => o.Count)
+            .Returns(array.Length);
+        mock.Setup(o => o.GetEnumerator())
+            .Returns(((IEnumerable<KeyValuePair<int, int>>)array).GetEnumerator());
+
+        ValidateIDictionary(mock.Object);
+
+        mock.Verify();
+    }
+
+    [Fact]
+    public void NoAllocEnumerate_IDictionary_OptimizedForEmpty()
+    {
+        Mock<IList<int>> mock = new(MockBehavior.Strict);
+
+        mock.SetupGet(o => o.Count).Returns(0);
+
+        // NOTE because the source is empty, GetEnumerator should not be called at all.
+
+        foreach (int i in mock.Object.NoAllocEnumerate())
+        {
+
+        }
+
+        mock.Verify();
+    }
+
+    private static void ValidateIDictionary(IDictionary<int, int> dictionary)
+    {
+        var actual = new List<KeyValuePair<int, int>>();
+
+        foreach (var pair in dictionary.NoAllocEnumerate())
+        {
+            actual.Add(pair);
+        }
+
+        Assert.Equal(4, actual.Count);
+        Assert.Equal(new KeyValuePair<int, int>(0, 0), actual[0]);
+        Assert.Equal(new KeyValuePair<int, int>(1, 1), actual[1]);
+        Assert.Equal(new KeyValuePair<int, int>(2, 2), actual[2]);
+        Assert.Equal(new KeyValuePair<int, int>(3, 3), actual[3]);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/12679

Regression? Last working version: N/A

## Description

Interfaces like `IEnumerable<T>`, `IList<T>` and `IDictionary<TKey, TValue>` are used in many APIs. The upside of this is that the implementation of these APIs may change the concrete type of the collection as it sees fit without breaking consumers. The downside of this is that some operations through the interface are more expensive than if they were performed directly on the concrete type. Enumeration is perhaps the biggest challege here, as enumerating through these interfaces with `foreach` always requires a heap allocation.

Most concrete implementations these implementations will be types such as `List<T>` and `Dictionary<TKey,TValue>` which have a non-allocating struct enumerators.

Specifically:

```c#
List<int> list = new();
IList<int> ilist = list;

foreach (int i in list) {} // does not allocate
foreach (int i in ilist) {} // ❌ allocates a boxed enumerator
```

This change adds `NoAllocEnumerate()` extension methods that avoid any enumerator allocation when the concrete collection type is known to have such a struct enumerator at runtime.

```c#
List<int> list = new();
IList<int> ilist = list;

foreach (int i in list) {} // does not allocate
foreach (int i in ilist.NoAllocEnumerate()) {} // ✅ does not allocate
```

Note that this pattern can be extended to other commonly enumerated types that have struct enumerators. Here it's specialized for `IEnumerable<T>`, `IList<T>` and `IDictionary<TKey,TValue>` in order to limit the number of struct enumerators needed on the structs themselves. It seems like NuGet.Client mostly uses `List<T>` and `Dictionary<TKey,TValue>` (as opposed to other collections like `ImmutableArray<T>`, `ImmutableList<T>`, `ImmutableDictionary<TKey,TValue>`, etc.). The list of supported types can be extended as investigations and investment in this area continue.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
