### PR TITLE
Revert "Pass through the cache context to the vulnerability resource (#5361)"

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProviders.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProviders.cs
@@ -39,12 +39,11 @@ namespace NuGet.Commands
         private static IReadOnlyList<IVulnerabilityInformationProvider> CreateVulnerabilityInfoProviders(IReadOnlyList<IRemoteDependencyProvider> remoteProviders)
         {
             List<IVulnerabilityInformationProvider> providers = new(remoteProviders.Count);
-            using var sourceCacheContext = new SourceCacheContext();
             for (int i = 0; i < remoteProviders.Count; i++)
             {
                 if (remoteProviders[i].SourceRepository != null)
                 {
-                    providers.Add(new VulnerabilityInformationProvider(remoteProviders[i].SourceRepository, sourceCacheContext, NullLogger.Instance));
+                    providers.Add(new VulnerabilityInformationProvider(remoteProviders[i].SourceRepository, NullLogger.Instance));
                 }
             }
             return providers;
@@ -151,7 +150,7 @@ namespace NuGet.Commands
             var vulnerabilityInfoProviders = new List<IVulnerabilityInformationProvider>(remoteProviders.Count);
             foreach (SourceRepository source in sources)
             {
-                var provider = new VulnerabilityInformationProvider(source, cacheContext, log);
+                var provider = new VulnerabilityInformationProvider(source, log);
                 vulnerabilityInfoProviders.Add(provider);
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProvidersCache.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProvidersCache.cs
@@ -120,7 +120,7 @@ namespace NuGet.Commands
             var vulnerabilityInformationProviders = new List<IVulnerabilityInformationProvider>(sources.Count);
             foreach (SourceRepository source in sources)
             {
-                IVulnerabilityInformationProvider provider = _vulnerabilityInformationProviders.GetOrAdd(source, s => new VulnerabilityInformationProvider(s, cacheContext, log));
+                IVulnerabilityInformationProvider provider = _vulnerabilityInformationProviders.GetOrAdd(source, s => new VulnerabilityInformationProvider(s, log));
                 vulnerabilityInformationProviders.Add(provider);
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
@@ -399,6 +399,7 @@ namespace NuGet.Commands.Restore.Utility
 
         internal enum NuGetAuditMode { Unknown, Direct, All }
 
+        // Enum parsing and ToString are a magnitude of times slower than a naive implementation. 
         private NuGetAuditMode ParseAuditMode()
         {
             string? auditMode = _restoreAuditProperties?.AuditMode?.Trim();
@@ -431,6 +432,7 @@ namespace NuGet.Commands.Restore.Utility
             ExplicitOptOut
         }
 
+        // Enum parsing and ToString are a magnitude of times slower than a naive implementation.
         public static EnabledValue ParseEnableValue(string? value, string projectFullPath, ILogger logger)
         {
             if (string.IsNullOrEmpty(value) || string.Equals(value, "default", StringComparison.OrdinalIgnoreCase))
@@ -455,6 +457,7 @@ namespace NuGet.Commands.Restore.Utility
             return EnabledValue.Invalid;
         }
 
+        // Enum parsing and ToString are a magnitude of times slower than a naive implementation.
         internal static string GetString(EnabledValue enableAudit)
         {
             return enableAudit switch
@@ -467,6 +470,7 @@ namespace NuGet.Commands.Restore.Utility
             };
         }
 
+        // Enum parsing and ToString are a magnitude of times slower than a naive implementation.
         internal static string GetString(NuGetAuditMode auditMode)
         {
             return auditMode switch

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
@@ -399,7 +399,6 @@ namespace NuGet.Commands.Restore.Utility
 
         internal enum NuGetAuditMode { Unknown, Direct, All }
 
-        // Enum parsing and ToString are a magnitude of times slower than a naive implementation. 
         private NuGetAuditMode ParseAuditMode()
         {
             string? auditMode = _restoreAuditProperties?.AuditMode?.Trim();
@@ -432,7 +431,6 @@ namespace NuGet.Commands.Restore.Utility
             ExplicitOptOut
         }
 
-        // Enum parsing and ToString are a magnitude of times slower than a naive implementation.
         public static EnabledValue ParseEnableValue(string? value, string projectFullPath, ILogger logger)
         {
             if (string.IsNullOrEmpty(value) || string.Equals(value, "default", StringComparison.OrdinalIgnoreCase))
@@ -457,7 +455,6 @@ namespace NuGet.Commands.Restore.Utility
             return EnabledValue.Invalid;
         }
 
-        // Enum parsing and ToString are a magnitude of times slower than a naive implementation.
         internal static string GetString(EnabledValue enableAudit)
         {
             return enableAudit switch
@@ -470,7 +467,6 @@ namespace NuGet.Commands.Restore.Utility
             };
         }
 
-        // Enum parsing and ToString are a magnitude of times slower than a naive implementation.
         internal static string GetString(NuGetAuditMode auditMode)
         {
             return auditMode switch

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/VulnerabilityInformationProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/VulnerabilityInformationProvider.cs
@@ -15,15 +15,13 @@ namespace NuGet.Commands
     internal sealed class VulnerabilityInformationProvider : IVulnerabilityInformationProvider
     {
         private readonly SourceRepository _source;
-        private readonly SourceCacheContext _sourceCacheContext;
         private readonly ILogger _logger;
 
         private readonly AsyncLazy<GetVulnerabilityInfoResult?> _vulnerabilityInfo;
 
-        public VulnerabilityInformationProvider(SourceRepository source, SourceCacheContext cacheContext, ILogger logger)
+        public VulnerabilityInformationProvider(SourceRepository source, ILogger logger)
         {
             _source = source;
-            _sourceCacheContext = cacheContext;
             _logger = logger;
 
             _vulnerabilityInfo = new AsyncLazy<GetVulnerabilityInfoResult?>(GetVulnerabilityInfoAsync);
@@ -44,7 +42,8 @@ namespace NuGet.Commands
                 return null;
             }
 
-            GetVulnerabilityInfoResult result = await vulnerabilityInfoResource.GetVulnerabilityInfoAsync(_sourceCacheContext, _logger, CancellationToken.None);
+            using SourceCacheContext cacheContext = new();
+            GetVulnerabilityInfoResult result = await vulnerabilityInfoResource.GetVulnerabilityInfoAsync(cacheContext, _logger, CancellationToken.None);
             return result;
         }
     }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/VulnerabilityInformationProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/VulnerabilityInformationProvider.cs
@@ -42,6 +42,13 @@ namespace NuGet.Commands
                 return null;
             }
 
+            // Don't re-use a SourceCacheContext from whatever triggered this, because installing packages
+            // (and a few other scenarios, look at everything that calls SourceCacheContext.MaxAge's setter)
+            // will ignore the http cache, because it wants to allow newly published packages to be installable.
+            // However, in VS, when a new project template installs packages, we don't want to force a re-download
+            // of the vulnerability data. Firstly, from a customer point of view, it's not necessary. The reason
+            // we bust the cache for package install doesn't apply to vulnerability data. Secondly, it triggers
+            // regressions in VS's performance tests.
             using SourceCacheContext cacheContext = new();
             GetVulnerabilityInfoResult result = await vulnerabilityInfoResource.GetVulnerabilityInfoAsync(cacheContext, _logger, CancellationToken.None);
             return result;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2461

Regression? yes Last working version: before https://github.com/NuGet/NuGet.Client/commit/9ea2defeabc6ab8687f11298e314c197e95a6b8f

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Preview install (which happens both for PM UI install, but also when other VS components call our IVsPackageInstaller.InstallPackage API), ignores the http-cache, so that newly published packages do not fail to install: 
https://github.com/NuGet/NuGet.Client/blob/e4a9922edc29c36e6458bc5d3b68a04e0ea14b91/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs#L2935-L2941

(also see other references to `SourceCacheContext.MaxAge`)

However, that "newly published package" scenario does not apply to the vulnerability database. There's no reason to force customers to redownload the vulnerability database, so this reverts the previous commit.

This PR isn't a straight revert, it has two modifications:

- Keep the comments about the enum helpers in `AuditUtils`, because they still apply
- Add a big comment in `VulnerabilityInformationProvider.cs` explaining why we're using a different cache context.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: reverting a commit that didn't have tests. Under time pressure to meet shipping dates, but we can consider some kind of complicated functional test to validate this scenario in the future.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
