### PR TITLE
Make PackageSourceMapping API nullable enabled and improve test coverage

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageSourceMappingActionViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageSourceMappingActionViewModel.cs
@@ -53,7 +53,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
                 else
                 {
                     var packageSourceMapping = UIController.UIContext.PackageSourceMapping;
-                    _isPackageMapped = packageSourceMapping?.GetConfiguredPackageSources(PackageId)?.Any() == true;
+                    _isPackageMapped = packageSourceMapping.GetConfiguredPackageSources(PackageId!).Any() == true;
                 }
                 return _isPackageMapped;
             }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSourceMapping/PackageSourceMapping.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSourceMapping/PackageSourceMapping.cs
@@ -22,7 +22,7 @@ namespace NuGet.Configuration
         /// </summary>
         internal IReadOnlyDictionary<string, IReadOnlyList<string>> Patterns { get; }
 
-        private Lazy<SearchTree?> SearchTree { get; }
+        private Lazy<SearchTree>? SearchTree { get; }
 
         /// <summary>
         /// Indicate if any packageSource exist in package source mapping section
@@ -37,7 +37,7 @@ namespace NuGet.Configuration
         /// <exception cref="ArgumentException"> if <paramref name="packageId"/> is null, empty, or whitespace only.</exception>
         public IReadOnlyList<string> GetConfiguredPackageSources(string packageId)
         {
-            if (SearchTree.Value is null)
+            if (SearchTree?.Value is null)
             {
                 return Array.Empty<string>();
             }
@@ -47,14 +47,14 @@ namespace NuGet.Configuration
 
         public string? SearchForPattern(string packageId)
         {
-            return SearchTree.Value?.SearchForPattern(packageId);
+            return SearchTree?.Value.SearchForPattern(packageId);
         }
 
         public PackageSourceMapping(IReadOnlyDictionary<string, IReadOnlyList<string>> patterns)
         {
             Patterns = patterns ?? throw new ArgumentNullException(nameof(patterns));
             IsEnabled = Patterns.Count > 0;
-            SearchTree = new Lazy<SearchTree?>(() => GetSearchTree());
+            SearchTree = IsEnabled ? new Lazy<SearchTree>(() => GetSearchTree()) : null;
         }
 
         /// <summary>
@@ -82,16 +82,9 @@ namespace NuGet.Configuration
             return new PackageSourceMapping(patterns);
         }
 
-        private SearchTree? GetSearchTree()
+        private SearchTree GetSearchTree()
         {
-            SearchTree? patternsLookup = null;
-
-            if (IsEnabled)
-            {
-                patternsLookup = new SearchTree(this);
-            }
-
-            return patternsLookup;
+            return new SearchTree(this);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSourceMapping/SearchNode.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSourceMapping/SearchNode.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System.Collections.Generic;
 
 namespace NuGet.Configuration
@@ -9,7 +11,7 @@ namespace NuGet.Configuration
     {
         public readonly Dictionary<char, SearchNode> Children;
         public bool IsGlobbing { get; set; }
-        public List<string> PackageSources;
+        public List<string>? PackageSources;
 
         public SearchNode()
         {

--- a/src/NuGet.Core/NuGet.Configuration/PackageSourceMapping/SearchTree.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSourceMapping/SearchTree.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -81,7 +83,7 @@ namespace NuGet.Configuration
         /// </summary>
         /// <param name="term">Term to search for in <see cref="PackageSourceMapping.Patterns"/>.</param>
         /// <returns>Found <see cref="PackageSourceMapping.Patterns"/> which satisfies the <paramref name="term"/>, or `null`.</returns>
-        public string SearchForPattern(string term)
+        public string? SearchForPattern(string term)
         {
             return SearchPatternByTerm(term);
         }
@@ -94,10 +96,16 @@ namespace NuGet.Configuration
         /// <exception cref="ArgumentException"> if <paramref name="term"/> is null, empty, or whitespace only.</exception>
         public IReadOnlyList<string> GetConfiguredPackageSources(string term)
         {
-            return SearchNodeByTerm(term)?.PackageSources;
+            SearchNode? searchNodeResult = SearchNodeByTerm(term);
+            if (searchNodeResult is null || searchNodeResult.PackageSources is null)
+            {
+                return Array.Empty<string>();
+            }
+
+            return searchNodeResult.PackageSources;
         }
 
-        private SearchNode SearchNodeByTerm(string term)
+        private SearchNode? SearchNodeByTerm(string term)
         {
             if (string.IsNullOrWhiteSpace(term))
             {
@@ -107,7 +115,7 @@ namespace NuGet.Configuration
             term = term.ToLower(CultureInfo.CurrentCulture).Trim();
 
             SearchNode currentNode = _root;
-            SearchNode longestMatchingPrefixNode = null;
+            SearchNode? longestMatchingPrefixNode = null;
 
             if (currentNode.IsGlobbing)
             {
@@ -141,7 +149,7 @@ namespace NuGet.Configuration
             return longestMatchingPrefixNode;
         }
 
-        private string SearchPatternByTerm(string term)
+        private string? SearchPatternByTerm(string term)
         {
             if (string.IsNullOrWhiteSpace(term))
             {

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
@@ -171,9 +171,9 @@ NuGet.Configuration.PackageSourceCredential.IsValid() -> bool
 ~NuGet.Configuration.PackageSourceCredential.ValidAuthenticationTypes.get -> System.Collections.Generic.IEnumerable<string>
 ~NuGet.Configuration.PackageSourceCredential.ValidAuthenticationTypesText.get -> string
 NuGet.Configuration.PackageSourceMapping
-~NuGet.Configuration.PackageSourceMapping.GetConfiguredPackageSources(string packageId) -> System.Collections.Generic.IReadOnlyList<string>
+NuGet.Configuration.PackageSourceMapping.GetConfiguredPackageSources(string! packageId) -> System.Collections.Generic.IReadOnlyList<string!>!
 NuGet.Configuration.PackageSourceMapping.IsEnabled.get -> bool
-~NuGet.Configuration.PackageSourceMapping.PackageSourceMapping(System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>> patterns) -> void
+NuGet.Configuration.PackageSourceMapping.PackageSourceMapping(System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<string!>!>! patterns) -> void
 NuGet.Configuration.PackageSourceMappingProvider
 ~NuGet.Configuration.PackageSourceMappingProvider.GetPackageSourceMappingItems() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSourceMappingSourceItem>
 ~NuGet.Configuration.PackageSourceMappingProvider.PackageSourceMappingProvider(NuGet.Configuration.ISettings settings) -> void
@@ -407,7 +407,7 @@ override NuGet.Configuration.UnknownItem.IsEmpty() -> bool
 ~static NuGet.Configuration.NuGetPathContext.Create(string settingsRoot) -> NuGet.Configuration.NuGetPathContext
 ~static NuGet.Configuration.NullSettings.Instance.get -> NuGet.Configuration.NullSettings
 ~static NuGet.Configuration.PackageSourceCredential.FromUserInput(string source, string username, string password, bool storePasswordInClearText, string validAuthenticationTypesText) -> NuGet.Configuration.PackageSourceCredential
-~static NuGet.Configuration.PackageSourceMapping.GetPackageSourceMapping(NuGet.Configuration.ISettings settings) -> NuGet.Configuration.PackageSourceMapping
+static NuGet.Configuration.PackageSourceMapping.GetPackageSourceMapping(NuGet.Configuration.ISettings! settings) -> NuGet.Configuration.PackageSourceMapping!
 ~static NuGet.Configuration.PackageSourceProvider.LoadPackageSources(NuGet.Configuration.ISettings settings) -> System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource>
 ~static NuGet.Configuration.ProxyCache.Instance.get -> NuGet.Configuration.ProxyCache
 ~static NuGet.Configuration.Settings.ApplyEnvironmentTransform(string value) -> string

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
 #nullable enable
 NuGet.Configuration.PackageSourceMappingProvider.ShouldSkipSave.get -> bool
-~NuGet.Configuration.PackageSourceMapping.SearchForPattern(string packageId) -> string
+NuGet.Configuration.PackageSourceMapping.SearchForPattern(string! packageId) -> string?
 ~NuGet.Configuration.PackageSourceMappingProvider.PackageSourceMappingProvider(NuGet.Configuration.ISettings settings, bool shouldSkipSave) -> void

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteWalkContext.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteWalkContext.cs
@@ -68,7 +68,7 @@ namespace NuGet.DependencyResolver
             {
                 IReadOnlyList<string> sources = PackageSourceMapping.GetConfiguredPackageSources(libraryRange.Name);
 
-                if (sources == null || sources.Count == 0)
+                if (sources.Count == 0)
                 {
                     return Array.Empty<IRemoteDependencyProvider>();
                 }

--- a/src/NuGet.Core/NuGet.PackageManagement/PackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/PackageDownloader.cs
@@ -105,7 +105,7 @@ namespace NuGet.PackageManagement
                 {
                     configuredPackageSources = downloadContext.PackageSourceMapping.GetConfiguredPackageSources(packageIdentity.Id);
 
-                    if (configuredPackageSources != null)
+                    if (configuredPackageSources.Count > 0)
                     {
                         var packageSourcesAtPrefix = string.Join(", ", configuredPackageSources);
                         logger.LogDebug(StringFormatter.Log_PackageSourceMappingMatchFound(packageIdentity.Id, packageSourcesAtPrefix));

--- a/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
@@ -542,7 +542,7 @@ namespace NuGet.PackageManagement
 
                 configuredPackageSources = _context.PackageSourceMapping.GetConfiguredPackageSources(package.Id);
 
-                if (configuredPackageSources != null)
+                if (configuredPackageSources.Count > 0)
                 {
                     var packageSourcesAtPrefix = string.Join(", ", configuredPackageSources);
                     _context.Log.LogDebug(StringFormatter.Log_PackageSourceMappingMatchFound((package.Id), packageSourcesAtPrefix));

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SearchTreeTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SearchTreeTest.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -258,7 +260,7 @@ namespace NuGet.Configuration.Test
             SearchTree searchTree = new SearchTree(configuration);
 
             // Act
-            string foundPattern = searchTree.SearchForPattern(term);
+            string? foundPattern = searchTree.SearchForPattern(term);
 
             // Assert
             configuration.IsEnabled.Should().BeTrue();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SearchTreeTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SearchTreeTest.cs
@@ -58,7 +58,7 @@ namespace NuGet.Configuration.Test
 
             // Act & Assert
             IReadOnlyList<string> configuredSources = searchTree.GetConfiguredPackageSources(term);
-            Assert.Null(configuredSources);
+            Assert.Empty(configuredSources);
         }
 
         [Theory]
@@ -105,7 +105,7 @@ namespace NuGet.Configuration.Test
 
             // Act & Assert
             IReadOnlyList<string> configuredSources = searchTree.GetConfiguredPackageSources(term);
-            Assert.Null(configuredSources);
+            Assert.Empty(configuredSources);
         }
 
         [Theory]
@@ -119,7 +119,7 @@ namespace NuGet.Configuration.Test
 
             // Act & Assert
             IReadOnlyList<string> configuredSources = searchTree.GetConfiguredPackageSources(term);
-            Assert.Null(configuredSources);
+            Assert.Empty(configuredSources);
         }
 
         [Theory]
@@ -139,7 +139,7 @@ namespace NuGet.Configuration.Test
 
             // Act & Assert
             IReadOnlyList<string> configuredSources = searchTree.GetConfiguredPackageSources(term);
-            Assert.Null(configuredSources);
+            Assert.Empty(configuredSources);
         }
 
         [Fact]
@@ -194,7 +194,7 @@ namespace NuGet.Configuration.Test
 
             // Act & Assert
             var packageSourcesMatch = searchTree.GetConfiguredPackageSources(term);
-            Assert.Null(packageSourcesMatch);
+            Assert.Empty(packageSourcesMatch);
         }
 
         [Theory]

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ResolverGatherTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ResolverGatherTests.cs
@@ -1576,7 +1576,7 @@ namespace NuGet.Test
 
             // Assert
             Assert.True(sourceMappingConfiguration.IsEnabled);
-            Assert.Null(configuredSources);
+            Assert.Empty(configuredSources);
 
             // Assert log.
             Assert.Contains($"Package '{packageId} 1.0.0' is not found in the following primary source(s)", exception.Message);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12794

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

_Predecessor to https://github.com/NuGet/NuGet.Client/pull/5295_

- Enable nullable compiler checks, and make changes to callers as needed.
- Add missing test coverage for `PackageDownloader`


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
