### PR TITLE
Use langword in XML doc comments

### DIFF
--- a/build/Shared/EqualityUtility.cs
+++ b/build/Shared/EqualityUtility.cs
@@ -325,7 +325,7 @@ namespace NuGet.Shared
         /// Determines if the current string contains a value equal "false".  Leading and trailing whitespace are trimmed and the comparison is case-insensitive
         /// </summary>
         /// <param name="value">The string to compare.</param>
-        /// <returns><c>true</c> if the current string is equal to a value of "false", otherwise <c>false></c>.</returns>
+        /// <returns><see langword="true" /> if the current string is equal to a value of "false", otherwise <see langword="false" />.</returns>
         internal static bool EqualsFalse(this string value)
         {
             return !string.IsNullOrWhiteSpace(value) && bool.FalseString.Equals(value.Trim(), StringComparison.OrdinalIgnoreCase);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/PackageSourceMappingUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/PackageSourceMappingUtility.cs
@@ -19,8 +19,8 @@ namespace NuGet.PackageManagement.UI
         /// <param name="addedPackageIds"></param>
         /// <param name="sourceMappingProvider"></param>
         /// <param name="existingPackageSourceMappingSourceItems"></param>
-        /// <param name="countCreatedTopLevelSourceMappings">For Top-Level packages: <c>null</c> if not applicable; 0 if none needed to be added; > 0 is the count of new package source mappings added.</param>
-        /// <param name="countCreatedTransitiveSourceMappings">For Transitive packages: <c>null</c> if not applicable; 0 if none needed to be added; > 0 is the count of new package source mappings added.</param>
+        /// <param name="countCreatedTopLevelSourceMappings">For Top-Level packages: <see langword="null" /> if not applicable; 0 if none needed to be added; > 0 is the count of new package source mappings added.</param>
+        /// <param name="countCreatedTransitiveSourceMappings">For Transitive packages: <see langword="null" /> if not applicable; 0 if none needed to be added; > 0 is the count of new package source mappings added.</param>
         internal static void ConfigureNewPackageSourceMapping(
             UserAction? userAction,
             IReadOnlyList<string>? addedPackageIds,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -477,7 +477,7 @@ namespace NuGet.PackageManagement.UI
         /// Appends <c>packages</c> to the internal <see cref="Items"> list
         /// </summary>
         /// <param name="packages">Packages collection to add</param>
-        /// <param name="refresh">Clears <see cref="Items"> list if set to <c>true</c></param>
+        /// <param name="refresh">Clears <see cref="Items"> list if set to <see langword="true" /></param>
         private void UpdatePackageList(IEnumerable<PackageItemViewModel> packages, bool refresh)
         {
             _joinableTaskFactory.Value.Run(async () =>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1723,7 +1723,7 @@ namespace NuGet.PackageManagement.UI
         /// </summary>
         /// <param name="packageId">Package ID to install</param>
         /// <param name="version">Package Version to install</param>
-        /// <param name="packagesInfo">Corresponding Package ViewModels from PM UI. Only needed for vulnerability telemetry counts. Can be <c>null</c></param>
+        /// <param name="packagesInfo">Corresponding Package ViewModels from PM UI. Only needed for vulnerability telemetry counts. Can be <see langword="null" /></param>
         internal void InstallPackage(string packageId, NuGetVersion version, IEnumerable<PackageItemViewModel> packagesInfo)
         {
             var sourceMappingSourceName = PackageSourceMappingUtility.GetNewSourceMappingSourceName(Model.UIController.UIContext.PackageSourceMapping, Model.UIController.ActivePackageSourceMoniker);
@@ -1744,7 +1744,7 @@ namespace NuGet.PackageManagement.UI
         /// Uninstall a package in open project(s)
         /// </summary>
         /// <param name="packageId">Package ID to uninstall</param>
-        /// <param name="packagesInfo">Corresponding Package ViewModels from PM UI. Only needed for vulnerability telemetry counts. Can be <c>null</c></param>
+        /// <param name="packagesInfo">Corresponding Package ViewModels from PM UI. Only needed for vulnerability telemetry counts. Can be <see langword="null" /></param>
         internal void UninstallPackage(string packageId, IEnumerable<PackageItemViewModel> packagesInfo)
         {
             var action = UserAction.CreateUnInstallAction(packageId, Model.IsSolution, UIUtility.ToContractsItemFilter(_topPanel.Filter));
@@ -1764,7 +1764,7 @@ namespace NuGet.PackageManagement.UI
         /// Updates packages in open project(s)
         /// </summary>
         /// <param name="packages">Packages identities to update</param>
-        /// <param name="packagesInfo">Corresponding Package ViewModels from PM UI. Only needed for vulnerability telemetry counts. Can be <c>null</c></param>
+        /// <param name="packagesInfo">Corresponding Package ViewModels from PM UI. Only needed for vulnerability telemetry counts. Can be <see langword="null" /></param>
         internal void UpdatePackage(List<PackageIdentity> packages, IEnumerable<PackageItemViewModel> packagesInfo)
         {
             if (packages.Count == 0)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
@@ -76,7 +76,7 @@ namespace NuGet.PackageManagement.VisualStudio
         }
 
         /// <summary>
-        /// Gets the directories marked for deletion. Returns empty is <see cref="PackagesFolderPath"/> is <c>null</c> >
+        /// Gets the directories marked for deletion. Returns empty is <see cref="PackagesFolderPath"/> is <see langword="null" /> >
         /// </summary>
         public IReadOnlyList<string> GetPackageDirectoriesMarkedForDeletion()
         {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/IPackageMetadataProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/IPackageMetadataProvider.cs
@@ -70,7 +70,7 @@ namespace NuGet.PackageManagement.VisualStudio
         /// </summary>
         /// <param name="identity">Desired package id with version</param>
         /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns>Package metadata, or <c>null</c> if not found in any local source</returns>
+        /// <returns>Package metadata, or <see langword="null" /> if not found in any local source</returns>
         Task<IPackageSearchMetadata> GetOnlyLocalPackageMetadataAsync(PackageIdentity identity, CancellationToken cancellationToken);
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/IPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/IPackageReferenceProject.cs
@@ -13,7 +13,7 @@ namespace NuGet.PackageManagement.VisualStudio
         /// Gets both the installed (top level) and transitive package references for this project, optionally including transitive origins for transitive packages.
         /// Returns the package reference as two separate lists (installed and transitive).
         /// </summary>
-        /// <param name="includeTransitiveOrigins">Set it to <c>true</c> to get transitive origins in transitive packages list</param>
+        /// <param name="includeTransitiveOrigins">Set it to <see langword="true" /> to get transitive origins in transitive packages list</param>
         /// <param name="token">Cancellation token</param>
         /// <returns>A <see cref="ProjectPackages"/>A struct with two lists: installed and transitive packages</returns>
         public Task<ProjectPackages> GetInstalledAndTransitivePackagesAsync(bool includeTransitiveOrigins, CancellationToken token);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -338,7 +338,7 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <param name="ct">Cancellation Token</param>
         /// <returns>A dictionary, indexed by Framework/Runtime-ID with all top (installed)
         /// packages that depends on given transitive package</returns>
-        /// <remarks>Computes all transitive origins for each Framework/Runtime-ID combiation. Runtime-ID can be <c>null</c>.
+        /// <remarks>Computes all transitive origins for each Framework/Runtime-ID combiation. Runtime-ID can be <see langword="null" />.
         /// Transitive origins are calculated using a Depth First Search algorithm on all direct dependencies exhaustively</remarks>
         internal static Dictionary<string, TransitiveEntry> ComputeTransitivePackageOrigins(List<PackageReference> installedPackages, IList<LockFileTarget> targetsList, CancellationToken ct)
         {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageFileService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageFileService.cs
@@ -213,7 +213,7 @@ namespace NuGet.PackageManagement.VisualStudio
         /// NuGet Embedded Uri verification
         /// </summary>
         /// <param name="uri">An URI to test</param>
-        /// <returns><c>true</c> if <c>uri</c> is an URI to an embedded file in a NuGet package</returns>
+        /// <returns><see langword="true" /> if <c>uri</c> is an URI to an embedded file in a NuGet package</returns>
         public static bool IsEmbeddedUri(Uri uri)
         {
             return uri != null

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/FrameworkAssemblyResolver.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/FrameworkAssemblyResolver.cs
@@ -97,7 +97,7 @@ namespace NuGet.PackageManagement.VisualStudio
         /// </summary>
         /// <param name="simpleAssemblyName">The simple assembly name (e.g.:  System.Runtime) without file extension.</param>
         /// <param name="targetFrameworkName">The target .NET Framework.</param>
-        /// <returns><c>true</c> if the assembly is a .NET Framework facade assembly; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if the assembly is a .NET Framework facade assembly; otherwise, <see langword="false" />.</returns>
         public static bool IsFrameworkFacade(string simpleAssemblyName, FrameworkName targetFrameworkName)
         {
             return IsFrameworkFacade(simpleAssemblyName, targetFrameworkName,
@@ -113,7 +113,7 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <param name="getPathToReferenceAssembliesFunc">A function that returns .NET Framework reference assemblies directories.</param>
         /// <param name="frameworkAssembliesDictionary">A dictionary mapping frameworks to lists of assemblies.
         /// The dictionary may be mutated by this function.</param>
-        /// <returns><c>true</c> if the assembly is a .NET Framework facade assembly; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if the assembly is a .NET Framework facade assembly; otherwise, <see langword="false" />.</returns>
         internal static bool IsFrameworkFacade(string simpleAssemblyName,
             FrameworkName targetFrameworkName,
             Func<FrameworkName, IList<string>> getPathToReferenceAssembliesFunc,

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -762,7 +762,7 @@ namespace NuGetVSExtension
         /// A string array containing the list of selected packages in the same hierarchy.
         /// If only one package is selected, the array will contain one package name, otherwise, it will be a list of package names.
         /// If the selected packages are across multiple hierarchies or if no packages are selected, an empty array will be returned.
-        /// This method will return <c>null</c> if it fails to retrieve the selected hierarchy.
+        /// This method will return <see langword="null" /> if it fails to retrieve the selected hierarchy.
         /// </returns>
         private string[] GetSelectedPackages()
         {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetProjectManagerService.cs
@@ -26,7 +26,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         /// Obtains the installed and transitive packages from all given projects, optionally including transitive origins for transitive packages.
         /// </summary>
         /// <param name="projectIds">Projects to retrieve installed and transitive packages</param>
-        /// <param name="includeTransitiveOrigins">Set it to <c>true</c> to get transitive origins of each transitive package</param>
+        /// <param name="includeTransitiveOrigins">Set it to <see langword="true" /> to get transitive origins of each transitive package</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>An object with two lists: installed and transitive packages from all projects</returns>
         ValueTask<IInstalledAndTransitivePackages> GetInstalledAndTransitivePackagesAsync(
@@ -98,7 +98,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         /// <param name="projectIds">A collection of project ID's</param>
         /// <param name="cancellationToken">Cancellation Token</param>
         /// <returns>A collection with all package folders found in each project assets file, deduplicated</returns>
-        /// <exception cref="ArgumentNullException">If <paramref name="projectIds"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentNullException">If <paramref name="projectIds"/> is <see langword="null" /></exception>
         /// <remarks><see cref="PackageManagement.VisualStudio.IPackageReferenceProject.GetPackageFoldersAsync(CancellationToken)"/></remarks>
         ValueTask<IReadOnlyCollection<string>> GetPackageFoldersAsync(
             IReadOnlyCollection<string> projectIds,

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsFrameworkCompatibility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsFrameworkCompatibility.cs
@@ -39,13 +39,13 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// Selects the framework from <paramref name="frameworks"/> that is nearest
         /// to the <paramref name="targetFramework"/>, according to NuGet's framework
-        /// compatibility rules. <c>null</c> is returned of none of the frameworks
+        /// compatibility rules. <see langword="null" /> is returned of none of the frameworks
         /// are compatible.
         /// </summary>
         /// <remarks>This API is <a href="https://github.com/microsoft/vs-threading/blob/main/doc/cookbook_vs.md#how-do-i-effectively-verify-that-my-code-is-fully-free-threaded">free-threaded.</a></remarks>
         /// <param name="targetFramework">The target framework.</param>
         /// <param name="frameworks">The list of frameworks to choose from.</param>
-        /// <exception cref="ArgumentException">If any of the arguments are <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If any of the arguments are <see langword="null" />.</exception>
         /// <returns>The nearest framework.</returns>
         [Obsolete("This API does not support .NET 5 and higher target frameworks with platforms. Use IVsFrameworkCompatibility3 instead.")]
         FrameworkName GetNearest(FrameworkName targetFramework, IEnumerable<FrameworkName> frameworks);

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsFrameworkCompatibility2.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsFrameworkCompatibility2.cs
@@ -19,7 +19,7 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// Selects the framework from <paramref name="frameworks"/> that is nearest
         /// to the <paramref name="targetFramework"/>, according to NuGet's framework
-        /// compatibility rules. <c>null</c> is returned of none of the frameworks
+        /// compatibility rules. <see langword="null" /> is returned of none of the frameworks
         /// are compatible.
         /// </summary>
         /// <remarks>This API is <a href="https://github.com/microsoft/vs-threading/blob/main/doc/cookbook_vs.md#how-do-i-effectively-verify-that-my-code-is-fully-free-threaded">free-threaded.</a></remarks>
@@ -29,7 +29,7 @@ namespace NuGet.VisualStudio
         /// These fallback frameworks are attempted in sequence after <paramref name="targetFramework"/>.
         /// </param>
         /// <param name="frameworks">The list of frameworks to choose from.</param>
-        /// <exception cref="ArgumentException">If any of the arguments are <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If any of the arguments are <see langword="null" />.</exception>
         /// <returns>The nearest framework.</returns>
         [Obsolete("This API does not support .NET 5 and higher target frameworks with platforms. Use IVsFrameworkCompatibility3 instead.")]
         FrameworkName GetNearest(

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsFrameworkCompatibility3.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsFrameworkCompatibility3.cs
@@ -17,7 +17,7 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// Selects the framework from <paramref name="frameworks"/> that is nearest
         /// to the <paramref name="targetFramework"/>, according to NuGet's framework
-        /// compatibility rules. <c>null</c> is returned of none of the frameworks
+        /// compatibility rules. <see langword="null" /> is returned of none of the frameworks
         /// are compatible.
         /// </summary>
         /// <param name="targetFramework">The target framework.</param>
@@ -31,7 +31,7 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// Selects the framework from <paramref name="frameworks"/> that is nearest
         /// to the <paramref name="targetFramework"/>, according to NuGet's framework
-        /// compatibility rules. <c>null</c> is returned of none of the frameworks
+        /// compatibility rules. <see langword="null" /> is returned of none of the frameworks
         /// are compatible.
         /// </summary>
         /// <param name="targetFramework">The target framework.</param>

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageInstaller.cs
@@ -21,7 +21,7 @@ namespace NuGet.VisualStudio
         /// <remarks>Can be called from a background thread, if the UI thread is not blocked waiting for this to finish.
         /// See <a href="https://github.com/nuget/home/issues/11476">https://github.com/nuget/home/issues/11476</a></remarks>
         /// <param name="source">
-        /// The package source to install the package from. This value can be <c>null</c>
+        /// The package source to install the package from. This value can be <see langword="null" />
         /// to indicate that the user's configured sources should be used. Otherwise,
         /// this should be the source path as a string. If the user has credentials
         /// configured for a source, this value must exactly match the configured source
@@ -30,7 +30,7 @@ namespace NuGet.VisualStudio
         /// <param name="project">The target project for package installation.</param>
         /// <param name="packageId">The package ID of the package to install.</param>
         /// <param name="version">
-        /// The version of the package to install. <c>null</c> can be provided to
+        /// The version of the package to install. <see langword="null" /> can be provided to
         /// install the latest version of the package.
         /// </param>
         /// <param name="ignoreDependencies">
@@ -46,7 +46,7 @@ namespace NuGet.VisualStudio
         /// <remarks>Can be called from a background thread, if the UI thread is not blocked waiting for this to finish.
         /// See <a href="https://github.com/nuget/home/issues/11476">https://github.com/nuget/home/issues/11476</a></remarks>
         /// <param name="source">
-        /// The package source to install the package from. This value can be <c>null</c>
+        /// The package source to install the package from. This value can be <see langword="null" />
         /// to indicate that the user's configured sources should be used. Otherwise,
         /// this should be the source path as a string. If the user has credentials
         /// configured for a source, this value must exactly match the configured source
@@ -55,7 +55,7 @@ namespace NuGet.VisualStudio
         /// <param name="project">The target project for package installation.</param>
         /// <param name="packageId">The package ID of the package to install.</param>
         /// <param name="version">
-        /// The version of the package to install. <c>null</c> can be provided to
+        /// The version of the package to install. <see langword="null" /> can be provided to
         /// install the latest version of the package.
         /// </param>
         /// <param name="ignoreDependencies">
@@ -71,7 +71,7 @@ namespace NuGet.VisualStudio
         /// <param name="project">The target project for package installation.</param>
         /// <param name="packageId">The package id of the package to install.</param>
         /// <param name="version">
-        /// The version of the package to install. <c>null</c> can be provided to
+        /// The version of the package to install. <see langword="null" /> can be provided to
         /// install the latest version of the package.
         /// </param>
         /// <param name="ignoreDependencies">

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageInstaller2.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageInstaller2.cs
@@ -17,7 +17,7 @@ namespace NuGet.VisualStudio
         /// <remarks>Can be called from a background thread, if the UI thread is not blocked waiting for this to finish.
         /// See <a href="https://github.com/nuget/home/issues/11476">https://github.com/nuget/home/issues/11476</a></remarks>
         /// <param name="source">
-        /// The package source to install the package from. This value can be <c>null</c>
+        /// The package source to install the package from. This value can be <see langword="null" />
         /// to indicate that the user's configured sources should be used. Otherwise,
         /// this should be the source path as a string. If the user has credentials
         /// configured for a source, this value must exactly match the configured source
@@ -34,7 +34,7 @@ namespace NuGet.VisualStudio
         /// during installation.
         /// </param>
         /// <exception cref="InvalidOperationException">
-        /// Thrown when <see paramref="includePrerelease"/> is <c>false</c> and no stable version
+        /// Thrown when <see paramref="includePrerelease"/> is <see langword="false" /> and no stable version
         /// of the package exists.
         /// </exception>
         void InstallLatestPackage(

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageInstallerServices.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPackageInstallerServices.cs
@@ -30,7 +30,7 @@ namespace NuGet.VisualStudio
         /// </summary>
         /// <param name="project">The project to check for NuGet package.</param>
         /// <param name="id">The id of the package to check.</param>
-        /// <returns><c>true</c> if the package is install. <c>false</c> otherwise.</returns>
+        /// <returns><see langword="true" /> if the package is install. <see langword="false" /> otherwise.</returns>
         /// <exception cref="InvalidOperationException">A "project not nominated" exception will be thrown if the project system has not yet told NuGet about the project.
         /// You can use <see cref="IVsNuGetProjectUpdateEvents"/> or Microsoft.VisualStudio.OperationProgress to be notified when the project is ready.</exception>
         [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead, and check the specific package you're interested in")]
@@ -42,7 +42,7 @@ namespace NuGet.VisualStudio
         /// <param name="project">The project to check for NuGet package.</param>
         /// <param name="id">The id of the package to check.</param>
         /// <param name="version">The version of the package to check.</param>
-        /// <returns><c>true</c> if the package is install. <c>false</c> otherwise.</returns>
+        /// <returns><see langword="true" /> if the package is install. <see langword="false" /> otherwise.</returns>
         /// <exception cref="InvalidOperationException">A "project not nominated" exception will be thrown if the project system has not yet told NuGet about the project.
         /// You can use <see cref="IVsNuGetProjectUpdateEvents"/> or Microsoft.VisualStudio.OperationProgress to be notified when the project is ready.</exception>
         [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead, and check the specific package you're interested in")]
@@ -54,7 +54,7 @@ namespace NuGet.VisualStudio
         /// <param name="project">The project to check for NuGet package.</param>
         /// <param name="id">The id of the package to check.</param>
         /// <param name="versionString">The version of the package to check.</param>
-        /// <returns><c>true</c> if the package is install. <c>false</c> otherwise.</returns>
+        /// <returns><see langword="true" /> if the package is install. <see langword="false" /> otherwise.</returns>
         /// <remarks>
         /// The reason this method is named IsPackageInstalledEx, instead of IsPackageInstalled, is that
         /// when client project compiles against this assembly, the compiler would attempt to bind against

--- a/src/NuGet.Clients/NuGet.VisualStudio/SolutionRestoreManager/IVsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/SolutionRestoreManager/IVsSolutionRestoreService.cs
@@ -42,7 +42,7 @@ namespace NuGet.SolutionRestoreManager
         /// When the requested restore operation for the given project completes the task will indicate operation success or failure.
         /// </returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="projectUniqueName" /> is not the path of a project file.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="projectRestoreInfo" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="projectRestoreInfo" /> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="token" /> is cancelled.</exception>
         Task<bool> NominateProjectAsync(string projectUniqueName, IVsProjectRestoreInfo projectRestoreInfo, CancellationToken token);
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio/SolutionRestoreManager/IVsSolutionRestoreService3.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/SolutionRestoreManager/IVsSolutionRestoreService3.cs
@@ -43,7 +43,7 @@ namespace NuGet.SolutionRestoreManager
         /// When the requested restore operation for the given project completes the task will indicate operation success or failure.
         /// </returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="projectUniqueName" /> is not the path of a project file.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="projectRestoreInfo" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="projectRestoreInfo" /> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="token" /> is cancelled.</exception>
         Task<bool> NominateProjectAsync(string projectUniqueName, IVsProjectRestoreInfo2 projectRestoreInfo, CancellationToken token);
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio/SolutionRestoreManager/IVsTargetFrameworks2.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/SolutionRestoreManager/IVsTargetFrameworks2.cs
@@ -24,7 +24,7 @@ namespace NuGet.SolutionRestoreManager
         /// </summary>
         /// <param name="index">Reference name or index.</param>
         /// <returns>Reference item matching index.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="index" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="index" /> is <see langword="null" />.</exception>
         IVsTargetFrameworkInfo2 Item(object index);
     }
 }

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/FileSystemInfoFullNameEqualityComparer.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/FileSystemInfoFullNameEqualityComparer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Build.NuGetSdkResolver
         /// </summary>
         /// <param name="x">The first <see cref="FileSystemInfo" /> to compare.</param>
         /// <param name="y">The second <see cref="FileSystemInfo" /> to compare.</param>
-        /// <returns><c>true</c> if the specified <see cref="FileSystemInfo" /> objects' <see cref="FileSystemInfo.FullName" /> property are equal, otherwise <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if the specified <see cref="FileSystemInfo" /> objects' <see cref="FileSystemInfo.FullName" /> property are equal, otherwise <see langword="false" />.</returns>
         public bool Equals(FileSystemInfo x, FileSystemInfo y)
         {
             return string.Equals(x.FullName, y.FullName, StringComparison.Ordinal);

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
@@ -122,8 +122,8 @@ namespace Microsoft.Build.NuGetSdkResolver
         /// </summary>
         /// <param name="file">The name of the file to search for.</param>
         /// <param name="startingDirectory">The <see cref="DirectoryInfo" /> to look in first and then search the parent directories of.</param>
-        /// <param name="fullPath">Receives a <see cref="FileInfo" /> of the file if one is found, otherwise <c>null</c>.</param>
-        /// <returns><c>true</c> if the specified file was found in the directory or one of its parents, otherwise <c>false</c>.</returns>
+        /// <param name="fullPath">Receives a <see cref="FileInfo" /> of the file if one is found, otherwise <see langword="null" />.</param>
+        /// <returns><see langword="true" /> if the specified file was found in the directory or one of its parents, otherwise <see langword="false" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool TryGetPathOfFileAbove(string file, DirectoryInfo startingDirectory, out FileInfo fullPath)
         {
@@ -160,7 +160,7 @@ namespace Microsoft.Build.NuGetSdkResolver
         /// Parses the <c>msbuild-sdks</c> section of the specified JSON string.
         /// </summary>
         /// <param name="json">The JSON to parse as a string.</param>
-        /// <returns>A <see cref="Dictionary{TKey, TValue}" /> containing MSBuild project SDK versions if any were found, otherwise <c>null</c>.</returns>
+        /// <returns>A <see cref="Dictionary{TKey, TValue}" /> containing MSBuild project SDK versions if any were found, otherwise <see langword="null" />.</returns>
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static Dictionary<string, string> ParseMSBuildSdkVersionsFromJson(string json)
         {
@@ -231,7 +231,7 @@ namespace Microsoft.Build.NuGetSdkResolver
         /// </summary>
         /// <param name="globalJsonPath"></param>
         /// <param name="sdkResolverContext">The current <see cref="SdkResolverContext" /> to use.</param>
-        /// <returns>A <see cref="Dictionary{TKey, TValue}" /> containing MSBuild project SDK versions if any were found, otherwise <c>null</c>.</returns>
+        /// <returns>A <see cref="Dictionary{TKey, TValue}" /> containing MSBuild project SDK versions if any were found, otherwise <see langword="null" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private Dictionary<string, string> ParseMSBuildSdkVersions(string globalJsonPath, SdkResolverContext sdkResolverContext)
         {

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkLogger.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkLogger.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Build.NuGetSdkResolver
         /// Initializes a new instance of the NuGetLogger class.
         /// </summary>
         /// <param name="sdkLogger">A <see cref="SdkLogger"/> to forward events to.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="sdkLogger" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="sdkLogger" /> is <see langword="null" />.</exception>
         public NuGetSdkLogger(SdkLogger sdkLogger)
         {
             _sdkLogger = sdkLogger ?? throw new ArgumentNullException(nameof(sdkLogger));

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Build.NuGetSdkResolver
         /// <param name="factory">Factory class to create an <see cref="T:Microsoft.Build.Framework.SdkResult" /></param>
         /// <returns>
         ///     An <see cref="T:Microsoft.Build.Framework.SdkResult" /> containing the resolved SDKs or associated error / reason
-        ///     the SDK could not be resolved.  Return <c>null</c> if the resolver is not
+        ///     the SDK could not be resolved.  Return <see langword="null" /> if the resolver is not
         ///     applicable for a particular <see cref="T:Microsoft.Build.Framework.SdkReference" />.
         /// </returns>
         public override SdkResult Resolve(SdkReference sdkReference, SdkResolverContext resolverContext, SdkResultFactory factory)

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -1022,7 +1022,7 @@ namespace NuGet.Build.Tasks.Console
         /// Determines the current settings for central package management for the specified project.
         /// </summary>
         /// <param name="project">The <see cref="IMSBuildProject" /> to get the central package management settings for.</param>
-        /// <param name="projectStyle">The <see cref="ProjectStyle?" /> of the specified project.  Specify <c>null</c> when the project does not define a restore style.</param>
+        /// <param name="projectStyle">The <see cref="ProjectStyle?" /> of the specified project.  Specify <see langword="null" /> when the project does not define a restore style.</param>
         /// <returns>A <see cref="Tuple{T1, T2}" /> containing values indicating whether or not central package management is enabled and if the ability to override a package version is disabled.</returns>
         internal static (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled) GetCentralPackageManagementSettings(IMSBuildProject project, ProjectStyle? projectStyle)
         {

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -725,8 +725,8 @@ namespace NuGet.Build.Tasks
         /// Gets the path to a packages.config for the specified project if one exists.
         /// </summary>
         /// <param name="projectFullPath">The full path to the project.</param>
-        /// <returns>The path to the packages.config file if one exists, otherwise <c>null</c>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="projectFullPath" /> is <c>null</c>.</exception>
+        /// <returns>The path to the packages.config file if one exists, otherwise <see langword="null" />.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="projectFullPath" /> is <see langword="null" />.</exception>
         public static string GetPackagesConfigFilePath(string projectFullPath)
         {
             if (string.IsNullOrWhiteSpace(projectFullPath))
@@ -742,8 +742,8 @@ namespace NuGet.Build.Tasks
         /// </summary>
         /// <param name="projectFullPath">The full path to the project directory.</param>
         /// <param name="projectName">The name of the project file.</param>
-        /// <returns>The path to the packages.config file if one exists, otherwise <c>null</c>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="projectDirectory" /> -or- <paramref name="projectName" /> is <c>null</c>.</exception>
+        /// <returns>The path to the packages.config file if one exists, otherwise <see langword="null" />.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="projectDirectory" /> -or- <paramref name="projectName" /> is <see langword="null" />.</exception>
         public static string GetPackagesConfigFilePath(string projectDirectory, string projectName)
         {
             if (string.IsNullOrWhiteSpace(projectDirectory))

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/ProjectPackagesPrintUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/ProjectPackagesPrintUtility.cs
@@ -241,7 +241,7 @@ namespace NuGet.CommandLine.XPlat.Utility
         /// Print user-friendly representation of a NuGet version.
         /// </summary>
         /// <param name="package">The package reference having its version printed.</param>
-        /// <param name="useLatest"><c>True</c> if we're printing the latest version; otherwise <c>False</c>.</param>
+        /// <param name="useLatest"><see langword="true" /> if we're printing the latest version; otherwise <see langword="false" />.</param>
         private static string GetPackageVersion(
             InstalledPackageReference package,
             bool useLatest = false)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -669,7 +669,7 @@ namespace NuGet.Commands
             /// </summary>
             /// <param name="x">The first <see cref="LockFileTargetLibrary" /> to compare.</param>
             /// <param name="y">The second <see cref="LockFileTargetLibrary" /> to compare.</param>
-            /// <returns><c>true</c> if the specified <see cref="LockFileTargetLibrary" /> objects' <see cref="LockFileTargetLibrary.Name" /> and <see cref="LockFileTargetLibrary.Version" /> properties are equal, otherwise <c>false</c>.</returns>
+            /// <returns><see langword="true" /> if the specified <see cref="LockFileTargetLibrary" /> objects' <see cref="LockFileTargetLibrary.Name" /> and <see cref="LockFileTargetLibrary.Version" /> properties are equal, otherwise <see langword="false" />.</returns>
             public bool Equals(LockFileTargetLibrary x, LockFileTargetLibrary y)
             {
                 return string.Equals(x.Name, y.Name, StringComparison.Ordinal) && x.Version.Equals(y.Version);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -75,12 +75,12 @@ namespace NuGet.Commands
         /// <param name="sourceRepository">A source repository.</param>
         /// <param name="logger">A logger.</param>
         /// <param name="cacheContext">A source cache context.</param>
-        /// <param name="ignoreFailedSources"><c>true</c> to ignore failed sources; otherwise <c>false</c>.</param>
-        /// <param name="ignoreWarning"><c>true</c> to ignore warnings; otherwise <c>false</c>.</param>
+        /// <param name="ignoreFailedSources"><see langword="true" /> to ignore failed sources; otherwise <see langword="false" />.</param>
+        /// <param name="ignoreWarning"><see langword="true" /> to ignore warnings; otherwise <see langword="false" />.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="sourceRepository" />
-        /// is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> is <see langword="null" />.</exception>
         public SourceRepositoryDependencyProvider(
             SourceRepository sourceRepository,
             ILogger logger,
@@ -97,12 +97,12 @@ namespace NuGet.Commands
         /// <param name="sourceRepository">A source repository.</param>
         /// <param name="logger">A logger.</param>
         /// <param name="cacheContext">A source cache context.</param>
-        /// <param name="ignoreFailedSources"><c>true</c> to ignore failed sources; otherwise <c>false</c>.</param>
-        /// <param name="ignoreWarning"><c>true</c> to ignore warnings; otherwise <c>false</c>.</param>
+        /// <param name="ignoreFailedSources"><see langword="true" /> to ignore failed sources; otherwise <see langword="false" />.</param>
+        /// <param name="ignoreWarning"><see langword="true" /> to ignore warnings; otherwise <see langword="false" />.</param>
         /// <param name="fileCache">Optional nuspec/file cache.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="sourceRepository" />
-        /// is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <see langword="null" />.</exception>
         public SourceRepositoryDependencyProvider(
             SourceRepository sourceRepository,
             ILogger logger,
@@ -150,7 +150,7 @@ namespace NuGet.Commands
         /// <summary>
         /// Gets the package source.
         /// </summary>
-        /// <remarks>Optional. This will be <c>null</c> for project providers.</remarks>
+        /// <remarks>Optional. This will be <see langword="null" /> for project providers.</remarks>
         public PackageSource Source => _sourceRepository.PackageSource;
 
         public SourceRepository SourceRepository => _sourceRepository;
@@ -168,13 +168,13 @@ namespace NuGet.Commands
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="LibraryIdentity" />
         /// instance.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="libraryRange" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="targetFramework" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task<LibraryIdentity> FindLibraryAsync(
@@ -313,13 +313,13 @@ namespace NuGet.Commands
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="LibraryDependencyInfo" />
         /// instance.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="libraryIdentity" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="targetFramework" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task<LibraryDependencyInfo> GetDependenciesAsync(
@@ -442,11 +442,11 @@ namespace NuGet.Commands
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="IPackageDownloader" />
         /// instance.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task<IPackageDownloader> GetPackageDownloaderAsync(

--- a/src/NuGet.Core/NuGet.Common/Preprocessor.cs
+++ b/src/NuGet.Core/NuGet.Common/Preprocessor.cs
@@ -23,9 +23,9 @@ namespace NuGet.Common
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="string" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="streamTaskFactory" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="tokenReplacement" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public static async Task<string> ProcessAsync(
@@ -58,9 +58,9 @@ namespace NuGet.Common
         /// <param name="tokenReplacement">A token replacement funciton.</param>
         /// <returns>The token-replaced stream content.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="stream" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="tokenReplacement" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public static string Process(Stream stream, Func<string, string> tokenReplacement)
         {
             if (stream == null)

--- a/src/NuGet.Core/NuGet.Configuration/Credential/ICredentialService.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Credential/ICredentialService.cs
@@ -23,7 +23,7 @@ namespace NuGet.Configuration
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="ICredentials" />.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="uri" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="uri" /> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         Task<ICredentials> GetCredentialsAsync(
@@ -37,15 +37,15 @@ namespace NuGet.Configuration
         /// Attempts to retrieve last known good credentials for a URI from a credentials cache.
         /// </summary>
         /// <remarks>
-        /// When the return value is <c>true</c>, <paramref name="credentials" /> will have last known
+        /// When the return value is <see langword="true" />, <paramref name="credentials" /> will have last known
         /// good credentials from the credentials cache.  These credentials may have become invalid
         /// since their last use, so there is no guarantee that the credentials are currently valid.
         /// </remarks>
         /// <param name="uri">The URI for which cached credentials should be retrieved.</param>
-        /// <param name="isProxy"><c>true</c> for proxy credentials; otherwise, <c>false</c>.</param>
-        /// <param name="credentials">Cached credentials or <c>null</c>.</param>
-        /// <returns><c>true</c> if a result is returned from the cache; otherwise, false.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="uri" /> is <c>null</c>.</exception>
+        /// <param name="isProxy"><see langword="true" /> for proxy credentials; otherwise, <see langword="false" />.</param>
+        /// <param name="credentials">Cached credentials or <see langword="null" />.</param>
+        /// <returns><see langword="true" /> if a result is returned from the cache; otherwise, false.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="uri" /> is <see langword="null" />.</exception>
         bool TryGetLastKnownGoodCredentialsFromCache(
             Uri uri,
             bool isProxy,

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsLoadingContext.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsLoadingContext.cs
@@ -44,7 +44,7 @@ namespace NuGet.Configuration
         /// <param name="isReadOnly">An optional value indicating whether or not the settings file is read-only.</param>
         /// <returns></returns>
         /// <exception cref="ObjectDisposedException">When the current object has been disposed.</exception>
-        /// <exception cref="ArgumentNullException">When <paramref name="filePath" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">When <paramref name="filePath" /> is <see langword="null" />.</exception>
         internal SettingsFile GetOrCreateSettingsFile(string filePath, bool isMachineWide = false, bool isReadOnly = false)
         {
             if (_isDisposed)

--- a/src/NuGet.Core/NuGet.Credentials/CredentialService.cs
+++ b/src/NuGet.Core/NuGet.Credentials/CredentialService.cs
@@ -148,15 +148,15 @@ namespace NuGet.Credentials
         /// Attempts to retrieve last known good credentials for a URI from a credentials cache.
         /// </summary>
         /// <remarks>
-        /// When the return value is <c>true</c>, <paramref name="credentials" /> will have last known
+        /// When the return value is <see langword="true" />, <paramref name="credentials" /> will have last known
         /// good credentials from the credentials cache.  These credentials may have become invalid
         /// since their last use, so there is no guarantee that the credentials are currently valid.
         /// </remarks>
         /// <param name="uri">The URI for which cached credentials should be retrieved.</param>
-        /// <param name="isProxy"><c>true</c> for proxy credentials; otherwise, <c>false</c>.</param>
-        /// <param name="credentials">Cached credentials or <c>null</c>.</param>
-        /// <returns><c>true</c> if a result is returned from the cache; otherwise, false.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="uri" /> is <c>null</c>.</exception>
+        /// <param name="isProxy"><see langword="true" /> for proxy credentials; otherwise, <see langword="false" />.</param>
+        /// <param name="credentials">Cached credentials or <see langword="null" />.</param>
+        /// <returns><see langword="true" /> if a result is returned from the cache; otherwise, false.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="uri" /> is <see langword="null" />.</exception>
         public bool TryGetLastKnownGoodCredentialsFromCache(
             Uri uri,
             bool isProxy,

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/IRemoteDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/IRemoteDependencyProvider.cs
@@ -28,13 +28,13 @@ namespace NuGet.DependencyResolver
         /// <summary>
         /// Gets the package source.
         /// </summary>
-        /// <remarks>Optional. This will be <c>null</c> for project providers.</remarks>
+        /// <remarks>Optional. This will be <see langword="null" /> for project providers.</remarks>
         PackageSource Source { get; }
 
         /// <summary>
         /// Gets the source repository.
         /// </summary>
-        /// <remarks>Optional. This will be <c>null</c> for project providers.</remarks>
+        /// <remarks>Optional. This will be <see langword="null" /> for project providers.</remarks>
         SourceRepository SourceRepository { get; }
 
         /// <summary>
@@ -50,13 +50,13 @@ namespace NuGet.DependencyResolver
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="LibraryIdentity" />
         /// instance.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="libraryRange" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="targetFramework" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         Task<LibraryIdentity> FindLibraryAsync(
@@ -78,13 +78,13 @@ namespace NuGet.DependencyResolver
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="LibraryDependencyInfo" />
         /// instance.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="libraryIdentity" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="targetFramework" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         Task<LibraryDependencyInfo> GetDependenciesAsync(
@@ -105,11 +105,11 @@ namespace NuGet.DependencyResolver
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="IPackageDownloader" />
         /// instance.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         Task<IPackageDownloader> GetPackageDownloaderAsync(

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
@@ -28,7 +28,7 @@ namespace NuGet.DependencyResolver
         /// </summary>
         /// <param name="dependencyProvider"></param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="dependencyProvider" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public LocalDependencyProvider(IDependencyProvider dependencyProvider)
         {
             if (dependencyProvider == null)
@@ -47,7 +47,7 @@ namespace NuGet.DependencyResolver
         /// <summary>
         /// Gets the package source.
         /// </summary>
-        /// <remarks>Optional. This will be <c>null</c> for project providers.</remarks>
+        /// <remarks>Optional. This will be <see langword="null" /> for project providers.</remarks>
         public PackageSource Source { get; private set; }
 
         public SourceRepository SourceRepository { get; private set; }
@@ -65,9 +65,9 @@ namespace NuGet.DependencyResolver
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="LibraryIdentity" />
         /// instance.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="libraryRange" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="targetFramework" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         public Task<LibraryIdentity> FindLibraryAsync(
             LibraryRange libraryRange,
             NuGetFramework targetFramework,
@@ -107,9 +107,9 @@ namespace NuGet.DependencyResolver
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="LibraryDependencyInfo" />
         /// instance.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="libraryIdentity" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="targetFramework" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         public Task<LibraryDependencyInfo> GetDependenciesAsync(
             LibraryIdentity libraryIdentity,
             NuGetFramework targetFramework,

--- a/src/NuGet.Core/NuGet.PackageManagement/FileModifiers/IPackageFileTransformer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/FileModifiers/IPackageFileTransformer.cs
@@ -23,9 +23,9 @@ namespace NuGet.ProjectManagement
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="streamTaskFactory" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="projectSystem" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         Task TransformFileAsync(
@@ -44,11 +44,11 @@ namespace NuGet.ProjectManagement
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="streamTaskFactory" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="matchingFiles" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="projectSystem" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         Task RevertFileAsync(

--- a/src/NuGet.Core/NuGet.PackageManagement/FileModifiers/Preprocessor.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/FileModifiers/Preprocessor.cs
@@ -23,9 +23,9 @@ namespace NuGet.ProjectManagement
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="streamTaskFactory" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="projectSystem" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task TransformFileAsync(
@@ -63,9 +63,9 @@ namespace NuGet.ProjectManagement
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="streamTaskFactory" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="projectSystem" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task RevertFileAsync(

--- a/src/NuGet.Core/NuGet.PackageManagement/FileModifiers/XdtTransformer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/FileModifiers/XdtTransformer.cs
@@ -29,9 +29,9 @@ namespace NuGet.ProjectManagement
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="streamTaskFactory" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="projectSystem" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task TransformFileAsync(
@@ -65,11 +65,11 @@ namespace NuGet.ProjectManagement
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="streamTaskFactory" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="matchingFiles" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="projectSystem" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task RevertFileAsync(

--- a/src/NuGet.Core/NuGet.PackageManagement/FileModifiers/XmlTransformer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/FileModifiers/XmlTransformer.cs
@@ -25,7 +25,7 @@ namespace NuGet.ProjectManagement
         /// </summary>
         /// <param name="nodeActions">A dictionary of XML node names to node actions.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="nodeActions" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public XmlTransformer(IDictionary<XName, Action<XElement, XElement>> nodeActions)
         {
             if (nodeActions == null)
@@ -45,9 +45,9 @@ namespace NuGet.ProjectManagement
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="streamTaskFactory" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="projectSystem" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task TransformFileAsync(
@@ -89,9 +89,9 @@ namespace NuGet.ProjectManagement
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="streamTaskFactory" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="projectSystem" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task RevertFileAsync(

--- a/src/NuGet.Core/NuGet.PackageManagement/IInstallationCompatibility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IInstallationCompatibility.cs
@@ -47,11 +47,11 @@ namespace NuGet.PackageManagement
         /// <param name="cancellationToken">A cancellation token.</param>.
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="nuGetProject" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="resourceResult" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         Task EnsurePackageCompatibilityAsync(

--- a/src/NuGet.Core/NuGet.PackageManagement/InstallationCompatibility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/InstallationCompatibility.cs
@@ -88,11 +88,11 @@ namespace NuGet.PackageManagement
         /// <param name="cancellationToken">A cancellation token.</param>.
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="nuGetProject" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="resourceResult" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task EnsurePackageCompatibilityAsync(

--- a/src/NuGet.Core/NuGet.PackageManagement/PackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/PackageDownloader.cs
@@ -35,13 +35,13 @@ namespace NuGet.PackageManagement
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="DownloadResourceResult" />
         /// instance.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="sources" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="downloadContext" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="token" />
         /// is cancelled.</exception>
         public static async Task<DownloadResourceResult> GetDownloadResourceResultAsync(
@@ -246,13 +246,13 @@ namespace NuGet.PackageManagement
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="DownloadResourceResult" />
         /// instance.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="sourceRepository" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="downloadContext" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="token" />
         /// is cancelled.</exception>
         public static async Task<DownloadResourceResult> GetDownloadResourceResultAsync(

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/FolderNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/FolderNuGetProject.cs
@@ -37,7 +37,7 @@ namespace NuGet.ProjectManagement
         /// Initializes a new <see cref="FolderNuGetProject" /> class.
         /// </summary>
         /// <param name="root">The folder project root path.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="root" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="root" /> is <see langword="null" />.</exception>
         public FolderNuGetProject(string root)
             : this(root, new PackagePathResolver(root))
         {
@@ -48,9 +48,9 @@ namespace NuGet.ProjectManagement
         /// </summary>
         /// <param name="root">The folder project root path.</param>
         /// <param name="packagePathResolver">A package path resolver.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="root" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="root" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packagePathResolver" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public FolderNuGetProject(string root, PackagePathResolver packagePathResolver)
             : this(root, packagePathResolver, NuGetFramework.AnyFramework)
         {
@@ -62,9 +62,9 @@ namespace NuGet.ProjectManagement
         /// <param name="root">The folder project root path.</param>
         /// <param name="packagePathResolver">A package path resolver.</param>
         /// <param name="targetFramework">Project target framework.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="root" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packagePathResolver" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="targetFramework" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="root" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packagePathResolver" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="targetFramework" /> is <see langword="null" />.</exception>
         public FolderNuGetProject(string root, PackagePathResolver packagePathResolver, NuGetFramework targetFramework)
         {
             if (targetFramework == null)
@@ -103,11 +103,11 @@ namespace NuGet.ProjectManagement
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="bool" />
         /// indication successfulness of the operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="downloadResourceResult" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="nuGetProjectContext" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentException">Thrown if the package stream for
         /// <paramref name="downloadResourceResult" /> is not seekable.</exception>
         public override Task<bool> InstallPackageAsync(
@@ -250,7 +250,7 @@ namespace NuGet.ProjectManagement
         /// <param name="packageIdentity">A package identity.</param>
         /// <returns>A flag indicating whether or not the package is installed.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public bool PackageExists(PackageIdentity packageIdentity)
         {
             if (packageIdentity == null)
@@ -268,7 +268,7 @@ namespace NuGet.ProjectManagement
         /// <param name="packageSaveMode">A package save mode.</param>
         /// <returns>A flag indicating whether or not the package is installed.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public bool PackageExists(PackageIdentity packageIdentity, PackageSaveMode packageSaveMode)
         {
             if (packageIdentity == null)
@@ -329,7 +329,7 @@ namespace NuGet.ProjectManagement
         /// <param name="packageIdentity">A package identity.</param>
         /// <returns>A flag indicating whether or not the package is installed.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public bool ManifestExists(PackageIdentity packageIdentity)
         {
             if (packageIdentity == null)
@@ -356,7 +356,7 @@ namespace NuGet.ProjectManagement
         /// <param name="packageIdentity">A package identity.</param>
         /// <returns>A flag indicating whether or not the package is installed.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public bool PackageAndManifestExists(PackageIdentity packageIdentity)
         {
             if (packageIdentity == null)
@@ -377,9 +377,9 @@ namespace NuGet.ProjectManagement
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="bool" />
         /// indication successfulness of the operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="nuGetProjectContext" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="token" />
         /// is cancelled.</exception>
         public async Task<bool> CopySatelliteFilesAsync(
@@ -412,12 +412,12 @@ namespace NuGet.ProjectManagement
         }
 
         /// <summary>
-        /// Gets the package .nupkg file path if it exists; otherwise, <c>null</c>.
+        /// Gets the package .nupkg file path if it exists; otherwise, <see langword="null" />.
         /// </summary>
         /// <param name="packageIdentity">A package identity.</param>
-        /// <returns>The package .nupkg file path if it exists; otherwise, <c>null</c>.</returns>
+        /// <returns>The package .nupkg file path if it exists; otherwise, <see langword="null" />.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public string GetInstalledPackageFilePath(PackageIdentity packageIdentity)
         {
             if (packageIdentity == null)
@@ -468,12 +468,12 @@ namespace NuGet.ProjectManagement
         }
 
         /// <summary>
-        /// Gets the package .nuspec file path if it exists; otherwise, <c>null</c>.
+        /// Gets the package .nuspec file path if it exists; otherwise, <see langword="null" />.
         /// </summary>
         /// <param name="packageIdentity">A package identity.</param>
-        /// <returns>The package .nuspec file path if it exists; otherwise, <c>null</c>.</returns>
+        /// <returns>The package .nuspec file path if it exists; otherwise, <see langword="null" />.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public string GetInstalledManifestFilePath(PackageIdentity packageIdentity)
         {
             if (packageIdentity == null)
@@ -498,12 +498,12 @@ namespace NuGet.ProjectManagement
         }
 
         /// <summary>
-        /// Gets the package download marker file path if it exists; otherwise, <c>null</c>.
+        /// Gets the package download marker file path if it exists; otherwise, <see langword="null" />.
         /// </summary>
         /// <param name="packageIdentity">A package identity.</param>
-        /// <returns>The package download marker file path if it exists; otherwise, <c>null</c>.</returns>
+        /// <returns>The package download marker file path if it exists; otherwise, <see langword="null" />.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public string GetPackageDownloadMarkerFilePath(PackageIdentity packageIdentity)
         {
             if (packageIdentity == null)
@@ -526,12 +526,12 @@ namespace NuGet.ProjectManagement
         }
 
         /// <summary>
-        /// Gets the package directory path if the package exists; otherwise, <c>null</c>.
+        /// Gets the package directory path if the package exists; otherwise, <see langword="null" />.
         /// </summary>
         /// <param name="packageIdentity">A package identity.</param>
-        /// <returns>The package directory path if the package exists; otherwise, <c>null</c>.</returns>
+        /// <returns>The package directory path if the package exists; otherwise, <see langword="null" />.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public string GetInstalledPath(PackageIdentity packageIdentity)
         {
             if (packageIdentity == null)
@@ -560,9 +560,9 @@ namespace NuGet.ProjectManagement
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="bool" />
         /// indication successfulness of the operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="nuGetProjectContext" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public async Task<bool> DeletePackage(PackageIdentity packageIdentity,
             INuGetProjectContext nuGetProjectContext,
             CancellationToken token)

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/FileSystemUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/FileSystemUtility.cs
@@ -309,11 +309,11 @@ namespace NuGet.ProjectManagement
         /// </summary>
         /// <param name="path">The path to a file.</param>
         /// <param name="streamFactory">A stream task factory.</param>
-        /// <returns><c>true</c> if contents are equal; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if contents are equal; otherwise, <see langword="false" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="path" /> is either
-        /// <c>null</c> or an empty string.</exception>
+        /// <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="streamFactory" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public static bool ContentEquals(string path, Func<Stream> streamFactory)
         {
             if (string.IsNullOrEmpty(path))
@@ -340,11 +340,11 @@ namespace NuGet.ProjectManagement
         /// <param name="streamTaskFactory">A stream task factory.</param>
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="bool" />
-        /// which is <c>true</c> if contents are equal; otherwise, <c>false</c>.</returns>
+        /// which is <see langword="true" /> if contents are equal; otherwise, <see langword="false" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="path" /> is either
-        /// <c>null</c> or an empty string.</exception>
+        /// <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="streamTaskFactory" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public static async Task<bool> ContentEqualsAsync(string path, Func<Task<Stream>> streamTaskFactory)
         {
             if (string.IsNullOrEmpty(path))

--- a/src/NuGet.Core/NuGet.Packaging/Core/ExtractPackageFileDelegate.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Core/ExtractPackageFileDelegate.cs
@@ -11,6 +11,6 @@ namespace NuGet.Packaging.Core
     /// <param name="sourceFile">The path of the file in the package.</param>
     /// <param name="targetPath">The path to write to.</param>
     /// <param name="fileStream">The file <see cref="Stream"/>.</param>
-    /// <returns>The file name if the file was written; otherwise <c>null</c>.</returns>
+    /// <returns>The file name if the file was written; otherwise <see langword="null" />.</returns>
     public delegate string ExtractPackageFileDelegate(string sourceFile, string targetPath, Stream fileStream);
 }

--- a/src/NuGet.Core/NuGet.Packaging/Definitions/IPackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Definitions/IPackageDownloader.cs
@@ -40,7 +40,7 @@ namespace NuGet.Packaging
         /// indicating whether or not the copy was successful.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="destinationFilePath" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         Task<bool> CopyNupkgFileToAsync(string destinationFilePath, CancellationToken cancellationToken);
@@ -55,7 +55,7 @@ namespace NuGet.Packaging
         /// representing the package hash.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="hashAlgorithm" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         Task<string> GetPackageHashAsync(string hashAlgorithm, CancellationToken cancellationToken);
@@ -66,16 +66,16 @@ namespace NuGet.Packaging
         /// <remarks>The exception handler returns a task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="bool" />
         /// indicating whether or not the exception was handled.  To handle an exception and stop its
-        /// propagation, the task should return <c>true</c>.  Otherwise, the exception will be rethrown.</remarks>
+        /// propagation, the task should return <see langword="true" />.  Otherwise, the exception will be rethrown.</remarks>
         /// <param name="handleExceptionAsync">An exception handler.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="handleExceptionAsync" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         void SetExceptionHandler(Func<Exception, Task<bool>> handleExceptionAsync);
 
         /// <summary>
         /// Sets a throttle for package downloads.
         /// </summary>
-        /// <param name="throttle">A throttle.  Can be <c>null</c>.</param>
+        /// <param name="throttle">A throttle.  Can be <see langword="null" />.</param>
         void SetThrottle(SemaphoreSlim throttle);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/LocalPackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/LocalPackageArchiveDownloader.cs
@@ -75,11 +75,11 @@ namespace NuGet.Packaging
         /// <param name="packageIdentity">A package identity.</param>
         /// <param name="logger">A logger.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageFilePath" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         public LocalPackageArchiveDownloader(
             string source,
             string packageFilePath,
@@ -145,7 +145,7 @@ namespace NuGet.Packaging
         /// indicating whether or not the copy was successful.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="destinationFilePath" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task<bool> CopyNupkgFileToAsync(string destinationFilePath, CancellationToken cancellationToken)
@@ -214,7 +214,7 @@ namespace NuGet.Packaging
         /// representing the package hash.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="hashAlgorithm" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public Task<string> GetPackageHashAsync(string hashAlgorithm, CancellationToken cancellationToken)
@@ -244,10 +244,10 @@ namespace NuGet.Packaging
         /// <remarks>The exception handler returns a task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="bool" />
         /// indicating whether or not the exception was handled.  To handle an exception and stop its
-        /// propagation, the task should return <c>true</c>.  Otherwise, the exception will be rethrown.</remarks>
+        /// propagation, the task should return <see langword="true" />.  Otherwise, the exception will be rethrown.</remarks>
         /// <param name="handleExceptionAsync">An exception handler.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="handleExceptionAsync" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public void SetExceptionHandler(Func<Exception, Task<bool>> handleExceptionAsync)
         {
             if (handleExceptionAsync == null)
@@ -261,7 +261,7 @@ namespace NuGet.Packaging
         /// <summary>
         /// Sets a throttle for package downloads.
         /// </summary>
-        /// <param name="throttle">A throttle.  Can be <c>null</c>.</param>
+        /// <param name="throttle">A throttle.  Can be <see langword="null" />.</param>
         public void SetThrottle(SemaphoreSlim throttle)
         {
             _throttle = throttle;

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -185,7 +185,7 @@ namespace NuGet.Packaging
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="string" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="nupkgFilePath" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<string> CopyNupkgAsync(

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -657,7 +657,7 @@ namespace NuGet.Packaging
         /// <param name="filePath">The file path to search for</param>
         /// <param name="packageFiles">The list of files to search within</param>
         /// <param name="filePathIncorrectCase">If the file was not found, this will be a path which almost matched but had the incorrect case</param>
-        /// <returns>An <see cref="IPackageFile"/> matching the specified path or <c>null</c></returns>
+        /// <returns>An <see cref="IPackageFile"/> matching the specified path or <see langword="null" /></returns>
         private static IPackageFile FindFileInPackage(string filePath, IEnumerable<IPackageFile> packageFiles, out string filePathIncorrectCase)
         {
             filePathIncorrectCase = null;

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Utility/FrameworkNameUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Utility/FrameworkNameUtility.cs
@@ -48,7 +48,7 @@ namespace NuGet.Packaging
         /// Parses the specified string into FrameworkName object.
         /// </summary>
         /// <param name="path">The string to be parse.</param>
-        /// <param name="strictParsing">if set to <c>true</c>, parse the first folder of path even if it is unrecognized framework.</param>
+        /// <param name="strictParsing">if set to <see langword="true" />, parse the first folder of path even if it is unrecognized framework.</param>
         /// <param name="effectivePath">returns the path after the parsed target framework</param>
         /// <returns></returns>
         public static FrameworkName ParseFrameworkFolderName(string path, bool strictParsing, out string effectivePath)
@@ -118,7 +118,7 @@ namespace NuGet.Packaging
         /// Parses the specified string into FrameworkName object.
         /// </summary>
         /// <param name="path">The string to be parse.</param>
-        /// <param name="strictParsing">if set to <c>true</c>, parse the first folder of path even if it is unrecognized framework.</param>
+        /// <param name="strictParsing">if set to <see langword="true" />, parse the first folder of path even if it is unrecognized framework.</param>
         /// <param name="effectivePath">returns the path after the parsed target framework</param>
         /// <returns></returns>
         public static NuGetFramework ParseNuGetFrameworkFolderName(string path, bool strictParsing, out string effectivePath)

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -33,7 +33,7 @@ namespace NuGet.Packaging
         /// Instantiates a new <see cref="PackageReaderBase" /> class.
         /// </summary>
         /// <param name="frameworkProvider">A framework mapping provider.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="frameworkProvider" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="frameworkProvider" /> is <see langword="null" />.</exception>
         public PackageReaderBase(IFrameworkNameProvider frameworkProvider)
             : this(frameworkProvider, new CompatibilityProvider(frameworkProvider))
         {
@@ -44,8 +44,8 @@ namespace NuGet.Packaging
         /// </summary>
         /// <param name="frameworkProvider">A framework mapping provider.</param>
         /// <param name="compatibilityProvider">A framework compatibility provider.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="frameworkProvider" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="compatibilityProvider" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="frameworkProvider" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="compatibilityProvider" /> is <see langword="null" />.</exception>
         public PackageReaderBase(IFrameworkNameProvider frameworkProvider, IFrameworkCompatibilityProvider compatibilityProvider)
         {
             if (frameworkProvider == null)

--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/IObjectWriter.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/IObjectWriter.cs
@@ -32,7 +32,7 @@ namespace NuGet.RuntimeModel
         /// Every call to WriteObjectStart must be balanced by a corresponding call to WriteObjectEnd.
         /// </summary>
         /// <param name="name">The name of the object.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name" /> is <see langword="null" />.</exception>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         void WriteObjectStart(string name);
 
@@ -52,7 +52,7 @@ namespace NuGet.RuntimeModel
         /// </summary>
         /// <param name="name">The name of the datum.</param>
         /// <param name="value">The datum.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name" /> is <see langword="null" />.</exception>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         void WriteNameValue(string name, int value);
 
@@ -61,7 +61,7 @@ namespace NuGet.RuntimeModel
         /// </summary>
         /// <param name="name">The name of the datum.</param>
         /// <param name="value">The datum.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name" /> is <see langword="null" />.</exception>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         void WriteNameValue(string name, bool value);
 
@@ -70,7 +70,7 @@ namespace NuGet.RuntimeModel
         /// </summary>
         /// <param name="name">The name of the datum.</param>
         /// <param name="value">The datum.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name" /> is <see langword="null" />.</exception>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         void WriteNameValue(string name, string value);
 
@@ -79,7 +79,7 @@ namespace NuGet.RuntimeModel
         /// </summary>
         /// <param name="name">The name of the data.</param>
         /// <param name="values">The data.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name" /> is <see langword="null" />.</exception>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         void WriteNameArray(string name, IEnumerable<string> values);
 
@@ -89,7 +89,7 @@ namespace NuGet.RuntimeModel
         /// Every call to WriteArrayStart needs to be balanced with a corresponding call to WriteArrayEnd and not WriteObjectEnd.
         /// </summary>
         /// <param name="name">The array name</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name" /> is <see langword="null" />.</exception>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         void WriteArrayStart(string name);
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveUtility.cs
@@ -76,7 +76,7 @@ namespace NuGet.Packaging.Signing
         /// <remarks>Callers should first verify that a package is signed before calling this method.</remarks>
         /// <param name="reader">A binary reader for a signed package.</param>
         /// <returns>A readable stream.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="reader" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="reader" /> is <see langword="null" />.</exception>
         /// <exception cref="SignatureException">Thrown if a package signature file is invalid or missing.</exception>
         public static Stream OpenPackageSignatureFileStream(BinaryReader reader)
         {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/AuthorSignPackageRequest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/AuthorSignPackageRequest.cs
@@ -20,7 +20,7 @@ namespace NuGet.Packaging.Signing
         /// <param name="certificate">The signing certificate.</param>
         /// <param name="hashAlgorithm">The signature and timestamp hash algorithm.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="certificate" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="hashAlgorithm" />
         /// is invalid.</exception>
         public AuthorSignPackageRequest(
@@ -40,7 +40,7 @@ namespace NuGet.Packaging.Signing
         /// <param name="signatureHashAlgorithm">The signature hash algorithm.</param>
         /// <param name="timestampHashAlgorithm">The timestamp hash algorithm.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="certificate" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="signatureHashAlgorithm" />
         /// is invalid.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="timestampHashAlgorithm" />

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/RepositorySignPackageRequest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/RepositorySignPackageRequest.cs
@@ -35,13 +35,13 @@ namespace NuGet.Packaging.Signing
         /// <param name="v3ServiceIndexUrl">The V3 service index URL.</param>
         /// <param name="packageOwners">A read-only list of package owners.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="certificate" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="signatureHashAlgorithm" />
         /// is invalid.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="timestampHashAlgorithm" />
         /// is invalid.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="v3ServiceIndexUrl" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="v3ServiceIndexUrl" />
         /// is neither absolute nor HTTPS.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageOwners" />

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/SigningOptions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/SigningOptions.cs
@@ -71,10 +71,10 @@ namespace NuGet.Packaging.Signing
         /// <param name="logger">A logger.</param>
         /// <remarks>Signing operations cannot be done in place; therefore, <paramref name="inputPackageStream"/>
         /// and <paramref name="outputPackageStream" /> should be different streams.</remarks>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="inputPackageStream" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="outputPackageStream" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="signatureProvider" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="inputPackageStream" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="outputPackageStream" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="signatureProvider" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="inputPackageStream" /> and
         /// <paramref name="outputPackageStream"/> are the same object.</exception>
         public SigningOptions(
@@ -101,12 +101,12 @@ namespace NuGet.Packaging.Signing
         /// <param name="logger">A logger.</param>
         /// <remarks>Signing operations cannot be done in place; therefore, <paramref name="inputPackageFilePath"/>
         /// and <paramref name="outputPackageFilePath" /> should be different file paths.</remarks>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="inputPackageFilePath" /> is <c>null</c>,
+        /// <exception cref="ArgumentException">Thrown if <paramref name="inputPackageFilePath" /> is <see langword="null" />,
         /// an empty string, or equivalent to <paramref name="outputPackageFilePath" />.</exception>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="inputPackageFilePath" /> is <c>null</c>,
+        /// <exception cref="ArgumentException">Thrown if <paramref name="inputPackageFilePath" /> is <see langword="null" />,
         /// an empty string, or equivalent to <paramref name="outputPackageFilePath" />.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="signatureProvider" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="signatureProvider" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <see langword="null" />.</exception>
         public static SigningOptions CreateFromFilePaths(
             string inputPackageFilePath,
             string outputPackageFilePath,

--- a/src/NuGet.Core/NuGet.Packaging/Signing/DerEncoding/DerEncoder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/DerEncoding/DerEncoder.cs
@@ -659,8 +659,8 @@ namespace NuGet.Packaging.Signing.DerEncoding
         /// </summary>
         /// <param name="chars">The characters to test.</param>
         /// <returns>
-        /// <c>true</c> if all of the characters in <paramref name="chars"/> are valid PrintableString characters,
-        /// <c>false</c> otherwise.
+        /// <see langword="true" /> if all of the characters in <paramref name="chars"/> are valid PrintableString characters,
+        /// <see langword="false" /> otherwise.
         /// </returns>
         internal static bool IsValidPrintableString(char[] chars)
         {
@@ -677,8 +677,8 @@ namespace NuGet.Packaging.Signing.DerEncoding
         /// <param name="offset">The starting character position within <paramref name="chars"/>.</param>
         /// <param name="count">The number of characters from <paramref name="chars"/> to read.</param>
         /// <returns>
-        /// <c>true</c> if all of the indexed characters in <paramref name="chars"/> are valid PrintableString
-        /// characters, <c>false</c> otherwise.
+        /// <see langword="true" /> if all of the indexed characters in <paramref name="chars"/> are valid PrintableString
+        /// characters, <see langword="false" /> otherwise.
         /// </returns>
         internal static bool IsValidPrintableString(char[] chars, int offset, int count)
         {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/X509TrustStore.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/X509TrustStore.cs
@@ -22,7 +22,7 @@ namespace NuGet.Packaging.Signing
         /// If initialization has already happened, a call to this method will have no effect.
         /// </summary>
         /// <param name="logger">A logger.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <see langword="null" />.</exception>
         public static void InitializeForDotNetSdk(ILogger logger)
         {
             _ = GetX509ChainFactory(X509StorePurpose.CodeSigning, logger, CreateX509ChainFactoryForDotNetSdk);

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/AttributeUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/AttributeUtility.cs
@@ -39,7 +39,7 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         /// <param name="signedAttributes">A <see cref="SignerInfo" /> signed attributes collection.</param>
         /// <remarks>Unknown OIDs are ignored.</remarks>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="signedAttributes" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="signedAttributes" /> is <see langword="null" />.</exception>
         /// <exception cref="SignatureException">Thrown if one or more attributes are invalid.</exception>
         public static SignatureType GetSignatureType(CryptographicAttributeObjectCollection signedAttributes)
         {
@@ -109,7 +109,7 @@ namespace NuGet.Packaging.Signing
         /// <param name="signedAttributes">A <see cref="SignerInfo" /> signed attributes collection.</param>
         /// <returns>The V3 service index HTTPS URL.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="signedAttributes" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="SignatureException">Thrown if either exactly one attribute is not present or if
         /// the attribute does not contain exactly one attribute value.</exception>
         public static Uri GetNuGetV3ServiceIndexUrl(CryptographicAttributeObjectCollection signedAttributes)
@@ -151,7 +151,7 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         /// <param name="packageOwners">A read-only list of package owners.</param>
         /// <returns>An attribute object.</returns>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="packageOwners" /> is either <c>null</c>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="packageOwners" /> is either <see langword="null" />
         /// or empty or if any package owner name is invalid.</exception>
         public static CryptographicAttributeObject CreateNuGetPackageOwners(IReadOnlyList<string> packageOwners)
         {
@@ -177,8 +177,8 @@ namespace NuGet.Packaging.Signing
         /// Gets a read-only list of package owners from an optional nuget-package-owners attribute.
         /// </summary>
         /// <param name="signedAttributes">A <see cref="SignerInfo" /> signed attributes collection.</param>
-        /// <returns>A read-only list of package owners or <c>null</c>.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="signedAttributes" /> is <c>null</c>.</exception>
+        /// <returns>A read-only list of package owners or <see langword="null" />.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="signedAttributes" /> is <see langword="null" />.</exception>
         /// <exception cref="SignatureException">Thrown if the attribute does not contain exactly one
         /// attribute value.</exception>
         public static IReadOnlyList<string> GetNuGetPackageOwners(CryptographicAttributeObjectCollection signedAttributes)
@@ -337,9 +337,9 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         /// <param name="attributes">A collection of attributes.</param>
         /// <param name="oid">The attribute OID to search for.</param>
-        /// <returns>Either a <see cref="CryptographicAttributeObject" /> or <c>null</c>, if no attribute was found.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="attributes" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="oid" /> is either <c>null</c> or an empty string.</exception>
+        /// <returns>Either a <see cref="CryptographicAttributeObject" /> or <see langword="null" />, if no attribute was found.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="attributes" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="oid" /> is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="CryptographicException">Thrown if multiple attribute instances with the specified OID were found.</exception>
         public static CryptographicAttributeObject GetAttribute(this CryptographicAttributeObjectCollection attributes, string oid)
         {
@@ -374,9 +374,9 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         /// <param name="attributes">A collection of attributes.</param>
         /// <param name="oid">The attribute OID to search for.</param>
-        /// <returns>Either a <see cref="CryptographicAttributeObject" /> or <c>null</c>, if no attribute was found.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="attributes" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="oid" /> is either <c>null</c> or an empty string.</exception>
+        /// <returns>Either a <see cref="CryptographicAttributeObject" /> or <see langword="null" />, if no attribute was found.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="attributes" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="oid" /> is either <see langword="null" /> or an empty string.</exception>
         public static IEnumerable<CryptographicAttributeObject> GetAttributes(this CryptographicAttributeObjectCollection attributes, string oid)
         {
             if (attributes == null)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateChainUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateChainUtility.cs
@@ -23,9 +23,9 @@ namespace NuGet.Packaging.Signing
         /// <returns>A certificate chain.</returns>
         /// <remarks>This is intended to be used only during signing and timestamping operations,
         /// not verification.</remarks>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="certificate" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="extraStore" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="certificate" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="extraStore" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="certificateType" /> is undefined.</exception>
         public static IX509CertificateChain GetCertificateChain(
             X509Certificate2 certificate,

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateUtility.cs
@@ -302,8 +302,8 @@ namespace NuGet.Packaging.Signing
         /// additional information (e.g.:  the issuer's certificate).  This method is not a guaranteed offline
         /// check.</remarks>
         /// <param name="certificate">The certificate to check.</param>
-        /// <returns><c>true</c> if the certificate is self-issued; otherwise, <c>false</c>.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="certificate" /> is <c>null</c>.</exception>
+        /// <returns><see langword="true" /> if the certificate is self-issued; otherwise, <see langword="false" />.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="certificate" /> is <see langword="null" />.</exception>
         public static bool IsSelfIssued(X509Certificate2 certificate)
         {
             if (certificate == null)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SignatureUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SignatureUtility.cs
@@ -30,7 +30,7 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         /// <param name="primarySignature">The primary signature.</param>
         /// <returns>A non-empty, read-only list of X.509 certificates ordered from signing certificate to root.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="primarySignature" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="primarySignature" /> is <see langword="null" />.</exception>
         /// <remarks>
         /// WARNING:  This method does not perform revocation, trust, or certificate validity checking.
         /// </remarks>
@@ -55,8 +55,8 @@ namespace NuGet.Packaging.Signing
         /// <param name="primarySignature">The primary signature.</param>
         /// <param name="repositoryCountersignature">The repository countersignature.</param>
         /// <returns>A non-empty, read-only list of X.509 certificates ordered from signing certificate to root.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="primarySignature" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="repositoryCountersignature" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="primarySignature" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="repositoryCountersignature" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="repositoryCountersignature" /> is
         /// unrelated to <paramref name="primarySignature" />.</exception>
         /// <remarks>
@@ -154,7 +154,7 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         /// <param name="primarySignature">The primary signature.</param>
         /// <returns>A non-empty, read-only list of X.509 certificates ordered from signing certificate to root.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="primarySignature" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="primarySignature" /> is <see langword="null" />.</exception>
         /// <exception cref="SignatureException">Thrown if <paramref name="primarySignature" /> does not have a valid
         /// timestamp.</exception>
         /// <remarks>
@@ -188,8 +188,8 @@ namespace NuGet.Packaging.Signing
         /// <param name="primarySignature">The primary signature.</param>
         /// <param name="repositoryCountersignature">The repository countersignature.</param>
         /// <returns>A non-empty, read-only list of X.509 certificates ordered from signing certificate to root.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="primarySignature" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="repositoryCountersignature" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="primarySignature" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="repositoryCountersignature" /> is <see langword="null" />.</exception>
         /// <exception cref="SignatureException">Thrown if <paramref name="repositoryCountersignature" /> does not have a valid
         /// timestamp.</exception>
         /// <remarks>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignedPackageVerifierSettings.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignedPackageVerifierSettings.cs
@@ -160,7 +160,7 @@ namespace NuGet.Packaging.Signing
         /// <summary>
         /// Default settings.
         /// </summary>
-        /// <param name="environmentVariableReader">An <see cref="IEnvironmentVariableReader" /> instance or <c>null</c> for the default environment variable reader.</param>
+        /// <param name="environmentVariableReader">An <see cref="IEnvironmentVariableReader" /> instance or <see langword="null" /> for the default environment variable reader.</param>
         /// <returns>A <see cref="SignedPackageVerifierSettings" /> instance.</returns>
         public static SignedPackageVerifierSettings GetDefault(IEnvironmentVariableReader environmentVariableReader = null)
         {
@@ -182,7 +182,7 @@ namespace NuGet.Packaging.Signing
         /// <summary>
         /// The accept mode policy.
         /// </summary>
-        /// <param name="environmentVariableReader">An <see cref="IEnvironmentVariableReader" /> instance or <c>null</c> for the default environment variable reader.</param>
+        /// <param name="environmentVariableReader">An <see cref="IEnvironmentVariableReader" /> instance or <see langword="null" /> for the default environment variable reader.</param>
         /// <returns>A <see cref="SignedPackageVerifierSettings" /> instance.</returns>
         public static SignedPackageVerifierSettings GetAcceptModeDefaultPolicy(IEnvironmentVariableReader environmentVariableReader = null)
         {
@@ -204,7 +204,7 @@ namespace NuGet.Packaging.Signing
         /// <summary>
         /// The require mode policy.
         /// </summary>
-        /// <param name="environmentVariableReader">An <see cref="IEnvironmentVariableReader" /> instance or <c>null</c> for the default environment variable reader.</param>
+        /// <param name="environmentVariableReader">An <see cref="IEnvironmentVariableReader" /> instance or <see langword="null" /> for the default environment variable reader.</param>
         /// <returns>A <see cref="SignedPackageVerifierSettings" /> instance.</returns>
         public static SignedPackageVerifierSettings GetRequireModeDefaultPolicy(IEnvironmentVariableReader environmentVariableReader = null)
         {
@@ -226,7 +226,7 @@ namespace NuGet.Packaging.Signing
         /// <summary>
         /// Default policy for nuget.exe verify --signatures command.
         /// </summary>
-        /// <param name="environmentVariableReader">An <see cref="IEnvironmentVariableReader" /> instance or <c>null</c> for the default environment variable reader.</param>
+        /// <param name="environmentVariableReader">An <see cref="IEnvironmentVariableReader" /> instance or <see langword="null" /> for the default environment variable reader.</param>
         /// <returns>A <see cref="SignedPackageVerifierSettings" /> instance.</returns>
         public static SignedPackageVerifierSettings GetVerifyCommandDefaultPolicy(IEnvironmentVariableReader environmentVariableReader = null)
         {

--- a/src/NuGet.Core/NuGet.Packaging/VersionFolderPathResolver.cs
+++ b/src/NuGet.Core/NuGet.Packaging/VersionFolderPathResolver.cs
@@ -34,8 +34,8 @@ namespace NuGet.Packaging
         /// Initializes a new <see cref="VersionFolderPathResolver" /> class.
         /// </summary>
         /// <param name="rootPath">The packages directory root folder.</param>
-        /// <param name="isLowercase"><c>true</c> if package ID's and versions are made lowercase;
-        /// otherwise <c>false</c>.</param>
+        /// <param name="isLowercase"><see langword="true" /> if package ID's and versions are made lowercase;
+        /// otherwise <see langword="false" />.</param>
         public VersionFolderPathResolver(string rootPath, bool isLowercase)
         {
             RootPath = rootPath;

--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -113,8 +113,8 @@ namespace NuGet.ProjectModel
         /// <param name="closure">The project's closure</param>
         /// <returns>A <see cref="DependencyGraphSpec" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="projectUniqueName" />
-        /// is <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="closure" /> is <c>null</c>.</exception>
+        /// is <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="closure" /> is <see langword="null" />.</exception>
         public DependencyGraphSpec CreateFromClosure(string projectUniqueName, IReadOnlyList<PackageSpec> closure)
         {
             if (string.IsNullOrEmpty(projectUniqueName))

--- a/src/NuGet.Core/NuGet.ProjectModel/HashObjectWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/HashObjectWriter.cs
@@ -31,7 +31,7 @@ namespace NuGet.ProjectModel
         /// <summary>
         /// Creates a new instance with the provide hash function.
         /// </summary>
-        /// <param name="hashFunc">An <see cref="IHashFunction"/> instance.  Throws if <c>null</c>.</param>
+        /// <param name="hashFunc">An <see cref="IHashFunction"/> instance.  Throws if <see langword="null" />.</param>
         public HashObjectWriter(IHashFunction hashFunc)
         {
             if (hashFunc == null)

--- a/src/NuGet.Core/NuGet.Protocol/Converters/SemanticVersionConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/SemanticVersionConverter.cs
@@ -16,7 +16,7 @@ namespace NuGet.Protocol
         /// Gets a flag indicating whether or not a type is convertible.
         /// </summary>
         /// <param name="objectType">An object type to check.</param>
-        /// <returns><c>true</c> if <paramref name="objectType" /> is convertible; otherwise <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if <paramref name="objectType" /> is convertible; otherwise <see langword="false" />.</returns>
         public override bool CanConvert(Type objectType) => objectType == typeof(SemanticVersion);
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/Converters/VersionRangeConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/VersionRangeConverter.cs
@@ -16,7 +16,7 @@ namespace NuGet.Protocol
         /// Gets a flag indicating whether or not a type is convertible.
         /// </summary>
         /// <param name="objectType">An object type to check.</param>
-        /// <returns><c>true</c> if <paramref name="objectType" /> is convertible; otherwise <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if <paramref name="objectType" /> is convertible; otherwise <see langword="false" />.</returns>
         public override bool CanConvert(Type objectType) => objectType == typeof(VersionRange);
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/DownloadResourceResult.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DownloadResourceResult.cs
@@ -41,7 +41,7 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         /// <param name="stream">A package stream.</param>
         /// <param name="source">A package source.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="stream" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="stream" /> is <see langword="null" />.</exception>
         public DownloadResourceResult(Stream stream, string source)
         {
             if (stream == null)
@@ -60,7 +60,7 @@ namespace NuGet.Protocol.Core.Types
         /// <param name="stream">A package stream.</param>
         /// <param name="packageReader">A package reader.</param>
         /// <param name="source">A package source.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="stream" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="stream" /> is <see langword="null" />.</exception>
         public DownloadResourceResult(Stream stream, PackageReaderBase packageReader, string source)
             : this(stream, source)
         {
@@ -72,7 +72,7 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         /// <param name="packageReader">A package reader.</param>
         /// <param name="source">A package source.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageReader" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageReader" /> is <see langword="null" />.</exception>
         public DownloadResourceResult(PackageReaderBase packageReader, string source)
         {
             if (packageReader == null)
@@ -92,19 +92,19 @@ namespace NuGet.Protocol.Core.Types
         /// <summary>
         /// Gets the package <see cref="PackageStream"/>.
         /// </summary>
-        /// <remarks>The value may be <c>null</c>.</remarks>
+        /// <remarks>The value may be <see langword="null" />.</remarks>
         public Stream PackageStream => _stream;
 
         /// <summary>
         /// Gets the source containing this package, if not from cache
         /// </summary>
-        /// <remarks>The value may be <c>null</c>.</remarks>
+        /// <remarks>The value may be <see langword="null" />.</remarks>
         public string PackageSource => _packageSource;
 
         /// <summary>
         /// Gets the <see cref="PackageReaderBase"/> for the package.
         /// </summary>
-        /// <remarks>The value may be <c>null</c>.</remarks>
+        /// <remarks>The value may be <see langword="null" />.</remarks>
         public PackageReaderBase PackageReader => _packageReader;
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/EnhancedHttpRetryHelper.cs
+++ b/src/NuGet.Core/NuGet.Protocol/EnhancedHttpRetryHelper.cs
@@ -86,14 +86,14 @@ namespace NuGet.Protocol
         /// Initializes a new instance of the <see cref="EnhancedHttpRetryHelper" /> class.
         /// </summary>
         /// <param name="environmentVariableReader">A <see cref="IEnvironmentVariableReader" /> to use when reading environment variables.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="environmentVariableReader" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="environmentVariableReader" /> is <see langword="null" />.</exception>
         public EnhancedHttpRetryHelper(IEnvironmentVariableReader environmentVariableReader)
         {
             _environmentVariableReader = environmentVariableReader ?? throw new ArgumentNullException(nameof(environmentVariableReader));
         }
 
         /// <summary>
-        /// Gets a value indicating whether or not enhanced HTTP retry should be enabled.  The default value is <c>true</c>.
+        /// Gets a value indicating whether or not enhanced HTTP retry should be enabled.  The default value is <see langword="true" />.
         /// </summary>
         internal bool IsEnabled => _isEnabled ??= GetBoolFromEnvironmentVariable(IsEnabledEnvironmentVariableName, defaultValue: DefaultEnabled, _environmentVariableReader);
 

--- a/src/NuGet.Core/NuGet.Protocol/LocalPackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalPackageArchiveDownloader.cs
@@ -76,11 +76,11 @@ namespace NuGet.Protocol
         /// <param name="packageIdentity">A package identity.</param>
         /// <param name="logger">A logger.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageFilePath" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public LocalPackageArchiveDownloader(
             string source,
             string packageFilePath,
@@ -146,7 +146,7 @@ namespace NuGet.Protocol
         /// indicating whether or not the copy was successful.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="destinationFilePath" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task<bool> CopyNupkgFileToAsync(string destinationFilePath, CancellationToken cancellationToken)
@@ -217,7 +217,7 @@ namespace NuGet.Protocol
         /// representing the package hash.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="hashAlgorithm" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public Task<string> GetPackageHashAsync(string hashAlgorithm, CancellationToken cancellationToken)
@@ -247,10 +247,10 @@ namespace NuGet.Protocol
         /// <remarks>The exception handler returns a task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="bool" />
         /// indicating whether or not the exception was handled.  To handle an exception and stop its
-        /// propagation, the task should return <c>true</c>.  Otherwise, the exception will be rethrown.</remarks>
+        /// propagation, the task should return <see langword="true" />.  Otherwise, the exception will be rethrown.</remarks>
         /// <param name="handleExceptionAsync">An exception handler.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="handleExceptionAsync" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public void SetExceptionHandler(Func<Exception, Task<bool>> handleExceptionAsync)
         {
             if (handleExceptionAsync == null)
@@ -264,7 +264,7 @@ namespace NuGet.Protocol
         /// <summary>
         /// Sets a throttle for package downloads.
         /// </summary>
-        /// <param name="throttle">A throttle.  Can be <c>null</c>.</param>
+        /// <param name="throttle">A throttle.  Can be <see langword="null" />.</param>
         public void SetThrottle(SemaphoreSlim throttle)
         {
             _throttle = throttle;

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV2FindPackageByIdResource.cs
@@ -39,7 +39,7 @@ namespace NuGet.Protocol
         /// </summary>
         /// <param name="packageSource">A package source.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageSource" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public LocalV2FindPackageByIdResource(PackageSource packageSource)
         {
             if (packageSource == null)
@@ -63,9 +63,9 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override Task<IEnumerable<NuGetVersion>> GetAllVersionsAsync(
@@ -122,11 +122,11 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="bool" /> indicating whether or not the .nupkg file was copied.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="destination" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="destination" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<bool> CopyNupkgToStreamAsync(
@@ -204,10 +204,10 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override Task<FindPackageByIdDependencyInfo> GetDependencyInfoAsync(
@@ -282,9 +282,9 @@ namespace NuGet.Protocol
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns an <see cref="IPackageDownloader" />.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override Task<IPackageDownloader> GetPackageDownloaderAsync(
@@ -346,10 +346,10 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override Task<bool> DoesPackageExistAsync(

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV3FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV3FindPackageByIdResource.cs
@@ -74,7 +74,7 @@ namespace NuGet.Protocol
         /// </summary>
         /// <param name="packageSource">A package source.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageSource" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public LocalV3FindPackageByIdResource(PackageSource packageSource)
         {
             if (packageSource == null)
@@ -100,9 +100,9 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override Task<IEnumerable<NuGetVersion>> GetAllVersionsAsync(
@@ -157,11 +157,11 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="bool" /> indicating whether or not the .nupkg file was copied.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="destination" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="destination" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<bool> CopyNupkgToStreamAsync(
@@ -239,10 +239,10 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override Task<FindPackageByIdDependencyInfo> GetDependencyInfoAsync(
@@ -313,9 +313,9 @@ namespace NuGet.Protocol
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns an <see cref="IPackageDownloader" />.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override Task<IPackageDownloader> GetPackageDownloaderAsync(
@@ -379,10 +379,10 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override Task<bool> DoesPackageExistAsync(

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/AutomaticProgressReporter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/AutomaticProgressReporter.cs
@@ -101,9 +101,9 @@ namespace NuGet.Protocol.Plugins
         /// <param name="interval">A progress interval.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="connection" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="interval" />
         /// is either less than <see cref="ProtocolConstants.MinTimeout" /> or greater than
         /// <see cref="ProtocolConstants.MaxTimeout" />.</exception>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Connection.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Connection.cs
@@ -46,7 +46,7 @@ namespace NuGet.Protocol.Plugins
         public ConnectionOptions Options { get; }
 
         /// <summary>
-        /// Gets the negotiated protocol version, or <c>null</c> if not yet connected.
+        /// Gets the negotiated protocol version, or <see langword="null" /> if not yet connected.
         /// </summary>
         public SemanticVersion ProtocolVersion { get; private set; }
 
@@ -57,10 +57,10 @@ namespace NuGet.Protocol.Plugins
         /// <param name="sender">A sender.</param>
         /// <param name="receiver">A receiver.</param>
         /// <param name="options">Connection options.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="dispatcher" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="sender" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="receiver" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="options" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="dispatcher" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="sender" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="receiver" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="options" /> is <see langword="null" />.</exception>
         public Connection(IMessageDispatcher dispatcher, ISender sender, IReceiver receiver, ConnectionOptions options)
             : this(dispatcher, sender, receiver, options, PluginLogger.DefaultInstance)
         {
@@ -74,11 +74,11 @@ namespace NuGet.Protocol.Plugins
         /// <param name="receiver">A receiver.</param>
         /// <param name="options">Connection options.</param>
         /// <param name="logger">A plugin logger.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="dispatcher" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="sender" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="receiver" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="options" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="dispatcher" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="sender" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="receiver" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="options" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <see langword="null" />.</exception>
         internal Connection(IMessageDispatcher dispatcher, ISender sender, IReceiver receiver, ConnectionOptions options, IPluginLogger logger)
         {
             if (dispatcher == null)
@@ -218,7 +218,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="message">The message to be sent.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="message" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="message" /> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         /// <exception cref="InvalidOperationException">Thrown if not connected.</exception>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/ConnectionOptions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/ConnectionOptions.cs
@@ -41,11 +41,11 @@ namespace NuGet.Protocol.Plugins
         /// <param name="handshakeTimeout">The plugin handshake timeout.</param>
         /// <param name="requestTimeout">The plugin request timeout.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="protocolVersion" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="minimumProtocolVersion" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="protocolVersion" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="protocolVersion" />
         /// is less than <paramref name="minimumProtocolVersion" />.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="handshakeTimeout" />

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/EmbeddedSignatureVerifier.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/EmbeddedSignatureVerifier.cs
@@ -15,9 +15,9 @@ namespace NuGet.Protocol.Plugins
         /// Checks if a file has a valid embedded signature.
         /// </summary>
         /// <param name="filePath">The path of a file to be checked.</param>
-        /// <returns><c>true</c> if the file has a valid signature; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if the file has a valid signature; otherwise, <see langword="false" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="filePath" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="PlatformNotSupportedException">Thrown if the current platform is unsupported.</exception>
         public abstract bool IsValid(string filePath);
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/FallbackEmbeddedSignatureVerifier.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/FallbackEmbeddedSignatureVerifier.cs
@@ -14,7 +14,7 @@ namespace NuGet.Protocol.Plugins
         /// Checks if a file has a valid embedded signature.
         /// </summary>
         /// <param name="filePath">The path of a file to be checked.</param>
-        /// <returns><c>true</c> if the file has a valid signature; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if the file has a valid signature; otherwise, <see langword="false" />.</returns>
         /// <exception cref="PlatformNotSupportedException">Thrown always.</exception>
         public override bool IsValid(string filePath)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/FaultedPluginEventArgs.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/FaultedPluginEventArgs.cs
@@ -25,8 +25,8 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="plugin">A plugin.</param>
         /// <param name="exception">An exception.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="exception" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="exception" /> is <see langword="null" />.</exception>
         public FaultedPluginEventArgs(IPlugin plugin, Exception exception)
         {
             if (plugin == null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IConnection.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IConnection.cs
@@ -34,7 +34,7 @@ namespace NuGet.Protocol.Plugins
         ConnectionOptions Options { get; }
 
         /// <summary>
-        /// Gets the negotiated protocol version, or <c>null</c> if not yet connected.
+        /// Gets the negotiated protocol version, or <see langword="null" /> if not yet connected.
         /// </summary>
         SemanticVersion ProtocolVersion { get; }
 
@@ -50,7 +50,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="message">The message to be sent.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="message" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="message" /> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         /// <exception cref="InvalidOperationException">Thrown if not connected.</exception>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IMessageDispatcher.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IMessageDispatcher.cs
@@ -101,7 +101,7 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Sets the connection to be used for dispatching messages.
         /// </summary>
-        /// <param name="connection">A connection instance.  Can be <c>null</c>.</param>
+        /// <param name="connection">A connection instance.  Can be <see langword="null" />.</param>
         void SetConnection(IConnection connection);
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginFactory.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginFactory.cs
@@ -25,13 +25,13 @@ namespace NuGet.Protocol.Plugins
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="Plugin" />
         /// instance.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="filePath" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="arguments" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="requestHandlers" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="options" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="sessionCancellationToken" />
         /// is cancelled.</exception>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginMulticlientUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginMulticlientUtilities.cs
@@ -20,9 +20,9 @@ namespace NuGet.Protocol.Plugins
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="key" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="taskFunc" />
-        /// is either <c>null</c>.</exception>
+        /// is either <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         Task DoOncePerPluginLifetimeAsync(string key, Func<Task> taskFunc, CancellationToken cancellationToken);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginProcess.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginProcess.cs
@@ -22,12 +22,12 @@ namespace NuGet.Protocol.Plugins
         event EventHandler<IPluginProcess> Exited;
 
         /// <summary>
-        /// Gets the exit code if the process has exited; otherwise, <c>null</c>.
+        /// Gets the exit code if the process has exited; otherwise, <see langword="null" />.
         /// </summary>
         int? ExitCode { get; }
 
         /// <summary>
-        /// Gets the process ID if the process was started; otherwise, <c>null</c>.
+        /// Gets the process ID if the process was started; otherwise, <see langword="null" />.
         /// </summary>
         int? Id { get; }
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IRequestHandler.cs
@@ -26,10 +26,10 @@ namespace NuGet.Protocol.Plugins
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="connection" />
-        /// is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="responseHandler" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         Task HandleResponseAsync(

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IRequestHandlers.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IRequestHandlers.cs
@@ -17,9 +17,9 @@ namespace NuGet.Protocol.Plugins
         /// <param name="addHandlerFunc">An add request handler function.</param>
         /// <param name="updateHandlerFunc">An update request handler function.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="addHandlerFunc" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="updateHandlerFunc" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         void AddOrUpdate(
             MessageMethod method,
             Func<IRequestHandler> addHandlerFunc,
@@ -30,8 +30,8 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="method">A message method.</param>
         /// <param name="handler">A request handler.</param>
-        /// <returns><c>true</c> if added; otherwise, <c>false</c>.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="handler" /> is <c>null</c>.</exception>
+        /// <returns><see langword="true" /> if added; otherwise, <see langword="false" />.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="handler" /> is <see langword="null" />.</exception>
         bool TryAdd(MessageMethod method, IRequestHandler handler);
 
         /// <summary>
@@ -39,14 +39,14 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="method">A message method.</param>
         /// <param name="handler">A request handler.</param>
-        /// <returns><c>true</c> if the request handler exists; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if the request handler exists; otherwise, <see langword="false" />.</returns>
         bool TryGet(MessageMethod method, out IRequestHandler handler);
 
         /// <summary>
         /// Attempts to remove a request handler for the specified message method.
         /// </summary>
         /// <param name="method">A message method.</param>
-        /// <returns><c>true</c> if a request handler was removed; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if a request handler was removed; otherwise, <see langword="false" />.</returns>
         bool TryRemove(MessageMethod method);
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IResponseHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IResponseHandler.cs
@@ -20,8 +20,8 @@ namespace NuGet.Protocol.Plugins
         /// <param name="payload">The response payload.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="payload" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="payload" /> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         Task SendResponseAsync<TPayload>(Message request, TPayload payload, CancellationToken cancellationToken)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/ISender.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/ISender.cs
@@ -34,7 +34,7 @@ namespace NuGet.Protocol.Plugins
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         /// <exception cref="InvalidOperationException">Thrown if <see cref="Connect" /> has not been called.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="message" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="message" /> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         Task SendAsync(Message message, CancellationToken cancellationToken);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestContext.cs
@@ -31,9 +31,9 @@ namespace NuGet.Protocol.Plugins
         /// <param name="requestId">A request ID.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="connection" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="requestId" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         public InboundRequestContext(
             IConnection connection,
             string requestId,
@@ -50,13 +50,13 @@ namespace NuGet.Protocol.Plugins
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <param name="logger">A plugin logger.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="connection" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="requestId" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="inboundRequestProcessingHandler" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         internal InboundRequestContext(
             IConnection connection,
             string requestId,
@@ -165,9 +165,9 @@ namespace NuGet.Protocol.Plugins
         /// <param name="request">The request.</param>
         /// <param name="exception">An exception.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" />
-        /// is either <c>null</c>.</exception>
+        /// is either <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="exception" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public void BeginFaultAsync(Message request, Exception exception)
         {
             if (request == null)
@@ -225,11 +225,11 @@ namespace NuGet.Protocol.Plugins
         /// <param name="requestHandler">A request handler.</param>
         /// <param name="responseHandler">A response handler.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="requestHandler" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="responseHandler" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public void BeginResponseAsync(
             Message request,
             IRequestHandler requestHandler,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/JsonSerializationUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/JsonSerializationUtilities.cs
@@ -41,7 +41,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="json">JSON to deserialize.</param>
         /// <returns>An instance of <typeparamref name="T" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="json" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         public static T Deserialize<T>(string json)
             where T : class
         {
@@ -62,7 +62,7 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="value">An object to serialize.</param>
         /// <returns>A <see cref="JObject" />.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="value" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="value" /> is <see langword="null" />.</exception>
         public static JObject FromObject(object value)
         {
             if (value == null)
@@ -78,7 +78,7 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="writer">A JSON writer.</param>
         /// <param name="value">The value to serialize.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="value" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="value" /> is <see langword="null" />.</exception>
         public static void Serialize(JsonWriter writer, object value)
         {
             if (writer == null)
@@ -95,7 +95,7 @@ namespace NuGet.Protocol.Plugins
         /// <typeparam name="T">The deserialization type.</typeparam>
         /// <param name="jObject">A JSON object.</param>
         /// <returns>An instance of <typeparamref name="T" />.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="jObject" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="jObject" /> is <see langword="null" />.</exception>
         public static T ToObject<T>(JObject jObject)
         {
             if (jObject == null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/MessageDispatcher.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/MessageDispatcher.cs
@@ -35,9 +35,9 @@ namespace NuGet.Protocol.Plugins
         /// <param name="requestHandlers">Request handlers.</param>
         /// <param name="idGenerator">A unique identifier generator.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="requestHandlers" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="idGenerator" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public MessageDispatcher(IRequestHandlers requestHandlers, IIdGenerator idGenerator)
             : this(requestHandlers, idGenerator, new InboundRequestProcessingHandler(), PluginLogger.DefaultInstance)
         {
@@ -49,13 +49,13 @@ namespace NuGet.Protocol.Plugins
         /// <param name="requestHandlers">Request handlers.</param>
         /// <param name="idGenerator">A unique identifier generator.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="requestHandlers" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="idGenerator" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="inboundRequestProcessingHandler" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         internal MessageDispatcher(IRequestHandlers requestHandlers, IIdGenerator idGenerator, InboundRequestProcessingHandler inboundRequestProcessingHandler, IPluginLogger logger)
         {
             if (requestHandlers == null)
@@ -152,7 +152,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="method">The message method.</param>
         /// <param name="payload">The message payload.</param>
         /// <returns>A message.</returns>
-        /// <exception cref="ArgumentNullException">Throws if <paramref name="payload" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Throws if <paramref name="payload" /> is <see langword="null" />.</exception>
         public Message CreateMessage<TPayload>(MessageType type, MessageMethod method, TPayload payload)
             where TPayload : class
         {
@@ -172,7 +172,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="request">The request.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public Task DispatchCancelAsync(Message request, CancellationToken cancellationToken)
@@ -202,7 +202,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="fault">The fault payload.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="fault" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="fault" /> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public Task DispatchFaultAsync(Message request, Fault fault, CancellationToken cancellationToken)
@@ -232,8 +232,8 @@ namespace NuGet.Protocol.Plugins
         /// <param name="progress">The progress payload.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="progress" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="progress" /> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public Task DispatchProgressAsync(Message request, Progress progress, CancellationToken cancellationToken)
@@ -307,8 +307,8 @@ namespace NuGet.Protocol.Plugins
         /// <param name="responsePayload">The response payload.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="responsePayload" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="responsePayload" /> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public Task DispatchResponseAsync<TOutbound>(
@@ -343,7 +343,7 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Sets the connection to be used for dispatching messages.
         /// </summary>
-        /// <param name="connection">A connection instance.  Can be <c>null</c>.</param>
+        /// <param name="connection">A connection instance.  Can be <see langword="null" />.</param>
         public void SetConnection(IConnection connection)
         {
             if (_connection == connection)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/MessageEventArgs.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/MessageEventArgs.cs
@@ -19,7 +19,7 @@ namespace NuGet.Protocol.Plugins
         /// Instantiates a new <see cref="MessageEventArgs" /> class.
         /// </summary>
         /// <param name="message">A message.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="message" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="message" /> is <see langword="null" />.</exception>
         public MessageEventArgs(Message message)
         {
             if (message == null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/MessageUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/MessageUtilities.cs
@@ -18,7 +18,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="method">The message method.</param>
         /// <returns>a <see cref="Message" /> instance.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="requestId" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         public static Message Create(
             string requestId,
             MessageType type,
@@ -42,8 +42,8 @@ namespace NuGet.Protocol.Plugins
         /// <param name="payload">The message payload.</param>
         /// <returns>a <see cref="Message" /> instance.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="requestId" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="payload" /> is <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="payload" /> is <see langword="null" />.</exception>
         public static Message Create<TPayload>(
             string requestId,
             MessageType type,
@@ -72,8 +72,8 @@ namespace NuGet.Protocol.Plugins
         /// <typeparam name="TPayload">The message payload type.</typeparam>
         /// <param name="message">The message.</param>
         /// <returns>The deserialized message payload of type <typeparamref name="TPayload" />
-        /// or <c>null</c> if no payload exists.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="message" /> is <c>null</c>.</exception>
+        /// or <see langword="null" /> if no payload exists.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="message" /> is <see langword="null" />.</exception>
         public static TPayload DeserializePayload<TPayload>(Message message)
         {
             if (message == null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/CopyFilesInPackageRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/CopyFilesInPackageRequest.cs
@@ -52,15 +52,15 @@ namespace NuGet.Protocol.Plugins
         /// <param name="filesInPackage">The files in the package to be copied.</param>
         /// <param name="destinationFolderPath">The destination folder path.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageSourceRepository" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageId" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageVersion" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="filesInPackage" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="destinationFolderPath" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         [JsonConstructor]
         public CopyFilesInPackageRequest(
             string packageSourceRepository,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/CopyFilesInPackageResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/CopyFilesInPackageResponse.cs
@@ -34,7 +34,7 @@ namespace NuGet.Protocol.Plugins
         /// is an undefined <see cref="MessageResponseCode" /> value.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="responseCode" /> 
         /// is <see cref="MessageResponseCode.Success" /> and <paramref name="copiedFiles" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         [JsonConstructor]
         public CopyFilesInPackageResponse(MessageResponseCode responseCode, IEnumerable<string> copiedFiles)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/CopyNupkgFileRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/CopyNupkgFileRequest.cs
@@ -43,13 +43,13 @@ namespace NuGet.Protocol.Plugins
         /// <param name="packageVersion">The package version.</param>
         /// <param name="destinationFilePath">The destination file path for the .nupkg file.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageSourceRepository" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageId" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageVersion" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="destinationFilePath" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         [JsonConstructor]
         public CopyNupkgFileRequest(
             string packageSourceRepository,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/Fault.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/Fault.cs
@@ -22,7 +22,7 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="message">The fault message.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="message" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         [JsonConstructor]
         public Fault(string message)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetFilesInPackageRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetFilesInPackageRequest.cs
@@ -36,11 +36,11 @@ namespace NuGet.Protocol.Plugins
         /// <param name="packageId">The package ID.</param>
         /// <param name="packageVersion">The package version.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageSourceRepository" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageId" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageVersion" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         [JsonConstructor]
         public GetFilesInPackageRequest(
             string packageSourceRepository,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetFilesInPackageResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetFilesInPackageResponse.cs
@@ -34,7 +34,7 @@ namespace NuGet.Protocol.Plugins
         /// is an undefined <see cref="MessageResponseCode" /> value.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="responseCode" /> 
         /// is <see cref="MessageResponseCode.Success" /> and <paramref name="files" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         [JsonConstructor]
         public GetFilesInPackageResponse(MessageResponseCode responseCode, IEnumerable<string> files)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetOperationClaimsResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetOperationClaimsResponse.cs
@@ -24,7 +24,7 @@ namespace NuGet.Protocol.Plugins
         /// Initializes a new instance of the <see cref="GetOperationClaimsResponse" /> class.
         /// </summary>
         /// <param name="claims">The operation claims.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="claims" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="claims" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="claims" /> contains
         /// undefined <see cref="OperationClaim" /> values.</exception>
         [JsonConstructor]

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetPackageHashRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetPackageHashRequest.cs
@@ -43,13 +43,13 @@ namespace NuGet.Protocol.Plugins
         /// <param name="packageVersion">The package version.</param>
         /// <param name="hashAlgorithm">The hash algorithm.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageSourceRepository" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageId" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageVersion" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="hashAlgorithm" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         [JsonConstructor]
         public GetPackageHashRequest(
             string packageSourceRepository,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetPackageHashResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetPackageHashResponse.cs
@@ -31,7 +31,7 @@ namespace NuGet.Protocol.Plugins
         /// is an undefined <see cref="MessageResponseCode" /> value.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="responseCode" /> 
         /// is <see cref="MessageResponseCode.Success" /> and <paramref name="hash" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         [JsonConstructor]
         public GetPackageHashResponse(MessageResponseCode responseCode, string hash)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetPackageVersionsRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetPackageVersionsRequest.cs
@@ -29,9 +29,9 @@ namespace NuGet.Protocol.Plugins
         /// <param name="packageSourceRepository">The package source repository location.</param>
         /// <param name="packageId">The package ID.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageSourceRepository" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageId" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         [JsonConstructor]
         public GetPackageVersionsRequest(
             string packageSourceRepository,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetPackageVersionsResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetPackageVersionsResponse.cs
@@ -34,7 +34,7 @@ namespace NuGet.Protocol.Plugins
         /// is an undefined <see cref="MessageResponseCode" /> value.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="responseCode" /> 
         /// is <see cref="MessageResponseCode.Success" /> and <paramref name="versions" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         [JsonConstructor]
         public GetPackageVersionsResponse(MessageResponseCode responseCode, IEnumerable<string> versions)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetServiceIndexResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetServiceIndexResponse.cs
@@ -33,7 +33,7 @@ namespace NuGet.Protocol.Plugins
         /// is an undefined <see cref="MessageResponseCode" /> value.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="responseCode" /> 
         /// is <see cref="MessageResponseCode.Success" /> and <paramref name="serviceIndex" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         [JsonConstructor]
         public GetServiceIndexResponse(MessageResponseCode responseCode, JObject serviceIndex)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/HandshakeRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/HandshakeRequest.cs
@@ -31,9 +31,9 @@ namespace NuGet.Protocol.Plugins
         /// <param name="protocolVersion">The requestor's plugin protocol version.</param>
         /// <param name="minimumProtocolVersion">The requestor's minimum plugin protocol version.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="protocolVersion" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="minimumProtocolVersion" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="protocolVersion" />
         /// is less than <paramref name="minimumProtocolVersion" />.</exception>
         [JsonConstructor]

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/HandshakeResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/HandshakeResponse.cs
@@ -21,7 +21,7 @@ namespace NuGet.Protocol.Plugins
 
         /// <summary>
         /// Gets the handshake responder's plugin protocol version if the handshake was successful;
-        /// otherwise, <c>null</c>.
+        /// otherwise, <see langword="null" />.
         /// </summary>
         public SemanticVersion ProtocolVersion { get; }
 
@@ -30,15 +30,15 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="responseCode">The handshake responder's handshake response code.</param>
         /// <param name="protocolVersion">The handshake responder's plugin protocol version
-        /// if the handshake was successful; otherwise, <c>null</c>.</param>
+        /// if the handshake was successful; otherwise, <see langword="null" />.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="responseCode" />
         /// is an undefined <see cref="MessageResponseCode" /> value.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="responseCode" />
         /// is <see cref="MessageResponseCode.Success" /> and <paramref name="protocolVersion" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="responseCode" />
         /// is not <see cref="MessageResponseCode.Success" /> and <paramref name="protocolVersion" />
-        /// is not <c>null</c>.</exception>
+        /// is not <see langword="null" />.</exception>
         [JsonConstructor]
         public HandshakeResponse(MessageResponseCode responseCode, SemanticVersion protocolVersion)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/InitializeRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/InitializeRequest.cs
@@ -35,9 +35,9 @@ namespace NuGet.Protocol.Plugins
         /// <param name="clientVersion">The requestor's NuGet client version.</param>
         /// <param name="culture">The requestor's current culture.</param>
         /// <param name="requestTimeout">The default request timeout.</param>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="clientVersion" /> is either <c>null</c>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="clientVersion" /> is either <see langword="null" />
         /// or an empty string.</exception>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="culture" /> is either <c>null</c>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="culture" /> is either <see langword="null" />
         /// or an empty string.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="requestTimeout" />
         /// is either less than <see cref="ProtocolConstants.MinTimeout" /> or greater than

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/LogRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/LogRequest.cs
@@ -32,7 +32,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="message">The message to be logged.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="logLevel" /> is an undefined
         /// <see cref="LogLevel" /> value.</exception>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="message" /> is either <c>null</c>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="message" /> is either <see langword="null" />
         /// or an empty string.</exception>
         [JsonConstructor]
         public LogRequest(LogLevel logLevel, string message)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/Message.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/Message.cs
@@ -44,7 +44,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="method">The message method.</param>
         /// <param name="payload">An optional message payload.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="requestId" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="type" />
         /// is an undefined <see cref="MessageType" /> value.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="method" />

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/PrefetchPackageRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/PrefetchPackageRequest.cs
@@ -36,11 +36,11 @@ namespace NuGet.Protocol.Plugins
         /// <param name="packageId">The package ID.</param>
         /// <param name="packageVersion">The package version.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageSourceRepository" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageId" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageVersion" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         [JsonConstructor]
         public PrefetchPackageRequest(
             string packageSourceRepository,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/NoOpDisposePlugin.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/NoOpDisposePlugin.cs
@@ -66,7 +66,7 @@ namespace NuGet.Protocol.Plugins
         /// Instantiates a new <see cref="NoOpDisposePlugin" /> class.
         /// </summary>
         /// <param name="plugin">A plugin</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" /> is <see langword="null" />.</exception>
         public NoOpDisposePlugin(IPlugin plugin)
         {
             if (plugin == null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext.cs
@@ -41,21 +41,21 @@ namespace NuGet.Protocol.Plugins
         /// Handles progress notifications for the outbound request.
         /// </summary>
         /// <param name="progress">A progress notification.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="progress" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="progress" /> is <see langword="null" />.</exception>
         public abstract void HandleProgress(Message progress);
 
         /// <summary>
         /// Handles a response for the outbound request.
         /// </summary>
         /// <param name="response">A response.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="response" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="response" /> is <see langword="null" />.</exception>
         public abstract void HandleResponse(Message response);
 
         /// <summary>
         /// Handles a fault response for the outbound request.
         /// </summary>
         /// <param name="fault">A fault response.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="fault" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="fault" /> is <see langword="null" />.</exception>
         public abstract void HandleFault(Message fault);
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext`1.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext`1.cs
@@ -42,9 +42,9 @@ namespace NuGet.Protocol.Plugins
         /// to reset the request timeout.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="connection" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public OutboundRequestContext(
@@ -68,13 +68,13 @@ namespace NuGet.Protocol.Plugins
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <param name="logger">A plugin logger.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="connection" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         internal OutboundRequestContext(
             IConnection connection,
             Message request,
@@ -146,7 +146,7 @@ namespace NuGet.Protocol.Plugins
         /// Handles progress notifications for the outbound request.
         /// </summary>
         /// <param name="progress">A progress notification.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="progress" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="progress" /> is <see langword="null" />.</exception>
         public override void HandleProgress(Message progress)
         {
             if (progress == null)
@@ -166,7 +166,7 @@ namespace NuGet.Protocol.Plugins
         /// Handles a response for the outbound request.
         /// </summary>
         /// <param name="response">A response.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="response" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="response" /> is <see langword="null" />.</exception>
         public override void HandleResponse(Message response)
         {
             if (response == null)
@@ -183,7 +183,7 @@ namespace NuGet.Protocol.Plugins
         /// Handles a fault response for the outbound request.
         /// </summary>
         /// <param name="fault">A fault response.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="fault" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="fault" /> is <see langword="null" />.</exception>
         public override void HandleFault(Message fault)
         {
             if (fault == null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Plugin.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Plugin.cs
@@ -72,13 +72,13 @@ namespace NuGet.Protocol.Plugins
         /// <param name="filePath">The plugin file path.</param>
         /// <param name="connection">The plugin connection.</param>
         /// <param name="process">The plugin process.</param>
-        /// <param name="isOwnProcess"><c>true</c> if <paramref name="process" /> is the current process;
-        /// otherwise, <c>false</c>.</param>
+        /// <param name="isOwnProcess"><see langword="true" /> if <paramref name="process" /> is the current process;
+        /// otherwise, <see langword="false" />.</param>
         /// <param name="idleTimeout">The plugin idle timeout.  Can be <see cref="Timeout.InfiniteTimeSpan" />.</param>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="filePath" /> is either <c>null</c>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="filePath" /> is either <see langword="null" />
         /// or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="connection" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="process" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="connection" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="process" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="idleTimeout" /> is smaller than
         /// <see cref="Timeout.InfiniteTimeSpan" />.</exception>
         public Plugin(string filePath, IConnection connection, IPluginProcess process, bool isOwnProcess, TimeSpan idleTimeout)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCreationResult.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCreationResult.cs
@@ -17,12 +17,12 @@ namespace NuGet.Protocol.Plugins
         public IReadOnlyList<OperationClaim> Claims { get; }
 
         /// <summary>
-        /// Gets a message if <see cref="Plugin" /> is <c>null</c>; otherwise, <c>null</c>.
+        /// Gets a message if <see cref="Plugin" /> is <see langword="null" />; otherwise, <see langword="null" />.
         /// </summary>
         public string Message { get; }
 
         /// <summary>
-        /// Gets the exception caught.  May be <c>null</c>.
+        /// Gets the exception caught.  May be <see langword="null" />.
         /// </summary>
         public Exception Exception { get; }
 
@@ -42,9 +42,9 @@ namespace NuGet.Protocol.Plugins
         /// <param name="plugin">A plugin.</param>
         /// <param name="utilities">A plugin multiclient utilities.</param>
         /// <param name="claims">The plugin's operation claims.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="utilities" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="claims" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="utilities" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="claims" /> is <see langword="null" />.</exception>
         public PluginCreationResult(IPlugin plugin, IPluginMulticlientUtilities utilities, IReadOnlyList<OperationClaim> claims)
         {
             if (plugin == null)
@@ -72,7 +72,7 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="message">A message why a plugin could not be created.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="message" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         public PluginCreationResult(string message)
         {
             if (string.IsNullOrEmpty(message))
@@ -89,8 +89,8 @@ namespace NuGet.Protocol.Plugins
         /// <param name="message">A message why a plugin could not be created.</param>
         /// <param name="exception">An exception.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="message" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="exception" /> is <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="exception" /> is <see langword="null" />.</exception>
         public PluginCreationResult(string message, Exception exception)
             : this(message)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
@@ -29,7 +29,7 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="rawPluginPaths">The raw semicolon-delimited list of supposed plugin file paths.</param>
         /// <param name="verifier">An embedded signature verifier.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="verifier" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="verifier" /> is <see langword="null" />.</exception>
         public PluginDiscoverer(string rawPluginPaths, EmbeddedSignatureVerifier verifier)
         {
             if (verifier == null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryResult.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryResult.cs
@@ -20,7 +20,7 @@ namespace NuGet.Protocol.Plugins
 
         /// <summary>
         /// Gets a message if <see cref="PluginFile.State" /> is not <see cref="PluginFileState.Valid" />;
-        /// otherwise, <c>null</c>.
+        /// otherwise, <see langword="null" />.
         /// </summary>
         public string Message
         {
@@ -66,9 +66,9 @@ namespace NuGet.Protocol.Plugins
         /// Instantiates a new <see cref="PluginDiscoveryResult" /> class.
         /// </summary>
         /// <param name="pluginFile">A plugin file.</param>
-        /// <see cref="PluginFileState.Valid" />; otherwise, <c>null</c>
+        /// <see cref="PluginFileState.Valid" />; otherwise, <see langword="null" />
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="pluginFile" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public PluginDiscoveryResult(PluginFile pluginFile)
         {
             PluginFile = pluginFile ?? throw new ArgumentNullException(nameof(pluginFile));

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginEventArgs.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginEventArgs.cs
@@ -19,7 +19,7 @@ namespace NuGet.Protocol.Plugins
         /// Instantiates a new <see cref="PluginEventArgs" /> class.
         /// </summary>
         /// <param name="plugin">A plugin.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" /> is <see langword="null" />.</exception>
         public PluginEventArgs(IPlugin plugin)
         {
             if (plugin == null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
@@ -86,13 +86,13 @@ namespace NuGet.Protocol.Plugins
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="Plugin" />
         /// instance.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="filePath" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="arguments" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="requestHandlers" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="options" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="sessionCancellationToken" />
         /// is cancelled.</exception>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
@@ -287,9 +287,9 @@ namespace NuGet.Protocol.Plugins
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="Plugin" />
         /// instance.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="requestHandlers" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="options" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="sessionCancellationToken" />
         /// is cancelled.</exception>
         /// <remarks>This is intended to be called by a plugin.</remarks>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginMulticlientUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginMulticlientUtilities.cs
@@ -31,9 +31,9 @@ namespace NuGet.Protocol.Plugins
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="key" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="taskFunc" />
-        /// is either <c>null</c>.</exception>
+        /// is either <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task DoOncePerPluginLifetimeAsync(

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageDownloader.cs
@@ -70,13 +70,13 @@ namespace NuGet.Protocol.Plugins
         /// <param name="packageReader">A plugin package reader.</param>
         /// <param name="packageSourceRepository">A package source repository location.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageReader" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="packageSourceRepository" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         public PluginPackageDownloader(
             IPlugin plugin,
             PackageIdentity packageIdentity,
@@ -136,7 +136,7 @@ namespace NuGet.Protocol.Plugins
         /// indicating whether or not the copy was successful.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="destinationFilePath" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task<bool> CopyNupkgFileToAsync(string destinationFilePath, CancellationToken cancellationToken)
@@ -177,7 +177,7 @@ namespace NuGet.Protocol.Plugins
         /// representing the package hash.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="hashAlgorithm" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task<string> GetPackageHashAsync(string hashAlgorithm, CancellationToken cancellationToken)
@@ -216,10 +216,10 @@ namespace NuGet.Protocol.Plugins
         /// <remarks>The exception handler returns a task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="bool" />
         /// indicating whether or not the exception was handled.  To handle an exception and stop its
-        /// propagation, the task should return <c>true</c>.  Otherwise, the exception will be rethrown.</remarks>
+        /// propagation, the task should return <see langword="true" />.  Otherwise, the exception will be rethrown.</remarks>
         /// <param name="handleExceptionAsync">An exception handler.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="handleExceptionAsync" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public void SetExceptionHandler(Func<Exception, Task<bool>> handleExceptionAsync)
         {
             if (handleExceptionAsync == null)
@@ -233,7 +233,7 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Sets a throttle for package downloads.
         /// </summary>
-        /// <param name="throttle">A throttle.  Can be <c>null</c>.</param>
+        /// <param name="throttle">A throttle.  Can be <see langword="null" />.</param>
         public void SetThrottle(SemaphoreSlim throttle)
         {
             // Do nothing.  Plugins are not implemented on macOS.

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -40,11 +40,11 @@ namespace NuGet.Protocol.Plugins
         /// <param name="plugin">A plugin.</param>
         /// <param name="packageIdentity">A package identity.</param>
         /// <param name="packageSourceRepository">A package source repository location.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageSourceRepository" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         public PluginPackageReader(IPlugin plugin, PackageIdentity packageIdentity, string packageSourceRepository)
             : base(DefaultFrameworkNameProvider.Instance, DefaultCompatibilityProvider.Instance)
         {
@@ -91,7 +91,7 @@ namespace NuGet.Protocol.Plugins
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="Stream" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="path" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<Stream> GetStreamAsync(string path, CancellationToken cancellationToken)
@@ -184,7 +184,7 @@ namespace NuGet.Protocol.Plugins
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{String}" />.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="folder" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="folder" /> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<IEnumerable<string>> GetFilesAsync(
@@ -233,10 +233,10 @@ namespace NuGet.Protocol.Plugins
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{String}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="destination" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageFiles" />
-        /// is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<IEnumerable<string>> CopyFilesAsync(
@@ -711,7 +711,7 @@ namespace NuGet.Protocol.Plugins
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{FrameworkSpecificGroup}" />.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="folderName" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="folderName" /> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override Task<IEnumerable<FrameworkSpecificGroup>> GetItemsAsync(
@@ -908,7 +908,7 @@ namespace NuGet.Protocol.Plugins
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="string" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="nupkgFilePath" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<string> CopyNupkgAsync(

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginProcess.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginProcess.cs
@@ -42,7 +42,7 @@ namespace NuGet.Protocol.Plugins
         internal string FilePath => _process.MainModule.FileName;
 
         /// <summary>
-        /// Gets the process ID if the process was started; otherwise, <c>null</c>.
+        /// Gets the process ID if the process was started; otherwise, <see langword="null" />.
         /// </summary>
         public int? Id
         {
@@ -69,7 +69,7 @@ namespace NuGet.Protocol.Plugins
         /// Instantiates a new <see cref="PluginProcess" /> class.
         /// </summary>
         /// <param name="startInfo">A plugin process.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="startInfo" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="startInfo" /> is <see langword="null" />.</exception>
         public PluginProcess(ProcessStartInfo startInfo)
         {
             if (startInfo == null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/ProtocolErrorEventArgs.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/ProtocolErrorEventArgs.cs
@@ -24,7 +24,7 @@ namespace NuGet.Protocol.Plugins
         /// Instantiates a new <see cref="ProtocolErrorEventArgs" /> class.
         /// </summary>
         /// <param name="exception">An exception.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="exception" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="exception" /> is <see langword="null" />.</exception>
         public ProtocolErrorEventArgs(Exception exception)
         {
             if (exception == null)
@@ -40,8 +40,8 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="exception">An exception.</param>
         /// <param name="message">A message.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="exception" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="message" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="exception" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="message" /> is <see langword="null" />.</exception>
         public ProtocolErrorEventArgs(Exception exception, Message message)
             : this(exception)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers.cs
@@ -28,9 +28,9 @@ namespace NuGet.Protocol.Plugins
         /// <param name="addHandlerFunc">An add request handler function.</param>
         /// <param name="updateHandlerFunc">An update request handler function.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="addHandlerFunc" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="updateHandlerFunc" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public void AddOrUpdate(
             MessageMethod method,
             Func<IRequestHandler> addHandlerFunc,
@@ -54,8 +54,8 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="method">A message method.</param>
         /// <param name="handler">A request handler.</param>
-        /// <returns><c>true</c> if added; otherwise, <c>false</c>.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="handler" /> is <c>null</c>.</exception>
+        /// <returns><see langword="true" /> if added; otherwise, <see langword="false" />.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="handler" /> is <see langword="null" />.</exception>
         public bool TryAdd(MessageMethod method, IRequestHandler handler)
         {
             if (handler == null)
@@ -71,7 +71,7 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="method">A message method.</param>
         /// <param name="handler">An existing request handler.</param>
-        /// <returns><c>true</c> if the request handler exists; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if the request handler exists; otherwise, <see langword="false" />.</returns>
         public bool TryGet(MessageMethod method, out IRequestHandler handler)
         {
             return _handlers.TryGetValue(method, out handler);
@@ -81,7 +81,7 @@ namespace NuGet.Protocol.Plugins
         /// Attempts to remove a request handler for the specified message method.
         /// </summary>
         /// <param name="method">A message method.</param>
-        /// <returns><c>true</c> if a request handler was removed; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if a request handler was removed; otherwise, <see langword="false" />.</returns>
         public bool TryRemove(MessageMethod method)
         {
             IRequestHandler handler;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/CloseRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/CloseRequestHandler.cs
@@ -21,7 +21,7 @@ namespace NuGet.Protocol.Plugins
         /// Initializes a new <see cref="CloseRequestHandler" /> class.
         /// </summary>
         /// <param name="plugin">A plugin.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" /> is <see langword="null" />.</exception>
         public CloseRequestHandler(IPlugin plugin)
         {
             if (plugin == null)
@@ -53,10 +53,10 @@ namespace NuGet.Protocol.Plugins
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="connection" />
-        /// is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="responseHandler" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public Task HandleResponseAsync(
             IConnection connection,
             Message request,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/GetCredentialsRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/GetCredentialsRequestHandler.cs
@@ -38,7 +38,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="proxy">A web proxy.</param>
         /// <param name="credentialService">An optional credential service.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public GetCredentialsRequestHandler(
             IPlugin plugin,
             IWebProxy proxy,
@@ -75,7 +75,7 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="sourceRepository">A source repository.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="sourceRepository" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public void AddOrUpdateSourceRepository(SourceRepository sourceRepository)
         {
             if (sourceRepository == null)
@@ -101,10 +101,10 @@ namespace NuGet.Protocol.Plugins
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="connection" />
-        /// is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="responseHandler" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task HandleResponseAsync(

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/GetServiceIndexRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/GetServiceIndexRequestHandler.cs
@@ -28,7 +28,7 @@ namespace NuGet.Protocol.Plugins
         /// Initializes a new <see cref="GetServiceIndexRequestHandler" /> class.
         /// </summary>
         /// <param name="plugin">A plugin.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" /> is <see langword="null" />.</exception>
         public GetServiceIndexRequestHandler(IPlugin plugin)
         {
             if (plugin == null)
@@ -60,7 +60,7 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="sourceRepository">A source repository.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="sourceRepository" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public void AddOrUpdateSourceRepository(SourceRepository sourceRepository)
         {
             if (sourceRepository == null)
@@ -86,10 +86,10 @@ namespace NuGet.Protocol.Plugins
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="connection" />
-        /// is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="responseHandler" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task HandleResponseAsync(

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/LogRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/LogRequestHandler.cs
@@ -25,7 +25,7 @@ namespace NuGet.Protocol.Plugins
         /// Instantiates a new instance of the <see cref="LogRequestHandler" /> class.
         /// </summary>
         /// <param name="logger">A logger.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <see langword="null" />.</exception>
         public LogRequestHandler(ILogger logger)
         {
             if (logger == null)
@@ -45,10 +45,10 @@ namespace NuGet.Protocol.Plugins
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="connection" />
-        /// is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="responseHandler" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task HandleResponseAsync(
@@ -97,7 +97,7 @@ namespace NuGet.Protocol.Plugins
         /// Sets the logger.
         /// </summary>
         /// <param name="logger">A logger.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <see langword="null" />.</exception>
         public void SetLogger(ILogger logger)
         {
             if (logger == null)
@@ -119,7 +119,7 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="logger">A logger.</param>
         /// <returns>A log level.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <see langword="null" />.</exception>
         public static LogLevel GetLogLevel(ILogger logger)
         {
             if (logger == null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/MonitorNuGetProcessExitRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/MonitorNuGetProcessExitRequestHandler.cs
@@ -24,7 +24,7 @@ namespace NuGet.Protocol.Plugins
         /// Initializes a new <see cref="MonitorNuGetProcessExitRequestHandler" /> class.
         /// </summary>
         /// <param name="plugin">A plugin.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" /> is <see langword="null" />.</exception>
         public MonitorNuGetProcessExitRequestHandler(IPlugin plugin)
         {
             if (plugin == null)
@@ -63,10 +63,10 @@ namespace NuGet.Protocol.Plugins
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="connection" />
-        /// is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="responseHandler" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public async Task HandleResponseAsync(
             IConnection connection,
             Message request,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/SymmetricHandshake.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/SymmetricHandshake.cs
@@ -108,7 +108,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="SemanticVersion" />
-        /// if the handshake was successful; otherwise, <c>null</c>.</returns>
+        /// if the handshake was successful; otherwise, <see langword="null" />.</returns>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task<SemanticVersion> HandshakeAsync(CancellationToken cancellationToken)
@@ -146,10 +146,10 @@ namespace NuGet.Protocol.Plugins
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="connection" />
-        /// is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="responseHandler" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task HandleResponseAsync(

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Sender.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Sender.cs
@@ -28,7 +28,7 @@ namespace NuGet.Protocol.Plugins
         /// Instantiates a new <see cref="Sender" /> class.
         /// </summary>
         /// <param name="writer">A text writer.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="writer" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="writer" /> is <see langword="null" />.</exception>
         public Sender(TextWriter writer)
         {
             if (writer == null)
@@ -106,7 +106,7 @@ namespace NuGet.Protocol.Plugins
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         /// <exception cref="InvalidOperationException">Thrown if <see cref="Connect" /> has not been called.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="message" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="message" /> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public Task SendAsync(Message message, CancellationToken cancellationToken)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/StandardInputReceiver.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/StandardInputReceiver.cs
@@ -25,7 +25,7 @@ namespace NuGet.Protocol.Plugins
         /// Instantiates a new <see cref="StandardInputReceiver" /> class.
         /// </summary>
         /// <param name="reader">A text reader.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="reader" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="reader" /> is <see langword="null" />.</exception>
         public StandardInputReceiver(TextReader reader)
         {
             if (reader == null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/StandardOutputReceiver.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/StandardOutputReceiver.cs
@@ -23,7 +23,7 @@ namespace NuGet.Protocol.Plugins
         /// Instantiates a new <see cref="StandardOutputReceiver" /> class.
         /// </summary>
         /// <param name="process">A plugin process.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="process" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="process" /> is <see langword="null" />.</exception>
         public StandardOutputReceiver(IPluginProcess process)
         {
             if (process == null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/TimeoutUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/TimeoutUtilities.cs
@@ -52,7 +52,7 @@ namespace NuGet.Protocol.Plugins
         /// Determines if a timeout is valid.
         /// </summary>
         /// <param name="timeout">A timeout.</param>
-        /// <returns><c>true</c> if the timeout is valid; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if the timeout is valid; otherwise, <see langword="false" />.</returns>
         public static bool IsValid(TimeSpan timeout)
         {
             if (ProtocolConstants.MinTimeout <= timeout && timeout <= ProtocolConstants.MaxTimeout)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/UnixAndMonoPlatformsEmbeddedSignatureVerifier.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/UnixAndMonoPlatformsEmbeddedSignatureVerifier.cs
@@ -14,9 +14,9 @@ namespace NuGet.Protocol.Plugins
         /// Checks if a file has a valid embedded signature.
         /// </summary>
         /// <param name="filePath">The path of a file to be checked.</param>
-        /// <returns><c>true</c> if the file has a valid signature; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if the file has a valid signature; otherwise, <see langword="false" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="filePath" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         /// <exception cref="PlatformNotSupportedException">Thrown if the current platform is unsupported.</exception>
         public override bool IsValid(string filePath)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/WindowsEmbeddedSignatureVerifier.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/WindowsEmbeddedSignatureVerifier.cs
@@ -20,9 +20,9 @@ namespace NuGet.Protocol.Plugins
         /// Checks if a file has a valid Authenticode signature.
         /// </summary>
         /// <param name="filePath">The path of a file to be checked.</param>
-        /// <returns><c>true</c> if the file has a valid signature; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if the file has a valid signature; otherwise, <see langword="false" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="filePath" />
-        /// is either <c>null</c> or an empty string.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
         public override bool IsValid(string filePath)
         {
             if (string.IsNullOrEmpty(filePath))

--- a/src/NuGet.Core/NuGet.Protocol/Providers/DownloadResourcePluginProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/DownloadResourcePluginProvider.cs
@@ -31,7 +31,7 @@ namespace NuGet.Protocol
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns a Tuple&lt;bool, INuGetResource&gt;</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="source"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="source"/> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken"/>
         /// is cancelled.</exception>
         public override async Task<Tuple<bool, INuGetResource>> TryCreate(

--- a/src/NuGet.Core/NuGet.Protocol/Providers/PluginResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/PluginResourceProvider.cs
@@ -35,7 +35,7 @@ namespace NuGet.Protocol.Core.Types
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns a Tuple&lt;bool, INuGetResource&gt;</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="source"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="source"/> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken"/>
         /// is cancelled.</exception>
         public override async Task<Tuple<bool, INuGetResource>> TryCreate(

--- a/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
@@ -76,12 +76,12 @@ namespace NuGet.Protocol
         /// <param name="packageIdentity">A package identity.</param>
         /// <param name="cacheContext">A source cache context.</param>
         /// <param name="logger">A logger.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="resource" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="resource" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" />
-        /// is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <see langword="null" />.</exception>
         public RemotePackageArchiveDownloader(
             string source,
             FindPackageByIdResource resource,
@@ -146,7 +146,7 @@ namespace NuGet.Protocol
         /// indicating whether or not the copy was successful.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="destinationFilePath" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async Task<bool> CopyNupkgFileToAsync(string destinationFilePath, CancellationToken cancellationToken)
@@ -212,7 +212,7 @@ namespace NuGet.Protocol
         /// representing the package hash.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="hashAlgorithm" />
-        /// is either <c>null</c> or empty.</exception>
+        /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public Task<string> GetPackageHashAsync(string hashAlgorithm, CancellationToken cancellationToken)
@@ -241,10 +241,10 @@ namespace NuGet.Protocol
         /// <remarks>The exception handler returns a task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="bool" />
         /// indicating whether or not the exception was handled.  To handle an exception and stop its
-        /// propagation, the task should return <c>true</c>.  Otherwise, the exception will be rethrown.</remarks>
+        /// propagation, the task should return <see langword="true" />.  Otherwise, the exception will be rethrown.</remarks>
         /// <param name="handleExceptionAsync">An exception handler.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="handleExceptionAsync" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public void SetExceptionHandler(Func<Exception, Task<bool>> handleExceptionAsync)
         {
             if (handleExceptionAsync == null)
@@ -258,7 +258,7 @@ namespace NuGet.Protocol
         /// <summary>
         /// Sets a throttle for package downloads.
         /// </summary>
-        /// <param name="throttle">A throttle.  Can be <c>null</c>.</param>
+        /// <param name="throttle">A throttle.  Can be <see langword="null" />.</param>
         public void SetThrottle(SemaphoreSlim throttle)
         {
             _throttle = throttle;

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
@@ -48,9 +48,9 @@ namespace NuGet.Protocol
         /// </summary>
         /// <param name="baseUris">Base URI's.</param>
         /// <param name="httpSource">An HTTP source.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="baseUris" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="baseUris" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="baseUris" /> is empty.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="httpSource" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="httpSource" /> is <see langword="null" />.</exception>
         public HttpFileSystemBasedFindPackageByIdResource(
             IReadOnlyList<Uri> baseUris,
             HttpSource httpSource) : this(baseUris, httpSource, EnvironmentVariableWrapper.Instance) { }
@@ -96,9 +96,9 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<IEnumerable<NuGetVersion>> GetAllVersionsAsync(
@@ -154,10 +154,10 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<FindPackageByIdDependencyInfo> GetDependencyInfoAsync(
@@ -233,11 +233,11 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="bool" /> indicating whether or not the .nupkg file was copied.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="destination" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="destination" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<bool> CopyNupkgToStreamAsync(
@@ -314,9 +314,9 @@ namespace NuGet.Protocol
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns an <see cref="IPackageDownloader" />.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<IPackageDownloader> GetPackageDownloaderAsync(
@@ -365,10 +365,10 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<bool> DoesPackageExistAsync(

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/PluginFindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/PluginFindPackageByIdResource.cs
@@ -41,11 +41,11 @@ namespace NuGet.Protocol.Core.Types
         /// <param name="utilities">A plugin multiclient utilities.</param>
         /// <param name="packageSource">A package source.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="utilities" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageSource" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public PluginFindPackageByIdResource(
             IPlugin plugin,
             IPluginMulticlientUtilities utilities,
@@ -104,9 +104,9 @@ namespace NuGet.Protocol.Core.Types
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns an <see cref="IPackageDownloader" />.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override Task<IPackageDownloader> GetPackageDownloaderAsync(
@@ -162,9 +162,9 @@ namespace NuGet.Protocol.Core.Types
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<IEnumerable<NuGetVersion>> GetAllVersionsAsync(
@@ -227,10 +227,10 @@ namespace NuGet.Protocol.Core.Types
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<FindPackageByIdDependencyInfo> GetDependencyInfoAsync(
@@ -322,10 +322,10 @@ namespace NuGet.Protocol.Core.Types
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<bool> DoesPackageExistAsync(

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/PluginFindPackageByIdResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/PluginFindPackageByIdResourceProvider.cs
@@ -31,7 +31,7 @@ namespace NuGet.Protocol
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns a Tuple&lt;bool, INuGetResource&gt;</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="source"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="source"/> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken"/>
         /// is cancelled.</exception>
         public override async Task<Tuple<bool, INuGetResource>> TryCreate(

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
@@ -47,9 +47,9 @@ namespace NuGet.Protocol
         /// <param name="packageSource">A package source.</param>
         /// <param name="httpSource">An HTTP source.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageSource" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="httpSource" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public RemoteV2FindPackageByIdResource(PackageSource packageSource, HttpSource httpSource)
         {
             if (packageSource == null)
@@ -86,9 +86,9 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<IEnumerable<NuGetVersion>> GetAllVersionsAsync(
@@ -144,10 +144,10 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<FindPackageByIdDependencyInfo> GetDependencyInfoAsync(
@@ -222,11 +222,11 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="bool" /> indicating whether or not the .nupkg file was copied.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="destination" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="destination" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<bool> CopyNupkgToStreamAsync(
@@ -301,9 +301,9 @@ namespace NuGet.Protocol
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns an <see cref="IPackageDownloader" />.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<IPackageDownloader> GetPackageDownloaderAsync(
@@ -369,10 +369,10 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<bool> DoesPackageExistAsync(

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
@@ -41,9 +41,9 @@ namespace NuGet.Protocol
         /// <param name="sourceRepository">A source repository.</param>
         /// <param name="httpSource">An HTTP source.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="sourceRepository" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="httpSource" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public RemoteV3FindPackageByIdResource(SourceRepository sourceRepository, HttpSource httpSource)
         {
             if (sourceRepository == null)
@@ -77,9 +77,9 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<IEnumerable<NuGetVersion>> GetAllVersionsAsync(
@@ -135,10 +135,10 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<FindPackageByIdDependencyInfo> GetDependencyInfoAsync(
@@ -212,11 +212,11 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="bool" /> indicating whether or not the .nupkg file was copied.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="destination" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="destination" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<bool> CopyNupkgToStreamAsync(
@@ -291,9 +291,9 @@ namespace NuGet.Protocol
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns an <see cref="IPackageDownloader" />.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<IPackageDownloader> GetPackageDownloaderAsync(
@@ -359,10 +359,10 @@ namespace NuGet.Protocol
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public override async Task<bool> DoesPackageExistAsync(

--- a/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResourcePlugin.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResourcePlugin.cs
@@ -31,11 +31,11 @@ namespace NuGet.Protocol
         /// <param name="utilities">A plugin multiclient utilities.</param>
         /// <param name="packageSource">A package source.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="plugin" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="utilities" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageSource" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public DownloadResourcePlugin(
             IPlugin plugin,
             IPluginMulticlientUtilities utilities,
@@ -72,10 +72,10 @@ namespace NuGet.Protocol
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns
         /// a <see cref="DownloadResourceResult" />.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="identity" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="identity" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="downloadContext" />
-        /// is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public async override Task<DownloadResourceResult> GetDownloadResourceResultAsync(

--- a/src/NuGet.Core/NuGet.Protocol/Resources/FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/FindPackageByIdResource.cs
@@ -29,9 +29,9 @@ namespace NuGet.Protocol.Core.Types
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public abstract Task<IEnumerable<NuGetVersion>> GetAllVersionsAsync(
@@ -52,10 +52,10 @@ namespace NuGet.Protocol.Core.Types
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public abstract Task<FindPackageByIdDependencyInfo> GetDependencyInfoAsync(
@@ -78,11 +78,11 @@ namespace NuGet.Protocol.Core.Types
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="bool" /> indicating whether or not the .nupkg file was copied.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="destination" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="destination" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public abstract Task<bool> CopyNupkgToStreamAsync(
@@ -102,9 +102,9 @@ namespace NuGet.Protocol.Core.Types
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns an <see cref="IPackageDownloader" />.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageIdentity" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public abstract Task<IPackageDownloader> GetPackageDownloaderAsync(
@@ -125,10 +125,10 @@ namespace NuGet.Protocol.Core.Types
         /// The task result (<see cref="Task{TResult}.Result" />) returns an
         /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
-        /// is either <c>null</c> or an empty string.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// is either <see langword="null" /> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         public abstract Task<bool> DoesPackageExistAsync(

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PluginResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PluginResource.cs
@@ -28,9 +28,9 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         /// <param name="pluginCreationResults">Plugin creation results.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="pluginCreationResults" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageSource" />
-        /// is <c>null</c>.</exception>
+        /// is <see langword="null" />.</exception>
         public PluginResource(
             IEnumerable<PluginCreationResult> pluginCreationResults,
             PackageSource packageSource,

--- a/src/NuGet.Core/NuGet.Versioning/SemanticVersionConverter.cs
+++ b/src/NuGet.Core/NuGet.Versioning/SemanticVersionConverter.cs
@@ -18,7 +18,7 @@ namespace NuGet.Versioning
         /// </summary>
         /// <param name="context">An <see cref="ITypeDescriptorContext"/> that provides a format context.</param>
         /// <param name="sourceType">A <see cref="Type"/> that represents the type you wish to convert from.</param>
-        /// <returns><c>true</c> if this object can perform the conversion; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if this object can perform the conversion; otherwise, <see langword="false" />.</returns>
         public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
         {
             return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
@@ -53,7 +53,7 @@ namespace NuGet.Versioning
         /// </summary>
         /// <param name="context">An <see cref="ITypeDescriptorContext"/> that provides a format context.</param>
         /// <param name="destinationType">A <see cref="Type"/> that represents the type you wish to convert to.</param>
-        /// <returns><c>true</c> if this object can perform the conversion; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if this object can perform the conversion; otherwise, <see langword="false" />.</returns>
         public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
         {
             return destinationType == typeof(string) || base.CanConvertTo(context, destinationType);

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/GlobalJsonReader_Tests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/GlobalJsonReader_Tests.cs
@@ -246,7 +246,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         /// <summary>
-        /// Verifies that <see cref="GlobalJsonReader.GetMSBuildSdkVersions(Framework.SdkResolverContext)" /> returns <c>null</c> when a file is not found in a parent directory.
+        /// Verifies that <see cref="GlobalJsonReader.GetMSBuildSdkVersions(Framework.SdkResolverContext)" /> returns <see langword="null" /> when a file is not found in a parent directory.
         /// </summary>
         [Fact]
         public void GetMSBuildSdkVersions_ReturnsNull_WhenGlobalJsonDoesNotExist()
@@ -274,7 +274,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         /// <summary>
-        /// Verifies that <see cref="GlobalJsonReader.GetMSBuildSdkVersions(Framework.SdkResolverContext)" /> returns <c>null</c> when the specified global.json is empty or does not contain an msbuild-sdks section.
+        /// Verifies that <see cref="GlobalJsonReader.GetMSBuildSdkVersions(Framework.SdkResolverContext)" /> returns <see langword="null" /> when the specified global.json is empty or does not contain an msbuild-sdks section.
         /// </summary>
         [Theory]
         [InlineData("{ }")]
@@ -305,7 +305,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         /// <summary>
-        /// Verifies that <see cref="GlobalJsonReader.GetMSBuildSdkVersions(Framework.SdkResolverContext)" /> returns <c>null</c> when the specified global.json contains valid JSON but the msbuild-sdks section isn't correctly declared.
+        /// Verifies that <see cref="GlobalJsonReader.GetMSBuildSdkVersions(Framework.SdkResolverContext)" /> returns <see langword="null" /> when the specified global.json contains valid JSON but the msbuild-sdks section isn't correctly declared.
         /// </summary>
         [Theory]
         [InlineData("1")] // A number value
@@ -341,7 +341,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         /// <summary>
-        /// Verifies that <see cref="GlobalJsonReader.GetMSBuildSdkVersions(Framework.SdkResolverContext)" /> returns <c>null</c> when the <see cref="Framework.SdkResolverContext.SolutionFilePath" /> and <see cref="Framework.SdkResolverContext.ProjectFilePath" /> is null.
+        /// Verifies that <see cref="GlobalJsonReader.GetMSBuildSdkVersions(Framework.SdkResolverContext)" /> returns <see langword="null" /> when the <see cref="Framework.SdkResolverContext.SolutionFilePath" /> and <see cref="Framework.SdkResolverContext.ProjectFilePath" /> is null.
         /// </summary>
         [Fact]
         public void GetMSBuildSdkVersions_ReturnsNull_WhenSolutionFilePathAndProjectFilePathIsNull()
@@ -472,7 +472,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         /// <summary>
-        /// Verifies that <see cref="GlobalJsonReader.TryGetPathOfFileAbove(string, DirectoryInfo, out FileInfo)" /> return <c>false</c> when a file could not be found.
+        /// Verifies that <see cref="GlobalJsonReader.TryGetPathOfFileAbove(string, DirectoryInfo, out FileInfo)" /> return <see langword="false" /> when a file could not be found.
         /// </summary>
         [Fact]
         public void TryGetPathOfFileAbove_ReturnsFalse_WhenFileIsNotFound()
@@ -493,7 +493,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         /// <summary>
-        /// Verifies that <see cref="GlobalJsonReader.TryGetPathOfFileAbove(string, DirectoryInfo, out FileInfo)" /> return <c>false</c> when specifying <c>null</c> for the file parameter.
+        /// Verifies that <see cref="GlobalJsonReader.TryGetPathOfFileAbove(string, DirectoryInfo, out FileInfo)" /> return <see langword="false" /> when specifying <see langword="null" /> for the file parameter.
         /// </summary>
         [Fact]
         public void TryGetPathOfFileAbove_ReturnsFalse_WhenFileIsNull()
@@ -508,7 +508,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         /// <summary>
-        /// Verifies that <see cref="GlobalJsonReader.TryGetPathOfFileAbove(string, DirectoryInfo, out FileInfo)" /> return <c>false</c> when specifying a starting directory that does not exist.
+        /// Verifies that <see cref="GlobalJsonReader.TryGetPathOfFileAbove(string, DirectoryInfo, out FileInfo)" /> return <see langword="false" /> when specifying a starting directory that does not exist.
         /// </summary>
         [Fact]
         public void TryGetPathOfFileAbove_ReturnsFalse_WhenStartingDirectoryDoesNotExist()
@@ -525,7 +525,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         /// <summary>
-        /// Verifies that <see cref="GlobalJsonReader.TryGetPathOfFileAbove(string, DirectoryInfo, out FileInfo)" /> return <c>false</c> when specifying <c>null</c> for the startingDirectory parameter.
+        /// Verifies that <see cref="GlobalJsonReader.TryGetPathOfFileAbove(string, DirectoryInfo, out FileInfo)" /> return <see langword="false" /> when specifying <see langword="null" /> for the startingDirectory parameter.
         /// </summary>
         [Fact]
         public void TryGetPathOfFileAbove_ReturnsFalse_WhenStartingDirectoryIsNull()
@@ -537,7 +537,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         /// <summary>
-        /// Verifies that <see cref="GlobalJsonReader.TryGetPathOfFileAbove(string, DirectoryInfo, out FileInfo)" /> return <c>true</c> and the path to the file when one is found.
+        /// Verifies that <see cref="GlobalJsonReader.TryGetPathOfFileAbove(string, DirectoryInfo, out FileInfo)" /> return <see langword="true" /> and the path to the file when one is found.
         /// </summary>
         [Fact]
         public void TryGetPathOfFileAbove_ReturnsTrue_WhenFileIsFound()

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/NuGetSdkResolver_Tests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/NuGetSdkResolver_Tests.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         /// <summary>
-        /// Verifies that <see cref="NuGetSdkResolver.TryGetNuGetVersionForSdk(string, string, SdkResolverContext, out object)" /> returns <c>null</c> when an invalid version is specified in global.json.
+        /// Verifies that <see cref="NuGetSdkResolver.TryGetNuGetVersionForSdk(string, string, SdkResolverContext, out object)" /> returns <see langword="null" /> when an invalid version is specified in global.json.
         /// </summary>
         [Fact]
         public void TryGetNuGetVersionForSdk_WhenInvalidVersionInGlobalJson_ReturnsNull()
@@ -169,7 +169,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         /// <summary>
-        /// Verifies that <see cref="NuGetSdkResolver.TryGetNuGetVersionForSdk(string, string, SdkResolverContext, out object)" /> returns <c>null</c> when an invalid version is specified in a project.
+        /// Verifies that <see cref="NuGetSdkResolver.TryGetNuGetVersionForSdk(string, string, SdkResolverContext, out object)" /> returns <see langword="null" /> when an invalid version is specified in a project.
         /// </summary>
         [Fact]
         public void TryGetNuGetVersionForSdk_WhenInvalidVersionSpecified_ReturnsNull()
@@ -199,7 +199,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         /// <summary>
-        /// Verifies that <see cref="NuGetSdkResolver.TryGetNuGetVersionForSdk(string, string, SdkResolverContext, out object)" /> returns <c>null</c> when the project path is <c>null</c>.
+        /// Verifies that <see cref="NuGetSdkResolver.TryGetNuGetVersionForSdk(string, string, SdkResolverContext, out object)" /> returns <see langword="null" /> when the project path is <see langword="null" />.
         /// </summary>
         [Fact]
         public void TryGetNuGetVersionForSdk_WhenProjectPathIsNullAndVersionIsNull_ReturnsNull()
@@ -214,7 +214,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         /// <summary>
-        /// Verifies that <see cref="NuGetSdkResolver.TryGetNuGetVersionForSdk(string, string, SdkResolverContext, out object)" /> returns <c>null</c> when the state of a previous call has no version specified.
+        /// Verifies that <see cref="NuGetSdkResolver.TryGetNuGetVersionForSdk(string, string, SdkResolverContext, out object)" /> returns <see langword="null" /> when the state of a previous call has no version specified.
         /// </summary>
         [Fact]
         public void TryGetNuGetVersionForSdk_WhenStateContainsNoVersion_ReturnsNull()

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -4082,7 +4082,7 @@ namespace NuGet.Commands.Test
         /// <summary>
         /// Verifies that <see cref="MSBuildRestoreUtility.GetDependencySpec(IEnumerable{IMSBuildItem})" /> applies version overrides correctly depending on whether or not central package management is enabled.
         /// </summary>
-        /// <param name="isCentralPackageManagementEnabled"><c>true</c> if central package management is enabled, otherwise <c>false</c>.</param>
+        /// <param name="isCentralPackageManagementEnabled"><see langword="true" /> if central package management is enabled, otherwise <see langword="false" />.</param>
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsLoadingContextTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsLoadingContextTests.cs
@@ -94,7 +94,7 @@ namespace NuGet.Configuration.Test
         }
 
         /// <summary>
-        /// Verifies that <see cref="SettingsLoadingContext.GetOrCreateSettingsFile(string, bool, bool)" /> throws an <see cref="ArgumentNullException"/> when passed a <c>null</c> value for the file path.
+        /// Verifies that <see cref="SettingsLoadingContext.GetOrCreateSettingsFile(string, bool, bool)" /> throws an <see cref="ArgumentNullException"/> when passed a <see langword="null" /> value for the file path.
         /// </summary>
         [Fact]
         public void GetOrCreateSettingsFile_ThrowsArgumentNullException_WhenFilePathIsNull()

--- a/test/TestUtilities/Test.Utility/CentralPackageVersionsManagementFile.cs
+++ b/test/TestUtilities/Test.Utility/CentralPackageVersionsManagementFile.cs
@@ -45,7 +45,7 @@ namespace NuGet.Test.Utility
         /// Creates a new central package management file (Directory.Packages.props) in the specified directory.
         /// </summary>
         /// <param name="directoryPath">The path to a directory to create the central package management in.</param>
-        /// <param name="managePackageVersionsCentrally"><c>true</c> to enable central package management (default), or <c>false</c> to disable it.</param>
+        /// <param name="managePackageVersionsCentrally"><see langword="true" /> to enable central package management (default), or <see langword="false" /> to disable it.</param>
         /// <returns></returns>
         public static CentralPackageVersionsManagementFile Create(string directoryPath, bool managePackageVersionsCentrally = true)
         {

--- a/test/TestUtilities/Test.Utility/TestFileSystemUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestFileSystemUtility.cs
@@ -98,7 +98,7 @@ namespace NuGet.Test.Utility
         /// Walks up the specified directory looking for NuGet.sln.
         /// </summary>
         /// <param name="startingDirectory">The <see cref="DirectoryInfo" /> to use as a starting directory.</param>
-        /// <returns>A <see cref="DirectoryInfo" /> representing the root of the respository if one is found, otherwise <c>null</c>.</returns>
+        /// <returns>A <see cref="DirectoryInfo" /> representing the root of the respository if one is found, otherwise <see langword="null" />.</returns>
         private static DirectoryInfo GetRepositoryRootFromStartingDirectory(DirectoryInfo startingDirectory)
         {
             DirectoryInfo currentDir = startingDirectory;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2473

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
I recently discovered the `see langword="" />` syntax for XML doc comments so this pull request migrates us to it.  It works well for `true`, `false`, and `null`.  Below you can see the word `null` becomes a language word instead of code.

Before:
![image](https://github.com/NuGet/NuGet.Client/assets/17556515/74d20fb6-a924-4f7a-9c8a-150dc82bc568)
After:
![image](https://github.com/NuGet/NuGet.Client/assets/17556515/30073383-7a5b-49f8-ae69-af2bf5279033)

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
