### PR TITLE
Improve hashing and equality allocations/performance

### DIFF
--- a/build/Shared/EqualityUtility.cs
+++ b/build/Shared/EqualityUtility.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace NuGet.Shared
@@ -22,7 +23,7 @@ namespace NuGet.Shared
         /// <param name="keySelector">The function to extract the key from each item in the list</param>
         /// <param name="orderComparer">An optional comparer for comparing keys</param>
         /// <param name="sequenceComparer">An optional comparer for sequences</param>
-        internal static bool OrderedEquals<TSource, TKey>(this IEnumerable<TSource> self, IEnumerable<TSource> other, Func<TSource, TKey> keySelector, IComparer<TKey>? orderComparer = null, IEqualityComparer<TSource>? sequenceComparer = null)
+        internal static bool OrderedEquals<TSource, TKey>(this IEnumerable<TSource>? self, IEnumerable<TSource>? other, Func<TSource, TKey> keySelector, IComparer<TKey>? orderComparer = null, IEqualityComparer<TSource>? sequenceComparer = null)
         {
             Debug.Assert(orderComparer != null || typeof(TKey) != typeof(string), "Argument " + "orderComparer" + " must be provided if " + "TKey" + " is a string.");
             Debug.Assert(sequenceComparer != null || typeof(TSource) != typeof(string), "Argument " + "sequenceComparer" + " must be provided if " + "TSource" + " is a string.");
@@ -48,7 +49,7 @@ namespace NuGet.Shared
         /// <param name="keySelector">The function to extract the key from each item in the list</param>
         /// <param name="orderComparer">An optional comparer for comparing keys</param>
         /// <param name="sequenceComparer">An optional comparer for sequences</param>
-        internal static bool OrderedEquals<TSource, TKey>(this ICollection<TSource> self, ICollection<TSource> other, Func<TSource, TKey> keySelector, IComparer<TKey>? orderComparer = null, IEqualityComparer<TSource>? sequenceComparer = null)
+        internal static bool OrderedEquals<TSource, TKey>(this ICollection<TSource>? self, ICollection<TSource>? other, Func<TSource, TKey> keySelector, IComparer<TKey>? orderComparer = null, IEqualityComparer<TSource>? sequenceComparer = null)
         {
             Debug.Assert(orderComparer != null || typeof(TKey) != typeof(string), "Argument " + "orderComparer" + " must be provided if " + "TKey" + " is a string.");
             Debug.Assert(sequenceComparer != null || typeof(TSource) != typeof(string), "Argument " + "sequenceComparer" + " must be provided if " + "TSource" + " is a string.");
@@ -84,7 +85,7 @@ namespace NuGet.Shared
         /// <param name="keySelector">The function to extract the key from each item in the list</param>
         /// <param name="orderComparer">An optional comparer for comparing keys</param>
         /// <param name="sequenceComparer">An optional comparer for sequences</param>
-        internal static bool OrderedEquals<TSource, TKey>(this IList<TSource> self, IList<TSource> other, Func<TSource, TKey> keySelector, IComparer<TKey>? orderComparer = null, IEqualityComparer<TSource>? sequenceComparer = null)
+        internal static bool OrderedEquals<TSource, TKey>(this IList<TSource>? self, IList<TSource>? other, Func<TSource, TKey> keySelector, IComparer<TKey>? orderComparer = null, IEqualityComparer<TSource>? sequenceComparer = null)
         {
             Debug.Assert(orderComparer != null || typeof(TKey) != typeof(string), "Argument " + "orderComparer" + " must be provided if " + "TKey" + " is a string.");
             Debug.Assert(sequenceComparer != null || typeof(TSource) != typeof(string), "Argument " + "sequenceComparer" + " must be provided if " + "TSource" + " is a string.");
@@ -120,8 +121,8 @@ namespace NuGet.Shared
         /// null for equality.
         /// </summary>
         internal static bool SequenceEqualWithNullCheck<T>(
-            this IEnumerable<T> self,
-            IEnumerable<T> other,
+            this IEnumerable<T>? self,
+            IEnumerable<T>? other,
             IEqualityComparer<T>? comparer = null)
         {
             bool identityEquals;
@@ -143,8 +144,8 @@ namespace NuGet.Shared
         /// null for equality.
         /// </summary>
         internal static bool SequenceEqualWithNullCheck<T>(
-            this ICollection<T> self,
-            ICollection<T> other,
+            this ICollection<T>? self,
+            ICollection<T>? other,
             IEqualityComparer<T>? comparer = null)
         {
             bool identityEquals;
@@ -176,8 +177,8 @@ namespace NuGet.Shared
         /// null for equality.
         /// </summary>
         internal static bool SequenceEqualWithNullCheck<T>(
-            this IList<T> self,
-            IList<T> other,
+            this IList<T>? self,
+            IList<T>? other,
             IEqualityComparer<T>? comparer = null)
         {
             bool identityEquals;
@@ -214,8 +215,8 @@ namespace NuGet.Shared
         /// If one is null, both have to be null for equality.
         /// </summary>
         internal static bool SetEqualsWithNullCheck<T>(
-            this ISet<T> self,
-            ISet<T> other,
+            this ISet<T>? self,
+            ISet<T>? other,
             IEqualityComparer<T>? comparer = null)
         {
             bool identityEquals;
@@ -324,7 +325,10 @@ namespace NuGet.Shared
             return !string.IsNullOrWhiteSpace(value) && bool.FalseString.Equals(value.Trim(), StringComparison.OrdinalIgnoreCase);
         }
 
-        private static bool TryIdentityEquals<T>(T? self, T? other, out bool equals)
+        private static bool TryIdentityEquals<T>(
+            [NotNullWhen(returnValue: false)] T? self,
+            [NotNullWhen(returnValue: false)] T? other,
+            out bool equals)
         {
             // Are they the same instance? This handles the case where both are null.
             if (ReferenceEquals(self, other))

--- a/build/Shared/EqualityUtility.cs
+++ b/build/Shared/EqualityUtility.cs
@@ -322,7 +322,7 @@ namespace NuGet.Shared
         }
 
         /// <summary>
-        /// Determines if the current string contains a value equal "false".  Leading and trailing whitespace are trimmed and the comparision is case-insensitive
+        /// Determines if the current string contains a value equal "false".  Leading and trailing whitespace are trimmed and the comparison is case-insensitive
         /// </summary>
         /// <param name="value">The string to compare.</param>
         /// <returns><c>true</c> if the current string is equal to a value of "false", otherwise <c>false></c>.</returns>

--- a/build/Shared/EqualityUtility.cs
+++ b/build/Shared/EqualityUtility.cs
@@ -70,6 +70,12 @@ namespace NuGet.Shared
                 return true;
             }
 
+            if (self.Count == 1)
+            {
+                sequenceComparer ??= EqualityComparer<TSource>.Default;
+                return sequenceComparer.Equals(self.First(), other.First());
+            }
+
             return self
                 .OrderBy(keySelector, orderComparer)
                 .SequenceEqual(other.OrderBy(keySelector, orderComparer), sequenceComparer);

--- a/build/Shared/HashCodeCombiner.cs
+++ b/build/Shared/HashCodeCombiner.cs
@@ -42,8 +42,8 @@ namespace NuGet.Shared
             AddHashCode(b ? 1 : 0);
         }
 
-        internal void AddObject<TValue>(TValue? o, IEqualityComparer<TValue> comparer)
-            where TValue : class
+        internal void AddObject<T>(T? o, IEqualityComparer<T> comparer)
+            where T : class
         {
             CheckInitialized();
             if (o != null)

--- a/build/Shared/HashCodeCombiner.cs
+++ b/build/Shared/HashCodeCombiner.cs
@@ -17,13 +17,13 @@ namespace NuGet.Shared
         // seed from String.GetHashCode()
         private const long Seed = 0x1505L;
 
-        private bool _initialized;
-        private long _combinedHash;
+        private long _combinedHash = Seed;
 
-        internal int CombinedHash
+        public HashCodeCombiner()
         {
-            get { return _combinedHash.GetHashCode(); }
         }
+
+        internal int CombinedHash => _combinedHash.GetHashCode();
 
         private void AddHashCode(int i)
         {
@@ -32,20 +32,17 @@ namespace NuGet.Shared
 
         internal void AddObject(int i)
         {
-            CheckInitialized();
             AddHashCode(i);
         }
 
         internal void AddObject(bool b)
         {
-            CheckInitialized();
             AddHashCode(b ? 1 : 0);
         }
 
         internal void AddObject<T>(T? o, IEqualityComparer<T> comparer)
             where T : class
         {
-            CheckInitialized();
             if (o != null)
             {
                 AddHashCode(comparer.GetHashCode(o));
@@ -55,7 +52,6 @@ namespace NuGet.Shared
         internal void AddObject<T>(T? o)
             where T : class
         {
-            CheckInitialized();
             if (o != null)
             {
                 AddHashCode(o.GetHashCode());
@@ -66,8 +62,6 @@ namespace NuGet.Shared
         internal void AddStruct<T>(T? o)
             where T : struct
         {
-            CheckInitialized();
-
             if (o.HasValue)
             {
                 AddHashCode(o.GetHashCode());
@@ -78,14 +72,11 @@ namespace NuGet.Shared
         internal void AddStruct<T>(T o)
             where T : struct
         {
-            CheckInitialized();
-
             AddHashCode(o.GetHashCode());
         }
 
         internal void AddStringIgnoreCase(string? s)
         {
-            CheckInitialized();
             if (s != null)
             {
                 AddHashCode(StringComparer.OrdinalIgnoreCase.GetHashCode(s));
@@ -96,7 +87,6 @@ namespace NuGet.Shared
         {
             if (sequence != null)
             {
-                CheckInitialized();
                 foreach (var item in sequence)
                 {
                     AddHashCode(item.GetHashCode());
@@ -108,7 +98,6 @@ namespace NuGet.Shared
         {
             if (array != null)
             {
-                CheckInitialized();
                 foreach (var item in array)
                 {
                     AddHashCode(item.GetHashCode());
@@ -120,7 +109,6 @@ namespace NuGet.Shared
         {
             if (list != null)
             {
-                CheckInitialized();
                 var count = list.Count;
                 for (var i = 0; i < count; i++)
                 {
@@ -133,7 +121,6 @@ namespace NuGet.Shared
         {
             if (list != null)
             {
-                CheckInitialized();
                 var count = list.Count;
                 for (var i = 0; i < count; i++)
                 {
@@ -148,7 +135,6 @@ namespace NuGet.Shared
         {
             if (dictionary != null)
             {
-                CheckInitialized();
                 foreach (var pair in dictionary.OrderBy(x => x.Key))
                 {
                     AddHashCode(pair.Key.GetHashCode());
@@ -165,7 +151,6 @@ namespace NuGet.Shared
             where T2 : notnull
         {
             var combiner = new HashCodeCombiner();
-            combiner.CheckInitialized();
 
             combiner.AddHashCode(o1.GetHashCode());
             combiner.AddHashCode(o2.GetHashCode());
@@ -182,22 +167,12 @@ namespace NuGet.Shared
             where T3 : notnull
         {
             var combiner = new HashCodeCombiner();
-            combiner.CheckInitialized();
 
             combiner.AddHashCode(o1.GetHashCode());
             combiner.AddHashCode(o2.GetHashCode());
             combiner.AddHashCode(o3.GetHashCode());
 
             return combiner.CombinedHash;
-        }
-
-        private void CheckInitialized()
-        {
-            if (!_initialized)
-            {
-                _combinedHash = Seed;
-                _initialized = true;
-            }
         }
     }
 }

--- a/build/Shared/HashCodeCombiner.cs
+++ b/build/Shared/HashCodeCombiner.cs
@@ -12,7 +12,7 @@ namespace NuGet.Shared
     /// <summary>
     /// Hash code creator, based on the original NuGet hash code combiner/ASP hash code combiner implementations
     /// </summary>
-    internal struct HashCodeCombiner
+    internal ref struct HashCodeCombiner
     {
         // seed from String.GetHashCode()
         private const long Seed = 0x1505L;

--- a/build/Shared/HashCodeCombiner.cs
+++ b/build/Shared/HashCodeCombiner.cs
@@ -83,7 +83,7 @@ namespace NuGet.Shared
             AddHashCode(o.GetHashCode());
         }
 
-        internal void AddStringIgnoreCase(string s)
+        internal void AddStringIgnoreCase(string? s)
         {
             CheckInitialized();
             if (s != null)
@@ -92,7 +92,7 @@ namespace NuGet.Shared
             }
         }
 
-        internal void AddSequence<T>(IEnumerable<T> sequence) where T : notnull
+        internal void AddSequence<T>(IEnumerable<T>? sequence) where T : notnull
         {
             if (sequence != null)
             {
@@ -104,7 +104,7 @@ namespace NuGet.Shared
             }
         }
 
-        internal void AddSequence<T>(T[] array) where T : notnull
+        internal void AddSequence<T>(T[]? array) where T : notnull
         {
             if (array != null)
             {
@@ -116,7 +116,7 @@ namespace NuGet.Shared
             }
         }
 
-        internal void AddSequence<T>(IList<T> list) where T : notnull
+        internal void AddSequence<T>(IList<T>? list) where T : notnull
         {
             if (list != null)
             {
@@ -129,7 +129,7 @@ namespace NuGet.Shared
             }
         }
 
-        internal void AddSequence<T>(IReadOnlyList<T> list) where T : notnull
+        internal void AddSequence<T>(IReadOnlyList<T>? list) where T : notnull
         {
             if (list != null)
             {
@@ -142,7 +142,7 @@ namespace NuGet.Shared
             }
         }
 
-        internal void AddDictionary<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> dictionary)
+        internal void AddDictionary<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>>? dictionary)
             where TKey : notnull
             where TValue : notnull
         {

--- a/spelling.dic
+++ b/spelling.dic
@@ -1,12 +1,15 @@
 anycpu
 csproj
 entityframework
+enumerables
 globalpackages
 globbing
 netcore
 netcoreapp
 netstandard
 netstandardapp
+nupkg
+snupkg
 winmd
 winrt
 Xunit

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageSearchMetadataCacheItem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageSearchMetadataCacheItem.cs
@@ -66,7 +66,7 @@ namespace NuGet.PackageManagement.VisualStudio
             var hashCodeCombiner = new HashCodeCombiner();
             hashCodeCombiner.AddSequence(packageSources);
             hashCodeCombiner.AddStringIgnoreCase(packageId);
-            hashCodeCombiner.AddObject(includePrerelease.GetHashCode());
+            hashCodeCombiner.AddObject(includePrerelease);
             return hashCodeCombiner.CombinedHash.ToString(CultureInfo.InvariantCulture);
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/TransitiveNoWarnUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/TransitiveNoWarnUtils.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using NuGet.Common;
 using NuGet.DependencyResolver;
@@ -722,7 +721,7 @@ namespace NuGet.Commands
             {
                 var hashCode = new HashCodeCombiner();
 
-                hashCode.AddSequence(ProjectWide);
+                hashCode.AddUnorderedSequence(ProjectWide);
                 hashCode.AddDictionary(PackageSpecific);
 
                 return hashCode.CombinedHash;

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceCredential.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceCredential.cs
@@ -113,7 +113,7 @@ namespace NuGet.Configuration
                 combiner.AddObject(PasswordText);
                 combiner.AddObject(IsPasswordClearText);
 
-                return combiner.GetHashCode();
+                return combiner.CombinedHash;
             });
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFile.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFile.cs
@@ -41,8 +41,8 @@ namespace NuGet.Packaging
             var combiner = new HashCodeCombiner();
 
             combiner.AddObject(Version);
-            combiner.AddSequence(ContentHash);
-            combiner.AddSequence(Source);
+            combiner.AddObject(ContentHash);
+            combiner.AddObject(Source);
 
             return combiner.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/CertificateHashAllowListEntry.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/CertificateHashAllowListEntry.cs
@@ -75,7 +75,7 @@ namespace NuGet.Packaging.Signing
             combiner.AddObject(Fingerprint);
             combiner.AddStruct(FingerprintAlgorithm);
 
-            return combiner.GetHashCode();
+            return combiner.CombinedHash;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/TrustedSignerAllowListEntry.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/TrustedSignerAllowListEntry.cs
@@ -60,11 +60,7 @@ namespace NuGet.Packaging.Signing
             combiner.AddStruct(Target);
             combiner.AddObject(Fingerprint);
             combiner.AddStruct(FingerprintAlgorithm);
-
-            if (Owners != null)
-            {
-                combiner.AddSequence(Owners);
-            }
+            combiner.AddSequence(Owners);
 
             return combiner.GetHashCode();
         }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/TrustedSignerAllowListEntry.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/TrustedSignerAllowListEntry.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Common;
@@ -62,7 +61,7 @@ namespace NuGet.Packaging.Signing
             combiner.AddStruct(FingerprintAlgorithm);
             combiner.AddSequence(Owners);
 
-            return combiner.GetHashCode();
+            return combiner.CombinedHash;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -129,49 +129,22 @@ namespace NuGet.ProjectModel
 
         public override int GetHashCode()
         {
+            StringComparer osStringComparer = PathUtility.GetStringComparerBasedOnOS();
+
             var hashCode = new HashCodeCombiner();
 
             hashCode.AddStruct(ProjectStyle);
-
-            StringComparer osStringComparer = PathUtility.GetStringComparerBasedOnOS();
-            if (ProjectPath != null)
-            {
-                hashCode.AddObject(osStringComparer.GetHashCode(ProjectPath));
-            }
-            if (ProjectJsonPath != null)
-            {
-                hashCode.AddObject(osStringComparer.GetHashCode(ProjectJsonPath));
-            }
-            if (OutputPath != null)
-            {
-                hashCode.AddObject(osStringComparer.GetHashCode(OutputPath));
-            }
-            if (ProjectName != null)
-            {
-                hashCode.AddObject(osStringComparer.GetHashCode(ProjectName));
-            }
-            if (ProjectUniqueName != null)
-            {
-                hashCode.AddObject(osStringComparer.GetHashCode(ProjectUniqueName));
-            }
-            hashCode.AddSequence(Sources.OrderBy(e => e.Source, StringComparer.OrdinalIgnoreCase));
-            if (PackagesPath != null)
-            {
-                hashCode.AddObject(osStringComparer.GetHashCode(PackagesPath));
-            }
-            foreach (var reference in ConfigFilePaths.OrderBy(s => s, osStringComparer))
-            {
-                hashCode.AddObject(osStringComparer.GetHashCode(reference));
-            }
-            foreach (var reference in FallbackFolders.OrderBy(s => s, osStringComparer))
-            {
-                hashCode.AddObject(osStringComparer.GetHashCode(reference));
-            }
-            hashCode.AddSequence(TargetFrameworks.OrderBy(dep => dep.TargetAlias, StringComparer.OrdinalIgnoreCase));
-            foreach (var reference in OriginalTargetFrameworks.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
-            {
-                hashCode.AddObject(StringComparer.OrdinalIgnoreCase.GetHashCode(reference));
-            }
+            hashCode.AddObject(ProjectPath, osStringComparer);
+            hashCode.AddObject(ProjectJsonPath, osStringComparer);
+            hashCode.AddObject(OutputPath, osStringComparer);
+            hashCode.AddObject(ProjectName, osStringComparer);
+            hashCode.AddObject(ProjectUniqueName, osStringComparer);
+            hashCode.AddUnorderedSequence(Sources);
+            hashCode.AddObject(PackagesPath, osStringComparer);
+            hashCode.AddUnorderedSequence(ConfigFilePaths, osStringComparer);
+            hashCode.AddUnorderedSequence(FallbackFolders, osStringComparer);
+            hashCode.AddUnorderedSequence(TargetFrameworks);
+            hashCode.AddUnorderedSequence(OriginalTargetFrameworks, StringComparer.OrdinalIgnoreCase);
             hashCode.AddObject(CrossTargeting);
             hashCode.AddObject(LegacyPackagesDirectory);
             hashCode.AddSequence(Files);

--- a/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
@@ -100,16 +100,16 @@ namespace NuGet.ProjectModel
 
             hashCode.AddObject(FrameworkName);
             hashCode.AddObject(AssetTargetFallback);
-            hashCode.AddSequence(Dependencies.OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase));
+            hashCode.AddUnorderedSequence(Dependencies);
             hashCode.AddSequence(Imports);
             hashCode.AddObject(Warn);
-            hashCode.AddSequence(DownloadDependencies.OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase));
-            hashCode.AddSequence(FrameworkReferences.OrderBy(s => s.Name, ComparisonUtility.FrameworkReferenceNameComparer));
+            hashCode.AddUnorderedSequence(DownloadDependencies);
+            hashCode.AddUnorderedSequence(FrameworkReferences);
             if (RuntimeIdentifierGraphPath != null)
             {
                 hashCode.AddObject(PathUtility.GetStringComparerBasedOnOS().GetHashCode(RuntimeIdentifierGraphPath));
             }
-            hashCode.AddSequence(CentralPackageVersions.Values.OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase));
+            hashCode.AddUnorderedSequence(CentralPackageVersions.Values);
             hashCode.AddStringIgnoreCase(TargetAlias);
             return hashCode.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/WarningProperties.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/WarningProperties.cs
@@ -61,9 +61,9 @@ namespace NuGet.ProjectModel
             var hashCode = new HashCodeCombiner();
 
             hashCode.AddObject(AllWarningsAsErrors);
-            hashCode.AddSequence(WarningsAsErrors.OrderBy(e => e));
-            hashCode.AddSequence(NoWarn.OrderBy(e => e));
-            hashCode.AddSequence(WarningsNotAsErrors.OrderBy(e => e));
+            hashCode.AddUnorderedSequence(WarningsAsErrors);
+            hashCode.AddUnorderedSequence(NoWarn);
+            hashCode.AddUnorderedSequence(WarningsNotAsErrors);
 
             return hashCode.CombinedHash;
         }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/NoAllocEnumerateExtensionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/NoAllocEnumerateExtensionsTests.cs
@@ -101,7 +101,7 @@ public class NoAllocEnumerateExtensionsTests
     }
 
     [Fact]
-    public void NoAllocEnumerate_IList_Fallback()
+    public void NoAllocEnumerate_IList_Mocked()
     {
         int[] array = { 0, 1, 2, 3 };
 
@@ -109,8 +109,11 @@ public class NoAllocEnumerateExtensionsTests
 
         mock.SetupGet(o => o.Count)
             .Returns(array.Length);
-        mock.Setup(o => o.GetEnumerator())
-            .Returns(((IEnumerable<int>)array).GetEnumerator());
+
+        mock.SetupGet(o => o[0]).Returns(0);
+        mock.SetupGet(o => o[1]).Returns(1);
+        mock.SetupGet(o => o[2]).Returns(2);
+        mock.SetupGet(o => o[3]).Returns(3);
 
         ValidateIList(mock.Object);
 

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/IncludeExcludeFilesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/IncludeExcludeFilesTests.cs
@@ -136,8 +136,6 @@ namespace NuGet.ProjectModel.Test
 
             var files = new IncludeExcludeFiles();
 
-            Assert.Equal(0, files.GetHashCode());
-
             files.Exclude = exclude;
             files.ExcludeFiles = excludeFiles;
             files.Include = include;

--- a/test/NuGet.Core.Tests/NuGet.Shared.Tests/HashCodeCombinerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Shared.Tests/HashCodeCombinerTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace NuGet.Shared.Tests;
+
+public class HashCodeCombinerTests
+{
+    [Fact]
+    public void AddDictionary_IsOrderIndependent()
+    {
+        var pairs1 = new[]
+        {
+            new KeyValuePair<int, string>(1, "A"),
+            new KeyValuePair<int, string>(2, "B")
+       };
+
+        var pairs2 = new[]
+        {
+            new KeyValuePair<int, string>(100, "AAAA"),
+            new KeyValuePair<int, string>(200, "BBB")
+       };
+
+        Assert.Equal(Compute(pairs1), Compute(pairs1.Reverse()));
+
+        Assert.Equal(Compute(pairs2), Compute(pairs2.Reverse()));
+
+        Assert.NotEqual(Compute(pairs1), Compute(pairs2));
+
+        static int Compute<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> pairs)
+        {
+            var combiner = new HashCodeCombiner();
+            combiner.AddDictionary(pairs);
+            return combiner.CombinedHash;
+        }
+    }
+
+    [Fact]
+    public void AddUnorderedSequence_NoComparer()
+    {
+        var values1 = new[] { 1, 2, 3, 4 };
+        var values2 = new[] { 100, 200, 300, 400 };
+
+        Assert.Equal(Compute(values1), Compute(values1.Reverse()));
+
+        Assert.Equal(Compute(values2), Compute(values2.Reverse()));
+
+        Assert.NotEqual(Compute(values1), Compute(values2));
+
+        static int Compute<T>(IEnumerable<T> pairs)
+        {
+            var combiner = new HashCodeCombiner();
+            combiner.AddUnorderedSequence(pairs);
+            return combiner.CombinedHash;
+        }
+    }
+
+    [Fact]
+    public void AddUnorderedSequence_DuplicateItems()
+    {
+        // Internally we use XOR to get unordered behaviour in an efficient manner.
+        // Because an XOR of a value with itself is a no-op, we want to ensure that
+        // duplicate items still produce unique hashes.
+
+        Assert.Equal(
+            Compute(new[] { 1, 1 }),
+            Compute(new[] { 1, 1 }));
+
+        Assert.NotEqual(
+            Compute(new[] { 1 }),
+            Compute(new[] { 1, 1 }));
+        Assert.NotEqual(
+            Compute(new[] { 1, 1 }),
+            Compute(new[] { 1, 1, 1 }));
+        Assert.NotEqual(
+            Compute(new[] { 1, 1 }),
+            Compute(new[] { 1, 1, 1, 1 }));
+
+        static int Compute<T>(IEnumerable<T> pairs)
+        {
+            var combiner = new HashCodeCombiner();
+            combiner.AddUnorderedSequence(pairs);
+            return combiner.CombinedHash;
+        }
+    }
+
+    [Fact]
+    public void AddUnorderedSequence_CustomComparer()
+    {
+        var valuesUpper = new[] { "A", "B", "C", "D" };
+        var valuesLower = new[] { "a", "b", "c", "d" };
+
+        Assert.Equal(
+            Compute(valuesUpper, StringComparer.Ordinal),
+            Compute(valuesUpper.Reverse(), StringComparer.Ordinal));
+
+        Assert.Equal(
+            Compute(valuesUpper, StringComparer.OrdinalIgnoreCase),
+            Compute(valuesUpper.Reverse(), StringComparer.OrdinalIgnoreCase));
+
+        Assert.Equal(
+            Compute(valuesLower, StringComparer.OrdinalIgnoreCase),
+            Compute(valuesUpper.Reverse(), StringComparer.OrdinalIgnoreCase));
+
+        Assert.NotEqual(
+            Compute(valuesUpper, StringComparer.Ordinal),
+            Compute(valuesLower, StringComparer.Ordinal));
+
+        static int Compute<T>(IEnumerable<T> pairs, IEqualityComparer<T> comparer)
+        {
+            var combiner = new HashCodeCombiner();
+            combiner.AddUnorderedSequence(pairs, comparer);
+            return combiner.CombinedHash;
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGet.Versioning.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGet.Versioning.Test.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedDirectory)\HashCodeCombiner.cs" />
+    <Compile Include="$(SharedDirectory)\NoAllocEnumerateExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/12746

Regression? Last working version: N/A

## Description

Improve the performance of hashing and equality checks.

- Create a `HashCodeCombiner.AddUnorderedSequence` that avoids needing calls to `OrderBy` that cause buffers to be allocated and sort algorithms to run.
- Improve `NoAllocEnumerate` for `IList<T>` to no longer allocate a fallback enumerator, and instead enumerate the list directly by index.
- Use `NoAllocEnumerate` in `HashCodeCombiner`.
- Improve `EqualityUtility.OrderedEquals` when sequence contains a single item, again, avoiding `OrderBy`.
- Fix incorrect calls to `HashCodeCombiner.GetHashCode` where callers should be using `CombinedHash` instead. The former boxes the struct in order to call the virtual `ValueType.GetHashCode`. Convert `HashCodeCombiner` to a `ref struct` to prevent this occurring in future.
- Fix places where strings were being treated as sequences of characters when adding to a hash.
- Remove `HashCodeCombiner.CheckInitialized`. This method has no practical utility in the existing code. It's possible to define the initial seed in a field initializer in newer versions of C#. Calling it from every method reduces that chance that calls can be inlined, and introduces branches that hurt perf.
- Null annotate some APIs.
- Add unit test class for `HashCodeCombiner`.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
