### PR TITLE
Test:  unskip signing tests

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateUtilityTests.cs
@@ -326,7 +326,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [Fact(Skip="https://github.com/NuGet/Home/issues/12687")]
+        [Fact]
         public void GetHashString_UnknownHashAlgorithm_Throws()
         {
             using (var certificate = _fixture.GetDefaultCertificate())

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificatesFixture.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificatesFixture.cs
@@ -113,9 +113,7 @@ namespace NuGet.Packaging.Test
 
         private static X509Certificate2 Clone(X509Certificate2 certificate)
         {
-            var bytes = certificate.Export(X509ContentType.Pkcs12);
-
-            return new X509Certificate2(bytes);
+            return new X509Certificate2(certificate);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/EssCertIdTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/EssCertIdTests.cs
@@ -38,7 +38,7 @@ namespace NuGet.Packaging.Test
         }
 
 #if IS_SIGNING_SUPPORTED
-        [Fact(Skip="https://github.com/NuGet/Home/issues/12687")]
+        [Fact]
         public void Read_WithValidInput_ReturnsEssCertId()
         {
             using (var certificate = _fixture.GetDefaultCertificate())

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageArchiveUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageArchiveUtilityTests.cs
@@ -309,7 +309,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [Fact(Skip="https://github.com/NuGet/Home/issues/12687")]
+        [Fact]
         public async Task RemoveRepositorySignaturesAsync_WithAuthorPrimarySignature_DoesNotChangePackage()
         {
             using (var test = new RemoveTest(_fixture))


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/12687

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Some tests copy a certificate and its private key, and they do so by exporting to PFX and then importing.  How this cloning is done is an implementation detail and unimportant to test scenarios.

My guess is certificate cloning was implemented in this way without knowing that a [`X509Certificate2`'s constructor](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2.-ctor?view=net-7.0#system-security-cryptography-x509certificates-x509certificate2-ctor(system-security-cryptography-x509certificates-x509certificate)) provides a much simpler way to clone.  This constructor avoids the exception thrown by the recent .NET breaking change.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
