### PR TITLE
Update System.Security.Cryptography.Pkcs version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
-    <CryptographyPackagesVersion Condition="'$(CryptographyPackagesVersion)' == ''">5.0.0</CryptographyPackagesVersion>
+    <CryptographyPackagesVersion Condition="'$(CryptographyPackagesVersion)' == ''">6.0.4</CryptographyPackagesVersion>
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)' == ''">3.3.4</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <NewtonsoftJsonPackageVersion Condition="'$(NewtonsoftJsonPackageVersion)' == ''">13.0.1</NewtonsoftJsonPackageVersion>
     <SystemPackagesVersion Condition="'$(SystemPackagesVersion)' == ''">4.3.0</SystemPackagesVersion>
@@ -95,7 +95,6 @@
     <PackageVersion Include="System.Resources.ResourceManager" Version="$(SystemPackagesVersion)" />
     <PackageVersion Include="System.Runtime.Extensions" Version="$(SystemPackagesVersion)" />
     <PackageVersion Include="System.Runtime.InteropServices" Version="$(SystemPackagesVersion)" />
-    <PackageVersion Include="System.Security.Cryptography.Cng" Version="$(CryptographyPackagesVersion)" />
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="$(CryptographyPackagesVersion)" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />

--- a/src/NuGet.Core/NuGet.Packaging/ArrayPool.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ArrayPool.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if NETFRAMEWORK
 
 using NuGet;
 

--- a/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
@@ -43,7 +43,6 @@
 
   <ItemGroup Condition=" '$(IsCore)' == 'true' ">
     <PackageReference Include="System.Security.Cryptography.Pkcs" />
-    <PackageReference Include="System.Security.Cryptography.Cng" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2372

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* System.Security.Cryptography.Pkcs has a known vulnerability, and needs to be upgraded. Or at least, it's easier to upgrade than to figure out if we're using the package in a way that's vulnerable or not.
* System.Security.Cryptography.Cng hasn't been getting newer versions since 5.0.0, but is listed as a dependency of System.Security.Cryptography.Pkcs, and we only used .Cng where were also used .Pkcs`, so I removed the `.Cng` references
* Although `CryptographyPackagesVersion` is now only used by 1 PackageVersion (Pkcs), I didn't rename the property, because I assume that source-build uses it to override the version
* The newer version of .Pkcs (or its dependencies) now bring System.Buffer into the restore graph for NuGet.Packaging's netstandard2.0 build, so the internal copy of `ArrayPool` was causing compiler errors. Hence, stop using it in netstandard2.0, since we can reference it from the .NET library.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
