### PR TITLE
Run dotnet.integration.tests with .NET 8 daily SDK

### DIFF
--- a/build/DotNetSdkVersions.txt
+++ b/build/DotNetSdkVersions.txt
@@ -1,5 +1,5 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Channel 8.0
+-Channel 8.0 -Quality daily
 -Channel 7.0
 -Channel 6.0 -Runtime dotnet
 -Channel 5.0

--- a/build/DotNetSdkVersions.txt
+++ b/build/DotNetSdkVersions.txt
@@ -1,5 +1,5 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Channel 8.0 -Version 8.0.100-preview.6.23330.14
+-Channel 8.0
 -Channel 7.0
 -Channel 6.0 -Runtime dotnet
 -Channel 5.0

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -153,7 +153,7 @@ stages:
       BuildRTM: "false"
       SemanticVersion: $[stageDependencies.Initialize.GetSemanticVersion.outputs['setsemanticversion.SemanticVersion']]
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEngSS-MicroBuild2022Preview-1ES
     steps:
     - template: Build_and_UnitTest.yml
       parameters:
@@ -175,7 +175,7 @@ stages:
       VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
       BuildRTM: "true"
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEngSS-MicroBuild2022Preview-1ES
     steps:
     - template: Build_and_UnitTest.yml
       parameters:
@@ -223,7 +223,7 @@ stages:
       MSBuildEnableWorkloadResolver: false
     condition: "and(succeeded(), ne(variables['RunFunctionalTestsOnWindows'], 'false'))"
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEngSS-MicroBuild2022Preview-1ES
     strategy:
       matrix:
         IsDesktop:
@@ -286,7 +286,7 @@ stages:
       BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
       FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     pool:
-      vmImage: windows-latest
+      name: VSEngSS-MicroBuild2022Preview-1ES
     steps:
     - template: CrossFramework_Tests_On_Windows.yml
 


### PR DESCRIPTION
This reverts commit 1177038a0057deeef0ab71cef4b081e5895decfa.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: CI

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
https://github.com/NuGet/NuGet.Client/pull/5357 pinned the .NET 8 SDK to preview 6 for testing, because of a blocking problem in the preview 7 SDK. However, we're also experiencing CI issues that may be related to a vstest bug that has been fixed. So, try using the .NET 8 daily build.

Once .NET 8 RC1 ships, we can consider removing the pinning, and allow the dotnet-install script to automatically get the default latest release.

## PR Checklist

- [x] PR has a meaningful title
- [x] ~PR has a linked issue~: not customer facing, not going to be in release notes
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
