### PR TITLE
[Draft] Preview Window shows the Source Mappings being created for all packages being installed

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PreviewResult.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PreviewResult.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System.Collections.Generic;
 
 namespace NuGet.PackageManagement.UI
@@ -13,22 +15,22 @@ namespace NuGet.PackageManagement.UI
 
         public IEnumerable<UpdatePreviewResult> Updated { get; }
 
-        public IEnumerable<string> NewSourceMappingsPackageIds { get; }
+        public IDictionary<string, IEnumerable<string>>? NewSourceMappings { get; }
 
-        public string Name { get; }
+        public string? Name { get; }
 
         public PreviewResult(
-            string projectName,
+            string? projectName,
             IEnumerable<AccessiblePackageIdentity> added,
             IEnumerable<AccessiblePackageIdentity> deleted,
             IEnumerable<UpdatePreviewResult> updated,
-            IEnumerable<string> newSourceMappingsPackageIds)
+            IDictionary<string, IEnumerable<string>>? newSourceMappings)
         {
             Name = projectName;
             Added = added;
             Deleted = deleted;
             Updated = updated;
-            NewSourceMappingsPackageIds = newSourceMappingsPackageIds;
+            NewSourceMappings = newSourceMappings;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PreviewResult.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PreviewResult.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -15,7 +16,7 @@ namespace NuGet.PackageManagement.UI
 
         public IEnumerable<UpdatePreviewResult> Updated { get; }
 
-        public IDictionary<string, IEnumerable<string>>? NewSourceMappings { get; }
+        public Dictionary<string, SortedSet<string>>? NewSourceMappings { get; }
 
         public string? Name { get; }
 
@@ -23,14 +24,21 @@ namespace NuGet.PackageManagement.UI
             string? projectName,
             IEnumerable<AccessiblePackageIdentity> added,
             IEnumerable<AccessiblePackageIdentity> deleted,
-            IEnumerable<UpdatePreviewResult> updated,
-            IDictionary<string, IEnumerable<string>>? newSourceMappings)
+            IEnumerable<UpdatePreviewResult> updated)
         {
             Name = projectName;
             Added = added;
             Deleted = deleted;
             Updated = updated;
+        }
+
+        public PreviewResult(Dictionary<string, SortedSet<string>>? newSourceMappings)
+        {
+            Name = "Solution";
             NewSourceMappings = newSourceMappings;
+            Added = Enumerable.Empty<AccessiblePackageIdentity>();
+            Deleted = Enumerable.Empty<AccessiblePackageIdentity>();
+            Updated = Enumerable.Empty<UpdatePreviewResult>();
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PreviewResult.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PreviewResult.cs
@@ -16,7 +16,7 @@ namespace NuGet.PackageManagement.UI
 
         public IEnumerable<UpdatePreviewResult> Updated { get; }
 
-        public Dictionary<string, SortedSet<string>>? NewSourceMappings { get; }
+        public IReadOnlyDictionary<string, SortedSet<string>>? NewSourceMappings { get; }
 
         public string? Name { get; }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PreviewResult.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PreviewResult.cs
@@ -13,7 +13,7 @@ namespace NuGet.PackageManagement.UI
 
         public IEnumerable<UpdatePreviewResult> Updated { get; }
 
-        public IEnumerable<AccessiblePackageIdentity> NewSourceMapping { get; }
+        public IEnumerable<string> NewSourceMappingsPackageIds { get; }
 
         public string Name { get; }
 
@@ -22,13 +22,13 @@ namespace NuGet.PackageManagement.UI
             IEnumerable<AccessiblePackageIdentity> added,
             IEnumerable<AccessiblePackageIdentity> deleted,
             IEnumerable<UpdatePreviewResult> updated,
-            IEnumerable<AccessiblePackageIdentity> newSourceMapping)
+            IEnumerable<string> newSourceMappingsPackageIds)
         {
             Name = projectName;
             Added = added;
             Deleted = deleted;
             Updated = updated;
-            NewSourceMapping = newSourceMapping;
+            NewSourceMappingsPackageIds = newSourceMappingsPackageIds;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PreviewResult.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PreviewResult.cs
@@ -13,18 +13,22 @@ namespace NuGet.PackageManagement.UI
 
         public IEnumerable<UpdatePreviewResult> Updated { get; }
 
+        public IEnumerable<AccessiblePackageIdentity> NewSourceMapping { get; }
+
         public string Name { get; }
 
         public PreviewResult(
             string projectName,
             IEnumerable<AccessiblePackageIdentity> added,
             IEnumerable<AccessiblePackageIdentity> deleted,
-            IEnumerable<UpdatePreviewResult> updated)
+            IEnumerable<UpdatePreviewResult> updated,
+            IEnumerable<AccessiblePackageIdentity> newSourceMapping)
         {
             Name = projectName;
             Added = added;
             Deleted = deleted;
             Updated = updated;
+            NewSourceMapping = newSourceMapping;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -10,7 +10,6 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using EnvDTE;
 using Microsoft;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Shell;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -1029,7 +1029,7 @@ namespace NuGet.PackageManagement.UI
                 return;
             }
 
-            List<string> addedPackagesWithNewSourceMappings = added.Select(_ => _.Id)
+            List<string> addedPackagesWithNoSourceMappings = added.Select(_ => _.Id)
                 .Where(addedPackage =>
                 {
                     IReadOnlyList<string> configuredSources = packageSourceMapping.GetConfiguredPackageSources(addedPackage);
@@ -1038,7 +1038,7 @@ namespace NuGet.PackageManagement.UI
                 .Distinct()
                 .ToList();
 
-            if (addedPackagesWithNewSourceMappings.Count == 0)
+            if (addedPackagesWithNoSourceMappings.Count == 0)
             {
                 return;
             }
@@ -1047,16 +1047,16 @@ namespace NuGet.PackageManagement.UI
             {
                 newSourceMappings = new Dictionary<string, SortedSet<string>>(capacity: 1)
                 {
-                    { newMappingSourceName, new SortedSet<string>(addedPackagesWithNewSourceMappings) }
+                    { newMappingSourceName, new SortedSet<string>(addedPackagesWithNoSourceMappings) }
                 };
             }
             else if (newSourceMappings.TryGetValue(newMappingSourceName, out SortedSet<string>? newMappingPackageIds))
             {
-                newMappingPackageIds.UnionWith(addedPackagesWithNewSourceMappings);
+                newMappingPackageIds.UnionWith(addedPackagesWithNoSourceMappings);
             }
             else
             {
-                newSourceMappings.Add(newMappingSourceName, new SortedSet<string>(addedPackagesWithNewSourceMappings));
+                newSourceMappings.Add(newMappingSourceName, new SortedSet<string>(addedPackagesWithNoSourceMappings));
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -169,7 +169,7 @@ namespace NuGet.PackageManagement.UI
                 string htmlLogFile = GenerateUpgradeReport(projectName, backupPath, upgradeInformationWindowModel);
                 try
                 {
-                    using var process = System.Diagnostics.Process.Start(htmlLogFile);
+                    using var process = Process.Start(htmlLogFile);
                 }
                 catch { }
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -78,7 +78,7 @@ namespace NuGet.PackageManagement.UI
                     uiService.RemoveDependencies,
                     uiService.ForceRemove,
                     newMappingID: userAction.PackageId,
-                    newMappingSource: userAction.SourceMappingSourceName,
+                    newMappingSource: userAction.SelectedSourceName,
                     cancellationToken),
                 cancellationToken);
         }
@@ -1023,7 +1023,7 @@ namespace NuGet.PackageManagement.UI
 
         private static void GetNewSourceMappingsFromAddedPackages(ref Dictionary<string, SortedSet<string>>? newSourceMappings, UserAction? userAction, List<AccessiblePackageIdentity> added, PackageSourceMapping packageSourceMapping)
         {
-            string? newMappingSourceName = userAction?.SourceMappingSourceName;
+            string? newMappingSourceName = userAction?.SelectedSourceName;
             if (newMappingSourceName is null || added.Count == 0 || packageSourceMapping is null)
             {
                 return;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -964,7 +964,7 @@ namespace NuGet.PackageManagement.UI
                 var added = new List<AccessiblePackageIdentity>();
                 var deleted = new List<AccessiblePackageIdentity>();
                 var updated = new List<UpdatePreviewResult>();
-                var addedPackagesWithNewSourceMappings = new List<AccessiblePackageIdentity>();
+                var addedPackageIdsWithNewSourceMappings = new List<string>();
 
                 foreach (var packageId in packageIds)
                 {
@@ -990,15 +990,14 @@ namespace NuGet.PackageManagement.UI
                 }
 
                 // Everything added which didn't already have a source mapping will be mentioned in the Preview Window.
-                addedPackagesWithNewSourceMappings = added.Where(addedPackage =>
+                addedPackageIdsWithNewSourceMappings = added.Select(_ => _.Id).Where(addedPackage =>
                     {
-                        IReadOnlyList<string> configuredSources = uiService.UIContext.PackageSourceMapping.GetConfiguredPackageSources(addedPackage.Id);
+                        IReadOnlyList<string> configuredSources = uiService.UIContext.PackageSourceMapping.GetConfiguredPackageSources(addedPackage);
                         return configuredSources == null || configuredSources.Count == 0;
                     })
                     .Distinct()
                     .ToList();
 
-                actions.
                 IProjectMetadataContextInfo projectMetadata = await projectManagerService.GetMetadataAsync(actions.Key, cancellationToken);
 
 #pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
@@ -1013,7 +1012,7 @@ namespace NuGet.PackageManagement.UI
                 }
 #pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
 
-                var result = new PreviewResult(projectName, added, deleted, updated, addedPackagesWithNewSourceMappings);
+                var result = new PreviewResult(projectName, added, deleted, updated, addedPackageIdsWithNewSourceMappings);
 
                 results.Add(result);
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -825,7 +825,8 @@ namespace NuGet.PackageManagement.UI
 
         public PackageSourceMappingActionViewModel PackageSourceMappingViewModel { get; }
 
-        public bool CanInstallWithPackageSourceMapping => true || (!PackageSourceMappingViewModel.IsPackageSourceMappingEnabled || PackageSourceMappingViewModel.IsPackageMapped);
+        public bool CanInstallWithPackageSourceMapping => true // TODO
+            || (!PackageSourceMappingViewModel.IsPackageSourceMappingEnabled || PackageSourceMappingViewModel.IsPackageMapped);
 
         public IEnumerable<IProjectContextInfo> NuGetProjects => _nugetProjects;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -825,7 +825,7 @@ namespace NuGet.PackageManagement.UI
 
         public PackageSourceMappingActionViewModel PackageSourceMappingViewModel { get; }
 
-        public bool CanInstallWithPackageSourceMapping => !PackageSourceMappingViewModel.IsPackageSourceMappingEnabled || PackageSourceMappingViewModel.IsPackageMapped;
+        public bool CanInstallWithPackageSourceMapping => true || (!PackageSourceMappingViewModel.IsPackageSourceMappingEnabled || PackageSourceMappingViewModel.IsPackageMapped);
 
         public IEnumerable<IProjectContextInfo> NuGetProjects => _nugetProjects;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PreviewWindowModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PreviewWindowModel.cs
@@ -53,13 +53,17 @@ namespace NuGet.PackageManagement.UI
                     }
                     sb.AppendLine("");
                 }
-                if (r.NewSourceMappingsPackageIds.Any())
+                if (r.NewSourceMappings.Any())
                 {
                     sb.AppendLine(Resources.Label_CreatingSourceMappings);
                     sb.AppendLine("");
-                    foreach (var p in r.NewSourceMappingsPackageIds)
+                    foreach (KeyValuePair<string, IEnumerable<string>> newSourceMapping in r.NewSourceMappings)
                     {
-                        sb.AppendLine(p.ToString());
+                        sb.AppendLine(newSourceMapping.Key);
+                        foreach (string newSourceMappingPackageId in newSourceMapping.Value)
+                        {
+                            sb.AppendLine(newSourceMappingPackageId.ToString());
+                        }
                     }
                     sb.AppendLine("");
                 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PreviewWindowModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PreviewWindowModel.cs
@@ -53,6 +53,16 @@ namespace NuGet.PackageManagement.UI
                     }
                     sb.AppendLine("");
                 }
+                if (r.NewSourceMapping.Any())
+                {
+                    sb.AppendLine("New source mappings created:");
+                    sb.AppendLine("");
+                    foreach (var p in r.NewSourceMapping)
+                    {
+                        sb.AppendLine(p.ToString());
+                    }
+                    sb.AppendLine("");
+                }
             }
             return sb.ToString();
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PreviewWindowModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PreviewWindowModel.cs
@@ -53,19 +53,18 @@ namespace NuGet.PackageManagement.UI
                     }
                     sb.AppendLine("");
                 }
-                if (r.NewSourceMappings.Any())
+                if (r.NewSourceMappings?.Any() == true)
                 {
-                    sb.AppendLine(Resources.Label_CreatingSourceMappings);
-                    sb.AppendLine("");
                     foreach (var newSourceMapping in r.NewSourceMappings)
                     {
-                        sb.AppendLine(newSourceMapping.Key);
+                        sb.AppendLine(string.Format(Resources.Label_CreatingSourceMappings, newSourceMapping.Key));
+                        sb.AppendLine("");
                         foreach (string newSourceMappingPackageId in newSourceMapping.Value)
                         {
-                            sb.AppendLine(newSourceMappingPackageId.ToString());
+                            sb.AppendLine(newSourceMappingPackageId);
                         }
+                        sb.AppendLine("");
                     }
-                    sb.AppendLine("");
                 }
             }
             return sb.ToString();

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PreviewWindowModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PreviewWindowModel.cs
@@ -55,7 +55,7 @@ namespace NuGet.PackageManagement.UI
                 }
                 if (r.NewSourceMappingsPackageIds.Any())
                 {
-                    sb.AppendLine("New source mappings created:");
+                    sb.AppendLine(Resources.Label_CreatingSourceMappings);
                     sb.AppendLine("");
                     foreach (var p in r.NewSourceMappingsPackageIds)
                     {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PreviewWindowModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PreviewWindowModel.cs
@@ -53,11 +53,11 @@ namespace NuGet.PackageManagement.UI
                     }
                     sb.AppendLine("");
                 }
-                if (r.NewSourceMapping.Any())
+                if (r.NewSourceMappingsPackageIds.Any())
                 {
                     sb.AppendLine("New source mappings created:");
                     sb.AppendLine("");
-                    foreach (var p in r.NewSourceMapping)
+                    foreach (var p in r.NewSourceMappingsPackageIds)
                     {
                         sb.AppendLine(p.ToString());
                     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PreviewWindowModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PreviewWindowModel.cs
@@ -57,7 +57,7 @@ namespace NuGet.PackageManagement.UI
                 {
                     sb.AppendLine(Resources.Label_CreatingSourceMappings);
                     sb.AppendLine("");
-                    foreach (KeyValuePair<string, IEnumerable<string>> newSourceMapping in r.NewSourceMappings)
+                    foreach (var newSourceMapping in r.NewSourceMappings)
                     {
                         sb.AppendLine(newSourceMapping.Key);
                         foreach (string newSourceMappingPackageId in newSourceMapping.Value)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -898,6 +898,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Creating package source mappings:.
+        /// </summary>
+        public static string Label_CreatingSourceMappings {
+            get {
+                return ResourceManager.GetString("Label_CreatingSourceMappings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Date published:.
         /// </summary>
         public static string Label_DatePublished {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -898,7 +898,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Creating package source mappings:.
+        ///   Looks up a localized string similar to Creating source mappings to &apos;{0}&apos;:.
         /// </summary>
         public static string Label_CreatingSourceMappings {
             get {
@@ -1218,6 +1218,15 @@ namespace NuGet.PackageManagement.UI {
         public static string Label_Repository {
             get {
                 return ResourceManager.GetString("Label_Repository", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Solution.
+        /// </summary>
+        public static string Label_Solution {
+            get {
+                return ResourceManager.GetString("Label_Solution", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -995,9 +995,13 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <comment>Button_Cancel and Button_OK must have underscore in different letters. See https://docs.microsoft.com/windows/apps/design/input/access-keys#choose-access-keys</comment>
   </data>
   <data name="Label_CreatingSourceMappings" xml:space="preserve">
-    <value>Creating package source mappings:</value>
+    <value>Creating source mappings to '{0}':</value>
+    <comment>{0} - The Name of a user-configured NuGet Package Source</comment>
   </data>
   <data name="Label_NetworkError" xml:space="preserve">
     <value>An error occurred while fetching additional information about the package. Refresh to try again.</value>
+  </data>
+  <data name="Label_Solution" xml:space="preserve">
+    <value>Solution</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -993,6 +993,9 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Button_OK" xml:space="preserve">
     <value>_OK</value>
     <comment>Button_Cancel and Button_OK must have underscore in different letters. See https://docs.microsoft.com/windows/apps/design/input/access-keys#choose-access-keys</comment>
+  </data
+  <data name="Label_CreatingSourceMappings" xml:space="preserve">
+    <value>Creating package source mappings:</value>
   </data>
   <data name="Label_NetworkError" xml:space="preserve">
     <value>An error occurred while fetching additional information about the package. Refresh to try again.</value>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -993,7 +993,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Button_OK" xml:space="preserve">
     <value>_OK</value>
     <comment>Button_Cancel and Button_OK must have underscore in different letters. See https://docs.microsoft.com/windows/apps/design/input/access-keys#choose-access-keys</comment>
-  </data
+  </data>
   <data name="Label_CreatingSourceMappings" xml:space="preserve">
     <value>Creating package source mappings:</value>
   </data>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserAction.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserAction.cs
@@ -26,16 +26,16 @@ namespace NuGet.PackageManagement.UI
             ActiveTab = activeTab;
         }
 
-        private UserAction(NuGetProjectActionType action, string packageId, NuGetVersion? packageVersion, bool isSolutionLevel, ContractsItemFilter activeTab, VersionRange versionRange, string? sourceMappingSourceName)
-            : this(action, packageId, packageVersion, isSolutionLevel, activeTab, sourceMappingSourceName)
+        private UserAction(NuGetProjectActionType action, string packageId, NuGetVersion? packageVersion, bool isSolutionLevel, ContractsItemFilter activeTab, VersionRange versionRange, string? selectedSourceName)
+            : this(action, packageId, packageVersion, isSolutionLevel, activeTab, selectedSourceName)
         {
             VersionRange = versionRange;
         }
 
-        private UserAction(NuGetProjectActionType action, string packageId, NuGetVersion? packageVersion, bool isSolutionLevel, ContractsItemFilter activeTab, string? sourceMappingSourceName)
+        private UserAction(NuGetProjectActionType action, string packageId, NuGetVersion? packageVersion, bool isSolutionLevel, ContractsItemFilter activeTab, string? selectedSourceName)
            : this(action, packageId, packageVersion, isSolutionLevel, activeTab)
         {
-            SourceMappingSourceName = sourceMappingSourceName;
+            SelectedSourceName = selectedSourceName;
         }
 
         public NuGetProjectActionType Action { get; private set; }
@@ -44,7 +44,7 @@ namespace NuGet.PackageManagement.UI
         public string PackageId { get; }
         public NuGetVersion? Version { get; }
         public VersionRange? VersionRange { get; }
-        public string? SourceMappingSourceName { get; }
+        public string? SelectedSourceName { get; }
 
         public static UserAction CreateInstallAction(string packageId, NuGetVersion? packageVersion, bool isSolutionLevel, ContractsItemFilter activeTab)
         {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserAction.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserAction.cs
@@ -26,8 +26,8 @@ namespace NuGet.PackageManagement.UI
             ActiveTab = activeTab;
         }
 
-        private UserAction(NuGetProjectActionType action, string packageId, NuGetVersion? packageVersion, bool isSolutionLevel, ContractsItemFilter activeTab, VersionRange versionRange)
-            : this(action, packageId, packageVersion, isSolutionLevel, activeTab)
+        private UserAction(NuGetProjectActionType action, string packageId, NuGetVersion? packageVersion, bool isSolutionLevel, ContractsItemFilter activeTab, VersionRange versionRange, string? sourceMappingSourceName)
+            : this(action, packageId, packageVersion, isSolutionLevel, activeTab, sourceMappingSourceName)
         {
             VersionRange = versionRange;
         }
@@ -61,14 +61,14 @@ namespace NuGet.PackageManagement.UI
             return new UserAction(NuGetProjectActionType.Install, packageId, packageVersion, isSolutionLevel, activeTab, sourceMappingSourceName);
         }
 
-        public static UserAction CreateInstallAction(string packageId, NuGetVersion? packageVersion, bool isSolutionLevel, ContractsItemFilter activeTab, VersionRange versionRange)
+        public static UserAction CreateInstallAction(string packageId, NuGetVersion? packageVersion, bool isSolutionLevel, ContractsItemFilter activeTab, VersionRange versionRange, string? sourceMappingSourceName)
         {
             if (packageVersion == null && versionRange == null)
             {
                 throw new ArgumentNullException(nameof(packageVersion));
             }
 
-            return new UserAction(NuGetProjectActionType.Install, packageId, packageVersion, isSolutionLevel, activeTab, versionRange);
+            return new UserAction(NuGetProjectActionType.Install, packageId, packageVersion, isSolutionLevel, activeTab, versionRange, sourceMappingSourceName);
         }
 
         public static UserAction CreateUnInstallAction(string packageId, bool isSolutionLevel, ContractsItemFilter activeTab)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/PackageSourceMappingUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/PackageSourceMappingUtility.cs
@@ -93,18 +93,11 @@ namespace NuGet.PackageManagement.UI
             mappingProvider.SavePackageSourceMappings(newAndExistingPackageSourceMappingItems);
         }
 
-        internal static string? GetNewSourceMappingSourceName(string packageId, PackageSourceMapping packageSourceMapping, PackageSourceMoniker activePackageSourceMoniker)
+        internal static string? GetNewSourceMappingSourceName(PackageSourceMapping packageSourceMapping, PackageSourceMoniker activePackageSourceMoniker)
         {
-            bool isInstallCreatingNewSourceMapping = false;
-            if (packageSourceMapping != null && packageSourceMapping.IsEnabled)
-            {
-                IReadOnlyList<string> configuredPackageSourcesForPackageId = packageSourceMapping.GetConfiguredPackageSources(packageId);
-                isInstallCreatingNewSourceMapping = configuredPackageSourcesForPackageId == null || !configuredPackageSourcesForPackageId.Any();
-            }
-
-            string? sourceMappingSourceName = isInstallCreatingNewSourceMapping
+            string? sourceMappingSourceName = packageSourceMapping.IsEnabled
                 && activePackageSourceMoniker.IsAggregateSource == false
-                ? activePackageSourceMoniker.PackageSourceNames.FirstOrDefault() : null;
+                ? activePackageSourceMoniker.PackageSourceNames.First() : null;
 
             return sourceMappingSourceName;
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/PackageSourceMappingUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/PackageSourceMappingUtility.cs
@@ -98,7 +98,8 @@ namespace NuGet.PackageManagement.UI
             bool isInstallCreatingNewSourceMapping = false;
             if (packageSourceMapping != null && packageSourceMapping.IsEnabled)
             {
-                isInstallCreatingNewSourceMapping = packageSourceMapping.GetConfiguredPackageSources(packageId)?.Count == 0;
+                IReadOnlyList<string> configuredPackageSourcesForPackageId = packageSourceMapping.GetConfiguredPackageSources(packageId);
+                isInstallCreatingNewSourceMapping = configuredPackageSourcesForPackageId == null || !configuredPackageSourcesForPackageId.Any();
             }
 
             string? sourceMappingSourceName = isInstallCreatingNewSourceMapping

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/PackageSourceMappingUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/PackageSourceMappingUtility.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Configuration;
+using NuGet.PackageManagement.VisualStudio;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -90,6 +91,21 @@ namespace NuGet.PackageManagement.UI
             }
 
             mappingProvider.SavePackageSourceMappings(newAndExistingPackageSourceMappingItems);
+        }
+
+        internal static string? GetNewSourceMappingSourceName(string packageId, PackageSourceMapping packageSourceMapping, PackageSourceMoniker activePackageSourceMoniker)
+        {
+            bool isInstallCreatingNewSourceMapping = false;
+            if (packageSourceMapping != null && packageSourceMapping.IsEnabled)
+            {
+                isInstallCreatingNewSourceMapping = packageSourceMapping.GetConfiguredPackageSources(packageId)?.Count == 0;
+            }
+
+            string? sourceMappingSourceName = isInstallCreatingNewSourceMapping
+                && activePackageSourceMoniker.IsAggregateSource == false
+                ? activePackageSourceMoniker.PackageSourceNames.FirstOrDefault() : null;
+
+            return sourceMappingSourceName;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/PackageSourceMappingUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/PackageSourceMappingUtility.cs
@@ -19,7 +19,7 @@ namespace NuGet.PackageManagement.UI
             PackageSourceMappingProvider sourceMappingProvider,
             IReadOnlyList<PackageSourceMappingSourceItem> existingPackageSourceMappingSourceItems)
         {
-            if (userAction?.SourceMappingSourceName is null || addedPackageIds is null)
+            if (userAction?.SelectedSourceName is null || addedPackageIds is null)
             {
                 return;
             }
@@ -47,7 +47,7 @@ namespace NuGet.PackageManagement.UI
                 .ToArray();
 
             CreateAndSavePackageSourceMappings(
-                userAction.SourceMappingSourceName,
+                userAction.SelectedSourceName,
                 packageIdsNeedingNewSourceMappings,
                 sourceMappingProvider,
                 existingPackageSourceMappingSourceItems);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -114,11 +114,10 @@ namespace NuGet.PackageManagement.UI
 
             if (model != null && model.SelectedVersion != null)
             {
-                var packageId = model.Id;
                 var sourceMappingSourceName = PackageSourceMappingUtility.GetNewSourceMappingSourceName(Control.Model.UIController.UIContext.PackageSourceMapping, Control.Model.UIController.ActivePackageSourceMoniker);
 
                 var userAction = UserAction.CreateInstallAction(
-                    packageId,
+                    packageId: model.Id,
                     model.SelectedVersion.Version,
                     Control.Model.IsSolution,
                     UIUtility.ToContractsItemFilter(Control._topPanel.Filter),
@@ -146,11 +145,10 @@ namespace NuGet.PackageManagement.UI
 
             if (model != null && model.SelectedVersion != null)
             {
-                var packageId = model.Id;
                 var sourceMappingSourceName = PackageSourceMappingUtility.GetNewSourceMappingSourceName(Control.Model.UIController.UIContext.PackageSourceMapping, Control.Model.UIController.ActivePackageSourceMoniker);
 
                 var userAction = UserAction.CreateInstallAction(
-                    packageId,
+                    packageId: model.Id,
                     model.SelectedVersion.Version,
                     Control.Model.IsSolution,
                     UIUtility.ToContractsItemFilter(Control._topPanel.Filter),

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -146,11 +146,15 @@ namespace NuGet.PackageManagement.UI
 
             if (model != null && model.SelectedVersion != null)
             {
+                var packageId = model.Id;
+                var sourceMappingSourceName = PackageSourceMappingUtility.GetNewSourceMappingSourceName(packageId, Control.Model.UIController.UIContext.PackageSourceMapping, Control.Model.UIController.ActivePackageSourceMoniker);
+
                 var userAction = UserAction.CreateInstallAction(
-                    model.Id,
+                    packageId,
                     model.SelectedVersion.Version,
                     Control.Model.IsSolution,
-                    UIUtility.ToContractsItemFilter(Control._topPanel.Filter));
+                    UIUtility.ToContractsItemFilter(Control._topPanel.Filter),
+                    sourceMappingSourceName);
 
                 ExecuteUserAction(userAction, NuGetActionType.Install);
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -11,7 +11,9 @@ using System.Windows.Documents;
 using System.Windows.Input;
 using Lucene.Net.Util;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.PackageManagement.Telemetry;
+using NuGet.PackageManagement.VisualStudio;
 using NuGet.ProjectManagement;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Telemetry;
@@ -112,17 +114,11 @@ namespace NuGet.PackageManagement.UI
 
             if (model != null && model.SelectedVersion != null)
             {
-                bool isInstallCreatingNewSourceMapping = false;
-                var packageSourceMapping = Control.Model.UIController.UIContext.PackageSourceMapping;
-                if (packageSourceMapping.IsEnabled)
-                {
-                    isInstallCreatingNewSourceMapping = packageSourceMapping.GetConfiguredPackageSources(model.Id)?.Count == 0;
-                }
-
-                string sourceMappingSourceName = Control.Model.UIController.ActivePackageSourceMoniker.IsAggregateSource == false ? Control.Model.UIController.ActivePackageSourceMoniker.PackageSourceNames.FirstOrDefault() : null;
+                var packageId = model.Id;
+                var sourceMappingSourceName = PackageSourceMappingUtility.GetNewSourceMappingSourceName(packageId, Control.Model.UIController.UIContext.PackageSourceMapping, Control.Model.UIController.ActivePackageSourceMoniker);
 
                 var userAction = UserAction.CreateInstallAction(
-                    model.Id,
+                    packageId,
                     model.SelectedVersion.Version,
                     Control.Model.IsSolution,
                     UIUtility.ToContractsItemFilter(Control._topPanel.Filter),

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -115,7 +115,7 @@ namespace NuGet.PackageManagement.UI
             if (model != null && model.SelectedVersion != null)
             {
                 var packageId = model.Id;
-                var sourceMappingSourceName = PackageSourceMappingUtility.GetNewSourceMappingSourceName(packageId, Control.Model.UIController.UIContext.PackageSourceMapping, Control.Model.UIController.ActivePackageSourceMoniker);
+                var sourceMappingSourceName = PackageSourceMappingUtility.GetNewSourceMappingSourceName(Control.Model.UIController.UIContext.PackageSourceMapping, Control.Model.UIController.ActivePackageSourceMoniker);
 
                 var userAction = UserAction.CreateInstallAction(
                     packageId,
@@ -147,7 +147,7 @@ namespace NuGet.PackageManagement.UI
             if (model != null && model.SelectedVersion != null)
             {
                 var packageId = model.Id;
-                var sourceMappingSourceName = PackageSourceMappingUtility.GetNewSourceMappingSourceName(packageId, Control.Model.UIController.UIContext.PackageSourceMapping, Control.Model.UIController.ActivePackageSourceMoniker);
+                var sourceMappingSourceName = PackageSourceMappingUtility.GetNewSourceMappingSourceName(Control.Model.UIController.UIContext.PackageSourceMapping, Control.Model.UIController.ActivePackageSourceMoniker);
 
                 var userAction = UserAction.CreateInstallAction(
                     packageId,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Input;
+using Lucene.Net.Util;
 using NuGet.Common;
 using NuGet.PackageManagement.Telemetry;
 using NuGet.ProjectManagement;
@@ -110,12 +112,22 @@ namespace NuGet.PackageManagement.UI
 
             if (model != null && model.SelectedVersion != null)
             {
+                bool isInstallCreatingNewSourceMapping = false;
+                var packageSourceMapping = Control.Model.UIController.UIContext.PackageSourceMapping;
+                if (packageSourceMapping.IsEnabled)
+                {
+                    isInstallCreatingNewSourceMapping = packageSourceMapping.GetConfiguredPackageSources(model.Id)?.Count == 0;
+                }
+
+                string sourceMappingSourceName = Control.Model.UIController.ActivePackageSourceMoniker.IsAggregateSource == false ? Control.Model.UIController.ActivePackageSourceMoniker.PackageSourceNames.FirstOrDefault() : null;
+
                 var userAction = UserAction.CreateInstallAction(
                     model.Id,
                     model.SelectedVersion.Version,
                     Control.Model.IsSolution,
                     UIUtility.ToContractsItemFilter(Control._topPanel.Filter),
-                    model.SelectedVersion.Range);
+                    model.SelectedVersion.Range,
+                    sourceMappingSourceName);
 
                 ExecuteUserAction(userAction, NuGetActionType.Install);
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1688,7 +1688,24 @@ namespace NuGet.PackageManagement.UI
         /// <param name="packagesInfo">Corresponding Package ViewModels from PM UI. Only needed for vulnerability telemetry counts. Can be <c>null</c></param>
         internal void InstallPackage(string packageId, NuGetVersion version, IEnumerable<PackageItemViewModel> packagesInfo)
         {
-            var action = UserAction.CreateInstallAction(packageId, version, Model.IsSolution, UIUtility.ToContractsItemFilter(_topPanel.Filter));
+            bool isInstallCreatingNewSourceMapping = false;
+            var packageSourceMapping = Model.UIController.UIContext.PackageSourceMapping;
+            if (packageSourceMapping.IsEnabled)
+            {
+                isInstallCreatingNewSourceMapping = packageSourceMapping.GetConfiguredPackageSources(packageId)?.Count == 0;
+            }
+
+            UserAction action = null;
+
+            if (isInstallCreatingNewSourceMapping)
+            {
+                var sourceMappingSourceName = Model.UIController.ActivePackageSourceMoniker.PackageSourceNames.FirstOrDefault();
+                action = UserAction.CreateInstallAction(packageId, version, Model.IsSolution, UIUtility.ToContractsItemFilter(_topPanel.Filter), sourceMappingSourceName);
+            }
+            else
+            {
+                action = UserAction.CreateInstallAction(packageId, version, Model.IsSolution, UIUtility.ToContractsItemFilter(_topPanel.Filter));
+            }
 
             ExecuteAction(
                 () =>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1688,7 +1688,7 @@ namespace NuGet.PackageManagement.UI
         /// <param name="packagesInfo">Corresponding Package ViewModels from PM UI. Only needed for vulnerability telemetry counts. Can be <c>null</c></param>
         internal void InstallPackage(string packageId, NuGetVersion version, IEnumerable<PackageItemViewModel> packagesInfo)
         {
-            var sourceMappingSourceName = PackageSourceMappingUtility.GetNewSourceMappingSourceName(packageId, Model.UIController.UIContext.PackageSourceMapping, Model.UIController.ActivePackageSourceMoniker);
+            var sourceMappingSourceName = PackageSourceMappingUtility.GetNewSourceMappingSourceName(Model.UIController.UIContext.PackageSourceMapping, Model.UIController.ActivePackageSourceMoniker);
             UserAction action = UserAction.CreateInstallAction(packageId, version, Model.IsSolution, UIUtility.ToContractsItemFilter(_topPanel.Filter), sourceMappingSourceName);
 
             ExecuteAction(

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1688,24 +1688,8 @@ namespace NuGet.PackageManagement.UI
         /// <param name="packagesInfo">Corresponding Package ViewModels from PM UI. Only needed for vulnerability telemetry counts. Can be <c>null</c></param>
         internal void InstallPackage(string packageId, NuGetVersion version, IEnumerable<PackageItemViewModel> packagesInfo)
         {
-            //bool isInstallCreatingNewSourceMapping = false;
-            //var packageSourceMapping = Model.UIController.UIContext.PackageSourceMapping;
-            //if (packageSourceMapping.IsEnabled)
-            //{
-            //    isInstallCreatingNewSourceMapping = packageSourceMapping.GetConfiguredPackageSources(packageId)?.Count == 0;
-            //}
-
-            UserAction action = null;
-
-            //if (isInstallCreatingNewSourceMapping)
-            //{
-            //    var sourceMappingSourceName = Model.UIController.ActivePackageSourceMoniker.PackageSourceNames.FirstOrDefault();
-            //    action = UserAction.CreateInstallAction(packageId, version, Model.IsSolution, UIUtility.ToContractsItemFilter(_topPanel.Filter), sourceMappingSourceName);
-            //}
-            //else
-            //{
-            action = UserAction.CreateInstallAction(packageId, version, Model.IsSolution, UIUtility.ToContractsItemFilter(_topPanel.Filter));
-            //}
+            var sourceMappingSourceName = PackageSourceMappingUtility.GetNewSourceMappingSourceName(packageId, Model.UIController.UIContext.PackageSourceMapping, Model.UIController.ActivePackageSourceMoniker);
+            UserAction action = UserAction.CreateInstallAction(packageId, version, Model.IsSolution, UIUtility.ToContractsItemFilter(_topPanel.Filter), sourceMappingSourceName);
 
             ExecuteAction(
                 () =>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1688,24 +1688,24 @@ namespace NuGet.PackageManagement.UI
         /// <param name="packagesInfo">Corresponding Package ViewModels from PM UI. Only needed for vulnerability telemetry counts. Can be <c>null</c></param>
         internal void InstallPackage(string packageId, NuGetVersion version, IEnumerable<PackageItemViewModel> packagesInfo)
         {
-            bool isInstallCreatingNewSourceMapping = false;
-            var packageSourceMapping = Model.UIController.UIContext.PackageSourceMapping;
-            if (packageSourceMapping.IsEnabled)
-            {
-                isInstallCreatingNewSourceMapping = packageSourceMapping.GetConfiguredPackageSources(packageId)?.Count == 0;
-            }
+            //bool isInstallCreatingNewSourceMapping = false;
+            //var packageSourceMapping = Model.UIController.UIContext.PackageSourceMapping;
+            //if (packageSourceMapping.IsEnabled)
+            //{
+            //    isInstallCreatingNewSourceMapping = packageSourceMapping.GetConfiguredPackageSources(packageId)?.Count == 0;
+            //}
 
             UserAction action = null;
 
-            if (isInstallCreatingNewSourceMapping)
-            {
-                var sourceMappingSourceName = Model.UIController.ActivePackageSourceMoniker.PackageSourceNames.FirstOrDefault();
-                action = UserAction.CreateInstallAction(packageId, version, Model.IsSolution, UIUtility.ToContractsItemFilter(_topPanel.Filter), sourceMappingSourceName);
-            }
-            else
-            {
-                action = UserAction.CreateInstallAction(packageId, version, Model.IsSolution, UIUtility.ToContractsItemFilter(_topPanel.Filter));
-            }
+            //if (isInstallCreatingNewSourceMapping)
+            //{
+            //    var sourceMappingSourceName = Model.UIController.ActivePackageSourceMoniker.PackageSourceNames.FirstOrDefault();
+            //    action = UserAction.CreateInstallAction(packageId, version, Model.IsSolution, UIUtility.ToContractsItemFilter(_topPanel.Filter), sourceMappingSourceName);
+            //}
+            //else
+            //{
+            action = UserAction.CreateInstallAction(packageId, version, Model.IsSolution, UIUtility.ToContractsItemFilter(_topPanel.Filter));
+            //}
 
             ExecuteAction(
                 () =>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
@@ -134,22 +134,37 @@
                     </ItemsControl.ItemTemplate>
                   </ItemsControl>
                 </StackPanel>
-                
+
                 <!-- New Source Mapping packages -->
                 <StackPanel
                   Margin="0,8"
-                  Visibility="{Binding Path=NewSourceMappingsPackageIds,Converter={StaticResource EnumerableToVisibilityConverter}}">
+                  Visibility="{Binding Path=NewSourceMappings,Converter={StaticResource EnumerableToVisibilityConverter}}">
                   <TextBlock
                     AutomationProperties.Name="{Binding Text}"
                     FontWeight="Bold"
                     Text="{x:Static nuget:Resources.Label_CreatingSourceMappings}" />
                   <ItemsControl
                     Margin="10,0,0,0"
-                    ItemsSource="{Binding Path=NewSourceMappingsPackageIds}"
+                    ItemsSource="{Binding Path=NewSourceMappings}"
                     IsTabStop="False">
                     <ItemsControl.ItemTemplate>
                       <DataTemplate>
-                        <TextBlock Text="{Binding}" AutomationProperties.Name="{Binding AutomationName}" />
+                        <StackPanel>
+                          <!-- New Source Mapping Source Name -->
+                          <TextBlock Text="{Binding Key}" />
+
+                          <!-- New Source Mapping Package IDs -->
+                          <ItemsControl ItemsSource="{Binding Value}"
+                            IsTabStop="False">
+                            <ItemsControl.ItemTemplate>
+                              <DataTemplate>
+                                <StackPanel>
+                                  <TextBlock Text="{Binding}" />
+                                </StackPanel>
+                              </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                          </ItemsControl>
+                        </StackPanel>
                       </DataTemplate>
                     </ItemsControl.ItemTemplate>
                   </ItemsControl>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
@@ -71,7 +71,6 @@
               <StackPanel
                 Margin="6, 6">
                 <TextBlock
-                  x:Name="_changeName"
                   AutomationProperties.Name="{Binding Text}"
                   FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font122PercentSizeConverter}}"
                   Text="{Binding Path=Name}" />
@@ -81,7 +80,6 @@
                   Margin="0,8"
                   Visibility="{Binding Path=Deleted,Converter={StaticResource EnumerableToVisibilityConverter}}">
                   <TextBlock
-                    x:Name="_uninstalledPackages"
                     AutomationProperties.Name="{Binding Text}"
                     FontWeight="Bold"
                     Text="{x:Static nuget:Resources.Label_UninstalledPackages}" />
@@ -102,7 +100,6 @@
                   Margin="0,8"
                   Visibility="{Binding Path=Updated,Converter={StaticResource EnumerableToVisibilityConverter}}">
                   <TextBlock
-                    x:Name="_updatedPackages"
                     AutomationProperties.Name="{Binding Text}"
                     FontWeight="Bold"
                     Text="{x:Static nuget:Resources.Label_UpdatedPackages}" />
@@ -123,7 +120,6 @@
                   Margin="0,8"
                   Visibility="{Binding Path=Added,Converter={StaticResource EnumerableToVisibilityConverter}}">
                   <TextBlock
-                    x:Name="_installedPackages"
                     AutomationProperties.Name="{Binding Text}"
                     FontWeight="Bold"
                     Text="{x:Static nuget:Resources.Label_InstalledPackages}" />
@@ -138,18 +134,18 @@
                     </ItemsControl.ItemTemplate>
                   </ItemsControl>
                 </StackPanel>
-                <!-- New Mapping packages -->
+                
+                <!-- New Source Mapping packages -->
                 <StackPanel
                   Margin="0,8"
-                  Visibility="{Binding Path=NewSourceMapping,Converter={StaticResource EnumerableToVisibilityConverter}}">
+                  Visibility="{Binding Path=NewSourceMappingsPackageIds,Converter={StaticResource EnumerableToVisibilityConverter}}">
                   <TextBlock
-                    x:Name="_newMappingPackages"
                     AutomationProperties.Name="{Binding Text}"
                     FontWeight="Bold"
-                    Text="Creating Package Source Mappings:" />
+                    Text="{x:Static nuget:Resources.Label_CreatingSourceMappings}" />
                   <ItemsControl
                     Margin="10,0,0,0"
-                    ItemsSource="{Binding Path=NewSourceMapping}"
+                    ItemsSource="{Binding Path=NewSourceMappingsPackageIds}"
                     IsTabStop="False">
                     <ItemsControl.ItemTemplate>
                       <DataTemplate>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
@@ -151,7 +151,10 @@
                       <DataTemplate>
                         <StackPanel>
                           <!-- New Source Mapping Source Name -->
-                          <TextBlock Text="{Binding Key}" />
+                          <TextBlock FontStyle="Italic">
+                            <Run Text="{x:Static nuget:Resources.Label_Repository}" />
+                            <Run Text="{Binding Key, Mode=OneTime}" />
+                          </TextBlock>
 
                           <!-- New Source Mapping Package IDs -->
                           <ItemsControl ItemsSource="{Binding Value}"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
@@ -135,14 +135,10 @@
                   </ItemsControl>
                 </StackPanel>
 
-                <!-- New Source Mapping packages -->
+                <!-- New Source Mappings for added packages -->
                 <StackPanel
                   Margin="0,8"
                   Visibility="{Binding Path=NewSourceMappings,Converter={StaticResource EnumerableToVisibilityConverter}}">
-                  <TextBlock
-                    AutomationProperties.Name="{Binding Text}"
-                    FontWeight="Bold"
-                    Text="{x:Static nuget:Resources.Label_CreatingSourceMappings}" />
                   <ItemsControl
                     Margin="10,0,0,0"
                     ItemsSource="{Binding Path=NewSourceMappings}"
@@ -150,10 +146,10 @@
                     <ItemsControl.ItemTemplate>
                       <DataTemplate>
                         <StackPanel>
-                          <!-- New Source Mapping Source Name -->
-                          <TextBlock FontStyle="Italic">
-                            <Run Text="{x:Static nuget:Resources.Label_Repository}" />
-                            <Run Text="{Binding Key, Mode=OneTime}" />
+                          <!-- New Source Mapping with Source Name -->
+                          <TextBlock
+                            FontWeight="Bold"
+                            Text="{Binding Key, Mode=OneWay, StringFormat={x:Static nuget:Resources.Label_CreatingSourceMappings}}">
                           </TextBlock>
 
                           <!-- New Source Mapping Package IDs -->

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
@@ -138,6 +138,26 @@
                     </ItemsControl.ItemTemplate>
                   </ItemsControl>
                 </StackPanel>
+                <!-- New Mapping packages -->
+                <StackPanel
+                  Margin="0,8"
+                  Visibility="{Binding Path=NewSourceMapping,Converter={StaticResource EnumerableToVisibilityConverter}}">
+                  <TextBlock
+                    x:Name="_newMappingPackages"
+                    AutomationProperties.Name="{Binding Text}"
+                    FontWeight="Bold"
+                    Text="Creating Package Source Mappings:" />
+                  <ItemsControl
+                    Margin="10,0,0,0"
+                    ItemsSource="{Binding Path=NewSourceMapping}"
+                    IsTabStop="False">
+                    <ItemsControl.ItemTemplate>
+                      <DataTemplate>
+                        <TextBlock Text="{Binding}" AutomationProperties.Name="{Binding AutomationName}" />
+                      </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                  </ItemsControl>
+                </StackPanel>
               </StackPanel>
             </DataTemplate>
           </ItemsControl.ItemTemplate>

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -3075,6 +3075,10 @@ namespace NuGet.PackageManagement
                         r.SummaryRequest.Request.Project.RestoreMetadata.ProjectPath,
                         buildIntegratedProject.MSBuildProjectPath,
                         StringComparison.OrdinalIgnoreCase));
+                string[] metadataFiles = Directory.GetFileSystemEntries(request.GlobalPackagesFolder, PackagingCoreConstants.NupkgMetadataFileExtension, SearchOption.AllDirectories);
+                NupkgMetadataFile metadata = NupkgMetadataFileFormat.Read(metadataPath);
+                string source = metadata.Source;
+                // restoreResult.SummaryRequest.Request.DependencyProviders
 
                 var unsuccessfulFrameworks = restoreResult
                     .Result


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

This Draft PR has been replaced by PR # 5355

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- If Source Mapping is disabled, nothing changes

_If Source Mapping is enabled..._
- Always calculate new Source Mappings for all **added packages** which do not have an existing source mapping.
  - (ie, the delta from the source mappings in the existing `nuget.config` and the source mappings resulting from this Install's PreviewRestore) 
- Enable Install button even when status is "Requires" mapping 
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/6b37f5e3-ff75-41c5-b176-fe8b845ed887)
- Works with Quick Install link (From packages list) :
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/fa759be9-7263-42be-91a8-42a34f6e9d8d)

- Preview Window, if enabled, will list the new mappings at the bottom of the list.
  - New section heading: "Solution". I chose this since Source Mapping applies to `nuget.config` which is a solution level concept.
    - ie, even in Project level PMUI, the text is "Solution"
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/5dfdd468-513b-4fad-a91d-3a1b25c595a2)

## TODOs
- Do we need an `Options` (in details pane) to allow customizing whether Install/actions automatically create mappings?
  -  If not, I can remove the boolean to see if the Install button should be disabled due to source mapping (currently hard coded to always `true`)
- Force Preview Window to show (regardless of setting) when there's an Error case or we need Customer's consent:
  - Check `nupkg.metadata` for source for packages in GPF
  - If transitive not available on any source, probably this PR will let it fail back to the Error List. 
    - Possibly: somehow allow customer to modify sources / select a source which does have the missing transitive

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
