### PR TITLE
Obsolete Clone methods on immutable types

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkRuntimePair.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkRuntimePair.cs
@@ -7,7 +7,10 @@ using NuGet.Shared;
 
 namespace NuGet.Frameworks
 {
-    public class FrameworkRuntimePair : IEquatable<FrameworkRuntimePair>, IComparable<FrameworkRuntimePair>
+    /// <remarks>
+    /// Immutable.
+    /// </remarks>
+    public sealed class FrameworkRuntimePair : IEquatable<FrameworkRuntimePair>, IComparable<FrameworkRuntimePair>
     {
         public NuGetFramework Framework { get; }
 
@@ -48,9 +51,10 @@ namespace NuGet.Frameworks
                 RuntimeIdentifier);
         }
 
+        [Obsolete("This type is immutable, so there is no need or point to clone it.")]
         public FrameworkRuntimePair Clone()
         {
-            return new FrameworkRuntimePair(Framework, RuntimeIdentifier);
+            return this;
         }
 
         public int CompareTo(FrameworkRuntimePair? other)

--- a/src/NuGet.Core/NuGet.LibraryModel/DownloadDependency.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/DownloadDependency.cs
@@ -8,7 +8,10 @@ using NuGet.Versioning;
 
 namespace NuGet.LibraryModel
 {
-    public class DownloadDependency : IEquatable<DownloadDependency>, IComparable<DownloadDependency>
+    /// <remarks>
+    /// Immutable.
+    /// </remarks>
+    public sealed class DownloadDependency : IEquatable<DownloadDependency>, IComparable<DownloadDependency>
     {
         public string Name { get; }
 
@@ -100,9 +103,10 @@ namespace NuGet.LibraryModel
                    EqualityUtility.EqualsWithNullCheck(VersionRange, other.VersionRange);
         }
 
+        [Obsolete("This type is immutable, so there is no need or point to clone it.")]
         public DownloadDependency Clone()
         {
-            return new DownloadDependency(Name, VersionRange);
+            return this;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/CompatibilityProfile.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/CompatibilityProfile.cs
@@ -53,7 +53,7 @@ namespace NuGet.RuntimeModel
 
         public CompatibilityProfile Clone()
         {
-            return new CompatibilityProfile(Name, RestoreContexts.Select(e => e.Clone()));
+            return new CompatibilityProfile(Name, RestoreContexts.ToList());
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimeDependencySet.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimeDependencySet.cs
@@ -9,7 +9,10 @@ using NuGet.Shared;
 
 namespace NuGet.RuntimeModel
 {
-    public class RuntimeDependencySet : IEquatable<RuntimeDependencySet>
+    /// <remarks>
+    /// Immutable.
+    /// </remarks>
+    public sealed class RuntimeDependencySet : IEquatable<RuntimeDependencySet>
     {
         /// <summary>
         /// Package Id
@@ -61,9 +64,10 @@ namespace NuGet.RuntimeModel
             return combiner.CombinedHash;
         }
 
+        [Obsolete("This type is immutable, so there is no need or point to clone it.")]
         public RuntimeDependencySet Clone()
         {
-            return new RuntimeDependencySet(Id, Dependencies.Values.Select(d => d.Clone()));
+            return this;
         }
 
         public override string ToString()

--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimeDescription.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimeDescription.cs
@@ -8,13 +8,17 @@ using NuGet.Shared;
 
 namespace NuGet.RuntimeModel
 {
-    public class RuntimeDescription : IEquatable<RuntimeDescription>
+    /// <remarks>
+    /// Immutable.
+    /// </remarks>
+    public sealed class RuntimeDescription : IEquatable<RuntimeDescription>
     {
         public string RuntimeIdentifier { get; }
+
         public IReadOnlyList<string> InheritedRuntimes { get; }
 
         /// <summary>
-        /// RID specific package dependencies.
+        /// RID specific package dependencies, keyed by <see cref="RuntimeDependencySet.Id"/>.
         /// </summary>
         public IReadOnlyDictionary<string, RuntimeDependencySet> RuntimeDependencySets { get; }
 
@@ -57,9 +61,10 @@ namespace NuGet.RuntimeModel
                 && RuntimeDependencySets.OrderedEquals(other.RuntimeDependencySets, p => p.Key, StringComparer.OrdinalIgnoreCase);
         }
 
+        [Obsolete("This type is immutable, so there is no need or point to clone it.")]
         public RuntimeDescription Clone()
         {
-            return new RuntimeDescription(RuntimeIdentifier, InheritedRuntimes, RuntimeDependencySets.Values.Select(d => d.Clone()));
+            return this;
         }
 
         /// <summary>
@@ -92,13 +97,13 @@ namespace NuGet.RuntimeModel
             var newSets = new Dictionary<string, RuntimeDependencySet>();
             foreach (var dependencySet in left.RuntimeDependencySets.Values)
             {
-                newSets[dependencySet.Id] = dependencySet.Clone();
+                newSets[dependencySet.Id] = dependencySet;
             }
 
             // Overwrite with things from the right
             foreach (var dependencySet in right.RuntimeDependencySets.Values)
             {
-                newSets[dependencySet.Id] = dependencySet.Clone();
+                newSets[dependencySet.Id] = dependencySet;
             }
 
             return new RuntimeDescription(left.RuntimeIdentifier, inheritedRuntimes, newSets.Values);

--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimeGraph.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimeGraph.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using NuGet.Shared;
 
@@ -50,15 +49,15 @@ namespace NuGet.RuntimeModel
         {
         }
 
-        private RuntimeGraph(Dictionary<string, RuntimeDescription> runtimes, Dictionary<string, CompatibilityProfile> supports)
+        private RuntimeGraph(IReadOnlyDictionary<string, RuntimeDescription> runtimes, IReadOnlyDictionary<string, CompatibilityProfile> supports)
         {
-            Runtimes = new ReadOnlyDictionary<string, RuntimeDescription>(runtimes);
-            Supports = new ReadOnlyDictionary<string, CompatibilityProfile>(supports);
+            Runtimes = runtimes;
+            Supports = supports;
         }
 
         public RuntimeGraph Clone()
         {
-            return new RuntimeGraph(Runtimes.Values.Select(r => r.Clone()), Supports.Values.Select(s => s.Clone()));
+            return new RuntimeGraph(Runtimes, Supports.ToDictionary(pair => pair.Key, pair => pair.Value.Clone()));
         }
 
         /// <summary>
@@ -70,7 +69,7 @@ namespace NuGet.RuntimeModel
             var runtimes = new Dictionary<string, RuntimeDescription>();
             foreach (var runtime in left.Runtimes.Values)
             {
-                runtimes[runtime.RuntimeIdentifier] = runtime.Clone();
+                runtimes[runtime.RuntimeIdentifier] = runtime;
             }
 
             // Merge the right-side runtimes

--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimePackageDependency.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimePackageDependency.cs
@@ -10,7 +10,10 @@ namespace NuGet.RuntimeModel
     /// <summary>
     /// A package dependency for a specific RID.
     /// </summary>
-    public class RuntimePackageDependency : IEquatable<RuntimePackageDependency>
+    /// <remarks>
+    /// Immutable.
+    /// </remarks>
+    public sealed class RuntimePackageDependency : IEquatable<RuntimePackageDependency>
     {
         /// <summary>
         /// Dependency package id.
@@ -28,9 +31,10 @@ namespace NuGet.RuntimeModel
             VersionRange = versionRange;
         }
 
+        [Obsolete("This type is immutable, so there is no need or point to clone it.")]
         public RuntimePackageDependency Clone()
         {
-            return new RuntimePackageDependency(Id, VersionRange);
+            return this;
         }
 
         public override string ToString()

--- a/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
@@ -73,7 +73,7 @@ namespace NuGet.ProjectModel
             Imports = new List<NuGetFramework>(cloneFrom.Imports);
             AssetTargetFallback = cloneFrom.AssetTargetFallback;
             Warn = cloneFrom.Warn;
-            DownloadDependencies = CloneList(cloneFrom.DownloadDependencies, static dep => dep.Clone());
+            DownloadDependencies = cloneFrom.DownloadDependencies.ToList();
             CentralPackageVersions = new Dictionary<string, CentralPackageVersion>(cloneFrom.CentralPackageVersions, StringComparer.OrdinalIgnoreCase);
             FrameworkReferences = new HashSet<FrameworkDependency>(cloneFrom.FrameworkReferences);
             RuntimeIdentifierGraphPath = cloneFrom.RuntimeIdentifierGraphPath;

--- a/src/NuGet.Core/NuGet.Versioning/VersionRange.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRange.cs
@@ -12,6 +12,9 @@ namespace NuGet.Versioning
     /// <summary>
     /// Represents a range of versions and a preferred order.
     /// </summary>
+    /// <remarks>
+    /// Immutable, although subclasses may introduce mutable state.
+    /// </remarks>
     public partial class VersionRange : VersionRangeBase, IFormattable
     {
         private readonly FloatRange? _floatRange;

--- a/src/NuGet.Core/NuGet.Versioning/VersionRangeFactory.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRangeFactory.cs
@@ -9,11 +9,10 @@ using System.Linq;
 
 namespace NuGet.Versioning
 {
-    /// <summary>
-    /// Static factory methods for creating version range objects.
-    /// </summary>
     public partial class VersionRange
     {
+        // Static factory methods for creating version range objects.
+
         /// <summary>
         /// A range that accepts all versions, prerelease and stable.
         /// </summary>

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTests.cs
@@ -760,6 +760,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Fact]
+        [Obsolete]
         public void FrameworkRuntimePairCloneTest()
         {
             //Setup
@@ -767,8 +768,7 @@ namespace NuGet.ProjectModel.Test
             //Act
             var clone = frp.Clone();
             //Assert
-            Assert.Equal(frp, clone);
-            Assert.False(object.ReferenceEquals(frp, clone));
+            Assert.Same(frp, clone);
         }
 
         private static CompatibilityProfile CreateCompatibilityProfile(string name, string tfm = "net461")
@@ -786,7 +786,7 @@ namespace NuGet.ProjectModel.Test
             //Assert
             Assert.Equal(compat, clone);
             Assert.False(object.ReferenceEquals(compat, clone));
-            Assert.False(object.ReferenceEquals(compat.RestoreContexts[0], clone.RestoreContexts[0]));
+            Assert.Same(compat.RestoreContexts[0], clone.RestoreContexts[0]); // FRP is immutable so the instance is reused
 
             // Act - Change the list of compat
             compat.RestoreContexts.Add(CreateFrameworkRuntimePair(rid: "win10-x64"));


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/12669

Regression? Last working version:

## Description

These types are immutable. There is no need to clone them, as the cloned value will be equivalent in every way to the original. The downside of cloning is the extra memory allocation and GC pressure such clones cause.

These types are immutable, so their `Clone` methods have been changed to just return the current instance, and they've been marked as `[Obsolete]` to discourage their use and promote better memory efficiency.

Code that calls them has been updated to avoid calling the obsolete methods.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
