### PR TITLE
Create backup pipeline to save build artifacts

### DIFF
--- a/eng/pipelines/backup_build_artifacts.yml
+++ b/eng/pipelines/backup_build_artifacts.yml
@@ -1,0 +1,102 @@
+# No CI trigger rely on Pipeline trigger only
+trigger: none
+
+resources:
+  pipelines:
+    - pipeline: officialbuild
+      source: NuGet.Client-Official
+      trigger: true
+
+jobs:
+  - job: Backup_Build_Artifacts
+    displayName: "Backup Build Artifacts"
+    timeoutInMinutes: 10
+    pool:
+      name: VSEngSS-MicroBuild2022-1ES
+
+    steps:
+      - checkout: none
+
+      - pwsh: |
+          $buildNumber = "$(resources.pipeline.officialbuild.runName)"
+          Write-Host "Setting build number to $buildNumber"
+          Write-Host "##vso[build.updatebuildnumber]$buildNumber"
+        displayName: "Set build number"
+
+      - pwsh: "Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize"
+        displayName: 'Display environment variables'
+
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download product NonRTM'
+        continueOnError: true # in case build didn't publish this artifact
+        inputs:
+          buildType: specific
+          project: $(resources.pipeline.officialbuild.projectID)
+          definition: $(resources.pipeline.officialbuild.pipelineID)
+          artifactName: 'VS15'
+          targetPath: $(Build.ArtifactStagingDirectory)/backup/VS15
+
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download product RTM'
+        continueOnError: true # in case build didn't publish this artifact
+        inputs:
+          buildType: specific
+          project: $(resources.pipeline.officialbuild.projectID)
+          definition: $(resources.pipeline.officialbuild.pipelineID)
+          artifactName: 'VS15-RTM'
+          targetPath: $(Build.ArtifactStagingDirectory)/backup/VS15-RTM
+
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download nupkgs'
+        continueOnError: true # in case build didn't publish this artifact
+        inputs:
+          buildType: specific
+          project: $(resources.pipeline.officialbuild.projectID)
+          definition: $(resources.pipeline.officialbuild.pipelineID)
+          artifactName: 'nupkgs - NonRTM'
+          targetPath: $(Build.ArtifactStagingDirectory)/backup/VS15/nupkgs
+
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download nupkgs RTM'
+        continueOnError: true # in case build didn't publish this artifact
+        inputs:
+          buildType: specific
+          project: $(resources.pipeline.officialbuild.projectID)
+          definition: $(resources.pipeline.officialbuild.pipelineID)
+          artifactName: 'nupkgs - RTM'
+          targetPath: $(Build.ArtifactStagingDirectory)/backup/VS15-RTM/nupkgs
+
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download symbols NonRTM'
+        continueOnError: true # in case build didn't publish this artifact
+        inputs:
+          buildType: specific
+          project: $(resources.pipeline.officialbuild.projectID)
+          definition: $(resources.pipeline.officialbuild.pipelineID)
+          artifactName: 'symbols - NonRTM'
+          targetPath: $(Build.ArtifactStagingDirectory)/backup/symbols
+
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download symbols RTM'
+        continueOnError: true # in case build didn't publish this artifact
+        inputs:
+          buildType: specific
+          project: $(resources.pipeline.officialbuild.projectID)
+          definition: $(resources.pipeline.officialbuild.pipelineID)
+          artifactName: 'symbols - RTM'
+          targetPath: $(Build.ArtifactStagingDirectory)/backup/symbols-rtm
+
+      - pwsh: gci -recurse -file | Resolve-Path -Relative
+        workingDirectory: $(Build.ArtifactStagingDirectory)/backup
+        displayName: "List files being backed up"
+
+      - task: artifactDropTask@0
+        displayName: "Upload Drop"
+        inputs:
+          dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
+          buildNumber: 'Backup/$(System.TeamProject)/NuGet.Client/$(resources.pipeline.officialbuild.pipelineName)/$(resources.pipeline.officialbuild.runName)'
+          sourcePath: "$(Build.ArtifactStagingDirectory)/backup"
+          toLowerCase: false
+          usePat: true
+          dropMetadataContainerName: "DropMetadata-Backup"
+          retentionDays: 186

--- a/eng/pipelines/backup_build_artifacts.yml
+++ b/eng/pipelines/backup_build_artifacts.yml
@@ -47,7 +47,7 @@ jobs:
           targetPath: $(Build.ArtifactStagingDirectory)/backup/VS15-RTM
 
       - task: DownloadPipelineArtifact@2
-        displayName: 'Download nupkgs'
+        displayName: 'Download nupkgs NonRTM'
         continueOnError: true # in case build didn't publish this artifact
         inputs:
           buildType: specific


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2479

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

copy build artifacts to a "drop" after a successful official build. We can use this as a backup, in case the normal process fails.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
