### PR TITLE
Fix license display when it comes from a File

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageLicenseUtilities.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageLicenseUtilities.cs
@@ -125,7 +125,7 @@ namespace NuGet.PackageManagement.UI
 
         private static Uri CreateEmbeddedLicenseUri(string packagePath, LicenseMetadata licenseMetadata)
         {
-            Uri baseUri = Convert(packagePath);
+            Uri baseUri = new Uri(packagePath, UriKind.Absolute);
 
             var builder = new UriBuilder(baseUri)
             {
@@ -133,21 +133,6 @@ namespace NuGet.PackageManagement.UI
             };
 
             return builder.Uri;
-        }
-
-        /// <summary>
-        /// Convert a string to a URI safely. This will return null if there are errors.
-        /// </summary>
-        private static Uri Convert(string uri)
-        {
-            Uri fullUri = null;
-
-            if (!string.IsNullOrEmpty(uri))
-            {
-                Uri.TryCreate(uri, UriKind.Absolute, out fullUri);
-            }
-
-            return fullUri;
         }
 
         private static void PopulateLicenseIdentifiers(NuGetLicenseExpression expression, IList<string> identifiers)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageLicenseUtilities.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageLicenseUtilities.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Documents;
 using Microsoft.ServiceHub.Framework;
+using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.Licenses;
@@ -109,6 +110,9 @@ namespace NuGet.PackageManagement.UI
                     break;
 
                 case LicenseType.File:
+                    NuGetPackageFileService.AddLicenseToCache(
+                        packageIdentity,
+                        CreateEmbeddedLicenseUri(packagePath, metadata));
                     list.Add(new LicenseFileText(Resources.Text_ViewLicense, licenseFileHeader, packagePath, metadata.License, packageIdentity));
                     break;
 
@@ -117,6 +121,33 @@ namespace NuGet.PackageManagement.UI
             }
 
             return list;
+        }
+
+        private static Uri CreateEmbeddedLicenseUri(string packagePath, LicenseMetadata licenseMetadata)
+        {
+            Uri baseUri = Convert(packagePath);
+
+            var builder = new UriBuilder(baseUri)
+            {
+                Fragment = licenseMetadata.License
+            };
+
+            return builder.Uri;
+        }
+
+        /// <summary>
+        /// Convert a string to a URI safely. This will return null if there are errors.
+        /// </summary>
+        private static Uri Convert(string uri)
+        {
+            Uri fullUri = null;
+
+            if (!string.IsNullOrEmpty(uri))
+            {
+                Uri.TryCreate(uri, UriKind.Absolute, out fullUri);
+            }
+
+            return fullUri;
         }
 
         private static void PopulateLicenseIdentifiers(NuGetLicenseExpression expression, IList<string> identifiers)

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageLicenseUtilitiesTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageLicenseUtilitiesTests.cs
@@ -156,23 +156,32 @@ namespace NuGet.PackageManagement.UI.Test
         [Fact]
         public void PackageLicenseUtility_GeneratesLinkForFiles()
         {
-            // Setup
-            var licenseFileLocation = "License.txt";
-            var licenseFileHeader = "header";
-            var licenseData = new LicenseMetadata(LicenseType.File, licenseFileLocation, null, null, LicenseMetadata.CurrentVersion);
+            using (TestDirectory testDir = TestDirectory.Create())
+            {
+                // Setup
+                // Create decoy nuget package
+                var zipPath = Path.Combine(testDir.Path, "file.nupkg");
+                CreateDummyPackage(zipPath: zipPath, licenseFile: "License.txt", licenseFileTargetElement: "");
 
-            // Act
-            var links = PackageLicenseUtilities.GenerateLicenseLinks(
-                licenseData,
-                licenseFileHeader,
-                licenseFileLocation,
-                packageIdentity: null);
+                var licenseFileLocation = "License.txt";
+                var licenseFileHeader = "header";
+                var licenseData = new LicenseMetadata(LicenseType.File, licenseFileLocation, null, null, LicenseMetadata.CurrentVersion);
 
-            Assert.Equal(1, links.Count);
-            Assert.True(links[0] is LicenseFileText);
-            var licenseFileText = links[0] as LicenseFileText;
-            Assert.Equal(Resources.Text_ViewLicense, licenseFileText.Text);
-            Assert.Equal(Resources.LicenseFile_Loading, ((Run)((Paragraph)licenseFileText.LicenseText.Blocks.AsEnumerable().First()).Inlines.First()).Text);
+                var packageIdentity = new PackageIdentity("AddLicenseToCache", NuGetVersion.Parse("1.0.0"));
+
+                // Act
+                var links = PackageLicenseUtilities.GenerateLicenseLinks(
+                    licenseData,
+                    licenseFileHeader,
+                    zipPath,
+                    packageIdentity: packageIdentity);
+
+                Assert.Equal(1, links.Count);
+                Assert.True(links[0] is LicenseFileText);
+                var licenseFileText = links[0] as LicenseFileText;
+                Assert.Equal(Resources.Text_ViewLicense, licenseFileText.Text);
+                Assert.Equal(Resources.LicenseFile_Loading, ((Run)((Paragraph)licenseFileText.LicenseText.Blocks.AsEnumerable().First()).Inlines.First()).Text);
+            }
         }
 
         private Mock<INuGetTelemetryProvider> _telemetryProvider = new Mock<INuGetTelemetryProvider>(MockBehavior.Strict);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12060
Fixes: https://github.com/NuGet/Home/issues/10670
Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
[NuGetPackageFileService.GetEmbeddedLicenseAsync tries to get a URI from an in-memory cache](https://github.com/NuGet/NuGet.Client/blob/629ec930a61f1a52dfdd3c6713a4f6abd48a02df/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageFileService.cs#L123), but the cache is never updated. With this change, I'm adding the correct information to the cache when the link is being created. This issue only occurs when the License comes from a file.

Fix for https://github.com/NuGet/Home/issues/10670:
![display-license-local](https://github.com/NuGet/NuGet.Client/assets/43253759/a3796a69-dbf7-47c7-bfb8-245a393c115f)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
