### PR TITLE
Move the vulnerable restore bar checks into the try part

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -497,6 +497,8 @@ namespace NuGet.SolutionRestoreManager
                                     isRestoreSucceeded = restoreSummaries.All(summary => summary.Success == true);
                                     _noOpProjectsCount += restoreSummaries.Where(summary => summary.NoOpRestore == true).Count();
                                     _solutionUpToDateChecker.SaveRestoreStatus(restoreSummaries);
+                                    // Display info bar in SolutionExplorer if there is a vulnerability during restore.
+                                    await _vulnerabilitiesFoundService.Value.ReportVulnerabilitiesAsync(AnyProjectHasVulnerablePackageWarning(restoreSummaries), t);
                                 }
                                 catch
                                 {
@@ -521,9 +523,6 @@ namespace NuGet.SolutionRestoreManager
                                         _status = NuGetOperationStatus.Failed;
                                     }
 
-                                    // Display info bar in SolutionExplorer if there is a vulnerability during restore.
-                                    await _vulnerabilitiesFoundService.Value.ReportVulnerabilitiesAsync(AnyProjectHasVulnerablePackageWarning(restoreSummaries), t);
-
                                     _nuGetProgressReporter.EndSolutionRestore(projectList);
                                 }
                             },
@@ -539,6 +538,8 @@ namespace NuGet.SolutionRestoreManager
 
         private bool AnyProjectHasVulnerablePackageWarning(IReadOnlyList<RestoreSummary> restoreSummaries)
         {
+            if (restoreSummaries == null) return false;
+
             foreach (RestoreSummary restoreSummary in restoreSummaries)
             {
                 foreach (IRestoreLogMessage restoreLogMessage in restoreSummary.Errors)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12939

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

RestoreSummaries can be null when the restore spec validation fails. 
An example is a project with an incorrect framework.

The vulnerable bar should've been in the try part anyways. 
The finally part must never throw. 

Note that this is an imperfect, partial fix. There's a follow up that'll need a longer fix in https://github.com/NuGet/Home/issues/12943.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Really hard to setup the test case as this would require an E2E/Apex right now, and get the tests to write a bad project file would be really hard. For now, gonna add an E2E test.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
