### PR TITLE
Set shadowCopy to false for Apex tests

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
@@ -45,7 +45,7 @@ namespace NuGet.Tests.Apex
             CommonUtility.AssertPackageInPackagesConfig(VisualStudio, projExt, "newtonsoft.json", XunitLogger);
         }
 
-        [StaFact(Skip = "https://github.com/NuGet/Home/issues/11308")]
+        [StaFact]
         public void SimpleUninstallFromIVsInstaller()
         {
             // Arrange
@@ -82,7 +82,7 @@ namespace NuGet.Tests.Apex
             userPackagesFolder.Should().NotBe(_pathContext.UserPackagesFolder);
         }
 
-        [StaFact(Skip = "https://github.com/NuGet/Home/issues/11308")]
+        [StaFact]
         public async Task SimpleInstallFromIVsInstaller_PackageSourceMapping_WithSingleFeed()
         {
             // Arrange
@@ -133,7 +133,7 @@ namespace NuGet.Tests.Apex
             File.Exists(uniqueContentFile).Should().BeTrue($"'{uniqueContentFile}' should exist");
         }
 
-        [StaFact(Skip = "https://github.com/NuGet/Home/issues/11308")]
+        [StaFact]
         public async Task SimpleInstallFromIVsInstaller_PackageSourceMapping_WithMultipleFeedsWithIdenticalPackages_InstallsCorrectPackage()
         {
             // Arrange

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -121,7 +121,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [NuGetWpfTheory]
+        [NuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/12898")]
         [MemberData(nameof(GetNetCoreTemplates))]
         public async Task WithSourceMappingEnabled_InstallAndUpdatePackageFromPMUIFromExpectedSource_Succeeds(ProjectTemplate projectTemplate)
         {

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -17,7 +17,7 @@ namespace NuGet.Tests.Apex
         }
 
         // basic create for .net core template
-        [NuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/11308")]
+        [NuGetWpfTheory]
         [MemberData(nameof(GetNetCoreTemplates))]
         public void CreateNetCoreProject_RestoresNewProject(ProjectTemplate projectTemplate)
         {
@@ -31,7 +31,7 @@ namespace NuGet.Tests.Apex
         }
 
         // basic create for .net core template
-        [NuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/9410")]
+        [NuGetWpfTheory]
         [MemberData(nameof(GetNetCoreTemplates))]
         public void CreateNetCoreProject_AddProjectReference(ProjectTemplate projectTemplate)
         {
@@ -121,7 +121,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [NuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/11308")]
+        [NuGetWpfTheory]
         [MemberData(nameof(GetNetCoreTemplates))]
         public async Task WithSourceMappingEnabled_InstallAndUpdatePackageFromPMUIFromExpectedSource_Succeeds(ProjectTemplate projectTemplate)
         {

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -21,7 +21,7 @@ namespace NuGet.Tests.Apex
         {
         }
 
-        [NuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/11308")]
+        [NuGetWpfTheory]
         [MemberData(nameof(GetPackageReferenceTemplates))]
         public async Task InstallPackageFromPMCWithNoAutoRestoreVerifyAssetsFileAsync(ProjectTemplate projectTemplate)
         {
@@ -199,7 +199,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [NuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/8469")]
+        [NuGetWpfTheory]
         [MemberData(nameof(GetNetCoreTemplates))]
         public async Task NetCoreTransitivePackageReferenceLimitAsync(ProjectTemplate projectTemplate)
         {
@@ -242,7 +242,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [NuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/8386")]
+        [NuGetWpfTheory]
         [InlineData(ProjectTemplate.ClassLibrary, false)]
         [InlineData(ProjectTemplate.NetCoreConsoleApp, true)]
         [InlineData(ProjectTemplate.NetStandardClassLib, true)]
@@ -293,7 +293,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [NuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/11308")]
+        [NuGetWpfTheory]
         [MemberData(nameof(GetPackagesConfigTemplates))]
         public async Task InstallPackageForPC_PackageSourceMapping_WithSingleFeed(ProjectTemplate projectTemplate)
         {
@@ -338,7 +338,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [NuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/11308")]
+        [NuGetWpfTheory]
         [MemberData(nameof(GetPackagesConfigTemplates))]
         public async Task UpdatePackageForPC_PackageSourceMapping_WithSingleFeed(ProjectTemplate projectTemplate)
         {
@@ -386,7 +386,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [NuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/11308")]
+        [NuGetWpfTheory]
         [MemberData(nameof(GetPackagesConfigTemplates))]
         public async Task InstallPackageForPC_PackageSourceMapping_WithMultipleFeedsWithIdenticalPackages_InstallsCorrectPackage(ProjectTemplate projectTemplate)
         {
@@ -449,7 +449,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [NuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/11308")]
+        [NuGetWpfTheory]
         [MemberData(nameof(GetPackagesConfigTemplates))]
         public async Task UpdatePackageForPC_PackageSourceMapping_WithMultipleFeedsWithIdenticalPackages_UpdatesCorrectPackage(ProjectTemplate projectTemplate)
         {
@@ -513,7 +513,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [NuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/8386")]
+        [NuGetWpfTheory]
         [InlineData(ProjectTemplate.ClassLibrary, false)]
         [InlineData(ProjectTemplate.NetStandardClassLib, true)]
         public async Task UpdateAllReinstall_WithPackageReferenceProject_WarnsAsync(ProjectTemplate projectTemplate, bool warns)
@@ -610,7 +610,7 @@ namespace NuGet.Tests.Apex
             Assert.True(VisualStudio.HasNoErrorsInOutputWindows());
         }
 
-        [NuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/11308")]
+        [NuGetWpfTheory]
         [MemberData(nameof(GetPackageReferenceTemplates))]
         public async Task UpdatePackageForPR_PackageNamespace_WithMultipleFeedsWithIdenticalPackages_InstallsCorrectPackage(ProjectTemplate projectTemplate)
         {

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -513,7 +513,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [NuGetWpfTheory]
+        [NuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/12899")]
         [InlineData(ProjectTemplate.ClassLibrary, false)]
         [InlineData(ProjectTemplate.NetStandardClassLib, true)]
         public async Task UpdateAllReinstall_WithPackageReferenceProject_WarnsAsync(ProjectTemplate projectTemplate, bool warns)

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetPackageSigningTests/AuthorSignedPackageTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetPackageSigningTests/AuthorSignedPackageTestCase.cs
@@ -45,7 +45,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [CIOnlyNuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/9476")]
+        [CIOnlyNuGetWpfTheory]
         [MemberData(nameof(GetPackagesConfigTemplates))]
         public async Task UninstallFromPMCForPC_SucceedAsync(ProjectTemplate projectTemplate)
         {
@@ -67,7 +67,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [CIOnlyNuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/11308")]
+        [CIOnlyNuGetWpfTheory]
         [MemberData(nameof(GetPackagesConfigTemplates))]
         public async Task UpdateUnsignedToSignedVersionFromPMCForPC_SucceedAsync(ProjectTemplate projectTemplate)
         {
@@ -91,7 +91,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [CIOnlyNuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/11308")]
+        [CIOnlyNuGetWpfTheory]
         [MemberData(nameof(GetPackagesConfigTemplates))]
         public async Task DowngradeSignedToUnsignedVersionFromPMCForPC_SucceedAsync(ProjectTemplate projectTemplate)
         {

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/xunit.runner.json
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/xunit.runner.json
@@ -2,5 +2,6 @@
   "methodDisplay": "classAndMethod",
   "longRunningTestSeconds": 300,
   "diagnosticMessages": true,
-  "preEnumerateTheories": false
+  "preEnumerateTheories": false,
+  "shadowCopy": false
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/1299 
Fixes: https://github.com/NuGet/Home/issues/11308

The following might be fixed:
Fixes: https://github.com/NuGet/Home/issues/9410
Fixes: https://github.com/NuGet/Home/issues/8386
Fixes: https://github.com/NuGet/Home/issues/9476

Regression? Last working version:

## Description

- Set `shadowCopy` to false in test/NuGet.Tests.Apex/NuGet.Tests.Apex/xunit.runner.json 
- Enable 16 out of 18 disabled Apex tests.

Context:
IPC error in Apex tests have been bothering us for a while. When working on migrating Apex tests from Xunit to MSTest, I found  loggings in flaky MSTest and it related to https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/9736/Shadow-Copying-Assemblies. And it suggests setting `shadowCopy` to false in the Xunit configuration file. 
[shadowCopy](https://xunit.net/docs/configuration-files#shadowCopy):
`Set this to true to use shadow copying when running tests in separate App Domains; set to false to run tests without shadow copying. When running tests without App Domains, this value is ignored.`
I then tried to enable all 18 disabled Apex tests and run 10 builds in a row, none of them failed for IPC error.
Out of the 10 runs:
2 Apex tests which were disabled long time ago constantly fail for assertion errors, we might need to change the test.
2 runs timed out. 
Other apex tests are good.

We will still need to migrate to MSTest since Xunit test is not able to time out single test case, and MSTest has more info for Apex tests so it will be easier for diagnosing.
So in the long run, this is a temporary fix, but there is no harm if we have better Apex tests than what we have for now.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
