### PR TITLE
OptProf test project should target latest SDK TFM

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.OptProf/Assets/PackageReferenceSdk/PackageReferenceSdk/PackageReferenceSdk.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.OptProf/Assets/PackageReferenceSdk/PackageReferenceSdk/PackageReferenceSdk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
     <NuGetAudit>true</NuGetAudit>
   </PropertyGroup>
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: CI

Regression? kind of, but not in NuGet. VS internal previews changed something that broke us.

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Changed the test project that OptProf training test use to use the most appropriate TargetFramework for the version of the .NET SDK currently installed.

The .NET SDK can build and run any version of .NET that is equal to or less than the SDK version. For example, .NET 7 SDK can target net7.0 and below, and .NET 8 SDK can target net8.0 and below. However, the SDK only has reference assemblies and other runtime files for the SDK's version. When a project is targeting a framework that is lower than the version of the SDK, the SDK will use `<PackageDownload` to download the required files. 

Sometimes these packages get new versions published, and so a new version of the .NET SDK will want to use the new package version. However, everything releases publicly on the same day, but the new version of the .NET SDK that uses the new packages needs to be inserted into VS days early, in order to build and test VS that will use the new package version.

That's where we're at today. Our test targets net7.0, and the .NET SDK in VS 17.8 is .NET 8, and there's going to be new versions of the .NET 7 runtime packages published when everything goes GA. Therefore, our test that uses nuget.org as the only package source fails.

We have at least one alternative: Change `build\test.optprof.vsconfig` to install the .NET 7 SDK and runtime. But eventually .NET 7 will go out of support. VSSetup still seems to have .NET Core 3.1 and .NET 5, so I guess it's not likely that .NET 7 SDK will be removed anytime soon. However, I feel like allowing VSSetup to install the recommended/default version of the .NET SDK, and automatically targeting that version for our test project is a better solution that will never need maintainance, as long as the .NET SDK keeps populating and updating this MSBuild property.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: manually ran OptProf pipeline to verify it works
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
