### PR TITLE
Show vulnerability indicators for transitive vulnerable packages

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -557,6 +557,8 @@ namespace NuGet.PackageManagement.UI
                         nuGetUI?.RecommenderVersion,
                         nuGetUI?.TopLevelVulnerablePackagesCount ?? 0,
                         nuGetUI?.TopLevelVulnerablePackagesMaxSeverities?.ToList() ?? new List<int>(),
+                        nuGetUI?.TransitiveVulnerablePackagesCount ?? 0,
+                        nuGetUI?.TransitiveVulnerablePackagesMaxSeverities?.ToList() ?? new List<int>(),
                         existingPackages,
                         addedPackages,
                         removedPackages,
@@ -609,6 +611,8 @@ namespace NuGet.PackageManagement.UI
             (string modelVersion, string vsixVersion)? recommenderVersion,
             int topLevelVulnerablePackagesCount,
             List<int> topLevelVulnerablePackagesMaxSeverities,
+            int transitiveVulnerablePackagesCount,
+            List<int> transitiveVulnerablePackagesMaxSeverities,
             HashSet<Tuple<string, string, string?>>? existingPackages,
             List<Tuple<string, string>>? addedPackages,
             List<string>? removedPackages,
@@ -645,6 +649,8 @@ namespace NuGet.PackageManagement.UI
 
             actionTelemetryEvent["TopLevelVulnerablePackagesCount"] = topLevelVulnerablePackagesCount;
             actionTelemetryEvent.ComplexData["TopLevelVulnerablePackagesMaxSeverities"] = topLevelVulnerablePackagesMaxSeverities;
+            actionTelemetryEvent["TransitiveVulnerablePackagesCount"] = transitiveVulnerablePackagesCount;
+            actionTelemetryEvent.ComplexData["TransitiveVulnerablePackagesMaxSeverities"] = transitiveVulnerablePackagesMaxSeverities;
 
             // log the installed package state
             if (existingPackages?.Count > 0)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -33,6 +33,7 @@ namespace NuGet.PackageManagement.UI
         private readonly IReadOnlyCollection<PackageSourceContextInfo> _packageSources;
         private readonly ContractItemFilter _itemFilter;
         private readonly bool _useRecommender;
+        private readonly IPackageVulnerabilityService _packageVulnerabilityService;
         private PackageCollection _installedPackages;
         private IEnumerable<IPackageReferenceContextInfo> _packageReferences;
         private PackageFeedSearchState _state = new PackageFeedSearchState();
@@ -52,7 +53,8 @@ namespace NuGet.PackageManagement.UI
             ContractItemFilter itemFilter,
             string searchText,
             bool includePrerelease,
-            bool useRecommender)
+            bool useRecommender,
+            IPackageVulnerabilityService vulnerabilityService = default)
         {
             Assumes.NotNull(serviceBroker);
             Assumes.NotNull(context);
@@ -66,6 +68,7 @@ namespace NuGet.PackageManagement.UI
             _packageSources = packageSources;
             _itemFilter = itemFilter;
             _useRecommender = useRecommender;
+            _packageVulnerabilityService = vulnerabilityService;
         }
 
         public static async ValueTask<PackageItemLoader> CreateAsync(
@@ -76,7 +79,8 @@ namespace NuGet.PackageManagement.UI
             ContractItemFilter itemFilter,
             string searchText = null,
             bool includePrerelease = true,
-            bool useRecommender = false)
+            bool useRecommender = false,
+            IPackageVulnerabilityService vulnerabilityService = default)
         {
             var itemLoader = new PackageItemLoader(
                 serviceBroker,
@@ -86,7 +90,8 @@ namespace NuGet.PackageManagement.UI
                 itemFilter,
                 searchText,
                 includePrerelease,
-                useRecommender);
+                useRecommender,
+                vulnerabilityService);
 
             await itemLoader.InitializeAsync();
 
@@ -103,7 +108,8 @@ namespace NuGet.PackageManagement.UI
             INuGetPackageFileService packageFileService,
             string searchText = null,
             bool includePrerelease = true,
-            bool useRecommender = false)
+            bool useRecommender = false,
+            IPackageVulnerabilityService vulnerabilityService = default)
         {
             var itemLoader = new PackageItemLoader(
                 serviceBroker,
@@ -113,7 +119,8 @@ namespace NuGet.PackageManagement.UI
                 itemFilter,
                 searchText,
                 includePrerelease,
-                useRecommender);
+                useRecommender,
+                vulnerabilityService);
 
             await itemLoader.InitializeAsync(packageFileService);
 
@@ -288,7 +295,7 @@ namespace NuGet.PackageManagement.UI
                     transitiveToolTipMessage = string.Format(CultureInfo.CurrentCulture, Resources.PackageVersionWithTransitiveOrigins, metadata.Identity.Version, string.Join(", ", metadata.TransitiveOrigins));
                 }
 
-                var listItem = new PackageItemViewModel(_searchService)
+                var listItem = new PackageItemViewModel(_searchService, _packageVulnerabilityService)
                 {
                     Id = metadata.Identity.Id,
                     Version = metadata.Identity.Version,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -383,6 +383,10 @@ namespace NuGet.PackageManagement.UI
 
         public IEnumerable<int> TopLevelVulnerablePackagesMaxSeverities { get; set; }
 
+        public int TransitiveVulnerablePackagesCount { get; set; }
+
+        public IEnumerable<int> TransitiveVulnerablePackagesMaxSeverities { get; set; }
+
         public PackageSourceMoniker ActivePackageSourceMoniker
         {
             get

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -33,11 +33,13 @@ namespace NuGet.PackageManagement.UI
         internal const int DecodePixelWidth = 32;
 
         private readonly CancellationTokenSource _cancellationTokenSource;
+        private readonly IPackageVulnerabilityService _vulnerabilityService;
 
-        public PackageItemViewModel(INuGetSearchService searchService)
+        public PackageItemViewModel(INuGetSearchService searchService, IPackageVulnerabilityService vulnerabilityService = default)
         {
             _cancellationTokenSource = new CancellationTokenSource();
             _searchService = searchService;
+            _vulnerabilityService = vulnerabilityService;
         }
 
         // same URIs can reuse the bitmapImage that we've already used.
@@ -746,15 +748,27 @@ namespace NuGet.PackageManagement.UI
             try
             {
                 var identity = new PackageIdentity(Id, Version);
-                (PackageSearchMetadataContextInfo packageMetadata, PackageDeprecationMetadataContextInfo deprecationMetadata) =
-                    await _searchService.GetPackageMetadataAsync(identity, Sources, IncludePrerelease, cancellationToken);
 
-                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-                cancellationToken.ThrowIfCancellationRequested();
+                if (PackageLevel == PackageLevel.TopLevel)
+                {
+                    (PackageSearchMetadataContextInfo packageMetadata, PackageDeprecationMetadataContextInfo deprecationMetadata) =
+                        await _searchService.GetPackageMetadataAsync(identity, Sources, IncludePrerelease, cancellationToken);
 
-                DeprecationMetadata = deprecationMetadata;
-                IsPackageDeprecated = deprecationMetadata != null;
-                VulnerabilityMaxSeverity = packageMetadata?.Vulnerabilities?.FirstOrDefault()?.Severity ?? -1;
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    DeprecationMetadata = deprecationMetadata;
+                    IsPackageDeprecated = deprecationMetadata != null;
+                    VulnerabilityMaxSeverity = packageMetadata?.Vulnerabilities?.FirstOrDefault()?.Severity ?? -1;
+                }
+                else if (PackageLevel == PackageLevel.Transitive && _vulnerabilityService != null)
+                {
+                    IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfoList =
+                        await _vulnerabilityService.GetVulnerabilityInfoAsync(identity, cancellationToken);
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    VulnerabilityMaxSeverity = vulnerabilityInfoList?.FirstOrDefault()?.Severity ?? -1;
+                }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -802,6 +816,10 @@ namespace NuGet.PackageManagement.UI
 
             // Transitive packages cannot be updated and can only be installed as top-level packages with their currently installed version.
             LatestVersion = installedVersion;
+
+            NuGetUIThreadHelper.JoinableTaskFactory
+                .RunAsync(ReloadPackageMetadataAsync)
+                .PostOnFailure(nameof(PackageItemViewModel), nameof(ReloadPackageMetadataAsync));
 
             OnPropertyChanged(nameof(Status));
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -192,8 +192,16 @@ namespace NuGet.PackageManagement.UI
                     nugetUi.RecommendedCount = model.RecommendedCount;
                     nugetUi.RecommendPackages = model.RecommendPackages;
                     nugetUi.RecommenderVersion = model.RecommenderVersion;
-                    nugetUi.TopLevelVulnerablePackagesCount = model.IsPackageVulnerable ? 1 : 0;
-                    nugetUi.TopLevelVulnerablePackagesMaxSeverities = new List<int>() { model.PackageVulnerabilityMaxSeverity };
+                    if (model is PackageDetailControlModel packageModel && packageModel.PackageLevel == PackageLevel.Transitive)
+                    {
+                        nugetUi.TransitiveVulnerablePackagesCount = model.IsPackageVulnerable ? 1 : 0;
+                        nugetUi.TransitiveVulnerablePackagesMaxSeverities = new List<int>() { model.PackageVulnerabilityMaxSeverity };
+                    }
+                    else
+                    {
+                        nugetUi.TopLevelVulnerablePackagesCount = model.IsPackageVulnerable ? 1 : 0;
+                        nugetUi.TopLevelVulnerablePackagesMaxSeverities = new List<int>() { model.PackageVulnerabilityMaxSeverity };
+                    }
                 });
         }
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1621,17 +1621,20 @@ namespace NuGet.PackageManagement.UI
             List<int> topLevelVulnerablePackagesMaxSeverities = new();
             int transitiveVulnerablePackagesCount = 0;
             List<int> transitiveVulnerablePackagesMaxSeverities = new();
-            foreach (PackageItemViewModel package in packages)
+            if (packages != null)
             {
-                if (package.PackageLevel == PackageLevel.TopLevel && package.IsPackageVulnerable)
+                foreach (PackageItemViewModel package in packages)
                 {
-                    topLevelVulnerablePackagesCount++;
-                    topLevelVulnerablePackagesMaxSeverities.Add(package.VulnerabilityMaxSeverity);
-                }
-                else if (package.PackageLevel == PackageLevel.Transitive && package.IsPackageVulnerable)
-                {
-                    transitiveVulnerablePackagesCount++;
-                    transitiveVulnerablePackagesMaxSeverities.Add(package.VulnerabilityMaxSeverity);
+                    if (package.PackageLevel == PackageLevel.TopLevel && package.IsPackageVulnerable)
+                    {
+                        topLevelVulnerablePackagesCount++;
+                        topLevelVulnerablePackagesMaxSeverities.Add(package.VulnerabilityMaxSeverity);
+                    }
+                    else if (package.PackageLevel == PackageLevel.Transitive && package.IsPackageVulnerable)
+                    {
+                        transitiveVulnerablePackagesCount++;
+                        transitiveVulnerablePackagesMaxSeverities.Add(package.VulnerabilityMaxSeverity);
+                    }
                 }
             }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1002,6 +1002,7 @@ namespace NuGet.PackageManagement.UI
             int deprecatedPackagesCount = 0;
             PackageCollection installedPackageCollection = null;
 
+            // Transitive dependencies are only displayed in Project-level PM UI.
             if (Model.IsSolution)
             {
                 installedPackageCollection = await loadContext.GetInstalledPackagesAsync();

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/SourceRepositoryExtensions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/SourceRepositoryExtensions.cs
@@ -8,7 +8,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
+using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Model;
 using NuGet.Versioning;
 using NuGet.VisualStudio.Internal.Contracts;
 
@@ -224,6 +226,21 @@ namespace NuGet.PackageManagement.VisualStudio
                     cancellationToken);
 
                 return packages;
+            }
+        }
+
+        public static async Task<GetVulnerabilityInfoResult> GetVulnerabilityInfoAsync(this SourceRepository sourceRepository, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var vulnerabilityResource = await sourceRepository.GetResourceAsync<IVulnerabilityInfoResource>(cancellationToken);
+            if (vulnerabilityResource is null)
+            {
+                return null;
+            }
+
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                return await vulnerabilityResource.GetVulnerabilityInfoAsync(sourceCacheContext, Common.NullLogger.Instance, cancellationToken);
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Packaging.Core;
+using NuGet.VisualStudio.Internal.Contracts;
+
+namespace NuGet.PackageManagement.VisualStudio
+{
+    public interface IPackageVulnerabilityService
+    {
+        Task<IEnumerable<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken);
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
@@ -11,6 +11,6 @@ namespace NuGet.PackageManagement.VisualStudio
 {
     public interface IPackageVulnerabilityService
     {
-        Task<IEnumerable<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken);
+        Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken);
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
@@ -26,7 +26,7 @@ namespace NuGet.PackageManagement.VisualStudio
             _logger = logger ?? throw new ArgumentNullException(nameof(logger)); ;
         }
 
-        public async Task<IEnumerable<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken)
+        public async Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken)
         {
             _vulnerabilities = await GetAllVulnerabilityDataAsync(cancellationToken);
             IEnumerable<PackageVulnerabilityInfo> packageVulnerabilities = Enumerable.Empty<PackageVulnerabilityInfo>();
@@ -118,14 +118,14 @@ namespace NuGet.PackageManagement.VisualStudio
             return vulnerabilities != null ? vulnerabilities.ToList() : null;
         }
 
-        private IEnumerable<PackageVulnerabilityMetadataContextInfo> ConvertToPackageVulnerabilityMetadataContextInfo(IEnumerable<PackageVulnerabilityInfo> packageVulnerabilities)
+        private List<PackageVulnerabilityMetadataContextInfo> ConvertToPackageVulnerabilityMetadataContextInfo(IEnumerable<PackageVulnerabilityInfo> packageVulnerabilities)
         {
             if (packageVulnerabilities == null || !packageVulnerabilities.Any())
             {
-                return Enumerable.Empty<PackageVulnerabilityMetadataContextInfo>();
+                return new List<PackageVulnerabilityMetadataContextInfo>(0);
             }
 
-            return packageVulnerabilities?.Select(pvi => new PackageVulnerabilityMetadataContextInfo(pvi.Url, (int)pvi.Severity));
+            return packageVulnerabilities?.Select(pvi => new PackageVulnerabilityMetadataContextInfo(pvi.Url, (int)pvi.Severity)).ToList();
         }
 
         private void ReplayErrors(AggregateException exceptions)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
@@ -1,0 +1,139 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Model;
+using NuGet.Versioning;
+using NuGet.VisualStudio.Internal.Contracts;
+
+namespace NuGet.PackageManagement.VisualStudio
+{
+    public class PackageVulnerabilityService : IPackageVulnerabilityService
+    {
+        private readonly IEnumerable<SourceRepository> _sourceRepositories;
+        private GetVulnerabilityInfoResult _vulnerabilities;
+        private INuGetUILogger _logger;
+
+        public PackageVulnerabilityService(IEnumerable<SourceRepository> sourceRepositories, INuGetUILogger logger)
+        {
+            _sourceRepositories = sourceRepositories ?? throw new ArgumentNullException(nameof(sourceRepositories));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger)); ;
+        }
+
+        public async Task<IEnumerable<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken)
+        {
+            _vulnerabilities = await GetAllVulnerabilityDataAsync(cancellationToken);
+            IEnumerable<PackageVulnerabilityInfo> packageVulnerabilities = Enumerable.Empty<PackageVulnerabilityInfo>();
+
+            if (_vulnerabilities?.Exceptions is not null)
+            {
+                ReplayErrors(_vulnerabilities.Exceptions);
+            }
+
+            IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> allVulnerabilities = _vulnerabilities?.KnownVulnerabilities;
+            if (allVulnerabilities is not null && allVulnerabilities.Any())
+            {
+                packageVulnerabilities = GetKnownVulnerabilities(packageId.Id, packageId.Version, allVulnerabilities);
+            }
+
+            return ConvertToPackageVulnerabilityMetadataContextInfo(packageVulnerabilities);
+        }
+
+        // Copied and adapted from NuGet.Commands.Restore.Utility.AuditUtility.GetAllVulnerabilityDataAsync
+        private async Task<GetVulnerabilityInfoResult> GetAllVulnerabilityDataAsync(CancellationToken cancellationToken)
+        {
+            IEnumerable<Task<GetVulnerabilityInfoResult>> results = _sourceRepositories.Select(sr => sr.GetVulnerabilityInfoAsync(cancellationToken));
+            await Task.WhenAll(results);
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            List<Exception> errors = null;
+            List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities = null;
+            foreach (var resultTask in results)
+            {
+                GetVulnerabilityInfoResult result = await resultTask;
+                if (result is null) continue;
+
+                if (result.KnownVulnerabilities != null)
+                {
+                    knownVulnerabilities ??= new();
+                    knownVulnerabilities.AddRange(result.KnownVulnerabilities);
+                }
+
+                if (result.Exceptions != null)
+                {
+                    if (errors == null)
+                    {
+                        errors = new();
+                    }
+
+                    errors.AddRange(result.Exceptions.InnerExceptions);
+                }
+            }
+
+            GetVulnerabilityInfoResult final =
+                knownVulnerabilities != null || errors != null
+                ? new(knownVulnerabilities, errors != null ? new AggregateException(errors) : null)
+                : null;
+            return final;
+        }
+
+        // Copied from NuGet.Commands.Restore.Utility.AuditUtility.GetKnownVulnerabilities
+        private static List<PackageVulnerabilityInfo> GetKnownVulnerabilities(
+            string name,
+            NuGetVersion version,
+            IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities)
+        {
+            HashSet<PackageVulnerabilityInfo> vulnerabilities = null;
+
+            if (knownVulnerabilities == null) return null;
+
+            foreach (var file in knownVulnerabilities)
+            {
+                if (file.TryGetValue(name, out var packageVulnerabilities))
+                {
+                    foreach (var vulnInfo in packageVulnerabilities)
+                    {
+                        if (vulnInfo.Versions.Satisfies(version))
+                        {
+                            if (vulnerabilities == null)
+                            {
+                                vulnerabilities = new();
+                            }
+                            vulnerabilities.Add(vulnInfo);
+                        }
+                    }
+                }
+            }
+
+            return vulnerabilities != null ? vulnerabilities.ToList() : null;
+        }
+
+        private IEnumerable<PackageVulnerabilityMetadataContextInfo> ConvertToPackageVulnerabilityMetadataContextInfo(IEnumerable<PackageVulnerabilityInfo> packageVulnerabilities)
+        {
+            if (packageVulnerabilities == null || !packageVulnerabilities.Any())
+            {
+                return Enumerable.Empty<PackageVulnerabilityMetadataContextInfo>();
+            }
+
+            return packageVulnerabilities?.Select(pvi => new PackageVulnerabilityMetadataContextInfo(pvi.Url, (int)pvi.Severity));
+        }
+
+        private void ReplayErrors(AggregateException exceptions)
+        {
+            foreach (Exception exception in exceptions.InnerExceptions)
+            {
+                _logger.Log(ProjectManagement.MessageLevel.Warning, Strings.Error_VulnerabilityDataFetch, exception.Message);
+            }
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.Designer.cs
@@ -250,6 +250,15 @@ namespace NuGet.PackageManagement.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error occurred while getting package vulnerability data: {0}.
+        /// </summary>
+        public static string Error_VulnerabilityDataFetch {
+            get {
+                return ResourceManager.GetString("Error_VulnerabilityDataFetch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to load &apos;{0}&apos;, while updating binding redirects. {1}.
         /// </summary>
         public static string Error_WhileLoadingConfigForBindingRedirects {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.resx
@@ -285,4 +285,8 @@
   <data name="Exception_InvalidContinuationToken" xml:space="preserve">
     <value>Invalid token</value>
   </data>
+  <data name="Error_VulnerabilityDataFetch" xml:space="preserve">
+    <value>Error occurred while getting package vulnerability data: {0}</value>
+    <comment>{0} is an error message</comment>
+  </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -16,7 +16,6 @@ using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.PackageManagement.Telemetry;
-using NuGet.PackageManagement.UI.Utility;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
@@ -269,6 +268,8 @@ namespace NuGet.PackageManagement.UI.Test
                 recommenderVersion: null,
                 topLevelVulnerablePackagesCount: 3,
                 topLevelVulnerablePackagesMaxSeverities: new List<int> { 1, 1, 3 }, // each package has its own max severity
+                transitiveVulnerablePackagesCount: 2,
+                transitiveVulnerablePackagesMaxSeverities: new List<int> { 2, 3 }, // each package has its own max severity
                 existingPackages: null,
                 addedPackages: null,
                 removedPackages: null,
@@ -285,13 +286,22 @@ namespace NuGet.PackageManagement.UI.Test
             // Assert
             Assert.NotNull(lastTelemetryEvent);
             Assert.NotNull(lastTelemetryEvent.ComplexData["TopLevelVulnerablePackagesMaxSeverities"] as List<int>);
-            var pkgSeverities = lastTelemetryEvent.ComplexData["TopLevelVulnerablePackagesMaxSeverities"] as List<int>;
-            Assert.Equal(lastTelemetryEvent["TopLevelVulnerablePackagesCount"], pkgSeverities.Count());
-            Assert.Collection(pkgSeverities,
+            var topLevelPkgSeverities = lastTelemetryEvent.ComplexData["TopLevelVulnerablePackagesMaxSeverities"] as List<int>;
+            Assert.Equal(lastTelemetryEvent["TopLevelVulnerablePackagesCount"], topLevelPkgSeverities.Count());
+            Assert.Collection(topLevelPkgSeverities,
                 item => Assert.Equal(1, item),
                 item => Assert.Equal(1, item),
                 item => Assert.Equal(3, item));
-            Assert.Equal(3, pkgSeverities.Count());
+            Assert.Equal(3, topLevelPkgSeverities.Count());
+
+            var transitivePkgSeverities = lastTelemetryEvent.ComplexData["TransitiveVulnerablePackagesMaxSeverities"] as List<int>;
+            Assert.Equal(lastTelemetryEvent["TransitiveVulnerablePackagesCount"], transitivePkgSeverities.Count());
+            Assert.Equal(lastTelemetryEvent["TransitiveVulnerablePackagesCount"], transitivePkgSeverities.Count());
+            Assert.Collection(transitivePkgSeverities,
+                item => Assert.Equal(2, item),
+                item => Assert.Equal(3, item));
+            Assert.Equal(2, transitivePkgSeverities.Count());
+
             Assert.Null(lastTelemetryEvent["CreatedTopLevelSourceMappingsCount"]);
             Assert.Null(lastTelemetryEvent["CreatedTransitiveSourceMappingsCount"]);
         }
@@ -333,6 +343,8 @@ namespace NuGet.PackageManagement.UI.Test
                 recommenderVersion: null,
                 topLevelVulnerablePackagesCount: 3,
                 topLevelVulnerablePackagesMaxSeverities: new List<int> { 1, 1, 3 }, // each package has its own max severity
+                transitiveVulnerablePackagesCount: 2,
+                transitiveVulnerablePackagesMaxSeverities: new List<int> { 2, 3 }, // each package has its own max severity
                 existingPackages: null,
                 addedPackages: null,
                 removedPackages: null,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/8756

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Fetch vulnerabilities database for all enabled sources from VulnerabilityInfoResource and check if transitive packages are vulnerable to show warning indicator by Installed tab and by transitive package in package list.

Updated the install / uninstall / update action code paths that log telemetry to include a count of transitive vulnerable packages and maximum severity of each package.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [x] Automated tests added
Updated existing test for telemetry although the test does not fully cover the scenario so we should consider adding additional tests in the future. Code copied from AuditUtility does not have tests as we are going to refactor the code to be shareable and put it under test.

  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
