### PR TITLE
Add MemberNotNullWhen to SemanticVersion.HasMetadata

### DIFF
--- a/src/NuGet.Core/NuGet.Versioning/SemanticVersion.cs
+++ b/src/NuGet.Core/NuGet.Versioning/SemanticVersion.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace NuGet.Versioning
@@ -231,6 +232,7 @@ namespace NuGet.Versioning
         /// <summary>
         /// True if metadata exists for the version.
         /// </summary>
+        [MemberNotNullWhen(true, nameof(Metadata))]
         public virtual bool HasMetadata
         {
             get { return !string.IsNullOrEmpty(Metadata); }

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/SemanticVersionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/SemanticVersionTests.cs
@@ -90,7 +90,7 @@ namespace NuGet.Versioning.Test
         [InlineData("1.2.3-A.00.B")]
         public void TryParseStrictReturnsFalseIfVersionIsNotStrictSemVer(string version)
         {
-            // Act 
+            // Act
             SemanticVersion? semanticVersion;
             var result = SemanticVersion.TryParse(version, out semanticVersion);
 
@@ -107,6 +107,20 @@ namespace NuGet.Versioning.Test
             string result = target.ToString();
 
             Assert.Equal("1.2.3", result);
+        }
+
+        [Fact]
+        public void Metadata_NoNullableWarning_After_HasMetadata_checked()
+        {
+            // Arrange
+            SemanticVersion target = new(1, 2, 3);
+
+            // Act
+            // should not result in a compiler warning CS8602: Dereference of a possibly null reference.
+            string result = target.HasMetadata ? target.Metadata[0..1] : "no-metadata";
+
+            // Assert
+            Assert.Equal("no-metadata", result);
         }
 
         private class ExtendedSemanticVersion : SemanticVersion

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/SemanticVersionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/SemanticVersionTests.cs
@@ -117,7 +117,7 @@ namespace NuGet.Versioning.Test
 
             // Act
             // should not result in a compiler warning CS8602: Dereference of a possibly null reference.
-            string result = target.HasMetadata ? target.Metadata[0..1] : "no-metadata";
+            string result = target.HasMetadata ? target.Metadata.Substring(1) : "no-metadata";
 
             // Assert
             Assert.Equal("no-metadata", result);


### PR DESCRIPTION
fixing NuGet/Home#12949

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12949

Regression? Last working version:

## Description

Adds `[MemberNotNullWhen(true, nameof(Metadata))]` to `HasMetadata`, making C# compiler behave nicely when accessing `.Metadata` conditionally.

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
