### PR TITLE
Ensure top-level package isn't duplicated in new source mappings

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/PackageSourceMappingUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/PackageSourceMappingUtility.cs
@@ -3,7 +3,6 @@
 
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Configuration;
@@ -48,22 +47,20 @@ namespace NuGet.PackageManagement.UI
                 addedPackageIdsWithoutExistingMappings.Add(userAction.PackageId);
             }
 
-            string[] packageIdsNeedingNewSourceMappings = addedPackageIdsWithoutExistingMappings.ToArray();
-
             CreateAndSavePackageSourceMappings(
                 userAction.SourceMappingSourceName,
-                packageIdsNeedingNewSourceMappings,
+                addedPackageIdsWithoutExistingMappings,
                 sourceMappingProvider,
                 existingPackageSourceMappingSourceItems);
         }
 
         private static void CreateAndSavePackageSourceMappings(
             string sourceName,
-            string[] newPackageIdsToSourceMap,
+            List<string> newPackageIdsToSourceMap,
             PackageSourceMappingProvider mappingProvider,
             IReadOnlyList<PackageSourceMappingSourceItem> existingPackageSourceMappingSourceItems)
         {
-            if (string.IsNullOrWhiteSpace(sourceName) || newPackageIdsToSourceMap is null || newPackageIdsToSourceMap.Length == 0)
+            if (string.IsNullOrWhiteSpace(sourceName) || newPackageIdsToSourceMap is null || newPackageIdsToSourceMap.Count == 0)
             {
                 return;
             }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12839

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

I'm not sure if this causes a problem today, but in a subsequent PR, I want to have an accurate count of newly mapped packages. So, I'd like this to only append package ID if it's not already included.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [X] Test exception - existing tests look at the end result, which shouldn't change with this refactoring.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
