### PR TITLE
Optout http warnings by setting allowInsecureConnections in settings

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
@@ -131,7 +131,7 @@ namespace NuGet.CommandLine
             List<PackageSource> httpPackageSources = null;
             foreach (PackageSource packageSource in packageSources)
             {
-                if (packageSource.IsHttp && !packageSource.IsHttps)
+                if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections)
                 {
                     if (httpPackageSources == null)
                     {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/CheckedListBoxAccessibleObject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/CheckedListBoxAccessibleObject.cs
@@ -34,7 +34,7 @@ namespace NuGet.PackageManagement.UI.Options
             {
                 var item = (PackageSourceContextInfo)CheckedListBox.Items[index];
                 PackageSource packageSource = new PackageSource(item.Source, item.Name);
-                if (packageSource.IsHttp && !packageSource.IsHttps)
+                if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections)
                 {
                     var sourceMessage = string.Concat(
                         Resources.Warning_HTTPSource,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourceCheckedListBox.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourceCheckedListBox.cs
@@ -136,10 +136,11 @@ namespace NuGet.PackageManagement.UI.Options
                         graphics.DrawString(currentItem.Name, e.Font, foreBrush, nameBounds, drawFormat);
 
                         var packageSource = new PackageSource(currentItem.Source, currentItem.Name);
-                        var isSourceHttp = packageSource.IsHttp && !packageSource.IsHttps;
+                        packageSource.AllowInsecureConnections = currentItem.AllowInsecureConnections;
+                        var shouldShowHttpWarningIcon = packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections;
                         Rectangle warningBounds = default;
 
-                        if (isSourceHttp)
+                        if (shouldShowHttpWarningIcon)
                         {
                             var warningIcon = GetWarningIcon();
 
@@ -152,7 +153,7 @@ namespace NuGet.PackageManagement.UI.Options
                         }
 
                         var sourceBounds = new Rectangle(
-                            isSourceHttp ? warningBounds.Right : nameBounds.Left,
+                            shouldShowHttpWarningIcon ? warningBounds.Right : nameBounds.Left,
                             nameBounds.Bottom,
                             textWidth,
                             e.Bounds.Bottom - nameBounds.Bottom);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.Designer.cs
@@ -124,7 +124,6 @@ namespace NuGet.PackageManagement.UI.Options
             resources.ApplyResources(this.NewPackageSource, "NewPackageSource");
             this.NewPackageSource.Name = "NewPackageSource";
             this.NewPackageSource.AccessibleName = "Source:";
-            this.NewPackageSource.TextChanged += new System.EventHandler(this.NewPackageSource_TextChanged);
             // 
             // NewPackageNameLabel
             // 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -152,6 +152,16 @@ namespace NuGet.PackageManagement.UI.Options
                 // Always enable addButton for PackageSourceListBox
                 addButton.Enabled = true;
             }
+
+            // Show HttpWarning for the selected source if needed
+            if (selectedSource != null)
+            {
+                SetHttpWarningVisibilityForSelectSource(selectedSource);
+            }
+            else if (selectedMachineSource != null)
+            {
+                SetHttpWarningVisibilityForSelectSource(selectedMachineSource);
+            }
         }
 
         internal async Task InitializeOnActivatedAsync(CancellationToken cancellationToken)
@@ -477,6 +487,8 @@ namespace NuGet.PackageManagement.UI.Options
             selectedPackageSource.Source = source;
             _packageSources.ResetCurrentItem();
 
+            SetHttpWarningVisibilityForSelectSource(selectedPackageSource);
+
             return TryUpdateSourceResults.Successful;
         }
 
@@ -703,12 +715,13 @@ namespace NuGet.PackageManagement.UI.Options
             return path.IndexOfAny(Path.GetInvalidPathChars()) == -1 && Path.IsPathRooted(path);
         }
 
-        private void NewPackageSource_TextChanged(object sender, EventArgs e)
+        private void SetHttpWarningVisibilityForSelectSource(PackageSourceContextInfo selectedSource)
         {
-            var source = new PackageSource(NewPackageSource.Text.Trim(), NewPackageName.Text.Trim());
+            var source = new PackageSource(selectedSource.Source, selectedSource.Name);
+            source.AllowInsecureConnections = selectedSource.AllowInsecureConnections;
 
-            // Warn if the source is http, support for this will be removed
-            if (source.IsHttp && !source.IsHttps)
+            // Warn if the selected source is http, and the AllowInsecureConnections for this source is set to false. 
+            if (source.IsHttp && !source.IsHttps && !source.AllowInsecureConnections)
             {
                 HttpWarning.Visible = true;
                 HttpWarningIcon.Visible = true;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -164,7 +164,7 @@ namespace NuGet.CommandLine.XPlat
             List<PackageSource> httpPackageSources = null;
             foreach (PackageSource packageSource in listPackageArgs.PackageSources)
             {
-                if (packageSource.IsHttp && !packageSource.IsHttps)
+                if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections)
                 {
                     if (httpPackageSources == null)
                     {

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
@@ -29,7 +29,7 @@ namespace NuGet.Commands
             source = CommandRunnerUtility.ResolveSource(sourceProvider, source);
             PackageSource packageSource = CommandRunnerUtility.GetOrCreatePackageSource(sourceProvider, source);
             // Only warn for V3 style sources because they have a service index which is different from the final push url.
-            if (packageSource.IsHttp && !packageSource.IsHttps &&
+            if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections &&
                 (packageSource.ProtocolVersion == 3 || packageSource.Source.EndsWith("json", StringComparison.OrdinalIgnoreCase)))
             {
                 logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "delete", packageSource.Source));
@@ -42,6 +42,7 @@ namespace NuGet.Commands
                 endpoint => apiKey ?? CommandRunnerUtility.GetApiKey(settings, endpoint, source),
                 desc => nonInteractive || confirmFunc(desc),
                 noServiceEndpoint,
+                packageSource.AllowInsecureConnections,
                 logger);
         }
     }

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -42,7 +42,7 @@ namespace NuGet.Commands
             var packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, packageSource);
 
             // Only warn for V3 style sources because they have a service index which is different from the final push url.
-            if (packageSource.IsHttp && !packageSource.IsHttps &&
+            if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections &&
                 (packageSource.ProtocolVersion == 3 || packageSource.Source.EndsWith("json", StringComparison.OrdinalIgnoreCase)))
             {
                 logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "push", packageSource.Source));
@@ -90,6 +90,7 @@ namespace NuGet.Commands
                 noServiceEndpoint,
                 skipDuplicate,
                 symbolPackageUpdateResource,
+                packageSource.AllowInsecureConnections,
                 logger);
         }
 

--- a/src/NuGet.Core/NuGet.Commands/ListCommand/ListCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/ListCommand/ListCommandRunner.cs
@@ -69,7 +69,7 @@ namespace NuGet.Commands
             List<PackageSource> httpPackageSources = null;
             foreach (PackageSource packageSource in listArgs.ListEndpoints)
             {
-                if (packageSource.IsHttp && !packageSource.IsHttps)
+                if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections)
                 {
                     if (httpPackageSources == null)
                     {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -239,11 +239,12 @@ namespace NuGet.Commands
                     _success = false;
                 }
 
-                if (_request.Project?.RestoreMetadata != null)
+                if (_request.DependencyProviders.RemoteProviders != null)
                 {
-                    foreach (var source in _request.Project.RestoreMetadata.Sources)
+                    foreach (var remoteProvider in _request.DependencyProviders.RemoteProviders)
                     {
-                        if (source.IsHttp && !source.IsHttps)
+                        var source = remoteProvider.Source;
+                        if (source.IsHttp && !source.IsHttps && !source.AllowInsecureConnections)
                         {
                             await _logger.LogAsync(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1803,
                                 string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "restore", source.Source)));

--- a/src/NuGet.Core/NuGet.Commands/SourcesCommands/SourceRunners.cs
+++ b/src/NuGet.Core/NuGet.Commands/SourcesCommands/SourceRunners.cs
@@ -63,7 +63,7 @@ namespace NuGet.Commands
 
             var newPackageSource = new Configuration.PackageSource(args.Source, args.Name);
 
-            if (newPackageSource.IsHttp && !newPackageSource.IsHttps)
+            if (newPackageSource.IsHttp && !newPackageSource.IsHttps && !newPackageSource.AllowInsecureConnections)
             {
                 getLogger().LogWarning(
                     string.Format(CultureInfo.CurrentCulture,
@@ -202,7 +202,7 @@ namespace NuGet.Commands
             List<PackageSource> httpPackageSources = null;
             foreach (PackageSource packageSource in sources)
             {
-                if (packageSource.IsHttp && !packageSource.IsHttps)
+                if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections)
                 {
                     if (httpPackageSources == null)
                     {
@@ -284,7 +284,7 @@ namespace NuGet.Commands
                 existingSource = new Configuration.PackageSource(args.Source, existingSource.Name);
 
                 // If the existing source is not http, warn the user
-                if (existingSource.IsHttp && !existingSource.IsHttps)
+                if (existingSource.IsHttp && !existingSource.IsHttps && !existingSource.AllowInsecureConnections)
                 {
                     getLogger().LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "update source", args.Source));
                 }
@@ -378,7 +378,7 @@ namespace NuGet.Commands
             {
                 getLogger().LogMinimal(string.Format(CultureInfo.CurrentCulture,
                     Strings.SourcesCommandSourceEnabledSuccessfully, name));
-                if (packageSource.IsHttp && !packageSource.IsHttps)
+                if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections)
                 {
                     getLogger().LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "enable source", packageSource.Source));
                 }

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
@@ -379,7 +379,7 @@ namespace NuGet.PackageManagement
             foreach (SourceRepository enabledSource in packageRestoreContext.SourceRepositories)
             {
                 PackageSource source = enabledSource.PackageSource;
-                if (source.IsHttp && !source.IsHttps)
+                if (source.IsHttp && !source.IsHttps && !source.AllowInsecureConnections)
                 {
                     packageRestoreContext.Logger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "restore", source.Source));
                 }

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -1126,7 +1126,7 @@ namespace NuGet.PackageManagement
                 foreach (SourceRepository enabledSource in allSources)
                 {
                     PackageSource source = enabledSource.PackageSource;
-                    if (source.IsHttp && !source.IsHttps)
+                    if (source.IsHttp && !source.IsHttps && !source.AllowInsecureConnections)
                     {
                         nuGetProjectContext.Log(MessageLevel.Warning, Strings.Warning_HttpServerUsage, "update", source.Source);
                     }
@@ -1816,7 +1816,7 @@ namespace NuGet.PackageManagement
             foreach (SourceRepository enabledSource in effectiveSources)
             {
                 PackageSource source = enabledSource.PackageSource;
-                if (source.IsHttp && !source.IsHttps)
+                if (source.IsHttp && !source.IsHttps && !source.AllowInsecureConnections)
                 {
                     nuGetProjectContext.Log(MessageLevel.Warning, Strings.Warning_HttpServerUsage, "install", source.Source);
                 }

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -925,7 +925,7 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;http&apos; source, &apos;{1}&apos;. Support for &apos;http&apos; sources will be removed in a future version..
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;HTTP&apos; source, &apos;{1}&apos;. Non-HTTPS access will be removed in a future version. Consider migrating to an &apos;HTTPS&apos; source..
         /// </summary>
         internal static string Warning_HttpServerUsage {
             get {

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -430,7 +430,8 @@
     <comment>{0} - package id</comment>
   </data>
   <data name="Warning_HttpServerUsage" xml:space="preserve">
-    <value>You are running the '{0}' operation with an 'http' source, '{1}'. Support for 'http' sources will be removed in a future version.</value>
+    <value>You are running the '{0}' operation with an 'HTTP' source, '{1}'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.</value>
+    <comment>0 - The command name. Ex. Push/Delete. 1 - server uri.</comment>
   </data>
   <data name="Error_VulnerabilityDataFetch" xml:space="preserve">
     <value>Error occurred while getting package vulnerability data: {0}</value>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -8,3 +8,5 @@ NuGet.Protocol.PackageVulnerabilitySeverity.Low = 0 -> NuGet.Protocol.PackageVul
 NuGet.Protocol.PackageVulnerabilitySeverity.Moderate = 1 -> NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.PackageVulnerabilitySeverity.Unknown = -1 -> NuGet.Protocol.PackageVulnerabilitySeverity
 ~const NuGet.Protocol.JsonProperties.Url = "url" -> string
+~NuGet.Protocol.Core.Types.PackageUpdateResource.Delete(string packageId, string packageVersion, System.Func<string, string> getApiKey, System.Func<string, bool> confirm, bool noServiceEndpoint, bool allowInsecureConnections, NuGet.Common.ILogger log) -> System.Threading.Tasks.Task
+~NuGet.Protocol.Core.Types.PackageUpdateResource.Push(System.Collections.Generic.IList<string> packagePaths, string symbolSource, int timeoutInSecond, bool disableBuffering, System.Func<string, string> getApiKey, System.Func<string, string> getSymbolApiKey, bool noServiceEndpoint, bool skipDuplicate, NuGet.Protocol.Core.Types.SymbolPackageUpdateResourceV3 symbolPackageUpdateResource, bool allowInsecureConnections, NuGet.Common.ILogger log) -> System.Threading.Tasks.Task

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -8,3 +8,5 @@ NuGet.Protocol.PackageVulnerabilitySeverity.Low = 0 -> NuGet.Protocol.PackageVul
 NuGet.Protocol.PackageVulnerabilitySeverity.Moderate = 1 -> NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.PackageVulnerabilitySeverity.Unknown = -1 -> NuGet.Protocol.PackageVulnerabilitySeverity
 ~const NuGet.Protocol.JsonProperties.Url = "url" -> string
+~NuGet.Protocol.Core.Types.PackageUpdateResource.Delete(string packageId, string packageVersion, System.Func<string, string> getApiKey, System.Func<string, bool> confirm, bool noServiceEndpoint, bool allowInsecureConnections, NuGet.Common.ILogger log) -> System.Threading.Tasks.Task
+~NuGet.Protocol.Core.Types.PackageUpdateResource.Push(System.Collections.Generic.IList<string> packagePaths, string symbolSource, int timeoutInSecond, bool disableBuffering, System.Func<string, string> getApiKey, System.Func<string, string> getSymbolApiKey, bool noServiceEndpoint, bool skipDuplicate, NuGet.Protocol.Core.Types.SymbolPackageUpdateResourceV3 symbolPackageUpdateResource, bool allowInsecureConnections, NuGet.Common.ILogger log) -> System.Threading.Tasks.Task

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -8,3 +8,5 @@ NuGet.Protocol.PackageVulnerabilitySeverity.Low = 0 -> NuGet.Protocol.PackageVul
 NuGet.Protocol.PackageVulnerabilitySeverity.Moderate = 1 -> NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.PackageVulnerabilitySeverity.Unknown = -1 -> NuGet.Protocol.PackageVulnerabilitySeverity
 ~const NuGet.Protocol.JsonProperties.Url = "url" -> string
+~NuGet.Protocol.Core.Types.PackageUpdateResource.Delete(string packageId, string packageVersion, System.Func<string, string> getApiKey, System.Func<string, bool> confirm, bool noServiceEndpoint, bool allowInsecureConnections, NuGet.Common.ILogger log) -> System.Threading.Tasks.Task
+~NuGet.Protocol.Core.Types.PackageUpdateResource.Push(System.Collections.Generic.IList<string> packagePaths, string symbolSource, int timeoutInSecond, bool disableBuffering, System.Func<string, string> getApiKey, System.Func<string, string> getSymbolApiKey, bool noServiceEndpoint, bool skipDuplicate, NuGet.Protocol.Core.Types.SymbolPackageUpdateResourceV3 symbolPackageUpdateResource, bool allowInsecureConnections, NuGet.Common.ILogger log) -> System.Threading.Tasks.Task

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -1209,7 +1209,62 @@ namespace NuGet.CommandLine.FuncTest.Commands
             // Assert
             result.Success.Should().BeTrue();
             Assert.Contains($"Added package 'A.1.0.0' to folder '{projectAPackages}'", result.Output);
-            Assert.Contains("You are running the 'restore' operation with an 'http' source, 'http://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
+            Assert.Contains("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
+        }
+
+        [Theory]
+        [InlineData("false", true)]
+        [InlineData("FALSE", true)]
+        [InlineData("invalidString", true)]
+        [InlineData("", true)]
+        [InlineData("true", false)]
+        [InlineData("TRUE", false)]
+        public async Task Restore_WithHttpSourceAndFalseAllowInsecureConnections_WarnsCorrectly(string allowInsecureConnections, bool hasHttpWarning)
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            // Set up solution, project, and packages
+            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+            var packageA = new SimpleTestPackageContext("a", "1.0.0");
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageA);
+            pathContext.Settings.AddSource("http-feed", "http://api.source/index.json", allowInsecureConnections);
+            pathContext.Settings.AddSource("https-feed", "https://api.source/index.json", allowInsecureConnections);
+
+            var net461 = NuGetFramework.Parse("net461");
+            var projectB = new SimpleTestProjectContext(
+                "b",
+                ProjectStyle.PackagesConfig,
+                pathContext.SolutionRoot);
+            projectB.Frameworks.Add(new SimpleTestProjectFrameworkContext(net461));
+            var projectBPackages = Path.Combine(pathContext.SolutionRoot, "packages");
+
+            Util.CreateFile(Path.GetDirectoryName(projectB.ProjectPath), "packages.config",
+@"<packages>
+  <package id=""A"" version=""1.0.0"" targetFramework=""net461"" />
+</packages>");
+
+            solution.Projects.Add(projectB);
+            solution.Create(pathContext.SolutionRoot);
+
+            // Act
+            CommandRunnerResult result = RunRestore(pathContext, _successExitCode);
+
+            // Assert
+            string formatString = "You are running the 'restore' operation with an 'HTTP' source, '{0}'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS'";
+            string warningForHttpSource = string.Format(formatString, "http://api.source/index.json");
+            string warningForHttpsSource = string.Format(formatString, "https://api.source/index.json");
+
+            result.Success.Should().BeTrue();
+            Assert.Contains($"Added package 'A.1.0.0' to folder '{projectBPackages}'", result.Output);
+            Assert.DoesNotContain(warningForHttpsSource, result.Output);
+            if (hasHttpWarning)
+            {
+                Assert.Contains(warningForHttpSource, result.Output);
+            }
+            else
+            {
+                Assert.DoesNotContain(warningForHttpSource, result.Output);
+            }
         }
 
         public static string GetResource(string name)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -2052,7 +2052,68 @@ namespace NuGet.CommandLine.Test
             // Assert
             result.Success.Should().BeTrue();
             result.AllOutput.Should().Contain($"Added package 'A.1.0.0' to folder '{pathContext.PackagesV2}'");
-            result.AllOutput.Should().Contain("You are running the 'restore' operation with an 'http' source, 'http://api.source/api/v2'. Support for 'http' sources will be removed in a future version.");
+            result.AllOutput.Should().Contain("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/api/v2'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.");
+        }
+
+        [Theory]
+        [InlineData("false", true)]
+        [InlineData("FALSE", true)]
+        [InlineData("invalidString", true)]
+        [InlineData("", true)]
+        [InlineData("true", false)]
+        [InlineData("TRUE", false)]
+        public async Task Install_PackagesConfigWithHttpSourceAndAllowInsecureConnections_WarnsCorrectly(string allowInsecureConnections, bool hasHttpWarning)
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            // Set up solution, project, and packages
+            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+            var packageA = new SimpleTestPackageContext("a", "1.0.0");
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageA);
+            var packageAPath = Path.Combine(pathContext.PackageSource, packageA.Id, packageA.Version, packageA.PackageName);
+
+            pathContext.Settings.AddSource("http-feed", "http://api.source/index.json", allowInsecureConnections);
+            pathContext.Settings.AddSource("https-feed", "https://api.source/index.json", allowInsecureConnections);
+
+            var projectB = new SimpleTestProjectContext(
+                "b",
+                ProjectStyle.PackagesConfig,
+                pathContext.SolutionRoot);
+
+            Util.CreateFile(Path.GetDirectoryName(projectB.ProjectPath), "packages.config",
+@"<packages>
+  <package id=""A"" version=""1.0.0"" targetFramework=""net461"" />
+</packages>");
+
+            solution.Projects.Add(projectB);
+            solution.Create(pathContext.SolutionRoot);
+
+            var config = Path.Combine(Path.GetDirectoryName(projectB.ProjectPath), "packages.config");
+            var args = new string[]
+            {
+                "-OutputDirectory",
+                pathContext.PackagesV2
+            };
+
+            // Act
+            CommandRunnerResult result = RunInstall(pathContext, config, expectedExitCode: 0, additionalArgs: args);
+
+            // Assert
+            string formatString = "You are running the 'restore' operation with an 'HTTP' source, '{0}'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS'";
+            string warningForHttpSource = string.Format(formatString, "http://api.source/index.json");
+            string warningForHttpsSource = string.Format(formatString, "https://api.source/index.json");
+
+            result.Success.Should().BeTrue();
+            result.AllOutput.Should().Contain($"Added package 'A.1.0.0' to folder '{pathContext.PackagesV2}'");
+            Assert.DoesNotContain(warningForHttpsSource, result.Output);
+            if (hasHttpWarning)
+            {
+                Assert.Contains(warningForHttpSource, result.Output);
+            }
+            else
+            {
+                Assert.DoesNotContain(warningForHttpSource, result.Output); ;
+            }
         }
 
         [Fact]
@@ -2073,7 +2134,7 @@ namespace NuGet.CommandLine.Test
 
             server.Stop();
             result.AllOutput.Should().Contain($"Added package 'A.1.0.0' to folder");
-            result.AllOutput.Should().Contain("You are running the 'install' operation with an 'http' source");
+            result.AllOutput.Should().Contain("You are running the 'install' operation with an 'HTTP' source");
         }
 
         public static CommandRunnerResult RunInstall(SimpleTestPathContext pathContext, string input, int expectedExitCode = 0, params string[] additionalArgs)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -2456,8 +2456,10 @@ namespace NuGet.CommandLine.Test
             Util.TestCommandInvalidArguments(cmd);
         }
 
-        [Fact]
-        public void PushCommand_WhenPushingToAnHttpServer_Warns()
+        [Theory]
+        [InlineData("true", false)]
+        [InlineData("false", true)]
+        public void PushCommand_WhenPushingToAnHttpServerWithAllowInsecureConnections_WarnsCorrectly(string allowInsecureConnections, bool isHttpWarningExpected)
         {
             var nugetexe = Util.GetNuGetExePath();
 
@@ -2477,20 +2479,43 @@ namespace NuGet.CommandLine.Test
 
                 return HttpStatusCode.Created;
             });
+
+            // Arrange the NuGet.Config file
+            string nugetConfigContent =
+$@"<configuration>
+    <packageSources>
+        <clear />
+        <add key='http-feed' value='{server.Uri}push' protocalVersion=""3"" allowInsecureConnections=""{allowInsecureConnections}"" />
+    </packageSources>
+</configuration>";
+            string configPath = Path.Combine(packageDirectory, "NuGet.Config");
+            File.WriteAllText(configPath, nugetConfigContent);
+
             server.Start();
 
             // Act
             var result = CommandRunner.Run(
                             nugetexe,
                             Directory.GetCurrentDirectory(),
-                            $"push {packageFileName} -Source {server.Uri}push");
+                            $"push {packageFileName} -ConfigFile {configPath} -Source {server.Uri}push");
+
             // Assert
             result.Success.Should().BeTrue(result.AllOutput);
-            result.AllOutput.Should().Contain("WARNING: You are running the 'push' operation with an 'HTTP' source");
+            string expectedWarning = "WARNING: You are running the 'push' operation with an 'HTTP' source";
+            if (isHttpWarningExpected)
+            {
+                Assert.Contains(expectedWarning, result.AllOutput);
+            }
+            else
+            {
+                Assert.DoesNotContain(expectedWarning, result.AllOutput);
+            }
         }
 
-        [Fact]
-        public void PushCommand_WhenPushingToAnHttpServerWithSymbols_Warns()
+        [Theory]
+        [InlineData("true", false)]
+        [InlineData("false", true)]
+        public void PushCommand_WhenPushingToAnHttpServerWithSymbolsAndAllowInsecureConnections_WarnsCorrectly(string allowInsecureConnections, bool isHttpWarningExpected)
         {
             using var packageDirectory = TestDirectory.Create();
             using var server = new MockServer();
@@ -2515,6 +2540,17 @@ namespace NuGet.CommandLine.Test
                     : HttpStatusCode.Unauthorized;
             });
 
+            // Arrange the NuGet.Config file
+            string nugetConfigContent =
+$@"<configuration>
+    <packageSources>
+        <clear />
+        <add key='http-feed' value='{server.Uri}push' protocalVersion=""3"" allowInsecureConnections=""{allowInsecureConnections}"" />
+    </packageSources>
+</configuration>";
+            string configPath = Path.Combine(packageDirectory, "NuGet.Config");
+            File.WriteAllText(configPath, nugetConfigContent);
+
             server.Start();
 
             var pushUri = $"{server.Uri}push";
@@ -2524,7 +2560,7 @@ namespace NuGet.CommandLine.Test
             CommandRunnerResult result = CommandRunner.Run(
                 Util.GetNuGetExePath(),
                 Directory.GetCurrentDirectory(),
-                $"push {packageFileName} -Source {pushUri} -SymbolSource {pushSymbolsUri} -ApiKey PushKey -SymbolApiKey PushSymbolsKey");
+                $"push {packageFileName} -Source {pushUri} -SymbolSource {pushSymbolsUri} -ConfigFile {configPath} -ApiKey PushKey -SymbolApiKey PushSymbolsKey");
 
             // Assert
             result.Success.Should().BeTrue(because: result.AllOutput);
@@ -2533,10 +2569,21 @@ namespace NuGet.CommandLine.Test
             Assert.Contains($"Pushing testPackage1.1.1.0.symbols.nupkg to '{pushSymbolsUri}'", result.Output);
             Assert.Contains($"Created {pushSymbolsUri}", result.Output);
             Assert.Contains("Your package was pushed.", result.Output);
-            Assert.Contains($"WARNING: You are running the 'push' operation with an 'HTTP' source, '{pushUri}/'", result.AllOutput);
-            Assert.Contains($"WARNING: You are running the 'push' operation with an 'HTTP' source, '{pushSymbolsUri}/'", result.AllOutput);
-        }
 
+            string expectedWarning = $"WARNING: You are running the 'push' operation with an 'HTTP' source, '{pushUri}/'";
+            string expectedSymbolWarning = $"WARNING: You are running the 'push' operation with an 'HTTP' source, '{pushSymbolsUri}/'";
+
+            if (isHttpWarningExpected)
+            {
+                Assert.Contains(expectedWarning, result.AllOutput);
+                Assert.Contains(expectedSymbolWarning, result.AllOutput);
+            }
+            else
+            {
+                Assert.DoesNotContain(expectedWarning, result.AllOutput);
+                Assert.DoesNotContain(expectedSymbolWarning, result.AllOutput);
+            }
+        }
         [Fact]
         public void PushCommand_WhenPushingToAnHttpServerV3_Warns()
         {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -1907,7 +1907,82 @@ namespace NuGet.CommandLine.Test
 
             // Assert
             r.Success.Should().BeTrue(r.AllOutput);
-            r.AllOutput.Should().Contain("You are running the 'update' operation with an 'http' source");
+            r.AllOutput.Should().Contain("You are running the 'update' operation with an 'HTTP' source");
         }
+
+        [Theory]
+        [InlineData("false", true)]
+        [InlineData("FALSE", true)]
+        [InlineData("invalidString", true)]
+        [InlineData("", true)]
+        [InlineData("true", false)]
+        [InlineData("TRUE", false)]
+        public async Task UpdateCommand_WithHttpSourceAndAllowInsecureConnections_WarnsCorrectly(string allowInsecureConnections, bool hasHttpWarning)
+        {
+            //Arrange
+            using var pathContext = new SimpleTestPathContext();
+            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+            var httpSourceDirectory = Path.Combine(pathContext.WorkingDirectory, "http-source");
+            var packageA100 = new SimpleTestPackageContext("a", "1.0.0");
+            var packageA200 = new SimpleTestPackageContext("a", "2.0.0");
+            await SimpleTestPackageUtility.CreatePackagesAsync(httpSourceDirectory, packageA100, packageA200);
+            var packageA100FileInfo = new FileInfo(Path.Combine(httpSourceDirectory, packageA100.PackageName));
+            var packageA200FileInfo = new FileInfo(Path.Combine(httpSourceDirectory, packageA200.PackageName));
+
+            using var server = Util.CreateMockServer(new[] { packageA100FileInfo, packageA200FileInfo });
+            server.Start();
+
+            var sourceUri = $"{server.Uri}nuget";
+            pathContext.Settings.AddSource("http-feed", $"{server.Uri}nuget", allowInsecureConnections);
+
+            var projectB = new SimpleTestProjectContext(
+                  "b",
+                  ProjectStyle.PackagesConfig,
+                  pathContext.SolutionRoot);
+
+            Util.CreateFile(Path.GetDirectoryName(projectB.ProjectPath), "packages.config",
+@"<packages>
+  <package id=""A"" version=""1.0.0"" targetFramework=""net461"" />
+</packages>");
+
+            solution.Projects.Add(projectB);
+            solution.Create(pathContext.SolutionRoot);
+
+            var args = new[]
+            {
+                    "restore",
+                    solution.SolutionPath
+            };
+
+            CommandRunnerResult restoreResult = CommandRunner.Run(
+                Util.GetNuGetExePath(),
+                pathContext.WorkingDirectory,
+                string.Join(" ", args));
+            restoreResult.Success.Should().BeTrue(restoreResult.AllOutput);
+            args = new[]
+            {
+                    "update",
+                    solution.SolutionPath,
+            };
+
+            // Act
+            CommandRunnerResult r = CommandRunner.Run(
+                Util.GetNuGetExePath(),
+                pathContext.WorkingDirectory,
+                string.Join(" ", args));
+            server.Stop();
+
+            // Assert
+            r.Success.Should().BeTrue(r.AllOutput);
+            if (hasHttpWarning)
+            {
+                r.AllOutput.Should().Contain("You are running the 'update' operation with an 'HTTP' source", because: r.AllOutput);
+            }
+            else
+            {
+                r.AllOutput.Should().NotContain("You are running the 'update' operation with an 'HTTP' source", because: r.AllOutput);
+            }
+        }
+
     }
 }

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -1140,7 +1140,75 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 // Assert
                 Assert.True(result.ExitCode == 0, result.AllOutput);
                 Assert.Contains("Added package 'x.1.0.0' to folder", result.AllOutput);
-                Assert.Contains("You are running the 'restore' operation with an 'http' source, 'http://api.source/index.json'. Support for 'http' sources will be removed in a future version.", result.Output);
+                Assert.Contains("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
+            }
+        }
+
+        [PlatformTheory(Platform.Windows)]
+        [InlineData("false", true)]
+        [InlineData("FALSE", true)]
+        [InlineData("invalidString", true)]
+        [InlineData("", true)]
+        [InlineData("true", false)]
+        [InlineData("TRUE", false)]
+        public async Task MsbuildRestore_PackagesConfigDependency_WithHttpSourceAndAllowInsecureConnections_WarnsCorrectly(string allowInsecureConnections, bool hasHttpWarning)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                pathContext.Settings.AddSource("http-feed", "http://api.source/index.json", allowInsecureConnections);
+                pathContext.Settings.AddSource("https-feed", "https://api.source/index.json", allowInsecureConnections);
+
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+                var net461 = NuGetFramework.Parse("net472");
+                var projectA = new SimpleTestProjectContext(
+                    "a",
+                    ProjectStyle.PackagesConfig,
+                    pathContext.SolutionRoot);
+                projectA.Frameworks.Add(new SimpleTestProjectFrameworkContext(net461));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.AddFile("lib/net472/a.dll");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                using (var writer = new StreamWriter(Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "packages.config")))
+                {
+                    writer.Write(
+@"<packages>
+  <package id=""x"" version=""1.0.0"" targetFramework=""net472"" />
+</packages>");
+                }
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX);
+
+                // Act
+                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true", ignoreExitCode: true);
+
+                // Assert
+                string formatString = "You are running the 'restore' operation with an 'HTTP' source, '{0}'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS'";
+                string warningForHttpSource = string.Format(formatString, "http://api.source/index.json");
+                string warningForHttpsSource = string.Format(formatString, "https://api.source/index.json");
+
+                Assert.True(result.ExitCode == 0, result.AllOutput);
+                Assert.Contains("Added package 'x.1.0.0' to folder", result.AllOutput);
+                Assert.DoesNotContain(warningForHttpsSource, result.Output);
+                if (hasHttpWarning)
+                {
+                    Assert.Contains(warningForHttpSource, result.Output);
+                }
+                else
+                {
+                    Assert.DoesNotContain(warningForHttpSource, result.Output);
+                }
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -4065,15 +4065,19 @@ namespace NuGet.Commands.FuncTest
             }
         }
 
-        [Fact]
-        public async Task Restore_WithHttpSource_Warns()
+        [Theory]
+        [InlineData("true", false)]
+        [InlineData("false", true)]
+        public async Task Restore_WithHttpSource_Warns(string allowInsecureConnections, bool isHttpWarningExpected)
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
             var packageA = new SimpleTestPackageContext("a", "1.0.0");
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageA);
-            pathContext.Settings.AddSource("http-feed", "http://api.source/index.json");
-            pathContext.Settings.AddSource("https-feed", "https://api.source/index.json");
+            string httpSourceUrl = "http://api.source/index.json";
+            string httpsSourceUrl = "https://api.source/index.json";
+            pathContext.Settings.AddSource("http-feed", httpSourceUrl, allowInsecureConnections);
+            pathContext.Settings.AddSource("https-feed", httpsSourceUrl, allowInsecureConnections);
 
             var logger = new TestLogger();
             ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
@@ -4087,10 +4091,20 @@ namespace NuGet.Commands.FuncTest
             // Assert
             result.Success.Should().BeTrue(because: logger.ShowMessages());
             result.LockFile.Libraries.Should().HaveCount(0);
-            result.LockFile.LogMessages.Should().HaveCount(1);
-            IAssetsLogMessage logMessage = result.LockFile.LogMessages[0];
-            logMessage.Code.Should().Be(NuGetLogCode.NU1803);
-            logMessage.Message.Should().Be("You are running the 'restore' operation with an 'HTTP' source, 'http://api.source/index.json'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.");
+
+            string expectedWarning = $"You are running the 'restore' operation with an 'HTTP' source, '{httpSourceUrl}'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.";
+
+            if (isHttpWarningExpected)
+            {
+                result.LockFile.LogMessages.Should().HaveCount(1);
+                IAssetsLogMessage logMessage = result.LockFile.LogMessages[0];
+                logMessage.Code.Should().Be(NuGetLogCode.NU1803);
+                Assert.Equal(expectedWarning, logMessage.Message);
+            }
+            else
+            {
+                result.LockFile.LogMessages.Should().HaveCount(0);
+            }
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
@@ -832,8 +832,10 @@ namespace NuGet.Protocol.Tests
             }
         }
 
-        [Fact]
-        public async Task Push_WithAnHttpSource_NupkgOnly_Warns()
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public async Task Push_WithAnHttpSourceAndAllowInsecureConnections_NupkgOnly_Warns(bool allowInsecureConnections, bool isHttpWarningExpected)
         {
             // Arrange
             using var workingDir = TestDirectory.Create();
@@ -866,17 +868,27 @@ namespace NuGet.Protocol.Tests
                 noServiceEndpoint: false,
                 skipDuplicate: false,
                 symbolPackageUpdateResource: null,
+                allowInsecureConnections: allowInsecureConnections,
                 log: logger);
 
             // Assert
             Assert.NotNull(sourceRequest);
-            Assert.Equal(1, logger.WarningMessages.Count);
-            Assert.Contains("You are running the 'push' operation with an 'HTTP' source", logger.WarningMessages.First());
+            if (isHttpWarningExpected)
+            {
+                Assert.Equal(1, logger.WarningMessages.Count);
+                Assert.Contains("You are running the 'push' operation with an 'HTTP' source", logger.WarningMessages.Single());
+            }
+            else
+            {
+                Assert.Equal(0, logger.WarningMessages.Count);
+            }
 
         }
 
-        [Fact]
-        public async Task Push_WhenPushingToAnHttpSymbolSource_Warns()
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public async Task Push_WhenPushingToAnHttpSymbolSourceAndAllowInsecureConnections_Warns(bool allowInsecureConnections, bool isHttpWarningExpected)
         {
             // Arrange
             using var workingDir = TestDirectory.Create();
@@ -924,17 +936,27 @@ namespace NuGet.Protocol.Tests
                 noServiceEndpoint: false,
                 skipDuplicate: false,
                 symbolPackageUpdateResource: null,
+                allowInsecureConnections: allowInsecureConnections,
                 log: logger);
 
             // Assert
             Assert.NotNull(sourceRequest);
             Assert.NotNull(symbolRequest);
-            Assert.Equal(1, logger.WarningMessages.Count);
-            Assert.Contains("You are running the 'push' operation with an 'HTTP' source", logger.WarningMessages.First());
+            if (isHttpWarningExpected)
+            {
+                Assert.Equal(1, logger.WarningMessages.Count);
+                Assert.Contains("You are running the 'push' operation with an 'HTTP' source", logger.WarningMessages.Single());
+            }
+            else
+            {
+                Assert.Equal(0, logger.WarningMessages.Count);
+            }
         }
 
-        [Fact]
-        public async Task Push_WhenPushingToAnHttpSourceAndSymbolSource_WarnsForBoth()
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public async Task Push_WhenPushingToAnHttpSourceAndSymbolSourceWithAllowInsecureConnections_WarnsForBoth(bool allowInsecureConnections, bool isHttpWarningExpected)
         {
             // Arrange
             using var workingDir = TestDirectory.Create();
@@ -982,14 +1004,22 @@ namespace NuGet.Protocol.Tests
                 noServiceEndpoint: false,
                 skipDuplicate: false,
                 symbolPackageUpdateResource: null,
+                allowInsecureConnections: allowInsecureConnections,
                 log: logger);
 
             // Assert
             Assert.NotNull(sourceRequest);
             Assert.NotNull(symbolRequest);
-            Assert.Equal(2, logger.WarningMessages.Count);
-            Assert.Contains("You are running the 'push' operation with an 'HTTP' source, 'http://www.nuget.org/api/v2/'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", logger.WarningMessages.First());
-            Assert.Contains("You are running the 'push' operation with an 'HTTP' source, 'http://other.smbsrc.net/api/v2/package/'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", logger.WarningMessages.Last());
+            if (isHttpWarningExpected)
+            {
+                Assert.Equal(2, logger.WarningMessages.Count);
+                Assert.Contains("You are running the 'push' operation with an 'HTTP' source, 'http://www.nuget.org/api/v2/'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", logger.WarningMessages.First());
+                Assert.Contains("You are running the 'push' operation with an 'HTTP' source, 'http://other.smbsrc.net/api/v2/package/'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", logger.WarningMessages.Last());
+            }
+            else
+            {
+                Assert.Equal(0, logger.WarningMessages.Count);
+            }
         }
 
         [Fact]

--- a/test/TestUtilities/Test.Utility/Commands/TestRestoreRequest.cs
+++ b/test/TestUtilities/Test.Utility/Commands/TestRestoreRequest.cs
@@ -37,7 +37,7 @@ namespace NuGet.Commands.Test
             ILogger log)
             : this(
                   project,
-                  sources.Select(source => Repository.Factory.GetCoreV3(source.Source)),
+                  sources.Select(source => Repository.Factory.GetCoreV3(source)),
                   packagesDirectory,
                   new List<string>(),
                   new TestSourceCacheContext(),
@@ -73,7 +73,7 @@ namespace NuGet.Commands.Test
                 RestoreCommandProviders.Create(
                     packagesDirectory,
                     fallbackPackageFolderPaths: new List<string>(),
-                    sources: sources.Select(source => Repository.Factory.GetCoreV3(source.Source)),
+                    sources: sources.Select(source => Repository.Factory.GetCoreV3(source)),
                     cacheContext: cacheContext,
                     packageFileCache: new LocalPackageFileCache(),
                     log: log),
@@ -110,7 +110,7 @@ namespace NuGet.Commands.Test
             ILogger log)
             : this(
                   project,
-                  sources.Select(source => Repository.Factory.GetCoreV3(source.Source)),
+                  sources.Select(source => Repository.Factory.GetCoreV3(source)),
                   packagesDirectory,
                   fallbackPackageFolders,
                   cacheContext,
@@ -165,7 +165,7 @@ namespace NuGet.Commands.Test
                 RestoreCommandProviders.Create(
                     packagesDirectory,
                     Enumerable.Empty<string>(),
-                    sources: sources.Select(source => Repository.Factory.GetCoreV3(source.Source)),
+                    sources: sources.Select(source => Repository.Factory.GetCoreV3(source)),
                     cacheContext: cacheContext,
                     packageFileCache: new LocalPackageFileCache(),
                     log: log),

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -200,6 +200,13 @@ namespace NuGet.Test.Utility
             Save();
         }
 
+        public void AddSource(string sourceName, string sourceUri, string allowInsecureConnectionsValue)
+        {
+            var section = GetOrAddSection(XML, "packageSources");
+            AddEntry(section, sourceName, sourceUri, "allowInsecureConnections", allowInsecureConnectionsValue);
+            Save();
+        }
+
         public void AddPackageSourceMapping(string sourceName, params string[] patterns)
         {
             XElement packageSourceMappingSection = GetOrAddSection(XML, "packageSourceMapping");


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes: https://github.com/NuGet/Home/issues/12785

Regression? Last working version:

## Description
Provide a way to opt-out of http warnings, by setting allowInsecureConnections to true in NuGet.Config.
Spec: https://github.com/NuGet/Home/blob/dev/proposed/2023/InsecureConnectionsDisableCertificateValidation.md

This PR combines all sub-PRs which are already reviewed. (You may find the list of sub issues in https://github.com/NuGet/Home/issues/12785)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled   https://github.com/NuGet/docs.microsoft.com-nuget/issues/3116
  - **OR**
  - [ ] N/A
