### PR TITLE
Update coding guidelines to avoid using as keyword for type casting

### DIFF
--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -239,7 +239,36 @@ For example the following are correct:
     }
     ```
 
-Exceptions are allowed when multiple type names coming from different namespaces are available.
+    Exceptions are allowed when multiple type names coming from different namespaces are available.
+
+1. Do not use `as` to cast types
+
+   These are correct:
+
+   ```cs
+   ListItem item = (ListItem)selectedItem; // InvalidCastException if wrong type
+   string name = item.Name;
+
+   if (obj is Type1 t1)
+   {
+       return t1.Value;
+   }
+   else if (obj is Type2 t2)
+   {
+       return t2.Value;
+   }
+   else
+   {
+        throw new InvalidOperationException($"Unexpected type {sender.GetType().Name}");
+   }
+   ```
+
+   This is incorrect:
+
+   ```cs
+   ListItem item = selectedItem as ListItem;
+   string name = item.Name; // NullReferenceException if selectedItem was not ListItem
+   ```
 
 Many of the guidelines, wherever possible, and potentially some not listed here, are enforced by an [EditorConfig](https://editorconfig.org "EditorConfig homepage") file (`.editorconfig`) at the root of the repository.
 

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -248,7 +248,9 @@ For example the following are correct:
    ```cs
    ListItem item = (ListItem)selectedItem; // InvalidCastException if wrong type
    string name = item.Name;
+   ```
 
+   ```cs
    if (obj is Type1 t1)
    {
        return t1.Value;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Update coding guidelines to avoid using `as` keyword for type casting, as it causes `NullReferenceException` to be thrown instead of `InvalidCastException`, making debugging much harder.

In the future, if we can enable [nullable referene types](https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references) throughout the repo, then the compiler will tell us that the code is not null safe. But enabling nullable everywhere takes a lot of effort to fix all the existing issues and annotating APIs. So, this coding guideline is a reminder for us to write better null safe code until we can have the compiler automate null safety for us.

## PR Checklist

- [x] ~PR has a meaningful title~ no product change
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
