### PR TITLE
Don't install .NET 3.1 on DartLab machines

### DIFF
--- a/build/tests.dev17.vsconfig
+++ b/build/tests.dev17.vsconfig
@@ -97,7 +97,6 @@
     "Microsoft.VisualStudio.Component.VSSDK",
     "Microsoft.VisualStudio.ComponentGroup.VisualStudioExtension.Prerequisites",
     "Microsoft.VisualStudio.Workload.VisualStudioExtension",
-    "Microsoft.NetCore.Component.Runtime.3.1",
     "Microsoft.Component.ClickOnce",
     "Microsoft.VisualStudio.Component.VisualStudioData",
     "Microsoft.Net.Component.4.6.1.SDK",


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
For: https://github.com/NuGet/Client.Engineering/issues/2504

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

.NET Core 3.1 is long out of support. Stop telling DartLab to install this version on VMs for testing.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
