### PR TITLE
Telemetry to Count Top Level & Transitive source mappings automatically created

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -364,6 +364,9 @@ namespace NuGet.PackageManagement.UI
 
             await _lockService.ExecuteNuGetOperationAsync(async () =>
             {
+                int? countCreatedTopLevelSourceMappings = null;
+                int? countCreatedTransitiveSourceMappings = null;
+
                 try
                 {
                     uiService.BeginOperation();
@@ -466,7 +469,7 @@ namespace NuGet.PackageManagement.UI
                     if (!cancellationToken.IsCancellationRequested)
                     {
                         List<string>? addedPackageIds = addedPackages != null ? addedPackages.Select(pair => pair.Item1).Distinct().ToList() : null;
-                        PackageSourceMappingUtility.ConfigureNewPackageSourceMapping(userAction, addedPackageIds, sourceMappingProvider, existingPackageSourceMappingSourceItems);
+                        PackageSourceMappingUtility.ConfigureNewPackageSourceMapping(userAction, addedPackageIds, sourceMappingProvider, existingPackageSourceMappingSourceItems, out countCreatedTopLevelSourceMappings, out countCreatedTransitiveSourceMappings);
 
                         await projectManagerService.ExecuteActionsAsync(
                             actions,
@@ -559,7 +562,9 @@ namespace NuGet.PackageManagement.UI
                         removedPackages,
                         updatedPackagesOld,
                         updatedPackagesNew,
-                        frameworks);
+                        frameworks,
+                        countCreatedTopLevelSourceMappings,
+                        countCreatedTransitiveSourceMappings);
 
                     if (packageToInstallWasTransitive.HasValue)
                     {
@@ -609,7 +614,9 @@ namespace NuGet.PackageManagement.UI
             List<string>? removedPackages,
             List<Tuple<string, string>>? updatedPackagesOld,
             List<Tuple<string, string>>? updatedPackagesNew,
-            IReadOnlyCollection<string> targetFrameworks)
+            IReadOnlyCollection<string> targetFrameworks,
+            int? countCreatedTopLevelSourceMappings,
+            int? countCreatedTransitiveSourceMappings)
         {
             // log possible cancel reasons
             if (!continueAfterPreview)
@@ -714,6 +721,16 @@ namespace NuGet.PackageManagement.UI
             if (targetFrameworks?.Count > 0)
             {
                 actionTelemetryEvent["TargetFrameworks"] = string.Join(";", targetFrameworks);
+            }
+
+            if (countCreatedTopLevelSourceMappings.HasValue)
+            {
+                actionTelemetryEvent["CreatedTopLevelSourceMappingsCount"] = countCreatedTopLevelSourceMappings.Value;
+            }
+
+            if (countCreatedTransitiveSourceMappings.HasValue)
+            {
+                actionTelemetryEvent["CreatedTransitiveSourceMappingsCount"] = countCreatedTransitiveSourceMappings.Value;
             }
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2450
Fixes: https://github.com/NuGet/Home/issues/12839

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- Telemetry will now have 2 integer properties for **counts of added top-level and transitive package source mappings**.
 - Top-level values can either be 0 or 1 in the current implementation (may become >1 in future iterations)
 - In scenarios when automatic mapping is not possible, the properties are not created (will be missing from telemetry).
  - **See description of Issue for telemetry samples**
  - Implements more of Assessment: https://github.com/NuGet/Client.Engineering/blob/main/designs/telemetry/assessment-source-mapping.md
- Secondarily, some refactoring is done in the utility class to return the counts
- Thirdly, the utility class implementation has changed
  - Determine in `ConfigureNewPackageSourceMapping` whether the top-level is already mapped, to avoid telemetry emitting `count:1` for top-level when it's already mapped.
  - Remove an unnecessary array.
  
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
