### PR TITLE
Show icon in InfiniteScrollList when network error getting package info

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1096,6 +1096,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error getting additional information about package. Refresh to try again..
+        /// </summary>
+        public static string Label_NetworkError {
+            get {
+                return ResourceManager.GetString("Label_NetworkError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to NuGet: {0}.
         /// </summary>
         public static string Label_NuGetWindowCaption {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1096,7 +1096,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error getting additional information about the package. Refresh to try again..
+        ///   Looks up a localized string similar to An error occurred while fetching additional information about the package. Please refresh to try again..
         /// </summary>
         public static string Label_NetworkError {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1096,7 +1096,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An error occurred while fetching additional information about the package. Please refresh to try again..
+        ///   Looks up a localized string similar to An error occurred while fetching additional information about the package. Refresh to try again..
         /// </summary>
         public static string Label_NetworkError {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1096,7 +1096,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error getting additional information about package. Refresh to try again..
+        ///   Looks up a localized string similar to Error getting additional information about the package. Refresh to try again..
         /// </summary>
         public static string Label_NetworkError {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -994,4 +994,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <value>_OK</value>
     <comment>Button_Cancel and Button_OK must have underscore in different letters. See https://docs.microsoft.com/windows/apps/design/input/access-keys#choose-access-keys</comment>
   </data>
+  <data name="Label_NetworkError" xml:space="preserve">
+    <value>Error getting additional information about package. Refresh to try again.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -995,6 +995,6 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <comment>Button_Cancel and Button_OK must have underscore in different letters. See https://docs.microsoft.com/windows/apps/design/input/access-keys#choose-access-keys</comment>
   </data>
   <data name="Label_NetworkError" xml:space="preserve">
-    <value>Error getting additional information about package. Refresh to try again.</value>
+    <value>Error getting additional information about the package. Refresh to try again.</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -995,6 +995,6 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <comment>Button_Cancel and Button_OK must have underscore in different letters. See https://docs.microsoft.com/windows/apps/design/input/access-keys#choose-access-keys</comment>
   </data>
   <data name="Label_NetworkError" xml:space="preserve">
-    <value>An error occurred while fetching additional information about the package. Please refresh to try again.</value>
+    <value>An error occurred while fetching additional information about the package. Refresh to try again.</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -995,6 +995,6 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <comment>Button_Cancel and Button_OK must have underscore in different letters. See https://docs.microsoft.com/windows/apps/design/input/access-keys#choose-access-keys</comment>
   </data>
   <data name="Label_NetworkError" xml:space="preserve">
-    <value>Error getting additional information about the package. Refresh to try again.</value>
+    <value>An error occurred while fetching additional information about the package. Please refresh to try again.</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -732,10 +732,10 @@ namespace NuGet.PackageManagement.UI
                 {
                     await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
                     IsPackageWithNetworkErrors = true;
-        }
+                }
                 catch (OperationCanceledException)
                 {
-                    // task cancelation
+                    // if cancellationToken cancelled before the above is scheduled on UI thread, don't log fault telemetry
                 }
             }
         }
@@ -770,7 +770,7 @@ namespace NuGet.PackageManagement.UI
                 }
                 catch (OperationCanceledException)
                 {
-                    // task cancelation
+                    // if cancellationToken cancelled before the above is scheduled on UI thread, don't log fault telemetry
                 }
             }
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -404,6 +404,20 @@ namespace NuGet.PackageManagement.UI
             get => IsPackageDeprecated || IsPackageVulnerable;
         }
 
+        private bool _isPackageWithNetworkErrors;
+        public bool IsPackageWithNetworkErrors
+        {
+            get => _isPackageWithNetworkErrors;
+            set
+            {
+                if (IsPackageWithNetworkErrors != value)
+                {
+                    _isPackageWithNetworkErrors = value;
+                    OnPropertyChanged(nameof(IsPackageWithNetworkErrors));
+                }
+            }
+        }
+
         private Uri _iconUrl;
         public Uri IconUrl
         {
@@ -711,6 +725,19 @@ namespace NuGet.PackageManagement.UI
             {
                 // UI requested cancellation
             }
+            catch (TaskCanceledException)
+            {
+                // HttpClient throws TaskCanceledExceptions for HTTP timeouts
+                try
+                {
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+                    IsPackageWithNetworkErrors = true;
+        }
+                catch (OperationCanceledException)
+                {
+                    // task cancelation
+                }
+            }
         }
 
         private async Task ReloadPackageMetadataAsync()
@@ -732,6 +759,19 @@ namespace NuGet.PackageManagement.UI
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 // UI requested cancellation.
+            }
+            catch (TaskCanceledException)
+            {
+                // HttpClient throws TaskCanceledExceptions for HTTP timeouts
+                try
+                {
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+                    IsPackageWithNetworkErrors = true;
+                }
+                catch (OperationCanceledException)
+                {
+                    // task cancelation
+                }
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -258,36 +258,47 @@
 
         <!-- row 0: -->
 
-        <!-- warnings indicator -->
-        <imaging:CrispImage
-                      x:Name="_warningIndicator"
+        <!-- warnings indicators -->
+        <StackPanel
                       Grid.Row="0"
                       Grid.Column="0"
+                      Orientation="Horizontal">
+          <imaging:CrispImage
+            VerticalAlignment="Center"
+            Moniker="{x:Static catalog:KnownMonikers.CloudError}"
+            Visibility="{Binding IsPackageWithNetworkErrors,Converter={StaticResource BooleanToVisibilityConverter}}">
+            <imaging:CrispImage.ToolTip>
+              <TextBlock Text="{x:Static nuget:Resources.Label_NetworkError}" />
+            </imaging:CrispImage.ToolTip>
+          </imaging:CrispImage>
+          <imaging:CrispImage
+                      x:Name="_warningIndicator"
                       Visibility="{Binding IsPackageWithWarnings,Converter={StaticResource BooleanToVisibilityConverter}}"
                       VerticalAlignment="Center"
                       AutomationProperties.Name="{x:Static nuget:Resources.Label_Deprecated}"
                       Moniker="{x:Static catalog:KnownMonikers.StatusWarning}">
-          <imaging:CrispImage.ToolTip>
-            <StackPanel>
-              <TextBlock
+            <imaging:CrispImage.ToolTip>
+              <StackPanel>
+                <TextBlock
                 Margin="0, 0, 0, 8"
                 Visibility="{Binding IsPackageVulnerable,Converter={StaticResource BooleanToVisibilityConverter}}">
-                <TextBlock.Text>
-                  <MultiBinding Converter="{StaticResource StringFormatConverter}">
-                    <Binding Source="{x:Static nuget:Resources.Label_PackageVulnerableToolTip}" />
-                    <Binding Path="VulnerabilityMaxSeverity" Converter="{StaticResource IntToVulnerabilitySeverityConverter}" />
-                  </MultiBinding>
-                </TextBlock.Text>
-              </TextBlock>
-              <TextBlock
+                  <TextBlock.Text>
+                    <MultiBinding Converter="{StaticResource StringFormatConverter}">
+                      <Binding Source="{x:Static nuget:Resources.Label_PackageVulnerableToolTip}" />
+                      <Binding Path="VulnerabilityMaxSeverity" Converter="{StaticResource IntToVulnerabilitySeverityConverter}" />
+                    </MultiBinding>
+                  </TextBlock.Text>
+                </TextBlock>
+                <TextBlock
                 Text="{x:Static nuget:Resources.Label_PackageDeprecatedToolTip}"
                 Margin="0, 0, 0, 8"
                 Visibility="{Binding IsPackageDeprecated,Converter={StaticResource BooleanToVisibilityConverter}}" />
-              <TextBlock
+                <TextBlock
                 Text="{x:Static nuget:Resources.Label_PackageSelectForInfoToolTip}" />
-            </StackPanel>
-          </imaging:CrispImage.ToolTip>
-        </imaging:CrispImage>
+              </StackPanel>
+            </imaging:CrispImage.ToolTip>
+          </imaging:CrispImage>
+        </StackPanel>
 
         <!-- installed version -->
         <TextBlock


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Maybe Fixes: https://github.com/NuGet/Client.Engineering/issues/2368

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Looking at NuGet's fault telemetry, the vast majority of `TaskCanceledException` faults come from `PackageItemViewModel`'s `ReloadPackageVersionsAsync` and `ReloadPackageMetadataAsync` methods. Since both of these already suppress the fault when the cancelation token requests cancelation, it's likely that the telemetry is due to `HttpClient` timeouts.

Since the error means that package information was not retrieved successfully (either vulnerability/deprecation, or version information), show something to the customer. This is particularly important for missing deprecation or vulnerability information, otherwise it looks like the package doesn't have vulnerabilities or deprecation information, whereas in fact PM UI doesn't know if it does or not.

Injecting some random failures, here's what it looks like with the tooltip:
![image](https://github.com/NuGet/NuGet.Client/assets/5030577/a9b4006b-1349-4ab2-9023-331040e65daa)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: I don't know how to test httptime exceptions in this codepath
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
