### PR TITLE
Fix NullReferenceException in .NET integration tests on Linux

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
@@ -456,9 +456,18 @@ namespace Dotnet.Integration.Test
 
         private static void KillDotnetExe(string pathToDotnetExe, params string[] workingDirectories)
         {
-            foreach (Process process in Process.GetProcessesByName("dotnet").Where(i => i.MainModule.FileName.Equals(pathToDotnetExe, StringComparison.OrdinalIgnoreCase)))
+            foreach (Process process in Process.GetProcessesByName("dotnet"))
             {
-                process.Kill();
+                try
+                {
+                    if (string.Equals(process.MainModule.FileName, pathToDotnetExe, StringComparison.OrdinalIgnoreCase))
+                    {
+                        process.Kill();
+                    }
+                }
+                catch (Exception)
+                {
+                }
             }
 
             foreach (Process process in Process.GetProcesses())


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2376

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
My recent change to improve the .NET integration tests seems to have introduced an intermittent NullReferenceException during clean up while reading process information.  This adds an additional `try...catch` around the reading of process information.

![image](https://github.com/NuGet/NuGet.Client/assets/17556515/a89b62bd-badc-4881-98f9-a11d6a559940)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
