### PR TITLE
Update diagnostics in NuGet.CommandLine.Test.NuGetClientCertCommandTests to log more information

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetClientCertCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetClientCertCommandTests.cs
@@ -11,16 +11,24 @@ using System.Security.Cryptography.X509Certificates;
 using NuGet.Configuration;
 using NuGet.Test.Utility;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.CommandLine.Test
 {
     public class NuGetClientCertCommandTests
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public NuGetClientCertCommandTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
         [Fact]
         public void ClientCertAddCommand_Fail_CertificateSourceCombinationSpecified()
         {
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 var args = new[]
                 {
@@ -52,7 +60,7 @@ namespace NuGet.CommandLine.Test
         public void ClientCertAddCommand_Fail_CertificateSourceNotSpecified()
         {
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 var args = new[]
                 {
@@ -80,7 +88,7 @@ namespace NuGet.CommandLine.Test
         public void ClientCertAddCommand_Fail_FileCertificateNotExist()
         {
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 var args = new[]
                 {
@@ -110,7 +118,7 @@ namespace NuGet.CommandLine.Test
         public void ClientCertAddCommand_Fail_NoSourceSpecified()
         {
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 var args = new[] { "client-certs", "add" };
 
@@ -130,7 +138,7 @@ namespace NuGet.CommandLine.Test
         public void ClientCertAddCommand_Fail_StoreCertificateNotExist()
         {
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 var args = new[]
                 {
@@ -160,7 +168,7 @@ namespace NuGet.CommandLine.Test
         public void ClientCertAddCommand_Success_FileCertificateAbsolute()
         {
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 testInfo.SetupCertificateFile();
 
@@ -194,7 +202,7 @@ namespace NuGet.CommandLine.Test
         public void ClientCertAddCommand_Success_FileCertificateNotExistForce()
         {
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 var packageSource = testInfo.PackageSourceName;
                 var path = "MyCertificate.pfx";
@@ -227,7 +235,7 @@ namespace NuGet.CommandLine.Test
         public void ClientCertAddCommand_Success_FileCertificateRelative()
         {
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 testInfo.SetupCertificateFile();
 
@@ -261,7 +269,7 @@ namespace NuGet.CommandLine.Test
         public void ClientCertAddCommand_Success_StoreCertificate()
         {
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 testInfo.SetupCertificateInStorage();
 
@@ -299,7 +307,7 @@ namespace NuGet.CommandLine.Test
         public void ClientCertAddCommand_Success_StoreCertificateNotExistForce()
         {
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 var args = new[]
                 {
@@ -336,7 +344,7 @@ namespace NuGet.CommandLine.Test
         public void ClientCertDefaultCommand_Success_NotEmpty()
         {
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 var args = new[]
                 {
@@ -354,7 +362,7 @@ namespace NuGet.CommandLine.Test
         public void ClientCertListCommand_Success_EmptyList()
         {
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 var args = new[]
                 {
@@ -373,7 +381,7 @@ namespace NuGet.CommandLine.Test
         public void ClientCertListCommand_Success_NotEmptyList()
         {
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 testInfo.SetupInitialItems(new FileClientCertItem(testInfo.PackageSourceName,
                                                                   testInfo.CertificateRelativeFilePath,
@@ -398,7 +406,7 @@ namespace NuGet.CommandLine.Test
         public void ClientCertRemoveCommand_Failed_NotExist()
         {
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 var args = new[]
                 {
@@ -421,7 +429,7 @@ namespace NuGet.CommandLine.Test
         public void ClientCertRemoveCommand_Success_ItemCertificate()
         {
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 testInfo.SetupInitialItems(new FileClientCertItem(testInfo.PackageSourceName,
                                                                   testInfo.CertificateAbsoluteFilePath,
@@ -450,7 +458,7 @@ namespace NuGet.CommandLine.Test
         public void ClientCertUpdateCommand_Fail_CertificateSourceCombinationSpecified()
         {
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 var args = new[]
                 {
@@ -482,7 +490,7 @@ namespace NuGet.CommandLine.Test
         public void ClientCertUpdateCommand_Fail_CertificateSourceNotFound()
         {
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 var args = new[]
                 {
@@ -514,7 +522,7 @@ namespace NuGet.CommandLine.Test
         public void ClientCertUpdateCommand_Fail_CertificateSourceNotSpecified()
         {
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 var args = new[]
                 {
@@ -545,7 +553,7 @@ namespace NuGet.CommandLine.Test
             var updatedPassword = "42";
 
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 testInfo.SetupInitialItems(new FileClientCertItem(testInfo.PackageSourceName,
                                                                   testInfo.CertificateAbsoluteFilePath,
@@ -588,7 +596,7 @@ namespace NuGet.CommandLine.Test
             var updatedFindValue = "SOMEUpdated";
 
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 testInfo.SetupInitialItems(new StoreClientCertItem(testInfo.PackageSourceName,
                                                                    testInfo.CertificateFindValue.ToString(),
@@ -633,7 +641,7 @@ namespace NuGet.CommandLine.Test
             var updatedPassword = "42";
 
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 testInfo.SetupInitialItems(new FileClientCertItem(testInfo.PackageSourceName,
                                                                   testInfo.CertificateAbsoluteFilePath,
@@ -674,7 +682,7 @@ namespace NuGet.CommandLine.Test
             var updatedPassword = "42";
 
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 var args = new[]
                 {
@@ -711,7 +719,7 @@ namespace NuGet.CommandLine.Test
             var updatedFindValue = "SOMEUpdated";
 
             // Arrange
-            using (var testInfo = new TestInfo())
+            using (var testInfo = new TestInfo(_testOutputHelper))
             {
                 testInfo.SetupInitialItems(new StoreClientCertItem(testInfo.PackageSourceName,
                                                                    testInfo.CertificateFindValue.ToString(),
@@ -751,6 +759,8 @@ namespace NuGet.CommandLine.Test
 
         private sealed class TestInfo : IDisposable
         {
+            private readonly ITestOutputHelper _testOutputHelper;
+
             private static CollectionCompareResult<TFirst, TSecond> Compare<TFirst, TSecond>(IEnumerable<TFirst> first, IEnumerable<TSecond> second)
             {
                 return Compare(first, second, null, null);
@@ -774,14 +784,16 @@ namespace NuGet.CommandLine.Test
                 };
             }
 
-            public TestInfo()
+            public TestInfo(ITestOutputHelper testOutputHelper)
             {
+                _testOutputHelper = testOutputHelper;
+
                 NuGetExePath = Util.GetNuGetExePath();
                 WorkingPath = TestDirectory.Create();
                 ConfigFile = Path.Combine(WorkingPath, "NuGet.config");
-                PackageSourceName = "Contoso";
+                PackageSourceName = $"Contoso-{Guid.NewGuid():N}";
                 InvalidPackageSourceName = "Bar";
-                CertificateFileName = "contoso.pfx";
+                CertificateFileName = PackageSourceName + ".pfx";
                 CertificateAbsoluteFilePath = Path.Combine(WorkingPath, CertificateFileName);
                 CertificateRelativeFilePath = ".\\" + CertificateFileName;
                 CertificatePassword = "password";
@@ -789,7 +801,7 @@ namespace NuGet.CommandLine.Test
                 CertificateStoreLocation = StoreLocation.CurrentUser;
                 CertificateStoreName = StoreName.My;
                 CertificateFindBy = X509FindType.FindByIssuerName;
-                CertificateFindValue = $"Contoso-{Guid.NewGuid():N})";
+                CertificateFindValue = PackageSourceName;
 
                 Util.CreateFile(Path.GetDirectoryName(ConfigFile),
                                 Path.GetFileName(ConfigFile),
@@ -820,19 +832,29 @@ namespace NuGet.CommandLine.Test
 
             public void RunNuGetExpectSuccess(string[] args, string expectedOutput = null)
             {
+                string arguments = string.Join(" ", args.Select(i => i.StartsWith("-") ? i : $"\"{i}\""));
+
+                _testOutputHelper.WriteLine("Running command {0} {1}", NuGetExePath, arguments);
+
                 CommandRunnerResult result = CommandRunner.Run(
                     NuGetExePath,
                     WorkingPath,
-                    string.Join(" ", args.Select(i => i.StartsWith("-") ? i : $"\"{i}\"")));
+                    arguments);
 
-                string extraDebugInfo = null;
+                _testOutputHelper.WriteLine("Exit code: {0}", result.ExitCode);
 
                 if (!result.Success)
                 {
-                    extraDebugInfo = $"{Environment.NewLine}Installed certificates:{Environment.NewLine}{string.Join(Environment.NewLine, EnumerateCurrentlyInstalledCertificates().Select(i => i.ToString()))}";
+                    _testOutputHelper.WriteLine("Output:");
+                    _testOutputHelper.WriteLine(result.Output);
+                    _testOutputHelper.WriteLine("Errors:");
+                    _testOutputHelper.WriteLine(result.Errors);
                 }
 
-                Util.VerifyResultSuccess(result, expectedOutput, extraDebugInfo);
+                LogInstalledCertificates();
+
+
+                Util.VerifyResultSuccess(result, expectedOutput);
             }
 
             public void Dispose()
@@ -845,6 +867,8 @@ namespace NuGet.CommandLine.Test
             {
                 var certificateData = CreateCertificate();
                 File.WriteAllBytes(CertificateAbsoluteFilePath, certificateData);
+
+                _testOutputHelper.WriteLine("Wrote certificate to file {0}", CertificateAbsoluteFilePath);
             }
 
             public void SetupCertificateInStorage()
@@ -858,8 +882,13 @@ namespace NuGet.CommandLine.Test
                         password.AppendChar(symbol);
                     }
 
-                    store.Add(new X509Certificate2(CreateCertificate(), password, X509KeyStorageFlags.Exportable));
+                    var cert = new X509Certificate2(CreateCertificate(), password, X509KeyStorageFlags.Exportable);
+                    store.Add(cert);
+
+                    _testOutputHelper.WriteLine("Added certificate {0} to store {1}\\{2}", cert.Subject, CertificateStoreLocation, CertificateStoreName);
                 }
+
+                LogInstalledCertificates();
             }
 
             public void SetupInitialItems(params ClientCertItem[] initialItems)
@@ -909,15 +938,16 @@ namespace NuGet.CommandLine.Test
                 }
             }
 
-            private IEnumerable<X509Certificate2> EnumerateCurrentlyInstalledCertificates()
+            private void LogInstalledCertificates()
             {
+                _testOutputHelper.WriteLine("Installed Certificates:");
                 using (var store = new X509Store(CertificateStoreName, CertificateStoreLocation))
                 {
                     store.Open(OpenFlags.ReadOnly);
 
                     foreach (X509Certificate2 cert in store.Certificates)
                     {
-                        yield return cert;
+                        _testOutputHelper.WriteLine("  {0}", cert.Subject);
                     }
                 }
             }
@@ -930,6 +960,9 @@ namespace NuGet.CommandLine.Test
                 var end = start.AddYears(1);
 
                 var cert = request.CreateSelfSigned(start, end);
+
+                _testOutputHelper.WriteLine("Created certificate {0}", request.SubjectName.Name);
+
                 return cert.Export(X509ContentType.Pfx, CertificatePassword);
             }
 
@@ -942,14 +975,23 @@ namespace NuGet.CommandLine.Test
 
             private void RemoveCertificateFromStorage()
             {
+                bool certificateRemoved = false;
+
                 using (var store = new X509Store(CertificateStoreName, CertificateStoreLocation))
                 {
                     store.Open(OpenFlags.ReadWrite);
                     var resultCertificates = store.Certificates.Find(CertificateFindBy, CertificateFindValue, false);
                     foreach (var certificate in resultCertificates)
                     {
+                        _testOutputHelper.WriteLine("Removing certificate {0} from store {1}\\{2}", certificate.Subject, CertificateStoreLocation, CertificateStoreName);
                         store.Remove(certificate);
+
+                        certificateRemoved = true;
                     }
+                }
+                if (certificateRemoved)
+                {
+                    LogInstalledCertificates();
                 }
             }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2382

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
My [previous PR](https://github.com/NuGet/NuGet.Client/pull/5298) added some diagnostics to the `NuGet.CommandLine.Test.NuGetClientCertCommandTests` tests but I'm still seeing failures and the extra info isn't helping me determine the problem.

```
Expected if (!string.IsNullOrEmpty(expectedOutputMessage)){result.Output to be 0 because nuget.exe should have succeeded with exit code 0 but returned exit code 1
Output:

Errors:
Certificate for the package source 'Contoso' was not found in 'CurrentUser.My' storage by 'IssuerName' criteria with 'Contoso-0044834630c44db09d4098d0458569e8)' value.

Installed certificates:
[Subject]
  CN=localhost

[Issuer]
  CN=localhost

[Serial Number]
  7BBADB00283BE963

[Not Before]
  7/29/2023 2:23:28 PM

[Not After]
  7/29/2024 2:23:28 PM

[Thumbprint]
  F18969BB5409B0162618474D0ED8E27E2A1ECD6E

[Subject]
  CN=1es-hostedpools.default.microsoft.com

[Issuer]
  CN=AME Infra CA 05, DC=AME, DC=GBL

[Serial Number]
  7C0395FAD102482FABBA3C80A900000395FAD1

[Not Before]
  7/12/2023 1:23:04 AM

[Not After]
  10/10/2023 1:23:04 AM

[Thumbprint]
  CC3F39E13DC221269325A0BDF0414C4AF6CE7781
```

This change uses xunit's TestOutputHelper to log more information as the test is running and hopefully tell me what's going on.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
