### PR TITLE
Reduce allocations in VersionRangeFormatter

### DIFF
--- a/src/NuGet.Core/NuGet.Versioning/VersionFormatter.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionFormatter.cs
@@ -122,7 +122,7 @@ namespace NuGet.Versioning
         /// Appends a normalized version string. This string is unique for each version 'identity' 
         /// and does not include leading zeros or metadata.
         /// </summary>
-        private static void AppendNormalized(StringBuilder builder, SemanticVersion version)
+        internal static void AppendNormalized(StringBuilder builder, SemanticVersion version)
         {
             AppendVersion(builder, version);
 


### PR DESCRIPTION
## Bug

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1841687
Fixes: https://github.com/NuGet/Home/issues/12707

Regression? Last working version: N/A

## Description

`VersionRangeFormatter` calls into `VersionFormatter` for almost all of its operations. The latter produces a `string` which the former then composes into its output. This intermediary `string` is a wasteful allocation that can be avoided. GCPauseWatson shows that `VersionRangeFormatter` calls into `VersionFormatter` often enough that these temporary strings contribute to GC pauses on customer machines in the real world.

This change creates a pathway for `VersionRangeFormatter` to pass a `StringBuilder` to `VersionFormatter` in order to avoid the temporary string allocation. It also changes `VersionRangeFormatter` to use a `StringBuilder` more consistently internally, and to pass that to other methods it invokes where possible.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
