### PR TITLE
Make GlobalJsonReader in NuGetSdkResolver a static singleton to improve caching

### DIFF
--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
@@ -24,14 +24,21 @@ namespace Microsoft.Build.NuGetSdkResolver
         public const string GlobalJsonFileName = "global.json";
 
         /// <summary>
-        /// Tthe section of global.json contains MSBuild project SDK versions.
+        /// The name of the section in global.json that contains MSBuild project SDK versions.
         /// </summary>
         public const string MSBuildSdksPropertyName = "msbuild-sdks";
 
         /// <summary>
         /// Represents a thread-safe cache for files based on their full path and last write time.
         /// </summary>
-        private readonly ConcurrentDictionary<FileInfo, (DateTime LastWriteTime, Lazy<Dictionary<string, string>> Lazy)> _fileCache = new ConcurrentDictionary<FileInfo, (DateTime, Lazy<Dictionary<string, string>>)>(FileSystemInfoFullNameEqualityComparer.Instance);
+        private static readonly ConcurrentDictionary<FileInfo, (DateTime LastWriteTime, Lazy<Dictionary<string, string>> Lazy)> FileCache = new ConcurrentDictionary<FileInfo, (DateTime, Lazy<Dictionary<string, string>>)>(FileSystemInfoFullNameEqualityComparer.Instance);
+
+
+        private GlobalJsonReader()
+        {
+        }
+
+        public static GlobalJsonReader Instance { get; } = new GlobalJsonReader();
 
         /// <summary>
         /// Occurs when a file is read.
@@ -70,7 +77,7 @@ namespace Microsoft.Build.NuGetSdkResolver
             }
 
             // Add a new file to the cache if it doesn't exist.  If the file is already in the cache, read it again if the file has changed
-            (DateTime _, Lazy<Dictionary<string, string>> Lazy) cacheEntry = _fileCache.AddOrUpdate(
+            (DateTime _, Lazy<Dictionary<string, string>> Lazy) cacheEntry = FileCache.AddOrUpdate(
                 globalJsonPath,
                 key => (key.LastWriteTime, new Lazy<Dictionary<string, string>>(() => ParseMSBuildSdkVersions(key.FullName, context))),
                 (key, item) =>

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Build.NuGetSdkResolver
         /// Initializes a new instance of the NuGetSdkResolver class.
         /// </summary>
         public NuGetSdkResolver()
-            : this(new GlobalJsonReader())
+            : this(GlobalJsonReader.Instance)
         {
         }
 

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/GlobalJsonReader_Tests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/GlobalJsonReader_Tests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
 
                 var context = new MockSdkResolverContext(testDirectory);
 
-                var globalJsonReader = new GlobalJsonReader();
+                var globalJsonReader = GlobalJsonReader.Instance;
 
                 string actualGlobalJsonPath = null;
 
@@ -94,7 +94,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
 }}
 }}");
 
-                var globalJsonReader = new GlobalJsonReader();
+                var globalJsonReader = GlobalJsonReader.Instance;
 
                 string actualGlobalJsonPath = null;
 
@@ -127,7 +127,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
 
                 var context = new MockSdkResolverContext(testDirectory);
 
-                var globalJsonReader = new GlobalJsonReader();
+                var globalJsonReader = GlobalJsonReader.Instance;
 
                 string actualGlobalJsonPath = null;
 
@@ -164,7 +164,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
 
                 var context = new MockSdkResolverContext(testDirectory);
 
-                var globalJsonReader = new GlobalJsonReader();
+                var globalJsonReader = GlobalJsonReader.Instance;
 
                 string actualGlobalJsonPath = null;
 
@@ -197,7 +197,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
 
                 var context = new MockSdkResolverContext(testDirectory);
 
-                var globalJsonReader = new GlobalJsonReader();
+                var globalJsonReader = GlobalJsonReader.Instance;
 
                 Dictionary<string, int> globalJsonReadCountByPath = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
@@ -258,7 +258,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
             {
                 var context = new MockSdkResolverContext(testDirectory);
 
-                var globalJsonReader = new GlobalJsonReader();
+                var globalJsonReader = GlobalJsonReader.Instance;
 
                 bool wasGlobalJsonRead = false;
 
@@ -289,7 +289,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
 
                 var context = new MockSdkResolverContext(testDirectory);
 
-                var globalJsonReader = new GlobalJsonReader();
+                var globalJsonReader = GlobalJsonReader.Instance;
 
                 bool wasGlobalJsonRead = false;
 
@@ -325,7 +325,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
   ""msbuild-sdks"": {msbuildSdksSection}
 }}");
 
-                var globalJsonReader = new GlobalJsonReader();
+                var globalJsonReader = GlobalJsonReader.Instance;
 
                 bool wasGlobalJsonRead = false;
 
@@ -348,7 +348,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         {
             var context = new MockSdkResolverContext(projectPath: null, solutionPath: null);
 
-            var globalJsonReader = new GlobalJsonReader();
+            var globalJsonReader = GlobalJsonReader.Instance;
 
             bool wasGlobalJsonRead = false;
 
@@ -404,7 +404,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
 
                 var context = new MockSdkResolverContext(testDirectory);
 
-                var globalJsonReader = new GlobalJsonReader();
+                var globalJsonReader = GlobalJsonReader.Instance;
 
                 bool wasGlobalJsonRead = false;
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12819

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
While investigating another issue with the NuGetSdkResolver, I noticed that it was reading `global.json` more than one time which is unexpected.  It turns out that the way Project System loads projects can case multiple instances of the NuGetSdkResolver to be instantiated.  This leads to each NuGetSdkResolver instance also creating its own instance of `GlobalJsonReader`.  Since `GlobalJsonReader` has a file cache based on file path and last write time, its safe to make it static and reuse the cache for the whole process. 

This change makes use of a static singleton to make sure that a single process only ever loads `global.json` once unless it changes on disk.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Existing tests were updated, no new tests needed.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
