### PR TITLE
Remove allocations from PackageSource.Source setter

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using NuGet.Common;
+using NuGet.Shared;
 
 namespace NuGet.Configuration
 {
@@ -37,7 +38,11 @@ namespace NuGet.Configuration
                 }
 
                 _source = value;
-                _hashCode = Name.ToUpperInvariant().GetHashCode() * 3137 + _source.ToUpperInvariant().GetHashCode();
+
+                HashCodeCombiner hash = new();
+                hash.AddStringIgnoreCase(Name);
+                hash.AddStringIgnoreCase(_source);
+                _hashCode = hash.CombinedHash;
 
                 if (value.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
                 {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/12692
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1840739
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1840740

Regression? Last working version:

## Description

the `PackageSource.Source` property setter computes a hash code that includes string values in a case-insensitive way. It used to do that by allocating upper case strings, then computing the hashes on them. There's no need to allocate those temporary strings, as you can just use a `StringComparer` to compute the same value more efficiently.

To remove these allocations I've delegated the hash code computation to `HashCodeCombiner`, which won't allocate (for ASCII strings, at least).

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
