### PR TITLE
Make pre-auth test http listener shutdown more reliable

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
@@ -196,6 +196,11 @@ namespace NuGet.Protocol.FuncTest
                     {
                         // .NET 5 throws here, whereas .NET Framework triggers the callback where we can check IsListening == false
                     }
+                    catch (InvalidOperationException)
+                    {
+                        // Sometimes BeginGetContext throws when httpListener is stopped. Possibly race condition between this callback
+                        // handler and the test stopping the httpListener at the end of the test. Appears to be .NET Framework only.
+                    }
                 }
             }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2445

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The test `GetAsync_GetPackageAfterServiceIndex_SecondUrlIsPreAuthenticated` uses a different `HttpListener` helper than all other tests, because none of the other tests using `HttpListener` need to do authentication, or do request counting.

When I wrote the tests initially, I tried following "best practices" and catch a specific exception type, not all `Exception`s. But it appears that on .NET Framework at least, there is a race condition where sometimes the event handler shuts down gracefully, other times it throws, and when it throws, it throws a different exception type to what .NET Core throws. So, catch that exception as well.

I still chose to catch specific exceptions, rather than just `catch {}`, not only to follow best practices, but also just in case there's yet another exception that causes tests to fail (in which case it would appear as an HTTP timeout, and without the exception details, we wouldn't know why the listener didn't handle the request).  But I could probably be talked into changing into a `catch {}`.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
