### PR TITLE
Stop using HttpClientHandler.PreAuthenticate

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
@@ -54,7 +54,6 @@ namespace NuGet.Protocol
             {
                 Proxy = proxy,
                 AutomaticDecompression = (DecompressionMethods.GZip | DecompressionMethods.Deflate),
-                PreAuthenticate = true
             };
 
 #if IS_DESKTOP

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Protocol.FuncTest
             _output = output;
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/12962")]
         public async Task GetAsync_GetPackageAfterServiceIndex_SecondUrlIsPreAuthenticated()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12961

Regression? Yes Last working version: 6.6

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The .NET runtime has a bug when using `HttpClientHandler.PreAuthenticate` that prevents it from getting new credentials when a time-limited credential expires, and the server starts requiring a new credential. NuGet's credential provider can provide the new credential, but `HttpClient` won't use it as long as `PreAuthenticate` is `true`.

* https://github.com/dotnet/runtime/issues/93340

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: We didn't have a test for the previous behaviour. Since we should re-introduce the functionality, I skipped the existing PreAuthenticate test, rather than deleting it, so it's easy to reactive once we have a new solution.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
