### PR TITLE
Disable tab navigation for items in Versions and ProjectList Combobox's in PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
@@ -260,6 +260,7 @@
           AutomationProperties.Name="{x:Static nuget:Resources.Label_Repository}"
           SelectionChanged="_sourceRepoList_SelectionChanged"
           HorizontalAlignment="Right"
+          PreviewKeyDown="SourceRepoList_PreviewKeyDown"
           ItemsSource="{Binding Source={StaticResource cvsPackageSources}}">
           <ComboBox.ItemTemplate>
             <DataTemplate>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
+using System.Windows.Input;
 using NuGet.PackageManagement.VisualStudio;
 using Resx = NuGet.PackageManagement.UI.Resources;
 
@@ -310,6 +311,20 @@ namespace NuGet.PackageManagement.UI
         private static ItemFilter GetItemFilter(TabItem item)
         {
             return (ItemFilter)item.Tag;
+        }
+
+        private void SourceRepoList_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            switch (e.Key)
+            {
+                case Key.Tab:
+                    _sourceRepoList.IsDropDownOpen = false;
+                    base.OnPreviewKeyDown(e);
+                    break;
+                default:
+                    base.OnPreviewKeyDown(e);
+                    break;
+            }
         }
     }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
@@ -98,6 +98,8 @@
     <Label Name="SubscriptionsLabel" Content="{x:Static local:Resources.Label_Version}" Visibility="Collapsed"/>
     <ComboBox
       x:Name="_versions"
+      PreviewKeyDown="Versions_PreviewKeyDown"
+      KeyUp="Versions_KeyUp"
       Grid.Row="1"
       Grid.Column="2"
       MinHeight="22"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
@@ -144,7 +144,6 @@ namespace NuGet.PackageManagement.UI
                 {
                     case Key.Tab:
                         _versions.IsDropDownOpen = false;
-                        e.Handled = true;
                         break;
                     default:
                         base.OnPreviewKeyDown(e);
@@ -237,7 +236,15 @@ namespace NuGet.PackageManagement.UI
             }
             else
             {
-                base.OnKeyUp(e);
+                switch (e.Key)
+                {
+                    case Key.Tab:
+                        e.Handled = true;
+                        break;
+                    default:
+                        base.OnKeyUp(e);
+                        break;
+                }
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml.cs
@@ -85,7 +85,7 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        protected override void OnPreviewKeyDown(KeyEventArgs e)
+        private void Versions_PreviewKeyDown(object sender, KeyEventArgs e)
         {
             if (PackageDetailControlModel.IsProjectPackageReference)
             {
@@ -140,11 +140,20 @@ namespace NuGet.PackageManagement.UI
             }
             else
             {
-                base.OnPreviewKeyDown(e);
+                switch (e.Key)
+                {
+                    case Key.Tab:
+                        _versions.IsDropDownOpen = false;
+                        e.Handled = true;
+                        break;
+                    default:
+                        base.OnPreviewKeyDown(e);
+                        break;
+                }
             }
         }
 
-        protected override void OnKeyUp(KeyEventArgs e)
+        private void Versions_KeyUp(object sender, KeyEventArgs e)
         {
             if (PackageDetailControlModel.IsProjectPackageReference)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
@@ -395,6 +395,7 @@
         Grid.Column="2"
         MinWidth="150"
         MinHeight="22"
+        PreviewKeyDown="Versions_PreviewKeyDown"
         AutomationProperties.Name="{x:Static local:Resources.Label_Version}"
         ItemsSource="{Binding Path=Versions}"
         SelectedItem="{Binding Path=SelectedVersion}">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
@@ -193,7 +193,6 @@
       Background="{DynamicResource {x:Static local:Brushes.ListPaneBackground}}"
       Foreground="{DynamicResource {x:Static local:Brushes.UIText}}"
       AutomationProperties.LabeledBy="{Binding ElementName=_installedVersionsCount}"
-      KeyboardNavigation.TabNavigation="Local"
       SelectionMode="Single">
 
       <ListView.Style>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml.cs
@@ -336,5 +336,19 @@ namespace NuGet.PackageManagement.UI
                 oldValue ? ToggleState.On : ToggleState.Off,
                 newValue ? ToggleState.On : ToggleState.Off);
         }
+
+        private void Versions_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            switch (e.Key)
+            {
+                case Key.Tab:
+                    _versions.IsDropDownOpen = false;
+                    base.OnPreviewKeyDown(e);
+                    break;
+                default:
+                    base.OnPreviewKeyDown(e);
+                    break;
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/1831 
And its related Feedback ticket that is mentioned in the issue

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Tab-ing in the Source combobox changes the focus to the next UI element.
![souce-list-tab](https://github.com/NuGet/NuGet.Client/assets/43253759/cc888959-831a-4d64-8d38-09b953d8a921)

Tab-ing in the Versions combobox changes the foucus to the next UI element. (Editable Combobox already follows this behavior due to the difference in implementation between Editable and NonEdtiable combobox)
![versions-combobox-tab](https://github.com/NuGet/NuGet.Client/assets/43253759/c0e6e11c-a8d6-494c-aae3-0c72e2b5a7b8)

Tab-ing in Project list in Solution PM UI changes to the next element, you can still navigate the list using the arrow keys.
![project-list-tab-navigation](https://github.com/NuGet/NuGet.Client/assets/43253759/ed35fde9-b259-46c8-84a2-e38b961f7154)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
