### PR TITLE
Use Equals when comparing VersionRange in the PackageVulnerability Equals method

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageVulnerabilityInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageVulnerabilityInfo.cs
@@ -49,7 +49,7 @@ namespace NuGet.Protocol.Model
             bool equals =
                 Url == other.Url &&
                 Severity == other.Severity &&
-                Versions == other.Versions;
+                Versions.Equals(other.Versions);
             return equals;
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageVulnerabilityInfoTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageVulnerabilityInfoTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using FluentAssertions;
+using NuGet.Protocol.Model;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class PackageVulnerabilityInfoTests
+    {
+
+        [Fact]
+        public void Constructor_WithNullUri_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new PackageVulnerabilityInfo(null, PackageVulnerabilitySeverity.Low, VersionRange.Parse("1.0.0")));
+        }
+
+        [Fact]
+        public void Constructor_WithNullVersionRange_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new PackageVulnerabilityInfo(new Uri("https://contoso.com/vulnerability1"), PackageVulnerabilitySeverity.Low, null));
+        }
+
+        [Fact]
+        public void Equals_WithEquivalentObjects_ReturnsTrue()
+        {
+            var packageVulnerabilityInfo1 = new PackageVulnerabilityInfo(new Uri("https://contoso.com/vulnerability1"), PackageVulnerabilitySeverity.Low, VersionRange.Parse("1.0.0"));
+            var packageVulnerabilityInfo2 = new PackageVulnerabilityInfo(new Uri("https://contoso.com/vulnerability1"), PackageVulnerabilitySeverity.Low, VersionRange.Parse("1.0.0"));
+            packageVulnerabilityInfo1.Should().Be(packageVulnerabilityInfo2);
+        }
+
+        [Theory]
+        [InlineData("https://contoso.com/vulnerability1", PackageVulnerabilitySeverity.Low, "1.0.0",
+                    "https://contoso.com/vulnerability2", PackageVulnerabilitySeverity.Low, "1.0.0")]
+        [InlineData("https://contoso.com/vulnerability1", PackageVulnerabilitySeverity.Low, "1.0.0",
+                    "https://contoso.com/vulnerability1", PackageVulnerabilitySeverity.High, "1.0.0")]
+        [InlineData("https://contoso.com/vulnerability1", PackageVulnerabilitySeverity.Low, "1.0.0",
+                    "https://contoso.com/vulnerability1", PackageVulnerabilitySeverity.Low, "2.0.0")]
+
+        public void Equals_WithVariousNotEquivalentInputs(string uri1, PackageVulnerabilitySeverity severity1, string version1,
+                                                       string uri2, PackageVulnerabilitySeverity severity2, string version2)
+        {
+            var packageVulnerabilityInfo1 = new PackageVulnerabilityInfo(new Uri(uri1), severity1, VersionRange.Parse(version1));
+            var packageVulnerabilityInfo2 = new PackageVulnerabilityInfo(new Uri(uri2), severity2, VersionRange.Parse(version2));
+            packageVulnerabilityInfo1.Should().NotBe(packageVulnerabilityInfo2);
+
+        }
+
+        [Fact]
+        public void HashCode_WithEquivalentObjects_ReturnsTrue()
+        {
+            var packageVulnerabilityInfo1 = new PackageVulnerabilityInfo(new Uri("https://contoso.com/vulnerability1"), PackageVulnerabilitySeverity.Low, VersionRange.Parse("1.0.0"));
+            var packageVulnerabilityInfo2 = new PackageVulnerabilityInfo(new Uri("https://contoso.com/vulnerability1"), PackageVulnerabilitySeverity.Low, VersionRange.Parse("1.0.0"));
+            packageVulnerabilityInfo1.GetHashCode().Should().Be(packageVulnerabilityInfo2.GetHashCode());
+        }
+
+        [Theory]
+        [InlineData("https://contoso.com/vulnerability1", PackageVulnerabilitySeverity.Low, "1.0.0",
+                    "https://contoso.com/vulnerability2", PackageVulnerabilitySeverity.Low, "1.0.0")]
+        [InlineData("https://contoso.com/vulnerability1", PackageVulnerabilitySeverity.Low, "1.0.0",
+                    "https://contoso.com/vulnerability1", PackageVulnerabilitySeverity.High, "1.0.0")]
+        [InlineData("https://contoso.com/vulnerability1", PackageVulnerabilitySeverity.Low, "1.0.0",
+                    "https://contoso.com/vulnerability1", PackageVulnerabilitySeverity.Low, "2.0.0")]
+
+        public void HashCode_WithVariousNotEquivalentInputs(string uri1, PackageVulnerabilitySeverity severity1, string version1,
+                                                       string uri2, PackageVulnerabilitySeverity severity2, string version2)
+        {
+            var packageVulnerabilityInfo1 = new PackageVulnerabilityInfo(new Uri(uri1), severity1, VersionRange.Parse(version1));
+            var packageVulnerabilityInfo2 = new PackageVulnerabilityInfo(new Uri(uri2), severity2, VersionRange.Parse(version2));
+            packageVulnerabilityInfo1.GetHashCode().Should().NotBe(packageVulnerabilityInfo2.GetHashCode());
+
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12844

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

PackageVulnerabilityInfo calls `==` to compare 2 VersionRange objects, but `==` is not implemented for VersionRange. 

I have also added tests to cover the scenario. 

Discovered this while adding tests for deduping warnings.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
