### PR TITLE
Fix case sensitivity of runtime dependency sets during merge

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimeDescription.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimeDescription.cs
@@ -104,7 +104,7 @@ namespace NuGet.RuntimeModel
             }
 
             // Merge dependency sets
-            var newSets = new Dictionary<string, RuntimeDependencySet>();
+            var newSets = new Dictionary<string, RuntimeDependencySet>(StringComparer.OrdinalIgnoreCase);
             foreach (var dependencySet in left.RuntimeDependencySets.Values)
             {
                 newSets[dependencySet.Id] = dependencySet;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/RuntimeModelTests/RuntimeDescriptionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/RuntimeModelTests/RuntimeDescriptionTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Linq;
+using Xunit;
+
+namespace NuGet.RuntimeModel;
+
+public sealed class RuntimeDescriptionTests
+{
+    [Fact]
+    public void Merge_DifferentIdsThrows()
+    {
+        RuntimeDescription l = new(runtimeIdentifier: "rid-left");
+        RuntimeDescription r = new(runtimeIdentifier: "rid-right");
+
+        Assert.Throws<InvalidOperationException>(() => RuntimeDescription.Merge(l, r));
+    }
+
+    [Fact]
+    public void Merge_PreservedRuntimeIdentifier()
+    {
+        RuntimeDescription l = new(runtimeIdentifier: "rid");
+        RuntimeDescription r = new(runtimeIdentifier: "rid");
+
+        var merged = RuntimeDescription.Merge(l, r);
+
+        Assert.Equal("rid", merged.RuntimeIdentifier);
+    }
+
+    [Fact]
+    public void Merge_PrefersRightImports()
+    {
+        RuntimeDescription l = new(runtimeIdentifier: "rid", new[] { "InheritedA" }, Array.Empty<RuntimeDependencySet>());
+        RuntimeDescription r = new(runtimeIdentifier: "rid", new[] { "InheritedB" }, Array.Empty<RuntimeDependencySet>());
+
+        var merged = RuntimeDescription.Merge(l, r);
+
+        Assert.Equal(new[] { "InheritedA" }, merged.InheritedRuntimes);
+    }
+
+    [Fact]
+    public void Merge_UsesLeftImportsIfRightEmpty()
+    {
+        RuntimeDescription l = new(runtimeIdentifier: "rid", Array.Empty<string>(),  Array.Empty<RuntimeDependencySet>());
+        RuntimeDescription r = new(runtimeIdentifier: "rid", new[] { "InheritedB" }, Array.Empty<RuntimeDependencySet>());
+
+        var merged = RuntimeDescription.Merge(l, r);
+
+        Assert.Equal(new[] { "InheritedB" }, merged.InheritedRuntimes);
+    }
+
+    [Fact]
+    public void Merge_EmptyImportsWhenNoneProvided()
+    {
+        RuntimeDescription l = new(runtimeIdentifier: "rid", Array.Empty<string>(), Array.Empty<RuntimeDependencySet>());
+        RuntimeDescription r = new(runtimeIdentifier: "rid", Array.Empty<string>(), Array.Empty<RuntimeDependencySet>());
+
+        var merged = RuntimeDescription.Merge(l, r);
+
+        Assert.Empty(merged.InheritedRuntimes);
+    }
+
+    [Fact]
+    public void Merge_CombinedDependencySets()
+    {
+        RuntimeDescription l = new(runtimeIdentifier: "rid", Array.Empty<string>(), new[] { new RuntimeDependencySet("SetA") });
+        RuntimeDescription r = new(runtimeIdentifier: "rid", Array.Empty<string>(), new[] { new RuntimeDependencySet("SetB") });
+
+        var merged = RuntimeDescription.Merge(l, r);
+
+        Assert.Collection(
+            merged.RuntimeDependencySets,
+            o => Assert.Same(l.RuntimeDependencySets.Single().Value, o.Value),
+            o => Assert.Same(r.RuntimeDependencySets.Single().Value, o.Value));
+    }
+
+    [Fact]
+    public void Merge_CombinedDependencySets_IdentifiersDifferByCase()
+    {
+        RuntimeDescription l = new(runtimeIdentifier: "rid", Array.Empty<string>(), new[] { new RuntimeDependencySet("SetA") });
+        RuntimeDescription r = new(runtimeIdentifier: "rid", Array.Empty<string>(), new[] { new RuntimeDependencySet("SETA") });
+
+        var merged = RuntimeDescription.Merge(l, r);
+
+        Assert.Collection(
+            merged.RuntimeDependencySets,
+            o => Assert.Same(r.RuntimeDependencySets.Single().Value, o.Value));
+    }
+}


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/12757

Regression? Last working version: Regressed in #5248

## Description

PR #5248 reworked how construction of `RuntimeDescription` instances happens, partly to reduce the number of redundant collection copies that occurred.

As an example of that innefficiency, the prior `RuntimeDesciption.Merge` method would build a dictionary of merged `RuntimeDependencySet` instances, then call a `RuntimeDescription` constructor that would copy those into a new dictionary. The PR added a new private constructor that allowed the copy to be avoided.

That change introduced a bug however. It turns out that during the redundant copy a case-insensitive key comparer was specified, while the `Merge` method's dictionary was case-sensitive. So if two different `RuntimeDependencySet` identifiers differed only by case, then the collection created internally within the `Merge` method would contain both instances, then the constructor call would merge them during the subsequent `ToDictionary` call.

The fix is to ensure that the `Merge` method uses the correct `StringComparer` for `RuntimeDependencySet` identifiers, to preserve the prior behaviour.

Several unit tests have been added to validate the behaviour of `RuntimeDescription.Merge`.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
