### PR TITLE
Simplify ProjectTestHelpers, unify RestoreRequest and DGSpec creation

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -156,9 +156,9 @@ namespace NuGet.CommandLine.Test
                 var logger = new TestLogger();
                 // Set-up command.
                 var request = ProjectTestHelpers.CreateRestoreRequest(
-                        ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net5.0", dependencyName: packageX.Id),
                         pathContext,
-                        logger);
+                        logger,
+                        ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net5.0", dependencyName: packageX.Id));
                 var command = new NuGet.Commands.RestoreCommand(request);
 
                 // Act

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -69,7 +69,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.0.0, )");
 
                 // Restore info
-                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
 
@@ -119,7 +119,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var packageSpec = GetPackageSpec(projectName, projectFullPath, "[*, )");
 
                 // Restore info
-                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
 
@@ -172,7 +172,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.0.0, )");
 
                 // Restore info
-                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
 
@@ -215,7 +215,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var packageSpec = GetPackageSpecNoPackages(projectName, projectFullPath);
 
                 // Restore info
-                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
 
@@ -259,7 +259,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.0.0, )");
 
                 // Restore info
-                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
 
@@ -309,7 +309,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var packageSpec = GetPackageSpecNoPackages(projectName, projectFullPath);
 
                 // Restore info
-                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
 
@@ -358,7 +358,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var packageSpec = GetPackageSpecMultipleVersions(projectName, projectFullPath);
 
                 // Restore info
-                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
 
@@ -418,7 +418,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var projectNames = GetTestProjectNames(projectFullPath, projectName);
 
                 // Restore info
-                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
 
@@ -453,7 +453,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 packageSpec = GetPackageSpec(projectName, testDirectory, "[3.0.0, )");
 
                 // Restore info
-                projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
 
@@ -535,7 +535,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     packageA_InitialVersion.Version);
 
                 // Restore info
-                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
 
@@ -568,7 +568,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 };
 
                 packageSpec.TargetFrameworks.First().Dependencies.Insert(0, installed);
-                projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
 
                 // Assert
@@ -646,7 +646,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     packageA_InitialVersion.Version);
 
                 // Restore info
-                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
 
@@ -679,7 +679,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 };
 
                 packageSpec.TargetFrameworks.First().Dependencies.Insert(0, installed);
-                projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
 
                 // Assert
@@ -772,7 +772,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProj = projectFullPath;
@@ -813,7 +813,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     var packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Insert(0, installed);
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     var projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -913,7 +913,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProj = projectFullPath;
@@ -941,7 +941,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     var packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Add(installed);
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     var projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -976,7 +976,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     var packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Insert(0, installed);
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     var projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -1071,7 +1071,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProj = projectFullPath;
@@ -1095,7 +1095,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     var packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Add(installed);
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     var projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -1206,7 +1206,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProj = projectFullPath;
@@ -1232,7 +1232,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     var packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Add(installed);
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     var projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -1355,7 +1355,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProj = projectFullPath;
@@ -1381,7 +1381,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     var packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Add(installed);
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     var projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -1505,7 +1505,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProj = projectFullPath;
@@ -1531,7 +1531,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     var packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Add(installed);
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     var projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -1655,7 +1655,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProj = projectFullPath;
@@ -1681,7 +1681,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     var packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Add(installed);
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     var projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -1805,7 +1805,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProj = projectFullPath;
@@ -1831,7 +1831,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     var packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Add(installed);
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     var projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -1943,7 +1943,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProj = projectFullPath;
@@ -1969,7 +1969,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     var packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Add(installed);
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     var projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -2077,7 +2077,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProj = projectFullPath;
@@ -2103,7 +2103,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     var packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Add(installed);
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     var projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -2210,7 +2210,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProj = projectFullPath;
@@ -2236,7 +2236,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     var packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Add(installed);
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     var projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -2347,7 +2347,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProj = projectFullPath;
@@ -2449,7 +2449,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProj = projectFullPath;
@@ -2557,7 +2557,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProj = projectFullPath;
@@ -2583,7 +2583,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     var packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Add(installed);
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     var projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -2712,7 +2712,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProj = projectFullPath;
@@ -2738,7 +2738,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     var packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Add(installed);
-                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     var projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -2921,7 +2921,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                 var projectNames = GetTestProjectNames(projectFullPath, projectName);
                 var originalSpec = GetPackageSpec(projectName, projectFullPath, "1.0.0");
-                projectCache.AddProjectRestoreInfo(projectNames, ProjectTestHelpers.GetDGSpecFromPackageSpecs(originalSpec), new List<IAssetsLogMessage>());
+                projectCache.AddProjectRestoreInfo(projectNames, ProjectTestHelpers.GetDGSpecForAllProjects(originalSpec), new List<IAssetsLogMessage>());
                 projectCache.AddProject(projectNames, new Mock<IVsProjectAdapter>().Object, project).Should().BeTrue();
 
                 var request = new TestRestoreRequest(originalSpec, sources, testContext.UserPackagesFolder, logger)
@@ -2953,7 +2953,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 packages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("1.0.0"))));
 
                 // Act - Simulate a nomination. This should reset the cache and bring it to spec equivalent.
-                projectCache.AddProjectRestoreInfo(projectNames, ProjectTestHelpers.GetDGSpecFromPackageSpecs(updatedSpec), new List<IAssetsLogMessage>());
+                projectCache.AddProjectRestoreInfo(projectNames, ProjectTestHelpers.GetDGSpecForAllProjects(updatedSpec), new List<IAssetsLogMessage>());
                 projectCache.AddProject(projectNames, new Mock<IVsProjectAdapter>().Object, project).Should().BeTrue();
 
                 // Assert
@@ -3029,7 +3029,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProjectFullPath = projectFullPath;
@@ -3055,7 +3055,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     PackageSpec packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Add(installed);
-                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     ProjectNames projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -3171,7 +3171,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProjectFullPath = projectFullPath;
@@ -3197,7 +3197,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     PackageSpec packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Add(installed);
-                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     ProjectNames projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -3316,7 +3316,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProjectFullPath = projectFullPath;
@@ -3342,7 +3342,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     PackageSpec packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Add(installed);
-                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     ProjectNames projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -3460,7 +3460,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProjectFullPath = projectFullPath;
@@ -3486,7 +3486,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     PackageSpec packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Add(installed);
-                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     ProjectNames projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -3606,7 +3606,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }
 
                     // Restore info
-                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                     projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
                     prevProjectFullPath = projectFullPath;
@@ -3632,7 +3632,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     PackageSpec packageSpec = packageSpecs[i];
                     packageSpec.TargetFrameworks.First().Dependencies.Add(installed);
-                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                    DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                     ProjectNames projectNames = GetTestProjectNames(projectFullPaths[i], $"project{i}");
                     projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 }
@@ -3673,7 +3673,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 PackageSpec packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.0.0, )");
 
                 // Restore info
-                DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
 
@@ -3732,7 +3732,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 PackageSpec packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.0.0, )");
 
                 // Restore info
-                DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
 
@@ -3800,7 +3800,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 PackageSpec packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.0.0, )");
 
                 // Restore info
-                DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
 
@@ -3851,7 +3851,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 PackageSpec packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.0.0, )");
 
                 // Restore info
-                DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
 
@@ -3912,7 +3912,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             PackageSpec packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.15.3, )");
 
             // Restore info
-            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
             projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
             IVsProjectAdapter projectAdapter = Mock.Of<IVsProjectAdapter>();
             projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
@@ -4261,7 +4261,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var packageSpec = GetPackageSpec(projectName, projectFullPath, "[1.0.0, )");
 
                 // Restore info
-                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
                 projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
 
@@ -4333,7 +4333,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
             var projectCache = new ProjectSystemCache();
             var projectName = "project";
-            var dependencyGraphSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(ProjectTestHelpers.GetPackageSpec(settings, projectName, rootPath: pathContext.SolutionRoot));
+            var dependencyGraphSpec = ProjectTestHelpers.GetDGSpecForAllProjects(ProjectTestHelpers.GetPackageSpec(settings, projectName, rootPath: pathContext.SolutionRoot));
             var projectFullPath = dependencyGraphSpec.Projects[0].FilePath;
             var cpsPackageReferenceProject = TestCpsPackageReferenceProject.CreateTestCpsPackageReferenceProject(projectName, projectFullPath, projectCache);
             testSolutionManager.NuGetProjects.Add(cpsPackageReferenceProject);
@@ -4380,7 +4380,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Child project
             var childProject = "childProject";
             var childProjectPackageSpec = ProjectTestHelpers.GetPackageSpec(settings, childProject, rootPath: pathContext.SolutionRoot);
-            var childDependencyGraphSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(childProjectPackageSpec);
+            var childDependencyGraphSpec = ProjectTestHelpers.GetDGSpecForAllProjects(childProjectPackageSpec);
             var childProjectFullPath = childDependencyGraphSpec.Projects[0].FilePath;
             var childPackageReferenceProject = TestCpsPackageReferenceProject.CreateTestCpsPackageReferenceProject(childProject, childProjectFullPath, projectCache);
 
@@ -4388,7 +4388,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var parentProject = "parentProject";
             var parentProjectPackageSpec = ProjectTestHelpers.GetPackageSpec(settings, parentProject, rootPath: pathContext.SolutionRoot);
             parentProjectPackageSpec = parentProjectPackageSpec.WithTestProjectReference(childProjectPackageSpec);
-            var parentDependencyGraphSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(parentProjectPackageSpec);
+            var parentDependencyGraphSpec = ProjectTestHelpers.GetDGSpecForAllProjects(parentProjectPackageSpec);
             var parentProjectFullPath = parentDependencyGraphSpec.Projects[0].FilePath;
             var parentPackageReferenceProject = TestCpsPackageReferenceProject.CreateTestCpsPackageReferenceProject(parentProject, parentProjectFullPath, projectCache);
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectFactories.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectFactories.cs
@@ -177,7 +177,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         internal static void UpdateProjectSystemCache(IProjectSystemCache projectCache, PackageSpec packageSpec, NuGetProject project)
         {
             ProjectNames projectNames = GetTestProjectNames(packageSpec.FilePath, packageSpec.Name);
-            DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+            DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
             projectCache.AddProjectRestoreInfo(projectNames, dgSpec, new List<IAssetsLogMessage>());
             projectCache.AddProject(projectNames, Mock.Of<IVsProjectAdapter>(), project);
         }
@@ -193,7 +193,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 CacheContext = new SourceCacheContext(),
             };
 
-            DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpecs);
+            DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpecs);
             var dgProvider = new DependencyGraphSpecRequestProvider(new RestoreCommandProvidersCache(), dgSpec);
 
             foreach (RestoreSummaryRequest request in await dgProvider.CreateRequests(restoreContext))

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
@@ -187,7 +187,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     nuGetProjectServices.Object,
                     projectId);
 
-                DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectRestoreInfo.AddProject(packageSpec);
                 var projectNames = new ProjectNames(
                     fullName: projectFullPath,
@@ -469,7 +469,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     projectId);
 
 
-                DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+                DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
                 projectRestoreInfo.AddProject(packageSpec);
                 var projectNames = new ProjectNames(
                     fullName: projectFullPath,
@@ -654,7 +654,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, "packageB", "2.0.0");
 
             // Restore info
-            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
             projectSystemCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
             projectSystemCache.AddProject(projectNames, projectAdapter, prProject).Should().BeTrue();
 
@@ -672,7 +672,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             // Now, make a NuGet-Restore
             var pajFilepath = Path.Combine(Path.GetDirectoryName(projectFullPath), "project.assets.json");
-            TestRestoreRequest restoreRequest = ProjectTestHelpers.CreateRestoreRequest(packageSpec, pathContext, _logger);
+            TestRestoreRequest restoreRequest = ProjectTestHelpers.CreateRestoreRequest(pathContext, _logger, packageSpec);
             restoreRequest.LockFilePath = pajFilepath;
             restoreRequest.ProjectStyle = ProjectStyle.PackageReference;
             var command = new RestoreCommand(restoreRequest);
@@ -810,7 +810,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             PackageSpec packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.0.0, )");
 
             // Restore info
-            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
             projectSystemCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
             projectSystemCache.AddProject(projectNames, projectAdapter, prProject).Should().BeTrue();
 
@@ -921,7 +921,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             PackageSpec packageSpec = JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, projectFullPath).WithTestRestoreMetadata();
 
             // Restore info
-            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
             projectSystemCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
             projectSystemCache.AddProject(projectNames, projectAdapter, prProject).Should().BeTrue();
 
@@ -1077,7 +1077,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             PackageSpec packageSpec = JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, projectFullPath).WithTestRestoreMetadata();
 
             // Restore info
-            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
             projectSystemCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
             projectSystemCache.AddProject(projectNames, projectAdapter, prProject).Should().BeTrue();
 
@@ -1262,7 +1262,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             PackageSpec packageSpec = JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, projectFullPath).WithTestRestoreMetadata();
 
             // Restore info
-            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
             projectSystemCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
             projectSystemCache.AddProject(projectNames, projectAdapter, prProject).Should().BeTrue();
 
@@ -1395,7 +1395,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             PackageSpec packageSpec = JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, projectFullPath).WithTestRestoreMetadata();
 
             // Restore info
-            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
             projectSystemCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
             projectSystemCache.AddProject(projectNames, projectAdapter, prProject).Should().BeTrue();
 
@@ -1403,7 +1403,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             // Perform NuGet restore
             var pajFilepath = Path.Combine(Path.GetDirectoryName(projectFullPath), "project.assets.json");
-            TestRestoreRequest restoreRequest = ProjectTestHelpers.CreateRestoreRequest(packageSpec, pathContext, _logger); // Adds 1 source
+            TestRestoreRequest restoreRequest = ProjectTestHelpers.CreateRestoreRequest(pathContext, _logger, packageSpec); // Adds 1 source
             restoreRequest.LockFilePath = pajFilepath;
             restoreRequest.ProjectStyle = ProjectStyle.PackageReference;
             var command = new RestoreCommand(restoreRequest);
@@ -1546,7 +1546,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             packageSpec.RestoreMetadata.CentralPackageVersionsEnabled = isCentralPackageVersionsEnabled;
 
             // Restore info
-            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
             projectSystemCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
             projectSystemCache.AddProject(projectNames, projectAdapter, prProject).Should().BeTrue();
 
@@ -1591,7 +1591,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             PackageSpec packageSpec = JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, projectFullPath).WithTestRestoreMetadata();
 
             // Restore info
-            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
             projectSystemCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
             projectSystemCache.AddProject(projectNames, projectAdapter, prProject).Should().BeTrue();
 
@@ -1641,7 +1641,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             };
 
             packageSpec.TargetFrameworks.First().Dependencies.Add(dependency);
-            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+            DependencyGraphSpec projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
             projectSystemCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, Array.Empty<IAssetsLogMessage>());
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionUpToDateCheckerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionUpToDateCheckerTests.cs
@@ -262,7 +262,7 @@ namespace NuGet.SolutionRestoreManager.Test
             // E => F
             projectE = projectE.WithTestProjectReference(projectF);
 
-            DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD, projectE, projectF);
+            DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(projectA, projectB, projectC, projectD, projectE, projectF);
 
             var checker = new SolutionUpToDateChecker();
 
@@ -278,7 +278,7 @@ namespace NuGet.SolutionRestoreManager.Test
             // Make projectE dirty by setting a random value that's usually not there :)
             projectF = projectF.Clone();
             projectF.RestoreMetadata.PackagesPath = @"C:\";
-            dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD, projectE, projectF);
+            dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(projectA, projectB, projectC, projectD, projectE, projectF);
 
             // Act & Assert.
             expected = GetUniqueNames(projectA, projectE);
@@ -340,7 +340,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 projectA = projectA.WithTestProjectReference(projectB);
                 // B => C
                 projectB = projectB.WithTestProjectReference(projectC);
-                DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD);
+                DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(projectA, projectB, projectC, projectD);
 
                 var checker = new SolutionUpToDateChecker();
 
@@ -353,7 +353,7 @@ namespace NuGet.SolutionRestoreManager.Test
 
                 // Set-up, B => D
                 projectB = projectB.WithTestProjectReference(projectD);
-                dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD);
+                dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(projectA, projectB, projectC, projectD);
 
                 // Act & Assert
                 actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
@@ -377,7 +377,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 projectA = projectA.WithTestProjectReference(projectB);
                 // B => C
                 projectB = projectB.WithTestProjectReference(projectC);
-                DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC);
+                DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(projectA, projectB, projectC);
 
                 var checker = new SolutionUpToDateChecker();
 
@@ -414,7 +414,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 projectA = projectA.WithTestProjectReference(projectB);
                 // B => C
                 projectB = projectB.WithTestProjectReference(projectC);
-                DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC);
+                DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(projectA, projectB, projectC);
 
                 var checker = new SolutionUpToDateChecker();
 
@@ -453,7 +453,7 @@ namespace NuGet.SolutionRestoreManager.Test
 
                 // A => B & C
                 projectA = projectA.WithTestProjectReference(projectB).WithTestProjectReference(projectC);
-                DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD);
+                DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(projectA, projectB, projectC, projectD);
 
                 var checker = new SolutionUpToDateChecker();
 
@@ -467,7 +467,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 // Set-up, make C dirty.
                 projectC = projectC.Clone();
                 projectC.RestoreMetadata.ConfigFilePaths = new List<string>() { "newFeed" };
-                dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD);
+                dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(projectA, projectB, projectC, projectD);
 
                 // Act & Assert
                 actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
@@ -489,7 +489,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 projectA = projectA.WithTestProjectReference(projectB);
                 // B => C
                 projectB = projectB.WithTestProjectReference(projectC);
-                DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC);
+                DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(projectA, projectB, projectC);
 
                 var checker = new SolutionUpToDateChecker();
 
@@ -523,7 +523,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 projectA = projectA.WithTestProjectReference(projectB);
                 // B => C
                 projectB = projectB.WithTestProjectReference(projectC);
-                DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC);
+                DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(projectA, projectB, projectC);
 
                 var checker = new SolutionUpToDateChecker();
 
@@ -715,7 +715,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 // A => D
                 projectA = projectA.WithTestProjectReference(projectD);
 
-                DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD, projectE);
+                DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(projectA, projectB, projectC, projectD, projectE);
 
                 var checker = new SolutionUpToDateChecker();
 
@@ -730,7 +730,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 projectD = projectD.WithTestProjectReference(projectE);
 
                 // Set-up dg spec
-                dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(projectA, projectB, projectC, projectD, projectE);
+                dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(projectA, projectB, projectC, projectD, projectE);
                 // 2nd check
                 actual = checker.PerformUpToDateCheck(dgSpec, NullLogger.Instance);
                 expected = GetUniqueNames(projectA, projectD);

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -3726,7 +3726,7 @@ namespace NuGet.Commands.FuncTest
 
             var spec = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net5.0", dependencyName: "a", useAssetTargetFallback: true, assetTargetFallbackFrameworks: "net472");
             var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(spec, pathContext, new TestLogger()));
-
+            // fix test
             // Act
             var result = await command.ExecuteAsync();
 
@@ -3941,7 +3941,7 @@ namespace NuGet.Commands.FuncTest
                     ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net5.0", dependencyName: packageA.Id),
                     pathContext,
                     new TestLogger()));
-
+            // todo - add sources
             // Act
             var result = await command.ExecuteAsync();
 
@@ -4112,7 +4112,7 @@ namespace NuGet.Commands.FuncTest
                 dependencyName: "a",
                 useAssetTargetFallback: true,
                 assetTargetFallbackFrameworks: "net472",
-                asAssetTargetFallback: true);
+                asAssetTargetFallback: true); // add sources
 
             var request = ProjectTestHelpers.CreateRestoreRequest(projectSpec, pathContext, logger);
             var command = new RestoreCommand(request);

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -742,7 +742,7 @@ namespace NuGet.Commands.FuncTest
                 assetTargetFallbackFrameworks: "net472",
                 asAssetTargetFallback: false);
             var logger = new TestLogger();
-            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(project1spec, pathContext, logger));
+            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1spec));
 
             // Act
             var result = await command.ExecuteAsync();
@@ -3689,7 +3689,7 @@ namespace NuGet.Commands.FuncTest
                 packageB);
 
             var spec = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net5.0", dependencyName: "a", useAssetTargetFallback: true, assetTargetFallbackFrameworks: "net472");
-            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(spec, pathContext, new TestLogger()));
+            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, new TestLogger(), spec));
 
             // Act
             var result = await command.ExecuteAsync();
@@ -3725,7 +3725,7 @@ namespace NuGet.Commands.FuncTest
                 packageB);
 
             var spec = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net5.0", dependencyName: "a", useAssetTargetFallback: true, assetTargetFallbackFrameworks: "net472");
-            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(spec, pathContext, new TestLogger()));
+            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, new TestLogger(), spec));
 
             // Act
             var result = await command.ExecuteAsync();
@@ -3761,7 +3761,7 @@ namespace NuGet.Commands.FuncTest
                 packageB);
 
             var spec = ProjectTestHelpers.GetPackageSpec("TestProject", pathContext.SolutionRoot, framework: "net5.0", dependencyName: "a", useAssetTargetFallback: true, assetTargetFallbackFrameworks: "net472");
-            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(spec, pathContext, new TestLogger()));
+            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, new TestLogger(), spec));
 
             // Act
             var result = await command.ExecuteAsync();
@@ -3938,9 +3938,9 @@ namespace NuGet.Commands.FuncTest
             // Set-up command.
             var command = new RestoreCommand(
                 ProjectTestHelpers.CreateRestoreRequest(
-                    ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net5.0", dependencyName: packageA.Id),
                     pathContext,
-                    new TestLogger()));
+                    new TestLogger(),
+                    ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net5.0", dependencyName: packageA.Id)));
             // todo - add sources
             // Act
             var result = await command.ExecuteAsync();
@@ -4078,7 +4078,7 @@ namespace NuGet.Commands.FuncTest
             var logger = new TestLogger();
             ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
             var project1Spec = ProjectTestHelpers.GetPackageSpec(settings, "Project1", pathContext.SolutionRoot, framework: "net5.0");
-            var request = ProjectTestHelpers.CreateRestoreRequest(project1Spec, pathContext, logger);
+            var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1Spec);
             var command = new RestoreCommand(request);
 
             // Act
@@ -4114,7 +4114,7 @@ namespace NuGet.Commands.FuncTest
                 assetTargetFallbackFrameworks: "net472",
                 asAssetTargetFallback: true); // add sources
 
-            var request = ProjectTestHelpers.CreateRestoreRequest(projectSpec, pathContext, logger);
+            var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, projectSpec);
             var command = new RestoreCommand(request);
 
             // Act
@@ -4150,7 +4150,7 @@ namespace NuGet.Commands.FuncTest
             project1spec.RestoreMetadata.ProjectWideWarningProperties.WarningsNotAsErrors.Add(NuGetLogCode.NU1701);
 
             var logger = new TestLogger();
-            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(project1spec, pathContext, logger));
+            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1spec));
 
             // Act
             RestoreResult result = await command.ExecuteAsync();

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -2248,7 +2248,7 @@ namespace NuGet.Commands.FuncTest
             pathContext.Settings.AddPackageSourceMapping("InvalidSource", packageA.Id);
             ISettings settings = Settings.LoadSettingsGivenConfigPaths(new string[] { pathContext.Settings.ConfigPath });
 
-            DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(project1Spec, project2Spec);
+            DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(project1Spec, project2Spec);
             var dgProvider = new DependencyGraphSpecRequestProvider(
                 new RestoreCommandProvidersCache(),
                 dgSpec,
@@ -2303,7 +2303,7 @@ namespace NuGet.Commands.FuncTest
             pathContext.Settings.AddPackageSourceMapping(PrimarySourceName, packageA.Id);
             ISettings settings = Settings.LoadSettingsGivenConfigPaths(new string[] { pathContext.Settings.ConfigPath });
 
-            DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(project1Spec, project2Spec);
+            DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(project1Spec, project2Spec);
             var dgProvider = new DependencyGraphSpecRequestProvider(
                 new RestoreCommandProvidersCache(),
                 dgSpec,
@@ -2359,7 +2359,7 @@ namespace NuGet.Commands.FuncTest
             pathContext.Settings.AddPackageSourceMapping(PrimarySourceName, packageA.Id);
             ISettings settings = Settings.LoadSettingsGivenConfigPaths(new string[] { pathContext.Settings.ConfigPath });
 
-            DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(project1Spec, project2Spec);
+            DependencyGraphSpec dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(project1Spec, project2Spec);
             var dgProvider = new DependencyGraphSpecRequestProvider(
                 new RestoreCommandProvidersCache(),
                 dgSpec,
@@ -3726,7 +3726,7 @@ namespace NuGet.Commands.FuncTest
 
             var spec = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net5.0", dependencyName: "a", useAssetTargetFallback: true, assetTargetFallbackFrameworks: "net472");
             var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(spec, pathContext, new TestLogger()));
-            // fix test
+
             // Act
             var result = await command.ExecuteAsync();
 
@@ -4005,7 +4005,7 @@ namespace NuGet.Commands.FuncTest
                 CacheContext = new SourceCacheContext()
             };
 
-            var dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(project1Spec, project2Spec);
+            var dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(project1Spec, project2Spec);
             var dgProvider = new DependencyGraphSpecRequestProvider(new RestoreCommandProvidersCache(), dgSpec);
 
             foreach (var request in await dgProvider.CreateRequests(restoreContext))
@@ -4050,7 +4050,7 @@ namespace NuGet.Commands.FuncTest
                 CacheContext = cacheContext,
             };
 
-            var dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(project1Spec, project2Spec);
+            var dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(project1Spec, project2Spec);
             var dgProvider = new DependencyGraphSpecRequestProvider(new RestoreCommandProvidersCache(), dgSpec);
 
             foreach (var request in await dgProvider.CreateRequests(restoreContext))

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -3476,7 +3476,7 @@ namespace NuGet.Commands.FuncTest
             cppCliProject = cppCliProject.WithTestProjectReference(managedProject);
             CreateFakeProjectFile(managedProject);
 
-            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(cppCliProject, new PackageSpec[] { managedProject }, pathContext, new TestLogger()));
+            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, new TestLogger(), cppCliProject, managedProject));
 
             // Preconditions
             var result = await command.ExecuteAsync();
@@ -3797,7 +3797,7 @@ namespace NuGet.Commands.FuncTest
             project1spec = project1spec.WithTestProjectReference(project2spec);
             CreateFakeProjectFile(project2spec);
 
-            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(project1spec, new PackageSpec[] { project2spec }, pathContext, new TestLogger()));
+            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, new TestLogger(), project1spec, project2spec));
 
             // Act
             var result = await command.ExecuteAsync();
@@ -3829,7 +3829,7 @@ namespace NuGet.Commands.FuncTest
             CreateFakeProjectFile(project2spec);
             CreateFakeProjectFile(project3spec);
 
-            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(project1spec, new PackageSpec[] { project2spec, project3spec }, pathContext, new TestLogger()));
+            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, new TestLogger(), project1spec, project2spec, project3spec));
 
             // Act
             var result = await command.ExecuteAsync();
@@ -3867,7 +3867,7 @@ namespace NuGet.Commands.FuncTest
             project1spec = project1spec.WithTestProjectReference(project2spec);
             CreateFakeProjectFile(project2spec);
 
-            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(project1spec, new PackageSpec[] { project2spec }, pathContext, new TestLogger()));
+            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, new TestLogger(), project1spec, project2spec));
 
             // Act
             var result = await command.ExecuteAsync();
@@ -3910,7 +3910,7 @@ namespace NuGet.Commands.FuncTest
             project1spec = project1spec.WithTestProjectReference(project2spec);
             CreateFakeProjectFile(project2spec);
 
-            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(project1spec, new PackageSpec[] { project2spec, project3spec }, pathContext, new TestLogger()));
+            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, new TestLogger(), project1spec, project2spec, project3spec));
 
             // Act
             var result = await command.ExecuteAsync();

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PackagesLockFileTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PackagesLockFileTests.cs
@@ -44,7 +44,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperations.AddOrUpdateDependency(packageSpec, packageA.Identity, packageSpec.TargetFrameworks.Select(e => e.FrameworkName));
 
                 // Preconditions.
-                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(packageSpec, pathContext, logger)).ExecuteAsync();
+                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec)).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
 
@@ -56,7 +56,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperations.RemoveDependency(packageSpec, packageA.Identity.Id);
                 logger.Clear();
                 // Act.
-                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(packageSpec, pathContext, logger)).ExecuteAsync();
+                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec)).ExecuteAsync();
 
                 // Assert.
                 result.Success.Should().BeFalse();
@@ -89,7 +89,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperations.AddOrUpdateDependency(packageSpec, packageA.Identity, packageSpec.TargetFrameworks.Select(e => e.FrameworkName));
 
                 // Preconditions.
-                var result = await (new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(packageSpec, pathContext, logger))).ExecuteAsync();
+                var result = await (new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec))).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
 
@@ -101,7 +101,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperationsUtility.AddTargetFramework(packageSpec, "net48");
                 logger.Clear();
                 // Act.
-                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(packageSpec, pathContext, logger)).ExecuteAsync();
+                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec)).ExecuteAsync();
 
                 // Assert.
                 result.Success.Should().BeFalse();
@@ -134,7 +134,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperations.AddOrUpdateDependency(packageSpec, packageA.Identity, packageSpec.TargetFrameworks.Select(e => e.FrameworkName));
 
                 // Preconditions.
-                var result = await (new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(packageSpec, pathContext, logger))).ExecuteAsync();
+                var result = await (new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec))).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
 
@@ -147,7 +147,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperationsUtility.AddTargetFramework(packageSpec, "net48");
                 logger.Clear();
                 // Act.
-                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(packageSpec, pathContext, logger)).ExecuteAsync();
+                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec)).ExecuteAsync();
 
                 // Assert.
                 result.Success.Should().BeFalse();
@@ -183,7 +183,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperations.AddOrUpdateDependency(packageSpec, packageA.Identity, packageSpec.TargetFrameworks.Select(e => e.FrameworkName));
 
                 // Preconditions.
-                var result = await (new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(packageSpec, pathContext, logger))).ExecuteAsync();
+                var result = await (new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec))).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
 
@@ -196,7 +196,7 @@ namespace NuGet.Commands.FuncTest
 
                 logger.Clear();
                 // Act.
-                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(packageSpec, pathContext, logger)).ExecuteAsync();
+                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec)).ExecuteAsync();
 
                 // Assert.
                 result.Success.Should().BeFalse();
@@ -234,7 +234,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperations.AddOrUpdateDependency(packageSpec, packageB.Identity, packageSpec.TargetFrameworks.Select(e => e.FrameworkName));
 
                 // Preconditions.
-                var result = await (new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(packageSpec, pathContext, logger))).ExecuteAsync();
+                var result = await (new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec))).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
 
@@ -247,7 +247,7 @@ namespace NuGet.Commands.FuncTest
 
                 logger.Clear();
                 // Act.
-                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(packageSpec, pathContext, logger)).ExecuteAsync();
+                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec)).ExecuteAsync();
 
                 // Assert.
                 result.Success.Should().BeFalse();
@@ -285,7 +285,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperations.AddOrUpdateDependency(packageSpec, packageB.Identity, packageSpec.TargetFrameworks.Select(e => e.FrameworkName));
 
                 // Preconditions.
-                var result = await (new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(packageSpec, pathContext, logger))).ExecuteAsync();
+                var result = await (new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec))).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
 
@@ -299,7 +299,7 @@ namespace NuGet.Commands.FuncTest
 
                 logger.Clear();
                 // Act.
-                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(packageSpec, pathContext, logger)).ExecuteAsync();
+                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec)).ExecuteAsync();
 
                 // Assert.
                 result.Success.Should().BeFalse();
@@ -335,7 +335,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperations.AddOrUpdateDependency(packageSpec, packageA.Identity, packageSpec.TargetFrameworks.Select(e => e.FrameworkName));
 
                 // Preconditions.
-                var result = await (new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(packageSpec, pathContext, logger))).ExecuteAsync();
+                var result = await (new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec))).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
 
@@ -347,7 +347,7 @@ namespace NuGet.Commands.FuncTest
                 packageSpec.RuntimeGraph = ProjectTestHelpers.GetRuntimeGraph(runtimeIdentifiers: new string[] { "win", "unix", "ios" }, runtimeSupports: new string[] { });
                 logger.Clear();
                 // Act.
-                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(packageSpec, pathContext, logger)).ExecuteAsync();
+                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec)).ExecuteAsync();
 
                 // Assert.
                 result.Success.Should().BeFalse();
@@ -669,7 +669,7 @@ namespace NuGet.Commands.FuncTest
                    childProject.RestoreMetadata.RestoreLockProperties.NuGetLockFilePath,
                    restoreLockedMode: false);
 
-                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(childProject, pathContext, logger)).ExecuteAsync();
+                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, childProject)).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PackagesLockFileTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PackagesLockFileTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -384,21 +383,18 @@ namespace NuGet.Commands.FuncTest
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .WithPackagesLockFile()
                     .Build();
-                allPackageSpecs.Add(rootPackageSpec);
 
                 projectName = "IntermediateProject1";
                 projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
                 var intermediateProject1PackageSpec = PackageReferenceSpecBuilder.Create(projectName, projectDirectory)
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .Build();
-                allPackageSpecs.Add(intermediateProject1PackageSpec);
 
                 projectName = "LeafProject";
                 projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
                 var leafProjectPackageSpec = PackageReferenceSpecBuilder.Create(projectName, projectDirectory)
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .Build();
-                allPackageSpecs.Add(leafProjectPackageSpec);
 
                 // Add the dependency to all frameworks
                 PackageSpecOperations.AddOrUpdateDependency(rootPackageSpec, packageA.Identity, rootPackageSpec.TargetFrameworks.Select(e => e.FrameworkName));
@@ -408,7 +404,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperationsUtility.AddProjectReference(intermediateProject1PackageSpec, leafProjectPackageSpec, targetFramework);
 
                 // Preconditions.
-                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(rootPackageSpec, allPackageSpecs, pathContext, logger)).ExecuteAsync();
+                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, rootPackageSpec, intermediateProject1PackageSpec, leafProjectPackageSpec)).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
 
@@ -425,10 +421,9 @@ namespace NuGet.Commands.FuncTest
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .Build();
                 PackageSpecOperationsUtility.AddProjectReference(rootPackageSpec, intermediateProject2PackageSpec, targetFramework);
-                allPackageSpecs.Add(intermediateProject2PackageSpec);
 
                 // Act.
-                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(rootPackageSpec, allPackageSpecs, pathContext, logger)).ExecuteAsync();
+                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, rootPackageSpec, intermediateProject1PackageSpec, leafProjectPackageSpec, intermediateProject2PackageSpec)).ExecuteAsync();
 
                 // Assert.
                 result.Success.Should().BeFalse();
@@ -456,7 +451,6 @@ namespace NuGet.Commands.FuncTest
                     packageC);
 
                 var targetFramework = CommonFrameworks.Net46;
-                var allPackageSpecs = new List<PackageSpec>();
 
                 var projectName = "RootProject";
                 var projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
@@ -464,21 +458,18 @@ namespace NuGet.Commands.FuncTest
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .WithPackagesLockFile()
                     .Build();
-                allPackageSpecs.Add(rootPackageSpec);
 
                 projectName = "IntermediateProject";
                 projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
                 var intermediatePackageSpec = PackageReferenceSpecBuilder.Create(projectName, projectDirectory)
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .Build();
-                allPackageSpecs.Add(intermediatePackageSpec);
 
                 projectName = "LeafProject1";
                 projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
                 var leafProject1PackageSpec = PackageReferenceSpecBuilder.Create(projectName, projectDirectory)
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .Build();
-                allPackageSpecs.Add(leafProject1PackageSpec);
 
                 // Add the dependency to all frameworks
                 PackageSpecOperations.AddOrUpdateDependency(rootPackageSpec, packageA.Identity, rootPackageSpec.TargetFrameworks.Select(e => e.FrameworkName));
@@ -488,7 +479,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperationsUtility.AddProjectReference(intermediatePackageSpec, leafProject1PackageSpec, targetFramework);
 
                 // Preconditions.
-                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(rootPackageSpec, allPackageSpecs, pathContext, logger)).ExecuteAsync();
+                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, rootPackageSpec, intermediatePackageSpec, leafProject1PackageSpec)).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
 
@@ -505,10 +496,9 @@ namespace NuGet.Commands.FuncTest
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .Build();
                 PackageSpecOperationsUtility.AddProjectReference(intermediatePackageSpec, leafProject2PackageSpec, targetFramework);
-                allPackageSpecs.Add(leafProject2PackageSpec);
 
                 // Act.
-                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(rootPackageSpec, allPackageSpecs, pathContext, logger)).ExecuteAsync();
+                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, rootPackageSpec, intermediatePackageSpec, leafProject1PackageSpec, leafProject2PackageSpec)).ExecuteAsync();
 
                 // Assert.
                 result.Success.Should().BeFalse();
@@ -533,7 +523,6 @@ namespace NuGet.Commands.FuncTest
                     packageA);
 
                 var targetFramework = CommonFrameworks.Net46;
-                var allPackageSpecs = new List<PackageSpec>();
 
                 var projectName = "RootProject";
                 var projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
@@ -541,21 +530,19 @@ namespace NuGet.Commands.FuncTest
                     .WithTargetFrameworks(new string[] { "net46" })
                     .WithPackagesLockFile()
                     .Build();
-                allPackageSpecs.Add(rootPackageSpec);
 
                 projectName = "IntermediateProject";
                 projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
                 var projectReferenceSpec = PackageReferenceSpecBuilder.Create(projectName, projectDirectory)
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .Build();
-                allPackageSpecs.Add(projectReferenceSpec);
 
                 // Add the dependency to all frameworks
                 PackageSpecOperations.AddOrUpdateDependency(rootPackageSpec, packageA.Identity, rootPackageSpec.TargetFrameworks.Select(e => e.FrameworkName));
                 PackageSpecOperationsUtility.AddProjectReference(rootPackageSpec, projectReferenceSpec, targetFramework);
 
                 // Preconditions.
-                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(rootPackageSpec, allPackageSpecs, pathContext, logger)).ExecuteAsync();
+                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, rootPackageSpec, projectReferenceSpec)).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
 
@@ -570,7 +557,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperationsUtility.AddTargetFramework(projectReferenceSpec, "net47");
 
                 // Act.
-                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(rootPackageSpec, allPackageSpecs, pathContext, logger)).ExecuteAsync();
+                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, rootPackageSpec, projectReferenceSpec)).ExecuteAsync();
 
                 // Assert.
                 result.Success.Should().BeFalse();
@@ -595,7 +582,6 @@ namespace NuGet.Commands.FuncTest
                     packageA);
 
                 var targetFramework = CommonFrameworks.Net46;
-                var allPackageSpecs = new List<PackageSpec>();
 
                 var projectName = "RootProject";
                 var projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
@@ -603,22 +589,18 @@ namespace NuGet.Commands.FuncTest
                     .WithTargetFrameworks(new string[] { "net46" })
                     .WithPackagesLockFile()
                     .Build();
-                allPackageSpecs.Add(rootPackageSpec);
 
                 projectName = "IntermediateProject";
                 projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
                 var intermediateProjectReferenceSpec = PackageReferenceSpecBuilder.Create(projectName, projectDirectory)
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .Build();
-                allPackageSpecs.Add(intermediateProjectReferenceSpec);
-
 
                 projectName = "LeafProject";
                 projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
                 var leafProjectReferenceSpec = PackageReferenceSpecBuilder.Create(projectName, projectDirectory)
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .Build();
-                allPackageSpecs.Add(leafProjectReferenceSpec);
 
                 // Add the dependency to all frameworks
                 PackageSpecOperations.AddOrUpdateDependency(rootPackageSpec, packageA.Identity, rootPackageSpec.TargetFrameworks.Select(e => e.FrameworkName));
@@ -626,7 +608,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperationsUtility.AddProjectReference(intermediateProjectReferenceSpec, leafProjectReferenceSpec, targetFramework);
 
                 // Preconditions.
-                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(rootPackageSpec, allPackageSpecs, pathContext, logger)).ExecuteAsync();
+                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, rootPackageSpec, intermediateProjectReferenceSpec, leafProjectReferenceSpec)).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
 
@@ -641,7 +623,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperationsUtility.AddTargetFramework(leafProjectReferenceSpec, "net47");
 
                 // Act.
-                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(rootPackageSpec, allPackageSpecs, pathContext, logger)).ExecuteAsync();
+                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, rootPackageSpec, intermediateProjectReferenceSpec, leafProjectReferenceSpec)).ExecuteAsync();
 
                 // Assert.
                 result.Success.Should().BeFalse();
@@ -665,7 +647,6 @@ namespace NuGet.Commands.FuncTest
                     packageA);
 
                 var targetFramework = CommonFrameworks.Net46;
-                var allPackageSpecs = new List<PackageSpec>();
 
                 var projectName = "childProject";
                 var projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
@@ -673,7 +654,6 @@ namespace NuGet.Commands.FuncTest
                     .WithTargetFrameworks(new string[] { "net46" })
                     .WithPackagesLockFile()
                     .Build();
-                allPackageSpecs.Add(childProject);
 
                 // Add the dependency
                 var dependency = new LibraryDependency
@@ -699,7 +679,6 @@ namespace NuGet.Commands.FuncTest
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .WithPackagesLockFile()
                     .Build();
-                allPackageSpecs.Add(parentProject);
 
                 PackageSpecOperationsUtility.AddProjectReference(parentProject, childProject, targetFramework);
 
@@ -709,7 +688,7 @@ namespace NuGet.Commands.FuncTest
                    parentProject.RestoreMetadata.RestoreLockProperties.NuGetLockFilePath,
                    restoreLockedMode: false);
 
-                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(parentProject, allPackageSpecs, pathContext, logger)).ExecuteAsync();
+                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, parentProject, childProject)).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
 
@@ -720,7 +699,7 @@ namespace NuGet.Commands.FuncTest
                    parentProject.RestoreMetadata.RestoreLockProperties.NuGetLockFilePath,
                    restoreLockedMode: true);
 
-                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(parentProject, allPackageSpecs, pathContext, logger)).ExecuteAsync();
+                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, parentProject, childProject)).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert.
@@ -746,7 +725,6 @@ namespace NuGet.Commands.FuncTest
                     packageC);
 
                 var targetFramework = CommonFrameworks.Net46;
-                var allPackageSpecs = new List<PackageSpec>();
 
                 var projectName = "RootProject";
                 var projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
@@ -754,14 +732,12 @@ namespace NuGet.Commands.FuncTest
                     .WithTargetFrameworks(new string[] { "net46" })
                     .WithPackagesLockFile()
                     .Build();
-                allPackageSpecs.Add(rootPackageSpec);
 
                 projectName = "IntermediateProject";
                 projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
                 var intermediateProjectReferenceSpec = PackageReferenceSpecBuilder.Create(projectName, projectDirectory)
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .Build();
-                allPackageSpecs.Add(intermediateProjectReferenceSpec);
 
 
                 projectName = "LeafProject";
@@ -769,7 +745,6 @@ namespace NuGet.Commands.FuncTest
                 var leafProjectReferenceSpec = PackageReferenceSpecBuilder.Create(projectName, projectDirectory)
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .Build();
-                allPackageSpecs.Add(leafProjectReferenceSpec);
 
                 // Add the dependency to all frameworks
                 PackageSpecOperations.AddOrUpdateDependency(rootPackageSpec, packageA.Identity, rootPackageSpec.TargetFrameworks.Select(e => e.FrameworkName));
@@ -778,7 +753,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperationsUtility.AddProjectReference(intermediateProjectReferenceSpec, leafProjectReferenceSpec, targetFramework);
 
                 // Preconditions.
-                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(rootPackageSpec, allPackageSpecs, pathContext, logger)).ExecuteAsync();
+                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, rootPackageSpec, intermediateProjectReferenceSpec, leafProjectReferenceSpec)).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
 
@@ -792,7 +767,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperations.AddOrUpdateDependency(intermediateProjectReferenceSpec, packageC.Identity, rootPackageSpec.TargetFrameworks.Select(e => e.FrameworkName));
 
                 // Act.
-                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(rootPackageSpec, allPackageSpecs, pathContext, logger)).ExecuteAsync();
+                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, rootPackageSpec, intermediateProjectReferenceSpec, leafProjectReferenceSpec)).ExecuteAsync();
 
                 // Assert.
                 result.Success.Should().BeFalse();
@@ -822,7 +797,6 @@ namespace NuGet.Commands.FuncTest
                     packageD);
 
                 var targetFramework = CommonFrameworks.Net46;
-                var allPackageSpecs = new List<PackageSpec>();
 
                 var projectName = "RootProject";
                 var projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
@@ -830,22 +804,18 @@ namespace NuGet.Commands.FuncTest
                     .WithTargetFrameworks(new string[] { "net46" })
                     .WithPackagesLockFile()
                     .Build();
-                allPackageSpecs.Add(rootPackageSpec);
 
                 projectName = "IntermediateProject";
                 projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
                 var intermediateProjectReferenceSpec = PackageReferenceSpecBuilder.Create(projectName, projectDirectory)
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .Build();
-                allPackageSpecs.Add(intermediateProjectReferenceSpec);
-
 
                 projectName = "LeafProject";
                 projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
                 var leafProjectReferenceSpec = PackageReferenceSpecBuilder.Create(projectName, projectDirectory)
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .Build();
-                allPackageSpecs.Add(leafProjectReferenceSpec);
 
                 // Add the dependency to all frameworks
                 PackageSpecOperations.AddOrUpdateDependency(rootPackageSpec, packageA.Identity, rootPackageSpec.TargetFrameworks.Select(e => e.FrameworkName));
@@ -855,7 +825,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperationsUtility.AddProjectReference(intermediateProjectReferenceSpec, leafProjectReferenceSpec, targetFramework);
 
                 // Preconditions.
-                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(rootPackageSpec, allPackageSpecs, pathContext, logger)).ExecuteAsync();
+                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, rootPackageSpec, intermediateProjectReferenceSpec, leafProjectReferenceSpec)).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
 
@@ -869,7 +839,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperations.AddOrUpdateDependency(leafProjectReferenceSpec, packageD.Identity, rootPackageSpec.TargetFrameworks.Select(e => e.FrameworkName));
 
                 // Act.
-                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(rootPackageSpec, allPackageSpecs, pathContext, logger)).ExecuteAsync();
+                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, rootPackageSpec, intermediateProjectReferenceSpec, leafProjectReferenceSpec)).ExecuteAsync();
 
                 // Assert.
                 result.Success.Should().BeFalse();
@@ -899,7 +869,6 @@ namespace NuGet.Commands.FuncTest
                     packageC);
 
                 var targetFramework = CommonFrameworks.Net46;
-                var allPackageSpecs = new List<PackageSpec>();
 
                 var projectName = "RootProject";
                 var projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
@@ -907,22 +876,18 @@ namespace NuGet.Commands.FuncTest
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .WithPackagesLockFile()
                     .Build();
-                allPackageSpecs.Add(rootPackageSpec);
 
                 projectName = "IntermediateProject";
                 projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
                 var intermediateProjectReferenceSpec = PackageReferenceSpecBuilder.Create(projectName, projectDirectory)
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .Build();
-                allPackageSpecs.Add(intermediateProjectReferenceSpec);
-
 
                 projectName = "LeafProject";
                 projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
                 var leafProjectReferenceSpec = PackageReferenceSpecBuilder.Create(projectName, projectDirectory)
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .Build();
-                allPackageSpecs.Add(leafProjectReferenceSpec);
 
                 // Add the dependency to all frameworks
                 PackageSpecOperations.AddOrUpdateDependency(rootPackageSpec, packageB.Identity, rootPackageSpec.TargetFrameworks.Select(e => e.FrameworkName));
@@ -931,7 +896,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperationsUtility.AddProjectReference(intermediateProjectReferenceSpec, leafProjectReferenceSpec, targetFramework);
 
                 // Preconditions.
-                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(rootPackageSpec, allPackageSpecs, pathContext, logger)).ExecuteAsync();
+                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, rootPackageSpec, intermediateProjectReferenceSpec, leafProjectReferenceSpec)).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
 
@@ -945,7 +910,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperations.AddOrUpdateDependency(intermediateProjectReferenceSpec, packageA200.Identity, rootPackageSpec.TargetFrameworks.Select(e => e.FrameworkName));
 
                 // Act.
-                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(rootPackageSpec, allPackageSpecs, pathContext, logger)).ExecuteAsync();
+                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, rootPackageSpec, intermediateProjectReferenceSpec, leafProjectReferenceSpec)).ExecuteAsync();
 
                 // Assert.
                 result.Success.Should().BeFalse();
@@ -973,7 +938,6 @@ namespace NuGet.Commands.FuncTest
                     packageC);
 
                 var targetFramework = CommonFrameworks.Net46;
-                var allPackageSpecs = new List<PackageSpec>();
 
                 var projectName = "RootProject";
                 var projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
@@ -981,22 +945,18 @@ namespace NuGet.Commands.FuncTest
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .WithPackagesLockFile()
                     .Build();
-                allPackageSpecs.Add(rootPackageSpec);
 
                 projectName = "IntermediateProject";
                 projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
                 var intermediateProjectReferenceSpec = PackageReferenceSpecBuilder.Create(projectName, projectDirectory)
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .Build();
-                allPackageSpecs.Add(intermediateProjectReferenceSpec);
-
 
                 projectName = "LeafProject";
                 projectDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
                 var leafProjectReferenceSpec = PackageReferenceSpecBuilder.Create(projectName, projectDirectory)
                     .WithTargetFrameworks(new string[] { targetFramework.GetShortFolderName() })
                     .Build();
-                allPackageSpecs.Add(leafProjectReferenceSpec);
 
                 // Add the dependency to all frameworks
                 PackageSpecOperations.AddOrUpdateDependency(rootPackageSpec, packageB.Identity, rootPackageSpec.TargetFrameworks.Select(e => e.FrameworkName));
@@ -1004,7 +964,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperationsUtility.AddProjectReference(rootPackageSpec, intermediateProjectReferenceSpec, targetFramework);
 
                 // Preconditions.
-                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(rootPackageSpec, allPackageSpecs, pathContext, logger)).ExecuteAsync();
+                var result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, rootPackageSpec, intermediateProjectReferenceSpec, leafProjectReferenceSpec)).ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue();
 
@@ -1018,7 +978,7 @@ namespace NuGet.Commands.FuncTest
                 PackageSpecOperations.RemoveDependency(intermediateProjectReferenceSpec, packageA100.Identity.Id);
                 PackageSpecOperationsUtility.AddProjectReference(intermediateProjectReferenceSpec, leafProjectReferenceSpec, targetFramework);
                 // Act.
-                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(rootPackageSpec, allPackageSpecs, pathContext, logger)).ExecuteAsync();
+                result = await new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, rootPackageSpec, intermediateProjectReferenceSpec, leafProjectReferenceSpec)).ExecuteAsync();
 
                 // Assert.
                 result.Success.Should().BeFalse();

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/ProjectRestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/ProjectRestoreCommandTests.cs
@@ -42,7 +42,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                     .WithPackagesLockFile()
                     .Build();
 
-                var restoreRequest = ProjectTestHelpers.CreateRestoreRequest(packageSpec, pathContext, _logger);
+                var restoreRequest = ProjectTestHelpers.CreateRestoreRequest(pathContext, _logger, packageSpec);
 
                 var projectRestoreRequest = new ProjectRestoreRequest(restoreRequest, packageSpec, restoreRequest.ExistingLockFile, _collector); ;
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
@@ -58,9 +58,8 @@ namespace NuGet.Commands.Test
 
                 File.WriteAllText(specPath1, project1Json);
 
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, projectName, specPath1);
+                var spec1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec(projectName, Path.Combine(workingDir, "projects"), project1Json);
 
-                spec1 = spec1.EnsureRestoreMetadata();
                 spec1.RestoreMetadata.Sources = new List<PackageSource> { new PackageSource(packageSource.FullName) };
                 spec1.RestoreMetadata.PackagesPath = packagesDir.FullName;
                 var dgSpec = new DependencyGraphSpec();
@@ -68,7 +67,7 @@ namespace NuGet.Commands.Test
                 dgSpec.AddRestore(spec1.RestoreMetadata.ProjectUniqueName);
 
                 var logger = new TestLogger();
-                var lockPath = Path.Combine(project1.FullName, "project.assets.json");
+                var lockPath = Path.Combine(spec1.RestoreMetadata.OutputPath, "project.assets.json");
 
                 var sourceRepos = sources.Select(source => Repository.Factory.GetCoreV3(source.Source)).ToList();
 
@@ -139,8 +138,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                spec1 = spec1.EnsureRestoreMetadata();
+                var spec1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project1", Path.Combine(workingDir, "projects"), project1Json);
                 spec1.RestoreMetadata.Sources = new List<PackageSource> { new PackageSource(packageSource.FullName) };
                 spec1.RestoreMetadata.PackagesPath = packagesDir.FullName;
                 var dgFile = new DependencyGraphSpec();
@@ -148,7 +146,7 @@ namespace NuGet.Commands.Test
                 dgFile.AddRestore(spec1.RestoreMetadata.ProjectUniqueName);
 
                 var logger = new TestLogger();
-                var lockPath = Path.Combine(project1.FullName, "project.assets.json");
+                var lockPath = Path.Combine(spec1.RestoreMetadata.OutputPath, "project.assets.json");
 
                 var sourceRepos = sources.Select(source => Repository.Factory.GetCoreV3(source.Source)).ToList();
 
@@ -187,8 +185,8 @@ namespace NuGet.Commands.Test
                         }
                     };
 
-                    var targetsPath = Path.Combine(project1.FullName, "project1.csproj.nuget.g.targets");
-                    var propsPath = Path.Combine(project1.FullName, "project1.nuget.props");
+                    var targetsPath = Path.Combine(spec1.RestoreMetadata.OutputPath, "project1.csproj.nuget.g.targets");
+                    var propsPath = Path.Combine(spec1.RestoreMetadata.OutputPath, "project1.nuget.props");
 
                     // Act
                     var summaries = await RestoreRunner.RunAsync(restoreContext);
@@ -337,11 +335,10 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(workingDir, "NuGet.Config"), string.Format(configFile, packageSource.FullName));
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project1", Path.Combine(workingDir, "projects"), project1Json);
                 var configPath = Path.Combine(workingDir, "NuGet.Config");
 
                 var dgFile = new DependencyGraphSpec();
-                spec1 = spec1.EnsureRestoreMetadata();
                 spec1.RestoreMetadata.ConfigFilePaths = new List<string> { configPath };
                 spec1.RestoreMetadata.Sources = new List<PackageSource> { new PackageSource(packageSource.FullName) };
                 spec1.RestoreMetadata.PackagesPath = packagesDir.FullName;
@@ -350,7 +347,7 @@ namespace NuGet.Commands.Test
                 dgFile.AddRestore(spec1.RestoreMetadata.ProjectUniqueName);
 
                 var logger = new TestLogger();
-                var lockPath = Path.Combine(project1.FullName, "project.assets.json");
+                var lockPath = Path.Combine(spec1.RestoreMetadata.OutputPath, "project.assets.json");
 
                 var providerCache = new RestoreCommandProvidersCache();
 
@@ -718,9 +715,8 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project1", Path.Combine(workingDir, "projects"), project1Json);
 
-                spec1 = spec1.EnsureRestoreMetadata();
                 spec1.RestoreMetadata.Sources = new List<PackageSource> { new PackageSource(packageSource.FullName) };
                 spec1.RestoreMetadata.PackagesPath = packagesDir.FullName;
                 var dgSpec = new DependencyGraphSpec();
@@ -728,7 +724,7 @@ namespace NuGet.Commands.Test
                 dgSpec.AddRestore(spec1.RestoreMetadata.ProjectUniqueName);
 
                 var logger = new TestLogger();
-                var lockPath1 = Path.Combine(project1.FullName, "project.assets.json");
+                var lockPath1 = Path.Combine(spec1.RestoreMetadata.OutputPath, "project.assets.json");
 
                 var sourceRepos = sources.Select(source => Repository.Factory.GetCoreV3(source.Source)).ToList();
 
@@ -793,8 +789,7 @@ namespace NuGet.Commands.Test
                 var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource")); packageSource.Create();
                 var project1Folder = new DirectoryInfo(Path.Combine(workingDir, "projects", project1)); project1Folder.Create();
                 // set up project1
-                var projectSpec = JsonPackageSpecReader.GetPackageSpec(packageSpec, project1, project1Folder.FullName);
-                projectSpec = projectSpec.EnsureRestoreMetadata();
+                var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project1", Path.Combine(workingDir, "projects"), packageSpec);
                 var sources = new List<PackageSource>() { new PackageSource(packageSource.FullName) };
                 projectSpec.RestoreMetadata.Sources = sources;
                 projectSpec.RestoreMetadata.PackagesPath = globalPackagesFolder.FullName;
@@ -837,9 +832,9 @@ namespace NuGet.Commands.Test
                     var summary = summaries.Single();
 
                     // Assert
-                    var assetsFilePath = Path.Combine(project1Folder.FullName, "project.assets.json");
-                    var targetsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
-                    var propsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
+                    var assetsFilePath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, "project.assets.json");
+                    var targetsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
+                    var propsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
 
                     Assert.True(summary.Success);
                     Assert.True(File.Exists(assetsFilePath), assetsFilePath);
@@ -882,8 +877,7 @@ namespace NuGet.Commands.Test
                 var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource")); packageSource.Create();
                 var project1Folder = new DirectoryInfo(Path.Combine(workingDir, "projects", project1)); project1Folder.Create();
                 // set up project1
-                var projectSpec = JsonPackageSpecReader.GetPackageSpec(packageSpec, project1, project1Folder.FullName);
-                projectSpec = projectSpec.EnsureRestoreMetadata();
+                var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project1", Path.Combine(workingDir, "projects"), packageSpec);
                 var sources = new List<PackageSource>() { new PackageSource(packageSource.FullName) };
                 projectSpec.RestoreMetadata.Sources = sources;
                 projectSpec.RestoreMetadata.PackagesPath = globalPackagesFolder.FullName;
@@ -932,9 +926,9 @@ namespace NuGet.Commands.Test
                     var summary = summaries.Single();
 
                     // Assert
-                    var assetsFilePath = Path.Combine(project1Folder.FullName, "project.assets.json");
-                    var targetsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
-                    var propsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
+                    var assetsFilePath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, "project.assets.json");
+                    var targetsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
+                    var propsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
 
                     Assert.True(summary.Success);
                     Assert.True(File.Exists(assetsFilePath), assetsFilePath);
@@ -981,8 +975,7 @@ namespace NuGet.Commands.Test
                 var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource")); packageSource.Create();
                 var project1Folder = new DirectoryInfo(Path.Combine(workingDir, "projects", project1)); project1Folder.Create();
                 // set up project1
-                var projectSpec = JsonPackageSpecReader.GetPackageSpec(packageSpec, project1, project1Folder.FullName);
-                projectSpec = projectSpec.EnsureRestoreMetadata();
+                var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project1", Path.Combine(workingDir, "projects"), packageSpec);
                 var sources = new List<PackageSource>() { new PackageSource(packageSource.FullName) };
                 projectSpec.RestoreMetadata.Sources = sources;
                 projectSpec.RestoreMetadata.PackagesPath = globalPackagesFolder.FullName;
@@ -1025,9 +1018,9 @@ namespace NuGet.Commands.Test
                     var summary = summaries.Single();
 
                     // Assert
-                    var assetsFilePath = Path.Combine(project1Folder.FullName, "project.assets.json");
-                    var targetsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
-                    var propsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
+                    var assetsFilePath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, "project.assets.json");
+                    var targetsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
+                    var propsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
 
                     Assert.False(summary.Success);
                     Assert.True(File.Exists(assetsFilePath), assetsFilePath);
@@ -1073,8 +1066,7 @@ namespace NuGet.Commands.Test
                 var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource")); packageSource.Create();
                 var project1Folder = new DirectoryInfo(Path.Combine(workingDir, "projects", project1)); project1Folder.Create();
                 // set up project1
-                var projectSpec = JsonPackageSpecReader.GetPackageSpec(packageSpec, project1, project1Folder.FullName);
-                projectSpec = projectSpec.EnsureRestoreMetadata();
+                var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project1", Path.Combine(workingDir, "projects"), packageSpec);
                 var sources = new List<PackageSource>() { new PackageSource(packageSource.FullName) };
                 projectSpec.RestoreMetadata.Sources = sources;
                 projectSpec.RestoreMetadata.PackagesPath = globalPackagesFolder.FullName;
@@ -1117,9 +1109,9 @@ namespace NuGet.Commands.Test
                     var summary = summaries.Single();
 
                     // Assert
-                    var assetsFilePath = Path.Combine(project1Folder.FullName, "project.assets.json");
-                    var targetsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
-                    var propsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
+                    var assetsFilePath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, "project.assets.json");
+                    var targetsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
+                    var propsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
 
                     Assert.False(summary.Success);
                     Assert.True(File.Exists(assetsFilePath), assetsFilePath);
@@ -1179,8 +1171,7 @@ namespace NuGet.Commands.Test
                 var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource")); packageSource.Create();
                 var project1Folder = new DirectoryInfo(Path.Combine(workingDir, "projects", project1)); project1Folder.Create();
                 // set up project1
-                var projectSpec = JsonPackageSpecReader.GetPackageSpec(packageSpec, project1, project1Folder.FullName);
-                projectSpec = projectSpec.EnsureRestoreMetadata();
+                var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project1", Path.Combine(workingDir, "projects"), packageSpec);
                 var sources = new List<PackageSource>() { new PackageSource(packageSource.FullName) };
                 projectSpec.RestoreMetadata.Sources = sources;
                 projectSpec.RestoreMetadata.PackagesPath = globalPackagesFolder.FullName;
@@ -1228,9 +1219,9 @@ namespace NuGet.Commands.Test
                     var summary = summaries.Single();
 
                     // Assert
-                    var assetsFilePath = Path.Combine(project1Folder.FullName, "project.assets.json");
-                    var targetsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
-                    var propsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
+                    var assetsFilePath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, "project.assets.json");
+                    var targetsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
+                    var propsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
 
                     Assert.True(summary.Success);
                     Assert.True(File.Exists(assetsFilePath), assetsFilePath);
@@ -1284,8 +1275,7 @@ namespace NuGet.Commands.Test
                 var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource")); packageSource.Create();
                 var project1Folder = new DirectoryInfo(Path.Combine(workingDir, "projects", project1)); project1Folder.Create();
                 // set up project1
-                var projectSpec = JsonPackageSpecReader.GetPackageSpec(packageSpec, project1, project1Folder.FullName);
-                projectSpec = projectSpec.EnsureRestoreMetadata();
+                var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project1", Path.Combine(workingDir, "projects"), packageSpec);
                 var sources = new List<PackageSource>() { new PackageSource(packageSource.FullName) };
                 projectSpec.RestoreMetadata.Sources = sources;
                 projectSpec.RestoreMetadata.PackagesPath = globalPackagesFolder.FullName;
@@ -1327,9 +1317,9 @@ namespace NuGet.Commands.Test
                     var summary = summaries.Single();
 
                     // Assert
-                    var assetsFilePath = Path.Combine(project1Folder.FullName, "project.assets.json");
-                    var targetsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
-                    var propsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
+                    var assetsFilePath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, "project.assets.json");
+                    var targetsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
+                    var propsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
 
                     Assert.False(summary.Success);
                     Assert.True(File.Exists(assetsFilePath), assetsFilePath);
@@ -1392,8 +1382,7 @@ namespace NuGet.Commands.Test
                 var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource")); packageSource.Create();
                 var project1Folder = new DirectoryInfo(Path.Combine(workingDir, "projects", project1)); project1Folder.Create();
                 // set up project1
-                var projectSpec = JsonPackageSpecReader.GetPackageSpec(packageSpec, project1, project1Folder.FullName);
-                projectSpec = projectSpec.EnsureRestoreMetadata();
+                var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project1", Path.Combine(workingDir, "projects"), packageSpec);
                 var sources = new List<PackageSource>() { new PackageSource(packageSource.FullName) };
                 projectSpec.RestoreMetadata.Sources = sources;
                 projectSpec.RestoreMetadata.PackagesPath = globalPackagesFolder.FullName;
@@ -1441,9 +1430,9 @@ namespace NuGet.Commands.Test
                     var summary = summaries.Single();
 
                     // Assert
-                    var assetsFilePath = Path.Combine(project1Folder.FullName, "project.assets.json");
-                    var targetsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
-                    var propsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
+                    var assetsFilePath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, "project.assets.json");
+                    var targetsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
+                    var propsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
 
                     Assert.False(summary.Success);
                     Assert.True(File.Exists(assetsFilePath), assetsFilePath);
@@ -1502,8 +1491,7 @@ namespace NuGet.Commands.Test
                 var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource")); packageSource.Create();
                 var project1Folder = new DirectoryInfo(Path.Combine(workingDir, "projects", project1)); project1Folder.Create();
                 // set up project1
-                var projectSpec = JsonPackageSpecReader.GetPackageSpec(packageSpec, project1, project1Folder.FullName);
-                projectSpec = projectSpec.EnsureRestoreMetadata();
+                var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project1", Path.Combine(workingDir, "projects"), packageSpec);
                 var sources = new List<PackageSource>() { new PackageSource(packageSource.FullName) };
                 projectSpec.RestoreMetadata.Sources = sources;
                 projectSpec.RestoreMetadata.PackagesPath = globalPackagesFolder.FullName;
@@ -1537,9 +1525,9 @@ namespace NuGet.Commands.Test
                     var summary = summaries.Single();
 
                     // Assert
-                    var assetsFilePath = Path.Combine(project1Folder.FullName, "project.assets.json");
-                    var targetsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
-                    var propsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
+                    var assetsFilePath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, "project.assets.json");
+                    var targetsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
+                    var propsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
 
                     Assert.True(summary.Success);
                     Assert.True(File.Exists(assetsFilePath), assetsFilePath);
@@ -1593,8 +1581,7 @@ namespace NuGet.Commands.Test
                 var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource")); packageSource.Create();
                 var project1Folder = new DirectoryInfo(Path.Combine(workingDir, "projects", project1)); project1Folder.Create();
                 // set up project1
-                var projectSpec = JsonPackageSpecReader.GetPackageSpec(packageSpec, project1, project1Folder.FullName);
-                projectSpec = projectSpec.EnsureRestoreMetadata();
+                var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project1", Path.Combine(workingDir, "projects"), packageSpec);
                 var sources = new List<PackageSource>() { new PackageSource(packageSource.FullName) };
                 projectSpec.RestoreMetadata.Sources = sources;
                 projectSpec.RestoreMetadata.PackagesPath = globalPackagesFolder.FullName;
@@ -1629,9 +1616,9 @@ namespace NuGet.Commands.Test
                     var summary = summaries.Single();
 
                     // Assert
-                    var assetsFilePath = Path.Combine(project1Folder.FullName, "project.assets.json");
-                    var targetsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
-                    var propsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
+                    var assetsFilePath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, "project.assets.json");
+                    var targetsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
+                    var propsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
 
                     Assert.True(summary.Success);
                     Assert.True(File.Exists(assetsFilePath), assetsFilePath);
@@ -1671,8 +1658,7 @@ namespace NuGet.Commands.Test
                 var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource")); packageSource.Create();
                 var project1Folder = new DirectoryInfo(Path.Combine(workingDir, "projects", project1)); project1Folder.Create();
                 // set up project1
-                var projectSpec = JsonPackageSpecReader.GetPackageSpec(packageSpec, project1, project1Folder.FullName);
-                projectSpec = projectSpec.EnsureRestoreMetadata();
+                var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project1", Path.Combine(workingDir, "projects"), packageSpec);
                 var sources = new List<PackageSource>() { new PackageSource(packageSource.FullName) };
                 projectSpec.RestoreMetadata.Sources = sources;
                 projectSpec.RestoreMetadata.PackagesPath = globalPackagesFolder.FullName;
@@ -1725,9 +1711,9 @@ namespace NuGet.Commands.Test
                     var summary = summaries.Single();
 
                     // Assert
-                    var assetsFilePath = Path.Combine(project1Folder.FullName, "project.assets.json");
-                    var targetsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
-                    var propsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
+                    var assetsFilePath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, "project.assets.json");
+                    var targetsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
+                    var propsPath = Path.Combine(projectSpec.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
 
                     Assert.True(summary.Success);
                     Assert.True(File.Exists(assetsFilePath), assetsFilePath);
@@ -1792,15 +1778,13 @@ namespace NuGet.Commands.Test
                 var project2Folder = new DirectoryInfo(Path.Combine(workingDir, "projects", project2)); project2Folder.Create();
 
                 // set up project1
-                var projectSpec1 = JsonPackageSpecReader.GetPackageSpec(packageSpec, project1, project1Folder.FullName);
-                projectSpec1 = projectSpec1.EnsureRestoreMetadata();
+                var projectSpec1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project1", Path.Combine(workingDir, "projects"), packageSpec);
                 var sources = new List<PackageSource>() { new PackageSource(packageSource.FullName) };
                 projectSpec1.RestoreMetadata.Sources = sources;
                 projectSpec1.RestoreMetadata.PackagesPath = globalPackagesFolder.FullName;
 
                 // set up project2
-                var projectSpec2 = JsonPackageSpecReader.GetPackageSpec(packageSpec2, project2, project2Folder.FullName);
-                projectSpec2 = projectSpec2.EnsureRestoreMetadata();
+                var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project2", Path.Combine(workingDir, "projects"), packageSpec2);
                 projectSpec2.RestoreMetadata.Sources = sources;
                 projectSpec2.RestoreMetadata.PackagesPath = globalPackagesFolder.FullName;
 
@@ -1855,9 +1839,9 @@ namespace NuGet.Commands.Test
                     Assert.True(summaries.All(e => e.Success), string.Join(Environment.NewLine, logger.Messages));
 
                     // Assert project 2
-                    var assetsFilePath2 = Path.Combine(project2Folder.FullName, "project.assets.json");
-                    var targetsPath2 = Path.Combine(project2Folder.FullName, $"{project2}.csproj.nuget.g.targets");
-                    var propsPath2 = Path.Combine(project2Folder.FullName, $"{project2}.csproj.nuget.g.targets");
+                    var assetsFilePath2 = Path.Combine(projectSpec2.RestoreMetadata.OutputPath, "project.assets.json");
+                    var targetsPath2 = Path.Combine(projectSpec2.RestoreMetadata.OutputPath, $"{project2}.csproj.nuget.g.targets");
+                    var propsPath2 = Path.Combine(projectSpec2.RestoreMetadata.OutputPath, $"{project2}.csproj.nuget.g.targets");
 
                     Assert.True(File.Exists(assetsFilePath2), assetsFilePath2);
                     var lockFile = LockFileUtilities.GetLockFile(assetsFilePath2, NullLogger.Instance);
@@ -1874,9 +1858,9 @@ namespace NuGet.Commands.Test
 
 
                     // Assert project 1
-                    var assetsFilePath = Path.Combine(project1Folder.FullName, "project.assets.json");
-                    var targetsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
-                    var propsPath = Path.Combine(project1Folder.FullName, $"{project1}.csproj.nuget.g.targets");
+                    var assetsFilePath = Path.Combine(projectSpec1.RestoreMetadata.OutputPath, "project.assets.json");
+                    var targetsPath = Path.Combine(projectSpec1.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
+                    var propsPath = Path.Combine(projectSpec1.RestoreMetadata.OutputPath, $"{project1}.csproj.nuget.g.targets");
 
                     Assert.True(File.Exists(assetsFilePath), assetsFilePath);
                     lockFile = LockFileUtilities.GetLockFile(assetsFilePath, NullLogger.Instance);

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/DependencyGraphRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/DependencyGraphRestoreUtilityTests.cs
@@ -159,7 +159,7 @@ namespace NuGet.PackageManagement.Test
 
             // Act
             IReadOnlyList<RestoreSummary> result = await DependencyGraphRestoreUtility.RestoreAsync(
-                ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec),
+                ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec),
                 new DependencyGraphCacheContext(),
                 new RestoreCommandProvidersCache(),
                 cacheContextModifier: _ => { },
@@ -205,7 +205,7 @@ namespace NuGet.PackageManagement.Test
             using var pathContext = new SimpleTestPathContext();
             var settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
             var packageSpec = ProjectTestHelpers.GetPackageSpec(settings, projectName: "projectName", rootPath: pathContext.SolutionRoot);
-            var dgSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+            var dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
             var progressReporter = new Mock<IRestoreProgressReporter>();
 
             // Pre-Conditions
@@ -287,7 +287,7 @@ namespace NuGet.PackageManagement.Test
 
             // Pre-Conditions
             IReadOnlyList<RestoreSummary> result = await DependencyGraphRestoreUtility.RestoreAsync(
-                ProjectTestHelpers.GetDGSpecFromPackageSpecs(project1, project2),
+                ProjectTestHelpers.GetDGSpecForAllProjects(project1, project2),
                 new DependencyGraphCacheContext(),
                 new RestoreCommandProvidersCache(),
                 cacheContextModifier: _ => { },
@@ -345,7 +345,7 @@ namespace NuGet.PackageManagement.Test
 
             // Act
             result = await DependencyGraphRestoreUtility.RestoreAsync(
-               ProjectTestHelpers.GetDGSpecFromPackageSpecs(project1.WithTestProjectReference(project2), project2),
+               ProjectTestHelpers.GetDGSpecForAllProjects(project1.WithTestProjectReference(project2), project2),
                new DependencyGraphCacheContext(),
                new RestoreCommandProvidersCache(),
                cacheContextModifier: _ => { },
@@ -402,7 +402,7 @@ namespace NuGet.PackageManagement.Test
 
             var projectName = "project";
             PackageSpec packageSpec = ProjectTestHelpers.GetPackageSpec(settings, projectName, rootPath: pathContext.SolutionRoot);
-            var dependencyGraphSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+            var dependencyGraphSpec = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
             mockProjectCache.Setup(pc => pc.TryGetProjectRestoreInfo(It.IsAny<string>(), out dependencyGraphSpec, out It.Ref<IReadOnlyList<IAssetsLogMessage>>.IsAny)).Returns(true);
 
             var projectCache = mockProjectCache.Object;
@@ -471,7 +471,7 @@ namespace NuGet.PackageManagement.Test
 
             var projectName = "project";
             PackageSpec packageSpec = ProjectTestHelpers.GetPackageSpec(settings, projectName, rootPath: pathContext.SolutionRoot);
-            var dependencyGraphSpec = ProjectTestHelpers.GetDGSpecFromPackageSpecs(packageSpec);
+            var dependencyGraphSpec = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
             mockProjectCache.Setup(pc => pc.TryGetProjectRestoreInfo(It.IsAny<string>(), out dependencyGraphSpec, out It.Ref<IReadOnlyList<IAssetsLogMessage>>.IsAny)).Returns(true);
 
             var projectCache = mockProjectCache.Object;

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileUtilitiesTests.cs
@@ -721,9 +721,9 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
             // Arrange
             var framework = CommonFrameworks.Net50;
             var frameworkShortName = framework.GetShortFolderName();
-            var projectA = ProjectTestHelpers.GetPackageSpec("A", framework: frameworkShortName);
-            var projectB = ProjectTestHelpers.GetPackageSpec("B", framework: frameworkShortName);
-            var projectC = ProjectTestHelpers.GetPackageSpec("C", framework: frameworkShortName);
+            var projectA = ProjectTestHelpers.GetPackageSpec("A", framework: frameworkShortName).WithTestRestoreMetadata();
+            var projectB = ProjectTestHelpers.GetPackageSpec("B", framework: frameworkShortName).WithTestRestoreMetadata();
+            var projectC = ProjectTestHelpers.GetPackageSpec("C", framework: frameworkShortName).WithTestRestoreMetadata();
 
             // A -> B
             projectA = projectA.WithTestProjectReference(projectB);
@@ -731,7 +731,7 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
             // A -> C
             projectA = projectA.WithTestProjectReference(projectC);
 
-            var dgSpec = ProjectTestHelpers.GetDGSpec(projectA, projectB, projectC);
+            var dgSpec = ProjectTestHelpers.GetDGSpecForFirstProject(projectA, projectB, projectC);
 
             var lockFile = new PackagesLockFileBuilder()
                         .WithTarget(target => target
@@ -754,9 +754,9 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
             // Arrange
             var framework = CommonFrameworks.Net50;
             var frameworkShortName = framework.GetShortFolderName();
-            var projectA = ProjectTestHelpers.GetPackageSpec("A", framework: frameworkShortName);
-            var projectB = ProjectTestHelpers.GetPackageSpec("B", framework: frameworkShortName);
-            var projectC = ProjectTestHelpers.GetPackageSpec("C", framework: frameworkShortName);
+            var projectA = ProjectTestHelpers.GetPackageSpec("A", framework: frameworkShortName).WithTestRestoreMetadata();
+            var projectB = ProjectTestHelpers.GetPackageSpec("B", framework: frameworkShortName).WithTestRestoreMetadata();
+            var projectC = ProjectTestHelpers.GetPackageSpec("C", framework: frameworkShortName).WithTestRestoreMetadata();
 
             // B -> C
             projectB = projectB.WithTestProjectReference(projectC);
@@ -764,7 +764,7 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
             // A -> B
             projectA = projectA.WithTestProjectReference(projectB);
 
-            var dgSpec = ProjectTestHelpers.GetDGSpec(projectA, projectB, projectC);
+            var dgSpec = ProjectTestHelpers.GetDGSpecForFirstProject(projectA, projectB, projectC);
 
             var lockFile = new PackagesLockFileBuilder()
                         .WithTarget(target => target
@@ -787,9 +787,9 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
             // Arrange
             var framework = CommonFrameworks.Net50;
             var frameworkShortName = framework.GetShortFolderName();
-            var projectA = ProjectTestHelpers.GetPackageSpec("A", framework: frameworkShortName);
-            var projectB = ProjectTestHelpers.GetPackageSpec("B", framework: frameworkShortName);
-            var projectD = ProjectTestHelpers.GetPackageSpec("D", framework: frameworkShortName);
+            var projectA = ProjectTestHelpers.GetPackageSpec("A", framework: frameworkShortName).WithTestRestoreMetadata();
+            var projectB = ProjectTestHelpers.GetPackageSpec("B", framework: frameworkShortName).WithTestRestoreMetadata();
+            var projectD = ProjectTestHelpers.GetPackageSpec("D", framework: frameworkShortName).WithTestRestoreMetadata();
 
             // B -> D
             projectB = projectB.WithTestProjectReference(projectD);
@@ -797,7 +797,7 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
             // A -> B
             projectA = projectA.WithTestProjectReference(projectB);
 
-            var dgSpec = ProjectTestHelpers.GetDGSpec(projectA, projectB, projectD);
+            var dgSpec = ProjectTestHelpers.GetDGSpecForFirstProject(projectA, projectB, projectD);
 
             var lockFile = new PackagesLockFileBuilder()
                         .WithTarget(target => target
@@ -824,8 +824,8 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
             // Arrange
             var framework = CommonFrameworks.Net50;
             var frameworkShortName = framework.GetShortFolderName();
-            var projectA = ProjectTestHelpers.GetPackageSpec("A", framework: frameworkShortName);
-            var projectB = ProjectTestHelpers.GetPackageSpec("B", framework: frameworkShortName);
+            var projectA = ProjectTestHelpers.GetPackageSpec("A", framework: frameworkShortName).WithTestRestoreMetadata();
+            var projectB = ProjectTestHelpers.GetPackageSpec("B", framework: frameworkShortName).WithTestRestoreMetadata();
 
             // A -> B
             projectA = projectA.WithTestProjectReference(projectB);
@@ -844,7 +844,7 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
 
             projectB.TargetFrameworks.First().Dependencies.Add(packageC);
 
-            var dgSpec = ProjectTestHelpers.GetDGSpec(projectA, projectB);
+            var dgSpec = ProjectTestHelpers.GetDGSpecForFirstProject(projectA, projectB);
 
             var lockFile = new PackagesLockFileBuilder()
                         .WithTarget(target => target
@@ -876,9 +876,9 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
             // Arrange
             var framework = CommonFrameworks.Net50;
             var frameworkShortName = framework.GetShortFolderName();
-            var projectA = ProjectTestHelpers.GetPackageSpec("A", framework: frameworkShortName);
-            var projectB = ProjectTestHelpers.GetPackageSpec("B", framework: frameworkShortName);
-            var projectC = ProjectTestHelpers.GetPackageSpec("C", framework: frameworkShortName);
+            var projectA = ProjectTestHelpers.GetPackageSpec("A", framework: frameworkShortName).WithTestRestoreMetadata();
+            var projectB = ProjectTestHelpers.GetPackageSpec("B", framework: frameworkShortName).WithTestRestoreMetadata();
+            var projectC = ProjectTestHelpers.GetPackageSpec("C", framework: frameworkShortName).WithTestRestoreMetadata();
 
             // B (PrivateAssets.All) -> C 
             projectB = projectB.WithTestProjectReference(projectC, privateAssets: LibraryIncludeFlags.All);
@@ -886,7 +886,7 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
             // A -> B
             projectA = projectA.WithTestProjectReference(projectB);
 
-            var dgSpec = ProjectTestHelpers.GetDGSpec(projectA, projectB, projectC);
+            var dgSpec = ProjectTestHelpers.GetDGSpecForFirstProject(projectA, projectB, projectC);
 
             var lockFile = new PackagesLockFileBuilder()
                         .WithTarget(target => target
@@ -913,10 +913,10 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
             // Arrange
             var framework = CommonFrameworks.Net50;
             var frameworkShortName = framework.GetShortFolderName();
-            var projectA = ProjectTestHelpers.GetPackageSpec("A", framework: frameworkShortName);
-            var projectB = ProjectTestHelpers.GetPackageSpec("B", framework: frameworkShortName);
-            var projectC = ProjectTestHelpers.GetPackageSpec("C", framework: frameworkShortName);
-            var projectD = ProjectTestHelpers.GetPackageSpec("D", framework: frameworkShortName);
+            var projectA = ProjectTestHelpers.GetPackageSpec("A", framework: frameworkShortName).WithTestRestoreMetadata();
+            var projectB = ProjectTestHelpers.GetPackageSpec("B", framework: frameworkShortName).WithTestRestoreMetadata();
+            var projectC = ProjectTestHelpers.GetPackageSpec("C", framework: frameworkShortName).WithTestRestoreMetadata();
+            var projectD = ProjectTestHelpers.GetPackageSpec("D", framework: frameworkShortName).WithTestRestoreMetadata();
 
             var packageC = new LibraryDependency(
                 new LibraryRange("packageC", versionRange: VersionRange.Parse("2.0.0"), LibraryDependencyTarget.Package),
@@ -945,7 +945,7 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
             // C -> PackageC
             projectC.TargetFrameworks.First().Dependencies.Add(packageC);
 
-            var dgSpec = ProjectTestHelpers.GetDGSpec(projectA, projectB, projectC, projectD);
+            var dgSpec = ProjectTestHelpers.GetDGSpecForFirstProject(projectA, projectB, projectC, projectD);
 
             var lockFile = new PackagesLockFileBuilder()
                         .WithTarget(target => target
@@ -987,9 +987,9 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
             // Arrange
             var framework = CommonFrameworks.Net50;
             var frameworkShortName = framework.GetShortFolderName();
-            var projectA = ProjectTestHelpers.GetPackageSpec("A", framework: frameworkShortName);
+            var projectA = ProjectTestHelpers.GetPackageSpec("A", framework: frameworkShortName).WithTestRestoreMetadata();
             var projectB = ProjectTestHelpers.GetPackagesConfigPackageSpec("B");
-            var projectC = ProjectTestHelpers.GetPackageSpec("C", framework: frameworkShortName);
+            var projectC = ProjectTestHelpers.GetPackageSpec("C", framework: frameworkShortName).WithTestRestoreMetadata();
 
             var packageC = new LibraryDependency(
                 new LibraryRange("packageC", versionRange: VersionRange.Parse("2.0.0"), LibraryDependencyTarget.Package),
@@ -1012,7 +1012,7 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
             // C -> PackageC
             projectC.TargetFrameworks.First().Dependencies.Add(packageC);
 
-            var dgSpec = ProjectTestHelpers.GetDGSpec(projectA, projectB, projectC);
+            var dgSpec = ProjectTestHelpers.GetDGSpecForFirstProject(projectA, projectB, projectC);
 
             var lockFile = new PackagesLockFileBuilder()
                         .WithTarget(target => target
@@ -1051,13 +1051,13 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
             var framework = CommonFrameworks.NetStandard;
             var frameworkShortName = framework.GetShortFolderName();
             var incompatibleFramework = CommonFrameworks.Net46;
-            var projectA = ProjectTestHelpers.GetPackageSpec("A", framework: frameworkShortName);
+            var projectA = ProjectTestHelpers.GetPackageSpec("A", framework: frameworkShortName).WithTestRestoreMetadata();
             var projectB = ProjectTestHelpers.GetPackagesConfigPackageSpec("B", framework: incompatibleFramework.GetShortFolderName());
 
             // A -> B
             projectA = projectA.WithTestProjectReference(projectB);
 
-            var dgSpec = ProjectTestHelpers.GetDGSpec(projectA, projectB);
+            var dgSpec = ProjectTestHelpers.GetDGSpecForFirstProject(projectA, projectB);
 
             var lockFile = new PackagesLockFileBuilder()
                         .WithTarget(target => target

--- a/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
@@ -218,13 +218,10 @@ namespace NuGet.Commands.Test
             return CreateRestoreRequest(projectToRestore, pathContext, logger, dgSpec);
         }
 
-        public static TestRestoreRequest CreateRestoreRequest(PackageSpec projectToRestore, IEnumerable<PackageSpec> packageSpecsClosure, SimpleTestPathContext pathContext, ILogger logger)
+        public static TestRestoreRequest CreateRestoreRequest(SimpleTestPathContext pathContext, ILogger logger, params PackageSpec[] projects)
         {
-            var projects = new List<PackageSpec>(packageSpecsClosure.Count() + 1);
-            projects.Add(projectToRestore);
-            projects.AddRange(packageSpecsClosure);
-            DependencyGraphSpec dgSpec = GetDGSpecForFirstProject(projects.ToArray());
-            return CreateRestoreRequest(projectToRestore, pathContext, logger, dgSpec);
+            DependencyGraphSpec dgSpec = GetDGSpecForFirstProject(projects);
+            return CreateRestoreRequest(projects[0], pathContext, logger, dgSpec);
         }
 
         private static TestRestoreRequest CreateRestoreRequest(PackageSpec projectToRestore, SimpleTestPathContext pathContext, ILogger logger, DependencyGraphSpec dgSpec)

--- a/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
@@ -211,13 +211,6 @@ namespace NuGet.Commands.Test
         /// <param name="projectToRestore"></param>
         /// <param name="pathContext"></param>
         /// <param name="logger"></param>
-        /// <returns></returns>
-        public static TestRestoreRequest CreateRestoreRequest(PackageSpec projectToRestore, SimpleTestPathContext pathContext, ILogger logger)
-        {
-            DependencyGraphSpec dgSpec = GetDGSpecForFirstProject(projectToRestore);
-            return CreateRestoreRequest(projectToRestore, pathContext, logger, dgSpec);
-        }
-
         public static TestRestoreRequest CreateRestoreRequest(SimpleTestPathContext pathContext, ILogger logger, params PackageSpec[] projects)
         {
             DependencyGraphSpec dgSpec = GetDGSpecForFirstProject(projects);

--- a/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
@@ -73,20 +73,6 @@ namespace NuGet.Commands.Test
         /// Add restore metadata only if not already set.
         /// Sets the project style to PackageReference.
         /// </summary>
-        public static PackageSpec EnsureRestoreMetadata(this PackageSpec spec)
-        {
-            if (string.IsNullOrEmpty(spec.RestoreMetadata?.ProjectUniqueName))
-            {
-                return spec.WithTestRestoreMetadata();
-            }
-
-            return spec;
-        }
-
-        /// <summary>
-        /// Add restore metadata only if not already set.
-        /// Sets the project style to PackageReference.
-        /// </summary>
         public static PackageSpec EnsureProjectJsonRestoreMetadata(this PackageSpec spec)
         {
             if (string.IsNullOrEmpty(spec.RestoreMetadata?.ProjectUniqueName))
@@ -327,7 +313,7 @@ namespace NuGet.Commands.Test
             return actualAssetTargetFallback;
         }
 
-        private static PackageSpec GetPackageSpecWithProjectNameAndSpec(string projectName, string rootPath, string spec)
+        public static PackageSpec GetPackageSpecWithProjectNameAndSpec(string projectName, string rootPath, string spec)
         {
             return JsonPackageSpecReader.GetPackageSpec(spec, projectName, Path.Combine(rootPath, projectName, projectName)).WithTestRestoreMetadata();
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2476

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Renamed GetDGSpec to GetDGSpecForFirstProject - more appropriate name
Renamed GetDGSpecFromPackageSpecs to GetDGSpecForAllProjects
Merged 2 CreateRestoreRequest implementations into 1. Now the PackageSpec sources are used if available to create the dependency provider. That unblocks https://github.com/NuGet/NuGet.Client/pull/5390
Refactor GetPackagesConfigPackageSpec as there's no other uses.
Remove EnsureRestoreMetadata, simplifying the number of utilities.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - This is test refactoring
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
