### PR TITLE
Bump runnable assemblies to net7.0

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -418,4 +418,17 @@
              Importance="High"
              Condition=" '$(SkipCoreAssemblies)' != 'true' AND '$(VSTestErrorCode)' == '0' " />
   </Target>
+
+      <!--
+    ============================================================
+    GetTargetFrameworks
+    ============================================================
+  -->
+  <Target Name="GetAllTargetFrameworks">
+      <MsBuild
+        Projects="@(AllRepoProjects)"
+        Targets="GetAllTargetFrameworks">
+    </MsBuild>
+  </Target>
+
 </Project>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -20,8 +20,8 @@
     <TargetFrameworksExeForSigning>$(TargetFrameworksExe);netcoreapp5.0</TargetFrameworksExeForSigning>
     <TargetFrameworksExeForSigning Condition=" '$(IsXPlat)' == 'true' ">$(NETCoreTargetFramework);netcoreapp5.0</TargetFrameworksExeForSigning>
     <TargetFrameworksExeForSigning Condition="'$(DotNetBuildFromSource)' == 'true'">$(TargetFrameworksExe)</TargetFrameworksExeForSigning>
-    <MinimalTargetFrameworksExeSigning>$(NETFXTargetFramework);netcoreapp5.0</MinimalTargetFrameworksExeSigning>
-    <MinimalTargetFrameworksExeSigning Condition=" '$(IsXPlat)' == 'true' ">netcoreapp5.0</MinimalTargetFrameworksExeSigning>
+    <MinimalTargetFrameworksExeSigning>$(NETFXTargetFramework);net7.0</MinimalTargetFrameworksExeSigning>
+    <MinimalTargetFrameworksExeSigning Condition=" '$(IsXPlat)' == 'true' ">net7.0</MinimalTargetFrameworksExeSigning>
     <MinimalTargetFrameworksExeSigning Condition="'$(DotNetBuildFromSource)' == 'true'">$(NETCoreTargetFramework)</MinimalTargetFrameworksExeSigning>
     <TargetFrameworksLibrary>$(NETFXTargetFramework);$(NetStandardVersion)</TargetFrameworksLibrary>
     <TargetFrameworksLibrary Condition="'$(DotNetBuildFromSource)' == 'true'">$(NETCoreTargetFramework);$(NetStandardVersion)</TargetFrameworksLibrary>

--- a/build/common.targets
+++ b/build/common.targets
@@ -395,7 +395,7 @@ Condition=" ('%(Extension)' == '.dll' OR '%(Filename)' == 'NuGet.CommandLine.XPl
   </Target>
 
   <Target Name="GetAllTargetFrameworks">
-      <PropertyGroup>
+  <PropertyGroup>
       <EffectiveFramework Condition=" '$(TargetFrameworks)' != '' ">$(TargetFrameworks)</EffectiveFramework>
       <EffectiveFramework Condition=" '$(EffectiveFramework)' == '' ">$(TargetFramework)</EffectiveFramework>
     </PropertyGroup>

--- a/build/common.targets
+++ b/build/common.targets
@@ -393,4 +393,14 @@ Condition=" ('%(Extension)' == '.dll' OR '%(Filename)' == 'NuGet.CommandLine.XPl
       Text="Newtonsoft.Json must be version $(NewtonsoftJsonPackageVersion) but resolved %(Reference.NuGetPackageVersion)"
       Condition=" %(Reference.NuGetPackageId) == 'Newtonsoft.Json' AND %(Reference.NuGetPackageVersion) != '$(NewtonsoftJsonPackageVersion)' " />
   </Target>
+
+  <Target Name="GetAllTargetFrameworks">
+      <PropertyGroup>
+      <EffectiveFramework Condition=" '$(TargetFrameworks)' != '' ">$(TargetFrameworks)</EffectiveFramework>
+      <EffectiveFramework Condition=" '$(EffectiveFramework)' == '' ">$(TargetFramework)</EffectiveFramework>
+    </PropertyGroup>
+    <Message
+      Text="$(MSBuildProjectFile) = $(EffectiveFramework)" Importance="High" />
+  </Target>
+
 </Project>

--- a/docs/updating-target-frameworks.md
+++ b/docs/updating-target-frameworks.md
@@ -1,0 +1,19 @@
+# Updating target frameworks
+
+Updating the target frameworks in our repository can be challenging.
+Our repository builds code for Visual Studio, .NET SDK, NuGet.exe in addition to [shipping packages to NuGet.org](https://www.nuget.org/profiles/nuget).
+
+Given that so many of our projects have different frameworks, these frameworks are defined in [common.projects.props](../build/common.project.props). 
+Note that `DotnetBuildFromSource` tends to build against different frameworks than the ones our repo builds against.
+
+To make it easier to determine the correct changes were made, you can use utility targets such as `GetAllTargetFrameworks` in [build.proj](../build/build.proj).
+It is important to pay attention to that changing frameworks.
+The recommended way to invoke these helper commands is by running the following from the root of the repo.
+
+> msbuild .\build\build.proj /t:GetAllTargetFrameworks /v:m /restore:false
+
+or
+
+> msbuild .\build\build.proj /t:GetAllTargetFrameworks /v:m /restore:false /p:DotnetBuildFromSource="true"
+
+This would generate an output that you can diff for before/after list of the frameworks.

--- a/test/NuGet.Core.FuncTests/NuGet.Signing.CrossFramework.Test/CrossVerifyTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Signing.CrossFramework.Test/CrossVerifyTestFixture.cs
@@ -19,7 +19,7 @@ namespace NuGet.Signing.CrossFramework.Test
         //In net472 code path, the SDK version and TFM could not be detected automatically, so we manually specified according to the sdk version we're testing against.
         //https://github.com/NuGet/Home/issues/12187
         private const string SdkVersion = "7";
-        private const string SdkTfm = "net5.0";
+        private const string SdkTfm = "net7.0";
         internal string _dotnetExePath;
 #else
         private const string NuGetExe = "NuGet.exe";

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/DotnetCliUtil.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/DotnetCliUtil.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using NuGet.Frameworks;
 using NuGet.Test.Utility;
 using Xunit;
 
@@ -76,24 +76,42 @@ namespace NuGet.XPlat.FuncTest
 #else
                 "Release";
 #endif
+                var configurationDirectory = Path.Combine(dir.FullName, "artifacts", "NuGet.CommandLine.XPlat", "bin", configuration);
+                var referenceTfm = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new Version(int.MaxValue, 0, 0));
+                var bestTfm = GetTfmToCopy(configurationDirectory, referenceTfm);
+                var filePath = Path.Combine(configurationDirectory, bestTfm, XPlatDll);
 
-                var relativePaths = new string[]
+                if (File.Exists(filePath))
                 {
-                    Path.Combine("artifacts", "NuGet.CommandLine.XPlat", "bin", configuration, "netcoreapp5.0", XPlatDll)
-                };
-
-                foreach (var relativePath in relativePaths)
-                {
-                    var filePath = Path.Combine(dir.FullName, relativePath);
-
-                    if (File.Exists(filePath))
-                    {
-                        return filePath;
-                    }
+                    return filePath;
                 }
             }
 
             return null;
+        }
+
+        private static string GetTfmToCopy(string projectArtifactsBinFolder, NuGetFramework referenceTfm)
+        {
+            var compiledTfms =
+                Directory.EnumerateDirectories(projectArtifactsBinFolder) // get all directories in bin folder
+                .Select(Path.GetFileName) // just the folder name (tfm)
+                .ToDictionary(folder => NuGetFramework.Parse(folder));
+
+            var reducer = new FrameworkReducer();
+            var selectedTfm = reducer.GetNearest(referenceTfm, compiledTfms.Keys);
+
+            if (selectedTfm == null)
+            {
+                var message = $@"Could not find suitable assets to copy in {projectArtifactsBinFolder}
+TFM being tested: {referenceTfm}
+project TFMs found: {string.Join(", ", compiledTfms.Keys.Select(k => k.ToString()))}";
+
+                throw new Exception(message);
+            }
+
+            var selectedVersion = compiledTfms[selectedTfm];
+
+            return selectedVersion;
         }
 
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using FluentAssertions;
 using NuGet.Common;
 using NuGet.Test.Utility;
 using Xunit;
@@ -38,8 +39,8 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("locals -l plugins-cache")]
         public static void Locals_List_Succeeds(string args)
         {
-            Assert.NotNull(DotnetCli);
-            Assert.NotNull(XplatDll);
+            DotnetCli.Should().NotBeNull(because: "Could not locate the dotnet CLI");
+            XplatDll.Should().NotBeNull(because: "Could not locate the Xplat dll");
 
             using (var mockBaseDirectory = TestDirectory.Create())
             {
@@ -94,8 +95,8 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("locals plugins-cache -c")]
         public static void Locals_Clear_Succeeds(string args)
         {
-            Assert.NotNull(DotnetCli);
-            Assert.NotNull(XplatDll);
+            DotnetCli.Should().NotBeNull(because: "Could not locate the dotnet CLI");
+            XplatDll.Should().NotBeNull(because: "Could not locate the Xplat dll");
 
             using (var mockBaseDirectory = TestDirectory.Create())
             {
@@ -208,8 +209,8 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("locals -c")]
         public static void Locals_Success_InvalidArguments_HelpMessage(string args)
         {
-            Assert.NotNull(DotnetCli);
-            Assert.NotNull(XplatDll);
+            DotnetCli.Should().NotBeNull(because: "Could not locate the dotnet CLI");
+            XplatDll.Should().NotBeNull(because: "Could not locate the Xplat dll");
 
             // Arrange
             var expectedResult = string.Concat("error: No Cache Type was specified.",
@@ -235,8 +236,8 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("locals -c unknownResource")]
         public static void Locals_Success_InvalidResourceName_HelpMessage(string args)
         {
-            Assert.NotNull(DotnetCli);
-            Assert.NotNull(XplatDll);
+            DotnetCli.Should().NotBeNull(because: "Could not locate the dotnet CLI");
+            XplatDll.Should().NotBeNull(because: "Could not locate the Xplat dll");
 
             // Arrange
             var expectedResult = string.Concat("error: An invalid local resource name was provided. " +
@@ -259,8 +260,8 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("locals --c")]
         public static void Locals_Success_InvalidFlags_HelpMessage(string args)
         {
-            Assert.NotNull(DotnetCli);
-            Assert.NotNull(XplatDll);
+            DotnetCli.Should().NotBeNull(because: "Could not locate the dotnet CLI");
+            XplatDll.Should().NotBeNull(because: "Could not locate the Xplat dll");
 
             // Arrange
             var expectedResult = string.Concat("Specify --help for a list of available options and commands.",
@@ -284,8 +285,8 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("locals plugins-cache")]
         public static void Locals_Success_NoFlags_HelpMessage(string args)
         {
-            Assert.NotNull(DotnetCli);
-            Assert.NotNull(XplatDll);
+            DotnetCli.Should().NotBeNull(because: "Could not locate the dotnet CLI");
+            XplatDll.Should().NotBeNull(because: "Could not locate the Xplat dll");
 
             // Arrange
             var expectedResult = string.Concat("error: Please specify an operation i.e. --list or --clear.",
@@ -318,8 +319,8 @@ namespace NuGet.XPlat.FuncTest
 
         public static void Locals_Success_BothFlags_HelpMessage(string args)
         {
-            Assert.NotNull(DotnetCli);
-            Assert.NotNull(XplatDll);
+            DotnetCli.Should().NotBeNull(because: "Could not locate the dotnet CLI");
+            XplatDll.Should().NotBeNull(because: "Could not locate the Xplat dll");
 
             // Arrange
             var expectedResult = string.Concat("error: Both operations, --list and --clear, are not supported in the same command. Please specify only one operation.",

--- a/test/TestUtilities/Test.Utility/AssemblyReader.cs
+++ b/test/TestUtilities/Test.Utility/AssemblyReader.cs
@@ -9,9 +9,9 @@ using NuGet.Frameworks;
 
 namespace NuGet.Test.Utility
 {
-    internal static class AssemblyReader
+    public static class AssemblyReader
     {
-        internal static NuGetFramework GetTargetFramework(string assemblyPath)
+        public static NuGetFramework GetTargetFramework(string assemblyPath)
         {
             using (var fileStream = File.OpenRead(assemblyPath))
             using (var peReader = new PEReader(fileStream))

--- a/test/TestUtilities/Test.Utility/AssemblyReader.cs
+++ b/test/TestUtilities/Test.Utility/AssemblyReader.cs
@@ -9,9 +9,9 @@ using NuGet.Frameworks;
 
 namespace NuGet.Test.Utility
 {
-    public static class AssemblyReader
+    internal static class AssemblyReader
     {
-        public static NuGetFramework GetTargetFramework(string assemblyPath)
+        internal static NuGetFramework GetTargetFramework(string assemblyPath)
         {
             using (var fileStream = File.OpenRead(assemblyPath))
             using (var peReader = new PEReader(fileStream))


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12908

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

This bumps a bunch of our runnable assemblies to net7.0. 
Some of these projects such as `nuget.command.xplat` and `nuget.build.tasks` need to depend on newer versions of msbuild assemblies which only tend to target newer .net versions. 
See for example: https://www.nuget.org/packages/Microsoft.Build#dependencies-body-tab. 

The delta in frameworks changes is: 

```diff
- NuGet.XPlat.FuncTest.csproj = net472;netcoreapp5.0
+ NuGet.XPlat.FuncTest.csproj = net472;net7.0
- Microsoft.Build.NuGetSdkResolver.Test.csproj = net472;netcoreapp5.0
+ Microsoft.Build.NuGetSdkResolver.Test.csproj = net472;net7.0
- NuGet.Build.Tasks.Console.Test.csproj = net472;netcoreapp5.0
+ NuGet.Build.Tasks.Console.Test.csproj = net472;net7.0
- NuGet.Build.Tasks.Pack.Test.csproj = net472;netcoreapp5.0
+ NuGet.Build.Tasks.Pack.Test.csproj = net472;net7.0
- NuGet.Build.Tasks.Test.csproj = net472;netcoreapp5.0
+ NuGet.Build.Tasks.Test.csproj = net472;net7.0
- NuGet.CommandLine.Xplat.Tests.csproj = net472;netcoreapp5.0
+ NuGet.CommandLine.Xplat.Tests.csproj = net472;net7.0
- Microsoft.Build.NuGetSdkResolver.csproj = net472;netcoreapp5.0
+ Microsoft.Build.NuGetSdkResolver.csproj = net472;net7.0
- NuGet.Build.Tasks.Console.csproj = net472;netcoreapp5.0
+ NuGet.Build.Tasks.Console.csproj = net472;net7.0
- NuGet.Build.Tasks.csproj = net472;netcoreapp5.0
+ NuGet.Build.Tasks.csproj = net472;net7.0
- NuGet.CommandLine.XPlat.csproj = net472;netcoreapp5.0
+ NuGet.CommandLine.XPlat.csproj = net472;net7.0
```

**Note** 

I added a very frequently used utility for making framework changes. 
I have uploaded the 4 files I generated using this. 
I've used this in previous PRs as well: https://github.com/NuGet/NuGet.Client/pull/5098/commits/853ca93e67ce1ce64f0999ce1f8fbdee670c05a9. 
 
[Before-BuildSource.txt](https://github.com/NuGet/NuGet.Client/files/12743856/Before-BuildSource.txt)

[Before-Standard.txt](https://github.com/NuGet/NuGet.Client/files/12743853/Before-Standard.txt)
[After-BuildSource.txt](https://github.com/NuGet/NuGet.Client/files/12743854/After-BuildSource.txt)
[After-standard.txt](https://github.com/NuGet/NuGet.Client/files/12743855/After-standard.txt)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. --> Automated tests added.

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
