### PR TITLE
Add .vdproj to the exclusion list

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -378,6 +378,7 @@ Copyright (c) .NET Foundation. All rights reserved.
        Condition=" '%(RestoreGraphProjectInputItems.Extension)' != '.metaproj'
                    AND '%(RestoreGraphProjectInputItems.Extension)' != '.shproj'
                    AND '%(RestoreGraphProjectInputItems.Extension)' != '.vcxitems'
+                   AND '%(RestoreGraphProjectInputItems.Extension)' != '.vdproj'
                    AND '%(RestoreGraphProjectInputItems.Extension)' != '' " />
     </ItemGroup>
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes: https://github.com/NuGet/Home/issues/7796

## Description
The projects with .vdproj extension are legacy installer projects which are not MSBuild-compatible, and yet they are supported even by the latest Visual Studio 2022. Running "nuget restore" on solutions containing such projects fails, unless "inclusionlist" mode is chosen. However "inclusionlist" option prevents certain other projects (e.g. .wixproj) from being restored. The .vdproj projects always have to be excluded from restore.


## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Test exception

- **Documentation**
  - [X] N/A
