### PR TITLE
OptProf should use latest VS Bootstrapper

### DIFF
--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -155,7 +155,7 @@ stages:
       displayName: "Install Signing Plugin"
     - task: MicroBuildSwixPlugin@4
       displayName: "Install Swix Plugin"
-    - task: MicroBuildBuildVSBootstrapper@2
+    - task: MicroBuildBuildVSBootstrapper@3
       displayName: 'Build a Visual Studio bootstrapper'
       inputs:
         channelName: "$(VsTargetChannel)"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2349

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

A few weeks ago, we changed the Build_And_UnitTest job in the PR build and official build to use the V3 task to create the VS bootstrapper, but we didn't change the OptProf task version, so it's been failing ever since (independently, I also changed alerting rules, so we should find out about OptProf pipeline failures quickly in the future).

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
