### PR TITLE
Add a retry in MockServer Start method

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -690,9 +690,8 @@ namespace NuGet.CommandLine.Test
                 var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 string outputFileName = Path.Combine(packageDirectory, "t1.nupkg");
 
-                using (var server = new MockServer())
+                using (var server = new MockServer(AuthenticationSchemes.Basic))
                 {
-                    server.Listener.AuthenticationSchemes = AuthenticationSchemes.Basic;
                     server.Put.Add("/nuget", r => new Action<HttpListenerResponse>(res =>
                     {
                         var h = r.Headers["Authorization"];
@@ -769,9 +768,8 @@ namespace NuGet.CommandLine.Test
                 var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 string outputFileName = Path.Combine(packageDirectory, "t1.nupkg");
 
-                using (var server = new MockServer())
+                using (var server = new MockServer(AuthenticationSchemes.Basic))
                 {
-                    server.Listener.AuthenticationSchemes = AuthenticationSchemes.Basic;
                     server.Put.Add("/nuget", r => new Action<HttpListenerResponse>(res =>
                     {
                         var h = r.Headers["Authorization"];
@@ -847,9 +845,8 @@ namespace NuGet.CommandLine.Test
                 var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 string outputFileName = Path.Combine(packageDirectory, "t1.nupkg");
 
-                using (var server = new MockServer())
+                using (var server = new MockServer(AuthenticationSchemes.IntegratedWindowsAuthentication))
                 {
-                    server.Listener.AuthenticationSchemes = AuthenticationSchemes.IntegratedWindowsAuthentication;
                     server.Put.Add("/nuget", r => new Action<HttpListenerResponse, IPrincipal>((res, user) =>
                     {
                         putUser = user;
@@ -890,9 +887,8 @@ namespace NuGet.CommandLine.Test
                 var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 string outputFileName = Path.Combine(packageDirectory, "t1.nupkg");
 
-                using (var server = new MockServer())
+                using (var server = new MockServer(AuthenticationSchemes.IntegratedWindowsAuthentication))
                 {
-                    server.Listener.AuthenticationSchemes = AuthenticationSchemes.IntegratedWindowsAuthentication;
                     server.Put.Add("/nuget", r => new Action<HttpListenerResponse, IPrincipal>((res, user) =>
                     {
                         putUser = user;
@@ -936,10 +932,9 @@ namespace NuGet.CommandLine.Test
                 var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 string outputFileName = Path.Combine(packageDirectory, "t1.nupkg");
 
-                using (var server = new MockServer())
+                using (var server = new MockServer(AuthenticationSchemes.Basic))
                 {
                     var credentialForPutRequest = new List<string>();
-                    server.Listener.AuthenticationSchemes = AuthenticationSchemes.Basic;
                     server.Put.Add("/nuget", r => new Action<HttpListenerResponse>(res =>
                     {
                         var h = r.Headers["Authorization"];
@@ -1001,10 +996,9 @@ namespace NuGet.CommandLine.Test
                 var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 string outputFileName = Path.Combine(packageDirectory, "t1.nupkg");
 
-                using (var server = new MockServer())
+                using (var server = new MockServer(AuthenticationSchemes.Basic))
                 {
                     var credentialForPutRequest = new List<string>();
-                    server.Listener.AuthenticationSchemes = AuthenticationSchemes.Basic;
                     server.Put.Add("/nuget", r => new Action<HttpListenerResponse>(res =>
                     {
                         var h = r.Headers["Authorization"];
@@ -1068,9 +1062,8 @@ namespace NuGet.CommandLine.Test
                 var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 string outputFileName = Path.Combine(packageDirectory, "t1.nupkg");
 
-                using (var server = new MockServer())
+                using (var server = new MockServer(AuthenticationSchemes.Basic))
                 {
-                    server.Listener.AuthenticationSchemes = AuthenticationSchemes.Basic;
                     server.Put.Add("/nuget", r => new Action<HttpListenerResponse>(res =>
                     {
                         var h = r.Headers["Authorization"];
@@ -1133,9 +1126,8 @@ namespace NuGet.CommandLine.Test
                 var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 string outputFileName = Path.Combine(packageDirectory, "t1.nupkg");
 
-                using (var server = new MockServer())
+                using (var server = new MockServer(AuthenticationSchemes.Basic))
                 {
-                    server.Listener.AuthenticationSchemes = AuthenticationSchemes.Basic;
                     server.Get.Add("/nuget", r =>
                     {
                         var h = r.Headers["Authorization"];
@@ -1204,9 +1196,8 @@ namespace NuGet.CommandLine.Test
                 var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 string outputFileName = Path.Combine(packageDirectory, "t1.nupkg");
 
-                using (var server = new MockServer())
+                using (var server = new MockServer(AuthenticationSchemes.Basic))
                 {
-                    server.Listener.AuthenticationSchemes = AuthenticationSchemes.Basic;
                     server.Get.Add("/nuget", r =>
                     {
                         var h = r.Headers["Authorization"];

--- a/test/TestUtilities/Test.Utility/MockServer.cs
+++ b/test/TestUtilities/Test.Utility/MockServer.cs
@@ -27,9 +27,7 @@ namespace Test.Utility
         private Task _listenerTask;
         private bool _disposed = false;
         private AuthenticationSchemes _authenticationSchemes;
-#pragma warning disable CA2213 // Disposable fields should be disposed
         private HttpListener _listener;
-#pragma warning restore CA2213 // Disposable fields should be disposed
 
         public string BasePath { get; }
         private PortReserverOfMockServer PortReserver { get; }
@@ -92,7 +90,7 @@ namespace Test.Utility
                         throw;
                     }
 
-                    Thread.Sleep(50);
+                    Thread.Sleep(200);
                 }
             }
             while (_listener == null);
@@ -509,7 +507,7 @@ namespace Test.Utility
                 // Disposing the PortReserver
                 PortReserver.Dispose();
 
-                _listener = null;
+                (_listener as IDisposable)?.Dispose();
 
                 _disposed = true;
             }

--- a/test/TestUtilities/Test.Utility/MockServer.cs
+++ b/test/TestUtilities/Test.Utility/MockServer.cs
@@ -64,8 +64,6 @@ namespace Test.Utility
         /// </summary>
         public void Start()
         {
-            // Try creating and starting
-
             int attempts = 1;
             do
             {

--- a/test/TestUtilities/Test.Utility/MockServer.cs
+++ b/test/TestUtilities/Test.Utility/MockServer.cs
@@ -26,9 +26,12 @@ namespace Test.Utility
     {
         private Task _listenerTask;
         private bool _disposed = false;
+        private AuthenticationSchemes _authenticationSchemes;
+#pragma warning disable CA2213 // Disposable fields should be disposed
+        private HttpListener _listener;
+#pragma warning restore CA2213 // Disposable fields should be disposed
 
         public string BasePath { get; }
-        public HttpListener Listener { get; }
         private PortReserverOfMockServer PortReserver { get; }
         public RouteTable Get { get; }
         public RouteTable Put { get; }
@@ -43,19 +46,13 @@ namespace Test.Utility
         /// <summary>
         /// Initializes an instance of MockServer.
         /// </summary>
-        public MockServer()
+        /// <param name="authenticationSchemes">The optional <see cref="AuthenticationSchemes" /> to use.</param>
+        public MockServer(AuthenticationSchemes authenticationSchemes = AuthenticationSchemes.Anonymous)
         {
+            _authenticationSchemes = authenticationSchemes;
             BasePath = $"/{Guid.NewGuid().ToString("D")}";
 
             PortReserver = new PortReserverOfMockServer(BasePath);
-
-            // tests that cancel downloads and exit will cause the mock server to throw, this should be ignored.
-            Listener = new HttpListener()
-            {
-                IgnoreWriteExceptions = true
-            };
-
-            Listener.Prefixes.Add(PortReserver.BaseUri);
 
             Get = new RouteTable(BasePath);
             Put = new RouteTable(BasePath);
@@ -69,7 +66,37 @@ namespace Test.Utility
         /// </summary>
         public void Start()
         {
-            Listener.Start();
+            // Try creating and starting
+
+            int attempts = 1;
+            do
+            {
+                try
+                {
+                    // tests that cancel downloads and exit will cause the mock server to throw, this should be ignored.
+                    _listener = new HttpListener()
+                    {
+                        IgnoreWriteExceptions = true
+                    };
+
+                    _listener.Prefixes.Add(PortReserver.BaseUri);
+                    _listener.AuthenticationSchemes = _authenticationSchemes;
+                    _listener.Start();
+                }
+                catch (Exception)
+                {
+                    _listener = null;
+
+                    if (attempts++ >= 5)
+                    {
+                        throw;
+                    }
+
+                    Thread.Sleep(50);
+                }
+            }
+            while (_listener == null);
+
             _listenerTask = Task.Factory.StartNew(() => HandleRequest());
         }
 
@@ -80,7 +107,7 @@ namespace Test.Utility
         {
             try
             {
-                Listener.Abort();
+                _listener.Abort();
 
                 var task = _listenerTask;
                 _listenerTask = null;
@@ -336,7 +363,7 @@ namespace Test.Utility
             {
                 try
                 {
-                    var context = Listener.GetContext();
+                    var context = _listener.GetContext();
 
                     GenerateResponse(context);
 
@@ -481,6 +508,8 @@ namespace Test.Utility
 
                 // Disposing the PortReserver
                 PortReserver.Dispose();
+
+                _listener = null;
 
                 _disposed = true;
             }

--- a/test/TestUtilities/Test.Utility/MockServer.cs
+++ b/test/TestUtilities/Test.Utility/MockServer.cs
@@ -360,6 +360,11 @@ namespace Test.Utility
             {
                 try
                 {
+                    if (_listener == null)
+                    {
+                        return;
+                    }
+
                     var context = _listener.GetContext();
 
                     GenerateResponse(context);
@@ -505,7 +510,7 @@ namespace Test.Utility
 
                 try
                 {
-                    (_listener as IDisposable)?.Dispose();
+                    _listener?.Close();
                 }
                 catch (SocketException)
                 {

--- a/test/TestUtilities/Test.Utility/MockServer.cs
+++ b/test/TestUtilities/Test.Utility/MockServer.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Security.Principal;
 using System.Text;
 using System.Threading;
@@ -502,10 +503,18 @@ namespace Test.Utility
                 // Closing the http listener
                 Stop();
 
+                try
+                {
+                    (_listener as IDisposable)?.Dispose();
+                }
+                catch (SocketException)
+                {
+                }
+
+                _listener = null;
+
                 // Disposing the PortReserver
                 PortReserver.Dispose();
-
-                (_listener as IDisposable)?.Dispose();
 
                 _disposed = true;
             }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2451

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Added a retry to `MockServer.Start()` because some tests fail intermittently when opening the connection.  Since the creation of the object must be in the retry loop, I also had to remove the `Listener` property which was being used by a few tests to set the `AuthenticationScheme` which I moved to the constructor instead.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
