### PR TITLE
Install ProcDump on Windows CI machines

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -282,6 +282,31 @@ Function Test-BuildEnvironment {
     }
 }
 
+Function Install-ProcDump {
+    [CmdletBinding()]
+    param()
+    if ($Env:OS -eq "Windows_NT")
+    {
+        Trace-Log "Downloading ProcDump..."
+        
+        $ProcDumpZip = Join-Path $env:TEMP 'ProcDump.zip'
+        $TestDir = Join-Path $NuGetClientRoot '.test'
+        $ProcDumpDir = Join-Path $TestDir 'ProcDump'
+
+        Invoke-WebRequest 'https://download.sysinternals.com/files/Procdump.zip' -OutFile $ProcDumpZip
+
+        Remove-Item $ProcDumpDir -Recurse -Force | Out-Null
+        New-Item $ProcDumpDir -ItemType Directory -Force | Out-Null
+        Expand-Archive $ProcDumpZip -DestinationPath $ProcDumpDir
+
+        if ($env:CI -eq "true") {
+            Write-Host "##vso[task.setvariable variable=PROCDUMP_PATH;isOutput=false;issecret=false;]$ProcDumpDir"
+        } else {
+            $env:PROCDUMP_PATH=$ProcDumpDir
+        }
+    }
+}
+
 Function Clear-PackageCache {
     [CmdletBinding()]
     param()

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -104,9 +104,6 @@ Function Invoke-BuildStep {
             }
             $completed = $true
         }
-        catch {
-            Error-Log $_
-        }
         finally {
             $sw.Stop()
             Reset-Colors
@@ -120,7 +117,7 @@ Function Invoke-BuildStep {
                 Trace-Log "[STOPPED +$(Format-ElapsedTime $sw.Elapsed)] $BuildStep"
             }
             else {
-                Error-Log "[FAILED +$(Format-ElapsedTime $sw.Elapsed)] $BuildStep"
+                Trace-Log "[FAILED +$(Format-ElapsedTime $sw.Elapsed)] $BuildStep"
             }
         }
     }

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -291,8 +291,9 @@ Function Install-ProcDump {
         $ProcDumpDir = Join-Path $TestDir 'ProcDump'
 
         Invoke-WebRequest 'https://download.sysinternals.com/files/Procdump.zip' -OutFile $ProcDumpZip
-
-        Remove-Item $ProcDumpDir -Recurse -Force | Out-Null
+        if (Test-Path $ProcDumpDir) {
+            Remove-Item $ProcDumpDir -Recurse -Force | Out-Null
+        }
         New-Item $ProcDumpDir -ItemType Directory -Force | Out-Null
         Expand-Archive $ProcDumpZip -DestinationPath $ProcDumpDir
 

--- a/configure.cmd
+++ b/configure.cmd
@@ -4,6 +4,9 @@ IF ERRORLEVEL 1 (
   EXIT /B %ERRORLEVEL%
 )
 
+IF EXIST "%~dp0.test\ProcDump\procdump.exe" (
+    SET PROCDUMP_PATH=%~dp0.test\ProcDump
+)
 SET "DOTNET_ROOT=%~dp0cli"
 SET DOTNET_MULTILEVEL_LOOKUP=0
 SET "PATH=%~dp0cli;%PATH%"

--- a/configure.ps1
+++ b/configure.ps1
@@ -27,7 +27,8 @@ Param (
     [Alias('f')]
     [switch]$Force,
     [switch]$RunTest,
-    [switch]$SkipDotnetInfo
+    [switch]$SkipDotnetInfo,
+    [switch]$ProcDump
 )
 
 $ErrorActionPreference = 'Stop'
@@ -37,6 +38,14 @@ $ErrorActionPreference = 'Stop'
 Trace-Log "Configuring NuGet.Client build environment"
 
 $BuildErrors = @()
+
+if ($ProcDump -eq $true -Or $env:CI -eq "true")
+{
+    Invoke-BuildStep 'Configuring Process Dump Collection' {
+    
+        Install-ProcDump
+    } -ev +BuildErrors
+}
 
 Invoke-BuildStep 'Configuring git repo' {
     Update-SubModules -Force:$Force


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2336

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This adds logic to download and unzip ProcDump on Windows agents.  It then sets the `PROCDUMP_PATH` environment variable so that the VS test blame collector can find it.

I also had to update `common.ps1` because the error messages weren't showing correctly.

By default, its enabled for CI machines and you can install it locally with the `-ProcDump` command-line argument of `configure.ps1`

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
