### PR TITLE
Fix CodeQL warning Unsafe 'DateTime' constructor using data from other 2 'DateTime' elements

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/TstInfoTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/TstInfoTests.cs
@@ -297,17 +297,17 @@ namespace NuGet.Packaging.Test
 
                 Hash = Common.HashAlgorithmName.SHA256.ComputeHash(data);
                 SerialNumber = GetRandomInteger().ToByteArray();
-                GenTime = DateTime.UtcNow;
+                var now = DateTime.UtcNow;
 
                 // Round to milliseconds
                 GenTime = new DateTime(
-                    GenTime.Year,
-                    GenTime.Month,
-                    GenTime.Day,
-                    GenTime.Hour,
-                    GenTime.Minute,
-                    GenTime.Second,
-                    GenTime.Millisecond,
+                    now.Year,
+                    now.Month,
+                    now.Day,
+                    now.Hour,
+                    now.Minute,
+                    now.Second,
+                    now.Millisecond,
                     DateTimeKind.Utc);
             }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1886814

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This is being flagged by [CodeQL](https://liquid.microsoft.com/Web/Object/Read/ScanningToolWarnings/Requirements/CodeQL.SM04500) so I new up a variable and get values only from it.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
