### PR TITLE
Add Mapping dialog has accessible Name & Help Text

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/AddMappingDialog.xaml
@@ -75,11 +75,12 @@
         </Setter>
       </Style>
     </Grid.Resources>
-    <TextBlock Grid.Row="0" Text="{x:Static nuget:Resources.VSOptions_Label_PackagePattern}" Margin="12,12,12,9"/>
+    <TextBlock x:Name="_labelPackagePattern" Grid.Row="0" Text="{x:Static nuget:Resources.VSOptions_Label_PackagePattern}" Margin="12,12,12,9"/>
     <vsui:WatermarkedTextBox Grid.Row="1"
                                  BorderBrush="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderBrushKey}}"
                                  BorderThickness="1"
-                                 AutomationProperties.Name="{x:Static nuget:Resources.VSOptions_Watermark_AddPackageNamespace}"
+                                 AutomationProperties.Name="{Binding Text, ElementName=_labelPackagePattern}"
+                                 AutomationProperties.HelpText="{x:Static nuget:Resources.VSOptions_Watermark_AddPackageNamespace}"
                                  x:Name="_packageID"
                                  MaxLength="100"
                                  Margin="12,0,12,0"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2431

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

For the "Add Package Source Mapping" dialog's `WatermarkedTextbox` control:
- Set the accessible Name property as the adjacent label's text
- Set the Help Text to the `Watermark` text which is essentially a help description.
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/6b5f5dfe-2f00-4afe-b193-5f42f891e023)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - See Accessibility Insights screenshot
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
