### PR TITLE
Add vulnerability severity enum to NuGet.Protocol public API

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -485,7 +485,7 @@ namespace NuGet.Commands
                 _logger);
             await audit.CheckPackageVulnerabilitiesAsync(token);
 
-            telemetry.TelemetryEvent[AuditLevel] = audit.MinSeverity;
+            telemetry.TelemetryEvent[AuditLevel] = (int)audit.MinSeverity;
             telemetry.TelemetryEvent[AuditMode] = AuditUtility.GetString(audit.AuditMode);
 
             if (audit.DirectPackagesWithAdvisory is not null) { AddPackagesList(telemetry, AuditDirectVulnerabilitiesPackages, audit.DirectPackagesWithAdvisory); }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
@@ -177,11 +177,11 @@ namespace NuGet.Commands.Restore.Utility
 
                     foreach (var advisory in auditInfo.GraphsPerVulnerability.Keys)
                     {
-                        int severity = advisory.Severity;
-                        if (severity == (int)PackageVulnerabilitySeverity.Low) { Sev0DirectMatches++; }
-                        else if (severity == (int)PackageVulnerabilitySeverity.Moderate) { Sev1DirectMatches++; }
-                        else if (severity == (int)PackageVulnerabilitySeverity.High) { Sev2DirectMatches++; }
-                        else if (severity == (int)PackageVulnerabilitySeverity.Critical) { Sev3DirectMatches++; }
+                        PackageVulnerabilitySeverity severity = (PackageVulnerabilitySeverity)advisory.Severity;
+                        if (severity == PackageVulnerabilitySeverity.Low) { Sev0DirectMatches++; }
+                        else if (severity == PackageVulnerabilitySeverity.Moderate) { Sev1DirectMatches++; }
+                        else if (severity == PackageVulnerabilitySeverity.High) { Sev2DirectMatches++; }
+                        else if (severity == PackageVulnerabilitySeverity.Critical) { Sev3DirectMatches++; }
                         else { InvalidSevDirectMatches++; }
                     }
                 }
@@ -191,11 +191,11 @@ namespace NuGet.Commands.Restore.Utility
 
                     foreach (var advisory in auditInfo.GraphsPerVulnerability.Keys)
                     {
-                        int severity = advisory.Severity;
-                        if (severity == (int)PackageVulnerabilitySeverity.Low) { Sev0TransitiveMatches++; }
-                        else if (severity == (int)PackageVulnerabilitySeverity.Moderate) { Sev1TransitiveMatches++; }
-                        else if (severity == (int)PackageVulnerabilitySeverity.High) { Sev2TransitiveMatches++; }
-                        else if (severity == (int)PackageVulnerabilitySeverity.Critical) { Sev3TransitiveMatches++; }
+                        PackageVulnerabilitySeverity severity = (PackageVulnerabilitySeverity)advisory.Severity;
+                        if (severity == PackageVulnerabilitySeverity.Low) { Sev0TransitiveMatches++; }
+                        else if (severity == PackageVulnerabilitySeverity.Moderate) { Sev1TransitiveMatches++; }
+                        else if (severity == PackageVulnerabilitySeverity.High) { Sev2TransitiveMatches++; }
+                        else if (severity == PackageVulnerabilitySeverity.Critical) { Sev3TransitiveMatches++; }
                         else { InvalidSevTransitiveMatches++; }
                     }
                 }
@@ -240,13 +240,13 @@ namespace NuGet.Commands.Restore.Utility
             switch (severity)
             {
                 case (int)PackageVulnerabilitySeverity.Low:
-                    return (Strings.Vulnerability_Severity_1, NuGetLogCode.NU1901);
+                    return (Strings.Vulnerability_Severity_Low, NuGetLogCode.NU1901);
                 case (int)PackageVulnerabilitySeverity.Moderate:
-                    return (Strings.Vulnerability_Severity_2, NuGetLogCode.NU1902);
+                    return (Strings.Vulnerability_Severity_Moderate, NuGetLogCode.NU1902);
                 case (int)PackageVulnerabilitySeverity.High:
-                    return (Strings.Vulnerability_Severity_3, NuGetLogCode.NU1903);
+                    return (Strings.Vulnerability_Severity_High, NuGetLogCode.NU1903);
                 case (int)PackageVulnerabilitySeverity.Critical:
-                    return (Strings.Vulnerability_Severity_4, NuGetLogCode.NU1904);
+                    return (Strings.Vulnerability_Severity_Critical, NuGetLogCode.NU1904);
                 default:
                     return (Strings.Vulnerability_Severity_unknown, NuGetLogCode.NU1900);
             }
@@ -370,7 +370,7 @@ namespace NuGet.Commands.Restore.Utility
 
             if (auditLevel == null)
             {
-                return 0;
+                return PackageVulnerabilitySeverity.Low;
             }
 
             if (string.Equals("low", auditLevel, StringComparison.OrdinalIgnoreCase))

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
@@ -273,7 +273,7 @@ namespace NuGet.Commands.Restore.Utility
 
                         foreach (PackageVulnerabilityInfo knownVulnerability in knownVulnerabilitiesForPackage)
                         {
-                            if ((int)knownVulnerability.Severity < (int)MinSeverity)
+                            if ((int)knownVulnerability.Severity < (int)MinSeverity && knownVulnerability.Severity != PackageVulnerabilitySeverity.Unknown)
                             {
                                 continue;
                             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
@@ -177,7 +177,7 @@ namespace NuGet.Commands.Restore.Utility
 
                     foreach (var advisory in auditInfo.GraphsPerVulnerability.Keys)
                     {
-                        PackageVulnerabilitySeverity severity = (PackageVulnerabilitySeverity)advisory.Severity;
+                        PackageVulnerabilitySeverity severity = advisory.Severity;
                         if (severity == PackageVulnerabilitySeverity.Low) { Sev0DirectMatches++; }
                         else if (severity == PackageVulnerabilitySeverity.Moderate) { Sev1DirectMatches++; }
                         else if (severity == PackageVulnerabilitySeverity.High) { Sev2DirectMatches++; }
@@ -191,7 +191,7 @@ namespace NuGet.Commands.Restore.Utility
 
                     foreach (var advisory in auditInfo.GraphsPerVulnerability.Keys)
                     {
-                        PackageVulnerabilitySeverity severity = (PackageVulnerabilitySeverity)advisory.Severity;
+                        PackageVulnerabilitySeverity severity = advisory.Severity;
                         if (severity == PackageVulnerabilitySeverity.Low) { Sev0TransitiveMatches++; }
                         else if (severity == PackageVulnerabilitySeverity.Moderate) { Sev1TransitiveMatches++; }
                         else if (severity == PackageVulnerabilitySeverity.High) { Sev2TransitiveMatches++; }
@@ -235,17 +235,17 @@ namespace NuGet.Commands.Restore.Utility
             return vulnerabilities != null ? vulnerabilities.ToList() : null;
         }
 
-        private static (string severityLabel, NuGetLogCode code) GetSeverityLabelAndCode(int severity)
+        private static (string severityLabel, NuGetLogCode code) GetSeverityLabelAndCode(PackageVulnerabilitySeverity severity)
         {
             switch (severity)
             {
-                case (int)PackageVulnerabilitySeverity.Low:
+                case PackageVulnerabilitySeverity.Low:
                     return (Strings.Vulnerability_Severity_Low, NuGetLogCode.NU1901);
-                case (int)PackageVulnerabilitySeverity.Moderate:
+                case PackageVulnerabilitySeverity.Moderate:
                     return (Strings.Vulnerability_Severity_Moderate, NuGetLogCode.NU1902);
-                case (int)PackageVulnerabilitySeverity.High:
+                case PackageVulnerabilitySeverity.High:
                     return (Strings.Vulnerability_Severity_High, NuGetLogCode.NU1903);
-                case (int)PackageVulnerabilitySeverity.Critical:
+                case PackageVulnerabilitySeverity.Critical:
                     return (Strings.Vulnerability_Severity_Critical, NuGetLogCode.NU1904);
                 default:
                     return (Strings.Vulnerability_Severity_unknown, NuGetLogCode.NU1900);
@@ -273,7 +273,7 @@ namespace NuGet.Commands.Restore.Utility
 
                         foreach (PackageVulnerabilityInfo knownVulnerability in knownVulnerabilitiesForPackage)
                         {
-                            if (knownVulnerability.Severity < (int)MinSeverity)
+                            if ((int)knownVulnerability.Severity < (int)MinSeverity)
                             {
                                 continue;
                             }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -2375,38 +2375,38 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to low.
+        ///   Looks up a localized string similar to critical.
         /// </summary>
-        internal static string Vulnerability_Severity_1 {
+        internal static string Vulnerability_Severity_Critical {
             get {
-                return ResourceManager.GetString("Vulnerability_Severity_1", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to moderate.
-        /// </summary>
-        internal static string Vulnerability_Severity_2 {
-            get {
-                return ResourceManager.GetString("Vulnerability_Severity_2", resourceCulture);
+                return ResourceManager.GetString("Vulnerability_Severity_Critical", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to high.
         /// </summary>
-        internal static string Vulnerability_Severity_3 {
+        internal static string Vulnerability_Severity_High {
             get {
-                return ResourceManager.GetString("Vulnerability_Severity_3", resourceCulture);
+                return ResourceManager.GetString("Vulnerability_Severity_High", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to critical.
+        ///   Looks up a localized string similar to low.
         /// </summary>
-        internal static string Vulnerability_Severity_4 {
+        internal static string Vulnerability_Severity_Low {
             get {
-                return ResourceManager.GetString("Vulnerability_Severity_4", resourceCulture);
+                return ResourceManager.GetString("Vulnerability_Severity_Low", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to moderate.
+        /// </summary>
+        internal static string Vulnerability_Severity_Moderate {
+            get {
+                return ResourceManager.GetString("Vulnerability_Severity_Moderate", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1041,19 +1041,19 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
     <value>Warning As Error: {0}</value>
     <comment>{0} is a warning message</comment>
   </data>
-  <data name="Vulnerability_Severity_1" xml:space="preserve">
+  <data name="Vulnerability_Severity_Low" xml:space="preserve">
     <value>low</value>
     <comment>As in "This package has a low severity vulnerability"</comment>
   </data>
-  <data name="Vulnerability_Severity_2" xml:space="preserve">
+  <data name="Vulnerability_Severity_Moderate" xml:space="preserve">
     <value>moderate</value>
     <comment>As in "This package has a moderate severity vulnerability"</comment>
   </data>
-  <data name="Vulnerability_Severity_3" xml:space="preserve">
+  <data name="Vulnerability_Severity_High" xml:space="preserve">
     <value>high</value>
     <comment>As in "This package has a high severity vulnerability"</comment>
   </data>
-  <data name="Vulnerability_Severity_4" xml:space="preserve">
+  <data name="Vulnerability_Severity_Critical" xml:space="preserve">
     <value>critical</value>
     <comment>As in "This package has a critical severity vulnerability"</comment>
   </data>

--- a/src/NuGet.Core/NuGet.Protocol/Converters/JsonExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/JsonExtensions.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
+using NuGet.Protocol.Converters;
 
 namespace NuGet.Protocol
 {
@@ -27,7 +28,8 @@ namespace NuGet.Protocol
                 new StringEnumConverter { NamingStrategy = new CamelCaseNamingStrategy() },
                 new IsoDateTimeConverter { DateTimeStyles = DateTimeStyles.AssumeUniversal },
                 new FingerprintsConverter(),
-                new VersionRangeConverter()
+                new VersionRangeConverter(),
+                new PackageVulnerabilityInfoConverter()
             },
         };
 

--- a/src/NuGet.Core/NuGet.Protocol/Converters/PackageVulnerabilityInfoConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/PackageVulnerabilityInfoConverter.cs
@@ -1,0 +1,81 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using Newtonsoft.Json;
+using NuGet.Protocol.Model;
+using NuGet.Versioning;
+
+namespace NuGet.Protocol.Converters
+{
+    internal class PackageVulnerabilityInfoConverter : JsonConverter<PackageVulnerabilityInfo>
+    {
+        public override PackageVulnerabilityInfo ReadJson(JsonReader reader, Type objectType, PackageVulnerabilityInfo? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            Uri? uri = null;
+            PackageVulnerabilitySeverity severity = PackageVulnerabilitySeverity.Unknown;
+            VersionRange? versionRange = null;
+
+            while (reader.Read() && reader.TokenType != JsonToken.EndObject)
+            {
+                if (reader.TokenType == JsonToken.PropertyName)
+                {
+                    string propertyName = (string)reader.Value!;
+                    switch (propertyName)
+                    {
+                        case JsonProperties.Url:
+                            reader.Read();
+                            uri = serializer.Deserialize<Uri>(reader);
+                            break;
+
+                        case JsonProperties.Severity:
+                            {
+                                int? value = reader.ReadAsInt32();
+                                if (value.HasValue && value.Value >= (int)PackageVulnerabilitySeverity.Low && value.Value <= (int)PackageVulnerabilitySeverity.Critical)
+                                {
+                                    severity = (PackageVulnerabilitySeverity)value.Value;
+                                }
+                            }
+                            break;
+
+                        case JsonProperties.Versions:
+                            reader.Read();
+                            versionRange = serializer.Deserialize<VersionRange>(reader);
+                            break;
+                    }
+                }
+            }
+
+            if (versionRange is null)
+            {
+                versionRange = new VersionRange(includeMinVersion: false, includeMaxVersion: false);
+            }
+
+            return new PackageVulnerabilityInfo(uri!, severity, versionRange);
+        }
+
+        public override void WriteJson(JsonWriter writer, PackageVulnerabilityInfo? value, JsonSerializer serializer)
+        {
+            if (value is null)
+            {
+                return;
+            }
+
+            writer.WriteStartObject();
+
+            writer.WritePropertyName(JsonProperties.Url);
+            serializer.Serialize(writer, value.Url);
+
+            //  The NuGet Server API defines severity as a number/integer, so don't write the enum name
+            writer.WritePropertyName(JsonProperties.Severity);
+            writer.WriteValue((int)value.Severity);
+
+            writer.WritePropertyName(JsonProperties.Versions);
+            serializer.Serialize(writer, value.Versions);
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Converters/ParserConstants.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/ParserConstants.cs
@@ -75,5 +75,6 @@ namespace NuGet.Protocol
         public const string Vulnerabilities = "vulnerabilities";
         public const string AdvisoryUrl = "advisoryUrl";
         public const string Severity = "severity";
+        public const string Url = "url";
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageVulnerabilityInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageVulnerabilityInfo.cs
@@ -14,21 +14,15 @@ namespace NuGet.Protocol.Model
     public sealed class PackageVulnerabilityInfo : IEquatable<PackageVulnerabilityInfo>
     {
         /// <summary>A URL to a CVE or another web page where more information about the vulnerability can be found.</summary>
-        [JsonProperty(PropertyName = "url")]
+        [JsonProperty(PropertyName = JsonProperties.Url)]
         public Uri Url { get; }
 
         /// <summary>The severity of the vulnerability</summary>
-        /// <value>
-        /// 0 - low<br/>
-        /// 1 - moderate<br/>
-        /// 2 - high<br/>
-        /// 3 - critical<br/>
-        /// </value>
-        [JsonProperty(PropertyName = "severity")]
-        public int Severity { get; }
+        [JsonProperty(PropertyName = JsonProperties.Severity)]
+        public PackageVulnerabilitySeverity Severity { get; }
 
         /// <summary>Which package versions are affected by this vulnerability.</summary>
-        [JsonProperty(PropertyName = "versions")]
+        [JsonProperty(PropertyName = JsonProperties.Versions)]
         public VersionRange Versions { get; }
 
         /// <summary>Creates an instance of the class</summary>
@@ -37,7 +31,7 @@ namespace NuGet.Protocol.Model
         /// <param name="versions">The value for <see cref="Versions"/></param>
         /// <exception cref="ArgumentNullException"></exception>
         [JsonConstructor]
-        public PackageVulnerabilityInfo(Uri url, int severity, VersionRange versions)
+        public PackageVulnerabilityInfo(Uri url, PackageVulnerabilitySeverity severity, VersionRange versions)
         {
             Url = url ?? throw new ArgumentNullException(paramName: nameof(url));
             Severity = severity;
@@ -67,7 +61,7 @@ namespace NuGet.Protocol.Model
         {
             var hashCode = new HashCodeCombiner();
             hashCode.AddObject(Url.OriginalString);
-            hashCode.AddStruct(Severity);
+            hashCode.AddObject((int)Severity);
             hashCode.AddObject(Versions);
             return hashCode.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageVulnerabilitySeverity.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageVulnerabilitySeverity.cs
@@ -8,6 +8,8 @@ namespace NuGet.Protocol
         Low = 0,
         Moderate = 1,
         High = 2,
-        Critical = 3
+        Critical = 3,
+
+        Unknown = -1
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageVulnerabilitySeverity.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageVulnerabilitySeverity.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Protocol
+{
+    public enum PackageVulnerabilitySeverity
+    {
+        Low = 0,
+        Moderate = 1,
+        High = 2,
+        Critical = 3
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -9,6 +9,11 @@ NuGet.Protocol.Model.PackageVulnerabilityInfo.Url.get -> System.Uri!
 NuGet.Protocol.Model.PackageVulnerabilityInfo.Versions.get -> NuGet.Versioning.VersionRange!
 NuGet.Protocol.Model.V3VulnerabilityIndexEntry.Updated.get -> string!
 NuGet.Protocol.Model.V3VulnerabilityIndexEntry.V3VulnerabilityIndexEntry(string! name, System.Uri! url, string! updated, string? comment) -> void
+NuGet.Protocol.PackageVulnerabilitySeverity
+NuGet.Protocol.PackageVulnerabilitySeverity.Critical = 3 -> NuGet.Protocol.PackageVulnerabilitySeverity
+NuGet.Protocol.PackageVulnerabilitySeverity.High = 2 -> NuGet.Protocol.PackageVulnerabilitySeverity
+NuGet.Protocol.PackageVulnerabilitySeverity.Low = 0 -> NuGet.Protocol.PackageVulnerabilitySeverity
+NuGet.Protocol.PackageVulnerabilitySeverity.Moderate = 1 -> NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.Resources.VulnerabilityInfoResourceV3.GetVulnerabilityDataAsync(NuGet.Protocol.Model.V3VulnerabilityIndexEntry! vulnerabilityPage, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Model.PackageVulnerabilityInfo!>!>!>!
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.Equals(object? obj) -> bool
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.GetHashCode() -> int

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -3,8 +3,8 @@ NuGet.Protocol.Model.GetVulnerabilityInfoResult.GetVulnerabilityInfoResult(Syste
 NuGet.Protocol.Model.GetVulnerabilityInfoResult.KnownVulnerabilities.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Model.PackageVulnerabilityInfo!>!>!>?
 NuGet.Protocol.Model.PackageVulnerabilityInfo
 NuGet.Protocol.Model.PackageVulnerabilityInfo.Equals(NuGet.Protocol.Model.PackageVulnerabilityInfo? other) -> bool
-NuGet.Protocol.Model.PackageVulnerabilityInfo.PackageVulnerabilityInfo(System.Uri! url, int severity, NuGet.Versioning.VersionRange! versions) -> void
-NuGet.Protocol.Model.PackageVulnerabilityInfo.Severity.get -> int
+NuGet.Protocol.Model.PackageVulnerabilityInfo.PackageVulnerabilityInfo(System.Uri! url, NuGet.Protocol.PackageVulnerabilitySeverity severity, NuGet.Versioning.VersionRange! versions) -> void
+NuGet.Protocol.Model.PackageVulnerabilityInfo.Severity.get -> NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.Model.PackageVulnerabilityInfo.Url.get -> System.Uri!
 NuGet.Protocol.Model.PackageVulnerabilityInfo.Versions.get -> NuGet.Versioning.VersionRange!
 NuGet.Protocol.Model.V3VulnerabilityIndexEntry.Updated.get -> string!
@@ -14,9 +14,11 @@ NuGet.Protocol.PackageVulnerabilitySeverity.Critical = 3 -> NuGet.Protocol.Packa
 NuGet.Protocol.PackageVulnerabilitySeverity.High = 2 -> NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.PackageVulnerabilitySeverity.Low = 0 -> NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.PackageVulnerabilitySeverity.Moderate = 1 -> NuGet.Protocol.PackageVulnerabilitySeverity
+NuGet.Protocol.PackageVulnerabilitySeverity.Unknown = -1 -> NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.Resources.VulnerabilityInfoResourceV3.GetVulnerabilityDataAsync(NuGet.Protocol.Model.V3VulnerabilityIndexEntry! vulnerabilityPage, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Model.PackageVulnerabilityInfo!>!>!>!
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.Equals(object? obj) -> bool
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.GetHashCode() -> int
+~const NuGet.Protocol.JsonProperties.Url = "url" -> string
 ~static readonly NuGet.Protocol.ServiceTypes.Version300rc -> string
 ~static readonly NuGet.Protocol.ServiceTypes.Version360 -> string
 NuGet.Protocol.IVulnerabilityInfoResource

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -9,6 +9,11 @@ NuGet.Protocol.Model.PackageVulnerabilityInfo.Url.get -> System.Uri!
 NuGet.Protocol.Model.PackageVulnerabilityInfo.Versions.get -> NuGet.Versioning.VersionRange!
 NuGet.Protocol.Model.V3VulnerabilityIndexEntry.Updated.get -> string!
 NuGet.Protocol.Model.V3VulnerabilityIndexEntry.V3VulnerabilityIndexEntry(string! name, System.Uri! url, string! updated, string? comment) -> void
+NuGet.Protocol.PackageVulnerabilitySeverity
+NuGet.Protocol.PackageVulnerabilitySeverity.Critical = 3 -> NuGet.Protocol.PackageVulnerabilitySeverity
+NuGet.Protocol.PackageVulnerabilitySeverity.High = 2 -> NuGet.Protocol.PackageVulnerabilitySeverity
+NuGet.Protocol.PackageVulnerabilitySeverity.Low = 0 -> NuGet.Protocol.PackageVulnerabilitySeverity
+NuGet.Protocol.PackageVulnerabilitySeverity.Moderate = 1 -> NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.Resources.VulnerabilityInfoResourceV3.GetVulnerabilityDataAsync(NuGet.Protocol.Model.V3VulnerabilityIndexEntry! vulnerabilityPage, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Model.PackageVulnerabilityInfo!>!>!>!
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.Equals(object? obj) -> bool
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.GetHashCode() -> int

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -3,8 +3,8 @@ NuGet.Protocol.Model.GetVulnerabilityInfoResult.GetVulnerabilityInfoResult(Syste
 NuGet.Protocol.Model.GetVulnerabilityInfoResult.KnownVulnerabilities.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Model.PackageVulnerabilityInfo!>!>!>?
 NuGet.Protocol.Model.PackageVulnerabilityInfo
 NuGet.Protocol.Model.PackageVulnerabilityInfo.Equals(NuGet.Protocol.Model.PackageVulnerabilityInfo? other) -> bool
-NuGet.Protocol.Model.PackageVulnerabilityInfo.PackageVulnerabilityInfo(System.Uri! url, int severity, NuGet.Versioning.VersionRange! versions) -> void
-NuGet.Protocol.Model.PackageVulnerabilityInfo.Severity.get -> int
+NuGet.Protocol.Model.PackageVulnerabilityInfo.PackageVulnerabilityInfo(System.Uri! url, NuGet.Protocol.PackageVulnerabilitySeverity severity, NuGet.Versioning.VersionRange! versions) -> void
+NuGet.Protocol.Model.PackageVulnerabilityInfo.Severity.get -> NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.Model.PackageVulnerabilityInfo.Url.get -> System.Uri!
 NuGet.Protocol.Model.PackageVulnerabilityInfo.Versions.get -> NuGet.Versioning.VersionRange!
 NuGet.Protocol.Model.V3VulnerabilityIndexEntry.Updated.get -> string!
@@ -14,9 +14,11 @@ NuGet.Protocol.PackageVulnerabilitySeverity.Critical = 3 -> NuGet.Protocol.Packa
 NuGet.Protocol.PackageVulnerabilitySeverity.High = 2 -> NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.PackageVulnerabilitySeverity.Low = 0 -> NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.PackageVulnerabilitySeverity.Moderate = 1 -> NuGet.Protocol.PackageVulnerabilitySeverity
+NuGet.Protocol.PackageVulnerabilitySeverity.Unknown = -1 -> NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.Resources.VulnerabilityInfoResourceV3.GetVulnerabilityDataAsync(NuGet.Protocol.Model.V3VulnerabilityIndexEntry! vulnerabilityPage, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Model.PackageVulnerabilityInfo!>!>!>!
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.Equals(object? obj) -> bool
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.GetHashCode() -> int
+~const NuGet.Protocol.JsonProperties.Url = "url" -> string
 ~static readonly NuGet.Protocol.ServiceTypes.Version300rc -> string
 ~static readonly NuGet.Protocol.ServiceTypes.Version360 -> string
 NuGet.Protocol.IVulnerabilityInfoResource

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -9,6 +9,11 @@ NuGet.Protocol.Model.PackageVulnerabilityInfo.Url.get -> System.Uri!
 NuGet.Protocol.Model.PackageVulnerabilityInfo.Versions.get -> NuGet.Versioning.VersionRange!
 NuGet.Protocol.Model.V3VulnerabilityIndexEntry.Updated.get -> string!
 NuGet.Protocol.Model.V3VulnerabilityIndexEntry.V3VulnerabilityIndexEntry(string! name, System.Uri! url, string! updated, string? comment) -> void
+NuGet.Protocol.PackageVulnerabilitySeverity
+NuGet.Protocol.PackageVulnerabilitySeverity.Critical = 3 -> NuGet.Protocol.PackageVulnerabilitySeverity
+NuGet.Protocol.PackageVulnerabilitySeverity.High = 2 -> NuGet.Protocol.PackageVulnerabilitySeverity
+NuGet.Protocol.PackageVulnerabilitySeverity.Low = 0 -> NuGet.Protocol.PackageVulnerabilitySeverity
+NuGet.Protocol.PackageVulnerabilitySeverity.Moderate = 1 -> NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.Resources.VulnerabilityInfoResourceV3.GetVulnerabilityDataAsync(NuGet.Protocol.Model.V3VulnerabilityIndexEntry! vulnerabilityPage, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Model.PackageVulnerabilityInfo!>!>!>!
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.Equals(object? obj) -> bool
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.GetHashCode() -> int

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -3,8 +3,8 @@ NuGet.Protocol.Model.GetVulnerabilityInfoResult.GetVulnerabilityInfoResult(Syste
 NuGet.Protocol.Model.GetVulnerabilityInfoResult.KnownVulnerabilities.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Model.PackageVulnerabilityInfo!>!>!>?
 NuGet.Protocol.Model.PackageVulnerabilityInfo
 NuGet.Protocol.Model.PackageVulnerabilityInfo.Equals(NuGet.Protocol.Model.PackageVulnerabilityInfo? other) -> bool
-NuGet.Protocol.Model.PackageVulnerabilityInfo.PackageVulnerabilityInfo(System.Uri! url, int severity, NuGet.Versioning.VersionRange! versions) -> void
-NuGet.Protocol.Model.PackageVulnerabilityInfo.Severity.get -> int
+NuGet.Protocol.Model.PackageVulnerabilityInfo.PackageVulnerabilityInfo(System.Uri! url, NuGet.Protocol.PackageVulnerabilitySeverity severity, NuGet.Versioning.VersionRange! versions) -> void
+NuGet.Protocol.Model.PackageVulnerabilityInfo.Severity.get -> NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.Model.PackageVulnerabilityInfo.Url.get -> System.Uri!
 NuGet.Protocol.Model.PackageVulnerabilityInfo.Versions.get -> NuGet.Versioning.VersionRange!
 NuGet.Protocol.Model.V3VulnerabilityIndexEntry.Updated.get -> string!
@@ -14,9 +14,11 @@ NuGet.Protocol.PackageVulnerabilitySeverity.Critical = 3 -> NuGet.Protocol.Packa
 NuGet.Protocol.PackageVulnerabilitySeverity.High = 2 -> NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.PackageVulnerabilitySeverity.Low = 0 -> NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.PackageVulnerabilitySeverity.Moderate = 1 -> NuGet.Protocol.PackageVulnerabilitySeverity
+NuGet.Protocol.PackageVulnerabilitySeverity.Unknown = -1 -> NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.Resources.VulnerabilityInfoResourceV3.GetVulnerabilityDataAsync(NuGet.Protocol.Model.V3VulnerabilityIndexEntry! vulnerabilityPage, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Model.PackageVulnerabilityInfo!>!>!>!
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.Equals(object? obj) -> bool
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.GetHashCode() -> int
+~const NuGet.Protocol.JsonProperties.Url = "url" -> string
 ~static readonly NuGet.Protocol.ServiceTypes.Version300rc -> string
 ~static readonly NuGet.Protocol.ServiceTypes.Version360 -> string
 NuGet.Protocol.IVulnerabilityInfoResource

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/PackageVulnerabilityInfoConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/PackageVulnerabilityInfoConverterTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using FluentAssertions;
+using NuGet.Protocol.Model;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Protocol.Tests.Converters
+{
+    public class PackageVulnerabilityInfoConverterTests
+    {
+        [Fact]
+        public void Deserialize_NormalJson_ReturnsValidObject()
+        {
+            string json = @"{
+    ""url"": ""https://cve.test/1"",
+    ""severity"": 2,
+    ""versions"": ""(, 2.0.0)""
+}";
+            var result = json.FromJson<PackageVulnerabilityInfo>();
+
+            result.Should().NotBeNull();
+            result.Url.OriginalString.Should().Be("https://cve.test/1");
+            result.Severity.Should().Be(PackageVulnerabilitySeverity.High);
+            result.Versions.Should().Be(new VersionRange(maxVersion: new NuGetVersion(2, 0, 0), includeMaxVersion: false));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(-1)]
+        [InlineData(-2)]
+        [InlineData(4)]
+        public void Deserialize_JsonWithInvalidSeverity_ReturnsUnknownSeverity(int? severity)
+        {
+            string json = severity.HasValue
+                ? $@"{{""url"":""https://cve.test/1"", ""versions"": ""(, 2.0.0)"", ""severity"": {severity.Value}}}"
+                : @"{""url"":""https://cve.test/1"", ""versions"": ""(, 2.0.0)""}";
+
+            var result = json.FromJson<PackageVulnerabilityInfo>();
+
+            result.Should().NotBeNull();
+            result.Severity.Should().Be(PackageVulnerabilitySeverity.Unknown);
+        }
+
+        [Fact]
+        public void Serialize_NormalObject_ReturnsJson()
+        {
+            var vulnerabilityInfo = new PackageVulnerabilityInfo(
+                new System.Uri("https://cve.test/1"),
+                PackageVulnerabilitySeverity.High,
+                new VersionRange(maxVersion: new NuGetVersion(2, 0, 0), includeMaxVersion: false));
+
+            string json = vulnerabilityInfo.ToJson();
+
+            const string expected = @"{""url"":""https://cve.test/1"",""severity"":2,""versions"":""(, 2.0.0)""}";
+            Assert.Equal(expected, json);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Model/VulnerabilityInfoTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Model/VulnerabilityInfoTests.cs
@@ -19,8 +19,8 @@ namespace NuGet.Protocol.Tests.Model
             // Arrange
             Uri cveUrl = new("https://contoso.test/cve/1");
             VersionRange versionRange = new(minVersion: new NuGetVersion(1, 0, 0), includeMinVersion: true, maxVersion: new NuGetVersion(2, 0, 0), includeMaxVersion: false);
-            PackageVulnerabilityInfo v1 = new(cveUrl, 1, versionRange);
-            PackageVulnerabilityInfo v2 = new(cveUrl, 1, versionRange);
+            PackageVulnerabilityInfo v1 = new(cveUrl, PackageVulnerabilitySeverity.Moderate, versionRange);
+            PackageVulnerabilityInfo v2 = new(cveUrl, PackageVulnerabilitySeverity.Moderate, versionRange);
 
             // Act & Assert
             v1.Equals(v2).Should().BeTrue();
@@ -35,8 +35,8 @@ namespace NuGet.Protocol.Tests.Model
             Uri cveUrl1 = new("https://contoso.test/cve/1");
             Uri cveUrl2 = new("https://contoso.test/CVE/1");
             VersionRange versionRange = new(minVersion: new NuGetVersion(1, 0, 0), includeMinVersion: true, maxVersion: new NuGetVersion(2, 0, 0), includeMaxVersion: false);
-            PackageVulnerabilityInfo v1 = new(cveUrl1, 1, versionRange);
-            PackageVulnerabilityInfo v2 = new(cveUrl2, 1, versionRange);
+            PackageVulnerabilityInfo v1 = new(cveUrl1, PackageVulnerabilitySeverity.Moderate, versionRange);
+            PackageVulnerabilityInfo v2 = new(cveUrl2, PackageVulnerabilitySeverity.Moderate, versionRange);
 
             // Act & Assert
             v1.Equals(v2).Should().BeFalse();
@@ -50,8 +50,8 @@ namespace NuGet.Protocol.Tests.Model
             // Arrange
             Uri cveUrl = new("https://contoso.test/cve/1");
             VersionRange versionRange = new(minVersion: new NuGetVersion(1, 0, 0), includeMinVersion: true, maxVersion: new NuGetVersion(2, 0, 0), includeMaxVersion: false);
-            PackageVulnerabilityInfo v1 = new(cveUrl, 1, versionRange);
-            PackageVulnerabilityInfo v2 = new(cveUrl, 2, versionRange);
+            PackageVulnerabilityInfo v1 = new(cveUrl, PackageVulnerabilitySeverity.Moderate, versionRange);
+            PackageVulnerabilityInfo v2 = new(cveUrl, PackageVulnerabilitySeverity.High, versionRange);
 
             // Act & Assert
             v1.Equals(v2).Should().BeFalse();
@@ -66,8 +66,8 @@ namespace NuGet.Protocol.Tests.Model
             Uri cveUrl = new("https://contoso.test/cve/1");
             VersionRange versionRange1 = new(minVersion: new NuGetVersion(1, 0, 0), includeMinVersion: true, maxVersion: new NuGetVersion(2, 0, 0), includeMaxVersion: false);
             VersionRange versionRange2 = new(minVersion: new NuGetVersion(1, 0, 1), includeMinVersion: true, maxVersion: new NuGetVersion(2, 0, 0), includeMaxVersion: false);
-            PackageVulnerabilityInfo v1 = new(cveUrl, 1, versionRange1);
-            PackageVulnerabilityInfo v2 = new(cveUrl, 1, versionRange2);
+            PackageVulnerabilityInfo v1 = new(cveUrl, PackageVulnerabilitySeverity.Moderate, versionRange1);
+            PackageVulnerabilityInfo v2 = new(cveUrl, PackageVulnerabilitySeverity.Moderate, versionRange2);
 
             // Act & Assert
             v1.Equals(v2).Should().BeFalse();

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/VulnerabilityInfoResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/VulnerabilityInfoResourceV3Tests.cs
@@ -134,7 +134,7 @@ namespace NuGet.Protocol.Tests.Resources
             packageVulnerability.Should().NotBeNull();
             packageVulnerability.Count.Should().Be(1);
             packageVulnerability[0].Url.OriginalString.Should().Be(cveUrl);
-            packageVulnerability[0].Severity.Should().Be(1);
+            packageVulnerability[0].Severity.Should().Be(PackageVulnerabilitySeverity.Moderate);
             packageVulnerability[0].Versions.OriginalString.Should().Be(rangeString);
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12781

Regression? no, new feature

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Address feedback on release-6.7.x cherry-pick PR: https://github.com/NuGet/NuGet.Client/pull/5315

Add enum with expected package vulnerability severity levels, mapping them to the specific int values documented in the protocol: https://learn.microsoft.com/en-us/nuget/api/vulnerability-info#vulnerability-page

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: existing tests cover the changed code
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
