### PR TITLE
Remove unused Moq package from E2E

### DIFF
--- a/test/EndToEnd/tests/TabExpansionTest.ps1
+++ b/test/EndToEnd/tests/TabExpansionTest.ps1
@@ -282,7 +282,6 @@ function Test-TabExpansionForVersionForUninstallPackage {
     # Arrange
     $p = New-WebApplication
     $p | Install-Package elmah -Version 1.1
-    $p | Install-Package Moq
 
     # Act
     $suggestion = TabExpansion "Uninstall-Package elmah -Version "


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2430

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Removes unused Moq reference in E2E test

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
