### PR TITLE
Remove NuGetOperationType

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
@@ -92,7 +92,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             var actionTelemetryEvent = VSTelemetryServiceUtility.GetActionTelemetryEvent(
                 OperationId.ToString(),
                 new[] { Project },
-                NuGetOperationType.Install,
+                NuGetProjectActionType.Install,
                 OperationSource.PMC,
                 startTime,
                 _status,

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UninstallPackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UninstallPackageCommand.cs
@@ -90,7 +90,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             var actionTelemetryEvent = VSTelemetryServiceUtility.GetActionTelemetryEvent(
                 OperationId.ToString(),
                 new[] { Project },
-                NuGetOperationType.Uninstall,
+                NuGetProjectActionType.Uninstall,
                 OperationSource.PMC,
                 startTime,
                 _status,

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
@@ -142,7 +142,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             var actionTelemetryEvent = VSTelemetryServiceUtility.GetActionTelemetryEvent(
                 OperationId.ToString(),
                 new[] { Project },
-                NuGetOperationType.Update,
+                NuGetProjectActionType.Update,
                 OperationSource.PMC,
                 startTime,
                 _status,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -60,16 +60,10 @@ namespace NuGet.PackageManagement.UI
             UserAction userAction,
             CancellationToken cancellationToken)
         {
-            var operationType = NuGetOperationType.Install;
-            if (userAction.Action == NuGetProjectActionType.Uninstall)
-            {
-                operationType = NuGetOperationType.Uninstall;
-            }
-
             await PerformActionAsync(
                 uiService,
                 userAction,
-                operationType,
+                userAction.Action,
                 (projectManagerService) => GetActionsAsync(
                     projectManagerService,
                     uiService,
@@ -215,7 +209,7 @@ namespace NuGet.PackageManagement.UI
                 await PerformActionAsync(
                     uiService,
                     userAction: null,
-                    NuGetOperationType.Update,
+                    NuGetProjectActionType.Update,
                     (projectManagerService) =>
                         ResolveActionsForUpdateAsync(projectManagerService, uiService, packagesToUpdate, cancellationToken),
                     cancellationToken);
@@ -251,7 +245,7 @@ namespace NuGet.PackageManagement.UI
         private async Task PerformActionAsync(
             INuGetUI uiService,
             UserAction? userAction,
-            NuGetOperationType operationType,
+            NuGetProjectActionType operationType,
             ResolveActionsAsync resolveActionsAsync,
             CancellationToken cancellationToken)
         {
@@ -294,7 +288,7 @@ namespace NuGet.PackageManagement.UI
             INuGetProjectManagerService projectManagerService,
             INuGetUI uiService,
             ResolveActionsAsync resolveActionsAsync,
-            NuGetOperationType operationType,
+            NuGetProjectActionType operationType,
             UserAction? userAction,
             CancellationToken cancellationToken)
         {
@@ -388,7 +382,7 @@ namespace NuGet.PackageManagement.UI
                     IReadOnlyList<ProjectAction> actions = await resolveActionsAsync(projectManagerService);
                     IReadOnlyList<PreviewResult> results = await GetPreviewResultsAsync(projectManagerService, actions, userAction, uiService, cancellationToken);
 
-                    if (operationType == NuGetOperationType.Uninstall)
+                    if (operationType == NuGetProjectActionType.Uninstall)
                     {
                         // removed packages don't have version info
                         removedPackages = results.SelectMany(result => result.Deleted)
@@ -423,7 +417,7 @@ namespace NuGet.PackageManagement.UI
                         if (updateCount > 0)
                         {
                             // set operation type to update when there are packages being updated
-                            operationType = NuGetOperationType.Update;
+                            operationType = NuGetProjectActionType.Update;
                         }
                     }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/VSTelemetryServiceUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/VSTelemetryServiceUtility.cs
@@ -41,7 +41,7 @@ namespace NuGet.PackageManagement.Telemetry
         public static VSActionsTelemetryEvent GetActionTelemetryEvent(
             string operationId,
             IEnumerable<NuGetProject> projects,
-            NuGetOperationType operationType,
+            NuGetProjectActionType operationType,
             OperationSource source,
             DateTimeOffset startTime,
             NuGetOperationStatus status,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/VSActionsTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/VSActionsTelemetryEvent.cs
@@ -17,7 +17,7 @@ namespace NuGet.VisualStudio
         public VSActionsTelemetryEvent(
            string operationId,
            string[] projectIds,
-           NuGetOperationType operationType,
+           NuGetProjectActionType operationType,
            OperationSource source,
            DateTimeOffset startTime,
            NuGetOperationStatus status,

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetProjectAction.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetProjectAction.cs
@@ -11,22 +11,6 @@ using NuGet.Versioning;
 namespace NuGet.PackageManagement
 {
     /// <summary>
-    /// Enum for the type of NuGetProjectAction
-    /// </summary>
-    public enum NuGetProjectActionType
-    {
-        /// <summary>
-        /// Install
-        /// </summary>
-        Install,
-
-        /// <summary>
-        /// Uninstall
-        /// </summary>
-        Uninstall
-    }
-
-    /// <summary>
     /// NuGetProjectAction
     /// </summary>
     [DebuggerDisplay("{NuGetProjectActionType} {PackageIdentity}")]

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetProjectActionType.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetProjectActionType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace NuGet.PackageManagement
@@ -21,11 +21,6 @@ namespace NuGet.PackageManagement
         /// <summary>
         /// Update
         /// </summary>
-        Update,
-
-        /// <summary>
-        /// PreferUpdateToInstall - Install if project doesn't have package. Update if project does have it.
-        /// </summary>
-        PreferUpdateToInstall
+        Update
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetProjectActionType.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetProjectActionType.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.PackageManagement
+{
+    /// <summary>
+    /// Enum for the type of NuGetProjectAction
+    /// </summary>
+    public enum NuGetProjectActionType
+    {
+        /// <summary>
+        /// Install
+        /// </summary>
+        Install,
+
+        /// <summary>
+        /// Uninstall
+        /// </summary>
+        Uninstall,
+
+        /// <summary>
+        /// Update
+        /// </summary>
+        Update,
+
+        /// <summary>
+        /// PreferUpdateToInstall - Install if project doesn't have package. Update if project does have it.
+        /// </summary>
+        PreferUpdateToInstall
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Shipped.txt
@@ -143,10 +143,6 @@ NuGet.PackageManagement.LogUtility
 ~NuGet.PackageManagement.NuGetEventArgs<T>
 ~NuGet.PackageManagement.NuGetEventArgs<T>.Arg.get -> T
 ~NuGet.PackageManagement.NuGetEventArgs<T>.NuGetEventArgs(T arg) -> void
-NuGet.PackageManagement.NuGetOperationType
-NuGet.PackageManagement.NuGetOperationType.Install = 0 -> NuGet.PackageManagement.NuGetOperationType
-NuGet.PackageManagement.NuGetOperationType.Uninstall = 2 -> NuGet.PackageManagement.NuGetOperationType
-NuGet.PackageManagement.NuGetOperationType.Update = 1 -> NuGet.PackageManagement.NuGetOperationType
 NuGet.PackageManagement.NuGetPackageManager
 NuGet.PackageManagement.NuGetPackageManager.BatchEnd -> System.EventHandler<NuGet.PackageManagement.PackageProjectEventArgs>
 NuGet.PackageManagement.NuGetPackageManager.BatchStart -> System.EventHandler<NuGet.PackageManagement.PackageProjectEventArgs>

--- a/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Shipped.txt
@@ -18,8 +18,6 @@ NuGet.PackageManagement.ActionsExecutedEventArgs
 ~NuGet.PackageManagement.ActionsExecutedEventArgs.Actions.get -> System.Collections.Generic.IEnumerable<NuGet.PackageManagement.ResolvedAction>
 ~NuGet.PackageManagement.ActionsExecutedEventArgs.ActionsExecutedEventArgs(System.Collections.Generic.IEnumerable<NuGet.PackageManagement.ResolvedAction> actions) -> void
 NuGet.PackageManagement.ActionsTelemetryEvent
-~NuGet.PackageManagement.ActionsTelemetryEvent.ActionsTelemetryEvent(string operationId, string[] projectIds, NuGet.PackageManagement.NuGetOperationType operationType, System.DateTimeOffset startTime, NuGet.Common.NuGetOperationStatus status, int packageCount, System.DateTimeOffset endTime, double duration) -> void
-NuGet.PackageManagement.ActionsTelemetryEvent.OperationType.get -> NuGet.PackageManagement.NuGetOperationType
 NuGet.PackageManagement.AssetsFileMissingStatusChanged
 NuGet.PackageManagement.BuildIntegratedProjectAction
 ~NuGet.PackageManagement.BuildIntegratedProjectAction.BuildIntegratedProjectAction(NuGet.ProjectManagement.NuGetProject project, NuGet.Packaging.Core.PackageIdentity packageIdentity, NuGet.PackageManagement.NuGetProjectActionType nuGetProjectActionType, NuGet.ProjectModel.LockFile originalLockFile, NuGet.Commands.RestoreResultPair restoreResultPair, System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Core.Types.SourceRepository> sources, System.Collections.Generic.IReadOnlyList<NuGet.PackageManagement.NuGetProjectAction> originalActions, NuGet.ProjectManagement.BuildIntegratedInstallationContext installationContext) -> void

--- a/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 NuGet.PackageManagement.ActionsTelemetryEvent.OperationType.get -> NuGet.PackageManagement.NuGetProjectActionType
+NuGet.PackageManagement.NuGetProjectActionType.Update = 2 -> NuGet.PackageManagement.NuGetProjectActionType
 ~NuGet.PackageManagement.ActionsTelemetryEvent.ActionsTelemetryEvent(string operationId, string[] projectIds, NuGet.PackageManagement.NuGetProjectActionType operationType, System.DateTimeOffset startTime, NuGet.Common.NuGetOperationStatus status, int packageCount, System.DateTimeOffset endTime, double duration) -> void
 ~static NuGet.PackageManagement.PackageReferenceComparer.Instance.get -> NuGet.PackageManagement.PackageReferenceComparer
 ~static NuGet.PackageManagement.SourceRepositoryComparer.Instance.get -> NuGet.PackageManagement.SourceRepositoryComparer

--- a/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
+NuGet.PackageManagement.ActionsTelemetryEvent.OperationType.get -> NuGet.PackageManagement.NuGetProjectActionType
+~NuGet.PackageManagement.ActionsTelemetryEvent.ActionsTelemetryEvent(string operationId, string[] projectIds, NuGet.PackageManagement.NuGetProjectActionType operationType, System.DateTimeOffset startTime, NuGet.Common.NuGetOperationStatus status, int packageCount, System.DateTimeOffset endTime, double duration) -> void
 ~static NuGet.PackageManagement.PackageReferenceComparer.Instance.get -> NuGet.PackageManagement.PackageReferenceComparer
 ~static NuGet.PackageManagement.SourceRepositoryComparer.Instance.get -> NuGet.PackageManagement.SourceRepositoryComparer

--- a/src/NuGet.Core/NuGet.PackageManagement/Telemetry/ActionsTelemetryEvent.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Telemetry/ActionsTelemetryEvent.cs
@@ -14,7 +14,7 @@ namespace NuGet.PackageManagement
         public ActionsTelemetryEvent(
             string operationId,
             string[] projectIds,
-            NuGetOperationType operationType,
+            NuGetProjectActionType operationType,
             DateTimeOffset startTime,
             NuGetOperationStatus status,
             int packageCount,
@@ -26,27 +26,6 @@ namespace NuGet.PackageManagement
 
         public const string NugetActionEventName = "NugetAction";
 
-        public NuGetOperationType OperationType => (NuGetOperationType)base[nameof(OperationType)];
-    }
-
-    /// <summary>
-    /// Define nuget operation type values.
-    /// </summary>
-    public enum NuGetOperationType
-    {
-        /// <summary>
-        /// Install package action.
-        /// </summary>
-        Install = 0,
-
-        /// <summary>
-        /// Update package action.
-        /// </summary>
-        Update = 1,
-
-        /// <summary>
-        /// Uninstall package action.
-        /// </summary>
-        Uninstall = 2,
+        public NuGetProjectActionType OperationType => (NuGetProjectActionType)base[nameof(OperationType)];
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -225,7 +225,7 @@ namespace NuGet.PackageManagement.UI.Test
             Assert.NotNull(lastTelemetryEvent);
             // expect cancelled action because we mocked just enough objects to emit telemetry
             Assert.Equal(NuGetOperationStatus.Cancelled, lastTelemetryEvent[nameof(ActionEventBase.Status)]);
-            Assert.Equal(NuGetOperationType.Install, lastTelemetryEvent[nameof(ActionsTelemetryEvent.OperationType)]);
+            Assert.Equal(NuGetProjectActionType.Install, lastTelemetryEvent[nameof(ActionsTelemetryEvent.OperationType)]);
             Assert.Equal(isSolutionLevel, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.IsSolutionLevel)]);
             Assert.Equal(activeTab, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.Tab)]);
             Assert.Equal(expectedPackageWasTransitive, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.PackageToInstallWasTransitive)]);
@@ -248,7 +248,7 @@ namespace NuGet.PackageManagement.UI.Test
             var actionTelemetryData = new VSActionsTelemetryEvent(
                 operationId,
                 projectIds: new[] { Guid.NewGuid().ToString() },
-                operationType: NuGetOperationType.Install,
+                operationType: NuGetProjectActionType.Install,
                 source: OperationSource.PMC,
                 startTime: DateTimeOffset.Now.AddSeconds(-1),
                 status: NuGetOperationStatus.NoOp,
@@ -323,7 +323,7 @@ namespace NuGet.PackageManagement.UI.Test
             var actionTelemetryData = new VSActionsTelemetryEvent(
                 operationId,
                 projectIds: new[] { Guid.NewGuid().ToString() },
-                operationType: NuGetOperationType.Install,
+                operationType: NuGetProjectActionType.Install,
                 source: OperationSource.PMC,
                 startTime: DateTimeOffset.Now.AddSeconds(-1),
                 status: NuGetOperationStatus.NoOp,
@@ -483,7 +483,7 @@ namespace NuGet.PackageManagement.UI.Test
             Assert.NotNull(lastTelemetryEvent);
             // expect cancelled action because we mocked just enough objects to emit telemetry
             Assert.Equal(NuGetOperationStatus.Cancelled, lastTelemetryEvent[nameof(ActionEventBase.Status)]);
-            Assert.Equal(NuGetOperationType.Install, lastTelemetryEvent[nameof(ActionsTelemetryEvent.OperationType)]);
+            Assert.Equal(NuGetProjectActionType.Install, lastTelemetryEvent[nameof(ActionsTelemetryEvent.OperationType)]);
             Assert.Equal(isSolutionLevel, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.IsSolutionLevel)]);
             Assert.Equal(activeTab, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.Tab)]);
             Assert.Equal(expectedPackageWasTransitive, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.PackageToInstallWasTransitive)]);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/ActionsTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/ActionsTelemetryServiceTests.cs
@@ -13,13 +13,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test
     public class ActionsTelemetryServiceTests
     {
         [Theory]
-        [InlineData(NuGetOperationType.Install, OperationSource.UI)]
-        [InlineData(NuGetOperationType.Update, OperationSource.UI)]
-        [InlineData(NuGetOperationType.Uninstall, OperationSource.UI)]
-        [InlineData(NuGetOperationType.Install, OperationSource.PMC)]
-        [InlineData(NuGetOperationType.Update, OperationSource.PMC)]
-        [InlineData(NuGetOperationType.Uninstall, OperationSource.PMC)]
-        public void ActionsTelemetryService_EmitActionEvent_OperationSucceed(NuGetOperationType operationType, OperationSource source)
+        [InlineData(NuGetProjectActionType.Install, OperationSource.UI)]
+        [InlineData(NuGetProjectActionType.Update, OperationSource.UI)]
+        [InlineData(NuGetProjectActionType.Uninstall, OperationSource.UI)]
+        [InlineData(NuGetProjectActionType.Install, OperationSource.PMC)]
+        [InlineData(NuGetProjectActionType.Update, OperationSource.PMC)]
+        [InlineData(NuGetProjectActionType.Uninstall, OperationSource.PMC)]
+        public void ActionsTelemetryService_EmitActionEvent_OperationSucceed(NuGetProjectActionType operationType, OperationSource source)
         {
             // Arrange
             var telemetrySession = new Mock<ITelemetrySession>();
@@ -52,13 +52,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Theory]
-        [InlineData(NuGetOperationType.Install, OperationSource.UI)]
-        [InlineData(NuGetOperationType.Update, OperationSource.UI)]
-        [InlineData(NuGetOperationType.Uninstall, OperationSource.UI)]
-        [InlineData(NuGetOperationType.Install, OperationSource.PMC)]
-        [InlineData(NuGetOperationType.Update, OperationSource.PMC)]
-        [InlineData(NuGetOperationType.Uninstall, OperationSource.PMC)]
-        public void ActionsTelemetryService_EmitActionEvent_OperationFailed(NuGetOperationType operationType, OperationSource source)
+        [InlineData(NuGetProjectActionType.Install, OperationSource.UI)]
+        [InlineData(NuGetProjectActionType.Update, OperationSource.UI)]
+        [InlineData(NuGetProjectActionType.Uninstall, OperationSource.UI)]
+        [InlineData(NuGetProjectActionType.Install, OperationSource.PMC)]
+        [InlineData(NuGetProjectActionType.Update, OperationSource.PMC)]
+        [InlineData(NuGetProjectActionType.Uninstall, OperationSource.PMC)]
+        public void ActionsTelemetryService_EmitActionEvent_OperationFailed(NuGetProjectActionType operationType, OperationSource source)
         {
             // Arrange
             var telemetrySession = new Mock<ITelemetrySession>();
@@ -91,10 +91,10 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Theory]
-        [InlineData(NuGetOperationType.Install)]
-        [InlineData(NuGetOperationType.Update)]
-        [InlineData(NuGetOperationType.Uninstall)]
-        public void ActionsTelemetryService_EmitActionEvent_OperationNoOp(NuGetOperationType operationType)
+        [InlineData(NuGetProjectActionType.Install)]
+        [InlineData(NuGetProjectActionType.Update)]
+        [InlineData(NuGetProjectActionType.Uninstall)]
+        public void ActionsTelemetryService_EmitActionEvent_OperationNoOp(NuGetProjectActionType operationType)
         {
             // Arrange
             var telemetrySession = new Mock<ITelemetrySession>();

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NavigatedTelemetryEventTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NavigatedTelemetryEventTests.cs
@@ -183,7 +183,7 @@ namespace NuGet.PackageManagement.Test.Telemetry
             var evtActions = new VSActionsTelemetryEvent(
                 operationId: It.IsAny<string>(),
                 projectIds: new[] { Guid.NewGuid().ToString() },
-                operationType: NuGetOperationType.Install,
+                operationType: NuGetProjectActionType.Install,
                 source: OperationSource.PMC,
                 startTime: DateTimeOffset.Now.AddSeconds(-1),
                 status: NuGetOperationStatus.NoOp,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/VsTelemetrySessionTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/VsTelemetrySessionTest.cs
@@ -17,7 +17,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var actionTelemetryData = new VSActionsTelemetryEvent(
                Guid.NewGuid().ToString(),
                projectIds: new[] { Guid.NewGuid().ToString() },
-               operationType: NuGetOperationType.Install,
+               operationType: NuGetProjectActionType.Install,
                source: OperationSource.UI,
                startTime: DateTimeOffset.Now.AddSeconds(-2),
                status: NuGetOperationStatus.Failed,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12866

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

While working conditional PR updating, I noticed myself doing *a lot* of duplicated work. See more details for motivation: https://github.com/NuGet/NuGet.Client/compare/dev-nkolev92-conditionalPackageReferenceUpdating?expand=1

For example, I had to do lots of conversions with NuGetProjectActionType and NuGetOperationType. 
This is redundant, and makes our code more complicated. 

I looked at the references and the only place where the NuGetOperationType is explicitly used is as an API is ActionTelemetryEvent, which is not used a lot.

Now this is a breaking change to a public API, which is why this refactoring is coming on its own instead as part of the PR that will follow, but the reasoning is that we should reducing duplication and unnecessary conversion. The likelihood of this API breaking anyone is super low. 

**Note** - Note that NuGet.PackageManagement is *not* part of the .NET SDK. It is the broadest package we ship and is primarily used by component that package all of the NuGet functionality themselves, rather than as an extension of NuGet.

If people are ok with this change, and I'm looking at @zivkan primarily, I'll create a bug matching the reasoning in this description, and mark with `Type:BreakingChange`. 

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added - The tests were changed to simply use the new type.
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
