### PR TITLE
Fix racing condition when stale a non-community PR

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -200,6 +200,12 @@
           {
             "name": "isOpen",
             "parameters": {}
+          },
+          {
+            "name": "noLabel",
+            "parameters": {
+              "label": "Status:No recent activity"
+            }
           }
         ],
         "taskName": "[stale non-community PR] [5-1] Search for PRs with no activity over 7 days and warn. (except community PRs)",


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/2486

Regression? Last working version:

## Description
Fix a racing condition between adding a stale label to a PR and closing a stale PR having stale label.
Previously, when a PR has no activity after 7 days, there are two tasks in racing condition:
1.add a "Status: no recent activity" label and leave a comment
2.close the PR if it has a "Status: no recent activity" label
If task 1 runs first, then task 2 won't run since a new comment is added which mean there is a new activity.
So this change is to exclude PRs with "Status: no recent activity" label when doing task1.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
