### PR TITLE
Create NuGetVsVersion in config.props

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -65,6 +65,10 @@
   <PropertyGroup Condition=" '$(Version)' == '' ">
     <Version>$(SemanticVersion)$(PreReleaseInformationVersion)</Version>
   </PropertyGroup>
+  
+  <PropertyGroup Condition=" '$(NuGetVsVersion)' == '' ">
+    <NuGetVsVersion>$(NuGetSdkVsSemanticVersion)$(PreReleaseInformationVersion)</NuGetVsVersion>
+  </PropertyGroup>
 
   <!-- Config -->
   <PropertyGroup>
@@ -100,8 +104,8 @@
   <Target Name="GetVsTargetMajorVersion">
     <Message Text="$(VsTargetMajorVersion)" Importance="High"/>
   </Target>
-  <Target Name="GetVersion">
-    <Message Text="$(Version)" Importance="High"/>
+  <Target Name="GetNuGetVsVersion">
+    <Message Text="$(NuGetVsVersion)" Importance="High"/>
   </Target>
   <Target Name="GetVsTargetBranch">
     <Message Text="$(VsTargetBranch)" Importance="High"/>

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -175,7 +175,7 @@ else
     $NuGetSdkVsVersion = ((& dotnet msbuild $RepositoryPath\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetNuGetSdkVsSemanticVersion) | Out-String).Trim()
     $VsTargetChannel = ((& dotnet msbuild $RepositoryPath\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetChannel) | Out-String).Trim()
     $VsTargetMajorVersion = ((& dotnet msbuild $RepositoryPath\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetMajorVersion) | Out-String).Trim()
-    $Version = ((& dotnet msbuild $RepositoryPath\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVersion) | Out-String).Trim()
+    $GetNuGetVsVersion = ((& dotnet msbuild $RepositoryPath\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetNuGetVsVersion) | Out-String).Trim()
 
     Write-Host "VS target branch: $VsTargetBranch"
     $jsonRepresentation = @{
@@ -188,7 +188,7 @@ else
         VsTargetChannel = $VstargetChannel
         VsTargetMajorVersion = $VsTargetMajorVersion
         NuGetSdkVsVersion = $NuGetSdkVsVersion
-        Version = $Version
+        NuGetVsVersion = $GetNuGetVsVersion
     }
 
     # First create the file locally so that we can laster publish it as a build artifact from a local source file instead of a remote source file.


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2167

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
In https://github.com/NuGet/NuGet.Client/pull/5300, the version is the NuGet version with the NuGet semantic version, but we need the VS semantic version for the VS packages.

```
C:\NuGet.Client [dev-donnie-msft-buildInfoJsonVersion ≡]> dotnet msbuild build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetNuGetVsVersion

  17.8.0-preview.1.32767
```
In NuGet Client Release, I've added a PowerShell step called "**Get NuGetVsVersion**", which will look for a non-blank `NuGetVsVersion`, and if found to be not-blank, set `$InsertPropsValues` and `$InsertConfigValues` so that the VS insertion will populate those respective values during insertion.
If they're blank, the insertion shouldn't change, meaning release branches won't have different behavior.

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
