### PR TITLE
Do not warn http sources in push/delete scenarios when allowInsecureConnections is set to true.  

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
@@ -29,19 +29,21 @@ namespace NuGet.Commands
             source = CommandRunnerUtility.ResolveSource(sourceProvider, source);
             PackageSource packageSource = CommandRunnerUtility.GetOrCreatePackageSource(sourceProvider, source);
             // Only warn for V3 style sources because they have a service index which is different from the final push url.
-            if (packageSource.IsHttp && !packageSource.IsHttps &&
+            if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections &&
                 (packageSource.ProtocolVersion == 3 || packageSource.Source.EndsWith("json", StringComparison.OrdinalIgnoreCase)))
             {
                 logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "delete", packageSource.Source));
             }
             var packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, packageSource);
 
+            bool allowInsecureConnections = packageSource.AllowInsecureConnections;
             await packageUpdateResource.Delete(
                 packageId,
                 packageVersion,
                 endpoint => apiKey ?? CommandRunnerUtility.GetApiKey(settings, endpoint, source),
                 desc => nonInteractive || confirmFunc(desc),
                 noServiceEndpoint,
+                allowInsecureConnections,
                 logger);
         }
     }

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
@@ -36,14 +36,13 @@ namespace NuGet.Commands
             }
             var packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, packageSource);
 
-            bool allowInsecureConnections = packageSource.AllowInsecureConnections;
             await packageUpdateResource.Delete(
                 packageId,
                 packageVersion,
                 endpoint => apiKey ?? CommandRunnerUtility.GetApiKey(settings, endpoint, source),
                 desc => nonInteractive || confirmFunc(desc),
                 noServiceEndpoint,
-                allowInsecureConnections,
+                packageSource.AllowInsecureConnections,
                 logger);
         }
     }

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -42,7 +42,7 @@ namespace NuGet.Commands
             var packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, packageSource);
 
             // Only warn for V3 style sources because they have a service index which is different from the final push url.
-            if (packageSource.IsHttp && !packageSource.IsHttps &&
+            if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections &&
                 (packageSource.ProtocolVersion == 3 || packageSource.Source.EndsWith("json", StringComparison.OrdinalIgnoreCase)))
             {
                 logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "push", packageSource.Source));
@@ -80,6 +80,7 @@ namespace NuGet.Commands
                 }
             }
 
+            bool allowInsecureConnections = packageSource.AllowInsecureConnections;
             await packageUpdateResource.Push(
                 packagePaths,
                 symbolSource,
@@ -90,6 +91,7 @@ namespace NuGet.Commands
                 noServiceEndpoint,
                 skipDuplicate,
                 symbolPackageUpdateResource,
+                allowInsecureConnections,
                 logger);
         }
 

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -80,7 +80,6 @@ namespace NuGet.Commands
                 }
             }
 
-            bool allowInsecureConnections = packageSource.AllowInsecureConnections;
             await packageUpdateResource.Push(
                 packagePaths,
                 symbolSource,
@@ -91,7 +90,7 @@ namespace NuGet.Commands
                 noServiceEndpoint,
                 skipDuplicate,
                 symbolPackageUpdateResource,
-                allowInsecureConnections,
+                packageSource.AllowInsecureConnections,
                 logger);
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -19,6 +19,8 @@ NuGet.Protocol.Resources.VulnerabilityInfoResourceV3.GetVulnerabilityDataAsync(N
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.Equals(object? obj) -> bool
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.GetHashCode() -> int
 ~const NuGet.Protocol.JsonProperties.Url = "url" -> string
+~NuGet.Protocol.Core.Types.PackageUpdateResource.Delete(string packageId, string packageVersion, System.Func<string, string> getApiKey, System.Func<string, bool> confirm, bool noServiceEndpoint, bool allowInsecureConnections, NuGet.Common.ILogger log) -> System.Threading.Tasks.Task
+~NuGet.Protocol.Core.Types.PackageUpdateResource.Push(System.Collections.Generic.IList<string> packagePaths, string symbolSource, int timeoutInSecond, bool disableBuffering, System.Func<string, string> getApiKey, System.Func<string, string> getSymbolApiKey, bool noServiceEndpoint, bool skipDuplicate, NuGet.Protocol.Core.Types.SymbolPackageUpdateResourceV3 symbolPackageUpdateResource, bool allowInsecureConnections, NuGet.Common.ILogger log) -> System.Threading.Tasks.Task
 ~static readonly NuGet.Protocol.ServiceTypes.Version300rc -> string
 ~static readonly NuGet.Protocol.ServiceTypes.Version360 -> string
 NuGet.Protocol.IVulnerabilityInfoResource

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -19,6 +19,8 @@ NuGet.Protocol.Resources.VulnerabilityInfoResourceV3.GetVulnerabilityDataAsync(N
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.Equals(object? obj) -> bool
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.GetHashCode() -> int
 ~const NuGet.Protocol.JsonProperties.Url = "url" -> string
+~NuGet.Protocol.Core.Types.PackageUpdateResource.Delete(string packageId, string packageVersion, System.Func<string, string> getApiKey, System.Func<string, bool> confirm, bool noServiceEndpoint, bool allowInsecureConnections, NuGet.Common.ILogger log) -> System.Threading.Tasks.Task
+~NuGet.Protocol.Core.Types.PackageUpdateResource.Push(System.Collections.Generic.IList<string> packagePaths, string symbolSource, int timeoutInSecond, bool disableBuffering, System.Func<string, string> getApiKey, System.Func<string, string> getSymbolApiKey, bool noServiceEndpoint, bool skipDuplicate, NuGet.Protocol.Core.Types.SymbolPackageUpdateResourceV3 symbolPackageUpdateResource, bool allowInsecureConnections, NuGet.Common.ILogger log) -> System.Threading.Tasks.Task
 ~static readonly NuGet.Protocol.ServiceTypes.Version300rc -> string
 ~static readonly NuGet.Protocol.ServiceTypes.Version360 -> string
 NuGet.Protocol.IVulnerabilityInfoResource

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -19,6 +19,8 @@ NuGet.Protocol.Resources.VulnerabilityInfoResourceV3.GetVulnerabilityDataAsync(N
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.Equals(object? obj) -> bool
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.GetHashCode() -> int
 ~const NuGet.Protocol.JsonProperties.Url = "url" -> string
+~NuGet.Protocol.Core.Types.PackageUpdateResource.Delete(string packageId, string packageVersion, System.Func<string, string> getApiKey, System.Func<string, bool> confirm, bool noServiceEndpoint, bool allowInsecureConnections, NuGet.Common.ILogger log) -> System.Threading.Tasks.Task
+~NuGet.Protocol.Core.Types.PackageUpdateResource.Push(System.Collections.Generic.IList<string> packagePaths, string symbolSource, int timeoutInSecond, bool disableBuffering, System.Func<string, string> getApiKey, System.Func<string, string> getSymbolApiKey, bool noServiceEndpoint, bool skipDuplicate, NuGet.Protocol.Core.Types.SymbolPackageUpdateResourceV3 symbolPackageUpdateResource, bool allowInsecureConnections, NuGet.Common.ILogger log) -> System.Threading.Tasks.Task
 ~static readonly NuGet.Protocol.ServiceTypes.Version300rc -> string
 ~static readonly NuGet.Protocol.ServiceTypes.Version360 -> string
 NuGet.Protocol.IVulnerabilityInfoResource

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
@@ -460,7 +460,7 @@ namespace NuGet.CommandLine.Test
                 Assert.Equal(0, r.ExitCode);
                 Assert.True(deleteRequestIsCalled);
 
-                string expectedWarning = "WARNING: You are running the 'delete' operation with an 'HTTP' source"; 
+                string expectedWarning = "WARNING: You are running the 'delete' operation with an 'HTTP' source";
                 if (isHttpWarningExpected)
                 {
                     Assert.Contains(expectedWarning, r.AllOutput);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
@@ -414,8 +414,10 @@ namespace NuGet.CommandLine.Test
             Util.TestCommandInvalidArguments(args);
         }
 
-        [Fact]
-        public void DeleteCommand_WhenDeleteWithHttpSource_Warns()
+        [Theory]
+        [InlineData("true", false)]
+        [InlineData("false", true)]
+        public void DeleteCommand_WhenDeleteWithHttpSourceAndAllowInsecureConnections_WarnsCorrectly(string allowInsecureConnections, bool isHttpWarningExpected)
         {
             var nugetexe = Util.GetNuGetExePath();
 
@@ -431,10 +433,23 @@ namespace NuGet.CommandLine.Test
                     return HttpStatusCode.OK;
                 });
 
+                using SimpleTestPathContext config = new SimpleTestPathContext();
+
+                // Arrange the NuGet.Config file
+                string nugetConfigContent =
+    $@"<configuration>
+    <packageSources>
+        <clear />
+        <add key='http-feed' value='{server.Uri}nuget' protocalVersion=""3"" allowInsecureConnections=""{allowInsecureConnections}"" />
+    </packageSources>
+</configuration>";
+                File.WriteAllText(config.NuGetConfig, nugetConfigContent);
+
                 // Act
                 string[] args = new string[] {
                     "delete", "testPackage1", "1.1.0",
-                    "-Source", server.Uri + "nuget", "-NonInteractive" };
+                    "-Source", server.Uri + "nuget",
+                    "-ConfigFile", config.NuGetConfig, "-NonInteractive" };
 
                 var r = CommandRunner.Run(
                     nugetexe,
@@ -444,7 +459,16 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.Equal(0, r.ExitCode);
                 Assert.True(deleteRequestIsCalled);
-                Assert.Contains("WARNING: You are running the 'delete' operation with an 'HTTP' source", r.AllOutput);
+
+                string expectedWarning = "WARNING: You are running the 'delete' operation with an 'HTTP' source"; 
+                if (isHttpWarningExpected)
+                {
+                    Assert.Contains(expectedWarning, r.AllOutput);
+                }
+                else
+                {
+                    Assert.DoesNotContain(expectedWarning, r.AllOutput);
+                }
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -2581,6 +2581,7 @@ $@"<configuration>
 
             string expectedWarning = $"WARNING: You are running the 'push' operation with an 'HTTP' source, '{pushUri}/'";
             string expectedSymbolWarning = $"WARNING: You are running the 'push' operation with an 'HTTP' source, '{pushSymbolsUri}/'";
+
             if (isHttpWarningExpected)
             {
                 Assert.Contains(expectedWarning, result.AllOutput);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
@@ -1020,7 +1020,7 @@ namespace NuGet.Protocol.Tests
             {
                 Assert.Equal(0, logger.WarningMessages.Count);
             }
-        }            
+        }
 
         [Fact]
         public async Task Delete_WhenDeletingFromHTTPSource_Warns()

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
@@ -1020,8 +1020,7 @@ namespace NuGet.Protocol.Tests
             {
                 Assert.Equal(0, logger.WarningMessages.Count);
             }
-        } 
-            
+        }            
 
         [Fact]
         public async Task Delete_WhenDeletingFromHTTPSource_Warns()

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
@@ -832,8 +832,10 @@ namespace NuGet.Protocol.Tests
             }
         }
 
-        [Fact]
-        public async Task Push_WithAnHttpSource_NupkgOnly_Warns()
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public async Task Push_WithAnHttpSourceAndAllowInsecureConnections_NupkgOnly_Warns(bool allowInsecureConnections, bool isHttpWarningExpected)
         {
             // Arrange
             using var workingDir = TestDirectory.Create();
@@ -866,17 +868,27 @@ namespace NuGet.Protocol.Tests
                 noServiceEndpoint: false,
                 skipDuplicate: false,
                 symbolPackageUpdateResource: null,
+                allowInsecureConnections: allowInsecureConnections,
                 log: logger);
 
             // Assert
             Assert.NotNull(sourceRequest);
-            Assert.Equal(1, logger.WarningMessages.Count);
-            Assert.Contains("You are running the 'push' operation with an 'HTTP' source", logger.WarningMessages.First());
+            if (isHttpWarningExpected)
+            {
+                Assert.Equal(1, logger.WarningMessages.Count);
+                Assert.Contains("You are running the 'push' operation with an 'HTTP' source", logger.WarningMessages.Single());
+            }
+            else
+            {
+                Assert.Equal(0, logger.WarningMessages.Count);
+            }
 
         }
 
-        [Fact]
-        public async Task Push_WhenPushingToAnHttpSymbolSource_Warns()
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public async Task Push_WhenPushingToAnHttpSymbolSourceAndAllowInsecureConnections_Warns(bool allowInsecureConnections, bool isHttpWarningExpected)
         {
             // Arrange
             using var workingDir = TestDirectory.Create();
@@ -924,17 +936,27 @@ namespace NuGet.Protocol.Tests
                 noServiceEndpoint: false,
                 skipDuplicate: false,
                 symbolPackageUpdateResource: null,
+                allowInsecureConnections: allowInsecureConnections,
                 log: logger);
 
             // Assert
             Assert.NotNull(sourceRequest);
             Assert.NotNull(symbolRequest);
-            Assert.Equal(1, logger.WarningMessages.Count);
-            Assert.Contains("You are running the 'push' operation with an 'HTTP' source", logger.WarningMessages.First());
+            if (isHttpWarningExpected)
+            {
+                Assert.Equal(1, logger.WarningMessages.Count);
+                Assert.Contains("You are running the 'push' operation with an 'HTTP' source", logger.WarningMessages.Single());
+            }
+            else
+            {
+                Assert.Equal(0, logger.WarningMessages.Count);
+            }
         }
 
-        [Fact]
-        public async Task Push_WhenPushingToAnHttpSourceAndSymbolSource_WarnsForBoth()
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public async Task Push_WhenPushingToAnHttpSourceAndSymbolSourceWithAllowInsecureConnections_WarnsForBoth(bool allowInsecureConnections, bool isHttpWarningExpected)
         {
             // Arrange
             using var workingDir = TestDirectory.Create();
@@ -982,15 +1004,24 @@ namespace NuGet.Protocol.Tests
                 noServiceEndpoint: false,
                 skipDuplicate: false,
                 symbolPackageUpdateResource: null,
+                allowInsecureConnections: allowInsecureConnections,
                 log: logger);
 
             // Assert
             Assert.NotNull(sourceRequest);
             Assert.NotNull(symbolRequest);
-            Assert.Equal(2, logger.WarningMessages.Count);
-            Assert.Contains("You are running the 'push' operation with an 'HTTP' source, 'http://www.nuget.org/api/v2/'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", logger.WarningMessages.First());
-            Assert.Contains("You are running the 'push' operation with an 'HTTP' source, 'http://other.smbsrc.net/api/v2/package/'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", logger.WarningMessages.Last());
-        }
+            if (isHttpWarningExpected)
+            {
+                Assert.Equal(2, logger.WarningMessages.Count);
+                Assert.Contains("You are running the 'push' operation with an 'HTTP' source, 'http://www.nuget.org/api/v2/'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", logger.WarningMessages.First());
+                Assert.Contains("You are running the 'push' operation with an 'HTTP' source, 'http://other.smbsrc.net/api/v2/package/'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", logger.WarningMessages.Last());
+            }
+            else
+            {
+                Assert.Equal(0, logger.WarningMessages.Count);
+            }
+        } 
+            
 
         [Fact]
         public async Task Delete_WhenDeletingFromHTTPSource_Warns()


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes: https://github.com/NuGet/Home/issues/12789

Regression? Last working version:

## Description
When `allowInsecureConnections  `property in packageSources section is set to true in NuGet.Config files, do not warn for HTTP sources in push/delete scenarios.
For push scenario, set `allowInsecureConnections  `property to true for push source will opt out the http warning for both package and symbol source.

The PR enable the HTTP warnings in this scenario is: https://github.com/NuGet/NuGet.Client/pull/4552

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
