### PR TITLE
Opt out Https everywhere in packages.config restore scenarios in all NuGet tools

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
@@ -379,7 +379,7 @@ namespace NuGet.PackageManagement
             foreach (SourceRepository enabledSource in packageRestoreContext.SourceRepositories)
             {
                 PackageSource source = enabledSource.PackageSource;
-                if (source.IsHttp && !source.IsHttps)
+                if (source.IsHttp && !source.IsHttps && !source.AllowInsecureConnections)
                 {
                     packageRestoreContext.Logger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "restore", source.Source));
                 }

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -1126,7 +1126,7 @@ namespace NuGet.PackageManagement
                 foreach (SourceRepository enabledSource in allSources)
                 {
                     PackageSource source = enabledSource.PackageSource;
-                    if (source.IsHttp && !source.IsHttps)
+                    if (source.IsHttp && !source.IsHttps && !source.AllowInsecureConnections)
                     {
                         nuGetProjectContext.Log(MessageLevel.Warning, Strings.Warning_HttpServerUsage, "update", source.Source);
                     }
@@ -1809,7 +1809,7 @@ namespace NuGet.PackageManagement
             foreach (SourceRepository enabledSource in effectiveSources)
             {
                 PackageSource source = enabledSource.PackageSource;
-                if (source.IsHttp && !source.IsHttps)
+                if (source.IsHttp && !source.IsHttps && !source.AllowInsecureConnections)
                 {
                     nuGetProjectContext.Log(MessageLevel.Warning, Strings.Warning_HttpServerUsage, "install", source.Source);
                 }

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -916,7 +916,7 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;http&apos; source, &apos;{1}&apos;. Support for &apos;http&apos; sources will be removed in a future version..
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;HTTP&apos; source, &apos;{1}&apos;. Non-HTTPS access will be removed in a future version. Consider migrating to an &apos;HTTPS&apos; source..
         /// </summary>
         internal static string Warning_HttpServerUsage {
             get {

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -430,6 +430,7 @@
     <comment>{0} - package id</comment>
   </data>
   <data name="Warning_HttpServerUsage" xml:space="preserve">
-    <value>You are running the '{0}' operation with an 'http' source, '{1}'. Support for 'http' sources will be removed in a future version.</value>
+    <value>You are running the '{0}' operation with an 'HTTP' source, '{1}'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.</value>
+    <comment>0 - The command name. Ex. Push/Delete. 1 - server uri.</comment>
   </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -1209,7 +1209,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             // Assert
             result.Success.Should().BeTrue();
             Assert.Contains($"Added package 'A.1.0.0' to folder '{projectAPackages}'", result.Output);
-            Assert.Contains("You are running the 'restore' operation with an 'http' source, 'http://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
+            Assert.Contains("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
         }
 
         [Theory]

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -1223,25 +1223,25 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using var pathContext = new SimpleTestPathContext();
             // Set up solution, project, and packages
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-            var packageB = new SimpleTestPackageContext("b", "1.0.0");
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageB);
+            var packageA = new SimpleTestPackageContext("a", "1.0.0");
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageA);
             pathContext.Settings.AddSource("http-feed", "http://api.source/index.json", allowInsecureConnections);
             pathContext.Settings.AddSource("https-feed", "https://api.source/index.json", allowInsecureConnections);
 
             var net461 = NuGetFramework.Parse("net461");
-            var projectA = new SimpleTestProjectContext(
-                "a",
+            var projectB = new SimpleTestProjectContext(
+                "b",
                 ProjectStyle.PackagesConfig,
                 pathContext.SolutionRoot);
-            projectA.Frameworks.Add(new SimpleTestProjectFrameworkContext(net461));
-            var projectAPackages = Path.Combine(pathContext.SolutionRoot, "packages");
+            projectB.Frameworks.Add(new SimpleTestProjectFrameworkContext(net461));
+            var projectBPackages = Path.Combine(pathContext.SolutionRoot, "packages");
 
-            Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+            Util.CreateFile(Path.GetDirectoryName(projectB.ProjectPath), "packages.config",
 @"<packages>
-  <package id=""B"" version=""1.0.0"" targetFramework=""net461"" />
+  <package id=""A"" version=""1.0.0"" targetFramework=""net461"" />
 </packages>");
 
-            solution.Projects.Add(projectA);
+            solution.Projects.Add(projectB);
             solution.Create(pathContext.SolutionRoot);
 
             // Act
@@ -1249,7 +1249,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
             // Assert
             result.Success.Should().BeTrue();
-            Assert.Contains($"Added package 'B.1.0.0' to folder '{projectAPackages}'", result.Output);
+            Assert.Contains($"Added package 'A.1.0.0' to folder '{projectBPackages}'", result.Output);
             Assert.Contains("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
             Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'https://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
         }
@@ -1263,26 +1263,26 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using var pathContext = new SimpleTestPathContext();
             // Set up solution, project, and packages
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-            var packageB = new SimpleTestPackageContext("b", "1.0.0");
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageB);
+            var packageA = new SimpleTestPackageContext("a", "1.0.0");
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageA);
 
             pathContext.Settings.AddSource("http-feed", "http://api.source/index.json", allowInsecureConnections);
             pathContext.Settings.AddSource("https-feed", "https://api.source/index.json", allowInsecureConnections);
 
             var net461 = NuGetFramework.Parse("net461");
-            var projectA = new SimpleTestProjectContext(
-                "a",
+            var projectB = new SimpleTestProjectContext(
+                "b",
                 ProjectStyle.PackagesConfig,
                 pathContext.SolutionRoot);
-            projectA.Frameworks.Add(new SimpleTestProjectFrameworkContext(net461));
-            var projectAPackages = Path.Combine(pathContext.SolutionRoot, "packages");
+            projectB.Frameworks.Add(new SimpleTestProjectFrameworkContext(net461));
+            var projectBPackages = Path.Combine(pathContext.SolutionRoot, "packages");
 
-            Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+            Util.CreateFile(Path.GetDirectoryName(projectB.ProjectPath), "packages.config",
 @"<packages>
-  <package id=""B"" version=""1.0.0"" targetFramework=""net461"" />
+  <package id=""A"" version=""1.0.0"" targetFramework=""net461"" />
 </packages>");
 
-            solution.Projects.Add(projectA);
+            solution.Projects.Add(projectB);
             solution.Create(pathContext.SolutionRoot);
 
             // Act
@@ -1290,7 +1290,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
             // Assert
             result.Success.Should().BeTrue();
-            Assert.Contains($"Added package 'B.1.0.0' to folder '{projectAPackages}'", result.Output);
+            Assert.Contains($"Added package 'A.1.0.0' to folder '{projectBPackages}'", result.Output);
             Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
             Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'https://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
         }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -1223,8 +1223,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using var pathContext = new SimpleTestPathContext();
             // Set up solution, project, and packages
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-            var packageA = new SimpleTestPackageContext("a", "1.0.0");
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageA);
+            var packageB = new SimpleTestPackageContext("b", "1.0.0");
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageB);
             pathContext.Settings.AddSource("http-feed", "http://api.source/index.json", allowInsecureConnections);
             pathContext.Settings.AddSource("https-feed", "https://api.source/index.json", allowInsecureConnections);
 
@@ -1238,20 +1238,20 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
             Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
 @"<packages>
-  <package id=""A"" version=""1.0.0"" targetFramework=""net461"" />
+  <package id=""B"" version=""1.0.0"" targetFramework=""net461"" />
 </packages>");
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
 
             // Act
-            var result = RunRestore(pathContext, _successExitCode);
+            CommandRunnerResult result = RunRestore(pathContext, _successExitCode);
 
             // Assert
             result.Success.Should().BeTrue();
-            Assert.Contains($"Added package 'A.1.0.0' to folder '{projectAPackages}'", result.Output);
-            Assert.Contains("You are running the 'restore' operation with an 'http' source, 'http://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
-            Assert.DoesNotContain("You are running the 'restore' operation with an 'http' source, 'https://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
+            Assert.Contains($"Added package 'B.1.0.0' to folder '{projectAPackages}'", result.Output);
+            Assert.Contains("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
+            Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'https://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
         }
 
         [Theory]
@@ -1263,12 +1263,11 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using var pathContext = new SimpleTestPathContext();
             // Set up solution, project, and packages
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-            var packageA = new SimpleTestPackageContext("a", "1.0.0");
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageA);
+            var packageB = new SimpleTestPackageContext("b", "1.0.0");
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageB);
 
             pathContext.Settings.AddSource("http-feed", "http://api.source/index.json", allowInsecureConnections);
             pathContext.Settings.AddSource("https-feed", "https://api.source/index.json", allowInsecureConnections);
-
 
             var net461 = NuGetFramework.Parse("net461");
             var projectA = new SimpleTestProjectContext(
@@ -1280,20 +1279,20 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
             Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
 @"<packages>
-  <package id=""A"" version=""1.0.0"" targetFramework=""net461"" />
+  <package id=""B"" version=""1.0.0"" targetFramework=""net461"" />
 </packages>");
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
 
             // Act
-            var result = RunRestore(pathContext, _successExitCode);
+            CommandRunnerResult result = RunRestore(pathContext, _successExitCode);
 
             // Assert
             result.Success.Should().BeTrue();
-            Assert.Contains($"Added package 'A.1.0.0' to folder '{projectAPackages}'", result.Output);
-            Assert.DoesNotContain("You are running the 'restore' operation with an 'http' source, 'http://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
-            Assert.DoesNotContain("You are running the 'restore' operation with an 'http' source, 'https://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
+            Assert.Contains($"Added package 'B.1.0.0' to folder '{projectAPackages}'", result.Output);
+            Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
+            Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'https://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
         }
 
         public static string GetResource(string name)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -2146,7 +2146,7 @@ namespace NuGet.CommandLine.Test
             result.Success.Should().BeTrue();
             result.AllOutput.Should().Contain($"Added package 'A.1.0.0' to folder '{pathContext.PackagesV2}'");
             Assert.Contains("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
-            Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'https://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output) ;
+            Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'https://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -2052,7 +2052,7 @@ namespace NuGet.CommandLine.Test
             // Assert
             result.Success.Should().BeTrue();
             result.AllOutput.Should().Contain($"Added package 'A.1.0.0' to folder '{pathContext.PackagesV2}'");
-            result.AllOutput.Should().Contain("You are running the 'restore' operation with an 'http' source, 'http://api.source/api/v2'. Support for 'http' sources will be removed in a future version.");
+            result.AllOutput.Should().Contain("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/api/v2'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.");
         }
 
         [Theory]
@@ -2167,7 +2167,7 @@ namespace NuGet.CommandLine.Test
 
             server.Stop();
             result.AllOutput.Should().Contain($"Added package 'A.1.0.0' to folder");
-            result.AllOutput.Should().Contain("You are running the 'install' operation with an 'http' source");
+            result.AllOutput.Should().Contain("You are running the 'install' operation with an 'HTTP' source");
         }
 
         public static CommandRunnerResult RunInstall(SimpleTestPathContext pathContext, string input, int expectedExitCode = 0, params string[] additionalArgs)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -355,11 +355,11 @@ namespace NuGet.CommandLine.Test
 
                 Directory.CreateDirectory(repositoryPath);
 
-                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "1.1.0", repositoryPath);
                 Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
 @"<packages>
-  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageB"" version=""1.1.0"" targetFramework=""net45"" />
   <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
@@ -368,7 +368,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.Equal(0, r.ExitCode);
-                var packageADir = Path.Combine(workingPath, "outputDir", "packageA");
+                var packageADir = Path.Combine(workingPath, "outputDir", "packageB");
                 var packageBDir = Path.Combine(workingPath, "outputDir", "packageB");
                 Assert.True(Directory.Exists(packageADir));
                 Assert.True(Directory.Exists(packageBDir));
@@ -414,11 +414,11 @@ namespace NuGet.CommandLine.Test
                 var repositoryPath = Path.Combine(workingPath, "Repository");
 
                 Directory.CreateDirectory(repositoryPath);
-                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "1.1.0", repositoryPath);
                 Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
     @"<packages>
-  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageB"" version=""1.1.0"" targetFramework=""net45"" />
   <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
@@ -435,7 +435,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.Equal(0, r.ExitCode);
-                var packageFileA = Path.Combine(workingPath, "outputDir", "packageA.1.1.0", "packageA.1.1.0.nupkg");
+                var packageFileA = Path.Combine(workingPath, "outputDir", "packageB.1.1.0", "packageB.1.1.0.nupkg");
                 var packageFileB = Path.Combine(workingPath, "outputDir", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
                 Assert.True(File.Exists(packageFileB));
@@ -458,12 +458,12 @@ namespace NuGet.CommandLine.Test
                 Directory.CreateDirectory(repositoryPath);
 
                 // Incorrect versions
-                Util.CreateTestPackage("packageA", "1.0.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "1.0.0", repositoryPath);
                 Util.CreateTestPackage("packageB", "2.0.0", repositoryPath);
 
                 Util.CreateFile(workingPath, "packages.config",
     @"<packages>
-  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageB"" version=""1.1.0"" targetFramework=""net45"" />
   <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
@@ -496,11 +496,11 @@ namespace NuGet.CommandLine.Test
                 var repositoryPath = Path.Combine(workingPath, "Repository");
 
                 Directory.CreateDirectory(repositoryPath);
-                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "1.1.0", repositoryPath);
                 Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
     @"<packages>
-  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageB"" version=""1.1.0"" targetFramework=""net45"" />
   <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
@@ -533,11 +533,11 @@ namespace NuGet.CommandLine.Test
                 var packagesConfig = Path.Combine(workingPath, "packages.config");
 
                 Directory.CreateDirectory(repositoryPath);
-                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "1.1.0", repositoryPath);
                 Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
     @"<packages>
-  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageB"" version=""1.1.0"" targetFramework=""net45"" />
   <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
@@ -554,7 +554,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.Equal(0, r.ExitCode);
-                var packageFileA = Path.Combine(workingPath, "outputDir", "packageA.1.1.0", "packageA.1.1.0.nupkg");
+                var packageFileA = Path.Combine(workingPath, "outputDir", "packageB.1.1.0", "packageB.1.1.0.nupkg");
                 var packageFileB = Path.Combine(workingPath, "outputDir", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
                 Assert.True(File.Exists(packageFileB));
@@ -593,11 +593,11 @@ namespace NuGet.CommandLine.Test
 
                 Directory.CreateDirectory(repositoryPath);
 
-                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "1.1.0", repositoryPath);
                 Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
     @"<packages>
-  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageB"" version=""1.1.0"" targetFramework=""net45"" />
   <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
@@ -616,7 +616,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.True(0 == r.ExitCode, $"{r.Output} {r.Errors}");
-                var packageFileA = Path.Combine(workingPath, "outputDir", "packageA.1.1.0", "packageA.1.1.0.nupkg");
+                var packageFileA = Path.Combine(workingPath, "outputDir", "packageB.1.1.0", "packageB.1.1.0.nupkg");
                 var packageFileB = Path.Combine(workingPath, "outputDir", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
                 Assert.True(File.Exists(packageFileB));
@@ -639,11 +639,11 @@ namespace NuGet.CommandLine.Test
                 var relativeFolderPath = $"..\\{folderName}";
 
                 Directory.CreateDirectory(repositoryPath);
-                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "1.1.0", repositoryPath);
                 Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
     @"<packages>
-  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageB"" version=""1.1.0"" targetFramework=""net45"" />
   <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
@@ -671,7 +671,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.Equal(0, r.ExitCode);
-                var packageFileA = Path.Combine(workingPath, "outputDir", "packageA.1.1.0", "packageA.1.1.0.nupkg");
+                var packageFileA = Path.Combine(workingPath, "outputDir", "packageB.1.1.0", "packageB.1.1.0.nupkg");
                 var packageFileB = Path.Combine(workingPath, "outputDir", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
                 Assert.True(File.Exists(packageFileB));
@@ -917,7 +917,7 @@ namespace NuGet.CommandLine.Test
                 Directory.CreateDirectory(repositoryPath);
                 Directory.CreateDirectory(proj1Directory);
 
-                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "1.1.0", repositoryPath);
                 Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
 
                 Util.CreateFile(workingPath, "my.config",
@@ -942,7 +942,7 @@ namespace NuGet.CommandLine.Test
 </Project>");
                 Util.CreateFile(proj1Directory, configFileName,
     @"<packages>
-  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageB"" version=""1.1.0"" targetFramework=""net45"" />
 </packages>");
                 // Act
                 var r = RunInstall(pathContext, configFileName, 0, " -Source " + repositoryPath + $@" -ConfigFile my.config -RequireConsent");
@@ -978,7 +978,7 @@ namespace NuGet.CommandLine.Test
                 Directory.CreateDirectory(repositoryPath);
                 Directory.CreateDirectory(proj1Directory);
 
-                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "1.1.0", repositoryPath);
                 Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
 
                 Util.CreateFile(workingPath, "my.config",
@@ -1003,7 +1003,7 @@ namespace NuGet.CommandLine.Test
 </Project>");
                 Util.CreateFile(proj1Directory, configFileName,
     @"<packages>
-  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageB"" version=""1.1.0"" targetFramework=""net45"" />
 </packages>");
                 // Act
                 var r = RunInstall(pathContext, configFileName, 0, " -Source " + repositoryPath + $@" -ConfigFile my.config");
@@ -2064,13 +2064,12 @@ namespace NuGet.CommandLine.Test
             using var pathContext = new SimpleTestPathContext();
             // Set up solution, project, and packages
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-            var packageA = new SimpleTestPackageContext("a", "1.0.0");
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageA);
-            var packageAPath = Path.Combine(pathContext.PackageSource, packageA.Id, packageA.Version, packageA.PackageName);
+            var packageB = new SimpleTestPackageContext("b", "1.0.0");
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageB);
+            var packageBPath = Path.Combine(pathContext.PackageSource, packageB.Id, packageB.Version, packageB.PackageName);
 
             pathContext.Settings.AddSource("http-feed", "http://api.source/index.json", allowInsecureConnections);
             pathContext.Settings.AddSource("https-feed", "https://api.source/index.json", allowInsecureConnections);
-
 
             var projectA = new SimpleTestProjectContext(
                 "a",
@@ -2079,7 +2078,7 @@ namespace NuGet.CommandLine.Test
 
             Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
 @"<packages>
-  <package id=""A"" version=""1.0.0"" targetFramework=""net461"" />
+  <package id=""B"" version=""1.0.0"" targetFramework=""net461"" />
 </packages>");
 
             solution.Projects.Add(projectA);
@@ -2093,13 +2092,13 @@ namespace NuGet.CommandLine.Test
             };
 
             // Act
-            var result = RunInstall(pathContext, config, expectedExitCode: 0, additionalArgs: args);
+            CommandRunnerResult result = RunInstall(pathContext, config, expectedExitCode: 0, additionalArgs: args);
 
             // Assert
             result.Success.Should().BeTrue();
-            result.AllOutput.Should().Contain($"Added package 'A.1.0.0' to folder '{pathContext.PackagesV2}'");
-            Assert.DoesNotContain("You are running the 'restore' operation with an 'http' source, 'http://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
-            Assert.DoesNotContain("You are running the 'restore' operation with an 'http' source, 'https://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
+            result.AllOutput.Should().Contain($"Added package 'B.1.0.0' to folder '{pathContext.PackagesV2}'");
+            Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
+            Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'https://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output); ;
         }
 
         [Theory]
@@ -2113,13 +2112,12 @@ namespace NuGet.CommandLine.Test
             using var pathContext = new SimpleTestPathContext();
             // Set up solution, project, and packages
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-            var packageA = new SimpleTestPackageContext("a", "1.0.0");
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageA);
-            var packageAPath = Path.Combine(pathContext.PackageSource, packageA.Id, packageA.Version, packageA.PackageName);
+            var packageB = new SimpleTestPackageContext("b", "1.0.0");
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageB);
+            var packageBPath = Path.Combine(pathContext.PackageSource, packageB.Id, packageB.Version, packageB.PackageName);
 
             pathContext.Settings.AddSource("http-feed", "http://api.source/index.json", allowInsecureConnections);
             pathContext.Settings.AddSource("https-feed", "https://api.source/index.json", allowInsecureConnections);
-
 
             var projectA = new SimpleTestProjectContext(
                 "a",
@@ -2128,7 +2126,7 @@ namespace NuGet.CommandLine.Test
 
             Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
 @"<packages>
-  <package id=""A"" version=""1.0.0"" targetFramework=""net461"" />
+  <package id=""B"" version=""1.0.0"" targetFramework=""net461"" />
 </packages>");
 
             solution.Projects.Add(projectA);
@@ -2142,13 +2140,13 @@ namespace NuGet.CommandLine.Test
             };
 
             // Act
-            var result = RunInstall(pathContext, config, expectedExitCode: 0, additionalArgs: args);
+            CommandRunnerResult result = RunInstall(pathContext, config, expectedExitCode: 0, additionalArgs: args);
 
             // Assert
             result.Success.Should().BeTrue();
-            result.AllOutput.Should().Contain($"Added package 'A.1.0.0' to folder '{pathContext.PackagesV2}'");
-            Assert.Contains("You are running the 'restore' operation with an 'http' source, 'http://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
-            Assert.DoesNotContain("You are running the 'restore' operation with an 'http' source, 'https://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
+            result.AllOutput.Should().Contain($"Added package 'B.1.0.0' to folder '{pathContext.PackagesV2}'");
+            Assert.Contains("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
+            Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'https://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output) ;
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -2056,9 +2056,13 @@ namespace NuGet.CommandLine.Test
         }
 
         [Theory]
-        [InlineData("true")]
-        [InlineData("TRUE")]
-        public async Task Install_PackagesConfigWithHttpSourceAndTrueAllowInsecureConnections_NoWarns(string allowInsecureConnections)
+        [InlineData("false", true)]
+        [InlineData("FALSE", true)]
+        [InlineData("invalidString", true)]
+        [InlineData("", true)]
+        [InlineData("true", false)]
+        [InlineData("TRUE",false)]
+        public async Task Install_PackagesConfigWithHttpSourceAndAllowInsecureConnections_WarnsCorrectly(string allowInsecureConnections, bool hasHttpWarning)
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
@@ -2095,58 +2099,21 @@ namespace NuGet.CommandLine.Test
             CommandRunnerResult result = RunInstall(pathContext, config, expectedExitCode: 0, additionalArgs: args);
 
             // Assert
+            string formatString = "You are running the 'restore' operation with an 'HTTP' source, '{0}'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS'";
+            string warningForHttpSource = string.Format(formatString, "http://api.source/index.json");
+            string warningForHttpsSource = string.Format(formatString, "https://api.source/index.json");
+
             result.Success.Should().BeTrue();
             result.AllOutput.Should().Contain($"Added package 'A.1.0.0' to folder '{pathContext.PackagesV2}'");
-            Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
-            Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'https://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output); ;
-        }
-
-        [Theory]
-        [InlineData("false")]
-        [InlineData("FALSE")]
-        [InlineData("invalidString")]
-        [InlineData("")]
-        public async Task Install_PackagesConfigWithHttpSourceAndFalseAllowInsecureConnections_Warns(string allowInsecureConnections)
-        {
-            // Arrange
-            using var pathContext = new SimpleTestPathContext();
-            // Set up solution, project, and packages
-            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-            var packageA = new SimpleTestPackageContext("a", "1.0.0");
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageA);
-            var packageAPath = Path.Combine(pathContext.PackageSource, packageA.Id, packageA.Version, packageA.PackageName);
-
-            pathContext.Settings.AddSource("http-feed", "http://api.source/index.json", allowInsecureConnections);
-            pathContext.Settings.AddSource("https-feed", "https://api.source/index.json", allowInsecureConnections);
-
-            var projectB = new SimpleTestProjectContext(
-                "b",
-                ProjectStyle.PackagesConfig,
-                pathContext.SolutionRoot);
-
-            Util.CreateFile(Path.GetDirectoryName(projectB.ProjectPath), "packages.config",
-@"<packages>
-  <package id=""A"" version=""1.0.0"" targetFramework=""net461"" />
-</packages>");
-
-            solution.Projects.Add(projectB);
-            solution.Create(pathContext.SolutionRoot);
-
-            var config = Path.Combine(Path.GetDirectoryName(projectB.ProjectPath), "packages.config");
-            var args = new string[]
+            Assert.DoesNotContain(warningForHttpsSource, result.Output);
+            if (hasHttpWarning)
             {
-                "-OutputDirectory",
-                pathContext.PackagesV2
-            };
-
-            // Act
-            CommandRunnerResult result = RunInstall(pathContext, config, expectedExitCode: 0, additionalArgs: args);
-
-            // Assert
-            result.Success.Should().BeTrue();
-            result.AllOutput.Should().Contain($"Added package 'A.1.0.0' to folder '{pathContext.PackagesV2}'");
-            Assert.Contains("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
-            Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'https://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
+                Assert.Contains(warningForHttpSource, result.Output);
+            }
+            else
+            {
+                Assert.DoesNotContain(warningForHttpSource, result.Output); ;
+            }
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -356,11 +356,11 @@ namespace NuGet.CommandLine.Test
                 Directory.CreateDirectory(repositoryPath);
 
                 Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
-                Util.CreateTestPackage("packageA", "2.2.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
 @"<packages>
   <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
-  <package id=""packageA"" version=""2.2.0"" targetFramework=""net45"" />
+  <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
                 // Act
@@ -369,7 +369,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.Equal(0, r.ExitCode);
                 var packageADir = Path.Combine(workingPath, "outputDir", "packageA");
-                var packageBDir = Path.Combine(workingPath, "outputDir", "packageA");
+                var packageBDir = Path.Combine(workingPath, "outputDir", "packageB");
                 Assert.True(Directory.Exists(packageADir));
                 Assert.True(Directory.Exists(packageBDir));
             }
@@ -415,11 +415,11 @@ namespace NuGet.CommandLine.Test
 
                 Directory.CreateDirectory(repositoryPath);
                 Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
-                Util.CreateTestPackage("packageA", "2.2.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
     @"<packages>
   <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
-  <package id=""packageA"" version=""2.2.0"" targetFramework=""net45"" />
+  <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
                 var args = new string[]
@@ -436,7 +436,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.Equal(0, r.ExitCode);
                 var packageFileA = Path.Combine(workingPath, "outputDir", "packageA.1.1.0", "packageA.1.1.0.nupkg");
-                var packageFileB = Path.Combine(workingPath, "outputDir", "packageA.2.2.0", "packageA.2.2.0.nupkg");
+                var packageFileB = Path.Combine(workingPath, "outputDir", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
                 Assert.True(File.Exists(packageFileB));
             }
@@ -459,12 +459,12 @@ namespace NuGet.CommandLine.Test
 
                 // Incorrect versions
                 Util.CreateTestPackage("packageA", "1.0.0", repositoryPath);
-                Util.CreateTestPackage("packageA", "2.0.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "2.0.0", repositoryPath);
 
                 Util.CreateFile(workingPath, "packages.config",
     @"<packages>
   <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
-  <package id=""packageA"" version=""2.2.0"" targetFramework=""net45"" />
+  <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
                 var args = new string[]
@@ -497,11 +497,11 @@ namespace NuGet.CommandLine.Test
 
                 Directory.CreateDirectory(repositoryPath);
                 Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
-                Util.CreateTestPackage("packageA", "2.2.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
     @"<packages>
   <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
-  <package id=""packageA"" version=""2.2.0"" targetFramework=""net45"" />
+  <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
                 var args = new string[]
@@ -534,11 +534,11 @@ namespace NuGet.CommandLine.Test
 
                 Directory.CreateDirectory(repositoryPath);
                 Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
-                Util.CreateTestPackage("packageA", "2.2.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
     @"<packages>
   <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
-  <package id=""packageA"" version=""2.2.0"" targetFramework=""net45"" />
+  <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
                 var args = new string[]
@@ -555,7 +555,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.Equal(0, r.ExitCode);
                 var packageFileA = Path.Combine(workingPath, "outputDir", "packageA.1.1.0", "packageA.1.1.0.nupkg");
-                var packageFileB = Path.Combine(workingPath, "outputDir", "packageA.2.2.0", "packageA.2.2.0.nupkg");
+                var packageFileB = Path.Combine(workingPath, "outputDir", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
                 Assert.True(File.Exists(packageFileB));
 
@@ -594,11 +594,11 @@ namespace NuGet.CommandLine.Test
                 Directory.CreateDirectory(repositoryPath);
 
                 Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
-                Util.CreateTestPackage("packageA", "2.2.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
     @"<packages>
   <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
-  <package id=""packageA"" version=""2.2.0"" targetFramework=""net45"" />
+  <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
                 var args = new string[]
@@ -617,7 +617,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.True(0 == r.ExitCode, $"{r.Output} {r.Errors}");
                 var packageFileA = Path.Combine(workingPath, "outputDir", "packageA.1.1.0", "packageA.1.1.0.nupkg");
-                var packageFileB = Path.Combine(workingPath, "outputDir", "packageA.2.2.0", "packageA.2.2.0.nupkg");
+                var packageFileB = Path.Combine(workingPath, "outputDir", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
                 Assert.True(File.Exists(packageFileB));
             }
@@ -640,11 +640,11 @@ namespace NuGet.CommandLine.Test
 
                 Directory.CreateDirectory(repositoryPath);
                 Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
-                Util.CreateTestPackage("packageA", "2.2.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
     @"<packages>
   <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
-  <package id=""packageA"" version=""2.2.0"" targetFramework=""net45"" />
+  <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
                 var args = new string[]
@@ -672,7 +672,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.Equal(0, r.ExitCode);
                 var packageFileA = Path.Combine(workingPath, "outputDir", "packageA.1.1.0", "packageA.1.1.0.nupkg");
-                var packageFileB = Path.Combine(workingPath, "outputDir", "packageA.2.2.0", "packageA.2.2.0.nupkg");
+                var packageFileB = Path.Combine(workingPath, "outputDir", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
                 Assert.True(File.Exists(packageFileB));
             }
@@ -918,7 +918,7 @@ namespace NuGet.CommandLine.Test
                 Directory.CreateDirectory(proj1Directory);
 
                 Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
-                Util.CreateTestPackage("packageA", "2.2.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
 
                 Util.CreateFile(workingPath, "my.config",
                     @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -979,7 +979,7 @@ namespace NuGet.CommandLine.Test
                 Directory.CreateDirectory(proj1Directory);
 
                 Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
-                Util.CreateTestPackage("packageA", "2.2.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
 
                 Util.CreateFile(workingPath, "my.config",
                     @"<?xml version=""1.0"" encoding=""utf-8""?>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -355,12 +355,12 @@ namespace NuGet.CommandLine.Test
 
                 Directory.CreateDirectory(repositoryPath);
 
-                Util.CreateTestPackage("packageB", "1.1.0", repositoryPath);
-                Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
+                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("packageA", "2.2.0", repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
 @"<packages>
-  <package id=""packageB"" version=""1.1.0"" targetFramework=""net45"" />
-  <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
+  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageA"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
                 // Act
@@ -368,8 +368,8 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.Equal(0, r.ExitCode);
-                var packageADir = Path.Combine(workingPath, "outputDir", "packageB");
-                var packageBDir = Path.Combine(workingPath, "outputDir", "packageB");
+                var packageADir = Path.Combine(workingPath, "outputDir", "packageA");
+                var packageBDir = Path.Combine(workingPath, "outputDir", "packageA");
                 Assert.True(Directory.Exists(packageADir));
                 Assert.True(Directory.Exists(packageBDir));
             }
@@ -414,12 +414,12 @@ namespace NuGet.CommandLine.Test
                 var repositoryPath = Path.Combine(workingPath, "Repository");
 
                 Directory.CreateDirectory(repositoryPath);
-                Util.CreateTestPackage("packageB", "1.1.0", repositoryPath);
-                Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
+                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("packageA", "2.2.0", repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
     @"<packages>
-  <package id=""packageB"" version=""1.1.0"" targetFramework=""net45"" />
-  <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
+  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageA"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
                 var args = new string[]
@@ -435,8 +435,8 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.Equal(0, r.ExitCode);
-                var packageFileA = Path.Combine(workingPath, "outputDir", "packageB.1.1.0", "packageB.1.1.0.nupkg");
-                var packageFileB = Path.Combine(workingPath, "outputDir", "packageB.2.2.0", "packageB.2.2.0.nupkg");
+                var packageFileA = Path.Combine(workingPath, "outputDir", "packageA.1.1.0", "packageA.1.1.0.nupkg");
+                var packageFileB = Path.Combine(workingPath, "outputDir", "packageA.2.2.0", "packageA.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
                 Assert.True(File.Exists(packageFileB));
             }
@@ -458,13 +458,13 @@ namespace NuGet.CommandLine.Test
                 Directory.CreateDirectory(repositoryPath);
 
                 // Incorrect versions
-                Util.CreateTestPackage("packageB", "1.0.0", repositoryPath);
-                Util.CreateTestPackage("packageB", "2.0.0", repositoryPath);
+                Util.CreateTestPackage("packageA", "1.0.0", repositoryPath);
+                Util.CreateTestPackage("packageA", "2.0.0", repositoryPath);
 
                 Util.CreateFile(workingPath, "packages.config",
     @"<packages>
-  <package id=""packageB"" version=""1.1.0"" targetFramework=""net45"" />
-  <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
+  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageA"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
                 var args = new string[]
@@ -496,12 +496,12 @@ namespace NuGet.CommandLine.Test
                 var repositoryPath = Path.Combine(workingPath, "Repository");
 
                 Directory.CreateDirectory(repositoryPath);
-                Util.CreateTestPackage("packageB", "1.1.0", repositoryPath);
-                Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
+                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("packageA", "2.2.0", repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
     @"<packages>
-  <package id=""packageB"" version=""1.1.0"" targetFramework=""net45"" />
-  <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
+  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageA"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
                 var args = new string[]
@@ -533,12 +533,12 @@ namespace NuGet.CommandLine.Test
                 var packagesConfig = Path.Combine(workingPath, "packages.config");
 
                 Directory.CreateDirectory(repositoryPath);
-                Util.CreateTestPackage("packageB", "1.1.0", repositoryPath);
-                Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
+                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("packageA", "2.2.0", repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
     @"<packages>
-  <package id=""packageB"" version=""1.1.0"" targetFramework=""net45"" />
-  <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
+  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageA"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
                 var args = new string[]
@@ -554,8 +554,8 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.Equal(0, r.ExitCode);
-                var packageFileA = Path.Combine(workingPath, "outputDir", "packageB.1.1.0", "packageB.1.1.0.nupkg");
-                var packageFileB = Path.Combine(workingPath, "outputDir", "packageB.2.2.0", "packageB.2.2.0.nupkg");
+                var packageFileA = Path.Combine(workingPath, "outputDir", "packageA.1.1.0", "packageA.1.1.0.nupkg");
+                var packageFileB = Path.Combine(workingPath, "outputDir", "packageA.2.2.0", "packageA.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
                 Assert.True(File.Exists(packageFileB));
 
@@ -593,12 +593,12 @@ namespace NuGet.CommandLine.Test
 
                 Directory.CreateDirectory(repositoryPath);
 
-                Util.CreateTestPackage("packageB", "1.1.0", repositoryPath);
-                Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
+                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("packageA", "2.2.0", repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
     @"<packages>
-  <package id=""packageB"" version=""1.1.0"" targetFramework=""net45"" />
-  <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
+  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageA"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
                 var args = new string[]
@@ -616,8 +616,8 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.True(0 == r.ExitCode, $"{r.Output} {r.Errors}");
-                var packageFileA = Path.Combine(workingPath, "outputDir", "packageB.1.1.0", "packageB.1.1.0.nupkg");
-                var packageFileB = Path.Combine(workingPath, "outputDir", "packageB.2.2.0", "packageB.2.2.0.nupkg");
+                var packageFileA = Path.Combine(workingPath, "outputDir", "packageA.1.1.0", "packageA.1.1.0.nupkg");
+                var packageFileB = Path.Combine(workingPath, "outputDir", "packageA.2.2.0", "packageA.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
                 Assert.True(File.Exists(packageFileB));
             }
@@ -639,12 +639,12 @@ namespace NuGet.CommandLine.Test
                 var relativeFolderPath = $"..\\{folderName}";
 
                 Directory.CreateDirectory(repositoryPath);
-                Util.CreateTestPackage("packageB", "1.1.0", repositoryPath);
-                Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
+                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("packageA", "2.2.0", repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
     @"<packages>
-  <package id=""packageB"" version=""1.1.0"" targetFramework=""net45"" />
-  <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
+  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageA"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
                 var args = new string[]
@@ -671,8 +671,8 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.Equal(0, r.ExitCode);
-                var packageFileA = Path.Combine(workingPath, "outputDir", "packageB.1.1.0", "packageB.1.1.0.nupkg");
-                var packageFileB = Path.Combine(workingPath, "outputDir", "packageB.2.2.0", "packageB.2.2.0.nupkg");
+                var packageFileA = Path.Combine(workingPath, "outputDir", "packageA.1.1.0", "packageA.1.1.0.nupkg");
+                var packageFileB = Path.Combine(workingPath, "outputDir", "packageA.2.2.0", "packageA.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
                 Assert.True(File.Exists(packageFileB));
             }
@@ -917,8 +917,8 @@ namespace NuGet.CommandLine.Test
                 Directory.CreateDirectory(repositoryPath);
                 Directory.CreateDirectory(proj1Directory);
 
-                Util.CreateTestPackage("packageB", "1.1.0", repositoryPath);
-                Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
+                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("packageA", "2.2.0", repositoryPath);
 
                 Util.CreateFile(workingPath, "my.config",
                     @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -942,7 +942,7 @@ namespace NuGet.CommandLine.Test
 </Project>");
                 Util.CreateFile(proj1Directory, configFileName,
     @"<packages>
-  <package id=""packageB"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
 </packages>");
                 // Act
                 var r = RunInstall(pathContext, configFileName, 0, " -Source " + repositoryPath + $@" -ConfigFile my.config -RequireConsent");
@@ -978,8 +978,8 @@ namespace NuGet.CommandLine.Test
                 Directory.CreateDirectory(repositoryPath);
                 Directory.CreateDirectory(proj1Directory);
 
-                Util.CreateTestPackage("packageB", "1.1.0", repositoryPath);
-                Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
+                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("packageA", "2.2.0", repositoryPath);
 
                 Util.CreateFile(workingPath, "my.config",
                     @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -1003,7 +1003,7 @@ namespace NuGet.CommandLine.Test
 </Project>");
                 Util.CreateFile(proj1Directory, configFileName,
     @"<packages>
-  <package id=""packageB"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
 </packages>");
                 // Act
                 var r = RunInstall(pathContext, configFileName, 0, " -Source " + repositoryPath + $@" -ConfigFile my.config");
@@ -2064,27 +2064,27 @@ namespace NuGet.CommandLine.Test
             using var pathContext = new SimpleTestPathContext();
             // Set up solution, project, and packages
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-            var packageB = new SimpleTestPackageContext("b", "1.0.0");
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageB);
-            var packageBPath = Path.Combine(pathContext.PackageSource, packageB.Id, packageB.Version, packageB.PackageName);
+            var packageA = new SimpleTestPackageContext("a", "1.0.0");
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageA);
+            var packageAPath = Path.Combine(pathContext.PackageSource, packageA.Id, packageA.Version, packageA.PackageName);
 
             pathContext.Settings.AddSource("http-feed", "http://api.source/index.json", allowInsecureConnections);
             pathContext.Settings.AddSource("https-feed", "https://api.source/index.json", allowInsecureConnections);
 
-            var projectA = new SimpleTestProjectContext(
-                "a",
+            var projectB = new SimpleTestProjectContext(
+                "b",
                 ProjectStyle.PackagesConfig,
                 pathContext.SolutionRoot);
 
-            Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+            Util.CreateFile(Path.GetDirectoryName(projectB.ProjectPath), "packages.config",
 @"<packages>
-  <package id=""B"" version=""1.0.0"" targetFramework=""net461"" />
+  <package id=""A"" version=""1.0.0"" targetFramework=""net461"" />
 </packages>");
 
-            solution.Projects.Add(projectA);
+            solution.Projects.Add(projectB);
             solution.Create(pathContext.SolutionRoot);
 
-            var config = Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "packages.config");
+            var config = Path.Combine(Path.GetDirectoryName(projectB.ProjectPath), "packages.config");
             var args = new string[]
             {
                 "-OutputDirectory",
@@ -2096,7 +2096,7 @@ namespace NuGet.CommandLine.Test
 
             // Assert
             result.Success.Should().BeTrue();
-            result.AllOutput.Should().Contain($"Added package 'B.1.0.0' to folder '{pathContext.PackagesV2}'");
+            result.AllOutput.Should().Contain($"Added package 'A.1.0.0' to folder '{pathContext.PackagesV2}'");
             Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
             Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'https://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output); ;
         }
@@ -2112,27 +2112,27 @@ namespace NuGet.CommandLine.Test
             using var pathContext = new SimpleTestPathContext();
             // Set up solution, project, and packages
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-            var packageB = new SimpleTestPackageContext("b", "1.0.0");
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageB);
-            var packageBPath = Path.Combine(pathContext.PackageSource, packageB.Id, packageB.Version, packageB.PackageName);
+            var packageA = new SimpleTestPackageContext("a", "1.0.0");
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageA);
+            var packageAPath = Path.Combine(pathContext.PackageSource, packageA.Id, packageA.Version, packageA.PackageName);
 
             pathContext.Settings.AddSource("http-feed", "http://api.source/index.json", allowInsecureConnections);
             pathContext.Settings.AddSource("https-feed", "https://api.source/index.json", allowInsecureConnections);
 
-            var projectA = new SimpleTestProjectContext(
-                "a",
+            var projectB = new SimpleTestProjectContext(
+                "b",
                 ProjectStyle.PackagesConfig,
                 pathContext.SolutionRoot);
 
-            Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+            Util.CreateFile(Path.GetDirectoryName(projectB.ProjectPath), "packages.config",
 @"<packages>
-  <package id=""B"" version=""1.0.0"" targetFramework=""net461"" />
+  <package id=""A"" version=""1.0.0"" targetFramework=""net461"" />
 </packages>");
 
-            solution.Projects.Add(projectA);
+            solution.Projects.Add(projectB);
             solution.Create(pathContext.SolutionRoot);
 
-            var config = Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "packages.config");
+            var config = Path.Combine(Path.GetDirectoryName(projectB.ProjectPath), "packages.config");
             var args = new string[]
             {
                 "-OutputDirectory",
@@ -2144,7 +2144,7 @@ namespace NuGet.CommandLine.Test
 
             // Assert
             result.Success.Should().BeTrue();
-            result.AllOutput.Should().Contain($"Added package 'B.1.0.0' to folder '{pathContext.PackagesV2}'");
+            result.AllOutput.Should().Contain($"Added package 'A.1.0.0' to folder '{pathContext.PackagesV2}'");
             Assert.Contains("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
             Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'https://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output) ;
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -2061,7 +2061,7 @@ namespace NuGet.CommandLine.Test
         [InlineData("invalidString", true)]
         [InlineData("", true)]
         [InlineData("true", false)]
-        [InlineData("TRUE",false)]
+        [InlineData("TRUE", false)]
         public async Task Install_PackagesConfigWithHttpSourceAndAllowInsecureConnections_WarnsCorrectly(string allowInsecureConnections, bool hasHttpWarning)
         {
             // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -1931,17 +1931,17 @@ namespace NuGet.CommandLine.Test
             var sourceUri = $"{server.Uri}nuget";
             pathContext.Settings.AddSource("http-feed", $"{server.Uri}nuget", allowInsecureConnections);
 
-            var projectA = new SimpleTestProjectContext(
-                  "a",
+            var projectB = new SimpleTestProjectContext(
+                  "b",
                   ProjectStyle.PackagesConfig,
                   pathContext.SolutionRoot);
 
-            Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+            Util.CreateFile(Path.GetDirectoryName(projectB.ProjectPath), "packages.config",
 @"<packages>
   <package id=""A"" version=""1.0.0"" targetFramework=""net461"" />
 </packages>");
 
-            solution.Projects.Add(projectA);
+            solution.Projects.Add(projectB);
             solution.Create(pathContext.SolutionRoot);
 
             var args = new[]
@@ -1950,7 +1950,7 @@ namespace NuGet.CommandLine.Test
                     solution.SolutionPath
             };
 
-            var restoreResult = CommandRunner.Run(
+            CommandRunnerResult restoreResult = CommandRunner.Run(
                 Util.GetNuGetExePath(),
                 pathContext.WorkingDirectory,
                 string.Join(" ", args));
@@ -1962,7 +1962,7 @@ namespace NuGet.CommandLine.Test
             };
 
             // Act
-            var r = CommandRunner.Run(
+            CommandRunnerResult r = CommandRunner.Run(
                 Util.GetNuGetExePath(),
                 pathContext.WorkingDirectory,
                 string.Join(" ", args));
@@ -1970,7 +1970,7 @@ namespace NuGet.CommandLine.Test
 
             // Assert
             r.Success.Should().BeTrue(r.AllOutput);
-            r.AllOutput.Should().NotContain("You are running the 'update' operation with an 'http' source", because: r.AllOutput);
+            r.AllOutput.Should().NotContain("You are running the 'update' operation with an 'HTTP' source", because: r.AllOutput);
         }
 
         [Theory]
@@ -1999,17 +1999,17 @@ namespace NuGet.CommandLine.Test
             var sourceUri = $"{server.Uri}nuget";
             pathContext.Settings.AddSource("http-feed", $"{server.Uri}nuget", allowInsecureConnections);
 
-            var projectA = new SimpleTestProjectContext(
-                  "a",
+            var projectB = new SimpleTestProjectContext(
+                  "b",
                   ProjectStyle.PackagesConfig,
                   pathContext.SolutionRoot);
 
-            Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+            Util.CreateFile(Path.GetDirectoryName(projectB.ProjectPath), "packages.config",
 @"<packages>
   <package id=""A"" version=""1.0.0"" targetFramework=""net461"" />
 </packages>");
 
-            solution.Projects.Add(projectA);
+            solution.Projects.Add(projectB);
             solution.Create(pathContext.SolutionRoot);
 
             var args = new[]
@@ -2018,7 +2018,7 @@ namespace NuGet.CommandLine.Test
                     solution.SolutionPath
             };
 
-            var restoreResult = CommandRunner.Run(
+            CommandRunnerResult restoreResult = CommandRunner.Run(
                 Util.GetNuGetExePath(),
                 pathContext.WorkingDirectory,
                 string.Join(" ", args));
@@ -2030,7 +2030,7 @@ namespace NuGet.CommandLine.Test
             };
 
             // Act
-            var r = CommandRunner.Run(
+            CommandRunnerResult r = CommandRunner.Run(
                 Util.GetNuGetExePath(),
                 pathContext.WorkingDirectory,
                 string.Join(" ", args));
@@ -2038,7 +2038,7 @@ namespace NuGet.CommandLine.Test
 
             // Assert
             r.Success.Should().BeTrue(r.AllOutput);
-            r.AllOutput.Should().Contain("You are running the 'update' operation with an 'http' source", because: r.AllOutput);
+            r.AllOutput.Should().Contain("You are running the 'update' operation with an 'HTTP' source", because: r.AllOutput);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -1907,7 +1907,7 @@ namespace NuGet.CommandLine.Test
 
             // Assert
             r.Success.Should().BeTrue(r.AllOutput);
-            r.AllOutput.Should().Contain("You are running the 'update' operation with an 'http' source");
+            r.AllOutput.Should().Contain("You are running the 'update' operation with an 'HTTP' source");
         }
 
         [Theory]

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -1140,7 +1140,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 // Assert
                 Assert.True(result.ExitCode == 0, result.AllOutput);
                 Assert.Contains("Added package 'x.1.0.0' to folder", result.AllOutput);
-                Assert.Contains("You are running the 'restore' operation with an 'http' source, 'http://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
+                Assert.Contains("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
             }
         }
 

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -10,7 +10,6 @@ using System.Xml.Linq;
 using FluentAssertions;
 using NuGet.Common;
 using NuGet.Frameworks;
-using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
@@ -1195,8 +1194,8 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 // Assert
                 Assert.True(result.ExitCode == 0, result.AllOutput);
                 Assert.Contains("Added package 'x.1.0.0' to folder", result.AllOutput);
-                Assert.Contains("You are running the 'restore' operation with an 'http' source, 'http://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
-                Assert.DoesNotContain("You are running the 'restore' operation with an 'http' source, 'https://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
+                Assert.Contains("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
+                Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'https://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
             }
         }
 
@@ -1248,8 +1247,8 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 // Assert
                 Assert.True(result.ExitCode == 0, result.AllOutput);
                 Assert.Contains("Added package 'x.1.0.0' to folder", result.AllOutput);
-                Assert.DoesNotContain("You are running the 'restore' operation with an 'http' source, 'http://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
-                Assert.DoesNotContain("You are running the 'restore' operation with an 'http' source, 'https://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
+                Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
+                Assert.DoesNotContain("You are running the 'restore' operation with an 'HTTP' source, 'https://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
             }
         }
 

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -10,6 +10,7 @@ using System.Xml.Linq;
 using FluentAssertions;
 using NuGet.Common;
 using NuGet.Frameworks;
+using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
@@ -1141,6 +1142,114 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 Assert.True(result.ExitCode == 0, result.AllOutput);
                 Assert.Contains("Added package 'x.1.0.0' to folder", result.AllOutput);
                 Assert.Contains("You are running the 'restore' operation with an 'http' source, 'http://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
+            }
+        }
+
+        [PlatformTheory(Platform.Windows)]
+        [InlineData("false")]
+        [InlineData("FALSE")]
+        [InlineData("invalidString")]
+        [InlineData("")]
+        public async Task MsbuildRestore_PackagesConfigDependency_WithHttpSourceAndFalseAllowInsecureConnections_WarnsCorrectly(string allowInsecureConnections)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                pathContext.Settings.AddSource("http-feed", "http://api.source/index.json", allowInsecureConnections);
+                pathContext.Settings.AddSource("https-feed", "https://api.source/index.json", allowInsecureConnections);
+
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+                var net461 = NuGetFramework.Parse("net472");
+                var projectA = new SimpleTestProjectContext(
+                    "a",
+                    ProjectStyle.PackagesConfig,
+                    pathContext.SolutionRoot);
+                projectA.Frameworks.Add(new SimpleTestProjectFrameworkContext(net461));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.AddFile("lib/net472/a.dll");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                using (var writer = new StreamWriter(Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "packages.config")))
+                {
+                    writer.Write(
+@"<packages>
+  <package id=""x"" version=""1.0.0"" targetFramework=""net472"" />
+</packages>");
+                }
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX);
+
+                // Act
+                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true", ignoreExitCode: true);
+
+                // Assert
+                Assert.True(result.ExitCode == 0, result.AllOutput);
+                Assert.Contains("Added package 'x.1.0.0' to folder", result.AllOutput);
+                Assert.Contains("You are running the 'restore' operation with an 'http' source, 'http://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
+                Assert.DoesNotContain("You are running the 'restore' operation with an 'http' source, 'https://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
+            }
+        }
+
+        [PlatformTheory(Platform.Windows)]
+        [InlineData("true")]
+        [InlineData("TRUE")]
+        public async Task MsbuildRestore_PackagesConfigDependency_WithHttpSourceAndTrueAllowInsecureConnections_NoWarns(string allowInsecureConnections)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                pathContext.Settings.AddSource("http-feed", "http://api.source/index.json", allowInsecureConnections);
+                pathContext.Settings.AddSource("https-feed", "https://api.source/index.json", allowInsecureConnections);
+
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+                var net461 = NuGetFramework.Parse("net472");
+                var projectA = new SimpleTestProjectContext(
+                    "a",
+                    ProjectStyle.PackagesConfig,
+                    pathContext.SolutionRoot);
+                projectA.Frameworks.Add(new SimpleTestProjectFrameworkContext(net461));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.AddFile("lib/net472/a.dll");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                using (var writer = new StreamWriter(Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "packages.config")))
+                {
+                    writer.Write(
+@"<packages>
+  <package id=""x"" version=""1.0.0"" targetFramework=""net472"" />
+</packages>");
+                }
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX);
+
+                // Act
+                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true", ignoreExitCode: true);
+
+                // Assert
+                Assert.True(result.ExitCode == 0, result.AllOutput);
+                Assert.Contains("Added package 'x.1.0.0' to folder", result.AllOutput);
+                Assert.DoesNotContain("You are running the 'restore' operation with an 'http' source, 'http://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
+                Assert.DoesNotContain("You are running the 'restore' operation with an 'http' source, 'https://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
             }
         }
 

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -200,6 +200,13 @@ namespace NuGet.Test.Utility
             Save();
         }
 
+        public void AddSource(string sourceName, string sourceUri, string allowInsecureConnectionsValue)
+        {
+            var section = GetOrAddSection(XML, "packageSources");
+            AddEntry(section, sourceName, sourceUri, "allowInsecureConnections", allowInsecureConnectionsValue);
+            Save();
+        }
+
         public void AddPackageSourceMapping(string sourceName, params string[] patterns)
         {
             XElement packageSourceMappingSection = GetOrAddSection(XML, "packageSourceMapping");


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes:https://github.com/NuGet/Home/issues/12788

Regression? Last working version:

## Description
When `allowInsecureConnections  `property in `packageSources `section is set to true in NuGet.Config files, suppress warnings for HTTP sources in packages.config restore scenarios(including install and update) in all NuGet tools.

The PRs enable the HTTP warnings in those scenarios are:
https://github.com/NuGet/NuGet.Client/pull/4583
https://github.com/NuGet/NuGet.Client/pull/4633

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
