### PR TITLE
[Draft] Transitive dependencies in GPF are automatically source mapped by actions in PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -462,8 +462,10 @@ namespace NuGet.PackageManagement.UI
 
                     if (!cancellationToken.IsCancellationRequested)
                     {
-                        List<string>? addedPackageIds = addedPackages != null ? addedPackages.Select(pair => pair.Item1).Distinct().ToList() : null;
-                        PackageSourceMappingUtility.ConfigureNewPackageSourceMapping(userAction, addedPackageIds, sourceMappingProvider, existingPackageSourceMappingSourceItems, out countCreatedTopLevelSourceMappings, out countCreatedTransitiveSourceMappings);
+                        IReadOnlyList<SourceRepository>? globalPackageFolders = _packageManager.GlobalPackageFolderRepositories;
+                        IEnumerable<SourceRepository> enabledSourceRepositories = _sourceProvider.GetRepositories().Where(e => e.PackageSource.IsEnabled);
+                        IReadOnlyList<string> enabledSources = enabledSourceRepositories.Where(repository => repository.PackageSource.IsLocal && repository.PackageSource.IsEnabled).Select(repository => repository.PackageSource.Source).ToList().AsReadOnly();
+                        PackageSourceMappingUtility.ConfigureNewPackageSourceMapping(userAction, addedPackages, sourceMappingProvider, existingPackageSourceMappingSourceItems, globalPackageFolders, enabledSources, out countCreatedTopLevelSourceMappings, out countCreatedTransitiveSourceMappings);
 
                         await projectManagerService.ExecuteActionsAsync(
                             actions,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->

DRAFT for https://github.com/NuGet/Client.Engineering/issues/2421
Superceded by https://github.com/NuGet/NuGet.Client/pull/5459

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

(Based on top of another branch for now.)
Jump to commit: https://github.com/NuGet/NuGet.Client/commit/dca7a6b91321ffd237c72a8315b0717887a92358

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
