### PR TITLE
Reduce allocations in NuGet.DependencyResolver.Tracker

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/Tracker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/Tracker.cs
@@ -33,6 +33,9 @@ namespace NuGet.DependencyResolver
             GetOrAddEntry(item).Ambiguous = true;
         }
 
+        /// <remarks>
+        /// Note, this method returns <see langword="true"/> for items that were never tracked.
+        /// </remarks>
         public bool IsBestVersion(GraphItem<TItem> item)
         {
             var entry = TryGetEntry(item);

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/Tracker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/Tracker.cs
@@ -3,83 +3,136 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+
+#nullable enable
 
 namespace NuGet.DependencyResolver
 {
     public class Tracker<TItem>
     {
-        private readonly Dictionary<string, Entry> _entries
-            = new Dictionary<string, Entry>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, Entry> _entryByLibraryName = new(StringComparer.OrdinalIgnoreCase);
 
         public void Track(GraphItem<TItem> item)
         {
-            var entry = GetEntry(item);
-            if (!entry.List.Contains(item))
-            {
-                entry.List.Add(item);
-            }
+            GetOrAddEntry(item).AddItem(item);
         }
 
         public bool IsDisputed(GraphItem<TItem> item)
         {
-            return GetEntry(item).List.Count > 1;
+            return TryGetEntry(item)?.HasMultipleItems ?? false;
         }
 
         public bool IsAmbiguous(GraphItem<TItem> item)
         {
-            return GetEntry(item).Ambiguous;
+            return TryGetEntry(item)?.Ambiguous ?? false;
         }
 
         public void MarkAmbiguous(GraphItem<TItem> item)
         {
-            GetEntry(item).Ambiguous = true;
+            GetOrAddEntry(item).Ambiguous = true;
         }
 
         public bool IsBestVersion(GraphItem<TItem> item)
         {
-            var entry = GetEntry(item);
+            var entry = TryGetEntry(item);
 
-            var version = item.Key.Version;
-
-            foreach (var known in entry.List)
+            if (entry is not null)
             {
-                if (version < known.Key.Version)
+                var version = item.Key.Version;
+
+                foreach (var known in entry.Items)
                 {
-                    return false;
+                    if (version < known.Key.Version)
+                    {
+                        return false;
+                    }
                 }
             }
 
             return true;
         }
 
-        public IEnumerable<GraphItem<TItem>> GetDisputes(GraphItem<TItem> item) => GetEntry(item).List;
+        public IEnumerable<GraphItem<TItem>> GetDisputes(GraphItem<TItem> item)
+        {
+            return TryGetEntry(item)?.Items ?? Enumerable.Empty<GraphItem<TItem>>();
+        }
 
         internal void Clear()
         {
-            _entries.Clear();
+            _entryByLibraryName.Clear();
         }
 
-        private Entry GetEntry(GraphItem<TItem> item)
+        private Entry? TryGetEntry(GraphItem<TItem> item)
         {
-            Entry itemList;
-            if (!_entries.TryGetValue(item.Key.Name, out itemList))
-            {
-                itemList = new Entry();
-                _entries[item.Key.Name] = itemList;
-            }
-            return itemList;
+            _entryByLibraryName.TryGetValue(item.Key.Name, out Entry? entry);
+            return entry;
         }
 
-        private class Entry
+        private Entry GetOrAddEntry(GraphItem<TItem> item)
         {
-            public Entry()
+            if (!_entryByLibraryName.TryGetValue(item.Key.Name, out Entry? entry))
             {
-                List = new HashSet<GraphItem<TItem>>();
+                entry = new Entry();
+                _entryByLibraryName[item.Key.Name] = entry;
             }
 
-            public HashSet<GraphItem<TItem>> List { get; set; }
+            return entry;
+        }
+
+        private sealed class Entry
+        {
+            /// <summary>
+            /// This field can have one of three values:
+            ///
+            /// - null: when no graph items exist in this entry
+            /// - a graph item: when only a single graph item exists in this entry
+            /// - a hash set of graph items: when multiple graph items exist in this entry
+            ///
+            /// This packing exists in order to reduce the size of this object in
+            /// memory. For large graphs, this can amount to a significant saving in memory,
+            /// which helps overall performance.
+            /// </summary>
+            private object? _storage;
 
             public bool Ambiguous { get; set; }
+
+            public void AddItem(GraphItem<TItem> item)
+            {
+                if (_storage is null)
+                {
+                    _storage = item;
+                }
+                else if (_storage is GraphItem<TItem> existingItem)
+                {
+                    if (!existingItem.Equals(item))
+                    {
+#if NETSTANDARD2_0
+                        _storage = new HashSet<GraphItem<TItem>>() { existingItem, item };
+#else
+                        _storage = new HashSet<GraphItem<TItem>>(capacity: 3) { existingItem, item };
+#endif
+                    }
+                }
+                else
+                {
+                    ((HashSet<GraphItem<TItem>>)_storage).Add(item);
+                }
+            }
+
+            public bool HasMultipleItems => _storage is HashSet<GraphItem<TItem>>;
+
+            public IEnumerable<GraphItem<TItem>> Items
+            {
+                get
+                {
+                    if (_storage is null)
+                        return Enumerable.Empty<GraphItem<TItem>>();
+                    if (_storage is GraphItem<TItem> item)
+                        return new[] { item };
+                    return (HashSet<GraphItem<TItem>>)_storage;
+                }
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/PublicAPI.Shipped.txt
@@ -117,12 +117,12 @@ NuGet.DependencyResolver.RemoteWalkContext.IsMsBuildBased.set -> void
 ~NuGet.DependencyResolver.RemoteWalkContext.RemoteWalkContext(NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Configuration.PackageSourceMapping packageSourceMapping, NuGet.Common.ILogger logger) -> void
 NuGet.DependencyResolver.ResolverUtility
 NuGet.DependencyResolver.Tracker<TItem>
-~NuGet.DependencyResolver.Tracker<TItem>.GetDisputes(NuGet.DependencyResolver.GraphItem<TItem> item) -> System.Collections.Generic.IEnumerable<NuGet.DependencyResolver.GraphItem<TItem>>
-~NuGet.DependencyResolver.Tracker<TItem>.IsAmbiguous(NuGet.DependencyResolver.GraphItem<TItem> item) -> bool
-~NuGet.DependencyResolver.Tracker<TItem>.IsBestVersion(NuGet.DependencyResolver.GraphItem<TItem> item) -> bool
-~NuGet.DependencyResolver.Tracker<TItem>.IsDisputed(NuGet.DependencyResolver.GraphItem<TItem> item) -> bool
-~NuGet.DependencyResolver.Tracker<TItem>.MarkAmbiguous(NuGet.DependencyResolver.GraphItem<TItem> item) -> void
-~NuGet.DependencyResolver.Tracker<TItem>.Track(NuGet.DependencyResolver.GraphItem<TItem> item) -> void
+NuGet.DependencyResolver.Tracker<TItem>.GetDisputes(NuGet.DependencyResolver.GraphItem<TItem>! item) -> System.Collections.Generic.IEnumerable<NuGet.DependencyResolver.GraphItem<TItem>!>!
+NuGet.DependencyResolver.Tracker<TItem>.IsAmbiguous(NuGet.DependencyResolver.GraphItem<TItem>! item) -> bool
+NuGet.DependencyResolver.Tracker<TItem>.IsBestVersion(NuGet.DependencyResolver.GraphItem<TItem>! item) -> bool
+NuGet.DependencyResolver.Tracker<TItem>.IsDisputed(NuGet.DependencyResolver.GraphItem<TItem>! item) -> bool
+NuGet.DependencyResolver.Tracker<TItem>.MarkAmbiguous(NuGet.DependencyResolver.GraphItem<TItem>! item) -> void
+NuGet.DependencyResolver.Tracker<TItem>.Track(NuGet.DependencyResolver.GraphItem<TItem>! item) -> void
 NuGet.DependencyResolver.Tracker<TItem>.Tracker() -> void
 NuGet.DependencyResolver.VersionConflictResult<TItem>
 ~NuGet.DependencyResolver.VersionConflictResult<TItem>.Conflicting.get -> NuGet.DependencyResolver.GraphNode<TItem>

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/TrackerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/TrackerTests.cs
@@ -1,0 +1,188 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Xunit;
+
+#nullable enable
+
+namespace NuGet.DependencyResolver.Core.Tests;
+
+public class TrackerTests
+{
+    [Fact]
+    public void IsDisputed()
+    {
+        var itemA1 = MakeItem("A", 1);
+        var itemA2 = MakeItem("A", 2);
+        var itemB1 = MakeItem("B", 1);
+
+        var tracker = new Tracker<string>();
+
+        Assert.False(tracker.IsDisputed(itemA1));
+        Assert.False(tracker.IsDisputed(itemA2));
+        Assert.False(tracker.IsDisputed(itemB1));
+
+        tracker.Track(itemA1);
+
+        Assert.False(tracker.IsDisputed(itemA1));
+        Assert.False(tracker.IsDisputed(itemA2));
+        Assert.False(tracker.IsDisputed(itemB1));
+
+        tracker.Track(itemA1);
+
+        Assert.False(tracker.IsDisputed(itemA1));
+        Assert.False(tracker.IsDisputed(itemA2));
+        Assert.False(tracker.IsDisputed(itemB1));
+
+        tracker.Track(itemA2);
+
+        Assert.True(tracker.IsDisputed(itemA1));
+        Assert.True(tracker.IsDisputed(itemA2));
+        Assert.False(tracker.IsDisputed(itemB1));
+
+        tracker.Track(itemB1);
+
+        Assert.True(tracker.IsDisputed(itemA1));
+        Assert.True(tracker.IsDisputed(itemA2));
+        Assert.False(tracker.IsDisputed(itemB1));
+
+        tracker.Clear();
+
+        Assert.False(tracker.IsDisputed(itemA1));
+        Assert.False(tracker.IsDisputed(itemA2));
+        Assert.False(tracker.IsDisputed(itemB1));
+    }
+
+    [Fact]
+    public void GetDisputes()
+    {
+        var itemA1 = MakeItem("A", 1);
+        var itemA2 = MakeItem("A", 2);
+        var itemB1 = MakeItem("B", 1);
+
+        var tracker = new Tracker<string>();
+
+        Assert.Empty(tracker.GetDisputes(itemA1));
+        Assert.Empty(tracker.GetDisputes(itemA2));
+        Assert.Empty(tracker.GetDisputes(itemB1));
+
+        tracker.Track(itemA1);
+
+        Validate(itemA1, new[] { itemA1 });
+        Validate(itemA2, new[] { itemA1 });
+        Assert.Empty(tracker.GetDisputes(itemB1));
+
+        tracker.Track(itemA2);
+
+        Validate(itemA1, new[] { itemA1, itemA2 });
+        Validate(itemA2, new[] { itemA1, itemA2 });
+        Assert.Empty(tracker.GetDisputes(itemB1));
+
+        tracker.Clear();
+
+        Assert.Empty(tracker.GetDisputes(itemA1));
+        Assert.Empty(tracker.GetDisputes(itemA2));
+        Assert.Empty(tracker.GetDisputes(itemB1));
+
+        void Validate(GraphItem<string> item, GraphItem<string>[] expected)
+        {
+            IEnumerable<GraphItem<string>> disputes = tracker.GetDisputes(item);
+
+            Assert.True(new HashSet<GraphItem<string>>(disputes).SetEquals(expected));
+        }
+    }
+
+    [Fact]
+    public void IsAmbiguous()
+    {
+        var itemA1 = MakeItem("A", 1);
+        var itemB1 = MakeItem("B", 1);
+
+        var tracker = new Tracker<string>();
+
+        Assert.False(tracker.IsAmbiguous(itemA1));
+        Assert.False(tracker.IsAmbiguous(itemB1));
+
+        tracker.MarkAmbiguous(itemA1);
+
+        Assert.True(tracker.IsAmbiguous(itemA1));
+        Assert.False(tracker.IsAmbiguous(itemB1));
+
+        tracker.MarkAmbiguous(itemB1);
+
+        Assert.True(tracker.IsAmbiguous(itemA1));
+        Assert.True(tracker.IsAmbiguous(itemB1));
+
+        tracker.Clear();
+
+        Assert.False(tracker.IsAmbiguous(itemA1));
+        Assert.False(tracker.IsAmbiguous(itemB1));
+    }
+
+    [Fact]
+    public void IsBestVersion()
+    {
+        var itemA1 = MakeItem("A", 1);
+        var itemA2 = MakeItem("A", 2);
+        var itemA3 = MakeItem("A", 3);
+        var itemB1 = MakeItem("B", 1);
+
+        var tracker = new Tracker<string>();
+
+        // NOTE this is strange behavior. An item that was never tracked is reported as the best version.
+        // However this existed at the time the tests were written, so may not be safe to change.
+        // These tests reflect the current behavior, which might not be the most sensible.
+
+        Assert.True(tracker.IsBestVersion(itemA1));
+        Assert.True(tracker.IsBestVersion(itemA2));
+        Assert.True(tracker.IsBestVersion(itemA3));
+        Assert.True(tracker.IsBestVersion(itemB1));
+
+        tracker.Track(itemA1);
+
+        Assert.True(tracker.IsBestVersion(itemA1));
+        Assert.True(tracker.IsBestVersion(itemA2));
+        Assert.True(tracker.IsBestVersion(itemA3));
+        Assert.True(tracker.IsBestVersion(itemB1));
+
+        tracker.Track(itemA2);
+
+        Assert.False(tracker.IsBestVersion(itemA1));
+        Assert.True(tracker.IsBestVersion(itemA2));
+        Assert.True(tracker.IsBestVersion(itemA3));
+        Assert.True(tracker.IsBestVersion(itemB1));
+
+        tracker.Track(itemA3);
+
+        Assert.False(tracker.IsBestVersion(itemA1));
+        Assert.False(tracker.IsBestVersion(itemA2));
+        Assert.True(tracker.IsBestVersion(itemA3));
+        Assert.True(tracker.IsBestVersion(itemB1));
+
+        tracker.Track(itemB1);
+
+        Assert.False(tracker.IsBestVersion(itemA1));
+        Assert.False(tracker.IsBestVersion(itemA2));
+        Assert.True(tracker.IsBestVersion(itemA3));
+        Assert.True(tracker.IsBestVersion(itemB1));
+
+        tracker.Clear();
+
+        Assert.True(tracker.IsBestVersion(itemA1));
+        Assert.True(tracker.IsBestVersion(itemA2));
+        Assert.True(tracker.IsBestVersion(itemA3));
+        Assert.True(tracker.IsBestVersion(itemB1));
+    }
+
+    private static GraphItem<string> MakeItem(string name, int version)
+    {
+        var key = new LibraryModel.LibraryIdentity()
+        {
+            Name = name,
+            Version = new Versioning.NuGetVersion(version, 0, 0)
+        };
+
+        return new GraphItem<string>(key);
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1826391
Fixes: https://github.com/NuGet/Home/issues/12719

Regression? Last working version:

## Description

`NuGet.DependencyResolver.Tracker` keeps track of graph items as they are observed. The internal implementation has been optimised to pack data in a more compact fashion, as this type was identified as contributing to GC pauses in VS by GCPauseWatson.

Unit tests were added to document the previous behaviour, then the class was rewritten to use less memory.

Some of the optimisations:

- Don't create an `Entry` for every look up operation. Only create it when some state actually needs to be written (adding a graph item, or marking ambiguous).
- Don't allocate the `HashSet` for every entry in the tracker. Only allocate one once there is more than one item for a given library.
- Don't call `Contains` on the `HashSet` before calling `Add`. If the item already exists, `Add` is a no-op.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
