### PR TITLE
Address component government alerts

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" />
     <!-- System.Security.Cryptography.Xml is a dependency of Microsoft.Build.Tasks.Core. Therefore, we have assigned the same ExcludeAssets value. -->
     <PackageReference Include="System.Security.Cryptography.Xml" ExcludeAssets="Runtime" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
@@ -34,13 +34,16 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" />
     <!-- System.Security.Cryptography.Xml is a dependency of Microsoft.Build.Tasks.Core. Therefore, we have assigned the same ExcludeAssets value. -->
     <PackageReference Include="System.Security.Cryptography.Xml" ExcludeAssets="Runtime" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
     <Reference Include="Microsoft.Build.Utilities.v4.0" Aliases="MicrosoftBuildUtilitiesv4" />
   </ItemGroup>
-
+  
+  <ItemGroup Condition=" '$(IsCore)' == 'true' ">
+    <PackageReference Include="System.Security.Cryptography.Pkcs" ExcludeAssets="Compile"/>
+  </ItemGroup>
+  
   <ItemGroup>
     <None Include="App.config" Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' " />
     <None Include="app.manifest" />

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -47,6 +47,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" GeneratePathProperty="true" />
     <!-- System.Security.Cryptography.Xml is a dependency of Microsoft.Build.Tasks.Core. Therefore, we have assigned the same ExcludeAssets value. -->
     <PackageReference Include="System.Security.Cryptography.Xml" ExcludeAssets="Runtime" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" GeneratePathProperty="true" />
     <!-- System.Security.Cryptography.Xml is a dependency of Microsoft.Build.Tasks.Core. Therefore, we have assigned the same ExcludeAssets value. -->
     <PackageReference Include="System.Security.Cryptography.Xml" ExcludeAssets="Runtime" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" ExcludeAssets="runtime" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
@@ -50,7 +50,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" />
     <!-- System.Security.Cryptography.Xml is a dependency of Microsoft.Build.Tasks.Core. Therefore, we have assigned the same ExcludeAssets value. -->
     <PackageReference Include="System.Security.Cryptography.Xml" ExcludeAssets="runtime" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" ExcludeAssets="runtime" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" ExcludeAssets="compile" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
@@ -50,6 +50,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" />
     <!-- System.Security.Cryptography.Xml is a dependency of Microsoft.Build.Tasks.Core. Therefore, we have assigned the same ExcludeAssets value. -->
     <PackageReference Include="System.Security.Cryptography.Xml" ExcludeAssets="runtime" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2372

Regression? Last working version:

## Description
Recently https://github.com/NuGet/NuGet.Client/pull/5289 upgraded  System.Security.Cryptography.Pkcs to non-vulnerable version, [still GC alert persists](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8053545&view=logs&j=cb98efd6-7062-56ef-f642-0176540bbe0a&t=f95ba3d8-e30a-5687-3fc7-3bc14bb0710b&l=3310). 

- Problem was https://www.nuget.org/packages/Microsoft.Build.Tasks.Core/17.3.1 defined in [Directory.Packages.props](https://github.com/NuGet/NuGet.Client/blob/b3c4e8094bbb924408180d700ae5b3d37713587c/Directory.Packages.props#L12) is still bringing same vulnerable version 6.0.1 into graph. 
![image](https://github.com/NuGet/NuGet.Client/assets/8766776/7b71f739-4d5c-49a5-a254-1561e7dd5a6a)
- Added override to version into respective projects to fix this.
- In `NuGet.Build.Tasks.Pack.csproj` we need to remove `ExcludeAssets="runtime" />` because this one is doing ILmerge, without this ilmerge fails with [strong name signature problem](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8056049&view=logs&j=d80b2849-30d4-52dd-74cd-d6536ba98fe0&t=c9202bea-0353-5c27-a52b-68d3d866d2ce&l=1112), see [here](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8056049&view=logs&j=d80b2849-30d4-52dd-74cd-d6536ba98fe0&t=86d56ec7-bfd0-5d56-4f04-a8bddd2f234f&l=235).


GC alert is no longer present in CI build after this fix: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8058016&view=logs&j=cb98efd6-7062-56ef-f642-0176540bbe0a&t=f95ba3d8-e30a-5687-3fc7-3bc14bb0710b&l=2327

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
