### PR TITLE
Make PackageSpecDependencyProvider consider the version being requested

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -86,7 +86,14 @@ namespace NuGet.ProjectModel
             // This must exist in the external references
             if (_externalProjectsByUniqueName.TryGetValue(name, out ExternalProjectReference externalReference))
             {
-                packageSpec = externalReference.PackageSpec;
+                if (libraryRange.VersionRange.FindBestMatch(new NuGetVersion[] { externalReference.PackageSpec.Version }) != null)
+                {
+                    packageSpec = externalReference.PackageSpec;
+                }
+                else
+                {
+                    externalReference = null;
+                }
             }
 
             if (externalReference == null && packageSpec == null)

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -86,7 +86,8 @@ namespace NuGet.ProjectModel
             // This must exist in the external references
             if (_externalProjectsByUniqueName.TryGetValue(name, out ExternalProjectReference externalReference))
             {
-                if (libraryRange.VersionRange.FindBestMatch(new NuGetVersion[] { externalReference.PackageSpec.Version }) != null)
+                if (externalReference.PackageSpec == null ||
+                    libraryRange.VersionRange.FindBestMatch(new NuGetVersion[] { externalReference.PackageSpec.Version }) != null)
                 {
                     packageSpec = externalReference.PackageSpec;
                 }

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -3238,8 +3238,8 @@ namespace NuGet.Commands.FuncTest
 
                 // Act
                 result = await newCommand.ExecuteAsync();
-                // Assert
 
+                // Assert
                 await result.CommitAsync(logger, CancellationToken.None);
                 result.Success.Should().BeTrue(because: logger.ShowMessages());
                 result.Should().BeAssignableTo<NoOpRestoreResult>(because: "This should be a no-op restore.");

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -3191,7 +3191,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         }
 
         [Fact]
-        public async Task ExecuteAsync_WithConditionalProjectAndPackageReferences()
+        public async Task ExecuteAsync_WithConditionalProjectAndPackageReferences_SelectsPackageWhereProjectIsNotAppropriate()
         {
             // Arrange
             using var context = new SourceCacheContext();
@@ -3252,7 +3252,6 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 ns203,
                 systemMemory,
                 systemNumericsVector);
-
 
             var logger = new TestLogger();
             var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, mainPackageSpec, systemNumericsVectorPackageSpec);

--- a/test/TestUtilities/Test.Utility/Commands/TestRestoreRequest.cs
+++ b/test/TestUtilities/Test.Utility/Commands/TestRestoreRequest.cs
@@ -205,6 +205,7 @@ namespace NuGet.Commands.Test
             DependencyGraphSpec.AddProject(project);
             DependencyGraphSpec.AddRestore(project.RestoreMetadata.ProjectUniqueName);
             AllowNoOp = true;
+            ProjectStyle = project.RestoreMetadata.ProjectStyle;
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/10368

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Replacement for https://github.com/NuGet/NuGet.Client/pull/5397. 
Projects are expected to be preferred over packages, but only when the version matches. Note that project version does that https://github.com/NuGet/NuGet.Client/blob/83912bcf8b650091655a9c0ea726c0adecc553fe/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs#L289-L299. 

If this is not done, then projects may be selected in frameworks in which the project was never referenced.

More details in https://github.com/NuGet/NuGet.Client/pull/5397#issuecomment-1712013483. 

Note that the test in question validates the scenario the runtime team is experiencing.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
