### PR TITLE
Move Version property to config.props & output to buildinfo.json

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -112,35 +112,6 @@
     <VsixPublishDestination>$(ArtifactRoot)$(VsixOutputDirName)\</VsixPublishDestination>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(PreReleaseVersion)' == '' ">
-    <PreReleaseVersion>32767</PreReleaseVersion>
-  </PropertyGroup>
-
-  <!--Setting the Pre-release/Build meta-data from CI if Version is set-->
-  <PropertyGroup Condition="'$(BuildNumber)' != ''">
-    <PreReleaseVersion>$(BuildNumber)</PreReleaseVersion>
-  </PropertyGroup>
-
-  <!--Setting the product information for Beta builds-->
-  <Choose>
-    <!-- If we aren't excluding the build number, use the release label and the build number. -->
-    <When Condition="'$(BuildRTM)' != 'true' AND '$(PreReleaseVersion)' != '' AND '$(PreReleaseVersion)' != '0' ">
-      <PropertyGroup>
-        <PreReleaseInformationVersion>-$(ReleaseLabel).$(PreReleaseVersion)</PreReleaseInformationVersion>
-      </PropertyGroup>
-    </When>
-    <!-- If we are excluding the build number, show the release label unless we are RTM. -->
-    <When Condition="'$(ReleaseLabel)' != 'rtm' AND '$(ReleaseLabel)' != 'svc' AND '$(ReleaseLabel)' != 'rc' ">
-      <PropertyGroup>
-        <PreReleaseInformationVersion>-$(ReleaseLabel)</PreReleaseInformationVersion>
-      </PropertyGroup>
-    </When>
-  </Choose>
-
-  <PropertyGroup Condition=" '$(Version)' == '' ">
-    <Version>$(SemanticVersion)$(PreReleaseInformationVersion)</Version>
-  </PropertyGroup>
-
   <!-- Set the output location for all non-test projects -->
   <!-- Test projects currently fail when the output dir is moved -->
   <PropertyGroup Condition=" '$(TestProject)' != 'true' OR '$(Shipping)' == 'true'">

--- a/build/config.props
+++ b/build/config.props
@@ -100,6 +100,9 @@
   <Target Name="GetVsTargetMajorVersion">
     <Message Text="$(VsTargetMajorVersion)" Importance="High"/>
   </Target>
+  <Target Name="GetVersion">
+    <Message Text="$(Version)" Importance="High"/>
+  </Target>
   <Target Name="GetVsTargetBranch">
     <Message Text="$(VsTargetBranch)" Importance="High"/>
   </Target>

--- a/build/config.props
+++ b/build/config.props
@@ -37,6 +37,35 @@
     <VsTargetChannel Condition="'$(IsEscrowMode)' == 'true'">int.d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetChannel>
   </PropertyGroup>
 
+ <PropertyGroup Condition=" '$(PreReleaseVersion)' == '' ">
+    <PreReleaseVersion>32767</PreReleaseVersion>
+  </PropertyGroup>
+
+  <!--Setting the Pre-release/Build meta-data from CI if Version is set-->
+  <PropertyGroup Condition="'$(BuildNumber)' != ''">
+    <PreReleaseVersion>$(BuildNumber)</PreReleaseVersion>
+  </PropertyGroup>
+
+  <!--Setting the product information for Beta builds-->
+  <Choose>
+    <!-- If we aren't excluding the build number, use the release label and the build number. -->
+    <When Condition="'$(BuildRTM)' != 'true' AND '$(PreReleaseVersion)' != '' AND '$(PreReleaseVersion)' != '0' ">
+      <PropertyGroup>
+        <PreReleaseInformationVersion>-$(ReleaseLabel).$(PreReleaseVersion)</PreReleaseInformationVersion>
+      </PropertyGroup>
+    </When>
+    <!-- If we are excluding the build number, show the release label unless we are RTM. -->
+    <When Condition="'$(ReleaseLabel)' != 'rtm' AND '$(ReleaseLabel)' != 'svc' AND '$(ReleaseLabel)' != 'rc' ">
+      <PropertyGroup>
+        <PreReleaseInformationVersion>-$(ReleaseLabel)</PreReleaseInformationVersion>
+      </PropertyGroup>
+    </When>
+  </Choose>
+
+  <PropertyGroup Condition=" '$(Version)' == '' ">
+    <Version>$(SemanticVersion)$(PreReleaseInformationVersion)</Version>
+  </PropertyGroup>
+
   <!-- Config -->
   <PropertyGroup>
     <RepositoryName>NuGet</RepositoryName>

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -175,6 +175,8 @@ else
     $NuGetSdkVsVersion = ((& dotnet msbuild $RepositoryPath\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetNuGetSdkVsSemanticVersion) | Out-String).Trim()
     $VsTargetChannel = ((& dotnet msbuild $RepositoryPath\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetChannel) | Out-String).Trim()
     $VsTargetMajorVersion = ((& dotnet msbuild $RepositoryPath\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetMajorVersion) | Out-String).Trim()
+    $Version = ((& dotnet msbuild $RepositoryPath\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVersion) | Out-String).Trim()
+
     Write-Host "VS target branch: $VsTargetBranch"
     $jsonRepresentation = @{
         BuildNumber = $newBuildCounter
@@ -186,6 +188,7 @@ else
         VsTargetChannel = $VstargetChannel
         VsTargetMajorVersion = $VsTargetMajorVersion
         NuGetSdkVsVersion = $NuGetSdkVsVersion
+        Version = $Version
     }
 
     # First create the file locally so that we can laster publish it as a build artifact from a local source file instead of a remote source file.


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2167

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

After moving this, my understanding is that `$(Version)` will contain the full package # that we insert into VS, so that it can be used in our insertion PRs.
I have already modified the NuGet Client Release to modify the following files, but I need the full version# of VS to put here:
- `nuget.packageconfig`
- `NuGetVisualStudio.props`

I don't know how to test this until I have an Official build to try the release on.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
