### PR TITLE
Pass SettingsLoadContext to LoadSettingsForSpecificConfigs

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -443,7 +443,8 @@ namespace NuGet.Configuration
                 validSettingFiles,
                 machineWideSettings,
                 loadUserWideSettings,
-                useTestingGlobalPath);
+                useTestingGlobalPath,
+                settingsLoadingContext);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -774,6 +774,11 @@ namespace NuGet.Configuration
             {
                 if (settingsLoadingContext != null)
                 {
+                    if (!Path.IsPathRooted(settingsPath) && !string.IsNullOrWhiteSpace(settingsRoot))
+                    {
+                        settingsPath = Path.Combine(settingsRoot, settingsPath);
+                    }
+
                     return settingsLoadingContext.GetOrCreateSettingsFile(settingsPath, isMachineWideSettings, isAdditionalUserWideConfig);
                 }
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsLoadingContext.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsLoadingContext.cs
@@ -57,6 +57,11 @@ namespace NuGet.Configuration
                 throw new ArgumentNullException(nameof(filePath));
             }
 
+            if (!Path.IsPathRooted(filePath))
+            {
+                throw new ArgumentException("SettingsLoadingContext requires a rooted path", nameof(filePath));
+            }
+
             Lazy<SettingsFile> settingsLazy = _cache.GetOrAdd(
                 filePath,
                 (key) => new Lazy<SettingsFile>(() =>

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsLoadingContextTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsLoadingContextTests.cs
@@ -130,5 +130,23 @@ namespace NuGet.Configuration.Test
                 .Should()
                 .Be(nameof(SettingsLoadingContext));
         }
+
+        /// <summary>
+        /// Verifies that <see cref="SettingsLoadingContext.GetOrCreateSettingsFile(string, bool, bool)" /> throws an <see cref="ArgumentException"/> when a non-rooted path is specified (ie just a filename).
+        /// </summary>
+        [Fact]
+        public void GetOrCreateSettingsFile_ThrowsArgumentException_WhenNonRootedPathSpecified()
+        {
+            var settingsLoadingContext = new SettingsLoadingContext();
+
+            Action action = () => settingsLoadingContext.GetOrCreateSettingsFile(filePath: "Something.config");
+
+            action.Should()
+                .Throw<ArgumentException>()
+                .Which
+                .ParamName
+                .Should()
+                .Be("filePath");
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12737

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
When the `SettingsLoadContext` class was added, it was missed that it could be passed from `Settings.LoadDefaultSettings()` to `Settings.LoadSettingsForSpecificConfigs()`.  There a few code paths that call this including the NuGet-based MSBuild project SDK resolver and static graph-based restore.  This leads to the machine-wide NuGet.config being read multiple times instead of being cached.

* Update `SettingsLoadingContext.GetOrCreateSettingsFile()` to guard against being called with a non-rooted path since it expects only rooted paths.  
* Update call to `SettingsLoadingContext.GetOrCreateSettingsFile()` to pass a rooted path

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception 
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
