### PR TITLE
Fix incorrect json array returned for locales with comma as decimal separator in TelemetryUtility.ToJsonArrayOfTimingsInSeconds

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -211,7 +212,7 @@ namespace NuGet.VisualStudio.Telemetry
             sb.Append("[");
             foreach (var item in sourceTimings)
             {
-                sb.Append(item.TotalSeconds);
+                sb.Append(item.TotalSeconds.ToString(CultureInfo.InvariantCulture));
                 sb.Append(",");
             }
             if (sb[sb.Length - 1] == ',')

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/TelemetryUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/TelemetryUtilityTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using System.Linq;
+using System.Threading;
 using FluentAssertions;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -204,9 +206,13 @@ namespace NuGet.VisualStudio.Common.Test.Telemetry
             TelemetryUtility.ToJsonArrayOfTimingsInSeconds(values).Should().Be("[5]");
         }
 
-        [Fact]
-        public void ToJsonArrayOfTimingsInSeconds_WithMultipleValues_AppendsValuesWithComma()
+        [Theory]
+        [InlineData("en")]
+        [InlineData("de")]
+        public void ToJsonArrayOfTimingsInSeconds_WithMultipleValues_AppendsValuesWithComma(string culture)
         {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+
             TimeSpan[] values = new[] { new TimeSpan(hours: 0, minutes: 0, seconds: 5), new TimeSpan(days: 0, hours: 0, minutes: 1, seconds: 0, milliseconds: 500) };
             TelemetryUtility.ToJsonArrayOfTimingsInSeconds(values).Should().Be("[5,60.5]");
         }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/TelemetryUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/TelemetryUtilityTests.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using System.Linq;
-using System.Threading;
 using FluentAssertions;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -206,13 +204,9 @@ namespace NuGet.VisualStudio.Common.Test.Telemetry
             TelemetryUtility.ToJsonArrayOfTimingsInSeconds(values).Should().Be("[5]");
         }
 
-        [Theory]
-        [InlineData("en")]
-        [InlineData("de")]
-        public void ToJsonArrayOfTimingsInSeconds_WithMultipleValues_AppendsValuesWithComma(string culture)
+        [Fact]
+        public void ToJsonArrayOfTimingsInSeconds_WithMultipleValues_AppendsValuesWithComma()
         {
-            Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
-
             TimeSpan[] values = new[] { new TimeSpan(hours: 0, minutes: 0, seconds: 5), new TimeSpan(days: 0, hours: 0, minutes: 1, seconds: 0, milliseconds: 500) };
             TelemetryUtility.ToJsonArrayOfTimingsInSeconds(values).Should().Be("[5,60.5]");
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12915

Regression? Last working version:

## Description
Related to: https://github.com/NuGet/Home/issues/12820

<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
[TelemetryUtility.ToJsonArrayOfTimingsInSeconds](https://github.com/NuGet/NuGet.Client/blob/b4115e8b4fa35c418086cedecd946c696dd4c7b1/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs#L203) returns incorrect json array on locales having comma as a decimal separator

Running test [NuGet.VisualStudio.Common.Test.Telemetry.TelemetryUtilityTests.ToJsonArrayOfTimingsInSeconds_WithMultipleValues_AppendsValuesWithComma](https://github.com/NuGet/NuGet.Client/blob/b4115e8b4fa35c418086cedecd946c696dd4c7b1/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/TelemetryUtilityTests.cs#L208C31-L208C31) on system with such locales (e.g. `de`) fails with the following error:
> Expected TelemetryUtility.ToJsonArrayOfTimingsInSeconds(values) to be "[5,60.5]", but "[5,60,5]" differs near ",5]" (index 5).

This PR:
- updates the above test to surface the issue when running in the test regardless of system's locale
- fixes the issue

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
