### PR TITLE
Fix NuGetAudit severity levels

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
@@ -119,7 +119,7 @@ namespace NuGet.Commands.Restore.Utility
             foreach (Exception exception in exceptions.InnerExceptions)
             {
                 var messageText = string.Format(Strings.Error_VulnerabilityDataFetch, exception.Message);
-                RestoreLogMessage logMessage = RestoreLogMessage.CreateError(NuGetLogCode.NU1900, messageText);
+                RestoreLogMessage logMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1900, messageText);
                 logMessage.ProjectPath = _projectFullPath;
                 _logger.Log(logMessage);
             }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12743

Regression? no, new feature

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Fix mapping between severity levels and the integer used in [the Vulnerability Info NuGet Server API resource](https://learn.microsoft.com/en-us/nuget/api/vulnerability-info#vulnerability-page).

Also, fixed a bug where server errors causing no vulnerability database to be loaded wasn't being reported.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
