### PR TITLE
Reduce size of LibraryDependency class

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -110,6 +110,7 @@
     <PackageVersion Include="VsWebSite.Interop" Version="$(VSFrameworkVersion)" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="Xunit.Combinatorial" Version="1.5.25" />
     <PackageVersion Include="Xunit.StaFact" Version="1.1.11" />
   </ItemGroup>
 

--- a/build/Shared/EqualityUtility.cs
+++ b/build/Shared/EqualityUtility.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace NuGet.Shared
@@ -176,8 +177,8 @@ namespace NuGet.Shared
         /// null for equality.
         /// </summary>
         internal static bool SequenceEqualWithNullCheck<T>(
-            this IList<T> self,
-            IList<T> other,
+            this IList<T>? self,
+            IList<T>? other,
             IEqualityComparer<T>? comparer = null)
         {
             bool identityEquals;
@@ -324,7 +325,10 @@ namespace NuGet.Shared
             return !string.IsNullOrWhiteSpace(value) && bool.FalseString.Equals(value.Trim(), StringComparison.OrdinalIgnoreCase);
         }
 
-        private static bool TryIdentityEquals<T>(T? self, T? other, out bool equals)
+        private static bool TryIdentityEquals<T>(
+            [NotNullWhen(returnValue: false)] T? self,
+            [NotNullWhen(returnValue: false)] T? other,
+            out bool equals)
         {
             // Are they the same instance? This handles the case where both are null.
             if (ReferenceEquals(self, other))

--- a/build/Shared/HashCodeCombiner.cs
+++ b/build/Shared/HashCodeCombiner.cs
@@ -83,7 +83,7 @@ namespace NuGet.Shared
             AddHashCode(o.GetHashCode());
         }
 
-        internal void AddStringIgnoreCase(string s)
+        internal void AddStringIgnoreCase(string? s)
         {
             CheckInitialized();
             if (s != null)
@@ -92,7 +92,7 @@ namespace NuGet.Shared
             }
         }
 
-        internal void AddSequence<T>(IEnumerable<T> sequence) where T : notnull
+        internal void AddSequence<T>(IEnumerable<T>? sequence) where T : notnull
         {
             if (sequence != null)
             {
@@ -104,7 +104,7 @@ namespace NuGet.Shared
             }
         }
 
-        internal void AddSequence<T>(T[] array) where T : notnull
+        internal void AddSequence<T>(T[]? array) where T : notnull
         {
             if (array != null)
             {
@@ -116,7 +116,7 @@ namespace NuGet.Shared
             }
         }
 
-        internal void AddSequence<T>(IList<T> list) where T : notnull
+        internal void AddSequence<T>(IList<T>? list) where T : notnull
         {
             if (list != null)
             {
@@ -129,7 +129,7 @@ namespace NuGet.Shared
             }
         }
 
-        internal void AddSequence<T>(IReadOnlyList<T> list) where T : notnull
+        internal void AddSequence<T>(IReadOnlyList<T>? list) where T : notnull
         {
             if (list != null)
             {
@@ -142,7 +142,7 @@ namespace NuGet.Shared
             }
         }
 
-        internal void AddDictionary<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> dictionary)
+        internal void AddDictionary<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>>? dictionary)
             where TKey : notnull
             where TValue : notnull
         {

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -968,7 +968,7 @@ namespace NuGet.Build.Tasks.Pack
                         }
                     }
 
-                    if (packageDependency.NoWarn.Count > 0)
+                    if (packageDependency.NoWarnCount > 0)
                     {
                         HashSet<(NuGetLogCode, NuGetFramework)> nowarnProperties = null;
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/PackageSpecificWarningProperties.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/PackageSpecificWarningProperties.cs
@@ -38,7 +38,10 @@ namespace NuGet.Commands
             {
                 foreach (var framework in packageSpec.TargetFrameworks)
                 {
-                    warningProperties.AddRangeOfCodes(dependency.NoWarn, dependency.Name, framework.FrameworkName);
+                    if (dependency.NoWarnCount != 0)
+                    {
+                        warningProperties.AddRangeOfCodes(dependency.NoWarn, dependency.Name, framework.FrameworkName);
+                    }
                 }
             }
 
@@ -46,7 +49,10 @@ namespace NuGet.Commands
             {
                 foreach (var dependency in framework.Dependencies)
                 {
-                    warningProperties.AddRangeOfCodes(dependency.NoWarn, dependency.Name, framework.FrameworkName);
+                    if (dependency.NoWarnCount != 0)
+                    {
+                        warningProperties.AddRangeOfCodes(dependency.NoWarn, dependency.Name, framework.FrameworkName);
+                    }
                 }
             }
 
@@ -67,14 +73,20 @@ namespace NuGet.Commands
 
             foreach (var dependency in packageSpec.Dependencies)
             {
-                warningProperties.AddRangeOfCodes(dependency.NoWarn, dependency.Name, framework);
+                if (dependency.NoWarnCount != 0)
+                {
+                    warningProperties.AddRangeOfCodes(dependency.NoWarn, dependency.Name, framework);
+                }
             }
 
             var targetFrameworkInformation = packageSpec.GetTargetFramework(framework);
 
             foreach (var dependency in targetFrameworkInformation.Dependencies)
             {
-                warningProperties.AddRangeOfCodes(dependency.NoWarn, dependency.Name, framework);
+                if (dependency.NoWarnCount != 0)
+                {
+                    warningProperties.AddRangeOfCodes(dependency.NoWarn, dependency.Name, framework);
+                }
             }
 
             return warningProperties;

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
@@ -261,7 +261,7 @@ namespace NuGet.LibraryModel
                         continue;
                     }
 
-                    if (centralPackageVersions.TryGetValue(d.Name, out CentralPackageVersion centralPackageVersion))
+                    if (centralPackageVersions.TryGetValue(d.Name, out CentralPackageVersion? centralPackageVersion))
                     {
                         d.LibraryRange!.VersionRange = centralPackageVersion.VersionRange;
                     }

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
@@ -3,10 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using NuGet.Common;
 using NuGet.Shared;
 using NuGet.Versioning;
+
+#nullable enable
 
 namespace NuGet.LibraryModel
 {
@@ -58,7 +61,7 @@ namespace NuGet.LibraryModel
         /// <summary>
         /// Lazily allocated backing collection for the <see cref="NoWarn"/> property.
         /// </summary>
-        private IList<NuGetLogCode> _noWarn;
+        private IList<NuGetLogCode>? _noWarn;
 
         public bool GeneratePathProperty
         {
@@ -118,6 +121,7 @@ namespace NuGet.LibraryModel
         /// This property lazily allocates its backing collection. Callers should check <see cref="NoWarnCount"/>
         /// for a non-zero value before reading this property to avoid redundant allocations.
         /// </remarks>
+        [AllowNull]
         public IList<NuGetLogCode> NoWarn
         {
             // Lazily allocate the list if needed.
@@ -130,16 +134,16 @@ namespace NuGet.LibraryModel
         /// </summary>
         public int NoWarnCount => _noWarn?.Count ?? 0;
 
-        public LibraryRange LibraryRange { get; set; }
+        public LibraryRange? LibraryRange { get; set; }
 
-        public string Name => LibraryRange.Name;
+        public string Name => LibraryRange!.Name;
 
-        public string Aliases { get; set; }
+        public string? Aliases { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating a version override for any centrally defined version.
         /// </summary>
-        public VersionRange VersionOverride { get; set; }
+        public VersionRange? VersionOverride { get; set; }
 
         public LibraryDependency()
         {
@@ -149,13 +153,13 @@ namespace NuGet.LibraryModel
             LibraryRange libraryRange,
             LibraryIncludeFlags includeType,
             LibraryIncludeFlags suppressParent,
-            IList<NuGetLogCode> noWarn,
+            IList<NuGetLogCode>? noWarn,
             bool autoReferenced,
             bool generatePathProperty,
             bool versionCentrallyManaged,
             LibraryDependencyReferenceType libraryDependencyReferenceType,
-            string aliases,
-            VersionRange versionOverride)
+            string? aliases,
+            VersionRange? versionOverride)
         {
             LibraryRange = libraryRange;
             IncludeType = includeType;
@@ -171,10 +175,10 @@ namespace NuGet.LibraryModel
 
         private LibraryDependency(
             int flags,
-            LibraryRange libraryRange,
-            IList<NuGetLogCode> noWarn,
-            string aliases,
-            VersionRange versionOverride)
+            LibraryRange? libraryRange,
+            IList<NuGetLogCode>? noWarn,
+            string? aliases,
+            VersionRange? versionOverride)
         {
             _flags = flags;
             LibraryRange = libraryRange;
@@ -186,7 +190,7 @@ namespace NuGet.LibraryModel
         public override string ToString()
         {
             // Explicitly call .ToString() to ensure string.Concat(string, string, string) overload is called.
-            return LibraryRange.ToString() + " " + LibraryIncludeFlagUtils.GetFlagString(IncludeType);
+            return LibraryRange?.ToString() + " " + LibraryIncludeFlagUtils.GetFlagString(IncludeType);
         }
 
         public override int GetHashCode()
@@ -201,12 +205,12 @@ namespace NuGet.LibraryModel
             return hashCode.CombinedHash;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as LibraryDependency);
         }
 
-        public bool Equals(LibraryDependency other)
+        public bool Equals(LibraryDependency? other)
         {
             if (other == null)
             {
@@ -228,7 +232,7 @@ namespace NuGet.LibraryModel
 
         public LibraryDependency Clone()
         {
-            var clonedLibraryRange = new LibraryRange(LibraryRange.Name, LibraryRange.VersionRange, LibraryRange.TypeConstraint);
+            var clonedLibraryRange = new LibraryRange(LibraryRange!.Name, LibraryRange.VersionRange, LibraryRange.TypeConstraint);
             var clonedNoWarn = _noWarn is null ? null : new List<NuGetLogCode>(_noWarn);
 
             return new LibraryDependency(_flags, clonedLibraryRange, clonedNoWarn, Aliases, VersionOverride);
@@ -249,18 +253,18 @@ namespace NuGet.LibraryModel
             }
             if (centralPackageVersions.Count > 0)
             {
-                foreach (LibraryDependency d in packageReferences.Where(d => !d.AutoReferenced && d.LibraryRange.VersionRange == null))
+                foreach (LibraryDependency d in packageReferences.Where(d => !d.AutoReferenced && d.LibraryRange!.VersionRange == null))
                 {
                     if (d.VersionOverride != null)
                     {
-                        d.LibraryRange.VersionRange = d.VersionOverride;
+                        d.LibraryRange!.VersionRange = d.VersionOverride;
 
                         continue;
                     }
 
                     if (centralPackageVersions.TryGetValue(d.Name, out CentralPackageVersion centralPackageVersion))
                     {
-                        d.LibraryRange.VersionRange = centralPackageVersion.VersionRange;
+                        d.LibraryRange!.VersionRange = centralPackageVersion.VersionRange;
                     }
 
                     d.VersionCentrallyManaged = true;

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
@@ -223,10 +223,9 @@ namespace NuGet.LibraryModel
             }
 
             return _flags == other._flags &&
-                   EqualityUtility.EqualsWithNullCheck(LibraryRange, other.LibraryRange) &&
-                   _noWarn is null == other._noWarn is null &&
-                   (_noWarn is null || _noWarn.SequenceEqualWithNullCheck(other._noWarn)) &&
                    Aliases == other.Aliases &&
+                   EqualityUtility.EqualsWithNullCheck(LibraryRange, other.LibraryRange) &&
+                   (_noWarn ?? Enumerable.Empty<NuGetLogCode>()).SequenceEqualWithNullCheck(other._noWarn ?? Enumerable.Empty<NuGetLogCode>()) &&
                    EqualityUtility.EqualsWithNullCheck(VersionOverride, other.VersionOverride);
         }
 

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
@@ -12,32 +12,127 @@ namespace NuGet.LibraryModel
 {
     public class LibraryDependency : IEquatable<LibraryDependency>
     {
-        public LibraryRange LibraryRange { get; set; }
+        // The size of this class has been reduced by packing six properties into a single 32-bit field.
+        // This packing is invisible to external consumers of this type.
+        //
+        // The packed fields are:
+        //
+        // Name                      CLR Type                         Unpacked size   Needed size   Packed size
+        // ----------------------------------------------------------------------------------------------------
+        // GeneratePathProperty      bool                             1 byte          1 bit         1 bit
+        // AutoReferenced            bool                             1 byte          1 bit         1 bit
+        // VersionCentrallyManaged   bool                             1 byte          1 bit         1 bit
+        // IncludeType               LibraryIncludeFlags              2 bytes         7 bits        10 bits
+        // SuppressParent            LibraryIncludeFlags              2 bytes         7 bits        10 bits
+        // ReferenceType             LibraryDependencyReferenceType   4 bytes         2 bits        6 bits
+        //
+        // This totals 12 bytes, with padding. It's possible to pack these values into 4 bytes (32 bits),
+        // saving 8 bytes per instance of this class.
+        //
+        // Each enum is given slightly more size than needed, to make any future expansion of the enum
+        // less likely to require changes in this class.
+        //
+        // See comments within each property for packing offsets.
 
-        public LibraryIncludeFlags IncludeType { get; set; } = LibraryIncludeFlags.All;
+        // Default values for the three packed enum values.
+        private const LibraryIncludeFlags DefaultIncludeType = LibraryIncludeFlags.All;
+        private const LibraryIncludeFlags DefaultSuppressParent = LibraryIncludeFlagUtils.DefaultSuppressParentConst;
+        private const LibraryDependencyReferenceType DefaultReferenceType = LibraryDependencyReferenceType.Direct;
 
-        public LibraryIncludeFlags SuppressParent { get; set; } = LibraryIncludeFlagUtils.DefaultSuppressParent;
+        // Computes, at compile time, the default value for the properties of this class that are packed
+        // into the _flags field. Note that all bool values default to false, so we only need to consider
+        // the enum values here.
+        private const int InitialState =
+            ((int)DefaultIncludeType << 3) |
+            ((int)DefaultSuppressParent << 13) |
+            ((int)DefaultReferenceType << 23);
 
-        public IList<NuGetLogCode> NoWarn { get; set; }
+        private const int Mask10Bits = 0b11_1111_1111;
+        private const int Mask6Bits = 0b11_1111;
 
-        public string Name => LibraryRange.Name;
+        /// <summary>
+        /// Holds the packed state of six different properties from this class.
+        /// </summary>
+        private int _flags = InitialState;
+
+        /// <summary>
+        /// Lazily allocated backing collection for the <see cref="NoWarn"/> property.
+        /// </summary>
+        private IList<NuGetLogCode> _noWarn;
+
+        public bool GeneratePathProperty
+        {
+            // This property is stored in the lowest bit (0b1) in position 00.
+            get => (_flags & 0b1) != 0;
+            set => _flags = value ? (_flags | 0b1) : (_flags & ~0b1);
+        }
 
         /// <summary>
         /// True if the PackageReference is added by the SDK and not the user.
         /// </summary>
-        public bool AutoReferenced { get; set; }
+        public bool AutoReferenced
+        {
+            // This property is stored in the second lowest bit (0b10) in position 01.
+            get => (_flags & 0b10) != 0;
+            set => _flags = value ? (_flags | 0b10) : (_flags & ~0b10);
+        }
 
         /// <summary>
-        /// True if the dependency has the version set through CentralPackagVersionManagement file.
+        /// True if the dependency has the version set through CentralPackageVersionManagement file.
         /// </summary>
-        public bool VersionCentrallyManaged { get; set; }
+        public bool VersionCentrallyManaged
+        {
+            // This property is stored in the third lowest bit (0b100) in position 02.
+            get => (_flags & 0b100) != 0;
+            set => _flags = value ? (_flags | 0b100) : (_flags & ~0b100);
+        }
+
+        public LibraryIncludeFlags IncludeType
+        {
+            // This property is stored in 10 bits (0b1111111111_000), in positions 03 to 12.
+            get => (LibraryIncludeFlags)((_flags >> 3) & Mask10Bits);
+            set => _flags = (_flags & ~(Mask10Bits << 3)) | ((int)value << 3);
+        }
+
+        public LibraryIncludeFlags SuppressParent
+        {
+            // This property is stored in 10 bits (0b1111111111_0000000000_000), in positions 13 to 22.
+            get => (LibraryIncludeFlags)((_flags >> 13) & Mask10Bits);
+            set => _flags = (_flags & ~(Mask10Bits << 13)) | ((int)value << 13);
+        }
 
         /// <summary>
         /// Information regarding if the dependency is direct or transitive.  
         /// </summary>
-        public LibraryDependencyReferenceType ReferenceType { get; set; } = LibraryDependencyReferenceType.Direct;
+        public LibraryDependencyReferenceType ReferenceType
+        {
+            // This property is stored in 6 bits (0b111111_0000000000_0000000000_000), in positions 23 to 28.
+            get => (LibraryDependencyReferenceType)((_flags >> 23) & Mask6Bits);
+            set => _flags = (_flags & ~(Mask6Bits << 23)) | ((int)value << 23);
+        }
 
-        public bool GeneratePathProperty { get; set; }
+        /// <summary>
+        /// Gets the list of NoWarn codes for this library dependency.
+        /// </summary>
+        /// <remarks>
+        /// This property lazily allocates its backing collection. Callers should check <see cref="NoWarnCount"/>
+        /// for a non-zero value before reading this property to avoid redundant allocations.
+        /// </remarks>
+        public IList<NuGetLogCode> NoWarn
+        {
+            // Lazily allocate the list if needed.
+            get => _noWarn ??= new List<NuGetLogCode>();
+            set => _noWarn = value;
+        }
+
+        /// <summary>
+        /// This internal field will help us avoid allocating a list when calling the count on a null.
+        /// </summary>
+        public int NoWarnCount => _noWarn?.Count ?? 0;
+
+        public LibraryRange LibraryRange { get; set; }
+
+        public string Name => LibraryRange.Name;
 
         public string Aliases { get; set; }
 
@@ -48,7 +143,6 @@ namespace NuGet.LibraryModel
 
         public LibraryDependency()
         {
-            NoWarn = new List<NuGetLogCode>();
         }
 
         internal LibraryDependency(
@@ -66,11 +160,25 @@ namespace NuGet.LibraryModel
             LibraryRange = libraryRange;
             IncludeType = includeType;
             SuppressParent = suppressParent;
-            NoWarn = noWarn;
+            _noWarn = noWarn;
             AutoReferenced = autoReferenced;
             GeneratePathProperty = generatePathProperty;
             VersionCentrallyManaged = versionCentrallyManaged;
             ReferenceType = libraryDependencyReferenceType;
+            Aliases = aliases;
+            VersionOverride = versionOverride;
+        }
+
+        private LibraryDependency(
+            int flags,
+            LibraryRange libraryRange,
+            IList<NuGetLogCode> noWarn,
+            string aliases,
+            VersionRange versionOverride)
+        {
+            _flags = flags;
+            LibraryRange = libraryRange;
+            _noWarn = noWarn;
             Aliases = aliases;
             VersionOverride = versionOverride;
         }
@@ -85,15 +193,10 @@ namespace NuGet.LibraryModel
         {
             var hashCode = new HashCodeCombiner();
 
+            hashCode.AddObject(_flags);
             hashCode.AddObject(LibraryRange);
-            hashCode.AddStruct(IncludeType);
-            hashCode.AddStruct(SuppressParent);
-            hashCode.AddObject(AutoReferenced);
-            hashCode.AddSequence(NoWarn);
-            hashCode.AddObject(GeneratePathProperty);
-            hashCode.AddObject(VersionCentrallyManaged);
+            hashCode.AddSequence(_noWarn);
             hashCode.AddObject(Aliases);
-            hashCode.AddStruct(ReferenceType);
 
             return hashCode.CombinedHash;
         }
@@ -115,24 +218,20 @@ namespace NuGet.LibraryModel
                 return true;
             }
 
-            return AutoReferenced == other.AutoReferenced &&
+            return _flags == other._flags &&
                    EqualityUtility.EqualsWithNullCheck(LibraryRange, other.LibraryRange) &&
-                   IncludeType == other.IncludeType &&
-                   SuppressParent == other.SuppressParent &&
-                   NoWarn.SequenceEqualWithNullCheck(other.NoWarn) &&
-                   GeneratePathProperty == other.GeneratePathProperty &&
-                   VersionCentrallyManaged == other.VersionCentrallyManaged &&
+                   _noWarn is null == other._noWarn is null &&
+                   (_noWarn is null || _noWarn.SequenceEqualWithNullCheck(other._noWarn)) &&
                    Aliases == other.Aliases &&
-                   EqualityUtility.EqualsWithNullCheck(VersionOverride, other.VersionOverride) &&
-                   ReferenceType == other.ReferenceType;
+                   EqualityUtility.EqualsWithNullCheck(VersionOverride, other.VersionOverride);
         }
 
         public LibraryDependency Clone()
         {
             var clonedLibraryRange = new LibraryRange(LibraryRange.Name, LibraryRange.VersionRange, LibraryRange.TypeConstraint);
-            var clonedNoWarn = new List<NuGetLogCode>(NoWarn);
+            var clonedNoWarn = _noWarn is null ? null : new List<NuGetLogCode>(_noWarn);
 
-            return new LibraryDependency(clonedLibraryRange, IncludeType, SuppressParent, clonedNoWarn, AutoReferenced, GeneratePathProperty, VersionCentrallyManaged, ReferenceType, Aliases, VersionOverride);
+            return new LibraryDependency(_flags, clonedLibraryRange, clonedNoWarn, Aliases, VersionOverride);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyReferenceType.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyReferenceType.cs
@@ -5,6 +5,9 @@ namespace NuGet.LibraryModel
 {
     public enum LibraryDependencyReferenceType
     {
+        // This enum is carefully packed in LibraryDependency.
+        // Any changes here should be verified there too.
+
         None,
         Transitive,
         Direct

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryIncludeFlag.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryIncludeFlag.cs
@@ -8,6 +8,9 @@ namespace NuGet.LibraryModel
     [Flags]
     public enum LibraryIncludeFlags : ushort
     {
+        // This enum is carefully packed in LibraryDependency.
+        // Any changes here should be verified there too.
+
         None = 0,
         Runtime = 1 << 0,
         Compile = 1 << 1,

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryIncludeFlagUtils.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryIncludeFlagUtils.cs
@@ -13,11 +13,13 @@ namespace NuGet.LibraryModel
     /// </summary>
     public static class LibraryIncludeFlagUtils
     {
+        internal const LibraryIncludeFlags DefaultSuppressParentConst =
+            (LibraryIncludeFlags.Build | LibraryIncludeFlags.ContentFiles | LibraryIncludeFlags.Analyzers);
+
         /// <summary>
         /// By default build, contentFiles, and analyzers do not flow transitively between projects.
         /// </summary>
-        public static readonly LibraryIncludeFlags DefaultSuppressParent =
-            (LibraryIncludeFlags.Build | LibraryIncludeFlags.ContentFiles | LibraryIncludeFlags.Analyzers);
+        public static readonly LibraryIncludeFlags DefaultSuppressParent = DefaultSuppressParentConst;
 
         public static readonly LibraryIncludeFlags NoContent = LibraryIncludeFlags.All & ~LibraryIncludeFlags.ContentFiles;
 

--- a/src/NuGet.Core/NuGet.LibraryModel/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.LibraryModel/PublicAPI.Shipped.txt
@@ -42,30 +42,30 @@ NuGet.LibraryModel.Library.Resolved.set -> void
 ~NuGet.LibraryModel.Library.this[string key].get -> object
 ~NuGet.LibraryModel.Library.this[string key].set -> void
 NuGet.LibraryModel.LibraryDependency
-~NuGet.LibraryModel.LibraryDependency.Aliases.get -> string
-~NuGet.LibraryModel.LibraryDependency.Aliases.set -> void
+NuGet.LibraryModel.LibraryDependency.Aliases.get -> string?
+NuGet.LibraryModel.LibraryDependency.Aliases.set -> void
 NuGet.LibraryModel.LibraryDependency.AutoReferenced.get -> bool
 NuGet.LibraryModel.LibraryDependency.AutoReferenced.set -> void
-~NuGet.LibraryModel.LibraryDependency.Clone() -> NuGet.LibraryModel.LibraryDependency
-~NuGet.LibraryModel.LibraryDependency.Equals(NuGet.LibraryModel.LibraryDependency other) -> bool
+NuGet.LibraryModel.LibraryDependency.Clone() -> NuGet.LibraryModel.LibraryDependency!
+NuGet.LibraryModel.LibraryDependency.Equals(NuGet.LibraryModel.LibraryDependency? other) -> bool
 NuGet.LibraryModel.LibraryDependency.GeneratePathProperty.get -> bool
 NuGet.LibraryModel.LibraryDependency.GeneratePathProperty.set -> void
 NuGet.LibraryModel.LibraryDependency.IncludeType.get -> NuGet.LibraryModel.LibraryIncludeFlags
 NuGet.LibraryModel.LibraryDependency.IncludeType.set -> void
 NuGet.LibraryModel.LibraryDependency.LibraryDependency() -> void
-~NuGet.LibraryModel.LibraryDependency.LibraryRange.get -> NuGet.LibraryModel.LibraryRange
-~NuGet.LibraryModel.LibraryDependency.LibraryRange.set -> void
-~NuGet.LibraryModel.LibraryDependency.Name.get -> string
-~NuGet.LibraryModel.LibraryDependency.NoWarn.get -> System.Collections.Generic.IList<NuGet.Common.NuGetLogCode>
-~NuGet.LibraryModel.LibraryDependency.NoWarn.set -> void
+NuGet.LibraryModel.LibraryDependency.LibraryRange.get -> NuGet.LibraryModel.LibraryRange?
+NuGet.LibraryModel.LibraryDependency.LibraryRange.set -> void
+NuGet.LibraryModel.LibraryDependency.Name.get -> string!
+NuGet.LibraryModel.LibraryDependency.NoWarn.get -> System.Collections.Generic.IList<NuGet.Common.NuGetLogCode>!
+NuGet.LibraryModel.LibraryDependency.NoWarn.set -> void
 NuGet.LibraryModel.LibraryDependency.ReferenceType.get -> NuGet.LibraryModel.LibraryDependencyReferenceType
 NuGet.LibraryModel.LibraryDependency.ReferenceType.set -> void
 NuGet.LibraryModel.LibraryDependency.SuppressParent.get -> NuGet.LibraryModel.LibraryIncludeFlags
 NuGet.LibraryModel.LibraryDependency.SuppressParent.set -> void
 NuGet.LibraryModel.LibraryDependency.VersionCentrallyManaged.get -> bool
 NuGet.LibraryModel.LibraryDependency.VersionCentrallyManaged.set -> void
-~NuGet.LibraryModel.LibraryDependency.VersionOverride.get -> NuGet.Versioning.VersionRange
-~NuGet.LibraryModel.LibraryDependency.VersionOverride.set -> void
+NuGet.LibraryModel.LibraryDependency.VersionOverride.get -> NuGet.Versioning.VersionRange?
+NuGet.LibraryModel.LibraryDependency.VersionOverride.set -> void
 NuGet.LibraryModel.LibraryDependencyInfo
 ~NuGet.LibraryModel.LibraryDependencyInfo.Dependencies.get -> System.Collections.Generic.IEnumerable<NuGet.LibraryModel.LibraryDependency>
 ~NuGet.LibraryModel.LibraryDependencyInfo.Framework.get -> NuGet.Frameworks.NuGetFramework
@@ -136,9 +136,9 @@ override NuGet.LibraryModel.DownloadDependency.GetHashCode() -> int
 ~override NuGet.LibraryModel.DownloadDependency.ToString() -> string
 override NuGet.LibraryModel.FrameworkDependency.GetHashCode() -> int
 ~override NuGet.LibraryModel.Library.ToString() -> string
-~override NuGet.LibraryModel.LibraryDependency.Equals(object obj) -> bool
+override NuGet.LibraryModel.LibraryDependency.Equals(object? obj) -> bool
 override NuGet.LibraryModel.LibraryDependency.GetHashCode() -> int
-~override NuGet.LibraryModel.LibraryDependency.ToString() -> string
+override NuGet.LibraryModel.LibraryDependency.ToString() -> string!
 ~override NuGet.LibraryModel.LibraryIdentity.Equals(object obj) -> bool
 override NuGet.LibraryModel.LibraryIdentity.GetHashCode() -> int
 ~override NuGet.LibraryModel.LibraryIdentity.ToString() -> string
@@ -153,7 +153,7 @@ override NuGet.LibraryModel.LibraryType.GetHashCode() -> int
 ~static NuGet.LibraryModel.FrameworkDependencyFlagsUtils.GetFlagString(NuGet.LibraryModel.FrameworkDependencyFlags flags) -> string
 ~static NuGet.LibraryModel.FrameworkDependencyFlagsUtils.GetFlags(System.Collections.Generic.IEnumerable<string> values) -> NuGet.LibraryModel.FrameworkDependencyFlags
 ~static NuGet.LibraryModel.FrameworkDependencyFlagsUtils.GetFlags(string flags) -> NuGet.LibraryModel.FrameworkDependencyFlags
-~static NuGet.LibraryModel.LibraryDependency.ApplyCentralVersionInformation(System.Collections.Generic.IList<NuGet.LibraryModel.LibraryDependency> packageReferences, System.Collections.Generic.IDictionary<string, NuGet.LibraryModel.CentralPackageVersion> centralPackageVersions) -> void
+static NuGet.LibraryModel.LibraryDependency.ApplyCentralVersionInformation(System.Collections.Generic.IList<NuGet.LibraryModel.LibraryDependency!>! packageReferences, System.Collections.Generic.IDictionary<string!, NuGet.LibraryModel.CentralPackageVersion!>! centralPackageVersions) -> void
 ~static NuGet.LibraryModel.LibraryDependencyInfo.Create(NuGet.LibraryModel.LibraryIdentity library, NuGet.Frameworks.NuGetFramework framework, System.Collections.Generic.IEnumerable<NuGet.LibraryModel.LibraryDependency> dependencies) -> NuGet.LibraryModel.LibraryDependencyInfo
 ~static NuGet.LibraryModel.LibraryDependencyInfo.CreateUnresolved(NuGet.LibraryModel.LibraryIdentity library, NuGet.Frameworks.NuGetFramework framework) -> NuGet.LibraryModel.LibraryDependencyInfo
 ~static NuGet.LibraryModel.LibraryDependencyTargetUtils.GetFlagString(NuGet.LibraryModel.LibraryDependencyTarget flags) -> string

--- a/src/NuGet.Core/NuGet.LibraryModel/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.LibraryModel/PublicAPI.Unshipped.txt
@@ -2,3 +2,4 @@
 NuGet.LibraryModel.LibraryType.LibraryType() -> void
 ~static NuGet.LibraryModel.LibraryDependencyTargetUtils.AsString(this NuGet.LibraryModel.LibraryDependencyTarget includeFlags) -> string
 ~static NuGet.LibraryModel.LibraryIncludeFlagUtils.AsString(this NuGet.LibraryModel.LibraryIncludeFlags includeFlags) -> string
+NuGet.LibraryModel.LibraryDependency.NoWarnCount.get -> int

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -464,7 +464,7 @@ namespace NuGet.ProjectModel
 
                     SetValueIfTrue(writer, "autoReferenced", dependency.AutoReferenced);
 
-                    if (dependency.NoWarn.Count > 0)
+                    if (dependency.NoWarnCount > 0)
                     {
                         SetArrayValue(writer, "noWarn", dependency
                             .NoWarn

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -2857,6 +2857,7 @@ namespace NuGet.Commands.Test
                 var packageDependency = project1Spec.TargetFrameworks[0].Dependencies[0];
 
                 // Assert
+                packageDependency.NoWarnCount.Should().Be(0);
                 packageDependency.NoWarn.Should().BeEmpty();
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/LibraryDependencyTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/LibraryDependencyTests.cs
@@ -125,6 +125,23 @@ namespace NuGet.LibraryModel.Tests
             Assert.Equal(0, libraryDependency.NoWarn.Count);
         }
 
+        [Fact]
+        public void Equal_NoWarn()
+        {
+            LibraryDependency dep1 = new();
+            LibraryDependency dep2 = new();
+
+            Assert.Equal(dep1, dep2);
+
+            _ = dep1.NoWarn; // force initialization of collection
+
+            Assert.Equal(dep1, dep2);
+
+            dep1.NoWarn.Add(new NuGetLogCode());
+
+            Assert.NotEqual(dep1, dep2);
+        }
+
         [Theory]
         //[CombinatorialData]
         [PairwiseData]

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/LibraryDependencyTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/LibraryDependencyTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using NuGet.Common;
 using NuGet.Versioning;
 using Xunit;
 
@@ -101,6 +102,82 @@ namespace NuGet.LibraryModel.Tests
                 },
                 SuppressParent = LibraryIncludeFlags.Analyzers | LibraryIncludeFlags.ContentFiles,
                 Aliases = "stuff",
+            };
+        }
+
+        [Fact]
+        public void NoWarnCount()
+        {
+            var libraryDependency = new LibraryDependency();
+            Assert.Equal(0, libraryDependency.NoWarnCount);
+            Assert.Equal(0, libraryDependency.NoWarn.Count);
+
+            libraryDependency.NoWarn = new List<NuGetLogCode> { NuGetLogCode.NU1001, NuGetLogCode.NU1006 };
+            Assert.Equal(2, libraryDependency.NoWarnCount);
+            Assert.Equal(2, libraryDependency.NoWarn.Count);
+
+            libraryDependency.NoWarn = new List<NuGetLogCode> { };
+            Assert.Equal(0, libraryDependency.NoWarnCount);
+            Assert.Equal(0, libraryDependency.NoWarn.Count);
+
+            libraryDependency.NoWarn = null;
+            Assert.Equal(0, libraryDependency.NoWarnCount);
+            Assert.Equal(0, libraryDependency.NoWarn.Count);
+        }
+
+        [Theory]
+        //[CombinatorialData]
+        [PairwiseData]
+        public void PackedProperties(
+            bool GeneratePathProperty,
+            bool AutoReferenced,
+            bool VersionCentrallyManaged,
+            [CombinatorialMemberData(nameof(GetLibraryIncludeFlags))] LibraryIncludeFlags includeType,
+            [CombinatorialMemberData(nameof(GetLibraryIncludeFlags))] LibraryIncludeFlags suppressParent,
+            [CombinatorialMemberData(nameof(GetLibraryDependencyReferenceType))] LibraryDependencyReferenceType referenceType)
+        {
+            var libraryDependency = new LibraryDependency
+            {
+                GeneratePathProperty = GeneratePathProperty,
+                AutoReferenced = AutoReferenced,
+                VersionCentrallyManaged = VersionCentrallyManaged,
+                IncludeType = includeType,
+                SuppressParent = suppressParent,
+                ReferenceType = referenceType
+            };
+
+            Assert.Equal(GeneratePathProperty, libraryDependency.GeneratePathProperty);
+            Assert.Equal(AutoReferenced, libraryDependency.AutoReferenced);
+            Assert.Equal(VersionCentrallyManaged, libraryDependency.VersionCentrallyManaged);
+            Assert.Equal(includeType, libraryDependency.IncludeType);
+            Assert.Equal(suppressParent, libraryDependency.SuppressParent);
+            Assert.Equal(referenceType, libraryDependency.ReferenceType);
+        }
+
+        public static IEnumerable<LibraryIncludeFlags> GetLibraryIncludeFlags()
+        {
+            // Only include a few values to keep test case count down
+            return new[]
+            {
+                LibraryIncludeFlags.None,
+                //LibraryIncludeFlags.Runtime,
+                LibraryIncludeFlags.Compile,
+                //LibraryIncludeFlags.Build,
+                //LibraryIncludeFlags.Native,
+                LibraryIncludeFlags.ContentFiles,
+                //LibraryIncludeFlags.Analyzers,
+                //LibraryIncludeFlags.BuildTransitive,
+                LibraryIncludeFlags.All
+            };
+        }
+
+        public static IEnumerable<LibraryDependencyReferenceType> GetLibraryDependencyReferenceType()
+        {
+            return new[]
+            {
+                LibraryDependencyReferenceType.None,
+                LibraryDependencyReferenceType.Transitive,
+                LibraryDependencyReferenceType.Direct
             };
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/NuGet.LibraryModel.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/NuGet.LibraryModel.Tests.csproj
@@ -10,6 +10,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Xunit.Combinatorial" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Bug

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1826369
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1835763

Regression? Last working version: N/A

## Description

_This PR is @melytc's work as part of the perfathon. I put together the PR as she's OOF the coming week._

The `LibraryDependency` class has been identified as contributing to high GC on customer machines, allocating up to 37MB/s. This change reduces the memory footprint of that type in two ways:

1. Six integral fields are packed into a single 32-bit integer, reducing 12 bytes down to 4 bytes.
2. The backing collection for the `NoWarn` property is now lazily allocated, as it will usually be empty.

For the packing of fields, there are three Boolean and three enum-based fields. With some masking and shifting, these can all be efficiently stored within a single 32-bit integer space. Unit tests have been added to ensure the correctness of those fields now and in future. Comments have been added to the enums being packed to ensure any future modifications to those enums take this packing strategy into account. The packing of enums does leave some headroom, so a few more members could be added to each without requiring any code changes in `LibraryDependency`.

For the `NoWarn` collection, an additional `NoWarnCount` property was added that allows callers to test whether the collection is empty before calling the `NoWarn` getter (which would lazily allocate a backing collection). This seems to be a pragmatic approach to this issue given the backwards compatibility requirements. Several callers have been updated to check the count first.

This PR also null annotates `LibraryDependency` and some other types that needed annotations in the process of doing so.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
