### PR TITLE
Fix "Sequence contains no matching element" when listing outdated packages and no latest version available

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -405,7 +405,7 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="frameworks"> List of <see cref="FrameworkPackages"/>.</param>
         /// <param name="packageMetadata">Package metadata from package sources</param>
         /// <param name="listPackageArgs">Arguments for list package to get the right latest version</param>
-        private async Task UpdatePackagesWithSourceMetadata(
+        internal async Task UpdatePackagesWithSourceMetadata(
             List<FrameworkPackages> frameworks,
             Dictionary<string, List<IPackageSearchMetadata>> packageMetadata,
             ListPackageArgs listPackageArgs)

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -540,18 +540,18 @@ namespace Dotnet.Integration.Test
         }
 
         [PlatformTheory(Platform.Windows)]
-        [InlineData("1.1.0", "")]
+        [InlineData("1.1.0-beta", "")]
         [InlineData("2.0.0-beta", "--highest-patch")]
         [InlineData("2.0.0-beta", "--highest-minor")]
-        public async Task DotnetListPackage_MultipleInstalledPackages_OutdatedWithNoVersionsFound_Succeeds(string currentVersion, string args)
+        public async Task DotnetListPackage_OutdatedWithNoAvailableVersion_Succeeds(string currentVersion, string args)
         {
             // Arrange
             using (var pathContext = _fixture.CreateSimpleTestPathContext())
             {
                 var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, "net7.0");
-                var packageX = XPlatTestUtils.CreatePackage(packageId: "packageX", packageVersion: "1.0.0");
+                var packageX = XPlatTestUtils.CreatePackage(packageId: "packageX", packageVersion: currentVersion);
                 var packageY = XPlatTestUtils.CreatePackage(packageId: "packageY", packageVersion: "1.0.0");
-                var packageY2 = XPlatTestUtils.CreatePackage(packageId: "packageY", packageVersion: "2.0.0");
+                var packageY2 = XPlatTestUtils.CreatePackage(packageId: "packageY", packageVersion: "1.0.1");
 
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(
                         pathContext.PackageSource,
@@ -575,6 +575,7 @@ namespace Dotnet.Integration.Test
 
                 // Assert
                 string[] lines = listResult.AllOutput.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+                Assert.True(lines.Any(l => l.Contains("packageY") && l.Contains("1.0.1")), "Line containing 'packageY' and '1.0.1' not found: " + listResult.AllOutput);
                 Assert.True(lines.Any(l => l.Contains("packageX") && l.Contains("Not found at the sources")), "Line containing 'packageX' and 'Not found at the sources' not found: " + listResult.AllOutput);
             }
         }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -548,7 +548,7 @@ namespace Dotnet.Integration.Test
             // Arrange
             using (var pathContext = _fixture.CreateSimpleTestPathContext())
             {
-                var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, "net7.0");
+                var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, "net472");
                 var packageX = XPlatTestUtils.CreatePackage(packageId: "packageX", packageVersion: currentVersion);
                 var packageY = XPlatTestUtils.CreatePackage(packageId: "packageY", packageVersion: "1.0.0");
                 var packageY2 = XPlatTestUtils.CreatePackage(packageId: "packageY", packageVersion: "1.0.1");


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12256

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This PR fixes a null reference when users try to list outdated packages. This happens when the user adds the options `--highest-minor` or `--highest-patch` to the command `dotnet list package --outdated` and there is no version available with these constraints.

Also, this was breaking the command and not listing the other packages that had a latest version available.

For example, if the user has installed a prerelease version and use the command `dotnet list package --outdated --highest-minor` we won't find a version available, not and since the user is not using `--include-prerelease` the installed version won't be listed as an available version. 

### Example:

#### CSPROJ
![image](https://github.com/NuGet/NuGet.Client/assets/43253759/25f358d0-df91-4fbb-afb6-4d19f4a1d0de)

#### Command output 
![image](https://github.com/NuGet/NuGet.Client/assets/43253759/4b3f29e9-4091-4034-99eb-c0c144d38e09)


## Fix
With this fix I'm just handling the null reference, that there is no `LatestPackageMetadata` and `UpdateLevel = UpdateLevel.NoUpdate` this will create an entry on the output table saying that there is no available version in the source.


### Command output (using the same csproj from previous example)
![image](https://github.com/NuGet/NuGet.Client/assets/43253759/c8f66538-61ef-4f83-bd77-d7c7102cc890)

#### Example with multiple table entries
![image](https://github.com/NuGet/NuGet.Client/assets/43253759/04517ff1-14c3-4f7f-98d8-9cacc9587355)


### Other considerations
Another approach I tried to fix this was to not add the outdated package to the list and show the regular message that there are no updates available and not show the table, But given that there is already a test for version not found and does create the table I decided to do it like this.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
