### PR TITLE
Add more diagnostics to NuGet.CommandLine.Test.NuGetClientCertCommandTests

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -7,28 +7,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.CommandLine\NuGet.CommandLine.csproj">
-      <Project>{957c4e99-3644-47dd-8f9a-ae36f41ebe4a}</Project>
-      <Name>NuGet.CommandLine</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\TestUtilities\Test.Utility\Test.Utility.csproj" />
+    <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.CommandLine\NuGet.CommandLine.csproj" />
     <ProjectReference Include="..\..\NuGet.Core.Tests\NuGet.Configuration.Test\NuGet.Configuration.Test.csproj" />
-    <ProjectReference Include="..\..\TestExtensions\SampleCommandLineExtensions\SampleCommandLineExtensions.csproj" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\..\TestExtensions\TestablePluginCredentialProvider\TestableCredentialProvider.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\TestExtensions\SampleCommandLineExtensions\SampleCommandLineExtensions.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="SampleCommandLineExtensionsOutputGroup" />
+    <ProjectReference Include="..\..\TestExtensions\TestablePluginCredentialProvider\TestableCredentialProvider.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="TestableCredentialProviderOutputGroup" />
+    <ProjectReference Include="..\..\TestUtilities\Test.Utility\Test.Utility.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -38,24 +29,32 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Remove="compiler\resources\*" />
     <EmbeddedResource Include="compiler\resources\*" />
+    <Content Include="$(PkgMicrosoft_TestPlatform_Portable)\tools\net451\**"
+             TargetPath="vstest\%(RecursiveDir)%(Filename)%(Extension)"
+             DestinationSubDirectory="vstest\"
+             CopyToOutputDirectory="PreserveNewest"
+             Visible="false"
+             Condition="'$(PkgMicrosoft_TestPlatform_Portable)' != ''" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <PostBuildEvent>
-      xcopy /diy $(ArtifactsDirectory)TestableCredentialProvider\bin\$(Configuration)\$(TargetFramework)\CredentialProvider.Testable.exe $(OutputPath)TestableCredentialProvider\
-      xcopy /diy $(ArtifactsDirectory)TestableCredentialProvider\bin\$(Configuration)\$(TargetFramework)\*.dll $(OutputPath)TestableCredentialProvider\
-      xcopy /diy $(ArtifactsDirectory)SampleCommandLineExtensions\bin\$(Configuration)\$(TargetFramework)\SampleCommandLineExtensions.dll $(OutputPath)NuGet\
-      if exist $(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe xcopy /diy $(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe $(OutputPath)NuGet\
-      xcopy /diys &quot;$(PkgMicrosoft_TestPlatform_Portable)\tools\net451&quot; $(OutputPath)vstest\
-    </PostBuildEvent>
-  </PropertyGroup>
-
+  <Target Name="AddProjectReferenceFilesToOutputDirectory" AfterTargets="ResolveProjectReferences">
+    <ItemGroup>
+      <ProjectReferenceFiles Include="@(SampleCommandLineExtensionsOutputGroup)"
+                             DestinationSubDirectory="NuGet\" />
+      <ProjectReferenceFiles Include="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe"
+                             DestinationSubDirectory="NuGet\"
+                             Condition="'$(SkipILMergeOfNuGetExe)' != 'true'" />
+      <ProjectReferenceFiles Include="%(TestableCredentialProviderOutputGroup.RootDir)\%(TestableCredentialProviderOutputGroup.Directory)**"
+                             DestinationSubDirectory="TestableCredentialProvider\" />
+      
+      <Content Include="@(ProjectReferenceFiles)"
+               TargetPath="%(DestinationSubDirectory)%(RecursiveDir)%(Filename)%(Extension)"
+               CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+  </Target>
+  
   <Target Name="CopyFinalNuGetExeToOutputPath">
     <Copy SourceFiles="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe"
           DestinationFolder="$(OutputPath)NuGet\" />

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetClientCertCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetClientCertCommandTests.cs
@@ -183,15 +183,9 @@ namespace NuGet.CommandLine.Test
                 };
 
                 // Act
-                var result = CommandRunner.Run(
-                    testInfo.NuGetExePath,
-                    testInfo.WorkingPath,
-                    string.Join(" ", args.Select(a => $"\"{a}\"")));
+                testInfo.RunNuGetExpectSuccess(args, expectedOutput: "was successfully added");
 
                 // Assert
-                var expectedOutput = "was successfully added";
-                Util.VerifyResultSuccess(result, expectedOutput);
-
                 testInfo.ValidateSettings(new FileClientCertItem(packageSource, path, password, false, testInfo.ConfigFile));
             }
         }
@@ -222,15 +216,9 @@ namespace NuGet.CommandLine.Test
                 };
 
                 // Act
-                var result = CommandRunner.Run(
-                    testInfo.NuGetExePath,
-                    testInfo.WorkingPath,
-                    string.Join(" ", args.Select(a => $"\"{a}\"")));
+                testInfo.RunNuGetExpectSuccess(args, expectedOutput: "was successfully added");
 
                 // Assert
-                var expectedOutput = "was successfully added";
-                Util.VerifyResultSuccess(result, expectedOutput);
-
                 testInfo.ValidateSettings(new FileClientCertItem(packageSource, path, password, false, testInfo.ConfigFile));
             }
         }
@@ -262,15 +250,9 @@ namespace NuGet.CommandLine.Test
                 };
 
                 // Act
-                var result = CommandRunner.Run(
-                    testInfo.NuGetExePath,
-                    testInfo.WorkingPath,
-                    string.Join(" ", args.Select(a => $"\"{a}\"")));
+                testInfo.RunNuGetExpectSuccess(args, expectedOutput: "was successfully added");
 
                 // Assert
-                var expectedOutput = "was successfully added";
-                Util.VerifyResultSuccess(result, expectedOutput);
-
                 testInfo.ValidateSettings(new FileClientCertItem(packageSource, path, password, false, testInfo.ConfigFile));
             }
         }
@@ -298,19 +280,13 @@ namespace NuGet.CommandLine.Test
                     "-FindBy",
                     testInfo.CertificateFindBy.ToString().Replace("FindBy", string.Empty),
                     "-FindValue",
-                    testInfo.CertificateFindValue
+                    testInfo.CertificateFindValue.ToString()
                 };
 
                 // Act
-                var result = CommandRunner.Run(
-                    testInfo.NuGetExePath,
-                    testInfo.WorkingPath,
-                    string.Join(" ", args.Select(a => $"\"{a}\"")));
+                testInfo.RunNuGetExpectSuccess(args, expectedOutput: "was successfully added");
 
                 // Assert
-                var expectedOutput = "was successfully added";
-                Util.VerifyResultSuccess(result, expectedOutput);
-
                 testInfo.ValidateSettings(new StoreClientCertItem(testInfo.PackageSourceName,
                                                                   testInfo.CertificateFindValue.ToString(),
                                                                   testInfo.CertificateStoreLocation,
@@ -340,20 +316,14 @@ namespace NuGet.CommandLine.Test
                     "-FindBy",
                     testInfo.CertificateFindBy.ToString().Replace("FindBy", string.Empty),
                     "-FindValue",
-                    testInfo.CertificateFindValue,
+                    testInfo.CertificateFindValue.ToString(),
                     "-Force"
                 };
 
                 // Act
-                var result = CommandRunner.Run(
-                    testInfo.NuGetExePath,
-                    testInfo.WorkingPath,
-                    string.Join(" ", args.Select(a => $"\"{a}\"")));
+                testInfo.RunNuGetExpectSuccess(args, expectedOutput: "was successfully added");
 
                 // Assert
-                var expectedOutput = "was successfully added";
-                Util.VerifyResultSuccess(result, expectedOutput);
-
                 testInfo.ValidateSettings(new StoreClientCertItem(testInfo.PackageSourceName,
                                                                   testInfo.CertificateFindValue.ToString(),
                                                                   testInfo.CertificateStoreLocation,
@@ -375,15 +345,8 @@ namespace NuGet.CommandLine.Test
                     testInfo.ConfigFile
                 };
 
-                // Act
-                var result = CommandRunner.Run(
-                    testInfo.NuGetExePath,
-                    testInfo.WorkingPath,
-                    string.Join(" ", args.Select(a => $"\"{a}\"")));
-
-                // Assert
-                var expectedOutput = "There are no client certificates";
-                Util.VerifyResultSuccess(result, expectedOutput);
+                // Act & Assert
+                testInfo.RunNuGetExpectSuccess(args, expectedOutput: "There are no client certificates");
             }
         }
 
@@ -401,15 +364,8 @@ namespace NuGet.CommandLine.Test
                     testInfo.ConfigFile
                 };
 
-                // Act
-                var result = CommandRunner.Run(
-                    testInfo.NuGetExePath,
-                    testInfo.WorkingPath,
-                    string.Join(" ", args.Select(a => $"\"{a}\"")));
-
-                // Assert
-                var expectedOutput = "There are no client certificates";
-                Util.VerifyResultSuccess(result, expectedOutput);
+                // Act & Assert
+                testInfo.RunNuGetExpectSuccess(args, expectedOutput: "There are no client certificates");
             }
         }
 
@@ -433,15 +389,8 @@ namespace NuGet.CommandLine.Test
                     testInfo.ConfigFile
                 };
 
-                // Act
-                var result = CommandRunner.Run(
-                    testInfo.NuGetExePath,
-                    testInfo.WorkingPath,
-                    string.Join(" ", args.Select(a => $"\"{a}\"")));
-
-                // Assert
-                var expectedOutput = $"{testInfo.PackageSourceName} [fileCert]";
-                Util.VerifyResultSuccess(result, expectedOutput);
+                // Act & Assert
+                testInfo.RunNuGetExpectSuccess(args, expectedOutput: $"{testInfo.PackageSourceName} [fileCert]");
             }
         }
 
@@ -462,15 +411,8 @@ namespace NuGet.CommandLine.Test
                 };
 
                 // Act
-                var result = CommandRunner.Run(
-                    testInfo.NuGetExePath,
-                    testInfo.WorkingPath,
-                    string.Join(" ", args.Select(a => $"\"{a}\"")));
-
+                testInfo.RunNuGetExpectSuccess(args, expectedOutput: "There are no client certificates configured for");
                 // Assert
-                var expectedOutput = "There are no client certificates configured for";
-                Util.VerifyResultSuccess(result, expectedOutput);
-
                 testInfo.ValidateSettings();
             }
         }
@@ -497,15 +439,9 @@ namespace NuGet.CommandLine.Test
                 };
 
                 // Act
-                var result = CommandRunner.Run(
-                    testInfo.NuGetExePath,
-                    testInfo.WorkingPath,
-                    string.Join(" ", args.Select(a => $"\"{a}\"")));
+                testInfo.RunNuGetExpectSuccess(args, expectedOutput: "was successfully removed");
 
                 // Assert
-                var expectedOutput = "was successfully removed";
-                Util.VerifyResultSuccess(result, expectedOutput);
-
                 testInfo.ValidateSettings();
             }
         }
@@ -632,15 +568,9 @@ namespace NuGet.CommandLine.Test
                 };
 
                 // Act
-                var result = CommandRunner.Run(
-                    testInfo.NuGetExePath,
-                    testInfo.WorkingPath,
-                    string.Join(" ", args.Select(a => $"\"{a}\"")));
+                testInfo.RunNuGetExpectSuccess(args, expectedOutput: "was successfully updated");
 
                 // Assert
-                var expectedOutput = "was successfully updated";
-                Util.VerifyResultSuccess(result, expectedOutput);
-
                 testInfo.ValidateSettings(new FileClientCertItem(testInfo.PackageSourceName,
                                                                  updatedPath,
                                                                  updatedPassword,
@@ -685,15 +615,9 @@ namespace NuGet.CommandLine.Test
                 };
 
                 // Act
-                var result = CommandRunner.Run(
-                    testInfo.NuGetExePath,
-                    testInfo.WorkingPath,
-                    string.Join(" ", args.Select(a => $"\"{a}\"")));
+                testInfo.RunNuGetExpectSuccess(args, expectedOutput: "was successfully updated");
 
                 // Assert
-                var expectedOutput = "was successfully updated";
-                Util.VerifyResultSuccess(result, expectedOutput);
-
                 testInfo.ValidateSettings(new StoreClientCertItem(testInfo.PackageSourceName,
                                                                   updatedFindValue,
                                                                   updatedStoreLocation,
@@ -865,7 +789,7 @@ namespace NuGet.CommandLine.Test
                 CertificateStoreLocation = StoreLocation.CurrentUser;
                 CertificateStoreName = StoreName.My;
                 CertificateFindBy = X509FindType.FindByIssuerName;
-                CertificateFindValue = "Contoso";
+                CertificateFindValue = $"Contoso-{Guid.NewGuid():N})";
 
                 Util.CreateFile(Path.GetDirectoryName(ConfigFile),
                                 Path.GetFileName(ConfigFile),
@@ -893,6 +817,23 @@ namespace NuGet.CommandLine.Test
 
             public string PackageSourceName { get; }
             public TestDirectory WorkingPath { get; }
+
+            public void RunNuGetExpectSuccess(string[] args, string expectedOutput = null)
+            {
+                CommandRunnerResult result = CommandRunner.Run(
+                    NuGetExePath,
+                    WorkingPath,
+                    string.Join(" ", args.Select(i => i.StartsWith("-") ? i : $"\"{i}\"")));
+
+                string extraDebugInfo = null;
+
+                if (!result.Success)
+                {
+                    extraDebugInfo = $"{Environment.NewLine}Installed certificates:{Environment.NewLine}{string.Join(Environment.NewLine, EnumerateCurrentlyInstalledCertificates().Select(i => i.ToString()))}";
+                }
+
+                Util.VerifyResultSuccess(result, expectedOutput, extraDebugInfo);
+            }
 
             public void Dispose()
             {
@@ -964,6 +905,19 @@ namespace NuGet.CommandLine.Test
                     else
                     {
                         throw new NotSupportedException();
+                    }
+                }
+            }
+
+            private IEnumerable<X509Certificate2> EnumerateCurrentlyInstalledCertificates()
+            {
+                using (var store = new X509Store(CertificateStoreName, CertificateStoreLocation))
+                {
+                    store.Open(OpenFlags.ReadOnly);
+
+                    foreach (X509Certificate2 cert in store.Certificates)
+                    {
+                        yield return cert;
                     }
                 }
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -10,6 +10,7 @@ using System.Net;
 using System.Reflection;
 using System.Text;
 using System.Xml.Linq;
+using FluentAssertions;
 using Moq;
 using Newtonsoft.Json.Linq;
 using NuGet.Configuration;
@@ -638,17 +639,13 @@ Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""proj1"",
 EndProject";
         }
 
-        public static void VerifyResultSuccess(CommandRunnerResult result, string expectedOutputMessage = null)
+        public static void VerifyResultSuccess(CommandRunnerResult result, string expectedOutputMessage = null, string extraDebugInfo = null)
         {
-            Assert.True(
-                result.ExitCode == 0,
-                "nuget.exe DID NOT SUCCEED: Ouput is " + result.Output + ". Error is " + result.Errors);
+            result.ExitCode.Should().Be(0, $"nuget.exe should have succeeded with exit code 0 but returned exit code {result.ExitCode}{Environment.NewLine}Output:{Environment.NewLine}{result.Output}{Environment.NewLine}Errors:{Environment.NewLine}{result.Errors}{extraDebugInfo}");
 
             if (!string.IsNullOrEmpty(expectedOutputMessage))
             {
-                Assert.Contains(
-                    expectedOutputMessage,
-                    result.Output);
+                result.Output.Should().Contain(expectedOutputMessage);
             }
         }
 
@@ -662,13 +659,9 @@ EndProject";
         public static void VerifyResultFailure(CommandRunnerResult result,
                                                string expectedErrorMessage)
         {
-            Assert.True(
-                result.ExitCode != 0,
-                "nuget.exe DID NOT FAIL: Ouput is " + result.Output + ". Error is " + result.Errors);
+            result.ExitCode.Should().NotBe(0, $"nuget.exe should have failed with a non zero exit code but returned exit code {result.ExitCode}{Environment.NewLine}Output:{Environment.NewLine}{result.Output}{Environment.NewLine}Errors:{Environment.NewLine}{result.Errors}");
 
-            Assert.True(
-                result.Errors.Contains(expectedErrorMessage),
-                "Expected error is " + expectedErrorMessage + ". Actual error is " + result.Errors);
+            result.Errors.Should().Contain(expectedErrorMessage);
         }
 
         public static void VerifyPackageExists(


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2382

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
I've seen the tests in this suite fail occasionally.  It appears that a test is installing a certificate but then when validating the result the certificate is gone.  I suspect that parallelization is causing us issues.

1. Re-organized `NuGet.CommandLine.Test.csproj` to get rid of usages of `xcopy` in favor of built-in .NET SDK logic which makes our projects more standard
2. Add new method `RunNuGetExpectSuccess()` which will add more diagnostic information in the case of a test failure.
3. Use a randomly generated certificate name to ensure that no two tests are using the same one to make them better for parallelization.
4. Updated `VerifyResultSuccess()` to use FluentAssertions so the value isn't truncated like MSTest assertions do.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
