### PR TITLE
stop running optprof pipeline for 17.3 (release-6.3.x branch)

### DIFF
--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -8,8 +8,11 @@ resources:
     source: NuGet.Client-Official
     trigger:
       branches:
+       include:
         - dev
         - release-*
+       exclude:
+        - release-6.3.x
   - pipeline: DartLab
     source: DartLab
     branch: main


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Tracking: https://github.com/NuGet/Client.Engineering/issues/2362

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Prevent the OptProf pipeline triggering for the 6.3.x branch. Followed the guidance in [doc](https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/azure-repos-git?view=azure-devops&tabs=yaml#branches) to exclude `release-6.3.x` from the pipeline trigger.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A
