### PR TITLE
Use singleton NuGetFrameworkSorter instance

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Utils/InstalledPackageEnumerator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Utils/InstalledPackageEnumerator.cs
@@ -241,7 +241,7 @@ namespace NuGetConsole.Host.PowerShell
                 // Process each framework/id/version once to avoid duplicate work
                 // Packages may have different dependency orders depending on the framework, but there is 
                 // no way to fully solve this across an entire solution so we make a best effort here.
-                foreach ((var framework, var packageIdentities) in packagesConfigInstalled.OrderByDescending(fw => fw.Key, new NuGetFrameworkSorter()))
+                foreach ((var framework, var packageIdentities) in packagesConfigInstalled.OrderByDescending(fw => fw.Key, NuGetFrameworkSorter.Instance))
                 {
                     foreach (var package in packageIdentities)
                     {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -34,7 +34,7 @@ namespace NuGet.PackageManagement.VisualStudio
     /// <typeparam name="U">Type of the collection elements for Installed and Transitive packages</typeparam>
     public abstract class PackageReferenceProject<T, U> : BuildIntegratedNuGetProject, IPackageReferenceProject where T : ICollection<U>, new()
     {
-        private static readonly NuGetFrameworkSorter FrameworkSorter = new();
+        private static readonly NuGetFrameworkSorter FrameworkSorter = NuGetFrameworkSorter.Instance;
 
         private static readonly ProjectPackages EmptyProjectPackages = new(Array.Empty<PackageReference>(), Array.Empty<TransitivePackageReference>());
 

--- a/src/NuGet.Core/NuGet.Frameworks/CompatibilityListProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/CompatibilityListProvider.cs
@@ -33,7 +33,7 @@ namespace NuGet.Frameworks
             remaining = ReduceDownwards(remaining);
 
             return remaining
-                .OrderBy(f => f, new NuGetFrameworkSorter());
+                .OrderBy(f => f, NuGetFrameworkSorter.Instance);
         }
 
         private IEnumerable<NuGetFramework> ReduceDownwards(IEnumerable<NuGetFramework> frameworks)

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
@@ -1083,7 +1083,7 @@ namespace NuGet.Frameworks
                 }
             }
 
-            _netStandardVersions.Sort(new NuGetFrameworkSorter());
+            _netStandardVersions.Sort(NuGetFrameworkSorter.Instance);
         }
 
         private void AddCompatibleCandidates()
@@ -1152,7 +1152,7 @@ namespace NuGet.Frameworks
             }
 
             _compatibleCandidates.AddRange(set);
-            _compatibleCandidates.Sort(new NuGetFrameworkSorter());
+            _compatibleCandidates.Sort(NuGetFrameworkSorter.Instance);
         }
 
         // Strong typed non-IEnumerator based HashSet functions

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkReducer.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkReducer.cs
@@ -216,7 +216,7 @@ namespace NuGet.Frameworks
                     // Sort by precedence rules, then by name in the case of a tie
                     nearest = reduced
                         .OrderBy(f => f, new FrameworkPrecedenceSorter(_mappings, false))
-                        .ThenByDescending(f => f, new NuGetFrameworkSorter())
+                        .ThenByDescending(f => f, NuGetFrameworkSorter.Instance)
                         .ThenBy(f => f.GetHashCode())
                         .First();
                 }
@@ -235,7 +235,7 @@ namespace NuGet.Frameworks
             // order first so we get consistent results for equivalent frameworks
             var input = frameworks
                 .OrderBy(f => f, new FrameworkPrecedenceSorter(_mappings, true))
-                .ThenByDescending(f => f, new NuGetFrameworkSorter())
+                .ThenByDescending(f => f, NuGetFrameworkSorter.Instance)
                 .ToArray();
 
             var duplicates = new HashSet<NuGetFramework>();

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI.Unshipped.txt
@@ -3,3 +3,4 @@ static NuGet.Frameworks.CompatibilityMappingComparer.Instance.get -> NuGet.Frame
 static NuGet.Frameworks.FrameworkRangeComparer.Instance.get -> NuGet.Frameworks.FrameworkRangeComparer!
 static NuGet.Frameworks.NuGetFrameworkFullComparer.Instance.get -> NuGet.Frameworks.NuGetFrameworkFullComparer!
 static NuGet.Frameworks.NuGetFrameworkNameComparer.Instance.get -> NuGet.Frameworks.NuGetFrameworkNameComparer!
+static NuGet.Frameworks.NuGetFrameworkSorter.Instance.get -> NuGet.Frameworks.NuGetFrameworkSorter!

--- a/src/NuGet.Core/NuGet.Frameworks/comparers/NuGetFrameworkSorter.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/comparers/NuGetFrameworkSorter.cs
@@ -13,6 +13,11 @@ namespace NuGet.Frameworks
     /// </summary>
     public class NuGetFrameworkSorter : IComparer<NuGetFramework>
     {
+#pragma warning disable CS0618 // Type or member is obsolete
+        public static NuGetFrameworkSorter Instance { get; } = new();
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        [Obsolete("Use Instance singleton instead")]
         public NuGetFrameworkSorter()
         {
         }

--- a/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
@@ -255,7 +255,7 @@ namespace NuGet.Packaging
             }
 
             // Sort items to make this deterministic for the caller
-            foreach ((var framework, var items) in groups.OrderBy(e => e.Key, new NuGetFrameworkSorter()))
+            foreach ((var framework, var items) in groups.OrderBy(e => e.Key, NuGetFrameworkSorter.Instance))
             {
                 var group = new FrameworkSpecificGroup(framework, items.OrderBy(item => item, StringComparer.OrdinalIgnoreCase));
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -378,7 +378,7 @@ namespace NuGet.Packaging
 
             frameworks.UnionWith(GetFrameworkItems().Select(g => g.TargetFramework));
 
-            return frameworks.Where(f => !f.IsUnsupported).OrderBy(f => f, new NuGetFrameworkSorter());
+            return frameworks.Where(f => !f.IsUnsupported).OrderBy(f => f, NuGetFrameworkSorter.Instance);
         }
 
         /// <summary>
@@ -444,7 +444,7 @@ namespace NuGet.Packaging
             }
 
             // Sort the groups by framework, and the items by ordinal string compare to keep things deterministic
-            foreach ((var framework, var items) in groups.OrderBy(e => e.Key, new NuGetFrameworkSorter()))
+            foreach ((var framework, var items) in groups.OrderBy(e => e.Key, NuGetFrameworkSorter.Instance))
             {
                 yield return new FrameworkSpecificGroup(framework, items.OrderBy(e => e, StringComparer.OrdinalIgnoreCase));
             }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -218,7 +218,7 @@ namespace NuGet.ProjectModel
                 writer.WriteObjectStart("frameworks");
 
                 var frameworkNames = new HashSet<string>();
-                var frameworkSorter = new NuGetFrameworkSorter();
+                var frameworkSorter = NuGetFrameworkSorter.Instance;
                 foreach (var framework in msbuildMetadata.TargetFrameworks.OrderBy(c => c.FrameworkName, frameworkSorter))
                 {
                     var frameworkName = framework.FrameworkName.GetShortFolderName();
@@ -564,7 +564,7 @@ namespace NuGet.ProjectModel
             if (frameworks.Any())
             {
                 writer.WriteObjectStart("frameworks");
-                var frameworkSorter = new NuGetFrameworkSorter();
+                var frameworkSorter = NuGetFrameworkSorter.Instance;
                 foreach (var framework in frameworks.OrderBy(c => c.FrameworkName, frameworkSorter))
                 {
                     writer.WriteObjectStart(framework.FrameworkName.GetShortFolderName());

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -525,7 +525,7 @@ namespace NuGet.Protocol.Plugins
 
             frameworks.UnionWith((await GetFrameworkItemsAsync(cancellationToken)).Select(g => g.TargetFramework));
 
-            return frameworks.Where(f => !f.IsUnsupported).OrderBy(f => f, new NuGetFrameworkSorter());
+            return frameworks.Where(f => !f.IsUnsupported).OrderBy(f => f, NuGetFrameworkSorter.Instance);
         }
 
         /// <summary>
@@ -1011,7 +1011,7 @@ namespace NuGet.Protocol.Plugins
             }
 
             // Sort the groups by framework, and the items by ordinal string compare to keep things deterministic
-            return groups.Keys.OrderBy(e => e, new NuGetFrameworkSorter())
+            return groups.Keys.OrderBy(e => e, NuGetFrameworkSorter.Instance)
                 .Select(framework => new FrameworkSpecificGroup(framework, groups[framework].OrderBy(e => e, StringComparer.OrdinalIgnoreCase)));
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -529,7 +529,7 @@ namespace Dotnet.Integration.Test
                     var dependencyGroups = nuspecReader
                         .GetDependencyGroups()
                         .OrderBy(x => x.TargetFramework,
-                            new NuGetFrameworkSorter())
+                            NuGetFrameworkSorter.Instance)
                         .ToList();
 
                     Assert.Equal(1,
@@ -613,7 +613,7 @@ namespace Dotnet.Integration.Test
                     var dependencyGroups = nuspecReader
                         .GetDependencyGroups()
                         .OrderBy(x => x.TargetFramework,
-                            new NuGetFrameworkSorter())
+                            NuGetFrameworkSorter.Instance)
                         .ToList();
 
                     Assert.Equal(1,
@@ -682,7 +682,7 @@ namespace Dotnet.Integration.Test
                     var dependencyGroups = nuspecReader
                         .GetDependencyGroups()
                         .OrderBy(x => x.TargetFramework,
-                            new NuGetFrameworkSorter())
+                            NuGetFrameworkSorter.Instance)
                         .ToList();
 
                     Assert.Equal(2,
@@ -945,7 +945,7 @@ namespace Dotnet.Integration.Test
                     var dependencyGroups = nuspecReader
                         .GetDependencyGroups()
                         .OrderBy(x => x.TargetFramework,
-                            new NuGetFrameworkSorter())
+                            NuGetFrameworkSorter.Instance)
                         .ToList();
 
                     Assert.Equal(1,
@@ -1051,7 +1051,7 @@ namespace Dotnet.Integration.Test
                     var dependencyGroups = nuspecReader
                         .GetDependencyGroups()
                         .OrderBy(x => x.TargetFramework,
-                            new NuGetFrameworkSorter())
+                            NuGetFrameworkSorter.Instance)
                         .ToList();
 
                     Assert.Equal(tfmValue.Split(';').Count(),
@@ -1133,7 +1133,7 @@ namespace Dotnet.Integration.Test
                     var dependencyGroups = nuspecReader
                         .GetDependencyGroups()
                         .OrderBy(x => x.TargetFramework,
-                            new NuGetFrameworkSorter())
+                            NuGetFrameworkSorter.Instance)
                         .ToList();
 
                     Assert.Equal(tfmValue.Split(';').Count(),
@@ -1223,7 +1223,7 @@ namespace Dotnet.Integration.Test
                     var dependencyGroups = nuspecReader
                         .GetDependencyGroups()
                         .OrderBy(x => x.TargetFramework,
-                            new NuGetFrameworkSorter())
+                            NuGetFrameworkSorter.Instance)
                         .ToList();
 
                     Assert.Equal(tfmValue.Split(';').Count(),
@@ -3343,7 +3343,7 @@ namespace ClassLibrary
                     var dependencyGroups = nuspecReader
                         .GetDependencyGroups()
                         .OrderBy(x => x.TargetFramework,
-                            new NuGetFrameworkSorter())
+                            NuGetFrameworkSorter.Instance)
                         .ToList();
 
                     Assert.Equal(1,
@@ -3931,7 +3931,7 @@ namespace ClassLibrary
                     var dependencyGroups = nuspecReader
                         .GetDependencyGroups()
                         .OrderBy(x => x.TargetFramework,
-                            new NuGetFrameworkSorter())
+                            NuGetFrameworkSorter.Instance)
                         .ToList();
 
                     Assert.Equal(1,
@@ -4002,7 +4002,7 @@ namespace ClassLibrary
                     var dependencyGroups = nuspecReader
                         .GetDependencyGroups()
                         .OrderBy(x => x.TargetFramework,
-                            new NuGetFrameworkSorter())
+                            NuGetFrameworkSorter.Instance)
                         .ToList();
 
                     Assert.Equal(expectedFrameworks.Where(t => !string.IsNullOrEmpty(t)).Count(),
@@ -5802,7 +5802,7 @@ namespace ClassLibrary
                     var dependencyGroups = nuspecReader
                         .GetDependencyGroups()
                         .OrderBy(x => x.TargetFramework,
-                            new NuGetFrameworkSorter())
+                            NuGetFrameworkSorter.Instance)
                         .ToList();
 
                     Assert.Equal(1,
@@ -5919,7 +5919,7 @@ namespace ClassLibrary
                     var dependencyGroups = nuspecReader
                         .GetDependencyGroups()
                         .OrderBy(x => x.TargetFramework,
-                            new NuGetFrameworkSorter())
+                            NuGetFrameworkSorter.Instance)
                         .ToList();
 
                     Assert.Equal(1,
@@ -6058,7 +6058,7 @@ namespace ClassLibrary
                     var dependencyGroups = nuspecReader
                         .GetDependencyGroups()
                         .OrderBy(x => x.TargetFramework,
-                            new NuGetFrameworkSorter())
+                            NuGetFrameworkSorter.Instance)
                         .ToList();
 
                     Assert.Equal(2,
@@ -6137,7 +6137,7 @@ namespace ClassLibrary
                     var dependencyGroups = nuspecReader
                         .GetDependencyGroups()
                         .OrderBy(x => x.TargetFramework,
-                            new NuGetFrameworkSorter())
+                            NuGetFrameworkSorter.Instance)
                         .ToList();
 
                     Assert.Equal(2,

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkComparerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkComparerTests.cs
@@ -48,7 +48,7 @@ namespace NuGet.Test
             // Act
             list = list
                 .OrderBy(f => f, new FrameworkPrecedenceSorter(DefaultFrameworkNameProvider.Instance, false))
-                .ThenByDescending(f => f, new NuGetFrameworkSorter())
+                .ThenByDescending(f => f, NuGetFrameworkSorter.Instance)
                 .ToList();
 
             // Assert
@@ -97,7 +97,7 @@ namespace NuGet.Test
             // Act
             list = list
                 .OrderBy(f => f, new FrameworkPrecedenceSorter(DefaultFrameworkNameProvider.Instance, false))
-                .ThenByDescending(f => f, new NuGetFrameworkSorter())
+                .ThenByDescending(f => f, NuGetFrameworkSorter.Instance)
                 .ToList();
 
             // Assert
@@ -143,7 +143,7 @@ namespace NuGet.Test
             // Act
             list = list
                 .OrderBy(f => f, new FrameworkPrecedenceSorter(DefaultFrameworkNameProvider.Instance, false))
-                .ThenByDescending(f => f, new NuGetFrameworkSorter())
+                .ThenByDescending(f => f, NuGetFrameworkSorter.Instance)
                 .ToList();
 
             // Assert
@@ -216,7 +216,7 @@ namespace NuGet.Test
             // Act
             list = list
                 .OrderBy(f => f, new FrameworkPrecedenceSorter(DefaultFrameworkNameProvider.Instance, false))
-                .ThenBy(f => f, new NuGetFrameworkSorter())
+                .ThenBy(f => f, NuGetFrameworkSorter.Instance)
                 .ToList();
 
             // Assert

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkExpanderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkExpanderTests.cs
@@ -66,7 +66,7 @@ namespace NuGet.Test
             FrameworkExpander expander = new FrameworkExpander();
             var expanded = expander
                 .Expand(framework)
-                .OrderBy(f => f, new NuGetFrameworkSorter())
+                .OrderBy(f => f, NuGetFrameworkSorter.Instance)
                 .ToArray();
 
             Assert.Equal(7, expanded.Length);
@@ -89,7 +89,7 @@ namespace NuGet.Test
             FrameworkExpander expander = new FrameworkExpander();
             var expanded = expander
                 .Expand(framework)
-                .OrderBy(f => f, new NuGetFrameworkSorter())
+                .OrderBy(f => f, NuGetFrameworkSorter.Instance)
                 .ToArray();
 
             Assert.Equal(10, expanded.Length);

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkNameProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkNameProviderTests.cs
@@ -162,7 +162,7 @@ namespace NuGet.Test
             provider.TryGetEquivalentFrameworks(input, out IEnumerable<NuGetFramework>? frameworks);
 
             var results = frameworks
-                .OrderBy(f => f, new NuGetFrameworkSorter())
+                .OrderBy(f => f, NuGetFrameworkSorter.Instance)
                 .Select(f => f.GetShortFolderName())
                 .ToArray();
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/12680

Regression? Last working version: No

## Description

Continues the approach taken in #5260.

Comparer classes tend not to have any instance state, or to come from a small pool of related comparers when they do. They also tend to be invoked in tight loops, where allocations can add up. This makes them great candidates for reuse.

This code makes all use of `NuGetFrameworkSorter` occur through a singleton instance, avoiding allocating temporary objects when comparisons are needed.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
