### PR TITLE
[DartLab B2B feature] dropname for base VS should be retrieved using the baseline.

### DIFF
--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -110,7 +110,7 @@ stages:
             targetType: 'inline'
             script: |
               $buildDrop = "${{parameters.baseBuildDrop}}" -split "/"
-              $dropName = "$($buildDrop[-2])/$($buildDrop[-1])"
+              $dropName = "Products/DevDiv/VS/$($buildDrop[-2])/$($buildDrop[-1])"
               Write-Host "##vso[task.setvariable variable=VisualStudio.BaseBuild.ProductsDropName]$dropName"
       preDeployAndRunTestsStepList:
         - task: PowerShell@1

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -91,6 +91,7 @@ stages:
         - task: PowerShell@2
           name: SetVisualStudioBaseBuildID
           displayName: Set 'VisualStudio.BaseBuild.ID'
+          condition: ne(variables['BaselineBuildCommitIds'], '')
           continueOnError: true
           inputs:
             filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildID.ps1

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -64,13 +64,13 @@ stages:
             filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
             arguments: -ClientSecret (ConvertTo-SecureString '$(CloudBuild-ClientSecret)' -AsPlainText -Force) -ClientID '$(CloudBuild-ClientID)' -SessionID '${{ parameters.QBuildSessionId }}' -OutVariableName 'BaselineBuildID'
         
-        - task: PowerShell@1
+        - task: PowerShell@2
           displayName: "Get Baseline build commit ids"
           name: "getbaselinebuildcommitids"
           continueOnError: true
           inputs:
-            scriptType: "inlineScript"
-            inlineScript: |
+            targetType: 'inline'
+            script: |
               try {
               Write-Host "Getting Baseline build commit ids for build: '$(BaselineBuildID)'"
               
@@ -107,8 +107,8 @@ stages:
           displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build
           condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
           inputs:
-            scriptType: "inlineScript"
-            inlineScript: |
+            targetType: 'inline'
+            script: |
               $buildDrop = "${{parameters.baseBuildDrop}}" -split "/"
               $dropName = "$($buildDrop[-2])/$($buildDrop[-1])"
               Write-Host "##vso[task.setvariable variable=VisualStudio.BaseBuild.ProductsDropName]$dropName"

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -67,6 +67,7 @@ stages:
         - task: PowerShell@2
           displayName: "Get Baseline build commit ids"
           name: "getbaselinebuildcommitids"
+          retryCountOnTaskFailure: 3
           continueOnError: true
           inputs:
             targetType: 'inline'
@@ -91,6 +92,7 @@ stages:
         - task: PowerShell@2
           name: SetVisualStudioBaseBuildID
           displayName: Set 'VisualStudio.BaseBuild.ID'
+          retryCountOnTaskFailure: 3
           condition: ne(variables['BaselineBuildCommitIds'], '')
           continueOnError: true
           inputs:
@@ -99,6 +101,7 @@ stages:
         - task: PowerShell@2
           name: SetVisualStudioBaseBuildProductsDropName
           displayName: Set 'VisualStudio.BaseBuild.ProductsDropName'
+          retryCountOnTaskFailure: 3
           condition: ne(variables['VisualStudio.BaseBuild.ID'], '')
           inputs:
             filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
@@ -106,6 +109,7 @@ stages:
         - task: PowerShell@2
           name: SetBaseProductsDropNameToTarget
           displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build
+          retryCountOnTaskFailure: 3
           condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
           inputs:
             targetType: 'inline'

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -86,7 +86,7 @@ stages:
 
               $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildCommitIDs.ps1 -BuildJson $baselineBuildsFile -OutVariableName "BaselineBuildCommitIds"
               } catch {
-                Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
+                Write-Host "Unable to get Baseline build commit ids: $_"
               }
         - task: PowerShell@2
           name: SetVisualStudioBaseBuildID

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -46,6 +46,7 @@ stages:
       testLabPoolName: VS-Platform
       dartLabEnvironment: ${{parameters.DartLabEnvironment}}
       visualStudioSigning: Test
+      testMachineConfigurationJobTimeoutInMinutes: 30
       testMachineDeploymentJobTimeoutInMinutes: 240
       testMachineConfigurationJobDisplayName: 'Apex Test Machine Configuration'
       testMachineDeploymentJobDisplayName: 'Apex Test Machine Deployment'

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -109,7 +109,7 @@ stages:
           inputs:
             scriptType: "inlineScript"
             inlineScript: |
-              $buildDrop = ${{parameters.baseBuildDrop}} -split "/"
+              $buildDrop = "${{parameters.baseBuildDrop}}" -split "/"
               $dropName = "$($buildDrop[-2])/$($buildDrop[-1])"
               Write-Host "##vso[task.setvariable variable=VisualStudio.BaseBuild.ProductsDropName]$dropName"
       preDeployAndRunTestsStepList:

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -41,7 +41,7 @@ stages:
           - ${{parameters.variables}}
       runSettingsURI: ${{parameters.runSettingsURI}}
       visualStudioBootstrapperURI: $(bootstrapperUrl)      
-      baseVisualStudioBootstrapperURI: ${{parameters.baseBuildDrop}};bootstrappers/Enterprise/vs_enterprise.exe
+      baseVisualStudioBootstrapperURI: https://vsdrop.corp.microsoft.com/file/v1/$(VisualStudio.BaseBuild.ProductsDropName);bootstrappers/Enterprise/vs_enterprise.exe
       candidateBaselineBuilds: $(BaselineBuildCommitIds)
       testLabPoolName: VS-Platform
       dartLabEnvironment: ${{parameters.DartLabEnvironment}}
@@ -86,7 +86,28 @@ stages:
               $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildCommitIDs.ps1 -BuildJson $baselineBuildsFile -OutVariableName "BaselineBuildCommitIds"
               } catch {
                 Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
-              }            
+              }
+        - task: PowerShell@2
+          name: SetVisualStudioBaseBuildID
+          displayName: Set 'VisualStudio.BaseBuild.ID'
+          continueOnError: true
+          inputs:
+            filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildID.ps1
+            arguments: -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -InstanceURL '$(System.CollectionUri)' -RepositoryName 'VS' -ProjectName '$(System.TeamProject)' -CommitIDs $(BaselineBuildCommitIds) -BuildDefinitionIDs 10289 -OutVariableName 'VisualStudio.BaseBuild.ID'
+        - task: PowerShell@2
+          name: SetVisualStudioBaseBuildProductsDropName
+          displayName: Set 'VisualStudio.BaseBuild.ProductsDropName'
+          condition: ne(variables['VisualStudio.BaseBuild.ID'], '')
+          inputs:
+            filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
+            arguments: -AccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -DropNamePrefix 'Products' -AccountURL '$(System.CollectionUri)' -ProjectName '$(System.TeamProject)' -BuildID $(VisualStudio.BaseBuild.ID) -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'
+        - task: PowerShell@2
+          name: SetBaseProductsDropNameToTarget
+          displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build
+          condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
+          inputs:
+            targetType: 'inline'
+            script: Write-Host "##vso[task.setvariable variable=VisualStudio.BaseBuild.ProductsDropName]$(setbasebuilddrop.BaseBuildDrop)"
       preDeployAndRunTestsStepList:
         - task: PowerShell@1
           displayName: "Print Environment Variables"

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -110,7 +110,7 @@ stages:
             scriptType: "inlineScript"
             inlineScript: |
               $buildDrop = ${{parameters.baseBuildDrop}} -split "/"
-              $dropName = "$buildDrop[-2]/$buildDrop[-1]"
+              $dropName = "$($buildDrop[-2])/$($buildDrop[-1])"
               Write-Host "##vso[task.setvariable variable=VisualStudio.BaseBuild.ProductsDropName]$dropName"
       preDeployAndRunTestsStepList:
         - task: PowerShell@1

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -107,7 +107,7 @@ stages:
           condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
           inputs:
             targetType: 'inline'
-            script: Write-Host "##vso[task.setvariable variable=VisualStudio.BaseBuild.ProductsDropName]$(setbasebuilddrop.BaseBuildDrop)"
+            script: Write-Host "##vso[task.setvariable variable=VisualStudio.BaseBuild.ProductsDropName]${{parameters.baseBuildDrop}}"
       preDeployAndRunTestsStepList:
         - task: PowerShell@1
           displayName: "Print Environment Variables"

--- a/eng/pipelines/templates/Apex_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows.yml
@@ -107,8 +107,11 @@ stages:
           displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build
           condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
           inputs:
-            targetType: 'inline'
-            script: Write-Host "##vso[task.setvariable variable=VisualStudio.BaseBuild.ProductsDropName]${{parameters.baseBuildDrop}}"
+            scriptType: "inlineScript"
+            inlineScript: |
+              $buildDrop = ${{parameters.baseBuildDrop}} -split "/"
+              $dropName = "$buildDrop[-2]/$buildDrop[-1]"
+              Write-Host "##vso[task.setvariable variable=VisualStudio.BaseBuild.ProductsDropName]$dropName"
       preDeployAndRunTestsStepList:
         - task: PowerShell@1
           displayName: "Print Environment Variables"

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -52,13 +52,14 @@ stages:
       value: ${{parameters.part}}
     - ${{if gt(length(parameters.variables), 0)}}:
       - ${{parameters.variables}}
-    baseVisualStudioBootstrapperURI: ${{parameters.baseBuildDrop}};bootstrappers/Enterprise/vs_enterprise.exe
+    baseVisualStudioBootstrapperURI: https://vsdrop.corp.microsoft.com/file/v1/$(VisualStudio.BaseBuild.ProductsDropName);bootstrappers/Enterprise/vs_enterprise.exe
     candidateBaselineBuilds: $(BaselineBuildCommitIds)
     visualStudioBootstrapperURI: $(bootstrapperUrl)
     visualStudioInstallationParameters: $(VisualStudio.InstallationUnderTest.SetupParameters)
     testLabPoolName: VS-Platform
     dartLabEnvironment: ${{parameters.DartLabEnvironment}}
     visualStudioSigning: Test
+    testMachineConfigurationJobTimeoutInMinutes: 30
     testMachineCleanUpStrategy: ${{parameters.testMachineCleanUpStrategy}}
     preTestMachineConfigurationStepList:
     - task: PowerShell@2
@@ -74,13 +75,13 @@ stages:
         filePath: $(DartLab.Path)\Scripts\AzureDevOps\Build\Get-BuildIdFromCloudBuildSessionID.ps1
         arguments: -ClientSecret (ConvertTo-SecureString '$(CloudBuild-ClientSecret)' -AsPlainText -Force) -ClientID '$(CloudBuild-ClientID)' -SessionID '${{ parameters.QBuildSessionId }}' -OutVariableName 'BaselineBuildID'
     
-    - task: PowerShell@1
+    - task: PowerShell@2
       displayName: "Get Baseline build commit ids"
       name: "getbaselinebuildcommitids"
       continueOnError: true
       inputs:
-        scriptType: "inlineScript"
-        inlineScript: |
+        targetType: 'inline'
+        script: |
           try {
           Write-Host "Getting Baseline build commit ids for build: '$(BaselineBuildID)'"
           
@@ -96,8 +97,33 @@ stages:
 
           $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildCommitIDs.ps1 -BuildJson $baselineBuildsFile -OutVariableName "BaselineBuildCommitIds"
           } catch {
-            Write-Host "##vso[task.LogIssue type=error;]Unable to get Baseline build commit ids: $_"
+            Write-Host "Unable to get Baseline build commit ids: $_"
           }
+    - task: PowerShell@2
+      name: SetVisualStudioBaseBuildID
+      displayName: Set 'VisualStudio.BaseBuild.ID'
+      condition: ne(variables['BaselineBuildCommitIds'], '')
+      continueOnError: true
+      inputs:
+        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-BaselineBuildID.ps1
+        arguments: -OAuthAccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -InstanceURL '$(System.CollectionUri)' -RepositoryName 'VS' -ProjectName '$(System.TeamProject)' -CommitIDs $(BaselineBuildCommitIds) -BuildDefinitionIDs 10289 -OutVariableName 'VisualStudio.BaseBuild.ID'
+    - task: PowerShell@2
+      name: SetVisualStudioBaseBuildProductsDropName
+      displayName: Set 'VisualStudio.BaseBuild.ProductsDropName'
+      condition: ne(variables['VisualStudio.BaseBuild.ID'], '')
+      inputs:
+        filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
+        arguments: -AccessToken (ConvertTo-SecureString '$(System.AccessToken)' -AsPlainText -Force) -DropNamePrefix 'Products' -AccountURL '$(System.CollectionUri)' -ProjectName '$(System.TeamProject)' -BuildID $(VisualStudio.BaseBuild.ID) -OutVariableName 'VisualStudio.BaseBuild.ProductsDropName'
+    - task: PowerShell@2
+      name: SetBaseProductsDropNameToTarget
+      displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build
+      condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
+      inputs:
+        targetType: 'inline'
+        script: |
+          $buildDrop = "${{parameters.baseBuildDrop}}" -split "/"
+          $dropName = "Products/DevDiv/VS/$($buildDrop[-2])/$($buildDrop[-1])"
+          Write-Host "##vso[task.setvariable variable=VisualStudio.BaseBuild.ProductsDropName]$dropName"
     deployAndRunTestsStepList:
     - task: PowerShell@1
       displayName: "Define variables"

--- a/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/End_To_End_Tests_On_Windows.yml
@@ -78,6 +78,7 @@ stages:
     - task: PowerShell@2
       displayName: "Get Baseline build commit ids"
       name: "getbaselinebuildcommitids"
+      retryCountOnTaskFailure: 3
       continueOnError: true
       inputs:
         targetType: 'inline'
@@ -102,6 +103,7 @@ stages:
     - task: PowerShell@2
       name: SetVisualStudioBaseBuildID
       displayName: Set 'VisualStudio.BaseBuild.ID'
+      retryCountOnTaskFailure: 3
       condition: ne(variables['BaselineBuildCommitIds'], '')
       continueOnError: true
       inputs:
@@ -110,6 +112,7 @@ stages:
     - task: PowerShell@2
       name: SetVisualStudioBaseBuildProductsDropName
       displayName: Set 'VisualStudio.BaseBuild.ProductsDropName'
+      retryCountOnTaskFailure: 3
       condition: ne(variables['VisualStudio.BaseBuild.ID'], '')
       inputs:
         filePath: $(DartLab.Path)\Scripts\VisualStudio\Build\Get-VisualStudioDropName.ps1
@@ -117,6 +120,7 @@ stages:
     - task: PowerShell@2
       name: SetBaseProductsDropNameToTarget
       displayName: Set 'VisualStudio.BaseBuild.ProductsDropName' to drop from target build
+      retryCountOnTaskFailure: 3
       condition: eq(variables['VisualStudio.BaseBuild.ID'], '')
       inputs:
         targetType: 'inline'


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2380

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

@kartheekp-ms noticed that B2B upgrade is disabled in almost 4 PR build logs. When B2B is disabled, DartLab installs VS from scratch instead of upgrading. To enable B2B upgrade, the base VS drop name needs to be retrieved from the baseline. Otherwise, if the base and target VS use the same drop, their versions will be identical, resulting in the disabling B2B upgrade.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A