### PR TITLE
Skip constantly failed Apex tests

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
@@ -19,10 +19,12 @@ namespace NuGet.Tests.Apex
         private const string PrimarySourceName = "source";
         private const string SecondarySourceName = "SecondarySource";
 
+        internal const int LongerTimeout = 10 * 60 * 1000; // 10 minutes
+
         private readonly SimpleTestPathContext _pathContext = new SimpleTestPathContext();
 
         [TestMethod]
-        [Timeout(DefaultTimeout)]
+        [Timeout(LongerTimeout)]
         public void SimpleInstallFromIVsInstaller()
         {
             // Arrange

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -693,6 +693,7 @@ namespace NuGet.Tests.Apex
             solutionService.Save();
         }
 
+        [Ignore("https://github.com/NuGet/Home/issues/12931")]
         [DataTestMethod]
         [DynamicData(nameof(GetNetCoreTemplates), DynamicDataSourceType.Method)]
         [Timeout(DefaultTimeout)]
@@ -701,7 +702,7 @@ namespace NuGet.Tests.Apex
             // Arrange
             EnsureVisualStudioHost();
 
-            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, addNetStandardFeeds: true))
             {
                 var packageName = "VerifyCacheFilePackage";
                 var packageVersion = "1.0.0";
@@ -726,7 +727,7 @@ namespace NuGet.Tests.Apex
         }
 
         [DataTestMethod]
-        [DataRow(ProjectTemplate.ClassLibrary, "PackageA", "1.0.0", "2.0.0", "PackageB", "1.0.1", "2.0.1")]
+        //[DataRow(ProjectTemplate.ClassLibrary, "PackageA", "1.0.0", "2.0.0", "PackageB", "1.0.1", "2.0.1")] [Ignore("https://github.com/NuGet/Home/issues/12932")]
         [DataRow(ProjectTemplate.NetStandardClassLib, "PackageC", "1.0.0", "2.0.0", "PackageD", "1.1.0", "2.2.0")]
         [Timeout(DefaultTimeout)]
         public async Task UpdateAllPackagesInPMC(ProjectTemplate projectTemplate, string packageName1, string packageVersion1, string packageVersion2, string packageName2, string packageVersion3, string packageVersion4)
@@ -772,6 +773,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
+        [Ignore("https://github.com/NuGet/Home/issues/12930")]
         [DataTestMethod]
         [DynamicData(nameof(GetIOSTemplates), DynamicDataSourceType.Method)]
         [Timeout(DefaultTimeout)]
@@ -806,6 +808,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
+        [Ignore("https://github.com/NuGet/Home/issues/12930")]
         [DataTestMethod]
         [DynamicData(nameof(GetIOSTemplates), DynamicDataSourceType.Method)]
         [Timeout(DefaultTimeout)]
@@ -847,6 +850,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
+        [Ignore("https://github.com/NuGet/Home/issues/12930")]
         [DataTestMethod]
         [DynamicData(nameof(GetIOSTemplates), DynamicDataSourceType.Method)]
         [Timeout(DefaultTimeout)]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

Fixes: https://github.com/NuGet/Client.Engineering/issues/2519

Regression? Last working version:

## Description
Skipped the following tests:
```
InstallPackageForIOSProjectInPMC
UpdatePackageForIOSProjectInPMC
UninstallPackageForIOSProjectInPMC
VerifyCacheFileInsideObjFolder
UpdateAllPackagesInPMC (ProjectTemplate.ClassLibrary, "PackageA", "1.0.0", "2.0.0", "PackageB", "1.0.1", "2.0.1")
```

Tried to fix the `VerifyCacheFileInsideObjFolder `test by adding netstandard source, as there is an exception in the dmp file, and the package installation failed because of this. But this doesn't fully fix this test.
![image](https://github.com/NuGet/NuGet.Client/assets/45407901/bf906497-d5fb-479e-b416-c6821ab2c4ee)

Based on the observation, `SimpleInstallFromIVsInstaller `is the first test and it usually takes 4-6 mins to finish. So extend the timeout limit from 5mins to 10 mins for this test only. If this test still fails in the future, we might need to skip it as well.


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
