### PR TITLE
Automatically create source mappings on Install for `PackageReference` & show in Preview Window

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PreviewResult.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PreviewResult.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace NuGet.PackageManagement.UI
@@ -16,7 +17,7 @@ namespace NuGet.PackageManagement.UI
 
         public IEnumerable<UpdatePreviewResult> Updated { get; }
 
-        public IReadOnlyDictionary<string, SortedSet<string>>? NewSourceMappings { get; }
+        public ImmutableDictionary<string, SortedSet<string>>? NewSourceMappings { get; }
 
         public string? Name { get; }
 
@@ -35,7 +36,7 @@ namespace NuGet.PackageManagement.UI
         public PreviewResult(Dictionary<string, SortedSet<string>>? newSourceMappings)
         {
             Name = Resources.Label_Solution;
-            NewSourceMappings = newSourceMappings;
+            NewSourceMappings = newSourceMappings?.ToImmutableDictionary();
             Added = Enumerable.Empty<AccessiblePackageIdentity>();
             Deleted = Enumerable.Empty<AccessiblePackageIdentity>();
             Updated = Enumerable.Empty<UpdatePreviewResult>();

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PreviewResult.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PreviewResult.cs
@@ -19,10 +19,10 @@ namespace NuGet.PackageManagement.UI
 
         public ImmutableDictionary<string, SortedSet<string>>? NewSourceMappings { get; }
 
-        public string? Name { get; }
+        public string Name { get; }
 
         public PreviewResult(
-            string? projectName,
+            string projectName,
             IEnumerable<AccessiblePackageIdentity> added,
             IEnumerable<AccessiblePackageIdentity> deleted,
             IEnumerable<UpdatePreviewResult> updated)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PreviewResult.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PreviewResult.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -13,10 +16,12 @@ namespace NuGet.PackageManagement.UI
 
         public IEnumerable<UpdatePreviewResult> Updated { get; }
 
-        public string Name { get; }
+        public IReadOnlyDictionary<string, SortedSet<string>>? NewSourceMappings { get; }
+
+        public string? Name { get; }
 
         public PreviewResult(
-            string projectName,
+            string? projectName,
             IEnumerable<AccessiblePackageIdentity> added,
             IEnumerable<AccessiblePackageIdentity> deleted,
             IEnumerable<UpdatePreviewResult> updated)
@@ -25,6 +30,15 @@ namespace NuGet.PackageManagement.UI
             Added = added;
             Deleted = deleted;
             Updated = updated;
+        }
+
+        public PreviewResult(Dictionary<string, SortedSet<string>>? newSourceMappings)
+        {
+            Name = Resources.Label_Solution;
+            NewSourceMappings = newSourceMappings;
+            Added = Enumerable.Empty<AccessiblePackageIdentity>();
+            Deleted = Enumerable.Empty<AccessiblePackageIdentity>();
+            Updated = Enumerable.Empty<UpdatePreviewResult>();
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -1010,7 +1010,7 @@ namespace NuGet.PackageManagement.UI
                 }
 #pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
 
-                var result = new PreviewResult(projectName, added, deleted, updated);
+                var result = new PreviewResult(projectName!, added, deleted, updated);
 
                 results.Add(result);
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -993,7 +993,7 @@ namespace NuGet.PackageManagement.UI
                 if (userAction?.SelectedSourceName != null)
                 {
                     // Everything added which didn't already have a source mapping will be mentioned in the Preview Window.
-                    PackageSourceMappingUtility.GetNewSourceMappingsFromAddedPackages(ref newSourceMappings, userAction.SelectedSourceName, added, uiService.UIContext.PackageSourceMapping);
+                    PackageSourceMappingUtility.AddNewSourceMappingsFromAddedPackages(ref newSourceMappings, userAction.SelectedSourceName, added, uiService.UIContext.PackageSourceMapping);
                 }
 
                 IProjectMetadataContextInfo projectMetadata = await projectManagerService.GetMetadataAsync(actions.Key, cancellationToken);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -7,7 +7,6 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web.Http;
 using System.Windows.Media.Imaging;
 using Microsoft.ServiceHub.Framework;
 using NuGet.PackageManagement.UI.ViewModels;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web.Http;
 using System.Windows.Media.Imaging;
 using Microsoft.ServiceHub.Framework;
 using NuGet.PackageManagement.UI.ViewModels;
@@ -49,6 +50,8 @@ namespace NuGet.PackageManagement.UI
 
         private Dictionary<NuGetVersion, DetailedPackageMetadata> _metadataDict = new Dictionary<NuGetVersion, DetailedPackageMetadata>();
 
+        private INuGetUI _uiController;
+
         protected DetailControlModel(
             IServiceBroker serviceBroker,
             IEnumerable<IProjectContextInfo> projects,
@@ -56,6 +59,7 @@ namespace NuGet.PackageManagement.UI
         {
             _nugetProjects = projects;
             ServiceBroker = serviceBroker;
+            _uiController = uiController;
 
             _options = new OptionsViewModel();
             PackageSourceMappingViewModel = PackageSourceMappingActionViewModel.Create(uiController);
@@ -825,7 +829,22 @@ namespace NuGet.PackageManagement.UI
 
         public PackageSourceMappingActionViewModel PackageSourceMappingViewModel { get; }
 
-        public bool CanInstallWithPackageSourceMapping => !PackageSourceMappingViewModel.IsPackageSourceMappingEnabled || PackageSourceMappingViewModel.IsPackageMapped;
+        public bool CanInstallWithPackageSourceMapping
+        {
+            get
+            {
+                // Don't allow install if package source mapping is enabled, with the selected package unmapped, and the 'All' package source selected.
+                if (PackageSourceMappingViewModel.IsPackageSourceMappingEnabled
+                    && !PackageSourceMappingViewModel.IsPackageMapped
+                    && PackageSourceMappingViewModel.ProjectsSupportAutomaticSourceMapping
+                    && !PackageSourceMappingViewModel.CanAutomaticallyCreateSourceMapping)
+                {
+                    return false;
+                }
+
+                return true;
+            }
+        }
 
         public IEnumerable<IProjectContextInfo> NuGetProjects => _nugetProjects;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PreviewWindowModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PreviewWindowModel.cs
@@ -53,6 +53,19 @@ namespace NuGet.PackageManagement.UI
                     }
                     sb.AppendLine("");
                 }
+                if (r.NewSourceMappings?.Any() == true)
+                {
+                    foreach (var newSourceMapping in r.NewSourceMappings)
+                    {
+                        sb.AppendLine(string.Format(Resources.Label_CreatingSourceMappings, newSourceMapping.Key));
+                        sb.AppendLine("");
+                        foreach (string newSourceMappingPackageId in newSourceMapping.Value)
+                        {
+                            sb.AppendLine(newSourceMappingPackageId);
+                        }
+                        sb.AppendLine("");
+                    }
+                }
             }
             return sb.ToString();
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PreviewWindowModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PreviewWindowModel.cs
@@ -53,7 +53,7 @@ namespace NuGet.PackageManagement.UI
                     }
                     sb.AppendLine("");
                 }
-                if (r.NewSourceMappings?.Any() == true)
+                if (r.NewSourceMappings?.Count > 0)
                 {
                     foreach (var newSourceMapping in r.NewSourceMappings)
                     {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -916,6 +916,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Creating source mappings to &apos;{0}&apos;:.
+        /// </summary>
+        public static string Label_CreatingSourceMappings {
+            get {
+                return ResourceManager.GetString("Label_CreatingSourceMappings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Date published:.
         /// </summary>
         public static string Label_DatePublished {
@@ -1227,6 +1236,15 @@ namespace NuGet.PackageManagement.UI {
         public static string Label_Repository {
             get {
                 return ResourceManager.GetString("Label_Repository", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Solution.
+        /// </summary>
+        public static string Label_Solution {
+            get {
+                return ResourceManager.GetString("Label_Solution", resourceCulture);
             }
         }
         
@@ -1994,6 +2012,15 @@ namespace NuGet.PackageManagement.UI {
         public static string Text_PackageFormatApply {
             get {
                 return ResourceManager.GetString("Text_PackageFormatApply", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A package source mapping will be created..
+        /// </summary>
+        public static string Text_PackageMappingsAutoCreate {
+            get {
+                return ResourceManager.GetString("Text_PackageMappingsAutoCreate", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1009,6 +1009,10 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <value>_OK</value>
     <comment>Button_Cancel and Button_OK must have underscore in different letters. See https://docs.microsoft.com/windows/apps/design/input/access-keys#choose-access-keys</comment>
   </data>
+  <data name="Label_CreatingSourceMappings" xml:space="preserve">
+    <value>Creating source mappings to '{0}':</value>
+    <comment>{0} - The Name of a user-configured NuGet Package Source</comment>
+  </data>
   <data name="Label_NetworkError" xml:space="preserve">
     <value>An error occurred while fetching additional information about the package. Refresh to try again.</value>
   </data>
@@ -1021,5 +1025,11 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Error_MetadataNotFound" xml:space="preserve">
     <value>Unable to find metadata of {0}</value>
     <comment>{0} is the package ID</comment>
+  </data>
+  <data name="Label_Solution" xml:space="preserve">
+    <value>Solution</value>
+  </data>
+  <data name="Text_PackageMappingsAutoCreate" xml:space="preserve">
+    <value>A package source mapping will be created.</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserAction.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserAction.cs
@@ -26,16 +26,16 @@ namespace NuGet.PackageManagement.UI
             ActiveTab = activeTab;
         }
 
-        private UserAction(NuGetProjectActionType action, string packageId, NuGetVersion? packageVersion, bool isSolutionLevel, ContractsItemFilter activeTab, VersionRange versionRange)
-            : this(action, packageId, packageVersion, isSolutionLevel, activeTab)
+        private UserAction(NuGetProjectActionType action, string packageId, NuGetVersion? packageVersion, bool isSolutionLevel, ContractsItemFilter activeTab, VersionRange versionRange, string? selectedSourceName)
+            : this(action, packageId, packageVersion, isSolutionLevel, activeTab, selectedSourceName)
         {
             VersionRange = versionRange;
         }
 
-        private UserAction(NuGetProjectActionType action, string packageId, NuGetVersion? packageVersion, bool isSolutionLevel, ContractsItemFilter activeTab, string? sourceMappingSourceName)
+        private UserAction(NuGetProjectActionType action, string packageId, NuGetVersion? packageVersion, bool isSolutionLevel, ContractsItemFilter activeTab, string? selectedSourceName)
            : this(action, packageId, packageVersion, isSolutionLevel, activeTab)
         {
-            SourceMappingSourceName = sourceMappingSourceName;
+            SelectedSourceName = selectedSourceName;
         }
 
         public NuGetProjectActionType Action { get; private set; }
@@ -44,7 +44,7 @@ namespace NuGet.PackageManagement.UI
         public string PackageId { get; }
         public NuGetVersion? Version { get; }
         public VersionRange? VersionRange { get; }
-        public string? SourceMappingSourceName { get; }
+        public string? SelectedSourceName { get; }
 
         public static UserAction CreateInstallAction(string packageId, NuGetVersion? packageVersion, bool isSolutionLevel, ContractsItemFilter activeTab)
         {
@@ -61,14 +61,14 @@ namespace NuGet.PackageManagement.UI
             return new UserAction(NuGetProjectActionType.Install, packageId, packageVersion, isSolutionLevel, activeTab, sourceMappingSourceName);
         }
 
-        public static UserAction CreateInstallAction(string packageId, NuGetVersion? packageVersion, bool isSolutionLevel, ContractsItemFilter activeTab, VersionRange versionRange)
+        public static UserAction CreateInstallAction(string packageId, NuGetVersion? packageVersion, bool isSolutionLevel, ContractsItemFilter activeTab, VersionRange versionRange, string? sourceMappingSourceName)
         {
             if (packageVersion == null && versionRange == null)
             {
                 throw new ArgumentNullException(nameof(packageVersion));
             }
 
-            return new UserAction(NuGetProjectActionType.Install, packageId, packageVersion, isSolutionLevel, activeTab, versionRange);
+            return new UserAction(NuGetProjectActionType.Install, packageId, packageVersion, isSolutionLevel, activeTab, versionRange, sourceMappingSourceName);
         }
 
         public static UserAction CreateUnInstallAction(string packageId, bool isSolutionLevel, ContractsItemFilter activeTab)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/INuGetUI.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/INuGetUI.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.PackageManagement.UI.ViewModels;
 using NuGet.PackageManagement.VisualStudio;
-using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.Resolver;
 using NuGet.VisualStudio;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -11,6 +11,7 @@ using Microsoft;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -386,11 +387,20 @@ namespace NuGet.PackageManagement.UI
         {
             get
             {
+                if (PackageManagerControl is null)
+                {
+                    return null;
+                }
+
                 PackageSourceMoniker source = null;
 
-                if (PackageManagerControl != null)
+                if (!ThreadHelper.CheckAccess())
                 {
                     InvokeOnUIThread(() => { source = PackageManagerControl.SelectedSource; });
+                }
+                else
+                {
+                    source = PackageManagerControl.SelectedSource;
                 }
 
                 return source;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/PackageSourceMappingUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/PackageSourceMappingUtility.cs
@@ -108,34 +108,30 @@ namespace NuGet.PackageManagement.UI
                 return;
             }
 
-            List<string> addedPackagesWithNoSourceMappings = added.Select(package => package.Id)
-                .Where(addedPackage =>
-                {
-                    IReadOnlyList<string> configuredSources = packageSourceMapping.GetConfiguredPackageSources(addedPackage);
-                    return configuredSources == null || configuredSources.Count == 0;
-                })
-                .Distinct()
-                .ToList();
+            foreach (AccessiblePackageIdentity addedPackage in added)
+            {
+                IReadOnlyList<string> configuredSources = packageSourceMapping.GetConfiguredPackageSources(packageId: addedPackage.Id);
 
-            if (addedPackagesWithNoSourceMappings.Count == 0)
-            {
-                return;
-            }
-
-            if (newSourceMappings is null)
-            {
-                newSourceMappings = new Dictionary<string, SortedSet<string>>(capacity: 1)
+                if (configuredSources.Count > 0)
                 {
-                    { newMappingSourceName, new SortedSet<string>(addedPackagesWithNoSourceMappings) }
-                };
-            }
-            else if (newSourceMappings.TryGetValue(newMappingSourceName, out SortedSet<string>? newMappingPackageIds))
-            {
-                newMappingPackageIds.UnionWith(addedPackagesWithNoSourceMappings);
-            }
-            else
-            {
-                newSourceMappings.Add(newMappingSourceName, new SortedSet<string>(addedPackagesWithNoSourceMappings));
+                    continue;
+                }
+
+                if (newSourceMappings is null)
+                {
+                    newSourceMappings = new Dictionary<string, SortedSet<string>>(capacity: 1)
+                    {
+                        { newMappingSourceName, new SortedSet<string>(new List<string>(capacity: added.Count) { addedPackage.Id }) }
+                    };
+                }
+                else if (newSourceMappings.TryGetValue(newMappingSourceName, out SortedSet<string>? newMappingPackageIds))
+                {
+                    newMappingPackageIds.Add(addedPackage.Id);
+                }
+                else
+                {
+                    newSourceMappings.Add(newMappingSourceName, new SortedSet<string>(new List<string>(capacity: added.Count) { addedPackage.Id }));
+                }
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/PackageSourceMappingUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/PackageSourceMappingUtility.cs
@@ -101,7 +101,7 @@ namespace NuGet.PackageManagement.UI
             return sourceMappingSourceName;
         }
 
-        internal static void GetNewSourceMappingsFromAddedPackages(ref Dictionary<string, SortedSet<string>>? newSourceMappings, string newMappingSourceName, List<AccessiblePackageIdentity> added, PackageSourceMapping packageSourceMapping)
+        internal static void AddNewSourceMappingsFromAddedPackages(ref Dictionary<string, SortedSet<string>>? newSourceMappings, string newMappingSourceName, List<AccessiblePackageIdentity> added, PackageSourceMapping packageSourceMapping)
         {
             if (newMappingSourceName is null || added.Count == 0 || packageSourceMapping is null)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/PackageSourceMappingUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/PackageSourceMappingUtility.cs
@@ -108,7 +108,7 @@ namespace NuGet.PackageManagement.UI
                 return;
             }
 
-            List<string> addedPackagesWithNoSourceMappings = added.Select(_ => _.Id)
+            List<string> addedPackagesWithNoSourceMappings = added.Select(package => package.Id)
                 .Where(addedPackage =>
                 {
                     IReadOnlyList<string> configuredSources = packageSourceMapping.GetConfiguredPackageSources(addedPackage);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageSourceMappingActionViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageSourceMappingActionViewModel.cs
@@ -71,7 +71,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
             }
         }
 
-        internal bool ProjectsSupportAutomaticSourceMapping => !UIController.UIContext.Projects.Any(_ => _.ProjectStyle != ProjectModel.ProjectStyle.PackageReference);
+        internal bool ProjectsSupportAutomaticSourceMapping => !UIController.UIContext.Projects.Any(project => project.ProjectStyle != ProjectModel.ProjectStyle.PackageReference);
 
         public string MappingStatus
         {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageSourceMappingActionViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageSourceMappingActionViewModel.cs
@@ -59,6 +59,20 @@ namespace NuGet.PackageManagement.UI.ViewModels
             }
         }
 
+        public bool CanAutomaticallyCreateSourceMapping
+        {
+            get
+            {
+                return IsPackageSourceMappingEnabled
+                    && !IsPackageMapped
+                    && ProjectsSupportAutomaticSourceMapping
+                    && UIController.ActivePackageSourceMoniker != null
+                    && !UIController.ActivePackageSourceMoniker.IsAggregateSource;
+            }
+        }
+
+        internal bool ProjectsSupportAutomaticSourceMapping => !UIController.UIContext.Projects.Any(_ => _.ProjectStyle != ProjectModel.ProjectStyle.PackageReference);
+
         public string MappingStatus
         {
             get
@@ -71,10 +85,13 @@ namespace NuGet.PackageManagement.UI.ViewModels
                 {
                     return Resources.Text_PackageMappingsFound;
                 }
-                else
+
+                if (CanAutomaticallyCreateSourceMapping)
                 {
-                    return Resources.Text_PackageMappingsNotFound;
+                    return Resources.Text_PackageMappingsAutoCreate;
                 }
+
+                return Resources.Text_PackageMappingsNotFound;
             }
         }
 
@@ -90,10 +107,12 @@ namespace NuGet.PackageManagement.UI.ViewModels
                 {
                     return KnownMonikers.StatusOK;
                 }
-                else
+                if (CanAutomaticallyCreateSourceMapping)
                 {
-                    return KnownMonikers.StatusError;
+                    return KnownMonikers.StatusInformation;
                 }
+
+                return KnownMonikers.StatusError;
             }
         }
 
@@ -103,6 +122,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
             RaisePropertyChanged(nameof(IsPackageMapped));
             RaisePropertyChanged(nameof(MappingStatus));
             RaisePropertyChanged(nameof(MappingStatusIcon));
+            RaisePropertyChanged(nameof(CanAutomaticallyCreateSourceMapping));
         }
 
         public static PackageSourceMappingActionViewModel Create(INuGetUI uiController)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -110,12 +110,15 @@ namespace NuGet.PackageManagement.UI
 
             if (model != null && model.SelectedVersion != null)
             {
+                var sourceMappingSourceName = PackageSourceMappingUtility.GetNewSourceMappingSourceName(Control.Model.UIController.UIContext.PackageSourceMapping, Control.Model.UIController.ActivePackageSourceMoniker);
+
                 var userAction = UserAction.CreateInstallAction(
-                    model.Id,
+                    packageId: model.Id,
                     model.SelectedVersion.Version,
                     Control.Model.IsSolution,
                     UIUtility.ToContractsItemFilter(Control._topPanel.Filter),
-                    model.SelectedVersion.Range);
+                    model.SelectedVersion.Range,
+                    sourceMappingSourceName);
 
                 ExecuteUserAction(userAction, NuGetActionType.Install);
             }
@@ -138,11 +141,14 @@ namespace NuGet.PackageManagement.UI
 
             if (model != null && model.SelectedVersion != null)
             {
+                var sourceMappingSourceName = PackageSourceMappingUtility.GetNewSourceMappingSourceName(Control.Model.UIController.UIContext.PackageSourceMapping, Control.Model.UIController.ActivePackageSourceMoniker);
+
                 var userAction = UserAction.CreateInstallAction(
-                    model.Id,
+                    packageId: model.Id,
                     model.SelectedVersion.Version,
                     Control.Model.IsSolution,
-                    UIUtility.ToContractsItemFilter(Control._topPanel.Filter));
+                    UIUtility.ToContractsItemFilter(Control._topPanel.Filter),
+                    sourceMappingSourceName);
 
                 ExecuteUserAction(userAction, NuGetActionType.Install);
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1179,6 +1179,8 @@ namespace NuGet.PackageManagement.UI
         {
             var timeSpan = GetTimeSinceLastRefreshAndRestart();
 
+            _detailModel.PackageSourceMappingViewModel.SettingsChanged();
+
             if (_dontStartNewSearch || !_initialized)
             {
                 EmitRefreshEvent(timeSpan, RefreshOperationSource.SourceSelectionChanged, RefreshOperationStatus.NoOp);
@@ -1680,7 +1682,8 @@ namespace NuGet.PackageManagement.UI
         /// <param name="packagesInfo">Corresponding Package ViewModels from PM UI. Only needed for vulnerability telemetry counts. Can be <c>null</c></param>
         internal void InstallPackage(string packageId, NuGetVersion version, IEnumerable<PackageItemViewModel> packagesInfo)
         {
-            var action = UserAction.CreateInstallAction(packageId, version, Model.IsSolution, UIUtility.ToContractsItemFilter(_topPanel.Filter));
+            var sourceMappingSourceName = PackageSourceMappingUtility.GetNewSourceMappingSourceName(Model.UIController.UIContext.PackageSourceMapping, Model.UIController.ActivePackageSourceMoniker);
+            UserAction action = UserAction.CreateInstallAction(packageId, version, Model.IsSolution, UIUtility.ToContractsItemFilter(_topPanel.Filter), sourceMappingSourceName);
 
             ExecuteAction(
                 () =>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
@@ -71,7 +71,6 @@
               <StackPanel
                 Margin="6, 6">
                 <TextBlock
-                  x:Name="_changeName"
                   AutomationProperties.Name="{Binding Text}"
                   FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font122PercentSizeConverter}}"
                   Text="{Binding Path=Name}" />
@@ -81,7 +80,6 @@
                   Margin="0,8"
                   Visibility="{Binding Path=Deleted,Converter={StaticResource EnumerableToVisibilityConverter}}">
                   <TextBlock
-                    x:Name="_uninstalledPackages"
                     AutomationProperties.Name="{Binding Text}"
                     FontWeight="Bold"
                     Text="{x:Static nuget:Resources.Label_UninstalledPackages}" />
@@ -102,7 +100,6 @@
                   Margin="0,8"
                   Visibility="{Binding Path=Updated,Converter={StaticResource EnumerableToVisibilityConverter}}">
                   <TextBlock
-                    x:Name="_updatedPackages"
                     AutomationProperties.Name="{Binding Text}"
                     FontWeight="Bold"
                     Text="{x:Static nuget:Resources.Label_UpdatedPackages}" />
@@ -123,7 +120,6 @@
                   Margin="0,8"
                   Visibility="{Binding Path=Added,Converter={StaticResource EnumerableToVisibilityConverter}}">
                   <TextBlock
-                    x:Name="_installedPackages"
                     AutomationProperties.Name="{Binding Text}"
                     FontWeight="Bold"
                     Text="{x:Static nuget:Resources.Label_InstalledPackages}" />
@@ -134,6 +130,40 @@
                     <ItemsControl.ItemTemplate>
                       <DataTemplate>
                         <TextBlock Text="{Binding}" AutomationProperties.Name="{Binding AutomationName}" />
+                      </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                  </ItemsControl>
+                </StackPanel>
+
+                <!-- New Source Mappings for added packages -->
+                <StackPanel
+                  Margin="0,8"
+                  Visibility="{Binding Path=NewSourceMappings,Converter={StaticResource EnumerableToVisibilityConverter}}">
+                  <ItemsControl
+                    Margin="10,0,0,0"
+                    ItemsSource="{Binding Path=NewSourceMappings}"
+                    IsTabStop="False">
+                    <ItemsControl.ItemTemplate>
+                      <DataTemplate>
+                        <StackPanel>
+                          <!-- New Source Mapping with Source Name -->
+                          <TextBlock
+                            FontWeight="Bold"
+                            Text="{Binding Key, Mode=OneWay, StringFormat={x:Static nuget:Resources.Label_CreatingSourceMappings}}">
+                          </TextBlock>
+
+                          <!-- New Source Mapping Package IDs -->
+                          <ItemsControl ItemsSource="{Binding Value}"
+                            IsTabStop="False">
+                            <ItemsControl.ItemTemplate>
+                              <DataTemplate>
+                                <StackPanel>
+                                  <TextBlock Text="{Binding}" />
+                                </StackPanel>
+                              </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                          </ItemsControl>
+                        </StackPanel>
                       </DataTemplate>
                     </ItemsControl.ItemTemplate>
                   </ItemsControl>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/PackageSourceMappingSourceItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/PackageSourceMappingSourceItem.cs
@@ -157,7 +157,7 @@ namespace NuGet.Configuration
 
             base.Update(other);
 
-            Dictionary<PackagePatternItem, PackagePatternItem> otherPatterns = packageSourceMappingSourceItem.Patterns.ToDictionary(c => c, c => c);
+            Dictionary<PackagePatternItem, PackagePatternItem> otherPatterns = packageSourceMappingSourceItem.Patterns.GroupBy(item => item).ToDictionary(c => c.Key, c => c.Key);
             var clonedPatterns = new List<PackagePatternItem>(Patterns);
             foreach (PackagePatternItem packagePatternItem in clonedPatterns)
             {

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -1678,6 +1678,13 @@ namespace NuGet.PackageManagement
 
             if (buildIntegratedProjectsToUpdate.Count != 0)
             {
+                // Only automatically create Source Mappings when there's exclusively BuildIntegratedProjects.
+                if (otherTargetProjectsToUpdate.Count > 0)
+                {
+                    newMappingID = null;
+                    newMappingSource = null;
+                }
+
                 // Run build integrated project preview for all projects at the same time
                 var resolvedActions = await PreviewBuildIntegratedProjectsActionsAsync(
                     buildIntegratedProjectsToUpdate,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -79,16 +79,16 @@ namespace NuGet.PackageManagement.UI.Test
                         NuGetProjectActionType.Install)
                 });
 
-            var mockUiController = new Mock<INuGetUI>();
+            var mockUIController = new Mock<INuGetUI>();
             var mockUIContext = new Mock<INuGetUIContext>();
-            mockUIContext.Setup(_ => _.PackageSourceMapping).Returns((PackageSourceMapping)null);
-            mockUiController.Setup(_ => _.UIContext).Returns(mockUIContext.Object);
+            mockUIContext.Setup(uiContext => uiContext.PackageSourceMapping).Returns((PackageSourceMapping)null);
+            mockUIController.Setup(uiController => uiController.UIContext).Returns(mockUIContext.Object);
 
             IReadOnlyList<PreviewResult> previewResults = await UIActionEngine.GetPreviewResultsAsync(
                 Mock.Of<INuGetProjectManagerService>(),
                 projectActions: new[] { uninstallAction, installAction },
                 userAction: null,
-                mockUiController.Object,
+                mockUIController.Object,
                 CancellationToken.None);
 
             Assert.Equal(1, previewResults.Count);
@@ -137,16 +137,16 @@ namespace NuGet.PackageManagement.UI.Test
                         NuGetProjectActionType.Install)
                 });
 
-            var mockUiController = new Mock<INuGetUI>();
+            var mockUIController = new Mock<INuGetUI>();
             var mockUIContext = new Mock<INuGetUIContext>();
-            mockUIContext.Setup(_ => _.PackageSourceMapping).Returns((PackageSourceMapping)null);
-            mockUiController.Setup(_ => _.UIContext).Returns(mockUIContext.Object);
+            mockUIContext.Setup(uiContext => uiContext.PackageSourceMapping).Returns((PackageSourceMapping)null);
+            mockUIController.Setup(uiController => uiController.UIContext).Returns(mockUIContext.Object);
 
             IReadOnlyList<PreviewResult> previewResults = await UIActionEngine.GetPreviewResultsAsync(
                 Mock.Of<INuGetProjectManagerService>(),
                 projectActions: new[] { installAction },
                 userAction: null,
-                mockUiController.Object,
+                mockUIController.Object,
                 CancellationToken.None);
 
             Assert.Equal(1, previewResults.Count);
@@ -456,7 +456,7 @@ namespace NuGet.PackageManagement.UI.Test
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => uiActionEngine.PerformInstallOrUninstallAsync(mockUIService.Object, action, CancellationToken.None));
 
             // Assert
-            mockNuGetUIContext.Verify(_ => _.PackageSourceMapping, timesSourceMappingCalled);
+            mockNuGetUIContext.Verify(uiContext => uiContext.PackageSourceMapping, timesSourceMappingCalled);
             Assert.Contains("Unable to find metadata of transitiveA.1.0.0", ex.Message);
         }
 
@@ -504,7 +504,7 @@ namespace NuGet.PackageManagement.UI.Test
             await uiActionEngine.PerformInstallOrUninstallAsync(mockUIService.Object, action, CancellationToken.None);
 
             // Assert
-            mockNuGetUIContext.Verify(_ => _.PackageSourceMapping, timesSourceMappingCalled);
+            mockNuGetUIContext.Verify(uiContext => uiContext.PackageSourceMapping, timesSourceMappingCalled);
         }
 
         [Theory]
@@ -549,7 +549,7 @@ namespace NuGet.PackageManagement.UI.Test
             await uiActionEngine.PerformInstallOrUninstallAsync(mockUIService.Object, action, CancellationToken.None);
 
             // Assert
-            mockNuGetUIContext.Verify(_ => _.PackageSourceMapping, timesSourceMappingCalled);
+            mockNuGetUIContext.Verify(uiContext => uiContext.PackageSourceMapping, timesSourceMappingCalled);
         }
 
         private void SetupUIServiceWithPackageSearchMetadata(
@@ -818,7 +818,7 @@ namespace NuGet.PackageManagement.UI.Test
             }
 
             var mockPackageSourceMapping = new Mock<PackageSourceMapping>(packageSourceMappingPatterns);
-            mockNuGetUIContext.Setup(_ => _.PackageSourceMapping).Returns(mockPackageSourceMapping.Object);
+            mockNuGetUIContext.Setup(uiContext => uiContext.PackageSourceMapping).Returns(mockPackageSourceMapping.Object);
         }
 
         private sealed class PackageIdentitySubclass : PackageIdentity

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -78,9 +78,17 @@ namespace NuGet.PackageManagement.UI.Test
                         packageIdentityB2,
                         NuGetProjectActionType.Install)
                 });
+
+            var mockUiController = new Mock<INuGetUI>();
+            var mockUIContext = new Mock<INuGetUIContext>();
+            mockUIContext.Setup(_ => _.PackageSourceMapping).Returns((PackageSourceMapping)null);
+            mockUiController.Setup(_ => _.UIContext).Returns(mockUIContext.Object);
+
             IReadOnlyList<PreviewResult> previewResults = await UIActionEngine.GetPreviewResultsAsync(
                 Mock.Of<INuGetProjectManagerService>(),
-                new[] { uninstallAction, installAction },
+                projectActions: new[] { uninstallAction, installAction },
+                userAction: null,
+                mockUiController.Object,
                 CancellationToken.None);
 
             Assert.Equal(1, previewResults.Count);
@@ -128,9 +136,17 @@ namespace NuGet.PackageManagement.UI.Test
                         packageIdentityC,
                         NuGetProjectActionType.Install)
                 });
+
+            var mockUiController = new Mock<INuGetUI>();
+            var mockUIContext = new Mock<INuGetUIContext>();
+            mockUIContext.Setup(_ => _.PackageSourceMapping).Returns((PackageSourceMapping)null);
+            mockUiController.Setup(_ => _.UIContext).Returns(mockUIContext.Object);
+
             IReadOnlyList<PreviewResult> previewResults = await UIActionEngine.GetPreviewResultsAsync(
                 Mock.Of<INuGetProjectManagerService>(),
-                new[] { installAction },
+                projectActions: new[] { installAction },
+                userAction: null,
+                mockUiController.Object,
                 CancellationToken.None);
 
             Assert.Equal(1, previewResults.Count);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
@@ -17,6 +17,7 @@ using Moq;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.PackageManagement.UI.Utility;
+using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Test.Utility;
@@ -53,6 +54,9 @@ namespace NuGet.PackageManagement.UI.Test.Models
 
             _mockNuGetUI = new Mock<INuGetUI>();
             _mockNuGetUIContext = new Mock<INuGetUIContext>();
+
+            _mockPackageSourceMapping = new Mock<PackageSourceMapping>(new Dictionary<string, IReadOnlyList<string>>());
+            _mockNuGetUIContext.Setup(_ => _.PackageSourceMapping).Returns(_mockPackageSourceMapping.Object);
             _mockNuGetUI.Setup(_ => _.UIContext).Returns(_mockNuGetUIContext.Object);
 
             var searchService = new Mock<IReconnectingNuGetSearchService>();
@@ -104,6 +108,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
         {
             if (packageSourceMappingPatterns != null)
             {
+                _mockPackageSourceMapping.Reset();
                 _mockPackageSourceMapping = new Mock<PackageSourceMapping>(packageSourceMappingPatterns);
                 _mockNuGetUIContext.Setup(_ => _.PackageSourceMapping).Returns(_mockPackageSourceMapping.Object);
             }
@@ -235,18 +240,37 @@ namespace NuGet.PackageManagement.UI.Test.Models
             var beforeEnablingPackageSourceMapping_CanInstallWithPackageSourceMapping = _testInstance.CanInstallWithPackageSourceMapping;
             var beforeEnablingPackageSourceMapping_IsInstallOrUpdateButtonEnabled = _testInstance.IsInstallorUpdateButtonEnabled;
 
+            PackageSourceMoniker singlePackageSourceMoniker = new("sourceName", new List<PackageSourceContextInfo>() { new PackageSourceContextInfo("sourceName") }, priorityOrder: 0);
+            PackageSourceMoniker aggregatePackageSourceMoniker = new("sourceName",
+                new List<PackageSourceContextInfo>() { new PackageSourceContextInfo("sourceName"), new PackageSourceContextInfo("sourceName2") },
+                priorityOrder: 0);
+
             // Act
 
-            // Enable package source mapping.
+            //********************************************************************************************************************************************
+            // Enable package source mapping; select an Aggregate package source so it won't allow automatically create a mapping when pressing Install.
+            //********************************************************************************************************************************************
             ConfigureNuGetUIWithPackageSourceMapping(packageSourceMappingPatterns);
-            var beforeSelectingPackageWithPackageSourceMapping_CanInstallWithPackageSourceMapping = _testInstance.CanInstallWithPackageSourceMapping;
-            var beforeSelectingPackageWithPackageSourceMapping_IsInstallorUpdateButtonEnabled = _testInstance.IsInstallorUpdateButtonEnabled;
+            _mockNuGetUI.Setup(_ => _.ActivePackageSourceMoniker).Returns(aggregatePackageSourceMoniker);
 
+            var packageNotMapped_AggregateSourceSelected_CanInstallWithPackageSourceMapping = _testInstance.CanInstallWithPackageSourceMapping;
+            var packageNotMapped_AggregateSourceSelected_IsInstallorUpdateButtonEnabled = _testInstance.IsInstallorUpdateButtonEnabled;
+
+            //********************************************************************************************************************************************
+            // Select a single package source so it will allow automatically create a mapping when pressing Install.
+            //********************************************************************************************************************************************
+            _mockNuGetUI.Setup(_ => _.ActivePackageSourceMoniker).Returns(singlePackageSourceMoniker);
+            var packageNotMapped_SingleSourceSelected_CanInstallWithPackageSourceMapping = _testInstance.CanInstallWithPackageSourceMapping;
+            var packageNotMapped_SingleSourceSelected_IsInstallOrUpdateButtonEnabled = _testInstance.IsInstallorUpdateButtonEnabled;
+
+            //********************************************************************************************************************************************
             // Select a package which has a configured Package Source Mapping.
+            //********************************************************************************************************************************************
             _testInstance.PackageSourceMappingViewModel.PackageId = packageIDWithSourceMapping;
-
             var afterSelectingPackageWithPackageSourceMapping_CanInstallWithPackageSourceMapping = _testInstance.CanInstallWithPackageSourceMapping;
-            var afterSelectingPackageWithPackageSourceMapping_IsInstallorUpdateButtonEnabled = _testInstance.IsInstallorUpdateButtonEnabled;
+            var afterSelectingPackageWithPackageSourceMapping_IsInstallOrUpdateButtonEnabled = _testInstance.IsInstallorUpdateButtonEnabled;
+
+            // Explicitly trigger PropertyChanged event.
             _testInstance.SetInstalledOrUpdateButtonIsEnabled();
             var afterSetInstalledOrUpdateButtonIsEnabled_CanInstallWithPackageSourceMapping = _testInstance.CanInstallWithPackageSourceMapping;
 
@@ -254,17 +278,22 @@ namespace NuGet.PackageManagement.UI.Test.Models
             Assert.True(beforeEnablingPackageSourceMapping_CanInstallWithPackageSourceMapping, "Package Source Mapping is disabled.");
             Assert.True(beforeEnablingPackageSourceMapping_IsInstallOrUpdateButtonEnabled, "Package Source Mapping is disabled.");
 
-            Assert.False(beforeSelectingPackageWithPackageSourceMapping_CanInstallWithPackageSourceMapping,
+            Assert.False(packageNotMapped_AggregateSourceSelected_CanInstallWithPackageSourceMapping,
                 "Package Source Mapping is enabled but the Selected Package ID has no mapping.");
-            Assert.False(beforeSelectingPackageWithPackageSourceMapping_IsInstallorUpdateButtonEnabled,
+            Assert.False(packageNotMapped_AggregateSourceSelected_IsInstallorUpdateButtonEnabled,
                 "Package Source Mapping is enabled but the Selected Package ID has no mapping.");
+
+            Assert.True(packageNotMapped_SingleSourceSelected_CanInstallWithPackageSourceMapping,
+                "Selected Package ID doesn't have a mapping but should automatically get one during Install.");
+            Assert.True(packageNotMapped_SingleSourceSelected_IsInstallOrUpdateButtonEnabled,
+                "Selected Package ID will automatically get a package source mapping, but the " + nameof(PackageDetailControlModel.IsInstallorUpdateButtonEnabled) + " hasn't been updated, yet.");
 
             Assert.True(afterSelectingPackageWithPackageSourceMapping_CanInstallWithPackageSourceMapping,
                 "Selected Package ID has a package source mapping.");
-            Assert.True(afterSelectingPackageWithPackageSourceMapping_IsInstallorUpdateButtonEnabled,
+            Assert.True(afterSelectingPackageWithPackageSourceMapping_IsInstallOrUpdateButtonEnabled,
                 "Selected Package ID has a package source mapping, but the " + nameof(PackageDetailControlModel.IsInstallorUpdateButtonEnabled) + " hasn't been updated, yet.");
-
             Assert.True(afterSetInstalledOrUpdateButtonIsEnabled_CanInstallWithPackageSourceMapping, "Package Source Mapping is enabled and the Package ID is mapped.");
+
             Assert.True(setInstalledOrUpdateButtonIsEnabled_RaisedPropertyChange_IsInstallOrUpdateButtonEnabled,
                 nameof(PackageDetailControlModel.IsInstallorUpdateButtonEnabled) + " should have raised a PropertyChanged when calling "
                 + nameof(DetailControlModel.SetInstalledOrUpdateButtonIsEnabled) + " and the value should become true.");
@@ -1395,9 +1424,9 @@ namespace NuGet.PackageManagement.UI.Test.Models
             project.SetupGet(p => p.ProjectId).Returns("ProjectId1");
 
             Mock<IProjectContextInfo> project2 = new Mock<IProjectContextInfo>();
-            project.SetupGet(p => p.ProjectKind).Returns(NuGetProjectKind.PackageReference);
-            project.SetupGet(p => p.ProjectStyle).Returns(ProjectModel.ProjectStyle.PackageReference);
-            project.SetupGet(p => p.ProjectId).Returns("ProjectId2");
+            project2.SetupGet(p => p.ProjectKind).Returns(NuGetProjectKind.PackageReference);
+            project2.SetupGet(p => p.ProjectStyle).Returns(ProjectModel.ProjectStyle.PackageReference);
+            project2.SetupGet(p => p.ProjectId).Returns("ProjectId2");
 
             ReadOnlyCollection<IProjectContextInfo> projects = new ReadOnlyCollection<IProjectContextInfo>(
                 new List<IProjectContextInfo>()
@@ -1600,7 +1629,16 @@ namespace NuGet.PackageManagement.UI.Test.Models
             };
             var packageSourceMappingPatterns = new ReadOnlyDictionary<string, IReadOnlyList<string>>(patterns);
 
-            _testInstance.SelectedVersion = new DisplayVersion(NuGetVersion.Parse("1.1.1"), additionalInfo: null);
+            var version = NuGetVersion.Parse("1.1.1");
+
+            _testInstance.SelectedVersion = new DisplayVersion(version, additionalInfo: null);
+
+            PackageInstallationInfo firstProject = _testInstance.Projects.First();
+            firstProject.IsSelected = true;
+            firstProject.InstalledVersion = version;
+
+            // Explicitly trigger PropertyChanged event.
+            _testInstance.SetInstalledOrUpdateButtonIsEnabled();
 
             bool afterSetInstalledOrUpdateButtonIsEnabled_CanInstall_RaisedPropertyChanged = false;
             bool afterSetInstalledOrUpdateButtonIsEnabled_CanUninstall_RaisedPropertyChanged = false;
@@ -1631,45 +1669,75 @@ namespace NuGet.PackageManagement.UI.Test.Models
             var beforeEnablingPackageSourceMapping_CanInstall = _testInstance.CanInstall;
             var beforeEnablingPackageSourceMapping_CanUninstall = _testInstance.CanUninstall;
 
+            PackageSourceMoniker singlePackageSourceMoniker = new("sourceName", new List<PackageSourceContextInfo>() { new PackageSourceContextInfo("sourceName") }, priorityOrder: 0);
+            PackageSourceMoniker aggregatePackageSourceMoniker = new("sourceName",
+                new List<PackageSourceContextInfo>() { new PackageSourceContextInfo("sourceName"), new PackageSourceContextInfo("sourceName2") },
+                priorityOrder: 0);
+
             // Act
 
-            // Enable package source mapping.
+            //********************************************************************************************************************************************
+            // Enable package source mapping; select an Aggregate package source so it won't allow automatically create a mapping when pressing Install.
+            //********************************************************************************************************************************************
             ConfigureNuGetUIWithPackageSourceMapping(packageSourceMappingPatterns);
-            var beforeSelectingPackageWithPackageSourceMapping_CanInstallWithPackageSourceMapping = _testInstance.CanInstallWithPackageSourceMapping;
-            var beforeSelectingPackageWithPackageSourceMapping_CanInstall = _testInstance.CanInstall;
-            var beforeSelectingPackageWithPackageSourceMapping_CanUninstall = _testInstance.CanUninstall;
+            _mockNuGetUI.Setup(_ => _.ActivePackageSourceMoniker).Returns(aggregatePackageSourceMoniker);
 
+            // Explicitly trigger PropertyChanged event.
+            _testInstance.SetInstalledOrUpdateButtonIsEnabled();
+
+            var packageNotMapped_AggregateSourceSelected_CanInstallWithPackageSourceMapping = _testInstance.CanInstallWithPackageSourceMapping;
+            var packageNotMapped_AggregateSourceSelected_CanInstall = _testInstance.CanInstall;
+            var packageNotMapped_AggregateSourceSelected_CanUninstall = _testInstance.CanUninstall;
+
+            //********************************************************************************************************************************************
+            // Select a single package source so it will allow automatically create a mapping when pressing Install.
+            //********************************************************************************************************************************************
+            _mockNuGetUI.Setup(_ => _.ActivePackageSourceMoniker).Returns(singlePackageSourceMoniker);
+
+            // Explicitly trigger PropertyChanged event.
+            _testInstance.SetInstalledOrUpdateButtonIsEnabled();
+
+            var packageNotMapped_SingleSourceSelected_CanInstallWithPackageSourceMapping = _testInstance.CanInstallWithPackageSourceMapping;
+            var packageNotMapped_SingleSourceSelected_CanInstall = _testInstance.CanInstall;
+            var packageNotMapped_SingleSourceSelected_CanUninstall = _testInstance.CanUninstall;
+
+            //********************************************************************************************************************************************
             // Select a package which has a configured Package Source Mapping.
+            //********************************************************************************************************************************************
             _testInstance.PackageSourceMappingViewModel.PackageId = packageIDWithSourceMapping;
 
             var afterSelectingPackageWithPackageSourceMapping_CanInstallWithPackageSourceMapping = _testInstance.CanInstallWithPackageSourceMapping;
+
+            // Explicitly trigger PropertyChanged event.
+            _testInstance.SetInstalledOrUpdateButtonIsEnabled();
+
             var afterSelectingPackageWithPackageSourceMapping_CanInstall = _testInstance.CanInstall;
             var afterSelectingPackageWithPackageSourceMapping_CanUninstall = _testInstance.CanUninstall;
-            _testInstance.SetInstalledOrUpdateButtonIsEnabled();
             var afterSetInstalledOrUpdateButtonIsEnabled_CanInstallWithPackageSourceMapping = _testInstance.CanInstallWithPackageSourceMapping;
 
             // Assert
             Assert.True(beforeEnablingPackageSourceMapping_CanInstallWithPackageSourceMapping, "Package Source Mapping is disabled.");
-            Assert.False(beforeEnablingPackageSourceMapping_CanInstall,
-                nameof(PackageSolutionDetailControlModel.CanInstall) + " won't become true due to state of Mocked objects.");
-            Assert.False(beforeEnablingPackageSourceMapping_CanUninstall,
-                nameof(PackageSolutionDetailControlModel.CanUninstall) + " won't become true due to state of Mocked objects.");
+            Assert.True(beforeEnablingPackageSourceMapping_CanInstall, "Package Source Mapping is disabled.");
+            Assert.True(beforeEnablingPackageSourceMapping_CanUninstall, "Package Source Mapping is disabled.");
 
-            Assert.False(beforeSelectingPackageWithPackageSourceMapping_CanInstallWithPackageSourceMapping,
+            Assert.False(packageNotMapped_AggregateSourceSelected_CanInstallWithPackageSourceMapping,
                 "Package Source Mapping is enabled but the Selected Package ID has no mapping.");
-            Assert.False(beforeSelectingPackageWithPackageSourceMapping_CanInstall,
-                nameof(PackageSolutionDetailControlModel.CanInstall) + " won't become true due to state of Mocked objects.");
-            Assert.False(beforeSelectingPackageWithPackageSourceMapping_CanUninstall,
-                nameof(PackageSolutionDetailControlModel.CanUninstall) + " won't become true due to state of Mocked objects.");
+            Assert.False(packageNotMapped_AggregateSourceSelected_CanInstall, "Package Source Mapping is enabled but the Selected Package ID has no mapping.");
+            Assert.True(packageNotMapped_AggregateSourceSelected_CanUninstall, "Should be able to Uninstall regardless of package source mapping.");
+
+            Assert.True(packageNotMapped_SingleSourceSelected_CanInstallWithPackageSourceMapping,
+                "Selected Package ID doesn't have a mapping but should automatically get one during Install.");
+            Assert.True(packageNotMapped_SingleSourceSelected_CanInstall,
+                "Selected Package ID will automatically get a package source mapping, but the " + nameof(PackageSolutionDetailControlModel.CanInstall) + " hasn't been updated, yet.");
+            Assert.True(packageNotMapped_SingleSourceSelected_CanUninstall,
+                "Selected Package ID will automatically get a package source mapping, but the " + nameof(PackageSolutionDetailControlModel.CanUninstall) + " hasn't been updated, yet.");
 
             Assert.True(afterSelectingPackageWithPackageSourceMapping_CanInstallWithPackageSourceMapping,
                 "Selected Package ID has a package source mapping.");
-            Assert.False(afterSelectingPackageWithPackageSourceMapping_CanInstall,
-                nameof(PackageSolutionDetailControlModel.CanInstall) + " won't become true due to state of Mocked objects.");
-            Assert.False(afterSelectingPackageWithPackageSourceMapping_CanUninstall,
-                nameof(PackageSolutionDetailControlModel.CanUninstall) + " won't become true due to state of Mocked objects.");
-
-            Assert.True(afterSetInstalledOrUpdateButtonIsEnabled_CanInstallWithPackageSourceMapping, "Package Source Mapping is enabled and the Package ID is mapped.");
+            Assert.True(afterSelectingPackageWithPackageSourceMapping_CanInstall, "Selected Package ID has a package source mapping.");
+            Assert.True(afterSelectingPackageWithPackageSourceMapping_CanUninstall, "Selected Package ID has a package source mapping.");
+            Assert.True(afterSetInstalledOrUpdateButtonIsEnabled_CanInstallWithPackageSourceMapping,
+                nameof(PackageSolutionDetailControlModel.SetInstalledOrUpdateButtonIsEnabled) + " should not have changed " + nameof(PackageSolutionDetailControlModel.CanInstallWithPackageSourceMapping) + ".");
 
             Assert.True(afterSetInstalledOrUpdateButtonIsEnabled_CanInstall_RaisedPropertyChanged,
                 nameof(PackageSolutionDetailControlModel.CanInstall) + " should have raised a PropertyChanged when calling "

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Utility/PackageSourceMappingUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Utility/PackageSourceMappingUtilityTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Moq;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.PackageManagement.UI.Test.Utility
+{
+    public class PackageSourceMappingUtilityTests
+    {
+        [Fact]
+        public void AddNewSourceMappingsFromAddedPackages_PackageNotMappedToMultipleExistingSources_CreatesSingleNewMapping()
+        {
+            // Arrange
+            Dictionary<string, SortedSet<string>> newSourceMappings = new();
+
+            // Existing Package Source Mappings.
+            var dictionary = new Dictionary<string, IReadOnlyList<string>>
+            {
+                { "sourceA", new List<string>() { "b", "c", "d" } },
+                { "sourceB", new List<string>() { "b", "c", "d" } }
+            };
+            var patterns = new ReadOnlyDictionary<string, IReadOnlyList<string>>(dictionary);
+            var mockPackageSourceMapping = new Mock<PackageSourceMapping>(patterns);
+
+            // Configure packages which are added by preview restore and may need new Package Source Mappings.
+            string newMappingSourceName = "sourceC";
+            List<AccessiblePackageIdentity> added = new List<AccessiblePackageIdentity>()
+            {
+                ConvertToAccessiblePackageIdentity("a"), // The only added package missing from existing mappings.
+                ConvertToAccessiblePackageIdentity("b"),
+                ConvertToAccessiblePackageIdentity("c"),
+                ConvertToAccessiblePackageIdentity("d"),
+            };
+
+            // Repeat the Act to simulate multiple ProjectActions to ensure a unique resulting set of packages is created.
+            for (int i = 0; i < 2; i++)
+            {
+                // Act
+                PackageSourceMappingUtility.AddNewSourceMappingsFromAddedPackages(ref newSourceMappings, newMappingSourceName, added, mockPackageSourceMapping.Object);
+
+                // Assert
+                Assert.Equal(1, newSourceMappings.Count);
+                Assert.True(newSourceMappings.ContainsKey(newMappingSourceName));;                
+                Assert.Equal(1, newSourceMappings[newMappingSourceName].Count);
+            }
+        }
+
+        private AccessiblePackageIdentity ConvertToAccessiblePackageIdentity(string packageId)
+        {
+            return new AccessiblePackageIdentity(new PackageIdentity(packageId, NuGetVersion.Parse("1.0.0")));
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Utility/PackageSourceMappingUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Utility/PackageSourceMappingUtilityTests.cs
@@ -46,7 +46,7 @@ namespace NuGet.PackageManagement.UI.Test.Utility
 
                 // Assert
                 Assert.Equal(1, newSourceMappings.Count);
-                Assert.True(newSourceMappings.ContainsKey(newMappingSourceName));;                
+                Assert.True(newSourceMappings.ContainsKey(newMappingSourceName));
                 Assert.Equal(1, newSourceMappings[newMappingSourceName].Count);
             }
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageSourceMappingActionViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageSourceMappingActionViewModelTests.cs
@@ -56,8 +56,8 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             var mockPackageSourceMapping = new Mock<PackageSourceMapping>(patterns);
 
             var mockUIContext = new Mock<INuGetUIContext>();
-            mockUIContext.Setup(_ => _.PackageSourceMapping).Returns(mockPackageSourceMapping.Object);
-            mockUiController.Setup(_ => _.UIContext).Returns(mockUIContext.Object);
+            mockUIContext.Setup(uiContext => uiContext.PackageSourceMapping).Returns(mockPackageSourceMapping.Object);
+            mockUiController.Setup(uiController => uiController.UIContext).Returns(mockUIContext.Object);
 
             // Act
             var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object);
@@ -89,8 +89,8 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             var mockPackageSourceMapping = new Mock<PackageSourceMapping>(patterns);
 
             var mockUIContext = new Mock<INuGetUIContext>();
-            mockUIContext.Setup(_ => _.PackageSourceMapping).Returns(mockPackageSourceMapping.Object);
-            mockUiController.Setup(_ => _.UIContext).Returns(mockUIContext.Object);
+            mockUIContext.Setup(uiContext => uiContext.PackageSourceMapping).Returns(mockPackageSourceMapping.Object);
+            mockUiController.Setup(uiController => uiController.UIContext).Returns(mockUIContext.Object);
 
             // Act
             var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object);
@@ -125,9 +125,9 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             var mockPackageSourceMapping = new Mock<PackageSourceMapping>(patterns);
 
             var mockUIContext = new Mock<INuGetUIContext>();
-            mockUIContext.Setup(_ => _.PackageSourceMapping).Returns(mockPackageSourceMapping.Object);
-            mockUiController.Setup(_ => _.UIContext).Returns(mockUIContext.Object);
-            mockUiController.Setup(_ => _.ActivePackageSourceMoniker).Returns(aggregatePackageSourceMoniker);
+            mockUIContext.Setup(uiContext => uiContext.PackageSourceMapping).Returns(mockPackageSourceMapping.Object);
+            mockUiController.Setup(uiController => uiController.UIContext).Returns(mockUIContext.Object);
+            mockUiController.Setup(uiController => uiController.ActivePackageSourceMoniker).Returns(aggregatePackageSourceMoniker);
 
             // Act
             var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object);
@@ -160,9 +160,9 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             var mockPackageSourceMapping = new Mock<PackageSourceMapping>(patterns);
 
             var mockUIContext = new Mock<INuGetUIContext>();
-            mockUIContext.Setup(_ => _.PackageSourceMapping).Returns(mockPackageSourceMapping.Object);
-            mockUiController.Setup(_ => _.UIContext).Returns(mockUIContext.Object);
-            mockUiController.Setup(_ => _.ActivePackageSourceMoniker).Returns(singlePackageSourceMoniker);
+            mockUIContext.Setup(uiContext => uiContext.PackageSourceMapping).Returns(mockPackageSourceMapping.Object);
+            mockUiController.Setup(uiController => uiController.UIContext).Returns(mockUIContext.Object);
+            mockUiController.Setup(uiController => uiController.ActivePackageSourceMoniker).Returns(singlePackageSourceMoniker);
 
             // Act
             var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object);
@@ -210,10 +210,10 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             var mockPackageSourceMapping = new Mock<PackageSourceMapping>(patterns);
 
             var mockUIContext = new Mock<INuGetUIContext>();
-            mockUIContext.Setup(_ => _.PackageSourceMapping).Returns(mockPackageSourceMapping.Object);
-            mockUIContext.Setup(_ => _.Projects).Returns(listMockProjects);
-            mockUiController.Setup(_ => _.UIContext).Returns(mockUIContext.Object);
-            mockUiController.Setup(_ => _.ActivePackageSourceMoniker).Returns(singlePackageSourceMoniker);
+            mockUIContext.Setup(uiContext => uiContext.PackageSourceMapping).Returns(mockPackageSourceMapping.Object);
+            mockUIContext.Setup(uiContext => uiContext.Projects).Returns(listMockProjects);
+            mockUiController.Setup(uiController => uiController.UIContext).Returns(mockUIContext.Object);
+            mockUiController.Setup(uiController => uiController.ActivePackageSourceMoniker).Returns(singlePackageSourceMoniker);
 
             // Act
             var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageSourceMappingActionViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageSourceMappingActionViewModelTests.cs
@@ -8,6 +8,8 @@ using Microsoft.VisualStudio.Imaging;
 using Moq;
 using NuGet.Configuration;
 using NuGet.PackageManagement.UI.ViewModels;
+using NuGet.PackageManagement.VisualStudio;
+using NuGet.VisualStudio.Internal.Contracts;
 using Xunit;
 
 namespace NuGet.PackageManagement.UI.Test.ViewModels
@@ -31,6 +33,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
 
             Assert.Equal(mockUiController.Object, target.UIController);
             Assert.Equal(false, target.IsPackageSourceMappingEnabled);
+            Assert.Equal(false, target.CanAutomaticallyCreateSourceMapping);
             Assert.Equal(false, target.IsPackageMapped);
             Assert.Equal(Resources.Text_PackageMappingsDisabled, target.MappingStatus);
             Assert.Equal(KnownMonikers.StatusInformation, target.MappingStatusIcon);
@@ -42,6 +45,8 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
         {
             // Arrange
             var mockUiController = new Mock<INuGetUI>();
+            string packageId = "b";
+
             // Enable Package Source Mapping by creating at least 1 source and pattern.
             var dictionary = new Dictionary<string, IReadOnlyList<string>>
             {
@@ -56,14 +61,18 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
 
             // Act
             var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object);
+            string targetPackageIdBeforeSelecting = target.PackageId;
+            target.PackageId = packageId;
 
             // Assert
             Assert.Equal(mockUiController.Object, target.UIController);
             Assert.Equal(true, target.IsPackageSourceMappingEnabled);
+            Assert.False(target.CanAutomaticallyCreateSourceMapping, "Expected default value since Selected package source is null.");
             Assert.Equal(false, target.IsPackageMapped);
             Assert.Equal(Resources.Text_PackageMappingsNotFound, target.MappingStatus);
             Assert.Equal(KnownMonikers.StatusError, target.MappingStatusIcon);
-            Assert.Null(target.PackageId);
+            Assert.Null(targetPackageIdBeforeSelecting);
+            Assert.Equal(packageId, target.PackageId);
         }
 
         [Fact]
@@ -90,9 +99,134 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             // Assert
             Assert.Equal(mockUiController.Object, target.UIController);
             Assert.Equal(true, target.IsPackageSourceMappingEnabled);
+            Assert.Equal(false, target.CanAutomaticallyCreateSourceMapping);
             Assert.Equal(true, target.IsPackageMapped);
             Assert.Equal(Resources.Text_PackageMappingsFound, target.MappingStatus);
             Assert.Equal(KnownMonikers.StatusOK, target.MappingStatusIcon);
+            Assert.Equal(packageId, target.PackageId);
+        }
+
+        [Fact]
+        public void PackageSourceMappingIsRequired_AggregateSource_CanNotAutomaticallyCreateMapping()
+        {
+            // Arrange
+            var mockUiController = new Mock<INuGetUI>();
+            string packageId = "b";
+            PackageSourceMoniker singlePackageSourceMoniker = new("sourceName", new List<PackageSourceContextInfo>() { new PackageSourceContextInfo("sourceName") }, priorityOrder: 0);
+            PackageSourceMoniker aggregatePackageSourceMoniker = new("sourceName",
+                new List<PackageSourceContextInfo>() { new PackageSourceContextInfo("sourceName"), new PackageSourceContextInfo("sourceName2") },
+                priorityOrder: 0);
+
+            var dictionary = new Dictionary<string, IReadOnlyList<string>>
+            {
+                { "sourceA", new List<string>() { "a" } }
+            };
+            var patterns = new ReadOnlyDictionary<string, IReadOnlyList<string>>(dictionary);
+            var mockPackageSourceMapping = new Mock<PackageSourceMapping>(patterns);
+
+            var mockUIContext = new Mock<INuGetUIContext>();
+            mockUIContext.Setup(_ => _.PackageSourceMapping).Returns(mockPackageSourceMapping.Object);
+            mockUiController.Setup(_ => _.UIContext).Returns(mockUIContext.Object);
+            mockUiController.Setup(_ => _.ActivePackageSourceMoniker).Returns(aggregatePackageSourceMoniker);
+
+            // Act
+            var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object);
+            target.PackageId = packageId;
+
+            // Assert
+            Assert.Equal(false, target.CanAutomaticallyCreateSourceMapping);
+            Assert.Equal(Resources.Text_PackageMappingsNotFound, target.MappingStatus);
+            Assert.Equal(KnownMonikers.StatusError, target.MappingStatusIcon);
+
+            Assert.Equal(mockUiController.Object, target.UIController);
+            Assert.Equal(true, target.IsPackageSourceMappingEnabled);
+            Assert.Equal(false, target.IsPackageMapped);
+            Assert.Equal(packageId, target.PackageId);
+        }
+
+        [Fact]
+        public void PackageSourceMappingIsRequired_SingleSource_CanAutomaticallyCreateMapping()
+        {
+            // Arrange
+            var mockUiController = new Mock<INuGetUI>();
+            string packageId = "b";
+            PackageSourceMoniker singlePackageSourceMoniker = new("sourceName", new List<PackageSourceContextInfo>() { new PackageSourceContextInfo("sourceName") }, priorityOrder: 0);
+
+            var dictionary = new Dictionary<string, IReadOnlyList<string>>
+            {
+                { "sourceA", new List<string>() { "a" } }
+            };
+            var patterns = new ReadOnlyDictionary<string, IReadOnlyList<string>>(dictionary);
+            var mockPackageSourceMapping = new Mock<PackageSourceMapping>(patterns);
+
+            var mockUIContext = new Mock<INuGetUIContext>();
+            mockUIContext.Setup(_ => _.PackageSourceMapping).Returns(mockPackageSourceMapping.Object);
+            mockUiController.Setup(_ => _.UIContext).Returns(mockUIContext.Object);
+            mockUiController.Setup(_ => _.ActivePackageSourceMoniker).Returns(singlePackageSourceMoniker);
+
+            // Act
+            var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object);
+            target.PackageId = packageId;
+
+            // Assert
+            Assert.Equal(true, target.CanAutomaticallyCreateSourceMapping);
+            Assert.Equal(Resources.Text_PackageMappingsAutoCreate, target.MappingStatus);
+            Assert.Equal(KnownMonikers.StatusInformation, target.MappingStatusIcon);
+
+            Assert.Equal(mockUiController.Object, target.UIController);
+            Assert.Equal(true, target.IsPackageSourceMappingEnabled);
+            Assert.Equal(false, target.IsPackageMapped);
+            Assert.Equal(packageId, target.PackageId);
+        }
+
+        [Fact]
+        public void PackageSourceMappingIsRequired_ProjectNotPackageReference_CanNotAutomaticallyCreateMapping()
+        {
+            // Arrange
+            var mockUiController = new Mock<INuGetUI>();
+            string packageId = "b";
+            PackageSourceMoniker singlePackageSourceMoniker = new("sourceName", new List<PackageSourceContextInfo>() { new PackageSourceContextInfo("sourceName") }, priorityOrder: 0);
+            Mock<INuGetProjectManagerService> projectManagerService = new Mock<INuGetProjectManagerService>();
+            Mock<IProjectContextInfo> project = new Mock<IProjectContextInfo>();
+            project.SetupGet(p => p.ProjectStyle).Returns(ProjectModel.ProjectStyle.PackageReference);
+            project.SetupGet(p => p.ProjectId).Returns("ProjectId1");
+
+            Mock<IProjectContextInfo> project2 = new Mock<IProjectContextInfo>();
+            project2.SetupGet(p => p.ProjectStyle).Returns(ProjectModel.ProjectStyle.PackagesConfig);
+            project2.SetupGet(p => p.ProjectId).Returns("ProjectId2");
+
+            ReadOnlyCollection<IProjectContextInfo> listMockProjects = new ReadOnlyCollection<IProjectContextInfo>(
+                new List<IProjectContextInfo>()
+                {
+                        project.Object,
+                        project2.Object
+                });
+
+            var dictionary = new Dictionary<string, IReadOnlyList<string>>
+            {
+                { "sourceA", new List<string>() { "a" } }
+            };
+            var patterns = new ReadOnlyDictionary<string, IReadOnlyList<string>>(dictionary);
+            var mockPackageSourceMapping = new Mock<PackageSourceMapping>(patterns);
+
+            var mockUIContext = new Mock<INuGetUIContext>();
+            mockUIContext.Setup(_ => _.PackageSourceMapping).Returns(mockPackageSourceMapping.Object);
+            mockUIContext.Setup(_ => _.Projects).Returns(listMockProjects);
+            mockUiController.Setup(_ => _.UIContext).Returns(mockUIContext.Object);
+            mockUiController.Setup(_ => _.ActivePackageSourceMoniker).Returns(singlePackageSourceMoniker);
+
+            // Act
+            var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object);
+            target.PackageId = packageId;
+
+            // Assert
+            Assert.False(target.CanAutomaticallyCreateSourceMapping, "At least one project is not PackageReference");
+            Assert.Equal(Resources.Text_PackageMappingsNotFound, target.MappingStatus);
+            Assert.Equal(KnownMonikers.StatusError, target.MappingStatusIcon);
+
+            Assert.Equal(mockUiController.Object, target.UIController);
+            Assert.Equal(true, target.IsPackageSourceMappingEnabled);
+            Assert.Equal(false, target.IsPackageMapped);
             Assert.Equal(packageId, target.PackageId);
         }
     }

--- a/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/ApexTestUIProject.cs
+++ b/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/ApexTestUIProject.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuGet.VisualStudio;
@@ -46,6 +47,14 @@ namespace NuGet.PackageManagement.UI.TestContract
             set
             {
                 UIInvoke(() => _packageManagerControl.ActiveFilter = value);
+            }
+        }
+
+        public PackageSourceMoniker SelectedSource
+        {
+            get
+            {
+                return UIInvoke(() => _packageManagerControl.SelectedSource);
             }
         }
 
@@ -155,6 +164,15 @@ namespace NuGet.PackageManagement.UI.TestContract
         {
             // First one is always 'All' option
             _packageManagerControl.SelectedSource = _packageManagerControl.PackageSources.First();
+        });
+
+        /// <summary>
+        /// Used for package source mapping Apex tests which require a specific package source to be selected.
+        /// </summary>
+        public void SetPackageSourceOptionToSource(string sourceName) => UIInvoke(() =>
+        {
+            _packageManagerControl.SelectedSource = _packageManagerControl.PackageSources.Single(
+                p => StringComparer.OrdinalIgnoreCase.Equals(p.SourceName, sourceName));
         });
 
         private void UIInvoke(Action action)

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetUIProjectTestExtension.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetUIProjectTestExtension.cs
@@ -101,5 +101,10 @@ namespace NuGet.Tests.Apex
         {
             _uiproject.SetPackageSourceOptionToAll();
         }
+
+        public void SetPackageSourceOptionToSource(string sourceName)
+        {
+            _uiproject.SetPackageSourceOptionToSource(sourceName);
+        }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -107,6 +107,10 @@ namespace NuGet.Tests.Apex
                     CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, XunitLogger);
                     var nugetTestService = GetNuGetTestService();
                     var uiwindow = nugetTestService.GetUIWindowfromProject(testContext.SolutionService.Projects[0]);
+
+                    // The Install action will automatically create a package source mapping to the selected package source if it's missing,
+                    // so select the source which already has a mapping.
+                    uiwindow.SetPackageSourceOptionToSource("PrivateRepository");
                     uiwindow.InstallPackageFromUI(packageName, packageVersion);
 
                     // Assert
@@ -240,6 +244,10 @@ namespace NuGet.Tests.Apex
                     CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, XunitLogger);
                     var nugetTestService = GetNuGetTestService();
                     var uiwindow = nugetTestService.GetUIWindowfromProject(testContext.SolutionService.Projects[0]);
+
+                    // The Install action will automatically create a package source mapping to the selected package source if it's missing,
+                    // so select the source which already has a mapping.
+                    uiwindow.SetPackageSourceOptionToSource("PrivateRepository");
                     uiwindow.InstallPackageFromUI(packageName, packageVersion);
 
                     // Assert                    


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11366
Spec: https://github.com/NuGet/Home/pull/12810

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
For PackageReference projects, when the top-level package doesn't have a source mapping, and a single source (not `All`) is selected, create a source mapping to that source for the top-level and any transitive dependencies that are brought in.
  - ie, the delta from the source mappings in the existing `nuget.config` and the source mappings resulting from this Install's PreviewRestore) 
  - If a transitive is not source mapped and not available on that source, the action will fail as it does today.
  - New status to indicate when this is going to happen, and an Enabled Install button:
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/17a16e39-bc68-4dd0-859d-b3bd45fdb7ce)

- Preview Window, if enabled, will list the new mappings at the bottom of the list.
  - New section heading: "Solution". I chose this since Source Mapping applies to `nuget.config` which is a solution level concept.
    - ie, even in Project level PMUI, the text is "Solution"
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/5dfdd468-513b-4fad-a91d-3a1b25c595a2)
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/6b6662d5-41bd-42d1-bd9d-3051939fb9d8)

- All projects affected must be `PackageReference`
  - eg, Packages.config behavior is unchanged.
  - Install button remains enabled & status indicates a required mapping:
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/9315902f-61ba-43ab-88aa-ba73f6ab4f8c)

## Summary of Conditions

Project type:
**Applicable**: Only `PackageReference` project(s) in scope
**Not Applicable**: Non-`PackageReference` project in scope

Selected source:
**Applicable**: Single source selected in Package Source dropdown.
**Not Applicable**: Aggregate source (`All`) selected in Package Source dropdown.

|State | Project Type (*) | Selected Source (*) | Change by PR|
|--|--|--|--|
|Source Mapping is off | - | - | None |
|Source Mapping is required | Not Applicable | - | None (must manually create mappings) |
|Source Mapping is required | Applicable | Not Applicable | None (must manually create mappings) |
|Source Mapping is required | Applicable | Applicable| Automatically map to selected source & show changes in Preview Window |
|Source Mapping found | Applicable | Applicable & selection is the mapped source | None (existing mapping remains) |
|Source Mapping found | Applicable | Applicable & selection is not the mapped source | Automatically create another mapping to selected source & show changes in Preview Window |

_(*) = see description above_

## Summary of GPF Behaviors


### Table: Behavior for Packages not Installed to the GPF

_Selected Source: A_

_Enabled Sources: A, B_

_Package is not already mapped_

Type|Package found on Source|Automatic Mapping Source| Implemented by PR?|
|--|--|--|--|
Direct|A|A|✅|
Transitive|A|A|✅|
Transitive|B|Error*|(✅)|

(*) Error responses:
- The existing error for NU1101 will be shown.

### Table: Behavior for Packages Installed to the GPF

_Selected Source: A_

_Enabled Sources: A, B_

_Package is not already mapped_

Type|GPF Source|Automatic Mapping Source| Implemented by PR?|
|--|--|--|--|
Direct|A|A| ✅|
Direct|B|A| ✅|
Direct|C|A| ✅|
Transitive|A|A| ✅|
Transitive|B|B| ❌ |
Transitive|C|Error*|❌|

(*) Error responses:
- The package is available in the GPF, but the source it came from is not one of your configured sources.
