### PR TITLE
Signing:  enable chain build retry policy by default (Windows only)

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/ChainBuilding/X509ChainBuildPolicyFactory.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/ChainBuilding/X509ChainBuildPolicyFactory.cs
@@ -8,7 +8,9 @@ namespace NuGet.Packaging.Signing
 {
     internal static class X509ChainBuildPolicyFactory
     {
+        private const string DefaultValue = "3,1000";
         // These fields are non-private only to facilitate testing.
+        internal const string DisabledValue = "0";
         internal const string EnvironmentVariableName = "NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY";
         internal const char ValueDelimiter = ',';
 
@@ -45,9 +47,9 @@ namespace NuGet.Packaging.Signing
 
             if (RuntimeEnvironmentHelper.IsWindows)
             {
-                string value = reader.GetEnvironmentVariable(EnvironmentVariableName);
+                string value = reader.GetEnvironmentVariable(EnvironmentVariableName) ?? DefaultValue;
 
-                if (string.IsNullOrWhiteSpace(value))
+                if (string.Equals(value, DisabledValue, StringComparison.Ordinal))
                 {
                     return DefaultX509ChainBuildPolicy.Instance;
                 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ChainBuilding/X509ChainBuildPolicyFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/ChainBuilding/X509ChainBuildPolicyFactoryTests.cs
@@ -30,8 +30,31 @@ namespace NuGet.Packaging.Test
             Assert.Same(policy0, policy1);
         }
 
+        [PlatformFact(Platform.Windows)]
+        public void CreateWithoutCaching_OnWindowsWhenEnvironmentVariableIsNotDefined_ReturnsRetriablePolicy()
+        {
+            Mock<IEnvironmentVariableReader> reader = CreateMockEnvironmentVariableReader(variableValue: null);
+
+            IX509ChainBuildPolicy policy = X509ChainBuildPolicyFactory.CreateWithoutCaching(reader.Object);
+
+            Assert.IsType<RetriableX509ChainBuildPolicy>(policy);
+
+            reader.VerifyAll();
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void CreateWithoutCaching_OnWindowsWhenEnvironmentVariableIsDisabled_ReturnsDefaultPolicy()
+        {
+            Mock<IEnvironmentVariableReader> reader = CreateMockEnvironmentVariableReader(variableValue: X509ChainBuildPolicyFactory.DisabledValue);
+
+            IX509ChainBuildPolicy policy = X509ChainBuildPolicyFactory.CreateWithoutCaching(reader.Object);
+
+            Assert.IsType<DefaultX509ChainBuildPolicy>(policy);
+
+            reader.VerifyAll();
+        }
+
         [PlatformTheory(Platform.Windows)]
-        [InlineData(null)]
         [InlineData("")]
         [InlineData(" ")]
         [InlineData(",")]
@@ -40,7 +63,7 @@ namespace NuGet.Packaging.Test
         [InlineData("0,1")]
         [InlineData("1,-2")]
         [InlineData("1,2,3")]
-        public void CreateWithoutCaching_OnWindowsWhenEnvironmentVariableIsInvalid_ReturnsDefaultPolicy(string value)
+        public void CreateWithoutCaching_OnWindowsWhenEnvironmentVariableValueIsInvalid_ReturnsDefaultPolicy(string value)
         {
             Mock<IEnvironmentVariableReader> reader = CreateMockEnvironmentVariableReader(value);
 
@@ -55,7 +78,7 @@ namespace NuGet.Packaging.Test
         [InlineData("1,0")]
         [InlineData("3,7")]
         [InlineData(" 5 , 9 ")]
-        public void CreateWithoutCaching_OnWindowsWhenEnvironmentVariableIsValid_ReturnsRetriablePolicy(string value)
+        public void CreateWithoutCaching_OnWindowsWhenEnvironmentVariableValueIsValid_ReturnsRetriablePolicy(string value)
         {
             Mock<IEnvironmentVariableReader> reader = CreateMockEnvironmentVariableReader(value);
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/12592

Regression? Last working version:  no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

This change enables the chain build retry policy described [here](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu3028#retry-untrusted-root-failures) by default on Windows only.  The default value of `3,1000` means that chain building will be retried up to 3 times with a 1-second wait in-between retries.  This retry behavior only applies narrowly to chain builds which fail with an untrusted root status and only on Windows.  See [this](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu3028#issue) for more context.

If users have already set the `NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY` environment variable, its value will be honored as before this change.

Up until now, this option has been opt-in, but this change makes it opt-out.  To opt-out, simply set the environment variable value to `0`, like so:

```
set NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY=0
```

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [X] Documentation PR or issue filled:  https://github.com/NuGet/docs.microsoft.com-nuget/issues/3133
  - **OR**
  - [ ] N/A
