### PR TITLE
Fix architecture specific msbuild path

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -558,6 +558,8 @@ namespace NuGet.CommandLine
         {
             var msbuildFile = Path.GetFileName(msbuildExe);
             var directory = Path.GetDirectoryName(msbuildExe);
+            var directoryName = new DirectoryInfo(directory).Name;
+            var parentDirectory = new DirectoryInfo(directory).Parent.FullName;
 
             //Given Visual Studio 2022 or later, the PATH environment variable in Developer Command Prompt contains the architecture specific path of msbuild.exe.
             // e.g. C:\Program Files\Microsoft Visual Studio\2022\Preview\\MSBuild\Current\Bin\arm64
@@ -569,9 +571,8 @@ namespace NuGet.CommandLine
             //If msbuildExe is already in the non-architecture specific folder, just return the directory.
             foreach (var architecture in ArchitectureFolderNames)
             {
-                if (new DirectoryInfo(directory).Name.Equals(architecture, StringComparison.OrdinalIgnoreCase))
+                if (directoryName.Equals(architecture, StringComparison.OrdinalIgnoreCase))
                 {
-                    var parentDirectory = new DirectoryInfo(directory).Parent.FullName;
                     if (File.Exists(Path.Combine(parentDirectory, msbuildFile)))
                     {
                         return parentDirectory;
@@ -579,8 +580,10 @@ namespace NuGet.CommandLine
                     else
                     {
                         throw new CommandException(
-                            LocalizedResourceManager.GetString(
-                                nameof(NuGetResources.Error_CannotFindMsbuild)));
+                            string.Format(
+                                CultureInfo.CurrentCulture,
+                                LocalizedResourceManager.GetString(nameof(NuGetResources.Error_CannotFindNonArchitectureSpecificMsbuild)),
+                                directory));
                     }
                 }
             }

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -28,6 +28,7 @@ namespace NuGet.CommandLine
 
         private readonly static string[] MSBuildVersions = new string[] { "14", "12", "4" };
 
+        private readonly static string[] ArchitectureFolderNames = new string[] { "arm64", "amd64" };
         public static bool IsMsBuildBasedProject(string projectFullPath)
         {
             return projectFullPath.EndsWith("proj", StringComparison.OrdinalIgnoreCase);
@@ -500,7 +501,7 @@ namespace NuGet.CommandLine
 
                     if (msbuildExe != null)
                     {
-                        var msBuildDirectory = Path.GetDirectoryName(msbuildExe);
+                        var msBuildDirectory = GetNonArchitectureDirectory(msbuildExe);
                         var msbuildVersion = FileVersionInfo.GetVersionInfo(msbuildExe)?.FileVersion;
                         return toolset = new MsBuildToolset(msbuildVersion, msBuildDirectory);
                     }
@@ -551,6 +552,39 @@ namespace NuGet.CommandLine
             {
                 LogToolsetToConsole(console, toolset);
             }
+        }
+
+        internal static string GetNonArchitectureDirectory(string msbuildExe)
+        {
+            var msbuildFile = Path.GetFileName(msbuildExe);
+            var directory = Path.GetDirectoryName(msbuildExe);
+
+            //Given Visual Studio 2022 or later, the PATH environment variable in Developer Command Prompt contains the architecture specific path of msbuild.exe.
+            // e.g. C:\Program Files\Microsoft Visual Studio\2022\Preview\\MSBuild\Current\Bin\arm64
+            //Using the architecture specific path will cause some runtime error when loading assembly, e.g."Microsoft.Build.Framework.dll".
+            //
+            //This method is to get the non-architecture specific path of msbuild.exe if the msbuildexe is in the architecture specific folder.
+            //     C:\Program Files\Microsoft Visual Studio\2022\Preview\\MSBuild\Current\Bin\arm64
+            //  => C:\Program Files\Microsoft Visual Studio\2022\Preview\\MSBuild\Current\Bin
+            //If msbuildExe is already in the non-architecture specific folder, just return the directory.
+            foreach (var architecture in ArchitectureFolderNames)
+            {
+                if (new DirectoryInfo(directory).Name.Equals(architecture, StringComparison.OrdinalIgnoreCase))
+                {
+                    var parentDirectory = new DirectoryInfo(directory).Parent.FullName;
+                    if (File.Exists(Path.Combine(parentDirectory, msbuildFile)))
+                    {
+                        return parentDirectory;
+                    }
+                    else
+                    {
+                        throw new CommandException(
+                            LocalizedResourceManager.GetString(
+                                nameof(NuGetResources.Error_CannotFindMsbuild)));
+                    }
+                }
+            }
+            return directory;
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -558,8 +558,9 @@ namespace NuGet.CommandLine
         {
             var msbuildFile = Path.GetFileName(msbuildExe);
             var directory = Path.GetDirectoryName(msbuildExe);
-            var directoryName = new DirectoryInfo(directory).Name;
-            var parentDirectory = new DirectoryInfo(directory).Parent.FullName;
+            var directoryInfo = new DirectoryInfo(directory);
+            var directoryName = directoryInfo.Name;
+            var parentDirectory = directoryInfo.Parent.FullName;
 
             //Given Visual Studio 2022 or later, the PATH environment variable in Developer Command Prompt contains the architecture specific path of msbuild.exe.
             // e.g. C:\Program Files\Microsoft Visual Studio\2022\Preview\\MSBuild\Current\Bin\arm64

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -286,7 +286,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The resolved msbuild directory is {0} is a architecure specific directory. Could not find msbuild in its parent directory (non-architecutre specific). .
+        ///   Looks up a localized string similar to The resolved MSBuild directory is `{0}` which is an architecture-specific directory. Could not find MSBuild in its parent directory (non-architecture specific)..
         /// </summary>
         public static string Error_CannotFindNonArchitectureSpecificMsbuild {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -286,6 +286,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The resolved msbuild directory is {0} is a architecure specific directory. Could not find msbuild in its parent directory (non-architecutre specific). .
+        /// </summary>
+        public static string Error_CannotFindNonArchitectureSpecificMsbuild {
+            get {
+                return ResourceManager.GetString("Error_CannotFindNonArchitectureSpecificMsbuild", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot get the GetAllProjectFileNamesMethod from type  Mono.XBuild.CommandLine.SolutionParser..
         /// </summary>
         public static string Error_CannotGetGetAllProjectFileNamesMethod {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -736,6 +736,6 @@ Do not localize `SDK`, `dotnet pack`, msbuild -t:pack` and 'true'.</comment>
     <comment>0 - Environment variable name, 1 - value set in environment variable</comment>
   </data>
   <data name="Error_CannotFindNonArchitectureSpecificMsbuild" xml:space="preserve">
-    <value>The resolved msbuild directory is {0} is a architecure specific directory. Could not find msbuild in its parent directory (non-architecutre specific). </value>
+    <value>The resolved MSBuild directory is `{0}` which is an architecture-specific directory. Could not find MSBuild in its parent directory (non-architecture specific).</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -735,4 +735,7 @@ Do not localize `SDK`, `dotnet pack`, msbuild -t:pack` and 'true'.</comment>
     <value>Invalid culture identifier in {0} environment variable. Value read is '{1}'</value>
     <comment>0 - Environment variable name, 1 - value set in environment variable</comment>
   </data>
+  <data name="Error_CannotFindNonArchitectureSpecificMsbuild" xml:space="preserve">
+    <value>The resolved msbuild directory is {0} is a architecure specific directory. Could not find msbuild in its parent directory (non-architecutre specific). </value>
+  </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -333,18 +333,13 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [Theory]
+        [SkipMonoTheory] // Mono does not have SxS installations so it's not relevant to get msbuild from the path.
         [InlineData("arm64", true)]
         [InlineData("amd64", true)]
         [InlineData("ARM64", true)]
         [InlineData("random", false)]
         public void GetNonArchitectureDirectory_PATHENVWithArchitecture_Succeeds(string architecutre, bool isArchitectureSpecificPath)
         {
-            if (RuntimeEnvironmentHelper.IsMono)
-            { // Mono does not have SxS installations so it's not relevant to get msbuild from the path.
-                return;
-            }
-
             using (var vsPath = TestDirectory.Create())
             {
                 var msBuildNonArchitectureDir = Directory.CreateDirectory(Path.Combine(vsPath, "MSBuild", "Current", "Bin"));
@@ -370,14 +365,9 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [Fact]
+        [SkipMono] // Mono does not have SxS installations so it's not relevant to get msbuild from the path.
         public void GetNonArchitectureDirectory_PATHENVWithArchitecture_Throws()
         {
-            if (RuntimeEnvironmentHelper.IsMono)
-            { // Mono does not have SxS installations so it's not relevant to get msbuild from the path.
-                return;
-            }
-
             using (var vsPath = TestDirectory.Create())
             {
                 var msBuildNonArchitectureDir = Directory.CreateDirectory(Path.Combine(vsPath, "MSBuild", "Current", "Bin"));

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -389,8 +389,9 @@ namespace NuGet.CommandLine.Test
                 CommandException exception = Assert.Throws<CommandException>(
                     () => MsBuildUtility.GetNonArchitectureDirectory(msBuildExeArchitecturePath));
 
-                Assert.Equal(LocalizedResourceManager.GetString(
-                    nameof(NuGetResources.Error_CannotFindMsbuild)),
+                Assert.Equal(string.Format(CultureInfo.CurrentCulture,
+                    LocalizedResourceManager.GetString(nameof(NuGetResources.Error_CannotFindNonArchitectureSpecificMsbuild)),
+                    msBuildArchitectureDir.FullName),
                     exception.Message);
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/2281

Regression? No

## Description
**Context**: NuGet.exe pack  failed in Developer Command prompt from VS2022, for `Could not load file or assembly 'file:///D:\ProgramFiles\Microsoft VisualStudio\2022\Preview\MSBuild\Current\Bin\arm64\Microsoft.Build.Framework.dll'
or one of its dependencies. The system cannot find the file specified.`  The reason is, NuGet tries to get the directory of msbuild.exe from [PATH env var ](https://github.com/NuGet/NuGet.Client/blob/f1e67ed45119f3906621516d134e026e7d25bc9c/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs#L496), and in Developer Command prompt, the path of a specific architecture name instead of a general one, is added into the PATH. 
However, msbuild doesn't plan to ship all of the MSBuild assemblies and their dependencies into the architecture specific folder(bin\arm64, bin \amd64). The copies one folder up in bin are the ones that get loaded in Visual Studio and in MSBuild.exe.

This PR is to get the general folder which contains msbuild.exe, if an architecture specific folder is found in the PATH env var.

Manually tested on an arm64 machine:
NuGet.exe 6.6.1
```
PS D:\Users\source\repos\ClassLibrary1> D:\Users\Downloads\nuget.exe pack .\ClassLibrary1\ClassLibrary1.csproj
Attempting to build package from 'ClassLibrary1.csproj'.
MSBuild auto-detection: using msbuild version '17.7.0.27901' from 'D:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\arm64'.
Could not load file or assembly 'file:///D:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\arm64\Microsoft.Build.Framework.dll' or one of its dependencies. The system cannot find the file specified.
```
The NuGet.exe from artifacts with this fix:
```
PS D:\Users\source\repos\ClassLibrary1> D:\Users\Downloads\fix\nuget.exe pack .\ClassLibrary1\ClassLibrary1.csproj
Attempting to build package from 'ClassLibrary1.csproj'.
MSBuild auto-detection: using msbuild version '17.7.0.27901' from 'D:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin'.
Packing files from 'D:\Users\source\repos\ClassLibrary1\ClassLibrary1\bin\Debug'.
WARNING: NU5115: Description was not specified. Using 'Description'.
The package ClassLibrary1.1.0.0 is missing a readme. Go to https://aka.ms/nuget/authoring-best-practices/readme to learn why package readmes are important.
Successfully created package 'D:\Users\source\repos\ClassLibrary1\ClassLibrary1.1.0.0.nupkg'.
```

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
