### PR TITLE
CheckBox styling has accessible contrast ratio for selected Package/Project List Items

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
@@ -186,7 +186,8 @@
     <Setter Property="FocusVisualStyle" Value="{StaticResource ControlsFocusVisualStyle}" />
   </Style>
 
-  <Style x:Key="{x:Type CheckBox}" TargetType="{x:Type CheckBox}" BasedOn="{StaticResource {x:Type CheckBox}}">
+  <Style x:Key="{x:Type CheckBox}" TargetType="{x:Type CheckBox}" BasedOn="{StaticResource {x:Static vs:VsResourceKeys.CheckBoxStyleKey}}" />
+  <Style x:Key="CheckBoxSelectorAware" TargetType="{x:Type CheckBox}" BasedOn="{StaticResource {x:Type CheckBox}}">
     <Setter Property="FocusVisualStyle" Value="{DynamicResource ControlsFocusVisualStyle}"/>
     <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}"/>
     <Setter Property="Template">
@@ -201,8 +202,18 @@
               <Border
                 x:Name="CheckMarkBorder"
                 Background="{DynamicResource {x:Static nuget:Brushes.CheckBoxBackgroundBrushKey}}"
-                BorderBrush="{DynamicResource {x:Static nuget:Brushes.CheckBoxBorderBrushKey}}"
-                BorderThickness="1"/>
+                BorderThickness="1">
+                <Border.Style>
+                  <Style TargetType="{x:Type Border}">
+                    <Setter Property="BorderBrush" Value="{DynamicResource {x:Static nuget:Brushes.CheckBoxBorderBrushKey}}" />
+                    <Style.Triggers>
+                      <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ListBoxItem}}" Value="True">
+                        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}" />
+                      </DataTrigger>
+                    </Style.Triggers>
+                  </Style>
+                </Border.Style>
+              </Border>
               <Path
                 x:Name="CheckMark"
                 Data="M 6.22,11.02 C6.22,11.02 2.50,7.24 2.50,7.24 2.50,7.24 4.05,5.71 4.05,5.71 4.05,5.71 5.97,7.65 5.97,7.65 5.97,7.65 10.52,1.38 10.52,1.38 10.52,1.38 13.19,1.38 13.19,1.38 13.19,1.38 6.22,11.02 6.22,11.02 6.22,11.02 6.22,11.02 6.22,11.02 z"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -84,6 +84,7 @@
       <!-- check box -->
       <CheckBox
                     Grid.Column="0"
+                    Style="{StaticResource CheckBoxSelectorAware}"
                     Margin="4,12,4,0"
                     VerticalAlignment="top"
                     Visibility="{Binding CheckBoxesEnabled, RelativeSource={RelativeSource AncestorType={x:Type nuget:InfiniteScrollList}}, Converter={StaticResource BooleanToHiddenVisibilityConverter}}"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
@@ -266,6 +266,7 @@
             <GridViewColumn.CellTemplate>
               <DataTemplate>
                 <CheckBox
+                  Style="{StaticResource CheckBoxSelectorAware}"
                   IsTabStop="False"
                   AutomationProperties.AutomationId="{Binding ProjectName, Mode=OneWay, StringFormat='ProjectCheckBox_{0}'}"
                   IsChecked="{Binding IsSelected}"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2367

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

**Customer reported bug**: It's difficult to see the checkbox for selected packages in our packages list in the Dark Theme.
https://developercommunity.visualstudio.com/t/Low-contrast-on-checkbox-for-nuget-updat/10393323

- I found the Projects list in the Solution PM UI has the same checkbox bug.

**Root cause**: a theming change which changed our list item color. I've filed the UX bug: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1853865
Once fixed, we should be able to remove all custom CheckBox styling for PM UI.

**Workaround**: UX team advised me to use the same color as the text/foreground for the CheckBox border. I've found this to look better in all themes!

**Summary of changes**:
- For  `CheckBox` that is nested within a `ListItem`, when the `ListItem` is selected, set the `CheckBox` border to match the text color.
- For every other `CheckBox`, use the VS CommonControls `CheckBox` styling instead of our own
  - This gives us indeterminate state (see below) for free.

_The screenshots are before/after on the left/right, respectively._

### "Select all" checkboxes now have Indeterminate state

"Select All" checkbox now indicates an indeterminate state when some, but not all, items are selected.
  - For Updates tab, this applies to the packages list.
  - For Solution View PM UI, this applies to the list of Projects in the details pane.

I believe this is a usability enhancement, because before, it could be hard to see in a long list of packages/projects whether some or all were all selected or not.
We get this behavior change due to now using the VS CommonControls styling.

![image](https://github.com/NuGet/NuGet.Client/assets/49205731/5543d82c-b8ce-49cf-861d-62a8802ed0ed)

### Solution View in Details Pane 
- Indeterminate state in Header (select all projects checkbox)
- Easier to see selected project row's CheckBox
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/3709c306-bb23-423b-bc98-784abb446d65)

### Package List CheckBox is easier to see while item is selected
_Dark theme (original bug report):_
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/31a2c414-db22-48b9-af94-2e62ecb8d554)

_Light theme:_
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/bf85fe5c-8eeb-43c0-b42f-30d00ae3abb6)

_Blue theme:_
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/63b9e736-62d6-4b36-92ed-e86d3721e5d9)

_High Contrast theme:_
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/0df4cecb-25d7-49ae-b37a-7ac7b9dbbfa7)


### Unselected package (no change)
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/899b32b2-45bd-4892-8244-1923e4304148)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - screenshots added for all themes
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
