### PR TITLE
Revert "Workaround: .NET SDK Installs version 8.0.100-preview.3 (#5169)"

### DIFF
--- a/build/DotNetSdkVersions.txt
+++ b/build/DotNetSdkVersions.txt
@@ -1,5 +1,5 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Channel 8.0 -Version 8.0.100-preview.3.23178.7
+-Channel 8.0
 -Channel 7.0
 -Channel 6.0 -Runtime dotnet
 -Channel 5.0

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -3662,27 +3662,22 @@ namespace ClassLibrary
                 // Act
                 msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
 
-                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
-                {
-                    var xml = XDocument.Load(stream);
-                    var ns = xml.Root.Name.Namespace;
-
-                    ProjectFileUtils.AddProperty(xml, "RepositoryType", "git");
-
-                    // mock implementation of InitializeSourceControlInformation common targets:
-                    xml.Root.Add(
-                        new XElement(ns + "Target",
-                            new XAttribute("Name", "InitializeSourceControlInformation"),
-                            new XElement(ns + "PropertyGroup",
-                                new XElement("SourceRevisionId", "e1c65e4524cd70ee6e22abe33e6cb6ec73938cb1"),
-                                new XElement("PrivateRepositoryUrl", "https://github.com/NuGet/NuGet.Client.git"))));
-
-                    xml.Root.Add(
-                        new XElement(ns + "PropertyGroup",
-                            new XElement("SourceControlInformationFeatureSupported", "false")));
-
-                    ProjectFileUtils.WriteXmlToFile(xml, stream);
-                }
+                File.WriteAllText(
+                    Path.Combine(workingDirectory, "Directory.Build.targets"),
+                    @"
+<Project>
+    <PropertyGroup>
+        <SourceControlInformationFeatureSupported>false</SourceControlInformationFeatureSupported>
+        <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
+        <RepositoryType>git</RepositoryType>
+    </PropertyGroup>
+    <Target Name=""InitializeSourceControlInformation1"">
+        <PropertyGroup>
+            <SourceRevisionId>e1c65e4524cd70ee6e22abe33e6cb6ec73938cb1</SourceRevisionId>
+            <PrivateRepositoryUrl>https://github.com/NuGet/NuGet.Client.git</PrivateRepositoryUrl>
+        </PropertyGroup>
+    </Target>
+</Project>");
 
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
                 msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory}");


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2291

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This reverts commit 9d95d880fd45c88f5e71c3a3d215514dcbe76a3c and fixes  `PackCommand_PackWithSourceControlInformation_Unsupported_VerifyNuspec` now that there was a change in .NET 8 that broke it.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
