### PR TITLE
Install .NET 5 runtime and fix tests in release-6.3.x

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -228,6 +228,13 @@ Function Install-DotnetCLI {
     # in a different process, to avoid treating their handled errors as build errors.
     & powershell $DotNetInstall -Runtime dotnet -Channel 3.1 -InstallDir $CLIRoot -NoPath
 
+    # Install the 5.x runtime because our tests target netcoreapp5.0
+    Trace-Log "$DotNetInstall -Runtime dotnet -Channel 5.0 -InstallDir $CLIRoot -NoPath"
+    # dotnet-install might make http requests that fail, but it handles those errors internally
+    # However, Invoke-BuildStep checks if any error happened, ever. Hence we need to run dotnet-install
+    # in a different process, to avoid treating their handled errors as build errors.
+    & powershell $DotNetInstall -Runtime dotnet -Channel 5.0 -InstallDir $CLIRoot -NoPath
+
     if ($LASTEXITCODE -ne 0)
     {
         throw "dotnet-install.ps1 exited with non-zero exit code"

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -67,7 +67,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
 
                 var lockFile = PackagesLockFileFormat.Read(projectA.NuGetLockFileOutputPath);
-                Assert.Equal(4, lockFile.Targets.Count);
+                Assert.True(lockFile.Targets.Count >= 4, $"lockFile.Targets.Count should be greater than or equal to 4 but was {lockFile.Targets.Count}");
 
                 var targets = lockFile.Targets.Where(t => t.Dependencies.Count > 0).ToList();
                 Assert.Equal(1, targets.Count);
@@ -140,7 +140,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 Assert.Equal(packagesLockFilePath, projectA.NuGetLockFileOutputPath);
 
                 var lockFile = PackagesLockFileFormat.Read(projectA.NuGetLockFileOutputPath);
-                Assert.Equal(4, lockFile.Targets.Count);
+                Assert.True(lockFile.Targets.Count >= 4, $"lockFile.Targets.Count should be greater than or equal to 4 but was {lockFile.Targets.Count}");
 
                 var targets = lockFile.Targets.Where(t => t.Dependencies.Count > 0).ToList();
                 Assert.Equal(1, targets.Count);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -10029,12 +10029,12 @@ namespace NuGet.CommandLine.Test
                 var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
                     "proj",
                     pathContext.SolutionRoot,
-                    "net5.0-windows");
+                    "net6.0-windows");
 
                 // Workaround: Set all the TFM properties ourselves.
                 // We can't rely on the SDK setting them, as only .NET 5 SDK P8 and later applies these correctly.
-                var net50windowsTFM = project.Frameworks.Where(f => f.TargetAlias.Equals("net5.0-windows")).Single();
-                net50windowsTFM.Properties.Add("TargetFrameworkMoniker", ".NETCoreApp, Version=v5.0");
+                var net50windowsTFM = project.Frameworks.Where(f => f.TargetAlias.Equals("net6.0-windows")).Single();
+                net50windowsTFM.Properties.Add("TargetFrameworkMoniker", ".NETCoreApp, Version=v6.0");
                 net50windowsTFM.Properties.Add("TargetPlatformMoniker", "Windows, Version=7.0");
 
                 project.AddPackageToAllFrameworks(packageX);
@@ -10054,7 +10054,7 @@ namespace NuGet.CommandLine.Test
 
                 var propsItemGroups = propsXML.Root.Elements().Where(e => e.Name.LocalName == "ItemGroup").ToList();
 
-                Assert.Contains("'$(TargetFramework)' == 'net5.0-windows' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Contains("'$(TargetFramework)' == 'net6.0-windows' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
             }
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2362

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
CI agents no longer have .NET 5 on them since its EOL.  This change installs the .NET 5 runtime as its needed by the test host app that runs our tests at the moment.

* Fixed a test that was compiling an app against NET 5.0 which was failing because the ref pack was not installed since we only install the runtime.
* Fixed tests that were failing because there's a newer target in the graph, `win10-arm` which the test was not expecting.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
