### PR TITLE
allow empty sb intermediate

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -6,6 +6,10 @@
     <GitHubRepositoryName>nuget-client</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
     <VersionPrefix>1.0.0</VersionPrefix>
+
+    <!-- Addresses empty intermediate issue originally found by https://github.com/dotnet/arcade/pull/13067 -->
+    <!-- Should be removed once https://github.com/NuGet/Home/issues/11059 is implemented -->
+    <AllowEmptySourceBuiltIntermediates>true</AllowEmptySourceBuiltIntermediates>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/dotnet/arcade/pull/13126

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Resolves an issue with NuGet source-build intermediate originally found by https://github.com/dotnet/arcade/pull/13067. This is achieved by introducing and empty intermediate check in source-build infra and allowing this repository to produce an empty intermediate until https://github.com/NuGet/Home/issues/11059 is resolved.
.
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
