### PR TITLE
Add option to enable floating versions in CPM

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -459,6 +459,7 @@ namespace NuGet.PackageManagement.VisualStudio
                         MSBuildStringUtility.IsTrue(GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.RestoreLockedMode))),
                     CentralPackageVersionsEnabled = isCpvmEnabled,
                     CentralPackageVersionOverrideDisabled = GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.CentralPackageVersionOverrideEnabled).EqualsFalse(),
+                    CentralPackageFloatingVersionsEnabled = MSBuildStringUtility.IsTrue(GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.CentralPackageFloatingVersionsEnabled)),
                     CentralPackageTransitivePinningEnabled = MSBuildStringUtility.IsTrue(GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.CentralPackageTransitivePinningEnabled)),
                     RestoreAuditProperties = auditProperties,
                 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -297,6 +297,11 @@ namespace NuGet.SolutionRestoreManager
             return GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.CentralPackageVersionOverrideEnabled, (value) => value.EqualsFalse());
         }
 
+        internal static bool IsCentralPackageFloatingVersionsEnabled(IEnumerable tfms)
+        {
+            return GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.CentralPackageFloatingVersionsEnabled, MSBuildStringUtility.IsTrue);
+        }
+
         internal static bool IsCentralPackageTransitivePinningEnabled(IEnumerable tfms)
         {
             return GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.CentralPackageTransitivePinningEnabled, MSBuildStringUtility.IsTrue);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -348,6 +348,7 @@ namespace NuGet.SolutionRestoreManager
                     CacheFilePath = NoOpRestoreUtilities.GetProjectCacheFilePath(cacheRoot: outputPath),
                     RestoreLockProperties = VSNominationUtilities.GetRestoreLockProperties(TargetFrameworks),
                     CentralPackageVersionsEnabled = cpvmEnabled,
+                    CentralPackageFloatingVersionsEnabled = VSNominationUtilities.IsCentralPackageFloatingVersionsEnabled(TargetFrameworks),
                     CentralPackageVersionOverrideDisabled = VSNominationUtilities.IsCentralPackageVersionOverrideDisabled(TargetFrameworks),
                     CentralPackageTransitivePinningEnabled = VSNominationUtilities.IsCentralPackageTransitivePinningEnabled(TargetFrameworks),
                     RestoreAuditProperties = VSNominationUtilities.GetRestoreAuditProperties(TargetFrameworks),

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -808,7 +808,7 @@ namespace NuGet.Build.Tasks.Console
 
             ProjectStyle? projectStyleOrNull = BuildTasksUtility.GetProjectRestoreStyleFromProjectProperty(project.GetProperty("RestoreProjectStyle"));
 
-            (bool isCentralPackageManagementEnabled, bool isCentralPackageVersionOverrideDisabled, bool isCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled) = GetCentralPackageManagementSettings(project, projectStyleOrNull);
+            (bool isCentralPackageManagementEnabled, bool isCentralPackageVersionOverrideDisabled, bool isCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled) = MSBuildRestoreUtility.GetCentralPackageManagementSettings(project, projectStyleOrNull);
 
             RestoreAuditProperties auditProperties = MSBuildRestoreUtility.GetRestoreAuditProperties(project);
 
@@ -1024,22 +1024,6 @@ namespace NuGet.Build.Tasks.Console
 
                 return null;
             }
-        }
-
-        /// <summary>
-        /// Determines the current settings for central package management for the specified project.
-        /// </summary>
-        /// <param name="project">The <see cref="IMSBuildProject" /> to get the central package management settings for.</param>
-        /// <param name="projectStyle">The <see cref="ProjectStyle?" /> of the specified project.  Specify <see langword="null" /> when the project does not define a restore style.</param>
-        /// <returns>A <see cref="Tuple{T1, T2, T3, T4}" /> containing values indicating whether or not central package management is enabled, if the ability to override a package version is disabled, if the ability to transitively pin a package version is enabled, and if floating versions are enabled.</returns>
-        internal static (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled, bool IsFloatingVersionsEnabled) GetCentralPackageManagementSettings(IMSBuildProject project, ProjectStyle? projectStyle)
-        {
-            if (!projectStyle.HasValue || (projectStyle.Value == ProjectStyle.PackageReference))
-            {
-                return (project.IsPropertyTrue("_CentralPackageVersionsEnabled"), project.IsPropertyFalse("CentralPackageVersionOverrideEnabled"), project.IsPropertyTrue("CentralPackageTransitivePinningEnabled"), project.IsPropertyTrue("CentralPackageFloatingVersionsEnabled"));
-            }
-
-            return (false, false, false, false);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -808,7 +808,7 @@ namespace NuGet.Build.Tasks.Console
 
             ProjectStyle? projectStyleOrNull = BuildTasksUtility.GetProjectRestoreStyleFromProjectProperty(project.GetProperty("RestoreProjectStyle"));
 
-            (bool isCentralPackageManagementEnabled, bool isCentralPackageVersionOverrideDisabled, bool isCentralPackageTransitivePinningEnabled) = GetCentralPackageManagementSettings(project, projectStyleOrNull);
+            (bool isCentralPackageManagementEnabled, bool isCentralPackageVersionOverrideDisabled, bool isCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled) = GetCentralPackageManagementSettings(project, projectStyleOrNull);
 
             RestoreAuditProperties auditProperties = MSBuildRestoreUtility.GetRestoreAuditProperties(project);
 
@@ -854,6 +854,7 @@ namespace NuGet.Build.Tasks.Console
                     SkipContentFileWrite = IsLegacyProject(project),
                     ValidateRuntimeAssets = project.IsPropertyTrue("ValidateRuntimeIdentifierCompatibility"),
                     CentralPackageVersionsEnabled = isCentralPackageManagementEnabled && projectStyle == ProjectStyle.PackageReference,
+                    CentralPackageFloatingVersionsEnabled = isCentralPackageFloatingVersionsEnabled,
                     CentralPackageVersionOverrideDisabled = isCentralPackageVersionOverrideDisabled,
                     CentralPackageTransitivePinningEnabled = isCentralPackageTransitivePinningEnabled,
                     RestoreAuditProperties = auditProperties
@@ -1030,15 +1031,15 @@ namespace NuGet.Build.Tasks.Console
         /// </summary>
         /// <param name="project">The <see cref="IMSBuildProject" /> to get the central package management settings for.</param>
         /// <param name="projectStyle">The <see cref="ProjectStyle?" /> of the specified project.  Specify <see langword="null" /> when the project does not define a restore style.</param>
-        /// <returns>A <see cref="Tuple{T1, T2}" /> containing values indicating whether or not central package management is enabled and if the ability to override a package version is disabled.</returns>
-        internal static (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled) GetCentralPackageManagementSettings(IMSBuildProject project, ProjectStyle? projectStyle)
+        /// <returns>A <see cref="Tuple{T1, T2, T3, T4}" /> containing values indicating whether or not central package management is enabled, if the ability to override a package version is disabled, if the ability to transitively pin a package version is enabled, and if floating versions are enabled.</returns>
+        internal static (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled, bool IsFloatingVersionsEnabled) GetCentralPackageManagementSettings(IMSBuildProject project, ProjectStyle? projectStyle)
         {
             if (!projectStyle.HasValue || (projectStyle.Value == ProjectStyle.PackageReference))
             {
-                return (project.IsPropertyTrue("_CentralPackageVersionsEnabled"), project.IsPropertyFalse("CentralPackageVersionOverrideEnabled"), project.IsPropertyTrue("CentralPackageTransitivePinningEnabled"));
+                return (project.IsPropertyTrue("_CentralPackageVersionsEnabled"), project.IsPropertyFalse("CentralPackageVersionOverrideEnabled"), project.IsPropertyTrue("CentralPackageTransitivePinningEnabled"), project.IsPropertyTrue("CentralPackageFloatingVersionsEnabled"));
             }
 
-            return (false, false, false);
+            return (false, false, false, false);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -849,6 +849,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <NuGetLockFilePath>$(NuGetLockFilePath)</NuGetLockFilePath>
         <RestoreLockedMode>$(RestoreLockedMode)</RestoreLockedMode>
         <_CentralPackageVersionsEnabled>$(_CentralPackageVersionsEnabled)</_CentralPackageVersionsEnabled>
+        <CentralPackageFloatingVersionsEnabled>$(CentralPackageFloatingVersionsEnabled)</CentralPackageFloatingVersionsEnabled>
         <CentralPackageVersionOverrideEnabled>$(CentralPackageVersionOverrideEnabled)</CentralPackageVersionOverrideEnabled>
         <CentralPackageTransitivePinningEnabled>$(CentralPackageTransitivePinningEnabled)</CentralPackageTransitivePinningEnabled>
         <NuGetAudit>$(NuGetAudit)</NuGetAudit>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -164,11 +164,15 @@ namespace NuGet.CommandLine.XPlat
                 packageReferenceArgs.Logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageVersions_MissingPackageVersion, string.Join(";", packageReferencedDependenciesWithoutCentralVersionDefined.Select(d => d.Name))));
                 return false;
             }
-            var floatingVersionDependencies = packageSpec.TargetFrameworks.SelectMany(tfm => tfm.CentralPackageVersions.Values).Where(cpv => cpv.VersionRange.IsFloating);
-            if (floatingVersionDependencies.Any())
+
+            if (!packageSpec.RestoreMetadata.CentralPackageFloatingVersionsEnabled)
             {
-                packageReferenceArgs.Logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageVersions_FloatingVersionsAreNotAllowed));
-                return false;
+                var floatingVersionDependencies = packageSpec.TargetFrameworks.SelectMany(tfm => tfm.CentralPackageVersions.Values).Where(cpv => cpv.VersionRange.IsFloating);
+                if (floatingVersionDependencies.Any())
+                {
+                    packageReferenceArgs.Logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageVersions_FloatingVersionsAreNotAllowed));
+                    return false;
+                }
             }
 
             // PackageVersion should not be defined outside the project file.

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+~static NuGet.Commands.MSBuildRestoreUtility.GetCentralPackageManagementSettings(NuGet.Commands.IMSBuildItem projectSpecItem, NuGet.ProjectModel.ProjectStyle? projectStyle) -> (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled)

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+~static NuGet.Commands.MSBuildRestoreUtility.GetCentralPackageManagementSettings(NuGet.Commands.IMSBuildItem projectSpecItem, NuGet.ProjectModel.ProjectStyle? projectStyle) -> (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled)

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+~static NuGet.Commands.MSBuildRestoreUtility.GetCentralPackageManagementSettings(NuGet.Commands.IMSBuildItem projectSpecItem, NuGet.ProjectModel.ProjectStyle? projectStyle) -> (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -599,12 +599,17 @@ namespace NuGet.Commands
                 await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1010, string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageVersions_MissingPackageVersion, string.Join(";", packageReferencedDependenciesWithoutCentralVersionDefined.Select(d => d.Name)))));
                 return false;
             }
-            var floatingVersionDependencies = _request.Project.TargetFrameworks.SelectMany(tfm => tfm.CentralPackageVersions.Values).Where(cpv => cpv.VersionRange.IsFloating);
-            if (floatingVersionDependencies.Any())
+
+            if (!restoreRequest.Project.RestoreMetadata.CentralPackageFloatingVersionsEnabled)
             {
-                await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1011, Strings.Error_CentralPackageVersions_FloatingVersionsAreNotAllowed));
-                return false;
+                var floatingVersionDependencies = _request.Project.TargetFrameworks.SelectMany(tfm => tfm.CentralPackageVersions.Values).Where(cpv => cpv.VersionRange.IsFloating);
+                if (floatingVersionDependencies.Any())
+                {
+                    await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1011, Strings.Error_CentralPackageVersions_FloatingVersionsAreNotAllowed));
+                    return false;
+                }
             }
+
             return true;
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -161,7 +161,7 @@ namespace NuGet.Commands
             {
                 ProjectStyle restoreType = GetProjectStyle(specItem);
 
-                (bool isCentralPackageManagementEnabled, bool isCentralPackageVersionOverrideDisabled, bool isCentralPackageTransitivePinningEnabled) = GetCentralPackageManagementSettings(specItem, restoreType);
+                (bool isCentralPackageManagementEnabled, bool isCentralPackageVersionOverrideDisabled, bool isCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled) = GetCentralPackageManagementSettings(specItem, restoreType);
 
                 // Get base spec
                 if (restoreType == ProjectStyle.ProjectJson)
@@ -296,6 +296,7 @@ namespace NuGet.Commands
 
                 result.RestoreMetadata.CentralPackageVersionsEnabled = isCentralPackageManagementEnabled;
                 result.RestoreMetadata.CentralPackageVersionOverrideDisabled = isCentralPackageVersionOverrideDisabled;
+                result.RestoreMetadata.CentralPackageFloatingVersionsEnabled = isCentralPackageFloatingVersionsEnabled;
                 result.RestoreMetadata.CentralPackageTransitivePinningEnabled = isCentralPackageTransitivePinningEnabled;
             }
 
@@ -1055,11 +1056,12 @@ namespace NuGet.Commands
             return restoreType;
         }
 
-        internal static (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled) GetCentralPackageManagementSettings(IMSBuildItem projectSpecItem, ProjectStyle projectStyle)
+        internal static (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled) GetCentralPackageManagementSettings(IMSBuildItem projectSpecItem, ProjectStyle projectStyle)
         {
             return (IsPropertyTrue(projectSpecItem, "_CentralPackageVersionsEnabled") && projectStyle == ProjectStyle.PackageReference,
                 IsPropertyFalse(projectSpecItem, "CentralPackageVersionOverrideEnabled"),
-                IsPropertyTrue(projectSpecItem, "CentralPackageTransitivePinningEnabled"));
+                IsPropertyTrue(projectSpecItem, "CentralPackageTransitivePinningEnabled"),
+                IsPropertyTrue(projectSpecItem, "CentralPackageFloatingVersionsEnabled"));
         }
 
         private static void AddCentralPackageVersions(PackageSpec spec, IEnumerable<IMSBuildItem> items)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -958,7 +958,7 @@ namespace NuGet.Commands
             return s;
         }
 
-        private static bool IsPropertyFalse(IMSBuildItem item, string propertyName, bool defaultValue = false)
+        internal static bool IsPropertyFalse(IMSBuildItem item, string propertyName, bool defaultValue = false)
         {
             string value = item.GetProperty(propertyName);
 
@@ -970,7 +970,7 @@ namespace NuGet.Commands
             return string.Equals(value, bool.FalseString, StringComparison.OrdinalIgnoreCase);
         }
 
-        private static bool IsPropertyTrue(IMSBuildItem item, string propertyName, bool defaultValue = false)
+        internal static bool IsPropertyTrue(IMSBuildItem item, string propertyName, bool defaultValue = false)
         {
             string value = item.GetProperty(propertyName);
 
@@ -1056,12 +1056,23 @@ namespace NuGet.Commands
             return restoreType;
         }
 
-        internal static (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled) GetCentralPackageManagementSettings(IMSBuildItem projectSpecItem, ProjectStyle projectStyle)
+        /// <summary>
+        /// Determines the current settings for central package management for the specified project.
+        /// </summary>
+        /// <param name="projectSpecItem">The <see cref="IMSBuildItem" /> to get the central package management settings from.</param>
+        /// <param name="projectStyle">The <see cref="ProjectStyle?" /> of the specified project.  Specify <see langword="null" /> when the project does not define a restore style.</param>
+        /// <returns>A <see cref="Tuple{T1, T2, T3, T4}" /> containing values indicating whether or not central package management is enabled, if the ability to override a package version 
+        public static (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled) GetCentralPackageManagementSettings(IMSBuildItem projectSpecItem, ProjectStyle? projectStyle)
         {
-            return (IsPropertyTrue(projectSpecItem, "_CentralPackageVersionsEnabled") && projectStyle == ProjectStyle.PackageReference,
+            if (!projectStyle.HasValue || (projectStyle.Value == ProjectStyle.PackageReference))
+            {
+                return (IsPropertyTrue(projectSpecItem, "_CentralPackageVersionsEnabled") && projectStyle == ProjectStyle.PackageReference,
                 IsPropertyFalse(projectSpecItem, "CentralPackageVersionOverrideEnabled"),
                 IsPropertyTrue(projectSpecItem, "CentralPackageTransitivePinningEnabled"),
                 IsPropertyTrue(projectSpecItem, "CentralPackageFloatingVersionsEnabled"));
+            }
+
+            return (false, false, false, false);
         }
 
         private static void AddCentralPackageVersions(PackageSpec spec, IEnumerable<IMSBuildItem> items)

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
@@ -59,5 +59,6 @@ namespace NuGet.ProjectManagement
         public const string NuGetAudit = nameof(NuGetAudit);
         public const string NuGetAuditLevel = nameof(NuGetAuditLevel);
         public const string NuGetAuditMode = nameof(NuGetAuditMode);
+        public const string CentralPackageFloatingVersionsEnabled = nameof(CentralPackageFloatingVersionsEnabled);
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+~const NuGet.ProjectManagement.ProjectBuildProperties.CentralPackageFloatingVersionsEnabled = "CentralPackageFloatingVersionsEnabled" -> string

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -902,6 +902,7 @@ namespace NuGet.ProjectModel
         private static void ReadMSBuildMetadata(JsonTextReader jsonReader, PackageSpec packageSpec)
         {
             var centralPackageVersionsManagementEnabled = false;
+            var centralPackageFloatingVersionsEnabled = false;
             var centralPackageVersionOverrideDisabled = false;
             var CentralPackageTransitivePinningEnabled = false;
             List<string> configFilePaths = null;
@@ -933,6 +934,10 @@ namespace NuGet.ProjectModel
                 {
                     case "centralPackageVersionsManagementEnabled":
                         centralPackageVersionsManagementEnabled = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);
+                        break;
+
+                    case "centralPackageFloatingVersionsEnabled":
+                        centralPackageFloatingVersionsEnabled = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);
                         break;
 
                     case "centralPackageVersionOverrideDisabled":
@@ -1131,6 +1136,7 @@ namespace NuGet.ProjectModel
             }
 
             msbuildMetadata.CentralPackageVersionsEnabled = centralPackageVersionsManagementEnabled;
+            msbuildMetadata.CentralPackageFloatingVersionsEnabled = centralPackageFloatingVersionsEnabled;
             msbuildMetadata.CentralPackageVersionOverrideDisabled = centralPackageVersionOverrideDisabled;
             msbuildMetadata.CentralPackageTransitivePinningEnabled = CentralPackageTransitivePinningEnabled;
             msbuildMetadata.RestoreAuditProperties = auditProperties;

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -176,6 +176,7 @@ namespace NuGet.ProjectModel
             SetValueIfTrue(writer, "validateRuntimeAssets", msbuildMetadata.ValidateRuntimeAssets);
             SetValueIfTrue(writer, "skipContentFileWrite", msbuildMetadata.SkipContentFileWrite);
             SetValueIfTrue(writer, "centralPackageVersionsManagementEnabled", msbuildMetadata.CentralPackageVersionsEnabled);
+            SetValueIfTrue(writer, "centralPackageFloatingVersionsEnabled", msbuildMetadata.CentralPackageFloatingVersionsEnabled);
             SetValueIfTrue(writer, "centralPackageVersionOverrideDisabled", msbuildMetadata.CentralPackageVersionOverrideDisabled);
             SetValueIfTrue(writer, "CentralPackageTransitivePinningEnabled", msbuildMetadata.CentralPackageTransitivePinningEnabled);
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -123,6 +123,11 @@ namespace NuGet.ProjectModel
         /// </summary>
         public bool CentralPackageVersionOverrideDisabled { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether or not floating versions are allowed when using central package management (CPM).
+        /// </summary>
+        public bool CentralPackageFloatingVersionsEnabled { get; set; }
+
         public bool CentralPackageTransitivePinningEnabled { get; set; }
 
         public RestoreAuditProperties RestoreAuditProperties { get; set; }
@@ -153,6 +158,7 @@ namespace NuGet.ProjectModel
             hashCode.AddObject(ProjectWideWarningProperties);
             hashCode.AddObject(RestoreLockProperties);
             hashCode.AddObject(CentralPackageVersionsEnabled);
+            hashCode.AddObject(CentralPackageFloatingVersionsEnabled);
             hashCode.AddObject(CentralPackageVersionOverrideDisabled);
             hashCode.AddObject(CentralPackageTransitivePinningEnabled);
             hashCode.AddObject(RestoreAuditProperties);
@@ -198,6 +204,7 @@ namespace NuGet.ProjectModel
                    EqualityUtility.EqualsWithNullCheck(ProjectWideWarningProperties, other.ProjectWideWarningProperties) &&
                    EqualityUtility.EqualsWithNullCheck(RestoreLockProperties, other.RestoreLockProperties) &&
                    EqualityUtility.EqualsWithNullCheck(CentralPackageVersionsEnabled, other.CentralPackageVersionsEnabled) &&
+                   EqualityUtility.EqualsWithNullCheck(CentralPackageFloatingVersionsEnabled, other.CentralPackageFloatingVersionsEnabled) &&
                    EqualityUtility.EqualsWithNullCheck(CentralPackageVersionOverrideDisabled, other.CentralPackageVersionOverrideDisabled) &&
                    EqualityUtility.EqualsWithNullCheck(CentralPackageTransitivePinningEnabled, other.CentralPackageTransitivePinningEnabled) &&
                    RestoreAuditProperties == other.RestoreAuditProperties;
@@ -233,6 +240,7 @@ namespace NuGet.ProjectModel
             clone.ProjectWideWarningProperties = ProjectWideWarningProperties?.Clone();
             clone.RestoreLockProperties = RestoreLockProperties?.Clone();
             clone.CentralPackageVersionsEnabled = CentralPackageVersionsEnabled;
+            clone.CentralPackageFloatingVersionsEnabled = CentralPackageFloatingVersionsEnabled;
             clone.CentralPackageVersionOverrideDisabled = CentralPackageVersionOverrideDisabled;
             clone.CentralPackageTransitivePinningEnabled = CentralPackageTransitivePinningEnabled;
             clone.RestoreAuditProperties = RestoreAuditProperties?.Clone();

--- a/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+NuGet.ProjectModel.ProjectRestoreMetadata.CentralPackageFloatingVersionsEnabled.get -> bool
+NuGet.ProjectModel.ProjectRestoreMetadata.CentralPackageFloatingVersionsEnabled.set -> void

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -1967,7 +1967,7 @@ namespace NuGet.SolutionRestoreManager.Test
         public void ToPackageSpec_CentralVersions_AreAddedToThePackageSpecIfCPVMIsEnabled()
         {
             // Arrange
-            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "prjectC", Guid.NewGuid().ToString());
+            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "projectC", Guid.NewGuid().ToString());
             var emptyReferenceItems = Array.Empty<VsReferenceItem>();
 
             var targetFrameworks = new VsTargetFrameworkInfo3[] { new VsTargetFrameworkInfo3(
@@ -2009,7 +2009,7 @@ namespace NuGet.SolutionRestoreManager.Test
         public void ToPackageSpec_CentralVersions_CPVMIsEnabled_NoPackageVersions()
         {
             // Arrange
-            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "prjectC", Guid.NewGuid().ToString());
+            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "projectC", Guid.NewGuid().ToString());
             var emptyReferenceItems = Array.Empty<VsReferenceItem>();
 
             var targetFrameworks = new VsTargetFrameworkInfo3[] { new VsTargetFrameworkInfo3(
@@ -2042,7 +2042,7 @@ namespace NuGet.SolutionRestoreManager.Test
         public void ToPackageSpec_CentralVersions_AreNotAddedToThePackageSpecIfCPVMIsNotEnabled(string packRefVersion, string managePackageVersionsCentrally)
         {
             // Arrange
-            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "prjectC", Guid.NewGuid().ToString());
+            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "projectC", Guid.NewGuid().ToString());
             var emptyReferenceItems = Array.Empty<VsReferenceItem>();
             var packageReferenceProperties = packRefVersion == null ?
                 new VsReferenceProperties() :
@@ -2090,7 +2090,7 @@ namespace NuGet.SolutionRestoreManager.Test
         public void ToPackageSpec_CentralVersionOverride_CanBeDisabled(string isCentralPackageVersionOverrideEnabled, bool expected)
         {
             // Arrange
-            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "prjectC", Guid.NewGuid().ToString());
+            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "projectC", Guid.NewGuid().ToString());
             var emptyReferenceItems = Array.Empty<VsReferenceItem>();
 
             var targetFrameworks = new VsTargetFrameworkInfo3[] { new VsTargetFrameworkInfo3(
@@ -2151,7 +2151,7 @@ namespace NuGet.SolutionRestoreManager.Test
         public void ToPackageSpec_TransitiveDependencyPinning_CanBeEnabled(string CentralPackageTransitivePinningEnabled, bool expected)
         {
             // Arrange
-            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "prjectC", Guid.NewGuid().ToString());
+            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "projectC", Guid.NewGuid().ToString());
             var emptyReferenceItems = Array.Empty<VsReferenceItem>();
 
             var targetFrameworks = new VsTargetFrameworkInfo3[] { new VsTargetFrameworkInfo3(
@@ -2180,6 +2180,49 @@ namespace NuGet.SolutionRestoreManager.Test
             else
             {
                 Assert.False(result.RestoreMetadata.CentralPackageTransitivePinningEnabled);
+            }
+        }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData(" ", false)]
+        [InlineData("invalid", false)]
+        [InlineData("false", false)]
+        [InlineData("true", true)]
+        [InlineData("           true    ", true)]
+        public void ToPackageSpec_CentralPackageFloatingVersions_CanBeEnabled(string centralPackageFloatingVersionsEnabled, bool expected)
+        {
+            // Arrange
+            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "projectC", Guid.NewGuid().ToString());
+            var emptyReferenceItems = Array.Empty<VsReferenceItem>();
+
+            var targetFrameworks = new VsTargetFrameworkInfo3[] { new VsTargetFrameworkInfo3(
+                targetFrameworkMoniker: CommonFrameworks.NetStandard20.ToString(),
+                packageReferences: new[] { new VsReferenceItem("foo", new VsReferenceProperties()) },
+                projectReferences: emptyReferenceItems,
+                packageDownloads: emptyReferenceItems,
+                frameworkReferences: emptyReferenceItems,
+                projectProperties: ProjectRestoreInfoBuilder.GetTargetFrameworkProperties(CommonFrameworks.NetStandard20).Concat(new VsProjectProperty[]
+                {
+                    new VsProjectProperty(ProjectBuildProperties.ManagePackageVersionsCentrally, "true"),
+                    new VsProjectProperty(ProjectBuildProperties.CentralPackageFloatingVersionsEnabled, centralPackageFloatingVersionsEnabled),
+                }),
+                centralPackageVersions: Array.Empty<IVsReferenceItem>())
+            };
+
+            // Act
+            PackageSpec result = VsSolutionRestoreService.ToPackageSpec(projectName, targetFrameworks, CommonFrameworks.NetStandard20.ToString(), string.Empty);
+
+            // Assert
+
+            if (expected)
+            {
+                Assert.True(result.RestoreMetadata.CentralPackageFloatingVersionsEnabled);
+            }
+            else
+            {
+                Assert.False(result.RestoreMetadata.CentralPackageFloatingVersionsEnabled);
             }
         }
 
@@ -2233,7 +2276,7 @@ namespace NuGet.SolutionRestoreManager.Test
         public void ToPackageSpec_TargetFrameworkWithAlias_DefinesAliasCorrectly()
         {
             // Arrange
-            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "prjectC", Guid.NewGuid().ToString());
+            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "projectC", Guid.NewGuid().ToString());
             var emptyReferenceItems = Array.Empty<VsReferenceItem>();
             var packageReferenceProperties = new VsReferenceProperties();
 

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
@@ -762,7 +762,7 @@ namespace NuGet.Build.Tasks.Console.Test
             });
 
             // Act
-            var result = MSBuildStaticGraphRestore.GetCentralPackageManagementSettings(project, projectStyle).IsEnabled;
+            var result = MSBuildRestoreUtility.GetCentralPackageManagementSettings(project, projectStyle).IsEnabled;
 
             // Assert
             Assert.Equal(expected, result);
@@ -786,7 +786,7 @@ namespace NuGet.Build.Tasks.Console.Test
                 });
 
             // Act
-            var result = MSBuildStaticGraphRestore.GetCentralPackageManagementSettings(project, ProjectStyle.PackageReference).IsVersionOverrideDisabled;
+            var result = MSBuildRestoreUtility.GetCentralPackageManagementSettings(project, ProjectStyle.PackageReference).IsVersionOverrideDisabled;
 
             // Assert
             Assert.Equal(disabled, result);
@@ -810,7 +810,7 @@ namespace NuGet.Build.Tasks.Console.Test
                 });
 
             // Act
-            var result = MSBuildStaticGraphRestore.GetCentralPackageManagementSettings(project, ProjectStyle.PackageReference).IsCentralPackageTransitivePinningEnabled;
+            var result = MSBuildRestoreUtility.GetCentralPackageManagementSettings(project, ProjectStyle.PackageReference).IsCentralPackageTransitivePinningEnabled;
 
             // Assert
             Assert.Equal(enabled, result);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -3725,11 +3725,9 @@ namespace NuGet.Commands.Test
         [Theory]
         [InlineData(null, false)]
         [InlineData("", false)]
-        [InlineData("                     ", false)]
         [InlineData("true", false)]
         [InlineData("invalid", false)]
         [InlineData("false", true)]
-        [InlineData("           false    ", true)]
         public void MSBuildRestoreUtility_GetPackageSpec_CPVM_VersionOverrideCanBeDisabled(string isCentralPackageVersionOverrideEnabled, bool disabled)
         {
             var projectName = "alegacycpvm";
@@ -3831,12 +3829,10 @@ namespace NuGet.Commands.Test
 
         [Theory]
         [InlineData(null, false)]
-        [InlineData("", false)]
         [InlineData("                     ", false)]
         [InlineData("false", false)]
         [InlineData("invalid", false)]
         [InlineData("true", true)]
-        [InlineData("           true    ", true)]
         public void MSBuildRestoreUtility_GetPackageSpec_CPVM_FloatingVersionsCanBeEnabled(string isCentralPackageFloatingVersionsEnabled, bool enabled)
         {
             var projectName = "alegacycpvm";
@@ -4699,6 +4695,47 @@ namespace NuGet.Commands.Test
                 net60Framework.FrameworkName.Profile.Should().Be(profile);
                 net60Framework.FrameworkName.HasPlatform.Should().BeFalse();
             }
+        }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("                     ", false)]
+        [InlineData("false", false)]
+        [InlineData("invalid", false)]
+        [InlineData("true", true)]
+        [InlineData("           true    ", true)]
+        public void IsPropertyTrue_ReturnsExpectedValue(string value, bool expected)
+        {
+            const string propertyName = "Property1";
+
+            MSBuildItem item = new("Item1", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [propertyName] = value
+            });
+
+            MSBuildRestoreUtility.IsPropertyTrue(item, propertyName).Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("                     ", false)]
+        [InlineData("false", true)]
+        [InlineData("   false     ", true)]
+        [InlineData("invalid", false)]
+        [InlineData("true", false)]
+        [InlineData("           true    ", false)]
+        public void IsPropertyFalse_ReturnsExpectedValue(string value, bool expected)
+        {
+            const string propertyName = "Property1";
+
+            MSBuildItem item = new("Item1", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [propertyName] = value
+            });
+
+            MSBuildRestoreUtility.IsPropertyFalse(item, propertyName).Should().Be(expected);
         }
 
         private static IDictionary<string, string> CreateProject(string root, string uniqueName)

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -3830,6 +3830,113 @@ namespace NuGet.Commands.Test
         }
 
         [Theory]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("                     ", false)]
+        [InlineData("false", false)]
+        [InlineData("invalid", false)]
+        [InlineData("true", true)]
+        [InlineData("           true    ", true)]
+        public void MSBuildRestoreUtility_GetPackageSpec_CPVM_FloatingVersionsCanBeEnabled(string isCentralPackageFloatingVersionsEnabled, bool enabled)
+        {
+            var projectName = "alegacycpvm";
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var projectUniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
+                var project1Root = Path.Combine(workingDir, projectName);
+                var project1Path = Path.Combine(project1Root, $"{projectName}.csproj");
+
+                var items = new List<IDictionary<string, string>>();
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "ProjectName", projectName },
+                    { "ProjectStyle", "PackageReference" },
+                    { "ProjectUniqueName", projectUniqueName },
+                    { "ProjectPath", project1Path },
+                    { "_CentralPackageVersionsEnabled", "true"},
+                    { "CentralPackageFloatingVersionsEnabled", isCentralPackageFloatingVersionsEnabled }
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", projectUniqueName },
+                    { "TargetFramework", "net472" },
+                    { "TargetFrameworkIdentifier", ".NETFramework" },
+                    { "TargetFrameworkVersion", "v4.7.2" },
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=v4.7.2" },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformMoniker", "" },
+                    { "TargetPlatformVersion", "" },
+                });
+
+                // Package reference
+                // No TargetFrameworks metadata
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "Dependency" },
+                    { "ProjectUniqueName", projectUniqueName },
+                    { "Id", "x" },
+                    { "IncludeAssets", "build;compile" },
+                    { "CrossTargeting", "true" },
+                });
+
+
+                // Central Version for the package above and another one for a package y
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "CentralPackageVersion" },
+                    { "ProjectUniqueName", projectUniqueName },
+                    { "Id", "x" },
+                    { "VersionRange", "1.0.0" },
+                });
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "CentralPackageVersion" },
+                    { "ProjectUniqueName", projectUniqueName },
+                    { "Id", "y" },
+                    { "VersionRange", "2.0.0" },
+                });
+
+                var wrappedItems = items.Select(CreateItems).ToList();
+
+                // Act
+                var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+                var project1Spec = dgSpec.Projects.Single(e => e.Name == projectName);
+
+                // Assert
+                Assert.Equal(1, project1Spec.TargetFrameworks.Count());
+                Assert.Equal(1, project1Spec.TargetFrameworks.First().Dependencies.Count);
+                Assert.Equal(2, project1Spec.TargetFrameworks.First().CentralPackageVersions.Count);
+
+                Assert.Equal("[1.0.0, )", project1Spec.TargetFrameworks.First().Dependencies[0].LibraryRange.VersionRange.ToNormalizedString());
+                Assert.Equal(LibraryIncludeFlags.Compile | LibraryIncludeFlags.Build, project1Spec.TargetFrameworks.First().Dependencies[0].IncludeType);
+
+                Assert.Equal("x", project1Spec.TargetFrameworks.First().CentralPackageVersions["x"].Name);
+                Assert.Equal("[1.0.0, )", project1Spec.TargetFrameworks.First().CentralPackageVersions["x"].VersionRange.ToNormalizedString());
+
+                Assert.Equal("y", project1Spec.TargetFrameworks.First().CentralPackageVersions["y"].Name);
+                Assert.Equal("[2.0.0, )", project1Spec.TargetFrameworks.First().CentralPackageVersions["y"].VersionRange.ToNormalizedString());
+
+                Assert.True(project1Spec.RestoreMetadata.CentralPackageVersionsEnabled);
+
+                if (enabled)
+                {
+                    Assert.True(project1Spec.RestoreMetadata.CentralPackageFloatingVersionsEnabled);
+                }
+                else
+                {
+                    Assert.False(project1Spec.RestoreMetadata.CentralPackageFloatingVersionsEnabled);
+                }
+            }
+        }
+
+        [Theory]
         [InlineData(ProjectStyle.DotnetCliTool)]
         [InlineData(ProjectStyle.DotnetToolReference)]
         [InlineData(ProjectStyle.PackagesConfig)]

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -1984,12 +1984,22 @@ namespace NuGet.Commands.Test.RestoreCommandTests
             }
         }
 
-        [Fact]
-        public async Task RestoreCommand_CentralVersion_ErrorWhenFloatingCentralVersions()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+
+        public async Task RestoreCommand_CentralVersion_ErrorWhenFloatingCentralVersionsAreDisabled(bool enabled)
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
             {
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    new SimpleTestPackageContext("foo", "1.0.0"));
+
+                using var context = new SourceCacheContext();
+
                 var projectName = "TestProject";
                 var projectPath = Path.Combine(pathContext.SolutionRoot, projectName);
                 var outputPath = Path.Combine(projectPath, "obj");
@@ -2005,23 +2015,27 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                     new List<LibraryDependency>() { packageRefDependecyFoo },
                     new List<CentralPackageVersion>() { centralVersionFoo });
 
-                var packageSpec = new PackageSpec(new List<TargetFrameworkInformation>() { tfi });
-                packageSpec.RestoreMetadata = new ProjectRestoreMetadata()
+                var packageSpec = new PackageSpec(new List<TargetFrameworkInformation>() { tfi })
                 {
-                    ProjectUniqueName = projectName,
-                    CentralPackageVersionsEnabled = true,
-                    ProjectStyle = ProjectStyle.PackageReference,
-                    OutputPath = outputPath,
+                    FilePath = projectPath,
+                    Name = projectName,
+                    RestoreMetadata = new ProjectRestoreMetadata()
+                    {
+                        ProjectUniqueName = projectName,
+                        CentralPackageVersionsEnabled = true,
+                        CentralPackageFloatingVersionsEnabled = enabled,
+                        ProjectStyle = ProjectStyle.PackageReference,
+                        OutputPath = outputPath,
+                    }
                 };
-                packageSpec.FilePath = projectPath;
 
                 var dgspec = new DependencyGraphSpec();
                 dgspec.AddProject(packageSpec);
 
-                var sources = new List<PackageSource>();
+                var sources = new List<PackageSource> { new PackageSource(pathContext.PackageSource) };
                 var logger = new TestLogger();
 
-                var request = new TestRestoreRequest(dgspec.GetProjectSpec(projectName), sources, "", logger)
+                var request = new TestRestoreRequest(packageSpec, sources, "", logger)
                 {
                     LockFilePath = Path.Combine(projectPath, "project.assets.json"),
                     ProjectStyle = ProjectStyle.PackageReference
@@ -2031,14 +2045,21 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
                 var result = await restoreCommand.ExecuteAsync();
 
-                // Assert
-                Assert.False(result.Success);
-                Assert.Equal(1, logger.ErrorMessages.Count);
-                logger.ErrorMessages.TryDequeue(out var errorMessage);
-                Assert.True(errorMessage.Contains("Centrally defined floating package versions are not allowed."));
-                var messagesForNU1011 = result.LockFile.LogMessages.Where(m => m.Code == NuGetLogCode.NU1011);
-                Assert.Equal(1, messagesForNU1011.Count());
-
+                if (enabled)
+                {
+                    // Assert
+                    Assert.True(result.Success);
+                }
+                else
+                {
+                    // Assert
+                    Assert.False(result.Success);
+                    Assert.Equal(1, logger.ErrorMessages.Count);
+                    logger.ErrorMessages.TryDequeue(out var errorMessage);
+                    Assert.True(errorMessage.Contains("Centrally defined floating package versions are not allowed."));
+                    var messagesForNU1011 = result.LockFile.LogMessages.Where(m => m.Code == NuGetLogCode.NU1011);
+                    Assert.Equal(1, messagesForNU1011.Count());
+                }
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -1987,7 +1987,6 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-
         public async Task RestoreCommand_CentralVersion_ErrorWhenFloatingCentralVersionsAreDisabled(bool enabled)
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -1987,7 +1987,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task RestoreCommand_CentralVersion_ErrorWhenFloatingCentralVersionsAreDisabled(bool enabled)
+        public async Task RestoreCommand_CentralVersion_ErrorWhenFloatingCentralVersions(bool enabled)
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -2045,14 +2045,13 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
                 var result = await restoreCommand.ExecuteAsync();
 
+                // Assert
                 if (enabled)
                 {
-                    // Assert
                     Assert.True(result.Success);
                 }
                 else
                 {
-                    // Assert
                     Assert.False(result.Success);
                     Assert.Equal(1, logger.ErrorMessages.Count);
                     logger.ErrorMessages.TryDequeue(out var errorMessage);

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -2996,6 +2996,48 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CentralPackageVersionsEnabled);
         }
 
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void GetPackageSpec_WhenCentralPackageFloatingVersionsEnabledValueIsValid_ReturnsCentralPackageFloatingVersionsEnabled(
+            bool? value,
+            bool expectedValue)
+        {
+            var json = $"{{\"restore\":{{\"centralPackageFloatingVersionsEnabled\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CentralPackageFloatingVersionsEnabled);
+        }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void GetPackageSpec_WhenCentralPackageVersionOverrideDisabledValueIsValid_ReturnsCentralPackageVersionOverrideDisabled(
+            bool? value,
+            bool expectedValue)
+        {
+            var json = $"{{\"restore\":{{\"centralPackageVersionOverrideDisabled\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CentralPackageVersionOverrideDisabled);
+        }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void GetPackageSpec_WhenCentralPackageTransitivePinningEnabledValueIsValid_ReturnsCentralPackageTransitivePinningEnabled(
+            bool? value,
+            bool expectedValue)
+        {
+            var json = $"{{\"restore\":{{\"CentralPackageTransitivePinningEnabled\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CentralPackageTransitivePinningEnabled);
+        }
+
         [Fact]
         public void GetPackageSpec_WhenSourcesValueIsEmptyObject_ReturnsEmptySources()
         {

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTests.cs
@@ -109,7 +109,7 @@ namespace NuGet.ProjectModel.Test
             Assert.NotEqual(originalPackOptions, clone);
             Assert.Equal(originalPackageName, clone.PackageType[0].Name);
 
-            // Set Up again
+            // Arrange again
             originalPackOptions.Mappings.Add("randomString", files);
 
             // Act again
@@ -229,7 +229,7 @@ namespace NuGet.ProjectModel.Test
         //[InlineData("ModifyRestoreSettings", true)] = Not really included in the equals and hash code comparisons
         public void PackageSpecCloneTest(string methodName, bool validateJson)
         {
-            // Set up
+            // Arrange
             var packageSpec = CreatePackageSpec();
             var clonedPackageSpec = packageSpec.Clone();
 
@@ -407,7 +407,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataCloneTest()
         {
-            // Set up
+            // Arrange
             var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
             // Act
 
@@ -421,7 +421,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataCloneChangeSourcesTest()
         {
-            // Set up
+            // Arrange
             var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
 
             // Preconditions
@@ -440,7 +440,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataCloneChangeCentralPackageVersionsEnabledTest()
         {
-            // Set up
+            // Arrange
             var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
 
             // Preconditions
@@ -459,7 +459,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataCloneChangeCentralPackageFloatingVersionsEnabledTest()
         {
-            // Set up
+            // Arrange
             var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
 
             // Preconditions
@@ -478,7 +478,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataCloneChangeCentralPackageVersionOverrideDisabledTest()
         {
-            // Set up
+            // Arrange
             var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
 
             // Preconditions
@@ -497,7 +497,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataCloneChangeCentralPackageTransitivePinningEnabledTest()
         {
-            // Set up
+            // Arrange
             var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
 
             // Preconditions
@@ -516,7 +516,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataCloneChangeFallbackFoldersTest()
         {
-            // Set up
+            // Arrange
             var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
 
             // Preconditions
@@ -535,7 +535,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataCloneChangeConfigFilePathsTest()
         {
-            // Set up
+            // Arrange
             var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
 
             // Preconditions
@@ -554,7 +554,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataCloneChangeOriginalTargetFrameworksTest()
         {
-            // Set up
+            // Arrange
             var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
 
             // Preconditions
@@ -573,7 +573,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataCloneChangeFilesTest()
         {
-            // Set up
+            // Arrange
             var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
 
             // Preconditions
@@ -592,7 +592,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataCloneChangeProjectWideWarningPropertiesTest()
         {
-            // Set up
+            // Arrange
             var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
 
             // Preconditions
@@ -611,7 +611,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataFileCloneTest()
         {
-            // Set up
+            // Arrange
             var originalProjectRestoreMetadataFile = new ProjectRestoreMetadataFile("packagePath", "absolutePath");
 
             // Act
@@ -655,7 +655,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreReferenceCloneTest()
         {
-            // Set up
+            // Arrange
             var originalProjectRestoreReference = new ProjectRestoreReference();
             originalProjectRestoreReference.ProjectPath = "Path";
             originalProjectRestoreReference.ProjectUniqueName = "ProjectUniqueName";
@@ -681,7 +681,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreSettingsCloneTest()
         {
-            // Set up
+            // Arrange
             var originalProjectRestoreSettings = CreateProjectRestoreSettings();
 
             // Act
@@ -725,7 +725,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void TargetFrameworkInformationCloneTest()
         {
-            // Set up
+            // Arrange
             var originalTargetFrameworkInformation = CreateTargetFrameworkInformation();
 
             // Act
@@ -807,7 +807,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void WarningPropertiesCloneTest()
         {
-            // Set up
+            // Arrange
             var allWarningsAsErrors = false;
             var noWarn = new HashSet<NuGetLogCode>() { NuGetLogCode.NU1000, NuGetLogCode.NU1500 };
             var warningsAsErrors = new HashSet<NuGetLogCode>() { NuGetLogCode.NU1001, NuGetLogCode.NU1501 };

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTests.cs
@@ -438,6 +438,82 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Fact]
+        public void ProjectRestoreMetadataCloneChangeCentralPackageVersionsEnabledTest()
+        {
+            // Set up
+            var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
+
+            // Preconditions
+            var happyClone = originalProjectRestoreMetadata.Clone();
+            Assert.Equal(originalProjectRestoreMetadata, happyClone);
+            Assert.False(object.ReferenceEquals(originalProjectRestoreMetadata, happyClone));
+
+            // Act
+            originalProjectRestoreMetadata.CentralPackageVersionsEnabled = !originalProjectRestoreMetadata.CentralPackageVersionsEnabled;
+
+            // Assert
+            Assert.NotEqual(originalProjectRestoreMetadata, happyClone);
+            Assert.Equal(originalProjectRestoreMetadata.CentralPackageVersionsEnabled, !happyClone.CentralPackageVersionsEnabled);
+        }
+
+        [Fact]
+        public void ProjectRestoreMetadataCloneChangeCentralPackageFloatingVersionsEnabledTest()
+        {
+            // Set up
+            var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
+
+            // Preconditions
+            var happyClone = originalProjectRestoreMetadata.Clone();
+            Assert.Equal(originalProjectRestoreMetadata, happyClone);
+            Assert.False(object.ReferenceEquals(originalProjectRestoreMetadata, happyClone));
+
+            // Act
+            originalProjectRestoreMetadata.CentralPackageFloatingVersionsEnabled = !originalProjectRestoreMetadata.CentralPackageFloatingVersionsEnabled;
+
+            // Assert
+            Assert.NotEqual(originalProjectRestoreMetadata, happyClone);
+            Assert.Equal(originalProjectRestoreMetadata.CentralPackageFloatingVersionsEnabled, !happyClone.CentralPackageFloatingVersionsEnabled);
+        }
+
+        [Fact]
+        public void ProjectRestoreMetadataCloneChangeCentralPackageVersionOverrideDisabledTest()
+        {
+            // Set up
+            var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
+
+            // Preconditions
+            var happyClone = originalProjectRestoreMetadata.Clone();
+            Assert.Equal(originalProjectRestoreMetadata, happyClone);
+            Assert.False(object.ReferenceEquals(originalProjectRestoreMetadata, happyClone));
+
+            // Act
+            originalProjectRestoreMetadata.CentralPackageVersionOverrideDisabled = !originalProjectRestoreMetadata.CentralPackageVersionOverrideDisabled;
+
+            // Assert
+            Assert.NotEqual(originalProjectRestoreMetadata, happyClone);
+            Assert.Equal(originalProjectRestoreMetadata.CentralPackageVersionOverrideDisabled, !happyClone.CentralPackageVersionOverrideDisabled);
+        }
+
+        [Fact]
+        public void ProjectRestoreMetadataCloneChangeCentralPackageTransitivePinningEnabledTest()
+        {
+            // Set up
+            var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
+
+            // Preconditions
+            var happyClone = originalProjectRestoreMetadata.Clone();
+            Assert.Equal(originalProjectRestoreMetadata, happyClone);
+            Assert.False(object.ReferenceEquals(originalProjectRestoreMetadata, happyClone));
+
+            // Act
+            originalProjectRestoreMetadata.CentralPackageTransitivePinningEnabled = !originalProjectRestoreMetadata.CentralPackageTransitivePinningEnabled;
+
+            // Assert
+            Assert.NotEqual(originalProjectRestoreMetadata, happyClone);
+            Assert.Equal(originalProjectRestoreMetadata.CentralPackageVersionOverrideDisabled, !happyClone.CentralPackageVersionOverrideDisabled);
+        }
+
+        [Fact]
         public void ProjectRestoreMetadataCloneChangeFallbackFoldersTest()
         {
             // Set up
@@ -525,7 +601,7 @@ namespace NuGet.ProjectModel.Test
             Assert.False(object.ReferenceEquals(originalProjectRestoreMetadata, happyClone));
 
             // Act
-            originalProjectRestoreMetadata.ProjectWideWarningProperties.AllWarningsAsErrors = false; ;
+            originalProjectRestoreMetadata.ProjectWideWarningProperties.AllWarningsAsErrors = false;
 
             // Assert
             Assert.NotEqual(originalProjectRestoreMetadata, happyClone);

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTests.cs
@@ -510,7 +510,7 @@ namespace NuGet.ProjectModel.Test
 
             // Assert
             Assert.NotEqual(originalProjectRestoreMetadata, happyClone);
-            Assert.Equal(originalProjectRestoreMetadata.CentralPackageVersionOverrideDisabled, !happyClone.CentralPackageVersionOverrideDisabled);
+            Assert.Equal(originalProjectRestoreMetadata.CentralPackageTransitivePinningEnabled, !happyClone.CentralPackageTransitivePinningEnabled);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreMetadataTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreMetadataTests.cs
@@ -334,6 +334,60 @@ namespace NuGet.ProjectModel.Test
         [InlineData(true, false, false)]
         [InlineData(false, true, false)]
         [InlineData(false, false, true)]
+        public void Equals_WithCentralPackageFloatingVersionsEnabled(bool left, bool right, bool expected)
+        {
+            var leftSide = new ProjectRestoreMetadata
+            {
+                CentralPackageFloatingVersionsEnabled = left
+            };
+            var rightSide = new ProjectRestoreMetadata
+            {
+                CentralPackageFloatingVersionsEnabled = right
+            };
+            AssertEquality(expected, leftSide, rightSide);
+        }
+
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, true)]
+        public void Equals_WithCentralPackageVersionOverrideDisabled(bool left, bool right, bool expected)
+        {
+            var leftSide = new ProjectRestoreMetadata
+            {
+                CentralPackageVersionOverrideDisabled = left
+            };
+            var rightSide = new ProjectRestoreMetadata
+            {
+                CentralPackageVersionOverrideDisabled = right
+            };
+            AssertEquality(expected, leftSide, rightSide);
+        }
+
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, true)]
+        public void Equals_WithCentralPackageTransitivePinningEnabled(bool left, bool right, bool expected)
+        {
+            var leftSide = new ProjectRestoreMetadata
+            {
+                CentralPackageTransitivePinningEnabled = left
+            };
+            var rightSide = new ProjectRestoreMetadata
+            {
+                CentralPackageTransitivePinningEnabled = right
+            };
+            AssertEquality(expected, leftSide, rightSide);
+        }
+
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, true)]
         public void Equals_WithSkipContentFileWrite(bool left, bool right, bool expected)
         {
             var leftSide = new ProjectRestoreMetadata
@@ -579,6 +633,41 @@ namespace NuGet.ProjectModel.Test
         [InlineData(true, false, false)]
         [InlineData(false, true, false)]
         [InlineData(false, false, true)]
+        public void HashCode_WithCentralPackageVersionOverrideDisabled(bool left, bool right, bool expected)
+        {
+            var leftSide = new ProjectRestoreMetadata
+            {
+                CentralPackageVersionOverrideDisabled = left
+            };
+            var rightSide = new ProjectRestoreMetadata
+            {
+                CentralPackageVersionOverrideDisabled = right
+            };
+            AssertHashCode(expected, leftSide, rightSide);
+        }
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, true)]
+        public void HashCode_WithCentralPackageTransitivePinningEnabled(bool left, bool right, bool expected)
+        {
+            var leftSide = new ProjectRestoreMetadata
+            {
+                CentralPackageTransitivePinningEnabled = left
+            };
+            var rightSide = new ProjectRestoreMetadata
+            {
+                CentralPackageTransitivePinningEnabled = right
+            };
+            AssertHashCode(expected, leftSide, rightSide);
+        }
+
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, true)]
         public void HashCode_WithCentralPackageVersionsEnabled(bool left, bool right, bool expected)
         {
             var leftSide = new ProjectRestoreMetadata
@@ -588,6 +677,24 @@ namespace NuGet.ProjectModel.Test
             var rightSide = new ProjectRestoreMetadata
             {
                 CentralPackageVersionsEnabled = right
+            };
+            AssertHashCode(expected, leftSide, rightSide);
+        }
+
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, true)]
+        public void HashCode_WithCentralPackageFloatingVersionsEnabled(bool left, bool right, bool expected)
+        {
+            var leftSide = new ProjectRestoreMetadata
+            {
+                CentralPackageFloatingVersionsEnabled = left
+            };
+            var rightSide = new ProjectRestoreMetadata
+            {
+                CentralPackageFloatingVersionsEnabled = right
             };
             AssertHashCode(expected, leftSide, rightSide);
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10432

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
By default, central package management (CPM) does not allow users to specify floating version (i.e. `1.*`).  CPM is considered an enterprise-level feature and since floating versions can introduce non-deterministic restores we want users to not be able to get situations where restores in different environments could not be identical.

However, the community has left a good amount of feedback that such a feature should be allowed with more details available in https://github.com/NuGet/Home/issues/10432.  This change allows a user to enable floating versions by setting an MSBuild property which remains off by default.

The only place the MSBuild property will be documented is at https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1011 where users will be encouraged to use non floating versions and educated on the potential issues they could encounter.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled: https://github.com/NuGet/Home/issues/12919
  - **OR**
  - [ ] N/A
