### PR TITLE
Remove allocations in hash code computations

### DIFF
--- a/build/Shared/HashCodeCombiner.cs
+++ b/build/Shared/HashCodeCombiner.cs
@@ -133,7 +133,7 @@ namespace NuGet.Shared
             {
                 int count = 0;
                 int hashCode = 0;
-                foreach (var item in list)
+                foreach (var item in list.NoAllocEnumerate())
                 {
                     // XOR is commutative -- the order of operations doesn't matter
                     hashCode ^= item.GetHashCode();
@@ -150,7 +150,7 @@ namespace NuGet.Shared
             {
                 int count = 0;
                 int hashCode = 0;
-                foreach (var item in list)
+                foreach (var item in list.NoAllocEnumerate())
                 {
                     // XOR is commutative -- the order of operations doesn't matter
                     hashCode ^= comparer.GetHashCode(item);

--- a/src/NuGet.Core/NuGet.Packaging/Core/FrameworkReferenceGroup.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Core/FrameworkReferenceGroup.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using NuGet.Frameworks;
 using NuGet.Shared;
 
@@ -61,17 +60,9 @@ namespace NuGet.Packaging
             var combiner = new HashCodeCombiner();
 
             combiner.AddObject(TargetFramework);
-
-            if (FrameworkReferences != null)
-            {
-                foreach (var frameworkReference in FrameworkReferences.OrderBy(e => e))
-                {
-                    combiner.AddObject(frameworkReference);
-                }
-            }
+            combiner.AddUnorderedSequence(FrameworkReferences);
 
             return combiner.CombinedHash;
         }
     }
 }
-

--- a/src/NuGet.Core/NuGet.Packaging/Core/FrameworkSpecificGroup.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Core/FrameworkSpecificGroup.cs
@@ -101,19 +101,7 @@ namespace NuGet.Packaging
             var combiner = new HashCodeCombiner();
 
             combiner.AddObject(TargetFramework);
-
-            if (Items != null)
-            {
-#if NETFRAMEWORK || NETSTANDARD
-
-                foreach (var hash in Items.Select(e => e.GetHashCode()).OrderBy(e => e))
-#else
-                foreach (var hash in Items.Select(e => e.GetHashCode(StringComparison.Ordinal)).OrderBy(e => e))
-#endif
-                {
-                    combiner.AddObject(hash);
-                }
-            }
+            combiner.AddUnorderedSequence(Items, StringComparer.Ordinal);
 
             return combiner.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.Packaging/Core/PackageDependencyGroup.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Core/PackageDependencyGroup.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Shared;
@@ -82,12 +81,7 @@ namespace NuGet.Packaging
             var combiner = new HashCodeCombiner();
 
             combiner.AddObject(TargetFramework.GetHashCode());
-
-            // order the dependencies by hash code to make this consistent
-            foreach (int hash in Packages.Select(p => p.GetHashCode()).OrderBy(h => h))
-            {
-                combiner.AddObject(hash);
-            }
+            combiner.AddUnorderedSequence(Packages);
 
             return combiner.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.Packaging/Core/comparers/PackageDependencyComparer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Core/comparers/PackageDependencyComparer.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using NuGet.Shared;
 using NuGet.Versioning;
 
@@ -82,21 +81,11 @@ namespace NuGet.Packaging.Core
             if (obj.VersionRange != null
                 && !obj.VersionRange.Equals(VersionRange.All))
             {
-                combiner.AddObject(_versionRangeComparer.GetHashCode(obj.VersionRange));
+                combiner.AddObject(obj.VersionRange, _versionRangeComparer);
             }
 
-            foreach (var include in obj.Include.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(include.ToLowerInvariant());
-            }
-
-            // separate the lists
-            combiner.AddObject(8);
-
-            foreach (var exclude in obj.Exclude.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(exclude.ToLowerInvariant());
-            }
+            combiner.AddUnorderedSequence(obj.Include, StringComparer.InvariantCultureIgnoreCase);
+            combiner.AddUnorderedSequence(obj.Exclude, StringComparer.InvariantCultureIgnoreCase);
 
             return combiner.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.Packaging/Core/comparers/PackageDependencyInfoComparer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Core/comparers/PackageDependencyInfoComparer.cs
@@ -86,13 +86,8 @@ namespace NuGet.Packaging.Core
 
             var combiner = new HashCodeCombiner();
 
-            combiner.AddObject(PackageIdentityComparer.Default.GetHashCode(obj));
-
-            // order the dependencies by hash code to make this consistent
-            foreach (int hash in obj.Dependencies.Select(e => _dependencyComparer.GetHashCode(e)).OrderBy(h => h))
-            {
-                combiner.AddObject(hash);
-            }
+            combiner.AddObject(obj, PackageIdentityComparer.Default);
+            combiner.AddUnorderedSequence(obj.Dependencies, _dependencyComparer);
 
             return combiner.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.Packaging/Core/comparers/PackageIdentityComparer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Core/comparers/PackageIdentityComparer.cs
@@ -97,7 +97,7 @@ namespace NuGet.Packaging.Core
             var combiner = new HashCodeCombiner();
 
             combiner.AddObject(obj.Id, StringComparer.OrdinalIgnoreCase);
-            combiner.AddObject(_versionComparer.GetHashCode(obj.Version));
+            combiner.AddObject(obj.Version, _versionComparer);
 
             return combiner.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/CentralTransitiveDependencyGroup.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/CentralTransitiveDependencyGroup.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Shared;
@@ -60,11 +59,7 @@ namespace NuGet.ProjectModel
         {
             var combiner = new HashCodeCombiner();
             combiner.AddStringIgnoreCase(FrameworkName);
-
-            foreach (var dependency in TransitiveDependencies.OrderBy(dep => dep.Name, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(dependency);
-            }
+            combiner.AddUnorderedSequence(TransitiveDependencies);
             return combiner.CombinedHash;
         }
     }

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFile.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFile.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Shared;
 using NuGet.Versioning;
@@ -192,62 +191,15 @@ namespace NuGet.ProjectModel
             var combiner = new HashCodeCombiner();
 
             combiner.AddObject(Version);
-
-            HashProjectFileDependencyGroups(combiner, ProjectFileDependencyGroups);
-
-            foreach (var item in Libraries.OrderBy(library => library.Name, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(item);
-            }
-
-            HashLockFileTargets(combiner, Targets);
-
-            foreach (var item in PackageFolders)
-            {
-                combiner.AddObject(item);
-            }
-
+            combiner.AddUnorderedSequence(ProjectFileDependencyGroups);
+            combiner.AddUnorderedSequence(Libraries);
+            combiner.AddUnorderedSequence(Targets);
+            combiner.AddSequence(PackageFolders); // ordered
             combiner.AddObject(PackageSpec);
-
-            HashLogMessages(combiner, LogMessages);
-
-            HashCentralTransitiveDependencyGroups(combiner, CentralTransitiveDependencyGroups);
+            combiner.AddUnorderedSequence(LogMessages);
+            combiner.AddUnorderedSequence(CentralTransitiveDependencyGroups);
 
             return combiner.CombinedHash;
-        }
-
-        private static void HashLockFileTargets(HashCodeCombiner combiner, IList<LockFileTarget> targets)
-        {
-            foreach (var item in targets.OrderBy(target => target.Name, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(item);
-            }
-        }
-
-        private static void HashProjectFileDependencyGroups(HashCodeCombiner combiner, IList<ProjectFileDependencyGroup> groups)
-        {
-            foreach (var item in groups.OrderBy(
-                group => @group.FrameworkName, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(item);
-            }
-        }
-
-        private static void HashCentralTransitiveDependencyGroups(HashCodeCombiner combiner, IList<CentralTransitiveDependencyGroup> groups)
-        {
-            foreach (CentralTransitiveDependencyGroup item in groups.OrderBy(group => group.FrameworkName, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(item);
-            }
-        }
-
-        private static void HashLogMessages(HashCodeCombiner combiner, IList<IAssetsLogMessage> logMessages)
-        {
-            foreach (var item in logMessages.OrderBy(
-                logMessage => @logMessage.Message, StringComparer.Ordinal))
-            {
-                combiner.AddObject(item);
-            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileLibrary.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileLibrary.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using NuGet.Shared;
 using NuGet.Versioning;
 
@@ -79,11 +78,7 @@ namespace NuGet.ProjectModel
             combiner.AddObject(Version);
             combiner.AddObject(Path);
             combiner.AddObject(MSBuildProject);
-
-            foreach (var file in Files.OrderBy(s => s, StringComparer.Ordinal))
-            {
-                combiner.AddObject(file);
-            }
+            combiner.AddUnorderedSequence(Files);
 
             return combiner.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileTarget.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileTarget.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using NuGet.Frameworks;
 using NuGet.Shared;
 
@@ -53,11 +52,7 @@ namespace NuGet.ProjectModel
             combiner.AddObject(TargetFramework);
             combiner.AddObject(RuntimeIdentifier);
             combiner.AddObject(Name);
-
-            foreach (var library in Libraries.OrderBy(library => library.Name, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(library);
-            }
+            combiner.AddUnorderedSequence(Libraries);
 
             return combiner.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileTargetLibrary.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileTargetLibrary.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using NuGet.Packaging.Core;
 using NuGet.Shared;
 using NuGet.Versioning;
@@ -201,7 +200,7 @@ namespace NuGet.ProjectModel
                 IList<T>? thisList = thisValue is IList<T> { Count: not 0 } list1 ? list1 : null;
                 IList<T>? thatList = thatValue is IList<T> { Count: not 0 } list2 ? list2 : null;
 
-                return thisList!.OrderedEquals<T, string>(thatList!, accessor, orderComparer: StringComparer.OrdinalIgnoreCase, sequenceComparer: sequenceComparer);
+                return thisList.OrderedEquals<T, string>(thatList, accessor, orderComparer: StringComparer.OrdinalIgnoreCase, sequenceComparer: sequenceComparer);
             }
         }
 
@@ -218,71 +217,19 @@ namespace NuGet.ProjectModel
             combiner.AddObject(Version);
             combiner.AddObject(Type);
             combiner.AddObject(Framework);
-
-            foreach (var dependency in Dependencies.OrderBy(dependency => dependency.Id, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(dependency);
-            }
-
-            foreach (var reference in FrameworkAssemblies.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddStringIgnoreCase(reference);
-            }
-
-            foreach (var reference in FrameworkReferences.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddStringIgnoreCase(reference);
-            }
-
-            foreach (var item in RuntimeAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(item);
-            }
-
-            foreach (var item in ResourceAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(item);
-            }
-
-            foreach (var item in CompileTimeAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(item);
-            }
-
-            foreach (var item in NativeLibraries.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(item);
-            }
-
-            foreach (var item in ContentFiles.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(item);
-            }
-
-            foreach (var item in RuntimeTargets.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(item);
-            }
-
-            foreach (var item in Build.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(item);
-            }
-
-            foreach (var item in BuildMultiTargeting.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(item);
-            }
-
-            foreach (var item in ToolsAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(item);
-            }
-
-            foreach (var item in EmbedAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
-            {
-                combiner.AddObject(item);
-            }
+            combiner.AddUnorderedSequence(Dependencies);
+            combiner.AddUnorderedSequence(FrameworkAssemblies, StringComparer.OrdinalIgnoreCase);
+            combiner.AddUnorderedSequence(FrameworkReferences, StringComparer.OrdinalIgnoreCase);
+            combiner.AddUnorderedSequence(RuntimeAssemblies);
+            combiner.AddUnorderedSequence(ResourceAssemblies);
+            combiner.AddUnorderedSequence(CompileTimeAssemblies);
+            combiner.AddUnorderedSequence(NativeLibraries);
+            combiner.AddUnorderedSequence(ContentFiles);
+            combiner.AddUnorderedSequence(RuntimeTargets);
+            combiner.AddUnorderedSequence(Build);
+            combiner.AddUnorderedSequence(BuildMultiTargeting);
+            combiner.AddUnorderedSequence(ToolsAssemblies);
+            combiner.AddUnorderedSequence(EmbedAssemblies);
 
             return combiner.CombinedHash;
 

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectFileDependencyGroup.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectFileDependencyGroup.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using NuGet.Shared;
 
 namespace NuGet.ProjectModel
@@ -55,14 +54,7 @@ namespace NuGet.ProjectModel
             var combiner = new HashCodeCombiner();
 
             combiner.AddStringIgnoreCase(FrameworkName);
-
-            if (Dependencies != null)
-            {
-                foreach (var dependency in Dependencies.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
-                {
-                    combiner.AddStringIgnoreCase(dependency);
-                }
-            }
+            combiner.AddUnorderedSequence(Dependencies, StringComparer.OrdinalIgnoreCase);
 
             return combiner.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.Protocol/RemoteSourceDependencyInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteSourceDependencyInfo.cs
@@ -79,12 +79,7 @@ namespace NuGet.Protocol.Core.Types
             var combiner = new HashCodeCombiner();
 
             combiner.AddObject(Identity);
-
-            foreach (var hash in DependencyGroups.Select(group => group.GetHashCode()).OrderBy(x => x))
-            {
-                combiner.AddObject(hash);
-            }
-
+            combiner.AddUnorderedSequence(DependencyGroups);
             combiner.AddObject(ContentUri);
 
             return combiner.CombinedHash;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/Core/comparers/PackageDependencyInfoComparerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/Core/comparers/PackageDependencyInfoComparerTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using NuGet.Packaging.Core;
 using NuGet.Shared;
 using NuGet.Versioning;
@@ -120,8 +119,8 @@ namespace NuGet.Packaging.Tests
         {
             var combiner = new HashCodeCombiner();
 
-            combiner.AddObject(PackageIdentityComparer.Default.GetHashCode(DependencyInfoA));
-            combiner.AddObject(DependencyInfoA.Dependencies.First());
+            combiner.AddObject(DependencyInfoA, PackageIdentityComparer.Default);
+            combiner.AddUnorderedSequence(DependencyInfoA.Dependencies);
 
             int expectedResult = combiner.CombinedHash;
             int actualResult = Comparer.GetHashCode(DependencyInfoA);


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/12746

Regression? Last working version: N/A

## Description

Builds on the work started in #5304.

Rather than ordering items to add them to the hash code in a stable fashion, we re-use the new `AddUnorderedSequence` method. That method does not need to order its inputs, meaning we can avoid allocating buffers for the inputs, and running sort algorithms on those items. Instead we can just enumerate the items once while computing the hash, keeping running state on the stack.

We also add `NoAllocEnumerate` calls within `HashCodeCombiner` to avoid allocating enumerators where possible.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
