### PR TITLE
Fix incorrect package version property for System.Security.Cryptograp…

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
-    <CryptographyPackagesVersion Condition="'$(CryptographyPackagesVersion)' == ''">6.0.4</CryptographyPackagesVersion>
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)' == ''">3.3.4</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <NewtonsoftJsonPackageVersion Condition="'$(NewtonsoftJsonPackageVersion)' == ''">13.0.1</NewtonsoftJsonPackageVersion>
     <SystemPackagesVersion Condition="'$(SystemPackagesVersion)' == ''">4.3.0</SystemPackagesVersion>
@@ -24,6 +23,7 @@
     <MicrosoftExtensionsFileSystemGlobbingPackageVersion Condition="'$(MicrosoftExtensionsFileSystemGlobbingPackageVersion)' == ''">6.0.0</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
     <MicrosoftWebXdtPackageVersion Condition="'$(MicrosoftWebXdtPackageVersion)' == ''">3.0.0</MicrosoftWebXdtPackageVersion>
     <SystemComponentModelCompositionPackageVersion Condition="'$(SystemComponentModelCompositionPackageVersion)' == ''">4.5.0</SystemComponentModelCompositionPackageVersion>
+    <SystemSecurityCryptographyPkcsVersion Condition="'$(SystemSecurityCryptographyPkcsVersion)' == ''">6.0.4</SystemSecurityCryptographyPkcsVersion>
     <!-- System.Security.Cryptography.Xml is a dependency of Microsoft.Build.Tasks.Core. This property can be probably removed when MSBuild is updated to a newer version. -->
     <SystemSecurityCryptographyXmlVersion Condition="'$(SystemSecurityCryptographyXmlVersion)' == ''">6.0.1</SystemSecurityCryptographyXmlVersion>
     <SystemSecurityCryptographyXmlVersion Condition="'$(MicrosoftBuildVersion)' == '16.8.0' Or '$(MicrosoftBuildVersion)' == '16.11.0'">4.7.1</SystemSecurityCryptographyXmlVersion>
@@ -95,7 +95,7 @@
     <PackageVersion Include="System.Resources.ResourceManager" Version="$(SystemPackagesVersion)" />
     <PackageVersion Include="System.Runtime.Extensions" Version="$(SystemPackagesVersion)" />
     <PackageVersion Include="System.Runtime.InteropServices" Version="$(SystemPackagesVersion)" />
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="$(CryptographyPackagesVersion)" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
     <PackageVersion Include="System.Text.Encoding.Extensions" Version="$(SystemPackagesVersion)" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -34,6 +34,10 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>30ab651fcb4354552bd4891619a0bdd81e0ebdbf</Sha>
     </Dependency>
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="6.0.4">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>e37fab9fc9f7bce120a7165491ed392a73f8ab51</Sha>
+    </Dependency>
     <Dependency Name="System.Security.Cryptography.Xml" Version="6.0.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>55fb7ef977e7d120dc12f0960edcff0739d7ee0e</Sha>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/12767

Regression? No

## Description

Package version property for `System.Security.Cryptography.Pkcs` does not follow .NET naming schema
https://github.com/NuGet/NuGet.Client/blob/0a6eb8ffcc20f9e7a801044ea1550b72e3309d47/Directory.Packages.props#L98

Instead of `CryptographyPackagesVersion` it should be `SystemSecurityCryptographyPkcsVersion`

Additionally, this new package should be added as a dependency in https://github.com/NuGet/NuGet.Client/blob/dev/eng/Version.Details.xml, to allow .NET product source-build to override property version and use live package, just built from source.