### PR TITLE
Combobox version is aware of labels when autoselecting version

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -252,7 +252,7 @@ namespace NuGet.PackageManagement.UI
             if ((UserInput.StartsWith("(", StringComparison.OrdinalIgnoreCase) || UserInput.StartsWith("[", StringComparison.OrdinalIgnoreCase)) &&
                VersionRange.TryParse(UserInput, out VersionRange userRange))
             {
-                if (o != null && NuGetVersion.TryParse(o.ToString(), out NuGetVersion userVersion))
+                if (o != null && NuGetVersion.TryParse(version.Version.ToString(), out NuGetVersion userVersion))
                 {
                     if (userRange.Satisfies(userVersion))
                     {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -252,12 +252,9 @@ namespace NuGet.PackageManagement.UI
             if ((UserInput.StartsWith("(", StringComparison.OrdinalIgnoreCase) || UserInput.StartsWith("[", StringComparison.OrdinalIgnoreCase)) &&
                VersionRange.TryParse(UserInput, out VersionRange userRange))
             {
-                if (o != null && NuGetVersion.TryParse(version.Version.ToString(), out NuGetVersion userVersion))
+                if (o != null && userRange.Satisfies(version.Version))
                 {
-                    if (userRange.Satisfies(userVersion))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
 
                 return false;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
@@ -161,7 +161,7 @@ namespace NuGet.PackageManagement.UI
                         if (_versions.SelectedIndex >= 0 && isAVersion)
                         {
                             // Check if the user typed a custom version
-                            if (isUserInputValidNuGetVersionRange)
+                            if (isUserInputValidNuGetVersionRange && userRequestedVersionRange != null && _versions.Items?.CurrentItem != null)
                             {
                                 // Search for the best version
                                 NuGetVersion rangeBestVersion = userRequestedVersionRange.FindBestMatch(versions);
@@ -169,8 +169,8 @@ namespace NuGet.PackageManagement.UI
                                 bool isBestOption = rangeBestVersion.ToString() == selectedVersion.Version.ToString();
                                 if (isBestOption)
                                 {
-                                    PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRequestedVersionRange, rangeBestVersion, additionalInfo: null, isVulnerable: false);
-                                    _versions.Text = comboboxText;
+                                    PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRequestedVersionRange, rangeBestVersion, additionalInfo: null, isVulnerable: selectedVersion.IsVulnerable, isDeprecated: selectedVersion.IsDeprecated);
+                                    _versions.Text = PackageDetailControlModel.SelectedVersion.ToString();
                                 }
                                 else
                                 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
@@ -169,6 +169,7 @@ namespace NuGet.PackageManagement.UI
                                 bool isBestOption = rangeBestVersion.ToString() == selectedVersion.Version.ToString();
                                 if (isBestOption)
                                 {
+                                    // Add vulnerable/deprecated labels to non floating/range versions
                                     if (userRequestedVersionRange.OriginalString.StartsWith("(", StringComparison.OrdinalIgnoreCase) ||
                                         userRequestedVersionRange.OriginalString.StartsWith("[", StringComparison.OrdinalIgnoreCase) ||
                                         userRequestedVersionRange.IsFloating)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
@@ -165,7 +165,8 @@ namespace NuGet.PackageManagement.UI
                             {
                                 // Search for the best version
                                 NuGetVersion rangeBestVersion = userRequestedVersionRange.FindBestMatch(versions);
-                                bool isBestOption = rangeBestVersion.ToString() == _versions.Items[_versions.SelectedIndex].ToString();
+                                DisplayVersion selectedVersion = _versions.Items.CurrentItem as DisplayVersion;
+                                bool isBestOption = rangeBestVersion.ToString() == selectedVersion.Version.ToString();
                                 if (isBestOption)
                                 {
                                     PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRequestedVersionRange, rangeBestVersion, additionalInfo: null, isVulnerable: false);
@@ -248,10 +249,13 @@ namespace NuGet.PackageManagement.UI
             for (int i = 0; i < _versions.Items.Count; i++)
             {
                 DisplayVersion currentItem = _versions.Items[i] as DisplayVersion;
-                if (currentItem != null && (comboboxText == _versions.Items[i].ToString() || _versions.Items[i].ToString() == matchVersion?.ToString()))
+                if (currentItem != null &&
+                    _versions.Items[i] != null && // null separator
+                    (comboboxText.Trim() == currentItem.Version.ToNormalizedString() || // trim extra spaces and compare versions without labels
+                     matchVersion?.ToString() == currentItem.Version.ToNormalizedString()))
                 {
                     _versions.SelectedIndex = i; // This is the "select" effect in the dropdown
-                    PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRange, matchVersion, additionalInfo: null, isVulnerable: currentItem.IsVulnerable);
+                    PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRange, matchVersion, additionalInfo: null, isDeprecated: currentItem.IsDeprecated, isVulnerable: currentItem.IsVulnerable);
                 }
             }
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
@@ -169,7 +169,16 @@ namespace NuGet.PackageManagement.UI
                                 bool isBestOption = rangeBestVersion.ToString() == selectedVersion.Version.ToString();
                                 if (isBestOption)
                                 {
-                                    PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRequestedVersionRange, rangeBestVersion, additionalInfo: null, isVulnerable: selectedVersion.IsVulnerable, isDeprecated: selectedVersion.IsDeprecated);
+                                    if (userRequestedVersionRange.OriginalString.StartsWith("(", StringComparison.OrdinalIgnoreCase) ||
+                                        userRequestedVersionRange.OriginalString.StartsWith("[", StringComparison.OrdinalIgnoreCase) ||
+                                        userRequestedVersionRange.IsFloating)
+                                    {
+                                        PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRequestedVersionRange, rangeBestVersion, additionalInfo: null);
+                                    }
+                                    else
+                                    {
+                                        PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRequestedVersionRange, rangeBestVersion, additionalInfo: null, isVulnerable: selectedVersion.IsVulnerable, isDeprecated: selectedVersion.IsDeprecated);
+                                    }
                                     _versions.Text = PackageDetailControlModel.SelectedVersion.ToString();
                                 }
                                 else

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
@@ -161,7 +161,7 @@ namespace NuGet.PackageManagement.UI
                         if (_versions.SelectedIndex >= 0 && isAVersion)
                         {
                             // Check if the user typed a custom version
-                            if (isUserInputValidNuGetVersionRange && userRequestedVersionRange != null && _versions.Items?.CurrentItem != null)
+                            if (isUserInputValidNuGetVersionRange)
                             {
                                 // Search for the best version
                                 NuGetVersion rangeBestVersion = userRequestedVersionRange.FindBestMatch(versions);
@@ -259,10 +259,8 @@ namespace NuGet.PackageManagement.UI
             for (int i = 0; i < _versions.Items.Count; i++)
             {
                 DisplayVersion currentItem = _versions.Items[i] as DisplayVersion;
-                if (currentItem != null &&
-                    _versions.Items[i] != null && // null separator
-                    (comboboxText.Trim() == currentItem.Version.ToNormalizedString() || // trim extra spaces and compare versions without labels
-                     matchVersion?.ToString() == currentItem.Version.ToNormalizedString()))
+                if (currentItem != null && // null, this represent a bar in UI in the Versions combobox 
+                    (comboboxText.Trim() == currentItem.Version.ToNormalizedString() || matchVersion?.ToString() == currentItem.Version.ToNormalizedString())) // trim extra spaces and compare versions without labels
                 {
                     _versions.SelectedIndex = i; // This is the "select" effect in the dropdown
                     PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRange, matchVersion, additionalInfo: null, isDeprecated: currentItem.IsDeprecated, isVulnerable: currentItem.IsVulnerable);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
@@ -165,7 +165,7 @@ namespace NuGet.PackageManagement.UI
                             {
                                 // Search for the best version
                                 NuGetVersion rangeBestVersion = userRequestedVersionRange.FindBestMatch(versions);
-                                DisplayVersion selectedVersion = _versions.Items.CurrentItem as DisplayVersion;
+                                DisplayVersion selectedVersion = (DisplayVersion)_versions.Items.CurrentItem;
                                 bool isBestOption = rangeBestVersion.ToString() == selectedVersion.Version.ToString();
                                 if (isBestOption)
                                 {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12724
Fixes: https://github.com/NuGet/Home/issues/12725

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
When trying to select a version using "Enter" key the auto selected version was not correctly set, this issue was happening to floating/ranges versions too.

With this PR the combobox is aware if the version has deprecated/vulnerable info and the comparison is made against `SelectedItem.Version` and not `SelectedItem.ToString()` which contains the label so users don't need to write the label to autoselect.

![combobox-versions-additionalInfo-after](https://github.com/NuGet/NuGet.Client/assets/43253759/30f12c4b-8fb3-457e-88f7-70ef041cc386)

Fix for https://github.com/NuGet/Home/issues/12725
![versions-show-label-combobox](https://github.com/NuGet/NuGet.Client/assets/43253759/401fbe1d-78a7-4b7f-987d-a0562516ce13)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. --> Will ask vendors to do some testing in this, we want to merge this to 17.7 too

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
