### PR TITLE
fix crash on cancel in Restore task

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -112,7 +112,7 @@ namespace NuGet.Build.Tasks
             {
                 return ExecuteAsync(log).Result;
             }
-            catch (AggregateException ex) when (_cts.Token.IsCancellationRequested && ex.InnerException is TaskCanceledException)
+            catch (AggregateException ex) when (_cts.Token.IsCancellationRequested && ex.InnerException is OperationCanceledException)
             {
                 // Canceled by user
                 log.LogError(Strings.RestoreCanceled);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12700

Regression? Last working version: dunno

## Description
This clearly is the wrong type, by inspection. And that caused the Restore task to crash, in https://github.com/dotnet/msbuild/issues/7145

Compare the VS codepath:
https://github.com/microsoft/nuget.client/blob/76da1abbb48b9b09c3075eece6794a6012c08d2b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreStatusProvider.cs#L77

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
This is not feasible to test without exceptional efforts.
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
