### PR TITLE
Specify protocol V3 when creating PackageSource in GetSymbolPackageUpdateResource

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs
@@ -106,7 +106,11 @@ namespace NuGet.Commands
 
             if (packageSource == null)
             {
-                packageSource = new PackageSource(source);
+                // Since SymbolPackageUpdateResourceV3 will be requested this should be a v3 PackageSource
+                packageSource = new PackageSource(source)
+                {
+                    ProtocolVersion = 3
+                };
             }
 
             var sourceRepositoryProvider = new CachingSourceProvider(sourceProvider);

--- a/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs
@@ -109,7 +109,7 @@ namespace NuGet.Commands
                 packageSource = new PackageSource(source);
                 
                 // If it ends with "index.json" then treat it as a V3 Protocol PackageSource
-                if (packageSource.Source.EndsWith("index.json", StringComparison.OrdinalIgnoreCase)
+                if (packageSource.Source.EndsWith("index.json", StringComparison.OrdinalIgnoreCase))
                 {
                     packageSource.ProtocolVersion = 3;
                 }

--- a/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs
@@ -106,11 +106,13 @@ namespace NuGet.Commands
 
             if (packageSource == null)
             {
-                // Since SymbolPackageUpdateResourceV3 will be requested this should be a v3 PackageSource
-                packageSource = new PackageSource(source)
+                packageSource = new PackageSource(source);
+                
+                // If it ends with "index.json" then treat it as a V3 Protocol PackageSource
+                if (packageSource.Source.EndsWith("index.json", StringComparison.OrdinalIgnoreCase)
                 {
-                    ProtocolVersion = 3
-                };
+                    packageSource.ProtocolVersion = 3;
+                }
             }
 
             var sourceRepositoryProvider = new CachingSourceProvider(sourceProvider);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12951

Regression? Last working version:

## Description
In `GetSymbolPackageUpdateResource` if the requested `source` cannot be found in the current `sourceProvider` a new `PackageSource` is created. Then using V3 requests the `SymbolPackageUpdateResourceV3` is attempted to be retreived. This will obviously fail on a V2 package source.

This changes the creation of `PackageSource` to use `ProtocolV3`.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
