### PR TITLE
Improve error when glob path used with nuget.exe restore

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -498,7 +498,22 @@ namespace NuGet.CommandLine
             {
                 // Restore takes multiple arguments, each could be a file or directory
                 var argument = Arguments.Single();
-                var fullPath = Path.GetFullPath(argument);
+                string fullPath;
+                try
+                {
+                    fullPath = Path.GetFullPath(argument);
+                }
+                catch (ArgumentException)
+                {
+                    // Treat "invalid characters in path" like a file not found.
+                    // Afterall, a filename with invalid characters can't exist.
+                    var message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        LocalizedResourceManager.GetString("RestoreCommandFileNotFound"),
+                        argument);
+
+                    throw new InvalidOperationException(message);
+                }
 
                 if (Directory.Exists(fullPath))
                 {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -32,14 +32,15 @@ namespace NuGet.CommandLine.Test
         private const int _failureCode = 1;
         private const int _successCode = 0;
 
-        [Fact]
-        public void RestoreCommand_BadInputPath()
+        [Theory]
+        [InlineData("bad/pat.h/myfile.blah")]
+        [InlineData("**/*.sln")]
+        public void RestoreCommand_BadInputPath(string solutionPath)
         {
             using (var randomTestFolder = TestDirectory.Create())
             {
                 // Arrange
                 var nugetexe = Util.GetNuGetExePath();
-                var solutionPath = "bad/pat.h/myfile.blah";
 
                 var args = new string[]
                 {
@@ -59,7 +60,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.NotEqual(_successCode, r.ExitCode);
                 var error = r.Errors;
-                Assert.Contains("Input file does not exist: bad/pat.h/myfile.blah", r.Errors, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains("Input file does not exist: " + solutionPath, r.Errors, StringComparison.OrdinalIgnoreCase);
             }
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12691

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Linked issue shows that previously when trying to pass a file glob to nuget.exe restore, it would show an exception with stack trace, the exception being "System.ArgumentException: Illegal characters in path.".

NuGet.exe doesn't support file globs, so treat it as a file not found and return the same error. MSBuild works in the same way.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
