### PR TITLE
Reduce allocations in ContentFileUtils.GetContentFileGroup

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/ContentFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/ContentFileUtils.cs
@@ -260,7 +260,7 @@ namespace NuGet.Commands
         // Find path relative to the TxM
         // Ex: contentFiles/cs/net45/config/config.xml -> config/config.xml
         // Ex: contentFiles/any/any/config/config.xml -> config/config.xml
-        private static string GetContentFileFolderRelativeToFramework(string itemPath)
+        internal static string GetContentFileFolderRelativeToFramework(string itemPath)
         {
             var parts = itemPath.Split('/');
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFileUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFileUtilsTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using Xunit;
+
+namespace NuGet.Commands.Test;
+
+public sealed class ContentFileUtilsTests
+{
+    [Theory]
+    [InlineData("contentFiles/cs/net45/config/config.xml", "config/config.xml")]
+    [InlineData("contentFiles/any/any/config/config.xml", "config/config.xml")]
+    [InlineData("", "")]
+    [InlineData("hello", "hello")]
+    [InlineData("a/b/", "a/b/")]
+    [InlineData("a/b/c/", "")]
+    [InlineData("a/b/c", "a/b/c")]
+    [InlineData("///config/config.xml", "config/config.xml")]
+    [InlineData("/a/b/config/config.xml", "config/config.xml")]
+    public void GetContentFileFolderRelativeToFramework(string input, string expected)
+    {
+        using var _ = new SuppressAsserts();
+
+        string actual = ContentFileUtils.GetContentFileFolderRelativeToFramework(input);
+
+        Assert.Equal(expected, actual);
+    }
+
+    private sealed class SuppressAsserts : IDisposable
+    {
+        private readonly TraceListener[] _suppressedListeners;
+
+        public SuppressAsserts()
+        {
+            _suppressedListeners = Trace.Listeners.Cast<TraceListener>().ToArray();
+
+            Trace.Listeners.Clear();
+        }
+
+        public void Dispose()
+        {
+            Trace.Listeners.AddRange(_suppressedListeners);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFileUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFileUtilsTests.cs
@@ -29,6 +29,11 @@ public sealed class ContentFileUtilsTests
         Assert.Equal(expected, actual);
     }
 
+    /// <summary>
+    /// Suppresses the default trace listeners for a specific duration. Useful to ensure that
+    /// debug asserts don't block unit tests indefinitely by showing modal dialog messages
+    /// about assertion failures.
+    /// </summary>
     private sealed class SuppressAsserts : IDisposable
     {
         private readonly TraceListener[] _suppressedListeners;

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFileUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFileUtilsTests.cs
@@ -24,7 +24,7 @@ public sealed class ContentFileUtilsTests
     {
         using var _ = new SuppressAsserts();
 
-        string actual = ContentFileUtils.GetContentFileFolderRelativeToFramework(input);
+        string actual = ContentFileUtils.GetContentFileFolderRelativeToFramework(input.AsSpan());
 
         Assert.Equal(expected, actual);
     }


### PR DESCRIPTION
## Bug

Fixes https://github.com/NuGet/Home/issues/12668

Regression? Last working version: N/A

## Description

This change adds a unit test for `ContentFileUtils.GetContentFileGroup` to ensure consistent behaviour, then rewrites the method to avoids a bunch of temporary string allocations, arrays and enumerators by using `ReadOnlySpan<char>` instead of `string`.

`SuppressAsserts` was added since there are Debug.Assert statements in the code tested by the new unit test, `GetContentFileFolderRelativeToFramework`.
eg,
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/c5dd50ba-9c40-4364-904b-3ebd409cb8b9)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
