### PR TITLE
Skip flaky test ClientCertAddCommand_Success_StoreCertificate

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetClientCertCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetClientCertCommandTests.cs
@@ -265,7 +265,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux, SkipMono = true)]
+        [PlatformFact(Platform.Windows, Platform.Linux, SkipMono = true, Skip = "https://github.com/NuGet/Home/issues/9684")]
         public void ClientCertAddCommand_Success_StoreCertificate()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Related: https://github.com/NuGet/Home/issues/9684

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This test has been flaky and I've tried adding output to the test to figure out the issue.  The output clearly shows the test certificate being created and installed but then the actual NuGet.exe fails.

```
Created certificate cn=Contoso-365050936e93424dbcccb4be8f06a71e
Added certificate CN=Contoso-365050936e93424dbcccb4be8f06a71e to store CurrentUser\My
Installed Certificates:
  CN=Contoso
  CN=localhost
  CN=Contoso-365050936e93424dbcccb4be8f06a71e
  CN=1es-hostedpools.default.microsoft.com
Running command D:\a\_work\1\s\test\NuGet.Clients.Tests\NuGet.CommandLine.Test\bin\release\net472\NuGet\NuGet.exe "client-certs" "add" -ConfigFile "D:\a\_work\1\s\.test\work\d2f328b9\dfccf0db\NuGet.config" -PackageSource "Contoso-365050936e93424dbcccb4be8f06a71e" -StoreLocation "CurrentUser" -StoreName "My" -FindBy "IssuerName" -FindValue "Contoso-365050936e93424dbcccb4be8f06a71e"
Exit code: 1
Output:

Errors:
Certificate for the package source 'Contoso-365050936e93424dbcccb4be8f06a71e' was not found in 'CurrentUser.My' storage by 'IssuerName' criteria with 'Contoso-365050936e93424dbcccb4be8f06a71e' value.

Installed Certificates:
  CN=localhost
  CN=1es-hostedpools.default.microsoft.com
```

I'm out of ideas and can't handle how frequently this test fails.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
