### PR TITLE
Sort installed packages by vulenrabilities, deprecation then a-z

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -743,6 +743,11 @@ namespace NuGet.PackageManagement.UI
             ItemsView.GroupDescriptions.Clear();
         }
 
+        internal void ClearPackageSorting()
+        {
+            ItemsView.SortDescriptions.Clear();
+        }
+
         internal void AddPackageLevelGrouping()
         {
             ItemsView.Refresh();
@@ -752,6 +757,14 @@ namespace NuGet.PackageManagement.UI
             {
                 ItemsView.GroupDescriptions.Add(new PropertyGroupDescription(nameof(PackageItemViewModel.PackageLevel)));
             }
+        }
+
+        internal void AddSortingForVulnerabilitiesAndDeprecation()
+        {
+            ItemsView.SortDescriptions.Add(new SortDescription(nameof(PackageItemViewModel.IsPackageVulnerable), ListSortDirection.Descending));
+            ItemsView.SortDescriptions.Add(new SortDescription(nameof(PackageItemViewModel.IsPackageDeprecated), ListSortDirection.Descending));
+            ItemsView.SortDescriptions.Add(new SortDescription(nameof(PackageItemViewModel.Id), ListSortDirection.Ascending));
+            ItemsView.Refresh();
         }
 
         private void Expander_ExpansionStateToggled(object sender, RoutedEventArgs e)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -892,6 +892,8 @@ namespace NuGet.PackageManagement.UI
                     _packageList.ClearPackageLevelGrouping();
                 }
 
+                _packageList.ClearPackageSorting();
+
                 bool useRecommender = GetUseRecommendedPackages(loadContext, searchText);
                 var loader = await PackageItemLoader.CreateAsync(
                     Model.Context.ServiceBroker,
@@ -931,6 +933,11 @@ namespace NuGet.PackageManagement.UI
                 if (!useCachedPackageMetadata)
                 {
                     await RefreshInstalledAndUpdatesTabsAsync();
+                }
+
+                if (ActiveFilter == ItemFilter.Installed)
+                {
+                    _packageList.AddSortingForVulnerabilitiesAndDeprecation();
                 }
             }
             catch (OperationCanceledException)
@@ -1236,6 +1243,7 @@ namespace NuGet.PackageManagement.UI
                         {
                             _packageList.ClearPackageLevelGrouping();
                         }
+                        _packageList.ClearPackageSorting();
                         await SearchPackagesAndRefreshUpdateCountAsync(useCacheForUpdates: true);
                     }, RefreshOperationSource.FilterSelectionChanged, timeSpan, sw);
                     _detailModel.OnFilterChanged(e.PreviousFilter, _topPanel.Filter);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12693

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

"Promote" vulnerable and deprecated packages to the top of the list in the Installed tab in PM UI

![image](https://github.com/NuGet/NuGet.Client/assets/43253759/09446466-28e0-48de-bfce-4edac76e8828)
![image](https://github.com/NuGet/NuGet.Client/assets/43253759/4642380f-3e5c-4346-a7df-297580bb1a91)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. --> I wasn't able to test this, I found that testing a vulnerable/deprecated package in the InfiniteScroll is hard since we do another query for that metadata information. 

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
