### PR TITLE
Remove usage of Moq from end-to-end tests in release-6.7.x

### DIFF
--- a/test/EndToEnd/tests/A-TopDownloadedPackages.ps1
+++ b/test/EndToEnd/tests/A-TopDownloadedPackages.ps1
@@ -24,7 +24,6 @@ $topDownloadedPackageIds = (
     'Modernizr',
     'Microsoft.Bcl.Build', # .Targets files
     'Microsoft.Bcl',
-    'Moq',
     'Antlr', # No target framework specific folders
     'Microsoft.Owin',
     'bootstrap',

--- a/test/EndToEnd/tests/TabExpansionTest.ps1
+++ b/test/EndToEnd/tests/TabExpansionTest.ps1
@@ -282,7 +282,6 @@ function Test-TabExpansionForVersionForUninstallPackage {
     # Arrange
     $p = New-WebApplication
     $p | Install-Package elmah -Version 1.1
-    $p | Install-Package Moq
 
     # Act
     $suggestion = TabExpansion "Uninstall-Package elmah -Version "


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2488

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
The Moq package is flagged by Component Governance and should not be used.  This is essentially a cherry-pick of https://github.com/NuGet/NuGet.Client/pull/5358 with an additional usage removed.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
