### PR TITLE
Don't box enumerators in ContentItemCollection

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemCollection.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemCollection.cs
@@ -27,7 +27,7 @@ namespace NuGet.ContentModel
             // Read already loaded assets
             _assets = new List<Asset>();
 
-            foreach (var path in paths)
+            foreach (var path in paths.NoAllocEnumerate())
             {
                 // Skip files in the root of the directory
                 if (IsValidAsset(path))
@@ -144,7 +144,7 @@ namespace NuGet.ContentModel
             {
                 itemGroups.Clear();
                 PopulateItemGroups(definition, itemGroups);
-                foreach (var criteriaEntry in criteria.Entries)
+                foreach (var criteriaEntry in criteria.Entries.NoAllocEnumerate())
                 {
                     ContentItemGroup bestGroup = null;
                     var bestAmbiguity = false;
@@ -152,7 +152,7 @@ namespace NuGet.ContentModel
                     foreach (var itemGroup in itemGroups)
                     {
                         var groupIsValid = true;
-                        foreach (var criteriaProperty in criteriaEntry.Properties)
+                        foreach (var criteriaProperty in criteriaEntry.Properties.NoAllocEnumerate())
                         {
                             if (criteriaProperty.Value == null)
                             {
@@ -192,7 +192,7 @@ namespace NuGet.ContentModel
                             else
                             {
                                 var groupComparison = 0;
-                                foreach (var criteriaProperty in criteriaEntry.Properties)
+                                foreach (var criteriaProperty in criteriaEntry.Properties.NoAllocEnumerate())
                                 {
                                     if (criteriaProperty.Value == null)
                                     {
@@ -241,7 +241,7 @@ namespace NuGet.ContentModel
 
             List<ContentItem> items = new();
 
-            foreach (var asset in assets)
+            foreach (var asset in assets.NoAllocEnumerate())
             {
                 var path = asset.Path;
 
@@ -279,7 +279,7 @@ namespace NuGet.ContentModel
             }
 
             List<string> relatedFileExtensionList = null;
-            foreach (Asset asset in assets)
+            foreach (Asset asset in assets.NoAllocEnumerate())
             {
                 if (asset.Path is not null)
                 {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/12689
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1837339

Regression? Last working version: N/A

## Description

`ContentItemCollection` has many `foreach` operations over interfaces such as `IEnumerable<>`, `IList<>` and `IDictionary<>`. We can avoid boxing these enumerators via the `NoAllocEnumerate()` extension method.

See https://github.com/NuGet/NuGet.Client/pull/5246 for more information on that extension method.

The allocation of these boxed enumerators was identified as a top contributor to GC pauses by GCPauseWatson.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
