### PR TITLE
Do less work in PackageSpecificWarningProperties classes

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/PackCommand/Logging/PackageSpecificWarningProperties.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommand/Logging/PackageSpecificWarningProperties.cs
@@ -55,33 +55,30 @@ namespace NuGet.Commands.PackCommand
         /// <param name="framework">Target graph for which no warning should be thrown.</param>
         internal void Add(NuGetLogCode code, string libraryId, NuGetFramework framework)
         {
-            if (Properties == null)
+            Properties ??= new Dictionary<NuGetLogCode, IDictionary<string, ISet<NuGetFramework>>>();
+
+            if (!Properties.TryGetValue(code, out IDictionary<string, ISet<NuGetFramework>> frameworksByLibraryId))
             {
-                Properties = new Dictionary<NuGetLogCode, IDictionary<string, ISet<NuGetFramework>>>();
+                frameworksByLibraryId = new Dictionary<string, ISet<NuGetFramework>>(StringComparer.OrdinalIgnoreCase);
+                Properties.Add(code, frameworksByLibraryId);
             }
 
-            if (!Properties.ContainsKey(code))
+            if (!frameworksByLibraryId.TryGetValue(libraryId, out ISet<NuGetFramework> frameworks))
             {
-                Properties.Add(code, new Dictionary<string, ISet<NuGetFramework>>(StringComparer.OrdinalIgnoreCase));
+                frameworks = new HashSet<NuGetFramework>(new NuGetFrameworkFullComparer());
+                frameworksByLibraryId.Add(libraryId, frameworks);
             }
 
-            if (Properties[code].ContainsKey(libraryId))
-            {
-                Properties[code][libraryId].Add(framework);
-            }
-            else
-            {
-                Properties[code].Add(libraryId, new HashSet<NuGetFramework>(new NuGetFrameworkFullComparer()) { framework });
-            }
+            frameworks.Add(framework);
         }
 
         /// <summary>
-        /// Checks if a NugetLogCode is part of the NoWarn list for the specified library Id and target graph.
+        /// Checks if a NuGetLogCode is part of the NoWarn list for the specified library Id and target graph.
         /// </summary>
-        /// <param name="code">NugetLogCode to be checked.</param>
+        /// <param name="code">NuGetLogCode to be checked.</param>
         /// <param name="libraryId">library Id to be checked.</param>
         /// <param name="framework">target graph to be checked.</param>
-        /// <returns>True if the NugetLogCode is part of the NoWarn list for the specified libraryId and Target Graph.</returns>
+        /// <returns>True if the NuGetLogCode is part of the NoWarn list for the specified libraryId and Target Graph.</returns>
         internal bool Contains(NuGetLogCode code, string libraryId, NuGetFramework framework)
         {
             return Properties != null &&

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/PackageSpecificWarningProperties.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/PackageSpecificWarningProperties.cs
@@ -88,24 +88,21 @@ namespace NuGet.Commands
         /// <param name="framework">Target graph for which no warning should be thrown.</param>
         public void Add(NuGetLogCode code, string libraryId, NuGetFramework framework)
         {
-            if (Properties == null)
+            Properties ??= new Dictionary<NuGetLogCode, IDictionary<string, ISet<NuGetFramework>>>();
+
+            if (!Properties.TryGetValue(code, out IDictionary<string, ISet<NuGetFramework>> frameworksByLibraryId))
             {
-                Properties = new Dictionary<NuGetLogCode, IDictionary<string, ISet<NuGetFramework>>>();
+                frameworksByLibraryId = new Dictionary<string, ISet<NuGetFramework>>(StringComparer.OrdinalIgnoreCase);
+                Properties.Add(code, frameworksByLibraryId);
             }
 
-            if (!Properties.ContainsKey(code))
+            if (!frameworksByLibraryId.TryGetValue(libraryId, out ISet<NuGetFramework> frameworks))
             {
-                Properties.Add(code, new Dictionary<string, ISet<NuGetFramework>>(StringComparer.OrdinalIgnoreCase));
+                frameworks = new HashSet<NuGetFramework>(new NuGetFrameworkFullComparer());
+                frameworksByLibraryId[libraryId] = frameworks;
             }
 
-            if (Properties[code].ContainsKey(libraryId))
-            {
-                Properties[code][libraryId].Add(framework);
-            }
-            else
-            {
-                Properties[code].Add(libraryId, new HashSet<NuGetFramework>(new NuGetFrameworkFullComparer()) { framework });
-            }
+            frameworks.Add(framework);
         }
 
         /// <summary>


### PR DESCRIPTION
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12678

Regression? Last working version:

## Description

When adding a NuGetLogCode to these collections, the previous code was performing many redundant collection lookups. This changes these methods to do less work.

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
