### PR TITLE
Add an allowInsecureConnections property in NuGet.Config

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSourcesService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSourcesService.cs
@@ -93,6 +93,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     if (packageSource.Name.Equals(packageSourceContextInfo.Name, StringComparison.InvariantCulture)
                         && packageSource.Source.Equals(packageSourceContextInfo.Source, StringComparison.InvariantCulture)
                         && packageSource.ProtocolVersion == packageSourceContextInfo.ProtocolVersion
+                        && packageSource.AllowInsecureConnections == packageSourceContextInfo.AllowInsecureConnections
                         && packageSource.IsEnabled == packageSourceContextInfo.IsEnabled)
                     {
                         newPackageSources.Add(packageSource);
@@ -111,6 +112,7 @@ namespace NuGet.PackageManagement.VisualStudio
                             ClientCertificates = packageSource.ClientCertificates,
                             Description = packageSource.Description,
                             ProtocolVersion = packageSourceContextInfo.ProtocolVersion,
+                            AllowInsecureConnections = packageSourceContextInfo.AllowInsecureConnections,
                             MaxHttpRequestsPerSource = packageSource.MaxHttpRequestsPerSource,
                         };
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSourceContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSourceContextInfo.cs
@@ -28,7 +28,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         }
 
         public PackageSourceContextInfo(string source, string name, bool isEnabled, int protocolVersion)
-            : this(source, name, isEnabled, protocolVersion, PackageSource.DefaultAllowInsecureConnections)
+            : this(source, name, isEnabled, protocolVersion, allowInsecureConnections: false)
         {
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSourceContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSourceContextInfo.cs
@@ -47,7 +47,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             hash.AddStringIgnoreCase(Name);
             hash.AddStringIgnoreCase(Source);
             hash.AddObject(ProtocolVersion);
-            hash.AddObject(allowInsecureConnections);
+            hash.AddObject(AllowInsecureConnections);
             _hashCode = hash.CombinedHash;
             OriginalHashCode = _hashCode;
         }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSourceContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSourceContextInfo.cs
@@ -28,6 +28,11 @@ namespace NuGet.VisualStudio.Internal.Contracts
         }
 
         public PackageSourceContextInfo(string source, string name, bool isEnabled, int protocolVersion)
+            : this(source, name, isEnabled, protocolVersion, PackageSource.DefaultAllowInsecureConnections)
+        {
+        }
+
+        public PackageSourceContextInfo(string source, string name, bool isEnabled, int protocolVersion, bool allowInsecureConnections)
         {
             Assumes.NotNullOrEmpty(name);
             Assumes.NotNullOrEmpty(source);
@@ -36,11 +41,13 @@ namespace NuGet.VisualStudio.Internal.Contracts
             Source = source;
             IsEnabled = isEnabled;
             ProtocolVersion = protocolVersion;
+            AllowInsecureConnections = allowInsecureConnections;
 
             var hash = new HashCodeCombiner();
             hash.AddStringIgnoreCase(Name);
             hash.AddStringIgnoreCase(Source);
             hash.AddObject(ProtocolVersion);
+            hash.AddObject(allowInsecureConnections);
             _hashCode = hash.CombinedHash;
             OriginalHashCode = _hashCode;
         }
@@ -48,6 +55,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         public string Name { get; set; }
         public string Source { get; set; }
         public int ProtocolVersion { get; set; }
+        public bool AllowInsecureConnections { get; set; }
         public bool IsMachineWide { get; internal set; }
         public bool IsEnabled { get; set; }
         public string? Description { get; internal set; }
@@ -86,7 +94,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         public PackageSourceContextInfo Clone()
         {
-            return new PackageSourceContextInfo(Source, Name, IsEnabled, ProtocolVersion)
+            return new PackageSourceContextInfo(Source, Name, IsEnabled, ProtocolVersion, AllowInsecureConnections)
             {
                 IsMachineWide = IsMachineWide,
                 Description = Description,
@@ -96,7 +104,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         public static PackageSourceContextInfo Create(PackageSource packageSource)
         {
-            return new PackageSourceContextInfo(packageSource.Source, packageSource.Name, packageSource.IsEnabled, packageSource.ProtocolVersion)
+            return new PackageSourceContextInfo(packageSource.Source, packageSource.Name, packageSource.IsEnabled, packageSource.ProtocolVersion, packageSource.AllowInsecureConnections)
             {
                 IsMachineWide = packageSource.IsMachineWide,
                 Description = packageSource.Description,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceContextInfoFormatter.cs
@@ -74,7 +74,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             Assumes.NotNullOrEmpty(source);
             Assumes.NotNullOrEmpty(name);
 
-            return new PackageSourceContextInfo(source, name, isEnabled, protocolVersion)
+            return new PackageSourceContextInfo(source, name, isEnabled, protocolVersion, allowInsecureConnections)
             {
                 IsMachineWide = isMachineWide,
                 Description = description,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceContextInfoFormatter.cs
@@ -34,7 +34,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             string? description = null;
             int originalHashCode = 0;
             int protocolVersion = PackageSource.DefaultProtocolVersion;
-            bool allowInsecureConnections = PackageSource.DefaultAllowInsecureConnections;
+            bool allowInsecureConnections = false;
 
             int propertyCount = reader.ReadMapHeader();
             for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceContextInfoFormatter.cs
@@ -13,6 +13,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         private const string SourcePropertyName = "source";
         private const string IsEnabledPropertyName = "isenabled";
         private const string ProtocolVersionPropertyName = "protocolversion";
+        private const string AllowInsecureConnectionsPropertyName = "allowInsecureConnections";
         private const string IsMachineWidePropertyName = "ismachinewide";
         private const string NamePropertyName = "name";
         private const string DescriptionPropertyName = "description";
@@ -33,6 +34,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             string? description = null;
             int originalHashCode = 0;
             int protocolVersion = PackageSource.DefaultProtocolVersion;
+            bool allowInsecureConnections = PackageSource.DefaultAllowInsecureConnections;
 
             int propertyCount = reader.ReadMapHeader();
             for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
@@ -60,6 +62,9 @@ namespace NuGet.VisualStudio.Internal.Contracts
                     case ProtocolVersionPropertyName:
                         protocolVersion = reader.ReadInt32();
                         break;
+                    case AllowInsecureConnectionsPropertyName:
+                        allowInsecureConnections = reader.ReadBoolean();
+                        break;
                     default:
                         reader.Skip();
                         break;
@@ -79,11 +84,13 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         protected override void SerializeCore(ref MessagePackWriter writer, PackageSourceContextInfo value, MessagePackSerializerOptions options)
         {
-            writer.WriteMapHeader(count: 7);
+            writer.WriteMapHeader(count: 8);
             writer.Write(SourcePropertyName);
             writer.Write(value.Source);
             writer.Write(ProtocolVersionPropertyName);
             writer.Write(value.ProtocolVersion);
+            writer.Write(AllowInsecureConnectionsPropertyName);
+            writer.Write(value.AllowInsecureConnections);
             writer.Write(IsEnabledPropertyName);
             writer.Write(value.IsEnabled);
             writer.Write(IsMachineWidePropertyName);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/PublicAPI.Unshipped.txt
@@ -4,6 +4,7 @@ NuGet.VisualStudio.Internal.Contracts.INuGetSearchService.GetAllPackageFoldersAs
 NuGet.VisualStudio.Internal.Contracts.IPackageReferenceContextInfo.VersionOverride.get -> NuGet.Versioning.VersionRange?
 NuGet.VisualStudio.Internal.Contracts.PackageReferenceContextInfo.VersionOverride.get -> NuGet.Versioning.VersionRange?
 NuGet.VisualStudio.Internal.Contracts.PackageSourceContextInfo.AllowInsecureConnections.get -> bool
+NuGet.VisualStudio.Internal.Contracts.PackageSourceContextInfo.AllowInsecureConnections.set -> void
 NuGet.VisualStudio.Internal.Contracts.PackageSourceContextInfo.PackageSourceContextInfo(string! source, string! name, bool isEnabled, int protocolVersion) -> void
 NuGet.VisualStudio.Internal.Contracts.PackageSourceContextInfo.PackageSourceContextInfo(string! source, string! name, bool isEnabled, int protocolVersion, bool allowInsecureConnections) -> void
 NuGet.VisualStudio.Internal.Contracts.PackageSourceContextInfo.ProtocolVersion.get -> int

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/PublicAPI.Unshipped.txt
@@ -3,7 +3,9 @@ NuGet.VisualStudio.Internal.Contracts.INuGetProjectManagerService.GetInstallActi
 NuGet.VisualStudio.Internal.Contracts.INuGetSearchService.GetAllPackageFoldersAsync(System.Collections.Generic.IReadOnlyCollection<NuGet.VisualStudio.Internal.Contracts.IProjectContextInfo!>! projectContextInfos, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Core.Types.SourceRepository!>!>!
 NuGet.VisualStudio.Internal.Contracts.IPackageReferenceContextInfo.VersionOverride.get -> NuGet.Versioning.VersionRange?
 NuGet.VisualStudio.Internal.Contracts.PackageReferenceContextInfo.VersionOverride.get -> NuGet.Versioning.VersionRange?
+NuGet.VisualStudio.Internal.Contracts.PackageSourceContextInfo.AllowInsecureConnections.get -> bool
 NuGet.VisualStudio.Internal.Contracts.PackageSourceContextInfo.PackageSourceContextInfo(string! source, string! name, bool isEnabled, int protocolVersion) -> void
+NuGet.VisualStudio.Internal.Contracts.PackageSourceContextInfo.PackageSourceContextInfo(string! source, string! name, bool isEnabled, int protocolVersion, bool allowInsecureConnections) -> void
 NuGet.VisualStudio.Internal.Contracts.PackageSourceContextInfo.ProtocolVersion.get -> int
 NuGet.VisualStudio.Internal.Contracts.PackageSourceContextInfo.ProtocolVersion.set -> void
 NuGet.VisualStudio.Internal.Contracts.TransitivePackageReferenceContextInfo.VersionOverride.get -> NuGet.Versioning.VersionRange?

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -19,7 +19,7 @@ namespace NuGet.Configuration
         /// </summary>
         public const int DefaultProtocolVersion = 2;
 
-        internal const bool DefaultAllowInsecureConnections = false;
+        public const bool DefaultAllowInsecureConnections = false;
 
         private int _hashCode;
         private string _source;

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -19,7 +19,7 @@ namespace NuGet.Configuration
         /// </summary>
         public const int DefaultProtocolVersion = 2;
 
-        public const bool DefaultAllowInsecureConnections = false;
+        internal const bool DefaultAllowInsecureConnections = false;
 
         private int _hashCode;
         private string _source;

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -19,6 +19,8 @@ namespace NuGet.Configuration
         /// </summary>
         public const int DefaultProtocolVersion = 2;
 
+        public const bool DefaultAllowInsecureConnections = false;
+
         private int _hashCode;
         private string _source;
         private bool _isHttp;
@@ -102,6 +104,11 @@ namespace NuGet.Configuration
         public int ProtocolVersion { get; set; } = DefaultProtocolVersion;
 
         /// <summary>
+        /// Gets or sets the allowInsecureConnections of the source. Defaults to false.
+        /// </summary>
+        public bool AllowInsecureConnections { get; set; } = DefaultAllowInsecureConnections;
+
+        /// <summary>
         /// Whether the source is using the HTTP protocol, including HTTPS.
         /// </summary>
         public bool IsHttp => _isHttp;
@@ -152,7 +159,13 @@ namespace NuGet.Configuration
             {
                 protocolVersion = $"{ProtocolVersion}";
             }
-            return new SourceItem(Name, Source, protocolVersion);
+
+            string? allowInsecureConnections = null;
+            if (AllowInsecureConnections != DefaultAllowInsecureConnections)
+            {
+                allowInsecureConnections = $"{AllowInsecureConnections}";
+            }
+            return new SourceItem(Name, Source, protocolVersion, allowInsecureConnections);
         }
 
         public bool Equals(PackageSource? other)
@@ -189,6 +202,7 @@ namespace NuGet.Configuration
                 ClientCertificates = ClientCertificates?.ToList(),
                 IsMachineWide = IsMachineWide,
                 ProtocolVersion = ProtocolVersion,
+                AllowInsecureConnections = AllowInsecureConnections,
             };
         }
     }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -199,6 +199,7 @@ namespace NuGet.Configuration
             }
 
             packageSource.ProtocolVersion = ReadProtocolVersion(setting);
+            packageSource.AllowInsecureConnections = ReadAllowInsecureConnections(setting);
 
             return packageSource;
         }
@@ -211,6 +212,16 @@ namespace NuGet.Configuration
             }
 
             return PackageSource.DefaultProtocolVersion;
+        }
+
+        private static bool ReadAllowInsecureConnections(SourceItem setting)
+        {
+            if (bool.TryParse(setting.AllowInsecureConnections, out var allowInsecureConnections))
+            {
+                return allowInsecureConnections;
+            }
+
+            return PackageSource.DefaultAllowInsecureConnections;
         }
 
         private static int AddOrUpdateIndexedSource(

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
@@ -281,6 +281,7 @@ NuGet.Configuration.SettingsUtility
 NuGet.Configuration.SourceItem
 ~NuGet.Configuration.SourceItem.ProtocolVersion.get -> string
 ~NuGet.Configuration.SourceItem.ProtocolVersion.set -> void
+~NuGet.Configuration.SourceItem.SourceItem(string key, string value, string protocolVersion) -> void
 NuGet.Configuration.StoreClientCertItem
 NuGet.Configuration.StoreClientCertItem.FindType.get -> System.Security.Cryptography.X509Certificates.X509FindType
 ~NuGet.Configuration.StoreClientCertItem.FindValue.get -> string

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
@@ -281,7 +281,6 @@ NuGet.Configuration.SettingsUtility
 NuGet.Configuration.SourceItem
 ~NuGet.Configuration.SourceItem.ProtocolVersion.get -> string
 ~NuGet.Configuration.SourceItem.ProtocolVersion.set -> void
-~NuGet.Configuration.SourceItem.SourceItem(string key, string value, string protocolVersion = "") -> void
 NuGet.Configuration.StoreClientCertItem
 NuGet.Configuration.StoreClientCertItem.FindType.get -> System.Security.Cryptography.X509Certificates.X509FindType
 ~NuGet.Configuration.StoreClientCertItem.FindValue.get -> string

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 #nullable enable
-const NuGet.Configuration.PackageSource.DefaultAllowInsecureConnections = false -> bool
 NuGet.Configuration.PackageSource.AllowInsecureConnections.get -> bool
 NuGet.Configuration.PackageSource.AllowInsecureConnections.set -> void
 NuGet.Configuration.PackageSourceMappingProvider.ShouldSkipSave.get -> bool
@@ -8,5 +7,5 @@ NuGet.Configuration.PackageSourceMapping.SearchForPattern(string! packageId) -> 
 ~NuGet.Configuration.SourceItem.AllowInsecureConnections.get -> string
 ~NuGet.Configuration.SourceItem.AllowInsecureConnections.set -> void
 ~NuGet.Configuration.SourceItem.SourceItem(string key, string value) -> void
-~NuGet.Configuration.SourceItem.SourceItem(string key, string value, string protocolVersion = "", string allowInsecureConnections = "") -> void
+~NuGet.Configuration.SourceItem.SourceItem(string key, string value, string protocolVersion, string allowInsecureConnections) -> void
 ~static readonly NuGet.Configuration.ConfigurationConstants.AllowInsecureConnections -> string

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 #nullable enable
-const NuGet.Configuration.PackageSource.DefaultAllowInsecureConnections = false -> bool
 NuGet.Configuration.PackageSource.AllowInsecureConnections.get -> bool
 NuGet.Configuration.PackageSource.AllowInsecureConnections.set -> void
 NuGet.Configuration.PackageSourceMappingProvider.ShouldSkipSave.get -> bool
@@ -9,5 +8,4 @@ NuGet.Configuration.PackageSourceMapping.SearchForPattern(string! packageId) -> 
 ~NuGet.Configuration.SourceItem.AllowInsecureConnections.set -> void
 ~NuGet.Configuration.SourceItem.SourceItem(string key, string value) -> void
 ~NuGet.Configuration.SourceItem.SourceItem(string key, string value, string protocolVersion = "", string allowInsecureConnections = "") -> void
-~NuGet.Configuration.SourceItem.SourceItem(string key, string value, string protocolVersion) -> void
 ~static readonly NuGet.Configuration.ConfigurationConstants.AllowInsecureConnections -> string

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+const NuGet.Configuration.PackageSource.DefaultAllowInsecureConnections = false -> bool
 NuGet.Configuration.PackageSource.AllowInsecureConnections.get -> bool
 NuGet.Configuration.PackageSource.AllowInsecureConnections.set -> void
 NuGet.Configuration.PackageSourceMappingProvider.ShouldSkipSave.get -> bool

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -1,4 +1,13 @@
 #nullable enable
+const NuGet.Configuration.PackageSource.DefaultAllowInsecureConnections = false -> bool
+NuGet.Configuration.PackageSource.AllowInsecureConnections.get -> bool
+NuGet.Configuration.PackageSource.AllowInsecureConnections.set -> void
 NuGet.Configuration.PackageSourceMappingProvider.ShouldSkipSave.get -> bool
 NuGet.Configuration.PackageSourceMapping.SearchForPattern(string! packageId) -> string?
 ~NuGet.Configuration.PackageSourceMappingProvider.PackageSourceMappingProvider(NuGet.Configuration.ISettings settings, bool shouldSkipSave) -> void
+~NuGet.Configuration.SourceItem.AllowInsecureConnections.get -> string
+~NuGet.Configuration.SourceItem.AllowInsecureConnections.set -> void
+~NuGet.Configuration.SourceItem.SourceItem(string key, string value) -> void
+~NuGet.Configuration.SourceItem.SourceItem(string key, string value, string protocolVersion = "", string allowInsecureConnections = "") -> void
+~NuGet.Configuration.SourceItem.SourceItem(string key, string value, string protocolVersion) -> void
+~static readonly NuGet.Configuration.ConfigurationConstants.AllowInsecureConnections -> string

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
@@ -21,12 +21,40 @@ namespace NuGet.Configuration
             set => AddOrUpdateAttribute(ConfigurationConstants.ProtocolVersionAttribute, value);
         }
 
-        public SourceItem(string key, string value, string protocolVersion = "")
+        public string AllowInsecureConnections
+        {
+            get
+            {
+                if (Attributes.TryGetValue(ConfigurationConstants.AllowInsecureConnections, out var attribute))
+                {
+                    return Settings.ApplyEnvironmentTransform(attribute);
+                }
+
+                return null;
+            }
+            set => AddOrUpdateAttribute(ConfigurationConstants.AllowInsecureConnections, value);
+        }
+
+        public SourceItem(string key, string value)
+            : this(key, value, protocolVersion: "", allowInsecureConnections: "")
+        {
+        }
+
+        public SourceItem(string key, string value, string protocolVersion)
+            : this(key, value, protocolVersion, allowInsecureConnections: "")
+        {
+        }
+
+        public SourceItem(string key, string value, string protocolVersion = "", string allowInsecureConnections = "")
             : base(key, value)
         {
             if (!string.IsNullOrEmpty(protocolVersion))
             {
                 ProtocolVersion = protocolVersion;
+            }
+            if (!string.IsNullOrEmpty(allowInsecureConnections))
+            {
+                AllowInsecureConnections = allowInsecureConnections;
             }
         }
 
@@ -37,7 +65,7 @@ namespace NuGet.Configuration
 
         public override SettingBase Clone()
         {
-            var newSetting = new SourceItem(Key, Value, ProtocolVersion);
+            var newSetting = new SourceItem(Key, Value, ProtocolVersion, AllowInsecureConnections);
 
             if (Origin != null)
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
@@ -45,7 +45,7 @@ namespace NuGet.Configuration
         {
         }
 
-        public SourceItem(string key, string value, string protocolVersion = "", string allowInsecureConnections = "")
+        public SourceItem(string key, string value, string protocolVersion, string allowInsecureConnections)
             : base(key, value)
         {
             if (!string.IsNullOrEmpty(protocolVersion))

--- a/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -11,6 +11,8 @@ namespace NuGet.Configuration
 
         public static readonly string AllowUntrustedRoot = "allowUntrustedRoot";
 
+        public static readonly string AllowInsecureConnections = "AllowInsecureConnections";
+
         public static readonly string ApiKeys = "apikeys";
 
         public static readonly string Author = "author";

--- a/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -11,7 +11,7 @@ namespace NuGet.Configuration
 
         public static readonly string AllowUntrustedRoot = "allowUntrustedRoot";
 
-        public static readonly string AllowInsecureConnections = "AllowInsecureConnections";
+        public static readonly string AllowInsecureConnections = "allowInsecureConnections";
 
         public static readonly string ApiKeys = "apikeys";
 

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
@@ -379,7 +379,7 @@ namespace NuGet.PackageManagement
             foreach (SourceRepository enabledSource in packageRestoreContext.SourceRepositories)
             {
                 PackageSource source = enabledSource.PackageSource;
-                if (source.IsHttp && !source.IsHttps && !source.AllowInsecureConnections)
+                if (source.IsHttp && !source.IsHttps)
                 {
                     packageRestoreContext.Logger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "restore", source.Source));
                 }

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
@@ -379,7 +379,7 @@ namespace NuGet.PackageManagement
             foreach (SourceRepository enabledSource in packageRestoreContext.SourceRepositories)
             {
                 PackageSource source = enabledSource.PackageSource;
-                if (source.IsHttp && !source.IsHttps)
+                if (source.IsHttp && !source.IsHttps && !source.AllowInsecureConnections)
                 {
                     packageRestoreContext.Logger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "restore", source.Source));
                 }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSourceContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSourceContextInfoFormatterTests.cs
@@ -19,6 +19,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
 
         public static TheoryData TestData => new TheoryData<PackageSourceContextInfo>
             {
+                { new PackageSourceContextInfo("source", "name", isEnabled: true, protocolVersion: 3, allowInsecureConnections: true) },
                 { new PackageSourceContextInfo("source", "name", isEnabled: true, protocolVersion: 3) },
                 { new PackageSourceContextInfo("source", "name", isEnabled: true) },
                 { new PackageSourceContextInfo("source", "name") },

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSourceContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSourceContextInfoFormatterTests.cs
@@ -14,7 +14,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
             PackageSourceContextInfo? actualResult = SerializeThenDeserialize(PackageSourceContextInfoFormatter.Instance, expectedResult);
 
             Assert.NotNull(actualResult);
-            Assert.Equal(expectedResult, actualResult);
+            Assert.Equal(expectedResult.GetHashCode(), actualResult.GetHashCode());
         }
 
         public static TheoryData TestData => new TheoryData<PackageSourceContextInfo>

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -845,7 +845,6 @@ namespace NuGet.Configuration.Test
             var loadedSource = values.Single();
             Assert.Equal("Source", loadedSource.Name);
             Assert.Equal("https://some-source.test", loadedSource.Source);
-            AssertCredentials(loadedSource.Credentials, "Source", "source-user", "source-password");
             Assert.Equal(PackageSource.DefaultAllowInsecureConnections, loadedSource.AllowInsecureConnections);
         }
 
@@ -872,7 +871,6 @@ namespace NuGet.Configuration.Test
             var loadedSource = values.Single();
             Assert.Equal("Source", loadedSource.Name);
             Assert.Equal("https://some-source.test", loadedSource.Source);
-            AssertCredentials(loadedSource.Credentials, "Source", "source-user", "source-password");
             Assert.Equal(PackageSource.DefaultAllowInsecureConnections, loadedSource.AllowInsecureConnections);
         }
 
@@ -903,7 +901,6 @@ namespace NuGet.Configuration.Test
             var loadedSource = values.Single();
             Assert.Equal("Source", loadedSource.Name);
             Assert.Equal("https://some-source.test", loadedSource.Source);
-            AssertCredentials(loadedSource.Credentials, "Source", "source-user", "source-password");
             Assert.Equal(bool.Parse(allowInsecureConnections), loadedSource.AllowInsecureConnections);
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -822,6 +822,56 @@ namespace NuGet.Configuration.Test
                     });
         }
 
+        [Theory]
+        [InlineData(true, null, null)]
+        [InlineData(true, "3", null)]
+        [InlineData(true, "3", "false")]
+        [InlineData(true, "2", "true")]
+        [InlineData(false, null, "true")]
+        [InlineData(false, "", "true")]
+        public void LoadPackageSources_ReadsSourcesWithAllowInsecureConnectionsFromPackageSourceSections(bool useStaticMethod, string protocolVersion, string allowInsecureConnections)
+        {
+            // Arrange
+            var settings = new Mock<ISettings>();
+            var sourceItem = new SourceItem("Source", "https://some-source.test", protocolVersion, allowInsecureConnections);
+
+            settings.Setup(s => s.GetSection("packageSources"))
+                .Returns(new VirtualSettingSection("packageSources",
+                    sourceItem));
+
+            settings
+                .Setup(s => s.GetSection("packageSourceCredentials"))
+                .Returns(new VirtualSettingSection("packageSourceCredentials",
+                    new CredentialsItem("Source", "source-user", "source-password", isPasswordClearText: true, validAuthenticationTypes: null)));
+
+            settings.Setup(s => s.GetConfigFilePaths())
+                .Returns(new List<string>());
+            // Act
+            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+
+            // Assert
+            var loadedSource = values.Single();
+            Assert.Equal("Source", loadedSource.Name);
+            Assert.Equal("https://some-source.test", loadedSource.Source);
+            AssertCredentials(loadedSource.Credentials, "Source", "source-user", "source-password");
+            if (string.IsNullOrEmpty(protocolVersion))
+            {
+                Assert.Equal(PackageSource.DefaultProtocolVersion, loadedSource.ProtocolVersion);
+            }
+            else
+            {
+                Assert.Equal(int.Parse(protocolVersion), loadedSource.ProtocolVersion);
+            }
+            if (string.IsNullOrEmpty(allowInsecureConnections))
+            {
+                Assert.Equal(PackageSource.DefaultAllowInsecureConnections, loadedSource.AllowInsecureConnections);
+            }
+            else
+            {
+                Assert.Equal(bool.Parse(allowInsecureConnections), loadedSource.AllowInsecureConnections);
+            }
+        }
+
         [Fact]
         public void DisablePackageSourceAddEntryToSettings()
         {

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -835,13 +835,9 @@ namespace NuGet.Configuration.Test
                 .Returns(new VirtualSettingSection("packageSources",
                     sourceItem));
 
-            settings
-                .Setup(s => s.GetSection("packageSourceCredentials"))
-                .Returns(new VirtualSettingSection("packageSourceCredentials",
-                    new CredentialsItem("Source", "source-user", "source-password", isPasswordClearText: true, validAuthenticationTypes: null)));
-
             settings.Setup(s => s.GetConfigFilePaths())
                 .Returns(new List<string>());
+
             // Act
             List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
 
@@ -856,23 +852,19 @@ namespace NuGet.Configuration.Test
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void LoadPackageSources_ReadsSourcesWithRandomAllowInsecureConnectionsFromPackageSourceSections_LoadsDefault(bool useStaticMethod)
+        public void LoadPackageSources_ReadsSourcesWithInvalidAllowInsecureConnectionsFromPackageSourceSections_LoadsDefault(bool useStaticMethod)
         {
             // Arrange
             var settings = new Mock<ISettings>();
-            var sourceItem = new SourceItem("Source", "https://some-source.test", protocolVersion: null, allowInsecureConnections: "randomString");
+            var sourceItem = new SourceItem("Source", "https://some-source.test", protocolVersion: null, allowInsecureConnections: "invalidString");
 
             settings.Setup(s => s.GetSection("packageSources"))
                 .Returns(new VirtualSettingSection("packageSources",
                     sourceItem));
 
-            settings
-                .Setup(s => s.GetSection("packageSourceCredentials"))
-                .Returns(new VirtualSettingSection("packageSourceCredentials",
-                    new CredentialsItem("Source", "source-user", "source-password", isPasswordClearText: true, validAuthenticationTypes: null)));
-
             settings.Setup(s => s.GetConfigFilePaths())
                 .Returns(new List<string>());
+
             // Act
             List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
 
@@ -901,13 +893,9 @@ namespace NuGet.Configuration.Test
                 .Returns(new VirtualSettingSection("packageSources",
                     sourceItem));
 
-            settings
-                .Setup(s => s.GetSection("packageSourceCredentials"))
-                .Returns(new VirtualSettingSection("packageSourceCredentials",
-                    new CredentialsItem("Source", "source-user", "source-password", isPasswordClearText: true, validAuthenticationTypes: null)));
-
             settings.Setup(s => s.GetConfigFilePaths())
                 .Returns(new List<string>());
+
             // Act
             List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
@@ -17,7 +17,8 @@ namespace NuGet.Configuration.Test
             var source = new PackageSource("Source", "SourceName", isEnabled: false)
             {
                 Credentials = credentials,
-                ProtocolVersion = 43
+                ProtocolVersion = 43,
+                AllowInsecureConnections = true
             };
 
             // Act
@@ -30,6 +31,7 @@ namespace NuGet.Configuration.Test
             Assert.Equal(source.Name, result.Name);
             Assert.Equal(source.IsEnabled, result.IsEnabled);
             Assert.Equal(source.ProtocolVersion, result.ProtocolVersion);
+            Assert.Equal(source.AllowInsecureConnections, result.AllowInsecureConnections);
 
             // source credential
             result.Credentials.Should().NotBeNull();
@@ -43,12 +45,14 @@ namespace NuGet.Configuration.Test
         {
             var source = new PackageSource("Source", "SourceName", isEnabled: false)
             {
-                ProtocolVersion = 43
+                ProtocolVersion = 43,
+                AllowInsecureConnections = true
             };
+            var result = source.AsSourceItem();
 
-            var expectedItem = new SourceItem("SourceName", "Source", "43");
+            var expectedItem = new SourceItem("SourceName", "Source", "43", "True");
 
-            SettingsTestUtils.DeepEquals(source.AsSourceItem(), expectedItem).Should().BeTrue();
+            SettingsTestUtils.DeepEquals(result, expectedItem).Should().BeTrue();
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
@@ -54,14 +54,20 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSources>
         <add key='nugetorg' value='http://serviceIndexorg.test/api/index.json' />
-        <add key='nuget2' value='http://serviceIndex.test/api/index.json' protocolVersion='3' />
+        <add key='nuget2' value='http://serviceIndex.test2/api/index.json' protocolVersion='3' />
+        <add key='nuget3' value='http://serviceIndex.test3/api/index.json' protocolVersion='3' allowInsecureConnections='true' />
+        <add key='nuget4' value='http://serviceIndex.test4/api/index.json' allowInsecureConnections='true' />
+        <add key='nuget5' value='http://serviceIndex.test5/api/index.json' allowInsecureConnections='false' protocolVersion='2' />
     </packageSources>
 </configuration>";
 
             var expectedValues = new List<SourceItem>()
             {
                 new SourceItem("nugetorg","http://serviceIndexorg.test/api/index.json"),
-                new SourceItem("nuget2","http://serviceIndex.test/api/index.json", "3" ),
+                new SourceItem("nuget2","http://serviceIndex.test2/api/index.json", "3" ),
+                new SourceItem("nuget3","http://serviceIndex.test3/api/index.json", protocolVersion: "3", allowInsecureConnections: "true" ),
+                new SourceItem("nuget4","http://serviceIndex.test4/api/index.json", allowInsecureConnections: "true"  ),
+                new SourceItem("nuget5","http://serviceIndex.test5/api/index.json", protocolVersion: "2", allowInsecureConnections: "false"),
             };
 
             var nugetConfigPath = "NuGet.Config";
@@ -76,14 +82,18 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("packageSources");
                 section.Should().NotBeNull();
 
-                var children = section.Items.ToList();
+                var children = section.Items.Select(c => c as SourceItem).ToList();
 
                 children.Should().NotBeEmpty();
-                children.Count.Should().Be(2);
+                children.Count.Should().Be(5);
 
                 for (var i = 0; i < children.Count; i++)
                 {
                     SettingsTestUtils.DeepEquals(children[i], expectedValues[i]).Should().BeTrue();
+                    children[i].Key.Should().Be(expectedValues[i].Key, because: $"SourceItem[{i}].Key is {children[i].Key}, but it's expected to be {expectedValues[i].Key}");
+                    children[i].Value.Should().Be(expectedValues[i].Value, because: $"SourceItem[{i}].Value is {children[i].Value}, but it's expected to be {expectedValues[i].Value}");
+                    children[i].ProtocolVersion.Should().Be(expectedValues[i].ProtocolVersion, because: $"SourceItem[{i}].ProtocolVersion is {children[i].ProtocolVersion}, but it's expected to be {expectedValues[i].ProtocolVersion}");
+                    children[i].AllowInsecureConnections.Should().Be(expectedValues[i].AllowInsecureConnections, because: $"SourceItem[{i}].AllowInsecureConnections is {children[i].AllowInsecureConnections}, but it's expected to be {expectedValues[i].AllowInsecureConnections}");
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Xml.Linq;
 using FluentAssertions;
 using NuGet.Test.Utility;
 using Xunit;
@@ -96,6 +97,42 @@ namespace NuGet.Configuration.Test
                     children[i].AllowInsecureConnections.Should().Be(expectedValues[i].AllowInsecureConnections, because: $"SourceItem[{i}].AllowInsecureConnections is {children[i].AllowInsecureConnections}, but it's expected to be {expectedValues[i].AllowInsecureConnections}");
                 }
             }
+        }
+
+        [Fact]
+        public void SourceItem_AsXNode_ReturnsExpectedXNode()
+        {
+            var configuration = new NuGetConfiguration(
+                new VirtualSettingSection("packageSources",
+                    new SourceItem("nuget1", "http://serviceIndex.test1/api/index.json", protocolVersion: "3", allowInsecureConnections: "true"),
+                    new SourceItem("nuget2", "http://serviceIndex.test2/api/index.json", protocolVersion: "2", allowInsecureConnections: "false"),
+                    new SourceItem("nuget3", "http://serviceIndex.test3/api/index.json", allowInsecureConnections: "true"),
+                    new SourceItem("nuget4", "http://serviceIndex.test4/api/index.json", protocolVersion: "3")));
+
+            var expectedXNode = new XElement("configuration",
+                new XElement("packageSources",
+                    new XElement("add",
+                        new XAttribute("key", "nuget1"),
+                        new XAttribute("value", "http://serviceIndex.test1/api/index.json"),
+                        new XAttribute("protocolVersion", "3"),
+                        new XAttribute("allowInsecureConnections", "true")),
+                    new XElement("add",
+                        new XAttribute("key", "nuget2"),
+                        new XAttribute("value", "http://serviceIndex.test2/api/index.json"),
+                        new XAttribute("protocolVersion", "2"),
+                        new XAttribute("allowInsecureConnections", "false")),
+                    new XElement("add",
+                        new XAttribute("key", "nuget3"),
+                        new XAttribute("value", "http://serviceIndex.test3/api/index.json"),
+                        new XAttribute("allowInsecureConnections", "true")),
+                    new XElement("add",
+                        new XAttribute("key", "nuget4"),
+                        new XAttribute("value", "http://serviceIndex.test4/api/index.json"),
+                        new XAttribute("protocolVersion", "3"))));
+
+            var xNode = configuration.AsXNode();
+
+            XNode.DeepEquals(xNode, expectedXNode).Should().BeTrue();
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
@@ -67,7 +67,7 @@ namespace NuGet.Configuration.Test
                 new SourceItem("nugetorg","http://serviceIndexorg.test/api/index.json"),
                 new SourceItem("nuget2","http://serviceIndex.test2/api/index.json", "3" ),
                 new SourceItem("nuget3","http://serviceIndex.test3/api/index.json", protocolVersion: "3", allowInsecureConnections: "true" ),
-                new SourceItem("nuget4","http://serviceIndex.test4/api/index.json", allowInsecureConnections: "true"  ),
+                new SourceItem("nuget4","http://serviceIndex.test4/api/index.json", protocolVersion: null, allowInsecureConnections: "true"  ),
                 new SourceItem("nuget5","http://serviceIndex.test5/api/index.json", protocolVersion: "2", allowInsecureConnections: "false"),
             };
 
@@ -83,7 +83,7 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("packageSources");
                 section.Should().NotBeNull();
 
-                var children = section.Items.Select(c => c as SourceItem).ToList();
+                var children = section.Items.Cast<SourceItem>().ToList();
 
                 children.Should().NotBeEmpty();
                 children.Count.Should().Be(5);
@@ -106,8 +106,9 @@ namespace NuGet.Configuration.Test
                 new VirtualSettingSection("packageSources",
                     new SourceItem("nuget1", "http://serviceIndex.test1/api/index.json", protocolVersion: "3", allowInsecureConnections: "true"),
                     new SourceItem("nuget2", "http://serviceIndex.test2/api/index.json", protocolVersion: "2", allowInsecureConnections: "false"),
-                    new SourceItem("nuget3", "http://serviceIndex.test3/api/index.json", allowInsecureConnections: "true"),
+                    new SourceItem("nuget3", "http://serviceIndex.test3/api/index.json", protocolVersion: null, allowInsecureConnections: "true"),
                     new SourceItem("nuget4", "http://serviceIndex.test4/api/index.json", protocolVersion: "3")));
+            var resultXml = SettingsTestUtils.RemoveWhitespace(configuration.AsXNode().ToString());
 
             var expectedXNode = new XElement("configuration",
                 new XElement("packageSources",
@@ -129,10 +130,9 @@ namespace NuGet.Configuration.Test
                         new XAttribute("key", "nuget4"),
                         new XAttribute("value", "http://serviceIndex.test4/api/index.json"),
                         new XAttribute("protocolVersion", "3"))));
+            var expectedXml = SettingsTestUtils.RemoveWhitespace(expectedXNode.ToString());
 
-            var xNode = configuration.AsXNode();
-
-            XNode.DeepEquals(xNode, expectedXNode).Should().BeTrue();
+            resultXml.Should().Be(expectedXml, because: resultXml);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
@@ -55,7 +55,7 @@ namespace NuGet.Configuration.Test
     <packageSources>
         <add key='nugetorg' value='http://serviceIndexorg.test/api/index.json' />
         <add key='nuget2' value='http://serviceIndex.test2/api/index.json' protocolVersion='3' />
-        <add key='nuget3' value='http://serviceIndex.test3/api/index.json' protocolVersion='3' allowInsecureConnections='true' />
+        <add key='nuget3' value='http://serviceIndex.test3/api/index.json' protocolVersion='3' ALLOWInsecureConnections='true' />
         <add key='nuget4' value='http://serviceIndex.test4/api/index.json' allowInsecureConnections='true' />
         <add key='nuget5' value='http://serviceIndex.test5/api/index.json' allowInsecureConnections='false' protocolVersion='2' />
     </packageSources>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes: https://github.com/NuGet/Home/issues/12786

Regression? No.

## Description
Add an `allowInsecureConnections` property into `packageSources` section in NuGet.Config files, as below:
```
<!-- Allows insecure connections on a specific http source -->
<packageSources>
    <add key="Contoso" value="http://contoso.com/packages/" allowInsecureConnections="true" />
</packageSources>
```
The default value will be false.
Spec: https://github.com/NuGet/Home/blob/dev/proposed/2023/InsecureConnectionsDisableCertificateValidation.md#package-source-nuget-config

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled  Tracking issue: https://github.com/NuGet/docs.microsoft.com-nuget/issues/3116
  - **OR**
  - [ ] N/A
