### PR TITLE
[CI] Install MicroBuild plugins before running configure script

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -5,6 +5,27 @@ parameters:
   type: string
 
 steps:
+- task: MicroBuildLocalizationPlugin@1
+  displayName: "Install Localization Plugin"
+
+- task: MicroBuildSigningPlugin@1
+  inputs:
+    signType: "$(SigningType)"
+    esrpSigning: "true"
+  displayName: "Install Signing Plugin"
+
+- task: MicroBuildSwixPlugin@4
+  displayName: "Install Swix Plugin"
+
+- task: MicroBuildOptProfPlugin@6
+  displayName: 'OptProfV2:  install the plugin'
+  inputs:
+    getDropNameByDrop: true
+    optimizationInputsDropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
+    ShouldSkipOptimize: $(ShouldSkipOptimize)
+    AccessToken: $(System.AccessToken)
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
 - task: PowerShell@1
   inputs:
     scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
@@ -31,27 +52,6 @@ steps:
     scriptType: "inlineScript"
     inlineScript: |
       Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
-
-- task: MicroBuildLocalizationPlugin@1
-  displayName: "Install Localization Plugin"
-
-- task: MicroBuildSigningPlugin@1
-  inputs:
-    signType: "$(SigningType)"
-    esrpSigning: "true"
-  displayName: "Install Signing Plugin"
-
-- task: MicroBuildSwixPlugin@4
-  displayName: "Install Swix Plugin"
-
-- task: MicroBuildOptProfPlugin@6
-  displayName: 'OptProfV2:  install the plugin'
-  inputs:
-    getDropNameByDrop: true
-    optimizationInputsDropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
-    ShouldSkipOptimize: $(ShouldSkipOptimize)
-    AccessToken: $(System.AccessToken)
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
 # NuGet.Client's official repo is on github, hence the source link metadata should use the github URL.
 # However, our official builds are built from a mirror in Azure DevOps, hence without any extra help, the SourceLink.GitHub package


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2392

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Change order of CI yaml tasks to install MicroBuild plugins before running anything else. One of the plugin install tasks processes the working directory, so when `configure.ps1` writes a whole lot of large binary files, it makes the plugin installer take a lot longer. This change will reduce official build duration by around 5 minutes.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
