### PR TITLE
Transitive dependencies in GPF are automatically source mapped by actions in PM UI 

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -772,6 +772,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The package `{0}` is available in the Global packages folder, but the source it came from `{1}` is not one of this solution&apos;s configured sources..
+        /// </summary>
+        public static string Error_SourceMapping_GPF_NotEnabled {
+            get {
+                return ResourceManager.GetString("Error_SourceMapping_GPF_NotEnabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Operation failed.
         /// </summary>
         public static string ErrorDialogBoxTitle {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1038,4 +1038,8 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Vulnerabilities_Loading" xml:space="preserve">
     <value>Loading vulnerable packages...</value>
   </data>
+  <data name="Error_SourceMapping_GPF_NotEnabled" xml:space="preserve">
+    <value>The package `{0}` is available in the Global packages folder, but the source it came from `{1}` is not one of this solution's configured sources.</value>
+    <comment>{0} is the package ID. {1} is the URI of the package source found in the Global packages folder.</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
@@ -137,15 +137,13 @@
 
                 <!-- New Source Mappings for added packages -->
                 <StackPanel
-                  Margin="0,8"
                   Visibility="{Binding Path=NewSourceMappings,Converter={StaticResource EnumerableToVisibilityConverter}}">
                   <ItemsControl
-                    Margin="10,0,0,0"
                     ItemsSource="{Binding Path=NewSourceMappings}"
                     IsTabStop="False">
                     <ItemsControl.ItemTemplate>
                       <DataTemplate>
-                        <StackPanel>
+                        <StackPanel Margin="0,8">
                           <!-- New Source Mapping with Source Name -->
                           <TextBlock
                             FontWeight="Bold"
@@ -153,7 +151,9 @@
                           </TextBlock>
 
                           <!-- New Source Mapping Package IDs -->
-                          <ItemsControl ItemsSource="{Binding Value}"
+                          <ItemsControl
+                            Margin="10,0,0,0"
+                            ItemsSource="{Binding Value}"
                             IsTabStop="False">
                             <ItemsControl.ItemTemplate>
                               <DataTemplate>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -20,6 +20,7 @@ using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
 using NuGet.Versioning;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
@@ -83,7 +84,8 @@ namespace NuGet.PackageManagement.UI.Test
             mockUIContext.Setup(uiContext => uiContext.PackageSourceMapping).Returns((PackageSourceMapping)null);
             mockUIController.Setup(uiController => uiController.UIContext).Returns(mockUIContext.Object);
 
-            IReadOnlyList<PreviewResult> previewResults = await UIActionEngine.GetPreviewResultsAsync(
+            UIActionEngine uiActionEngine = CreateUIActionEngine();
+            IReadOnlyList<PreviewResult> previewResults = await uiActionEngine.GetPreviewResultsAsync(
                 Mock.Of<INuGetProjectManagerService>(),
                 projectActions: new[] { uninstallAction, installAction },
                 userAction: null,
@@ -141,7 +143,8 @@ namespace NuGet.PackageManagement.UI.Test
             mockUIContext.Setup(uiContext => uiContext.PackageSourceMapping).Returns((PackageSourceMapping)null);
             mockUIController.Setup(uiController => uiController.UIContext).Returns(mockUIContext.Object);
 
-            IReadOnlyList<PreviewResult> previewResults = await UIActionEngine.GetPreviewResultsAsync(
+            UIActionEngine uiActionEngine = CreateUIActionEngine();
+            IReadOnlyList<PreviewResult> previewResults = await uiActionEngine.GetPreviewResultsAsync(
                 Mock.Of<INuGetProjectManagerService>(),
                 projectActions: new[] { installAction },
                 userAction: null,
@@ -156,6 +159,21 @@ namespace NuGet.PackageManagement.UI.Test
             Assert.Equal(packageIdentityA.Id, addedResults[0].Id);
             Assert.Equal(packageIdentityB.Id, addedResults[1].Id);
             Assert.Equal(packageIdentityC.Id, addedResults[2].Id);
+        }
+
+        private UIActionEngine CreateUIActionEngine(ISettings settings = null)
+        {
+            settings = settings ?? Mock.Of<ISettings>();
+            var sourceRepositoryProvider = Mock.Of<ISourceRepositoryProvider>();
+            var packageManager = new NuGetPackageManager(
+                sourceRepositoryProvider,
+                Mock.Of<ISettings>(),
+                TestDirectory.Create().Path);
+
+            return new UIActionEngine(
+                sourceRepositoryProvider,
+                packageManager,
+                Mock.Of<INuGetLockService>());
         }
 
         [Theory]

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Utility/PackageSourceMappingUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Utility/PackageSourceMappingUtilityTests.cs
@@ -1,11 +1,15 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Threading.Tasks;
 using Moq;
 using NuGet.Configuration;
 using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Xunit;
 
@@ -14,9 +18,10 @@ namespace NuGet.PackageManagement.UI.Test.Utility
     public class PackageSourceMappingUtilityTests
     {
         [Fact]
-        public void AddNewSourceMappingsFromAddedPackages_PackageNotMappedToMultipleExistingSources_CreatesSingleNewMapping()
+        public void AddNewSourceMappingsFromAddedPackages_PackageNotMappedToMultipleEnabledSources_CreatesSingleNewMapping()
         {
             // Arrange
+            string topLevelPackageId = "a";
             Dictionary<string, SortedSet<string>> newSourceMappings = new();
 
             // Existing Package Source Mappings.
@@ -29,7 +34,7 @@ namespace NuGet.PackageManagement.UI.Test.Utility
             var mockPackageSourceMapping = new Mock<PackageSourceMapping>(patterns);
 
             // Configure packages which are added by preview restore and may need new Package Source Mappings.
-            string newMappingSourceName = "sourceC";
+            string selectedSourceName = "sourceC";
             List<AccessiblePackageIdentity> added = new List<AccessiblePackageIdentity>()
             {
                 ConvertToAccessiblePackageIdentity("a"), // The only added package missing from existing mappings.
@@ -42,18 +47,295 @@ namespace NuGet.PackageManagement.UI.Test.Utility
             for (int i = 0; i < 2; i++)
             {
                 // Act
-                PackageSourceMappingUtility.AddNewSourceMappingsFromAddedPackages(ref newSourceMappings, newMappingSourceName, added, mockPackageSourceMapping.Object);
+                PackageSourceMappingUtility.AddNewSourceMappingsFromAddedPackages(
+                    ref newSourceMappings,
+                    selectedSourceName,
+                    topLevelPackageId,
+                    added,
+                    mockPackageSourceMapping.Object,
+                    globalPackageFolders: null,
+                    enabledSourceRepositories: new List<SourceRepository>(capacity: 2)
+                    {
+                        new SourceRepository(new PackageSource("sourceA"), new List<INuGetResourceProvider>()),
+                    });
 
                 // Assert
                 Assert.Equal(1, newSourceMappings.Count);
-                Assert.True(newSourceMappings.ContainsKey(newMappingSourceName));
-                Assert.Equal(1, newSourceMappings[newMappingSourceName].Count);
+                Assert.True(newSourceMappings.ContainsKey(selectedSourceName));
+                Assert.Equal(1, newSourceMappings[selectedSourceName].Count);
+            }
+        }
+
+        /// <summary>
+        /// Install package `a` which is not currently mapped.
+        /// Selected source: `sourceA`
+        /// Enabled sources: `sourceA`, `sourceB`, `sourceC`.
+        /// Added packages are: `a`, `b`, `c`, `d`.
+        /// Source mappings exist for: `a`, `b`, `d`.
+        /// Transitive dependency `c` does not exist in the GPF, so it should now be mapped to the selected source (`sourceA`).
+        /// </summary>
+        [Fact]
+        public void AddNewSourceMappingsFromAddedPackages_TransitiveDoesNotExistInGPF_CreatesNewMappingToSelectedSource()
+        {
+            // Arrange
+            string topLevelPackageId = "a";
+            string selectedSourceName = "sourceA";
+            AccessiblePackageIdentity packageC = ConvertToAccessiblePackageIdentity("c");
+
+            // Existing Package Source Mappings.
+            var dictionary = new Dictionary<string, IReadOnlyList<string>>
+            {
+                { "sourceA", new List<string>() { "a", "b", } },
+                { "sourceB", new List<string>() { "d" } }
+            };
+            var patterns = new ReadOnlyDictionary<string, IReadOnlyList<string>>(dictionary);
+            var mockPackageSourceMapping = new Mock<PackageSourceMapping>(patterns);
+            var contextPackageC = new SimpleTestPackageContext(packageC);
+
+            // Configure packages which are added by preview restore and may need new Package Source Mappings.
+            List<AccessiblePackageIdentity> added = new List<AccessiblePackageIdentity>()
+            {
+                ConvertToAccessiblePackageIdentity("a"),
+                ConvertToAccessiblePackageIdentity("b"),
+                packageC,
+                ConvertToAccessiblePackageIdentity("d"),
+            };
+
+            SourceRepository sourceA = CreateSourceRepository("sourceA");
+            SourceRepository sourceB = CreateSourceRepository("sourceB");
+            SourceRepository sourceC = CreateSourceRepository("sourceC");
+
+            IReadOnlyList<SourceRepository> enabledSourceRepositories = new List<SourceRepository>(capacity: added.Count)
+            {
+                sourceA,
+                sourceB,
+                sourceC,
+            };
+
+            using SimpleTestPathContext gpfContext = new SimpleTestPathContext();
+
+            SourceRepository gpfSourceRepository = CreateGPFSourceRepository(gpfContext.UserPackagesFolder);
+
+            IReadOnlyList<SourceRepository> globalPackageFolders = new List<SourceRepository>(capacity: 1)
+            {
+                gpfSourceRepository
+            };
+
+            Dictionary<string, SortedSet<string>> newSourceMappings = new();
+
+            // Repeat the Act to simulate multiple ProjectActions to ensure a unique resulting set of packages is created.
+            for (int i = 0; i < 2; i++)
+            {
+                // Act
+                PackageSourceMappingUtility.AddNewSourceMappingsFromAddedPackages(
+                    ref newSourceMappings,
+                    selectedSourceName,
+                    topLevelPackageId,
+                    added,
+                    mockPackageSourceMapping.Object,
+                    globalPackageFolders,
+                    enabledSourceRepositories);
+
+                // Assert
+                Assert.Equal(1, newSourceMappings.Count);
+                Assert.True(newSourceMappings.ContainsKey(selectedSourceName));
+                Assert.Equal(1, newSourceMappings[selectedSourceName].Count);
+                Assert.True(newSourceMappings[selectedSourceName].Contains(packageC.Id));
+            }
+        }
+
+        /// <summary>
+        /// Install package `a` which is not currently mapped.
+        /// Selected source: `sourceA`
+        /// Enabled sources: `sourceA`, `sourceB`, `sourceC`.
+        /// Added packages are: `a`, `b`, `c`, `d`.
+        /// Source mappings exist for: `a`, `b`, `d`.
+        /// Transitive dependency `c` exists in the GPF to `sourceC`, which is an enabled source and should now be mapped.
+        /// </summary>
+        [Fact]
+        public async Task AddNewSourceMappingsFromAddedPackages_TransitiveExistsInGPFToEnabledSource_CreatesNewMappingToGPFSource()
+        {
+            // Arrange
+            string topLevelPackageId = "a";
+            string selectedSourceName = "sourceA";
+            AccessiblePackageIdentity packageC = ConvertToAccessiblePackageIdentity("c");
+
+            // Existing Package Source Mappings.
+            var dictionary = new Dictionary<string, IReadOnlyList<string>>
+            {
+                { "sourceA", new List<string>() { "a", "b", } },
+                { "sourceB", new List<string>() { "d" } }
+            };
+            var patterns = new ReadOnlyDictionary<string, IReadOnlyList<string>>(dictionary);
+            var mockPackageSourceMapping = new Mock<PackageSourceMapping>(patterns);
+            var contextPackageC = new SimpleTestPackageContext(packageC);
+
+            // Configure packages which are added by preview restore and may need new Package Source Mappings.
+            List<AccessiblePackageIdentity> added = new List<AccessiblePackageIdentity>()
+            {
+                ConvertToAccessiblePackageIdentity("a"),
+                ConvertToAccessiblePackageIdentity("b"),
+                packageC,
+                ConvertToAccessiblePackageIdentity("d"),
+            };
+
+            SourceRepository sourceA = CreateSourceRepository("sourceA");
+            SourceRepository sourceB = CreateSourceRepository("sourceB");
+            SourceRepository sourceC = CreateSourceRepository("sourceC");
+
+            IReadOnlyList<SourceRepository> enabledSourceRepositories = new List<SourceRepository>(capacity: added.Count)
+            {
+                sourceA,
+                sourceB,
+                sourceC,
+            };
+
+            using SimpleTestPathContext gpfContext = new SimpleTestPathContext();
+
+            SourceRepository gpfSourceRepository = CreateGPFSourceRepository(gpfContext.UserPackagesFolder);
+            await SimpleTestPackageUtility.CreateFolderFeedV3WithNupkgMetadataAsync(
+                root: gpfContext.UserPackagesFolder,
+                nupkgMetadataSource: sourceC.PackageSource.Source,
+                contextPackageC);
+
+            string nupkgMetadataSourceName = sourceC.PackageSource.Name;
+
+            IReadOnlyList<SourceRepository> globalPackageFolders = new List<SourceRepository>(capacity: 1)
+            {
+                gpfSourceRepository
+            };
+
+            Dictionary<string, SortedSet<string>> newSourceMappings = new();
+
+            // Repeat the Act to simulate multiple ProjectActions to ensure a unique resulting set of packages is created.
+            for (int i = 0; i < 2; i++)
+            {
+                // Act
+                PackageSourceMappingUtility.AddNewSourceMappingsFromAddedPackages(
+                    ref newSourceMappings,
+                    selectedSourceName,
+                    topLevelPackageId,
+                    added,
+                    mockPackageSourceMapping.Object,
+                    globalPackageFolders,
+                    enabledSourceRepositories);
+
+                // Assert
+                Assert.Equal(1, newSourceMappings.Count);
+                Assert.True(newSourceMappings.ContainsKey(nupkgMetadataSourceName));
+                Assert.Equal(1, newSourceMappings[nupkgMetadataSourceName].Count);
+                Assert.True(newSourceMappings[nupkgMetadataSourceName].Contains(packageC.Id));
+            }
+        }
+
+        /// <summary>
+        /// Install package `a` which is not currently mapped.
+        /// Selected source: `sourceA`
+        /// Enabled sources: `sourceA`, `sourceB`.
+        /// Added packages are: `a`, `b`, `c`, `d`.
+        /// Source mappings exist for: `a`, `b`, `d`.
+        /// Transitive dependency `c` exists in the GPF, but the indicated package source `sourceC` is not enabled so an exception is thrown.
+        /// </summary>
+        [Fact]
+        public async Task AddNewSourceMappingsFromAddedPackages_TransitiveExistsInGPFToNotEnabledSource_Throws()
+        {
+            // Arrange
+            string topLevelPackageId = "a";
+            string selectedSourceName = "sourceA";
+            AccessiblePackageIdentity packageC = ConvertToAccessiblePackageIdentity("c");
+
+            // Existing Package Source Mappings.
+            var dictionary = new Dictionary<string, IReadOnlyList<string>>
+            {
+                { "sourceA", new List<string>() { "a", "b", } },
+                { "sourceB", new List<string>() { "d" } }
+            };
+            var patterns = new ReadOnlyDictionary<string, IReadOnlyList<string>>(dictionary);
+            var mockPackageSourceMapping = new Mock<PackageSourceMapping>(patterns);
+            var contextPackageC = new SimpleTestPackageContext(packageC);
+
+            // Configure packages which are added by preview restore and may need new Package Source Mappings.
+            List<AccessiblePackageIdentity> added = new List<AccessiblePackageIdentity>()
+            {
+                ConvertToAccessiblePackageIdentity("a"),
+                ConvertToAccessiblePackageIdentity("b"),
+                packageC,
+                ConvertToAccessiblePackageIdentity("d"),
+            };
+
+            SourceRepository sourceA = CreateSourceRepository("sourceA");
+            SourceRepository sourceB = CreateSourceRepository("sourceB");
+            SourceRepository sourceC = CreateSourceRepository("sourceC");
+
+            IReadOnlyList<SourceRepository> enabledSourceRepositories = new List<SourceRepository>(capacity: added.Count)
+            {
+                sourceA,
+                sourceB,
+            };
+
+            using SimpleTestPathContext gpfContext = new SimpleTestPathContext();
+
+            SourceRepository gpfSourceRepository = CreateGPFSourceRepository(gpfContext.UserPackagesFolder);
+            await SimpleTestPackageUtility.CreateFolderFeedV3WithNupkgMetadataAsync(
+                root: gpfContext.UserPackagesFolder,
+                nupkgMetadataSource: sourceC.PackageSource.Source,
+                contextPackageC);
+
+            string nupkgMetadataSourceName = sourceC.PackageSource.Name;
+
+            IReadOnlyList<SourceRepository> globalPackageFolders = new List<SourceRepository>(capacity: 1)
+            {
+                gpfSourceRepository
+            };
+
+            Dictionary<string, SortedSet<string>> newSourceMappings = new();
+
+            // Repeat the Act to simulate multiple ProjectActions to ensure a unique resulting set of packages is created.
+            for (int i = 0; i < 2; i++)
+            {
+                // Act
+                var exception = Assert.Throws<ApplicationException>(
+                    () => PackageSourceMappingUtility.AddNewSourceMappingsFromAddedPackages(
+                        ref newSourceMappings,
+                        selectedSourceName,
+                        topLevelPackageId,
+                        added,
+                        mockPackageSourceMapping.Object,
+                        globalPackageFolders,
+                        enabledSourceRepositories));
+
+                // Assert
+                var expectedExceptionMessage = $"The package `{contextPackageC.Id}` is available in the Global packages folder," +
+                    $" but the source it came from `{sourceC.PackageSource.Source}` is not one of this solution's configured sources.";
+                Assert.Equal(expectedExceptionMessage, exception.Message);
             }
         }
 
         private AccessiblePackageIdentity ConvertToAccessiblePackageIdentity(string packageId)
         {
             return new AccessiblePackageIdentity(new PackageIdentity(packageId, NuGetVersion.Parse("1.0.0")));
+        }
+
+        private static SourceRepository CreateGPFSourceRepository(string gpfPath)
+        {
+            PackageSource gpfPackageSource = new(gpfPath);
+
+            var mockSourceRepository = new Mock<SourceRepository>(gpfPackageSource, new List<INuGetResourceProvider>());
+            mockSourceRepository.SetupGet(m => m.PackageSource).Returns(gpfPackageSource);
+
+            return mockSourceRepository.Object;
+        }
+
+        private static SourceRepository CreateSourceRepository(string name, bool isEnabled = true)
+        {
+            string source = $"https://{name}.testsource.com/v3/index.json";
+            PackageSource packageSource = new(source, name);
+            packageSource.IsEnabled = isEnabled;
+
+            var mockSourceRepository = new Mock<SourceRepository>(packageSource, new List<INuGetResourceProvider>());
+            mockSourceRepository.SetupGet(m => m.PackageSource).Returns(packageSource);
+
+            return mockSourceRepository.Object;
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
@@ -524,6 +524,16 @@ namespace NuGet.Test.Utility
             }
         }
 
+        public static async Task CreateFolderFeedV3WithNupkgMetadataAsync(string root, string nupkgMetadataSource, params SimpleTestPackageContext[] contexts)
+        {
+            using var tempRoot = TestDirectory.Create();
+            await CreatePackagesAsync(tempRoot, contexts);
+
+            var saveMode = PackageSaveMode.Nupkg | PackageSaveMode.Nuspec;
+
+            await CreateFolderFeedV3Async(root, nupkgMetadataSource, saveMode, Directory.GetFiles(tempRoot));
+        }
+
         /// <summary>
         /// Create a v3 folder of nupkgs
         /// </summary>
@@ -537,10 +547,15 @@ namespace NuGet.Test.Utility
             }
         }
 
+        public static async Task CreateFolderFeedV3Async(string root, PackageSaveMode saveMode, params string[] nupkgPaths)
+        {
+            await CreateFolderFeedV3Async(root, nupkgMetadataSource: null, saveMode, nupkgPaths);
+        }
+
         /// <summary>
         /// Create a v3 folder of nupkgs
         /// </summary>
-        public static async Task CreateFolderFeedV3Async(string root, PackageSaveMode saveMode, params string[] nupkgPaths)
+        public static async Task CreateFolderFeedV3Async(string root, string nupkgMetadataSource, PackageSaveMode saveMode, params string[] nupkgPaths)
         {
             var pathResolver = new VersionFolderPathResolver(root);
 
@@ -558,7 +573,7 @@ namespace NuGet.Test.Utility
                     using (var fileStream = File.OpenRead(file))
                     {
                         await PackageExtractor.InstallFromSourceAsync(
-                            null,
+                            source: nupkgMetadataSource,
                             identity,
                             (stream) => fileStream.CopyToAsync(stream, 4096, CancellationToken.None),
                             new VersionFolderPathResolver(root),
@@ -573,8 +588,13 @@ namespace NuGet.Test.Utility
             }
         }
 
+        public static async Task CreateFolderFeedV3WithNupkgMetadataAsync(string root, string nupkgMetadataSource, PackageSaveMode saveMode, params string[] nupkgPaths)
+        {
+            await CreateFolderFeedV3Async(root, nupkgMetadataSource, saveMode, nupkgPaths);
+        }
+
         /// <summary>
-        /// Create a packagets.config folder of nupkgs
+        /// Create a packages.config folder of nupkgs
         /// </summary>
         public static async Task CreateFolderFeedPackagesConfigAsync(string root, params PackageIdentity[] packages)
         {
@@ -584,7 +604,7 @@ namespace NuGet.Test.Utility
         }
 
         /// <summary>
-        /// Create a packagets.config folder of nupkgs
+        /// Create a packages.config folder of nupkgs
         /// </summary>
         public static async Task CreateFolderFeedPackagesConfigAsync(string root, params SimpleTestPackageContext[] contexts)
         {
@@ -597,7 +617,7 @@ namespace NuGet.Test.Utility
         }
 
         /// <summary>
-        /// Create a packagets.config folder of nupkgs
+        /// Create a packages.config folder of nupkgs
         /// </summary>
         public static async Task CreateFolderFeedPackagesConfigAsync(string root, params string[] nupkgPaths)
         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2421

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Creating source mappings from PM UI actions now considers the GPF for transitive dependencies.

Following the [Tables of Behaviors in the spec](https://github.com/NuGet/Home/blob/dev/proposed/2023/package-source-mapping-actions-PMUI.md#table-behavior-for-packages-not-installed-to-the-gpf), when transitive packages exists in the GPF:
  1. If it's an enabled source for this solution, map to that source.
  2. If it's not an enabled source in this solution, fail with an error indicating the package/source in the message. 
       - The error is thrown from PM UI in this PR. Eventually, when implementing https://github.com/NuGet/Client.Engineering/issues/1166, we will be able to move this error to Restore.

Made a UI adjustment to the margins of the Preview Changes dialog so that multiple sources have spacing between them (ie, it appears as if a blank line separates each `Creating source mappings to` block in the list).

#### Top-level & Transitive packages not mapped (multiple sources found in GPF)
Multiple sources based on GPF state:
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/6123d68f-8414-4a2f-b14d-4304f459a30a)

#### Transitive not mapped & in GPF to enabled source
Even just missing a mapping for 1 transitive (top level already mapped) still gets a mapping created:
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/8d79e849-5863-47f9-b6aa-394180098962)

#### Transitive not mapped & not in GPF
After clearing `System.IO` from my GPF, now it pulled it from selected source `vside`
(Notice the output window indicates downloading the package unlike the previous screenshot)
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/2573a7b9-7562-4bac-a8ab-fa1f969b8d7e)

#### Transitive not mapped & in GPF but the source is not enabled
An error is thrown from PM UI since the GPF is pointing to `vside`, which is a source I have temporarily disabled here:
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/a0f4d302-bd13-400d-9c07-742e1da5d0c2)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added.
  
There wasn't a test utility to write `.nupkg.metadata`, so I added a method signature to `SimpleTestPackageUtility` that accepts a source. It was only writing `null`, before.

  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
