### PR TITLE
Update 6.8 branding to RC

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -19,7 +19,7 @@
 
     <!-- ** Change for each new preview/rc -->
     <!-- Check the VS schedule and manually enter a preview number here that makes sense. -->
-    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview.1</ReleaseLabel>
+    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">rc</ReleaseLabel>
 
     <IsEscrowMode>false</IsEscrowMode>
 
@@ -65,7 +65,7 @@
   <PropertyGroup Condition=" '$(Version)' == '' ">
     <Version>$(SemanticVersion)$(PreReleaseInformationVersion)</Version>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition=" '$(NuGetVsVersion)' == '' ">
     <NuGetVsVersion>$(NuGetSdkVsSemanticVersion)$(PreReleaseInformationVersion)</NuGetVsVersion>
   </PropertyGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: n/a

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Looks like we forgot to update branding to preview 2, and now we're preparing for preview 3, which is typically the last where we update NuGet, so set branding to `rc` in preparation for release.

## PR Checklist

- [x] PR has a meaningful title
- [x] ~PR has a linked issue.~
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
