### PR TITLE
Select the correct installed version when version is not normalized in nuspec.

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -732,7 +732,7 @@ namespace NuGet.PackageManagement.UI
             }
             else
             {
-                var installedVersion = _searchResultPackage?.AllowedVersions?.OriginalString ?? _searchResultPackage?.InstalledVersion.ToString();
+                var installedVersion = _searchResultPackage?.AllowedVersions?.OriginalString ?? _searchResultPackage?.InstalledVersion.ToNormalizedString();
                 SelectedVersion =
                     possibleVersions.FirstOrDefault(v => StringComparer.OrdinalIgnoreCase.Equals(v.Range?.OriginalString, installedVersion))
                     ?? possibleVersions.FirstOrDefault(v => v.IsValidVersion);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12661


Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

`InstalledVersion` property in the PM UI is calculated with the metadata of the installed package. If the user packs with our official tooling a validation will be run and the version will be correct, but users can create their nuspec and zip the package themselves, this can lead to versions with the `revision` property.

In this case the package version `Microsoft.Net.Http 2.0.20710` has a nuspec version of `2.0.20710.0` which will break the combobox since we are comparing strings and select another version (latest one), this quick change of versions makes the UI change really fast and make the "flash" effect. `ToNormalizedString();` help us to remove that extra 0. 

![installed-version-fix](https://github.com/NuGet/NuGet.Client/assets/43253759/36a05808-672f-485f-991a-58604b218169)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. --> I'll ask vendors to test this again

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
