### PR TITLE
Set NuGetAudit property defaults in MSBuild

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.props
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.props
@@ -38,4 +38,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CentralPackageVersionsFileImported>true</CentralPackageVersionsFileImported>
   </PropertyGroup>
 
+  <!--
+    Setup default NuGet property values.
+    Visual Studio's project property page requires defaults to be set to inform customers what the default values are.
+  -->
+  <PropertyGroup>
+    <NuGetAudit Condition=" '$(NuGetAudit)' == '' ">true</NuGetAudit>
+    <NuGetAuditLevel Condition=" '$(NuGetAuditLevel)' == '' ">low</NuGetAuditLevel>
+    <NuGetAuditMode Condition=" '$(NuGetAuditMode)' == '' ">direct</NuGetAuditMode>
+  </PropertyGroup>
+
 </Project>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.props
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.props
@@ -38,14 +38,4 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CentralPackageVersionsFileImported>true</CentralPackageVersionsFileImported>
   </PropertyGroup>
 
-  <!--
-    Setup default NuGet property values.
-    Visual Studio's project property page requires defaults to be set to inform customers what the default values are.
-  -->
-  <PropertyGroup>
-    <NuGetAudit Condition=" '$(NuGetAudit)' == '' ">true</NuGetAudit>
-    <NuGetAuditLevel Condition=" '$(NuGetAuditLevel)' == '' ">low</NuGetAuditLevel>
-    <NuGetAuditMode Condition=" '$(NuGetAuditMode)' == '' ">direct</NuGetAuditMode>
-  </PropertyGroup>
-
 </Project>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -63,6 +63,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_CentralPackageVersionsEnabled Condition="'$(ManagePackageVersionsCentrally)' == 'true' AND '$(CentralPackageVersionsFileImported)' == 'true'">true</_CentralPackageVersionsEnabled>
   </PropertyGroup>
 
+  <!--
+    Visual Studio's project property page requires defaults to be set to inform customers what the default values are.
+    Project-system uses DefaultValueSourceLocation.AfterContext to detect when a customer's project changes the value, so these defaults must be set here in the targets file.
+  -->
+  <PropertyGroup>
+    <!-- Enable NuGetAudit by default -->
+    <NuGetAudit Condition=" '$(NuGetAudit)' == '' ">true</NuGetAudit>
+    <!-- Report on low severity vulnerabilities, and higher. Allowed values are: low, moderate, high, critical -->
+    <NuGetAuditLevel Condition=" '$(NuGetAuditLevel)' == '' ">low</NuGetAuditLevel>
+    <!-- Report known vulnerabilities on direct dependencies only. Allowed values are: direct, all -->
+    <NuGetAuditMode Condition=" '$(NuGetAuditMode)' == '' ">direct</NuGetAuditMode>
+  </PropertyGroup>
+
   <PropertyGroup>
     <!-- Exclude packages from changing restore inputs.  -->
     <_GenerateRestoreGraphProjectEntryInputProperties>ExcludeRestorePackageImports=true</_GenerateRestoreGraphProjectEntryInputProperties>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -304,14 +304,14 @@ namespace NuGet.Commands
                     });
                 }
 
-                AuditUtility.EnabledValue enableAudit = AuditUtility.ParseEnableValue(
+                bool auditEnabled = AuditUtility.ParseEnableValue(
                     _request.Project.RestoreMetadata?.RestoreAuditProperties?.EnableAudit,
                     _request.Project.FilePath,
                     _logger);
-                telemetry.TelemetryEvent[AuditEnabled] = AuditUtility.GetString(enableAudit);
-                if (enableAudit != AuditUtility.EnabledValue.ExplicitOptOut)
+                telemetry.TelemetryEvent[AuditEnabled] = auditEnabled ? "enabled" : "disabled";
+                if (auditEnabled)
                 {
-                    await PerformAuditAsync(enableAudit, graphs, telemetry, token);
+                    await PerformAuditAsync(graphs, telemetry, token);
                 }
 
                 telemetry.StartIntervalMeasure();
@@ -477,11 +477,10 @@ namespace NuGet.Commands
             }
         }
 
-        private async Task PerformAuditAsync(AuditUtility.EnabledValue enableAudit, IEnumerable<RestoreTargetGraph> graphs, TelemetryActivity telemetry, CancellationToken token)
+        private async Task PerformAuditAsync(IEnumerable<RestoreTargetGraph> graphs, TelemetryActivity telemetry, CancellationToken token)
         {
             telemetry.StartIntervalMeasure();
             var audit = new AuditUtility(
-                enableAudit,
                 _request.Project.RestoreMetadata.RestoreAuditProperties,
                 _request.Project.FilePath,
                 graphs,

--- a/test/EndToEnd/tests/NetCoreProjectTest.ps1
+++ b/test/EndToEnd/tests/NetCoreProjectTest.ps1
@@ -139,6 +139,8 @@ function Test-NetCoreConsoleAppRebuildDoesNotDeleteCacheFile {
 }
 
 function Test-NetCoreVSandMSBuildNoOp {
+    [SkipTest('https://github.com/NuGet/Home/issues/13003')]
+    param ()
 
     # Arrange
     $project = New-NetCoreConsoleApp ConsoleApp
@@ -163,6 +165,8 @@ function Test-NetCoreVSandMSBuildNoOp {
 }
 
 function Test-NetCoreTargetFrameworksVSandMSBuildNoOp {
+    [SkipTest('https://github.com/NuGet/Home/issues/13003')]
+    param ()
 
     # Arrange
     $project = New-NetCoreConsoleTargetFrameworksApp ConsoleApp

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -2851,7 +2851,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 ["HttpSourcesCount"] = value => value.Should().Be(0),
                 ["LocalSourcesCount"] = value => value.Should().Be(1),
                 ["FallbackFoldersCount"] = value => value.Should().Be(0),
-                ["Audit.Enabled"] = value => value.Should().Be("ExplicitOptIn"),
+                ["Audit.Enabled"] = value => value.Should().Be("enabled"),
                 ["Audit.Level"] = value => value.Should().Be(0),
                 ["Audit.Mode"] = value => value.Should().Be("Unknown"),
                 ["Audit.Vulnerability.Direct.Count"] = value => value.Should().Be(0),

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/Utility/AuditUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/Utility/AuditUtilityTests.cs
@@ -46,21 +46,14 @@ public class AuditUtilityTests
     {
         // Arrange
         string projectPath = "my.csproj";
-        TestLogger? logger = expectLog ? new TestLogger() : null;
+        TestLogger logger = new TestLogger();
 
         // Act
-        bool actual = AuditUtility.ParseEnableValue(input, projectPath, logger ?? NullLogger.Instance);
+        bool actual = AuditUtility.ParseEnableValue(input, projectPath, logger);
 
         // Assert
         actual.Should().Be(expected);
-
-        if (expectLog)
-        {
-            logger!.Errors.Should().Be(1);
-            RestoreLogMessage message = logger.LogMessages.Cast<RestoreLogMessage>().Single();
-            message.Code.Should().Be(NuGetLogCode.NU1014);
-            message.Level.Should().Be(LogLevel.Error);
-        }
+        logger.LogMessages.Cast<RestoreLogMessage>().Count(m => m.Code == NuGetLogCode.NU1014).Should().Be(expectLog ? 1 : 0);
     }
 
     [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12960

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

In order to make Visual Studio's project properties window more user friendly, we need to set these properties default values in project evaluation. See https://github.com/dotnet/project-system/issues/9246 for more info.

Since this breaks NuGetAudit's telemetry for telling the difference between "explicit enable" and "implicit enable", it was changed to just "enabled" or "disabled". This is a breaking change, so telemetry queries need to be updated, but it reduces long term confusion for people looking at telemetry, as they no longer need to understand what implicit/explicit really mean.

Added skips for 2 VS E2E tests that are failing because project system's nomination isn't passing through the `NuGetAuditMode` property. I already have a PR to fix that, but we have to wait until it's merged into the dotnet/project-system repo, and then dotnet/project-system is inserted into VS, before these tests can work. Fortunately project-system inserts pretty much every day, so it shouldn't take long, just depends on how quick the PR gets merged. We can either merge this PR with the skips and I'll need to revert the skips afterwards, or we can wait for project-system to merge and insert, then I can update this PR. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
