### PR TITLE
Package Source textbox has an accessible name

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.Designer.cs
@@ -123,6 +123,7 @@ namespace NuGet.PackageManagement.UI.Options
             // 
             resources.ApplyResources(this.NewPackageSource, "NewPackageSource");
             this.NewPackageSource.Name = "NewPackageSource";
+            this.NewPackageSource.AccessibleName = "Source:";
             this.NewPackageSource.TextChanged += new System.EventHandler(this.NewPackageSource_TextChanged);
             // 
             // NewPackageNameLabel


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2386

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Add an accessible name for the WinForms textbox.
Tested using AccessibilityInsights & Narrator:

![image](https://github.com/NuGet/NuGet.Client/assets/49205731/37754bdb-a68a-4307-91bd-d09742c08179)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Tested using AccessibilityInsights & Narrator
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
