### PR TITLE
Do not show warning icons for HTTP sources in VS Options when allowIn…

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/CheckedListBoxAccessibleObject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/CheckedListBoxAccessibleObject.cs
@@ -34,7 +34,7 @@ namespace NuGet.PackageManagement.UI.Options
             {
                 var item = (PackageSourceContextInfo)CheckedListBox.Items[index];
                 PackageSource packageSource = new PackageSource(item.Source, item.Name);
-                if (packageSource.IsHttp && !packageSource.IsHttps)
+                if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections)
                 {
                     var sourceMessage = string.Concat(
                         Resources.Warning_HTTPSource,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourceCheckedListBox.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourceCheckedListBox.cs
@@ -136,10 +136,11 @@ namespace NuGet.PackageManagement.UI.Options
                         graphics.DrawString(currentItem.Name, e.Font, foreBrush, nameBounds, drawFormat);
 
                         var packageSource = new PackageSource(currentItem.Source, currentItem.Name);
-                        var isSourceHttp = packageSource.IsHttp && !packageSource.IsHttps;
+                        packageSource.AllowInsecureConnections = currentItem.AllowInsecureConnections;
+                        var shouldShowHttpWarningIcon = packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections;
                         Rectangle warningBounds = default;
 
-                        if (isSourceHttp)
+                        if (shouldShowHttpWarningIcon)
                         {
                             var warningIcon = GetWarningIcon();
 
@@ -152,7 +153,7 @@ namespace NuGet.PackageManagement.UI.Options
                         }
 
                         var sourceBounds = new Rectangle(
-                            isSourceHttp ? warningBounds.Right : nameBounds.Left,
+                            shouldShowHttpWarningIcon ? warningBounds.Right : nameBounds.Left,
                             nameBounds.Bottom,
                             textWidth,
                             e.Bounds.Bottom - nameBounds.Bottom);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.Designer.cs
@@ -124,7 +124,6 @@ namespace NuGet.PackageManagement.UI.Options
             resources.ApplyResources(this.NewPackageSource, "NewPackageSource");
             this.NewPackageSource.Name = "NewPackageSource";
             this.NewPackageSource.AccessibleName = "Source:";
-            this.NewPackageSource.TextChanged += new System.EventHandler(this.NewPackageSource_TextChanged);
             // 
             // NewPackageNameLabel
             // 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -152,6 +152,16 @@ namespace NuGet.PackageManagement.UI.Options
                 // Always enable addButton for PackageSourceListBox
                 addButton.Enabled = true;
             }
+
+            // Show HttpWarning for the selected source if needed
+            if (selectedSource != null)
+            {
+                SetHttpWarningVisibilityForSelectSource(selectedSource);
+            }
+            else if (selectedMachineSource != null)
+            {
+                SetHttpWarningVisibilityForSelectSource(selectedMachineSource);
+            }
         }
 
         internal async Task InitializeOnActivatedAsync(CancellationToken cancellationToken)
@@ -477,6 +487,8 @@ namespace NuGet.PackageManagement.UI.Options
             selectedPackageSource.Source = source;
             _packageSources.ResetCurrentItem();
 
+            SetHttpWarningVisibilityForSelectSource(selectedPackageSource);
+
             return TryUpdateSourceResults.Successful;
         }
 
@@ -703,12 +715,13 @@ namespace NuGet.PackageManagement.UI.Options
             return path.IndexOfAny(Path.GetInvalidPathChars()) == -1 && Path.IsPathRooted(path);
         }
 
-        private void NewPackageSource_TextChanged(object sender, EventArgs e)
+        private void SetHttpWarningVisibilityForSelectSource(PackageSourceContextInfo selectedSource)
         {
-            var source = new PackageSource(NewPackageSource.Text.Trim(), NewPackageName.Text.Trim());
+            var source = new PackageSource(selectedSource.Source, selectedSource.Name);
+            source.AllowInsecureConnections = selectedSource.AllowInsecureConnections;
 
-            // Warn if the source is http, support for this will be removed
-            if (source.IsHttp && !source.IsHttps)
+            // Warn if the selected source is http, and the AllowInsecureConnections for this source is set to false. 
+            if (source.IsHttp && !source.IsHttps && !source.AllowInsecureConnections)
             {
                 HttpWarning.Visible = true;
                 HttpWarningIcon.Visible = true;


### PR DESCRIPTION
…secureConnections is true

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes: https://github.com/NuGet/Home/issues/12792

Regression? Last working version:

## Description
When allowInsecureConnections property in packageSources section is set to true in NuGet.Config files, do not show warning icons to HTTP sources in VS Options NuGet Package Manager.

For a NuGet.Config file as below, you will see the warning icon shown in the gif:
```
<configuration>
  <packageSources>
    <clear /> 
    <add key="test1" value="http://test1.index.json" allowInsecureConnections="True" />
    <add key="test2" value="http://test2.index.json" allowInsecureConnections="False"/>
    <add key="test3" value="http://test3.index.json" />
    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
  </packageSources>
</configuration>
```
![allowInsecureConnections2](https://github.com/NuGet/NuGet.Client/assets/45407901/27f0bf6f-9413-40b4-99c5-092acd7a7dd0)


The PR enable the HTTP warnings in this scenario is: https://github.com/NuGet/NuGet.Client/pull/4647
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
