### PR TITLE
Retry downloads in configure.ps1 and configure.sh

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 
 CLI_DIR="$(pwd)/cli"
-
+DOTNET_INSTALL_SCRIPT_URL=https://dot.net/v1/dotnet-install.sh
+DOTNET_INSTALL_SCRIPT_DESTINATION=$CLI_DIR/dotnet-install.sh
 # Download the CLI install script to cli
-echo "Installing .NET SDKs..."
 mkdir -p $CLI_DIR
-curl -o $CLI_DIR/dotnet-install.sh -L https://dot.net/v1/dotnet-install.sh --silent
-if (( $? )); then
+echo "Downloading '$DOTNET_INSTALL_SCRIPT_URL' to '$DOTNET_INSTALL_SCRIPT_DESTINATION'"
+HTTPCODE=$(curl -o $DOTNET_INSTALL_SCRIPT_DESTINATION -L $DOTNET_INSTALL_SCRIPT_URL -w "%{http_code}" --retry 5 --retry-connrefused --no-progress-meter)
+
+if [ "$HTTPCODE" != "200" ]; then
     echo "Could not download 'dotnet-install.sh' script. Please check your network and try again!"
     return 1
 fi
@@ -20,6 +22,7 @@ if [ "$DOTNET_SDK_VERSIONS" != "" ]; then
     IFS=';' read -ra array <<< "$DOTNET_SDK_VERSIONS"
     for CliArgs in "${array[@]}";
     do
+        echo "Installing .NET SDKs..."
         echo "'cli/dotnet-install.sh -InstallDir $CLI_DIR -NoPath $CliArgs'"
         
         cli/dotnet-install.sh -InstallDir $CLI_DIR -NoPath $CliArgs


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2443

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Our `configure.ps1` and `configure.sh` scripts download the .NET installer scripts and ProcDump which can intermittently fail.  This change adds retries.  For Windows, I added a PowerShell function to retry the download and for Linux/Mac I added command-line arguments to `curl` to have it retry.

Sample output:

### Windows
```
D:\NuGet>configure.cmd
[11:25:23 +0]   Configuring NuGet.Client build environment
[11:25:23 +0]   [BEGIN] Configuring git repo
[11:25:23 +0]   Updating and initializing submodules
[11:25:23 +0]   git submodule update --init --quiet
[11:25:24 +1]   [DONE +00:00:00] Configuring git repo
[11:25:24 +0]   [BEGIN] Installing .NET CLI
[11:25:24 +0]   Downloading .NET CLI install script
[11:25:24 +0]   Downloading 'https://dot1.net/v1/dotnet-install.ps1' to 'D:\NuGet\cli\dotnet-install.ps1'
WARNING: [11:25:25 +1] Failed to download 'https://dot1.net/v1/dotnet-install.ps1': The remote server returned an error: (410) Gone.
[11:25:25 +0]   Waiting 10 seconds before retrying. Retries left: 4
[11:25:35 +10]  Downloading 'https://dot1.net/v1/dotnet-install.ps1' to 'D:\NuGet\cli\dotnet-install.ps1'
WARNING: [11:25:35 +0] Failed to download 'https://dot1.net/v1/dotnet-install.ps1': The remote server returned an error: (410) Gone.
[11:25:35 +0]   Waiting 10 seconds before retrying. Retries left: 3
[11:25:45 +10]  Downloading 'https://dot1.net/v1/dotnet-install.ps1' to 'D:\NuGet\cli\dotnet-install.ps1'
WARNING: [11:25:45 +0] Failed to download 'https://dot1.net/v1/dotnet-install.ps1': The remote server returned an error: (410) Gone.
[11:25:45 +0]   Waiting 10 seconds before retrying. Retries left: 2
[11:25:55 +10]  Downloading 'https://dot1.net/v1/dotnet-install.ps1' to 'D:\NuGet\cli\dotnet-install.ps1'
WARNING: [11:25:56 +0] Failed to download 'https://dot1.net/v1/dotnet-install.ps1': The remote server returned an error: (410) Gone.
[11:25:56 +0]   Waiting 10 seconds before retrying. Retries left: 1
[11:26:06 +10]  Downloading 'https://dot1.net/v1/dotnet-install.ps1' to 'D:\NuGet\cli\dotnet-install.ps1'
WARNING: [11:26:06 +0] Failed to download 'https://dot1.net/v1/dotnet-install.ps1': The remote server returned an error: (410) Gone.
[11:26:06 +0]   Waiting 10 seconds before retrying. Retries left: 0
[11:26:16 +10]  Downloading 'https://dot1.net/v1/dotnet-install.ps1' to 'D:\NuGet\cli\dotnet-install.ps1'
WARNING: [11:26:16 +0] Failed to download 'https://dot1.net/v1/dotnet-install.ps1': The remote server returned an error: (410) Gone.
[11:26:16 +0]   [FAILED +00:00:52] Installing .NET CLI
The remote server returned an error: (410) Gone.
At D:\NuGet\build\common.ps1:366 char:17
+                 throw $exception
+                 ~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (:) [], WebException
    + FullyQualifiedErrorId : The remote server returned an error: (410) Gone.
```

### Linux
```
jeff@JEFFKL-DEV:/mnt/d/NuGet$ . configure.sh
Downloading 'https://dotasdfsafsdf.net/v1/dotnet-install.sh' to '/mnt/d/NuGet/cli/dotnet-install.sh'
curl: (6) Could not resolve host: dotasdfsafsdf.net
Warning: Transient problem: timeout Will retry in 1 seconds. 5 retries left.
curl: (6) Could not resolve host: dotasdfsafsdf.net
Warning: Transient problem: timeout Will retry in 2 seconds. 4 retries left.
curl: (6) Could not resolve host: dotasdfsafsdf.net
Warning: Transient problem: timeout Will retry in 4 seconds. 3 retries left.
curl: (6) Could not resolve host: dotasdfsafsdf.net
Warning: Transient problem: timeout Will retry in 8 seconds. 2 retries left.
curl: (6) Could not resolve host: dotasdfsafsdf.net
Warning: Transient problem: timeout Will retry in 16 seconds. 1 retries left.
curl: (6) Could not resolve host: dotasdfsafsdf.net
Could not download 'dotnet-install.sh' script. Please check your network and try again!
```

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
