### PR TITLE
Display requested version when CPM enabled in dotnet list package

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/InstalledPackageReference.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/InstalledPackageReference.cs
@@ -22,6 +22,7 @@ namespace NuGet.CommandLine.XPlat
         internal IPackageSearchMetadata LatestPackageMetadata { get; set; }
         internal bool AutoReference { get; set; }
         internal UpdateLevel UpdateLevel { get; set; }
+        internal bool IsVersionOverride { get; set; }
 
         /// <summary>
         /// A constructor that takes a name of a package

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -115,7 +115,7 @@ namespace NuGet.CommandLine.XPlat
                     List<FrameworkPackages> frameworks;
                     try
                     {
-                        frameworks = msBuild.GetResolvedVersions(project, listPackageArgs.Frameworks, assetsFile, listPackageArgs.IncludeTransitive, includeProjects: listPackageArgs.ReportType == ReportType.Default);
+                        frameworks = msBuild.GetResolvedVersions(project, listPackageArgs.Frameworks, assetsFile, listPackageArgs.IncludeTransitive);
                     }
                     catch (InvalidOperationException ex)
                     {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -115,7 +115,7 @@ namespace NuGet.CommandLine.XPlat
                     List<FrameworkPackages> frameworks;
                     try
                     {
-                        frameworks = msBuild.GetResolvedVersions(project.FullPath, listPackageArgs.Frameworks, assetsFile, listPackageArgs.IncludeTransitive);
+                        frameworks = msBuild.GetResolvedVersions(project, listPackageArgs.Frameworks, assetsFile, listPackageArgs.IncludeTransitive, includeProjects: listPackageArgs.ReportType == ReportType.Default);
                     }
                     catch (InvalidOperationException ex)
                     {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -750,8 +750,7 @@ namespace NuGet.CommandLine.XPlat
                         {
                             try
                             { // In case proj and assets file are not in sync and some refs were deleted
-                                var isPackageCentrallyManaged = tfmInformation.CentralPackageVersions.Any(cpv => cpv.Key.Equals(topLevelPackage.Name, StringComparison.Ordinal));
-                                if (isPackageCentrallyManaged)
+                                if (assetsFile.PackageSpec.RestoreMetadata.CentralPackageVersionsEnabled)
                                 {
                                     var packageCentralVersion = tfmInformation.CentralPackageVersions.Where(cpv => cpv.Key.Equals(topLevelPackage.Name, StringComparison.Ordinal)).First();
                                     installedPackage = new InstalledPackageReference(topLevelPackage.Name)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -750,7 +750,19 @@ namespace NuGet.CommandLine.XPlat
                         {
                             try
                             { // In case proj and assets file are not in sync and some refs were deleted
-                                installedPackage = projPackages.Where(p => p.Name.Equals(topLevelPackage.Name, StringComparison.Ordinal)).First();
+                                var isPackageCentrallyManaged = tfmInformation.CentralPackageVersions.Any(cpv => cpv.Key.Equals(topLevelPackage.Name, StringComparison.Ordinal));
+                                if (isPackageCentrallyManaged)
+                                {
+                                    var packageCentralVersion = tfmInformation.CentralPackageVersions.Where(cpv => cpv.Key.Equals(topLevelPackage.Name, StringComparison.Ordinal)).First();
+                                    installedPackage = new InstalledPackageReference(topLevelPackage.Name)
+                                    {
+                                        OriginalRequestedVersion = packageCentralVersion.Value.VersionRange.MinVersion.ToString(),
+                                    };
+                                }
+                                else
+                                {
+                                    installedPackage = projPackages.Where(p => p.Name.Equals(topLevelPackage.Name, StringComparison.Ordinal)).First();
+                                }
                             }
                             catch (Exception)
                             {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -756,13 +756,23 @@ namespace NuGet.CommandLine.XPlat
                                 // If the project is using CPM and it's not using VersionOverride, get the version from Directory.Package.props file
                                 if (assetsFile.PackageSpec.RestoreMetadata.CentralPackageVersionsEnabled && !projectPackage.IsVersionOverride)
                                 {
-                                    ProjectRootElement directoryBuildPropsRootElement = GetDirectoryBuildPropsRootElement(project);
-                                    ProjectItemElement packageInCPM = directoryBuildPropsRootElement.Items.Where(i => i.ItemType == PACKAGE_VERSION_TYPE_TAG && i.Include.Equals(topLevelPackage.Name, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
-
-                                    installedPackage = new InstalledPackageReference(topLevelPackage.Name)
+                                    if (topLevelPackage.VersionOverride?.OriginalString is not null)
                                     {
-                                        OriginalRequestedVersion = topLevelPackage.VersionOverride?.OriginalString ?? packageInCPM.Metadata.FirstOrDefault(i => i.Name.Equals("Version", StringComparison.OrdinalIgnoreCase)).Value,
-                                    };
+                                        installedPackage = new InstalledPackageReference(topLevelPackage.Name)
+                                        {
+                                            OriginalRequestedVersion = topLevelPackage.VersionOverride?.OriginalString,
+                                        };
+                                    }
+                                    else
+                                    {
+                                        ProjectRootElement directoryBuildPropsRootElement = GetDirectoryBuildPropsRootElement(project);
+                                        ProjectItemElement packageInCPM = directoryBuildPropsRootElement.Items.Where(i => (i.ItemType == PACKAGE_VERSION_TYPE_TAG || i.ItemType.Equals("GlobalPackageReference")) && i.Include.Equals(topLevelPackage.Name, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+
+                                        installedPackage = new InstalledPackageReference(topLevelPackage.Name)
+                                        {
+                                            OriginalRequestedVersion = packageInCPM.Metadata.FirstOrDefault(i => i.Name.Equals("Version", StringComparison.OrdinalIgnoreCase)).Value,
+                                        };
+                                    }
                                 }
                                 else
                                 {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -758,7 +758,7 @@ namespace NuGet.CommandLine.XPlat
                                         {
                                             installedPackage = new InstalledPackageReference(topLevelPackage.Name)
                                             {
-                                                OriginalRequestedVersion = packageCentralVersion.Value.VersionRange.MinVersion.ToString(),
+                                                OriginalRequestedVersion = topLevelPackage.VersionOverride?.MinVersion.ToString() ?? packageCentralVersion.Value.VersionRange.MinVersion.ToString(),
                                             };
                                             break;
                                         }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -648,14 +648,14 @@ namespace NuGet.CommandLine.XPlat
         /// Prepares the dictionary that maps frameworks to packages top-level
         /// and transitive.
         /// </summary>
-        /// <param name="project"> Project </param>
+        /// <param name="project">Project to get the resoled versions from</param>
         /// <param name="userInputFrameworks">A list of frameworks</param>
         /// <param name="assetsFile">Assets file for all targets and libraries</param>
         /// <param name="transitive">Include transitive packages/projects in the result</param>
         /// <returns>FrameworkPackages collection with top-level and transitive package/project
         /// references for each framework, or null on error</returns>
         internal List<FrameworkPackages> GetResolvedVersions(
-            Project project, IEnumerable<string> userInputFrameworks, LockFile assetsFile, bool transitive, bool includeProjects)
+            Project project, IEnumerable<string> userInputFrameworks, LockFile assetsFile, bool transitive)
         {
             if (userInputFrameworks == null)
             {
@@ -728,7 +728,7 @@ namespace NuGet.CommandLine.XPlat
 
                 //The packages for the framework that were retrieved with GetRequestedVersions
                 var frameworkDependencies = tfmInformation.Dependencies;
-                var projPackages = GetPackageReferencesFromTargets(projectPath, tfmInformation.ToString());
+                var projectPackages = GetPackageReferencesFromTargets(projectPath, tfmInformation.ToString());
                 var topLevelPackages = new List<InstalledPackageReference>();
                 var transitivePackages = new List<InstalledPackageReference>();
 
@@ -751,9 +751,9 @@ namespace NuGet.CommandLine.XPlat
                         {
                             try
                             { // In case proj and assets file are not in sync and some refs were deleted
-                                var projectPackage = projPackages.Where(p => p.Name.Equals(topLevelPackage.Name, StringComparison.Ordinal)).First();
+                                var projectPackage = projectPackages.Where(p => p.Name.Equals(topLevelPackage.Name, StringComparison.Ordinal)).First();
 
-                                // If the project is using CPM and its not using VersionOverride, get the version from Directory.Package.props file
+                                // If the project is using CPM and it's not using VersionOverride, get the version from Directory.Package.props file
                                 if (assetsFile.PackageSpec.RestoreMetadata.CentralPackageVersionsEnabled && !projectPackage.IsVersionOverride)
                                 {
                                     ProjectRootElement directoryBuildPropsRootElement = GetDirectoryBuildPropsRootElement(project);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -743,7 +743,7 @@ namespace NuGet.CommandLine.XPlat
                     if (matchingPackages.Any())
                     {
                         var topLevelPackage = matchingPackages.Single();
-                        InstalledPackageReference installedPackage;
+                        InstalledPackageReference installedPackage = default;
 
                         //If the package is not auto-referenced, get the version from the project file. Otherwise fall back on the assets file
                         if (!topLevelPackage.AutoReferenced)
@@ -752,11 +752,17 @@ namespace NuGet.CommandLine.XPlat
                             { // In case proj and assets file are not in sync and some refs were deleted
                                 if (assetsFile.PackageSpec.RestoreMetadata.CentralPackageVersionsEnabled)
                                 {
-                                    var packageCentralVersion = tfmInformation.CentralPackageVersions.Where(cpv => cpv.Key.Equals(topLevelPackage.Name, StringComparison.Ordinal)).First();
-                                    installedPackage = new InstalledPackageReference(topLevelPackage.Name)
+                                    foreach (KeyValuePair<string, CentralPackageVersion> packageCentralVersion in tfmInformation.CentralPackageVersions)
                                     {
-                                        OriginalRequestedVersion = packageCentralVersion.Value.VersionRange.MinVersion.ToString(),
-                                    };
+                                        if (packageCentralVersion.Key.Equals(topLevelPackage.Name, StringComparison.Ordinal))
+                                        {
+                                            installedPackage = new InstalledPackageReference(topLevelPackage.Name)
+                                            {
+                                                OriginalRequestedVersion = packageCentralVersion.Value.VersionRange.MinVersion.ToString(),
+                                            };
+                                            break;
+                                        }
+                                    }
                                 }
                                 else
                                 {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -756,23 +756,13 @@ namespace NuGet.CommandLine.XPlat
                                 // If the project is using CPM and it's not using VersionOverride, get the version from Directory.Package.props file
                                 if (assetsFile.PackageSpec.RestoreMetadata.CentralPackageVersionsEnabled && !projectPackage.IsVersionOverride)
                                 {
-                                    if (topLevelPackage.VersionOverride?.OriginalString is not null)
-                                    {
-                                        installedPackage = new InstalledPackageReference(topLevelPackage.Name)
-                                        {
-                                            OriginalRequestedVersion = topLevelPackage.VersionOverride?.OriginalString,
-                                        };
-                                    }
-                                    else
-                                    {
-                                        ProjectRootElement directoryBuildPropsRootElement = GetDirectoryBuildPropsRootElement(project);
-                                        ProjectItemElement packageInCPM = directoryBuildPropsRootElement.Items.Where(i => (i.ItemType == PACKAGE_VERSION_TYPE_TAG || i.ItemType.Equals("GlobalPackageReference")) && i.Include.Equals(topLevelPackage.Name, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                                    ProjectRootElement directoryBuildPropsRootElement = GetDirectoryBuildPropsRootElement(project);
+                                    ProjectItemElement packageInCPM = directoryBuildPropsRootElement.Items.Where(i => (i.ItemType == PACKAGE_VERSION_TYPE_TAG || i.ItemType.Equals("GlobalPackageReference")) && i.Include.Equals(topLevelPackage.Name, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
 
-                                        installedPackage = new InstalledPackageReference(topLevelPackage.Name)
-                                        {
-                                            OriginalRequestedVersion = packageInCPM.Metadata.FirstOrDefault(i => i.Name.Equals("Version", StringComparison.OrdinalIgnoreCase)).Value,
-                                        };
-                                    }
+                                    installedPackage = new InstalledPackageReference(topLevelPackage.Name)
+                                    {
+                                        OriginalRequestedVersion = packageInCPM.Metadata.FirstOrDefault(i => i.Name.Equals("Version", StringComparison.OrdinalIgnoreCase)).Value,
+                                    };
                                 }
                                 else
                                 {

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -165,8 +165,8 @@ namespace Dotnet.Integration.Test
                 CommandRunnerResult listResult = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName,
                     $"list {projectA.ProjectPath} package");
 
-                // Assert Requested version is 2.0.0, but was override by VersionOverride tag
-                Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, "2.0.0"));
+                // Assert Resolved version is 1.0.0 and Requested version is 1.0.0, since it was overridden by VersionOverride tag
+                Assert.False(ContainsIgnoringSpaces(listResult.AllOutput, "2.0.0"));
                 Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, "1.0.0"));
             }
         }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -88,7 +88,7 @@ namespace Dotnet.Integration.Test
         {
             using (var pathContext = _fixture.CreateSimpleTestPathContext())
             {
-                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net7.0");
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
 
                 var packageX = XPlatTestUtils.CreatePackage();
 
@@ -168,6 +168,56 @@ namespace Dotnet.Integration.Test
                 // Assert Requested version is 2.0.0, but was override by VersionOverride tag
                 Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, "2.0.0"));
                 Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, "1.0.0"));
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task DotnetListPackage_WithCPM_GlobalPackageReference()
+        {
+            using (var pathContext = _fixture.CreateSimpleTestPathContext())
+            {
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
+
+                var packageX = XPlatTestUtils.CreatePackage("X", "2.0.0", "net46");
+
+                // Generate Package
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var propsFile =
+@$"<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <GlobalPackageReference Include=""X"" Version=""1.0.0"" />
+    </ItemGroup>
+</Project>";
+
+                File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props"), propsFile);
+
+                string projectContent =
+@$"<Project  Sdk=""Microsoft.NET.Sdk"">
+<PropertyGroup>                   
+	<TargetFramework>net46</TargetFramework>
+	</PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include=""X""/>
+    </ItemGroup>
+</Project>";
+                File.WriteAllText(Path.Combine(pathContext.SolutionRoot, ProjectName, string.Concat(ProjectName, ".csproj")), projectContent);
+
+                _fixture.RunDotnetExpectSuccess(Path.Combine(pathContext.SolutionRoot, projectA.ProjectName),
+                    $"restore {projectA.ProjectName}.csproj");
+
+                CommandRunnerResult listResult = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName,
+                    $"list {projectA.ProjectPath} package");
+
+                // Assert Requested version is 1.0.0, but the resolved version is 2.0.0
+                Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, "1.0.0"));
+                Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, "2.0.0"));
             }
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -124,7 +124,7 @@ namespace Dotnet.Integration.Test
         {
             using (var pathContext = _fixture.CreateSimpleTestPathContext())
             {
-                var projectA = XPlatTestUtils.CreateProject("projectA", pathContext, "net7.0");
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net7.0");
 
                 var packageX = XPlatTestUtils.CreatePackage("X", "1.0.0", "net7.0");
                 var packageX2 = XPlatTestUtils.CreatePackage("X", "2.0.0", "net7.0");
@@ -157,7 +157,7 @@ namespace Dotnet.Integration.Test
         <PackageReference Include=""X"" VersionOverride=""1.0.0""/>
     </ItemGroup>
 </Project>";
-                File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "projectA", "projectA.csproj"), projectContent);
+                File.WriteAllText(Path.Combine(pathContext.SolutionRoot, ProjectName, string.Concat(ProjectName, ".csproj")), projectContent);
 
                 _fixture.RunDotnetExpectSuccess(Path.Combine(pathContext.SolutionRoot, projectA.ProjectName),
                     $"restore {projectA.ProjectName}.csproj");

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -84,56 +84,6 @@ namespace Dotnet.Integration.Test
         }
 
         [PlatformFact(Platform.Windows)]
-        public async Task DotnetListPackage_WithCPM()
-        {
-            using (var pathContext = _fixture.CreateSimpleTestPathContext())
-            {
-                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
-
-                var packageX = XPlatTestUtils.CreatePackage("X", "1.0.0");
-
-                // Generate Package
-                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    pathContext.PackageSource,
-                    PackageSaveMode.Defaultv3,
-                    packageX);
-
-                var propsFile =
-@$"<Project>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageVersion Include=""X"" Version=""0.1.0"" />
-    </ItemGroup>
-</Project>";
-
-                File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props"), propsFile);
-
-                string projectContent =
-@$"<Project  Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>                   
-	<TargetFramework>net46</TargetFramework>
-	</PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include=""X""/>
-    </ItemGroup>
-</Project>";
-                File.WriteAllText(Path.Combine(pathContext.SolutionRoot, ProjectName, string.Concat(ProjectName, ".csproj")), projectContent);
-
-                _fixture.RunDotnetExpectSuccess(Path.Combine(pathContext.SolutionRoot, projectA.ProjectName),
-                    $"restore {projectA.ProjectName}.csproj");
-
-                CommandRunnerResult listResult = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName,
-                    $"list {projectA.ProjectPath} package");
-
-                // Assert Requested version is 0.1.0, but 1.0.0 was resolved
-                Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, "0.1.0"));
-                Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, "1.0.0"));
-            }
-        }
-
-        [PlatformFact(Platform.Windows)]
         public async Task DotnetListPackage_VersionRanges_WithCPM()
         {
             using (var pathContext = _fixture.CreateSimpleTestPathContext())
@@ -184,7 +134,7 @@ namespace Dotnet.Integration.Test
         }
 
         [PlatformFact(Platform.Windows)]
-        public async Task DotnetListPackage_WithCPM_WithOverrideVersion()
+        public async Task DotnetListPackage_WithCPM_WithVersionOverride()
         {
             using (var pathContext = _fixture.CreateSimpleTestPathContext())
             {

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -90,7 +90,7 @@ namespace Dotnet.Integration.Test
             {
                 var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
 
-                var packageX = XPlatTestUtils.CreatePackage("X", "1.0.0", "net46");
+                var packageX = XPlatTestUtils.CreatePackage("X", "1.0.0");
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(
@@ -126,7 +126,7 @@ namespace Dotnet.Integration.Test
             {
                 var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
 
-                var packageX = XPlatTestUtils.CreatePackage("X", "1.0.0", "net46");
+                var packageX = XPlatTestUtils.CreatePackage("X", "1.0.0");
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -273,8 +273,11 @@ namespace Dotnet.Integration.Test
 </Project>";
                 File.WriteAllText(Path.Combine(pathContext.SolutionRoot, ProjectName, string.Concat(ProjectName, ".csproj")), projectContent);
 
-                _fixture.RunDotnetExpectSuccess(Path.Combine(pathContext.SolutionRoot, projectA.ProjectName),
-                    $"restore {projectA.ProjectName}.csproj");
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, ProjectName);
+                var projectFilePath = Path.Combine(projectDirectory, $"{ProjectName}.csproj");
+
+                _fixture.RunDotnetExpectSuccess(projectDirectory,
+                    $"restore {projectFilePath}");
 
                 CommandRunnerResult listResult = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName,
                     $"list {projectA.ProjectPath} package");

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -98,17 +98,31 @@ namespace Dotnet.Integration.Test
                     PackageSaveMode.Defaultv3,
                     packageX);
 
-                var propsFile = @$"<Project>
-                                <PropertyGroup>
-                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                </PropertyGroup>
-                            </Project>
-                            ";
+                var propsFile =
+@$"<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include=""X"" Version=""0.1.0"" />
+    </ItemGroup>
+</Project>";
 
                 File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props"), propsFile);
 
+                string projectContent =
+@$"<Project  Sdk=""Microsoft.NET.Sdk"">
+<PropertyGroup>                   
+	<TargetFramework>net46</TargetFramework>
+	</PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include=""X""/>
+    </ItemGroup>
+</Project>";
+                File.WriteAllText(Path.Combine(pathContext.SolutionRoot, ProjectName, string.Concat(ProjectName, ".csproj")), projectContent);
+
                 _fixture.RunDotnetExpectSuccess(Path.Combine(pathContext.SolutionRoot, projectA.ProjectName),
-                    $"add {projectA.ProjectPath} package packageX -v 0.1.0");
+                    $"restore {projectA.ProjectName}.csproj");
 
                 CommandRunnerResult listResult = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName,
                     $"list {projectA.ProjectPath} package");
@@ -124,7 +138,7 @@ namespace Dotnet.Integration.Test
         {
             using (var pathContext = _fixture.CreateSimpleTestPathContext())
             {
-                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net7.0");
 
                 var packageX = XPlatTestUtils.CreatePackage("X", "1.0.0");
 
@@ -134,17 +148,31 @@ namespace Dotnet.Integration.Test
                     PackageSaveMode.Defaultv3,
                     packageX);
 
-                var propsFile = @$"<Project>
-                                <PropertyGroup>
-                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                </PropertyGroup>
-                            </Project>
-                            ";
+                var propsFile =
+@$"<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include=""X"" Version=""[0.1.0,)"" />
+    </ItemGroup>
+</Project>";
 
                 File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props"), propsFile);
 
+                string projectContent =
+@$"<Project  Sdk=""Microsoft.NET.Sdk"">
+<PropertyGroup>                   
+	<TargetFramework>net46</TargetFramework>
+	</PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include=""X""/>
+    </ItemGroup>
+</Project>";
+                File.WriteAllText(Path.Combine(pathContext.SolutionRoot, ProjectName, string.Concat(ProjectName, ".csproj")), projectContent);
+
                 _fixture.RunDotnetExpectSuccess(Path.Combine(pathContext.SolutionRoot, projectA.ProjectName),
-                    $"add {projectA.ProjectPath} package packageX -v [0.1.0,)");
+                    $"restore {projectA.ProjectName}.csproj");
 
                 CommandRunnerResult listResult = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName,
                     $"list {projectA.ProjectPath} package");

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -126,8 +126,8 @@ namespace Dotnet.Integration.Test
             {
                 var projectA = XPlatTestUtils.CreateProject("projectA", pathContext, "net7.0");
 
-                var packageX = XPlatTestUtils.CreatePackage();
-                var packageX2 = XPlatTestUtils.CreatePackage("X", "2.0.0");
+                var packageX = XPlatTestUtils.CreatePackage("X", "1.0.0", "net7.0");
+                var packageX2 = XPlatTestUtils.CreatePackage("X", "2.0.0", "net7.0");
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -242,7 +242,7 @@ namespace Dotnet.Integration.Test
             {
                 var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net7.0");
 
-                var packageX = XPlatTestUtils.CreatePackage("X", "2.0.0");
+                var packageX = XPlatTestUtils.CreatePackage("X", "1.0.0");
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(
@@ -256,7 +256,7 @@ namespace Dotnet.Integration.Test
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     </PropertyGroup>
     <ItemGroup>
-        <GlobalPackageReference Include=""X"" Version=""1.0.0"" />
+        <GlobalPackageReference Include=""X"" Version=""0.1.0"" />
     </ItemGroup>
 </Project>";
 
@@ -282,9 +282,9 @@ namespace Dotnet.Integration.Test
                 CommandRunnerResult listResult = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName,
                     $"list {projectA.ProjectPath} package");
 
-                // Assert Requested version is 1.0.0, but the resolved version is 2.0.0
+                // Assert Requested version is 0.1.0, but the resolved version is 1.0.0
+                Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, "0.1.0"));
                 Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, "1.0.0"));
-                Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, "2.0.0"));
             }
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -84,6 +84,94 @@ namespace Dotnet.Integration.Test
         }
 
         [PlatformFact(Platform.Windows)]
+        public async Task DotnetListPackage_WithCPM()
+        {
+            using (var pathContext = _fixture.CreateSimpleTestPathContext())
+            {
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net7.0");
+
+                var packageX = XPlatTestUtils.CreatePackage();
+
+                // Generate Package
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var propsFile = @$"<Project>
+                                <PropertyGroup>
+                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                </PropertyGroup>
+                            </Project>
+                            ";
+
+                File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props"), propsFile);
+
+                _fixture.RunDotnetExpectSuccess(Path.Combine(pathContext.SolutionRoot, projectA.ProjectName),
+                    $"add {projectA.ProjectPath} package packageX -v 0.1.0");
+
+                CommandRunnerResult listResult = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName,
+                    $"list {projectA.ProjectPath} package");
+
+                // Assert Requested version is 0.1.0, but 1.0.0 was resolved
+                Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, "0.1.0"));
+                Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, "1.0.0"));
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task DotnetListPackage_WithCPM_WithOverrideVersion()
+        {
+            using (var pathContext = _fixture.CreateSimpleTestPathContext())
+            {
+                var projectA = XPlatTestUtils.CreateProject("projectA", pathContext, "net7.0");
+
+                var packageX = XPlatTestUtils.CreatePackage();
+                var packageX2 = XPlatTestUtils.CreatePackage("X", "2.0.0");
+
+                // Generate Package
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX,
+                    packageX2);
+
+                var propsFile =
+@$"<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include=""X"" Version=""2.0.0"" />
+    </ItemGroup>
+</Project>";
+
+                File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props"), propsFile);
+
+                string projectContent =
+@$"<Project  Sdk=""Microsoft.NET.Sdk"">
+<PropertyGroup>                   
+	<TargetFramework>net7.0</TargetFramework>
+	</PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include=""X"" VersionOverride=""1.0.0""/>
+    </ItemGroup>
+</Project>";
+                File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "projectA", "projectA.csproj"), projectContent);
+
+                _fixture.RunDotnetExpectSuccess(Path.Combine(pathContext.SolutionRoot, projectA.ProjectName),
+                    $"restore {projectA.ProjectName}.csproj");
+
+                CommandRunnerResult listResult = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName,
+                    $"list {projectA.ProjectPath} package");
+
+                // Assert Requested version is 2.0.0, but was override by VersionOverride tag
+                Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, "2.0.0"));
+                Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, "1.0.0"));
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
         public async Task DotnetListPackage_Transitive()
         {
             using (var pathContext = _fixture.CreateSimpleTestPathContext())

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -188,10 +188,10 @@ namespace Dotnet.Integration.Test
         {
             using (var pathContext = _fixture.CreateSimpleTestPathContext())
             {
-                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net7.0");
 
-                var packageX = XPlatTestUtils.CreatePackage("X", "1.0.0", "net46");
-                var packageX2 = XPlatTestUtils.CreatePackage("X", "2.0.0", "net46");
+                var packageX = XPlatTestUtils.CreatePackage("X", "1.0.0",);
+                var packageX2 = XPlatTestUtils.CreatePackage("X", "2.0.0");
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(
@@ -240,9 +240,9 @@ namespace Dotnet.Integration.Test
         {
             using (var pathContext = _fixture.CreateSimpleTestPathContext())
             {
-                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net7.0");
 
-                var packageX = XPlatTestUtils.CreatePackage("X", "2.0.0", "net46");
+                var packageX = XPlatTestUtils.CreatePackage("X", "2.0.0");
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -124,10 +124,10 @@ namespace Dotnet.Integration.Test
         {
             using (var pathContext = _fixture.CreateSimpleTestPathContext())
             {
-                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net7.0");
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
 
-                var packageX = XPlatTestUtils.CreatePackage("X", "1.0.0", "net7.0");
-                var packageX2 = XPlatTestUtils.CreatePackage("X", "2.0.0", "net7.0");
+                var packageX = XPlatTestUtils.CreatePackage("X", "1.0.0", "net46");
+                var packageX2 = XPlatTestUtils.CreatePackage("X", "2.0.0", "net46");
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(
@@ -151,7 +151,7 @@ namespace Dotnet.Integration.Test
                 string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
 <PropertyGroup>                   
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
         <PackageReference Include=""X"" VersionOverride=""1.0.0""/>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -190,7 +190,7 @@ namespace Dotnet.Integration.Test
             {
                 var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net7.0");
 
-                var packageX = XPlatTestUtils.CreatePackage("X", "1.0.0",);
+                var packageX = XPlatTestUtils.CreatePackage("X", "1.0.0");
                 var packageX2 = XPlatTestUtils.CreatePackage("X", "2.0.0");
 
                 // Generate Package


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12765

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
`dotnet list package` retrieves the information from the project or asset files, since CPM disables the ability of using the `Version` property in `PackageReference` tag, `Requested` version information is missing when doing the command.

This PR checks if the version is CentrallyManaged and populates the `Requested` information from the Directory.Packages.props file instead of the project file.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
