### PR TITLE
Protocol to convert VulnerabilityInfoResource with System.Text.Json

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -189,6 +189,7 @@
       <_allowBuildFromSourcePackage Include="System.Security.Cryptography.Pkcs" />
       <_allowBuildFromSourcePackage Include="System.Security.Cryptography.ProtectedData" />
       <_allowBuildFromSourcePackage Include="System.Security.Cryptography.Xml" />
+      <_allowBuildFromSourcePackage Include="System.Text.Json" />
 
       <_sourceBuildUnexpectedPackage Include="@(PackageReference)" Exclude="@(_allowBuildFromSourcePackage)" />
     </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
 
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)' == ''">3.3.4</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <NewtonsoftJsonPackageVersion Condition="'$(NewtonsoftJsonPackageVersion)' == ''">13.0.3</NewtonsoftJsonPackageVersion>
+    <SystemTextJsonVersion Condition="'$(SystemTextJsonVersion)' == ''">7.0.3</SystemTextJsonVersion>
     <SystemPackagesVersion Condition="'$(SystemPackagesVersion)' == ''">4.3.0</SystemPackagesVersion>
     <VSFrameworkVersion Condition="'$(VSFrameworkVersion)' == ''">17.4.33103.184</VSFrameworkVersion>
     <VSServicesVersion Condition="'$(VSServicesVersion)' == ''">16.153.0</VSServicesVersion>
@@ -99,6 +100,7 @@
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
     <PackageVersion Include="System.Text.Encoding.Extensions" Version="$(SystemPackagesVersion)" />
+    <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
     <PackageVersion Include="System.Threading" Version="$(SystemPackagesVersion)" />
     <PackageVersion Include="System.Threading.Tasks" Version="$(SystemPackagesVersion)" />
     <!--

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -48,6 +48,7 @@
     <NoWarn>$(NoWarn);NU5105;MSB3277;NETSDK1138</NoWarn>
     <!-- additional warnings new in .NET 6 that we need to disable when building with source-build -->
     <NoWarn Condition="'$(DotNetBuildFromSource)' == 'true'">$(NoWarn);CS1998;CA1416;CS0618;CS1574</NoWarn>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <!-- Defaults -->

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -95,4 +95,8 @@
     <UsagePattern IdentityGlob="System.Threading.Tasks/*" />
     <UsagePattern IdentityGlob="System.Threading.Tasks.Dataflow/*" />
   </IgnorePatterns>
+  <Usages>
+    <Usage Id="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <Usage Id="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </Usages>
 </UsageData>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -25,6 +25,7 @@
     <!--
       Packages owned by .NET - exclusion of all versions.
     -->
+    <UsagePattern IdentityGlob="Microsoft.Bcl.AsyncInterfaces/*" />
     <UsagePattern IdentityGlob="Microsoft.Build/*" />
     <UsagePattern IdentityGlob="Microsoft.Build.Framework/*" />
     <UsagePattern IdentityGlob="Microsoft.Build.Tasks.Core/*" />
@@ -94,9 +95,6 @@
     <UsagePattern IdentityGlob="System.Threading/*" />
     <UsagePattern IdentityGlob="System.Threading.Tasks/*" />
     <UsagePattern IdentityGlob="System.Threading.Tasks.Dataflow/*" />
+    <UsagePattern IdentityGlob="System.Threading.Tasks.Extensions/*" />
   </IgnorePatterns>
-  <Usages>
-    <Usage Id="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-    <Usage Id="System.Threading.Tasks.Extensions" Version="4.5.4" />
-  </Usages>
 </UsageData>

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/ilmerge.props
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/ilmerge.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0">
   <ItemGroup>
+    <MergeInclude Include="$(OutputPath)Microsoft.Bcl.AsyncInterfaces.dll"/>
     <MergeInclude Include="$(OutputPath)Microsoft.Extensions.FileProviders.Abstractions.dll"/>
     <MergeInclude Include="$(OutputPath)Microsoft.Extensions.FileSystemGlobbing.dll"/>
     <MergeInclude Include="$(OutputPath)Microsoft.Extensions.Primitives.dll"/>
@@ -25,7 +26,11 @@
     <MergeInclude Include="$(OutputPath)System.Memory.dll"/>
     <MergeInclude Include="$(OutputPath)System.Numerics.Vectors.dll"/>
     <MergeInclude Include="$(OutputPath)System.Runtime.CompilerServices.Unsafe.dll"/>
+    <MergeInclude Include="$(OutputPath)System.Text.Encodings.Web.dll"/>
+    <MergeInclude Include="$(OutputPath)System.Text.Json.dll"/>
     <MergeInclude Include="$(OutputPath)System.Threading.Tasks.Dataflow.dll"/>
+    <MergeInclude Include="$(OutputPath)System.Threading.Tasks.Extensions.dll"/>
+    <MergeInclude Include="$(OutputPath)System.ValueTuple.dll"/>
 
     <MergeExclude Include="$(OutputPath)Microsoft.VisualStudio.Setup.Configuration.Interop.dll"/>
     <MergeExclude Include="$(OutputPath)Microsoft.CSharp.dll"/>

--- a/src/NuGet.Core/NuGet.Protocol/Converters/JsonExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/JsonExtensions.cs
@@ -35,6 +35,18 @@ namespace NuGet.Protocol
 
         internal static readonly JsonSerializer JsonObjectSerializer = JsonSerializer.Create(ObjectSerializationSettings);
 
+        internal static readonly System.Text.Json.JsonSerializerOptions JsonSerializerOptions = CreateJsonSerializerOptions();
+
+        private static System.Text.Json.JsonSerializerOptions CreateJsonSerializerOptions()
+        {
+            var options = new System.Text.Json.JsonSerializerOptions()
+            {
+                PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase
+            };
+            options.Converters.Add(new VersionRangeStjConverter());
+            return options;
+        }
+
         /// <summary>
         /// Serialize object to the JSON.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Protocol/Converters/VersionRangeStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/VersionRangeStjConverter.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NuGet.Versioning;
+
+namespace NuGet.Protocol.Converters
+{
+    internal class VersionRangeStjConverter : JsonConverter<VersionRange>
+    {
+        public override VersionRange Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var stringValue = reader.GetString();
+            if (stringValue == null)
+            {
+                // This is actually impossible to get to, because JsonSerializer won't call into the converter when the JSON is null
+                throw new JsonException("Value for version range cannot be null");
+            }
+
+            return VersionRange.Parse(stringValue);
+        }
+
+        public override void Write(Utf8JsonWriter writer, VersionRange value, JsonSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteStringValue(value.ToNormalizedString());
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Converters/VersionRangeStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/VersionRangeStjConverter.cs
@@ -10,6 +10,9 @@ using NuGet.Versioning;
 
 namespace NuGet.Protocol.Converters
 {
+    /// <summary>
+    /// A <see cref="JsonConverter{T}"/> to allow System.Text.Json to read/write <see cref="VersionRange"/>
+    /// </summary>
     internal class VersionRangeStjConverter : JsonConverter<VersionRange>
     {
         public override VersionRange Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -18,7 +21,7 @@ namespace NuGet.Protocol.Converters
             if (stringValue == null)
             {
                 // This is actually impossible to get to, because JsonSerializer won't call into the converter when the JSON is null
-                throw new JsonException("Value for version range cannot be null");
+                throw new InvalidOperationException("Value for version range cannot be null");
             }
 
             return VersionRange.Parse(stringValue);

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageVulnerabilityInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageVulnerabilityInfo.cs
@@ -4,7 +4,7 @@
 #nullable enable
 
 using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using NuGet.Shared;
 using NuGet.Versioning;
 
@@ -14,15 +14,15 @@ namespace NuGet.Protocol.Model
     public sealed class PackageVulnerabilityInfo : IEquatable<PackageVulnerabilityInfo>
     {
         /// <summary>A URL to a CVE or another web page where more information about the vulnerability can be found.</summary>
-        [JsonProperty(PropertyName = JsonProperties.Url)]
+        [JsonPropertyName(JsonProperties.Url)]
         public Uri Url { get; }
 
         /// <summary>The severity of the vulnerability</summary>
-        [JsonProperty(PropertyName = JsonProperties.Severity)]
+        [JsonPropertyName(JsonProperties.Severity)]
         public PackageVulnerabilitySeverity Severity { get; }
 
         /// <summary>Which package versions are affected by this vulnerability.</summary>
-        [JsonProperty(PropertyName = JsonProperties.Versions)]
+        [JsonPropertyName(JsonProperties.Versions)]
         public VersionRange Versions { get; }
 
         /// <summary>Creates an instance of the class</summary>

--- a/src/NuGet.Core/NuGet.Protocol/Model/V3VulnerabilityIndexEntry.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/V3VulnerabilityIndexEntry.cs
@@ -4,7 +4,7 @@
 #nullable enable
 
 using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace NuGet.Protocol.Model
 {
@@ -14,19 +14,19 @@ namespace NuGet.Protocol.Model
     {
         /// <summary>A short name </summary>
         /// <remarks>The name must be unique within the vulnerability index. See the server API docs for more information.</remarks>
-        [JsonProperty(PropertyName = "@name")]
+        [JsonPropertyName("@name")]
         public string Name { get; }
 
         /// <summary>The URL for the vulnerability data.</summary>
-        [JsonProperty(PropertyName = "@id")]
+        [JsonPropertyName("@id")]
         public Uri Url { get; }
 
         /// <summary>A string that can be used to determine if a previously cached value is no longer up-to-date.</summary>
-        [JsonProperty(PropertyName = "@updated")]
+        [JsonPropertyName("@updated")]
         public string Updated { get; }
 
         /// <summary>Free text that the server administrator can add to the JSON object.</summary>
-        [JsonProperty(PropertyName = "comment")]
+        [JsonPropertyName("comment")]
         public string? Comment { get; }
 
         public V3VulnerabilityIndexEntry(string name, Uri url, string updated, string? comment)

--- a/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
@@ -21,6 +21,10 @@
     <ProjectReference Include="..\NuGet.Packaging\NuGet.Packaging.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' OR '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Update="Strings.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/src/NuGet.Core/NuGet.Protocol/Resources/VulnerabilityInfoResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/VulnerabilityInfoResourceV3.cs
@@ -5,11 +5,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Model;
@@ -46,14 +45,10 @@ namespace NuGet.Protocol.Resources
             try
             {
                 vulnFiles = await httpSourceResource.HttpSource.GetAsync(request,
-                    result =>
+                    async result =>
                     {
-                        using (var textReader = new StreamReader(result.Stream))
-                        using (var jsonReader = new JsonTextReader(textReader))
-                        {
-                            var parsed = JsonExtensions.JsonObjectSerializer.Deserialize<IReadOnlyList<V3VulnerabilityIndexEntry>>(jsonReader);
-                            return Task.FromResult(parsed);
-                        }
+                        var parsed = await JsonSerializer.DeserializeAsync<IReadOnlyList<V3VulnerabilityIndexEntry>>(result.Stream, JsonExtensions.JsonSerializerOptions);
+                        return parsed;
                     },
                     log,
                     cancellationToken);
@@ -101,14 +96,10 @@ namespace NuGet.Protocol.Resources
             try
             {
                 data = await httpSourceResource.HttpSource.GetAsync(request,
-                    result =>
+                    async result =>
                     {
-                        using (var textReader = new StreamReader(result.Stream))
-                        using (var jsonReader = new JsonTextReader(textReader))
-                        {
-                            var parsed = JsonExtensions.JsonObjectSerializer.Deserialize<CaseInsensitiveDictionary<IReadOnlyList<PackageVulnerabilityInfo>>>(jsonReader);
-                            return Task.FromResult(parsed);
-                        }
+                        var parsed = await JsonSerializer.DeserializeAsync<CaseInsensitiveDictionary<IReadOnlyList<PackageVulnerabilityInfo>>>(result.Stream, JsonExtensions.JsonSerializerOptions);
+                        return parsed;
                     },
                     logger,
                     cancellationToken);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/VersionRangeStjConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/VersionRangeStjConverterTests.cs
@@ -58,5 +58,33 @@ namespace NuGet.Protocol.Tests.Converters
             const string expected = $"\"{rangeString}\"";
             actual.Should().Be(expected);
         }
+
+        [Fact]
+        public void VersionRange_RoundTripsSerialization()
+        {
+            // Arrange
+            var range = VersionRange.Parse("[1.0.0, 2.0.0)");
+
+            // Act
+            var json = JsonSerializer.Serialize(range, JsonExtensions.JsonSerializerOptions);
+            var actual = JsonSerializer.Deserialize<VersionRange>(json, JsonExtensions.JsonSerializerOptions);
+
+            // Assert
+            actual.Should().BeEquivalentTo(range);
+        }
+
+        [Fact]
+        public void Json_RoundTripsSerialization()
+        {
+            // Arrange
+            var json = "\"[1.0.0, 2.0.0)\"";
+
+            // Act
+            var versionRange = JsonSerializer.Deserialize<VersionRange>(json, JsonExtensions.JsonSerializerOptions);
+            var actual = JsonSerializer.Serialize(versionRange, JsonExtensions.JsonSerializerOptions);
+
+            // Assert
+            actual.Should().Be(json);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/VersionRangeStjConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/VersionRangeStjConverterTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Text.Json;
+using FluentAssertions;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Protocol.Tests.Converters
+{
+    public class VersionRangeStjConverterTests
+    {
+        [Fact]
+        public void Deserialize_ValidString_ReturnsVersionRange()
+        {
+            // Arrange
+            const string range = "1.2.3";
+            const string json = $"\"{range}\"";
+
+            // Act
+            var actual = JsonSerializer.Deserialize<VersionRange>(json, JsonExtensions.JsonSerializerOptions);
+
+            // Assert
+            actual.Should().NotBeNull();
+            actual!.OriginalString.Should().Be(range);
+        }
+
+        [Fact]
+        public void Deserialize_InvalidString_ThrowsException()
+        {
+            Assert.Throws<ArgumentException>(() => JsonSerializer.Deserialize<VersionRange>("\"not a range\"", JsonExtensions.JsonSerializerOptions));
+        }
+
+        [Fact]
+        public void Deserialize_Null_ReturnsNull()
+        {
+            // Act
+            var actual = JsonSerializer.Deserialize<VersionRange>("null", JsonExtensions.JsonSerializerOptions);
+
+            // Assert
+            actual.Should().BeNull();
+        }
+
+        [Fact]
+        public void Serialize_Range_ReturnsString()
+        {
+            // Arrange
+            const string rangeString = "[1.2.3, )";
+            var range = VersionRange.Parse(rangeString);
+
+            // Act
+            var actual = JsonSerializer.Serialize(range, JsonExtensions.JsonSerializerOptions);
+
+            // Assert
+            const string expected = $"\"{rangeString}\"";
+            actual.Should().Be(expected);
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12855
 
Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

See linked issue for benchmarks of Newtonsoft.Json vs System.Text.Json benchmarks for the vulnerability data. Basically, on .NET Framework, there are about 1/3rd of the allocations, and on .NET 8 it's more like 1/4. Technically it's a little faster too, but the wall clock different is meaningless, because if you take a trace of any NuGet action, JSON deserialization doesn't use up any significant time.

This is the first time we're using System.Text.Json in NuGet, so some infrastructure had to be set up to make everything work properly. I didn't verify, but I expect that all our ILMerged assemblies have bloated in size because of this. If we ever migrate all other Newtonsoft.Json usage, then we can remove it and reclaim its size.

|Component|Changes|
|--|--|
|NuGet.exe ILMerge|No changes, it automatically ILMerges *.dll in the bin directory|
|NuGet.MSSign.exe|Updated ilmerge.props for the new dll, plus its new dependencies|
|Pack ILMerge|no changes. I can't think of any scenario where pack will use NuGet.Protocol, so I don't think it's needed. Internestingly ilmerge didn't complain about missing assemblies, so perhaps it also includes bin's *.dll, like nuget.exe does|
|VSIX|It's already in vsixignore, as it's a dependency of other packages we already use. System.Text.Json is part of VS's public assemblies, so no need for it in our VSIX for VS experiences. MSBuild has its own copy, so no need for msbuild CLI restore either|

I had to add `SuppressTfmSupportBuildWarnings` to the common project properties, because a lot of system .NET v7 packages [have props/targets that error out on TFMs that are "out of support"](https://github.com/dotnet/runtime/blob/1aecc383f38b58acb8e256eae19b217b7e951b6d/eng/packaging.targets#L209-L214), but the package still provides binaries for, and our test projects are still targeting .NET 5 and .NET Core 3.1.

Created a sharable `JsonSerializerOptions` in `JsonExtensions`, similar to how we have a Newtonsoft.Json serializer, so future protocol migrations to System.Text.Json might not need to create its own. New converters will need to be added, but by using the shared options, it will only be a one time effort per converter.

Only one `JsonConverter` was needed for VulnerabilityInfoResource, `VersionRangeConverter`, named `VersionRangeStjConverter` due to the name clash with the Newtonsoft.Json converter (both extend classes, not interfaces, so we can't easily have one that implements both). Added tests for the new converter, but otherwise else existing tests to cover NuGetAudt's functionality.

Finally, the changes to VulnerabilityInfoResourceV3 to use System.Text.Json vs Newtonsoft.Json was minimal, almost trivial.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
