### PR TITLE
Migrate PackageRestoreManagerTests to FluentAssertions

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageRestoreManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageRestoreManagerTests.cs
@@ -369,7 +369,7 @@ namespace NuGet.Test
                 restoreFailedPackages.Select(i => i.Key.PackageIdentity).Should().BeEquivalentTo(new[] { testPackage1, testPackage2 });
 
                 restoreFailedPackages[restoreFailedPackages.Keys.Where(r => r.PackageIdentity.Equals(testPackage1)).First()].Should().BeEquivalentTo(new[] { "projectB", "projectC" });
-                
+
                 restoreFailedPackages[restoreFailedPackages.Keys.Where(r => r.PackageIdentity.Equals(testPackage2)).First()].Should().BeEquivalentTo(new[] { "projectA", "projectC" });
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageRestoreManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageRestoreManagerTests.cs
@@ -1,13 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using NuGet.PackageManagement;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
@@ -65,18 +65,15 @@ namespace NuGet.Test
                 var packagesFromSolutionList = packagesFromSolution.ToList();
                 var missingPackagesFromSolutionList = packagesFromSolution.Where(p => p.IsMissing).ToList();
 
-                Assert.Equal(1, packagesFromSolutionList.Count);
-                Assert.Equal(0, missingPackagesFromSolutionList.Count);
+                packagesFromSolutionList.Should().ContainSingle();
+                missingPackagesFromSolutionList.Should().BeEmpty();
 
                 // Delete packages folder
                 TestFileSystemUtility.DeleteRandomTestFolder(Path.Combine(testSolutionManager.SolutionDirectory, "packages"));
 
                 packagesFromSolution = (await packageRestoreManager.GetPackagesInSolutionAsync(testSolutionManager.SolutionDirectory, token));
 
-                packagesFromSolutionList = packagesFromSolution.ToList();
-                missingPackagesFromSolutionList = packagesFromSolution.Where(p => p.IsMissing).ToList();
-
-                Assert.Equal(1, missingPackagesFromSolutionList.Count);
+                packagesFromSolution.Where(p => p.IsMissing).Should().ContainSingle();
             }
         }
 
@@ -103,7 +100,7 @@ namespace NuGet.Test
                 // Act
                 var packagesFromSolution = (await packageRestoreManager.GetPackagesInSolutionAsync(testSolutionManager.SolutionDirectory, token));
 
-                Assert.False(packagesFromSolution.Any());
+                packagesFromSolution.Any().Should().BeFalse();
             }
         }
 
@@ -148,12 +145,12 @@ namespace NuGet.Test
                         }
                     };
 
-                Assert.True(nuGetPackageManager.PackageExistsInPackagesFolder(packageIdentity));
+                nuGetPackageManager.PackageExistsInPackagesFolder(packageIdentity).Should().BeTrue();
 
                 // Delete packages folder
                 TestFileSystemUtility.DeleteRandomTestFolder(Path.Combine(testSolutionManager.SolutionDirectory, "packages"));
 
-                Assert.False(nuGetPackageManager.PackageExistsInPackagesFolder((packageIdentity)));
+                nuGetPackageManager.PackageExistsInPackagesFolder((packageIdentity)).Should().BeFalse();
 
                 // Act
                 await packageRestoreManager.RestoreMissingPackagesInSolutionAsync(testSolutionManager.SolutionDirectory,
@@ -161,8 +158,8 @@ namespace NuGet.Test
                     new TestLogger(),
                     CancellationToken.None);
 
-                Assert.Equal(1, restoredPackages.Count);
-                Assert.True(nuGetPackageManager.PackageExistsInPackagesFolder((packageIdentity)));
+                restoredPackages.Should().ContainSingle();
+                nuGetPackageManager.PackageExistsInPackagesFolder((packageIdentity)).Should().BeTrue();
             }
         }
 
@@ -209,8 +206,8 @@ namespace NuGet.Test
                 await packageRestoreManager.RaisePackagesMissingEventForSolutionAsync(testSolutionManager.SolutionDirectory, token);
 
                 // Assert
-                Assert.Equal(1, packagesMissingEventCount);
-                Assert.False(packagesMissing);
+                packagesMissingEventCount.Should().Be(1);
+                packagesMissing.Should().BeFalse();
 
                 // Delete packages folder
                 TestFileSystemUtility.DeleteRandomTestFolder(Path.Combine(testSolutionManager.SolutionDirectory, "packages"));
@@ -219,8 +216,8 @@ namespace NuGet.Test
                 await packageRestoreManager.RaisePackagesMissingEventForSolutionAsync(testSolutionManager.SolutionDirectory, token);
 
                 // Assert
-                Assert.Equal(2, packagesMissingEventCount);
-                Assert.True(packagesMissing);
+                packagesMissingEventCount.Should().Be(2);
+                packagesMissing.Should().BeTrue();
             }
         }
 
@@ -256,12 +253,12 @@ namespace NuGet.Test
                     sourceRepositoryProvider,
                     testSettings,
                     testSolutionManager);
-                Assert.True(nuGetPackageManager.PackageExistsInPackagesFolder(packageIdentity));
+                nuGetPackageManager.PackageExistsInPackagesFolder(packageIdentity).Should().BeTrue();
 
                 // Delete packages folder
                 TestFileSystemUtility.DeleteRandomTestFolder(Path.Combine(testSolutionManager.SolutionDirectory, "packages"));
 
-                Assert.False(nuGetPackageManager.PackageExistsInPackagesFolder((packageIdentity)));
+                nuGetPackageManager.PackageExistsInPackagesFolder((packageIdentity)).Should().BeFalse();
 
                 // Act
                 await packageRestoreManager.RestoreMissingPackagesInSolutionAsync(testSolutionManager.SolutionDirectory,
@@ -269,7 +266,7 @@ namespace NuGet.Test
                     new TestLogger(),
                     CancellationToken.None);
 
-                Assert.True(nuGetPackageManager.PackageExistsInPackagesFolder((packageIdentity)));
+                nuGetPackageManager.PackageExistsInPackagesFolder((packageIdentity)).Should().BeTrue();
             }
         }
 
@@ -345,15 +342,15 @@ namespace NuGet.Test
                         (Packaging.PackageReference packageReference, IEnumerable<string> oldValue) => { return oldValue; });
                 };
 
-                Assert.True(nuGetPackageManager.PackageExistsInPackagesFolder(jQueryValidation));
+                nuGetPackageManager.PackageExistsInPackagesFolder(jQueryValidation).Should().BeTrue();
 
                 // Delete packages folder
                 TestFileSystemUtility.DeleteRandomTestFolder(Path.Combine(testSolutionManager.SolutionDirectory, "packages"));
 
-                Assert.False(nuGetPackageManager.PackageExistsInPackagesFolder(jQuery144));
-                Assert.False(nuGetPackageManager.PackageExistsInPackagesFolder(jQueryValidation));
-                Assert.False(nuGetPackageManager.PackageExistsInPackagesFolder(testPackage1));
-                Assert.False(nuGetPackageManager.PackageExistsInPackagesFolder(testPackage2));
+                nuGetPackageManager.PackageExistsInPackagesFolder(jQuery144).Should().BeFalse();
+                nuGetPackageManager.PackageExistsInPackagesFolder(jQueryValidation).Should().BeFalse();
+                nuGetPackageManager.PackageExistsInPackagesFolder(testPackage1).Should().BeFalse();
+                nuGetPackageManager.PackageExistsInPackagesFolder(testPackage2).Should().BeFalse();
 
                 // Act
                 await packageRestoreManager.RestoreMissingPackagesInSolutionAsync(testSolutionManager.SolutionDirectory,
@@ -362,35 +359,18 @@ namespace NuGet.Test
                     CancellationToken.None);
 
                 // Assert
-                Assert.True(nuGetPackageManager.PackageExistsInPackagesFolder(jQuery144));
-                Assert.True(nuGetPackageManager.PackageExistsInPackagesFolder(jQueryValidation));
-                Assert.False(nuGetPackageManager.PackageExistsInPackagesFolder(testPackage1));
-                Assert.False(nuGetPackageManager.PackageExistsInPackagesFolder(testPackage2));
+                nuGetPackageManager.PackageExistsInPackagesFolder(jQuery144).Should().BeTrue();
+                nuGetPackageManager.PackageExistsInPackagesFolder(jQueryValidation).Should().BeTrue();
+                nuGetPackageManager.PackageExistsInPackagesFolder(testPackage1).Should().BeFalse();
+                nuGetPackageManager.PackageExistsInPackagesFolder(testPackage2).Should().BeFalse();
 
-                Assert.Equal(4, restoredPackages.Count);
-                // The ordering is not guaranteed and can vary. Do not assert based on that
-                Assert.True(restoredPackages.Contains(jQuery144));
-                Assert.True(restoredPackages.Contains(jQueryValidation));
-                Assert.True(restoredPackages.Contains(testPackage1));
-                Assert.True(restoredPackages.Contains(testPackage2));
+                restoredPackages.Should().BeEquivalentTo(new[] { jQuery144, jQueryValidation, testPackage1, testPackage2 }, (options) => options.WithoutStrictOrdering());
 
-                Assert.Equal(2, restoreFailedPackages.Count);
+                restoreFailedPackages.Select(i => i.Key.PackageIdentity).Should().BeEquivalentTo(new[] { testPackage1, testPackage2 });
 
-                // The ordering is not guaranteed and can vary. Do not assert based on that
-                var restoreFailedPackageKeys = restoreFailedPackages.Keys;
-                var testPackage1Key = restoreFailedPackageKeys.Where(r => r.PackageIdentity.Equals(testPackage1)).First();
-                var testPackage1ProjectNames = restoreFailedPackages[testPackage1Key].ToList();
-
-                Assert.Equal(2, testPackage1ProjectNames.Count);
-                Assert.True(testPackage1ProjectNames.Contains("projectB", StringComparer.OrdinalIgnoreCase));
-                Assert.True(testPackage1ProjectNames.Contains("projectC", StringComparer.OrdinalIgnoreCase));
-
-                var testPackage2Key = restoreFailedPackageKeys.Where(r => r.PackageIdentity.Equals(testPackage2)).First();
-                var testPackage2ProjectNames = restoreFailedPackages[testPackage2Key].ToList();
-
-                Assert.Equal(2, testPackage2ProjectNames.Count);
-                Assert.True(testPackage2ProjectNames.Contains("projectA", StringComparer.OrdinalIgnoreCase));
-                Assert.True(testPackage2ProjectNames.Contains("projectC", StringComparer.OrdinalIgnoreCase));
+                restoreFailedPackages[restoreFailedPackages.Keys.Where(r => r.PackageIdentity.Equals(testPackage1)).First()].Should().BeEquivalentTo(new[] { "projectB", "projectC" });
+                
+                restoreFailedPackages[restoreFailedPackages.Keys.Where(r => r.PackageIdentity.Equals(testPackage2)).First()].Should().BeEquivalentTo(new[] { "projectA", "projectC" });
             }
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Related to https://github.com/NuGet/Client.Engineering/issues/2442

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
In https://github.com/NuGet/Client.Engineering/issues/2442 you can see that `Test_PackageRestoreFailure_WithRaisedEvents` is flaky.  However, its not obvious why its failing so this pull request migrates the test to FluentAssertions to give us a better idea of which packages were restored so we can hopefully figure out what's going on.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
