### PR TITLE
Make MigrationRunner tests more reliable

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
+++ b/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
@@ -70,20 +70,16 @@ namespace NuGet.Common.Migrations
 
         internal static string GetMigrationsDirectory()
         {
-            string migrationsDirectory;
             if (RuntimeEnvironmentHelper.IsWindows)
             {
-                migrationsDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "NuGet", "Migrations");
-            }
-            else
-            {
-                var XdgDataHome = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
-                migrationsDirectory = string.IsNullOrEmpty(XdgDataHome)
-                    ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share", "NuGet", "Migrations")
-                    : Path.Combine(XdgDataHome, "NuGet", "Migrations");
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "NuGet", "Migrations");
             }
 
-            return migrationsDirectory;
+            var XdgDataHome = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+
+            return string.IsNullOrEmpty(XdgDataHome)
+                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share", "NuGet", "Migrations")
+                : Path.Combine(XdgDataHome, "NuGet", "Migrations");
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
+++ b/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
@@ -14,6 +14,12 @@ namespace NuGet.Common.Migrations
         public static void Run()
         {
             string migrationsDirectory = GetMigrationsDirectory();
+
+            Run(migrationsDirectory);
+        }
+
+        internal static void Run(string migrationsDirectory)
+        {
             var expectedMigrationFilename = Path.Combine(migrationsDirectory, MaxMigrationFilename);
 
             if (!File.Exists(expectedMigrationFilename))
@@ -26,6 +32,8 @@ namespace NuGet.Common.Migrations
                     {
                         try
                         {
+                            Directory.CreateDirectory(migrationsDirectory);
+
                             // Only run migrations that have not already been run
                             if (!File.Exists(expectedMigrationFilename))
                             {

--- a/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
+++ b/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
@@ -82,7 +82,7 @@ namespace NuGet.Common.Migrations
                     ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share", "NuGet", "Migrations")
                     : Path.Combine(XdgDataHome, "NuGet", "Migrations");
             }
-            Directory.CreateDirectory(migrationsDirectory);
+
             return migrationsDirectory;
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2452

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
These tests all run against the live Migrations directory but that causes them to be unreliable.  I've added an `internal` overload that accepts a migration directory to test the migration functionality against a temporary location.  This allows the tests to run in parallel and be reliable.

1. Refactored the tests to use `FluentAssertions`.
2. Refactored `GetMigrationsDirectory()` to not create the directory and simplify branching logic.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
