### PR TITLE
Combobox version is aware of labels when autoselecting version (#5291)

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -252,12 +252,9 @@ namespace NuGet.PackageManagement.UI
             if ((UserInput.StartsWith("(", StringComparison.OrdinalIgnoreCase) || UserInput.StartsWith("[", StringComparison.OrdinalIgnoreCase)) &&
                VersionRange.TryParse(UserInput, out VersionRange userRange))
             {
-                if (o != null && NuGetVersion.TryParse(o.ToString(), out NuGetVersion userVersion))
+                if (o != null && userRange.Satisfies(version.Version))
                 {
-                    if (userRange.Satisfies(userVersion))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
 
                 return false;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
@@ -165,11 +165,22 @@ namespace NuGet.PackageManagement.UI
                             {
                                 // Search for the best version
                                 NuGetVersion rangeBestVersion = userRequestedVersionRange.FindBestMatch(versions);
-                                bool isBestOption = rangeBestVersion.ToString() == _versions.Items[_versions.SelectedIndex].ToString();
+                                DisplayVersion selectedVersion = (DisplayVersion)_versions.Items.CurrentItem;
+                                bool isBestOption = rangeBestVersion.ToString() == selectedVersion.Version.ToString();
                                 if (isBestOption)
                                 {
-                                    PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRequestedVersionRange, rangeBestVersion, additionalInfo: null, isVulnerable: false);
-                                    _versions.Text = comboboxText;
+                                    // Add vulnerable/deprecated labels to non floating/range versions
+                                    if (userRequestedVersionRange.OriginalString.StartsWith("(", StringComparison.OrdinalIgnoreCase) ||
+                                        userRequestedVersionRange.OriginalString.StartsWith("[", StringComparison.OrdinalIgnoreCase) ||
+                                        userRequestedVersionRange.IsFloating)
+                                    {
+                                        PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRequestedVersionRange, rangeBestVersion, additionalInfo: null);
+                                    }
+                                    else
+                                    {
+                                        PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRequestedVersionRange, rangeBestVersion, additionalInfo: null, isVulnerable: selectedVersion.IsVulnerable, isDeprecated: selectedVersion.IsDeprecated);
+                                    }
+                                    _versions.Text = PackageDetailControlModel.SelectedVersion.ToString();
                                 }
                                 else
                                 {
@@ -248,10 +259,11 @@ namespace NuGet.PackageManagement.UI
             for (int i = 0; i < _versions.Items.Count; i++)
             {
                 DisplayVersion currentItem = _versions.Items[i] as DisplayVersion;
-                if (currentItem != null && (comboboxText == _versions.Items[i].ToString() || _versions.Items[i].ToString() == matchVersion?.ToString()))
+                if (currentItem != null && // null, this represent a bar in UI in the Versions combobox 
+                    (comboboxText.Trim() == currentItem.Version.ToNormalizedString() || matchVersion?.ToString() == currentItem.Version.ToNormalizedString())) // trim extra spaces and compare versions without labels
                 {
                     _versions.SelectedIndex = i; // This is the "select" effect in the dropdown
-                    PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRange, matchVersion, additionalInfo: null, isVulnerable: currentItem.IsVulnerable);
+                    PackageDetailControlModel.SelectedVersion = new DisplayVersion(userRange, matchVersion, additionalInfo: null, isDeprecated: currentItem.IsDeprecated, isVulnerable: currentItem.IsVulnerable);
                 }
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12724
Fixes: https://github.com/NuGet/Home/issues/12725

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Cherry pick https://github.com/NuGet/NuGet.Client/pull/5291 onto `release-6.7.x` branch
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
