### PR TITLE
Vulnerability InfoBar hyperlink wraps with text in Solution Explorer

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VulnerablePackagesInfoBar.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VulnerablePackagesInfoBar.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Globalization;
 using System.Threading;
@@ -138,12 +139,14 @@ namespace NuGet.SolutionRestoreManager
 
         protected InfoBarModel GetInfoBarModel()
         {
+            IEnumerable<IVsInfoBarTextSpan> textSpans = new IVsInfoBarTextSpan[]
+            {
+                new InfoBarTextSpan(Resources.InfoBar_TextMessage + " "),
+                new InfoBarHyperlink(Resources.InfoBar_HyperlinkMessage)
+            };
+
             return new InfoBarModel(
-                Resources.InfoBar_TextMessage,
-                new IVsInfoBarActionItem[]
-                {
-                    new InfoBarHyperlink(Resources.InfoBar_HyperlinkMessage),
-                },
+                textSpans,
                 KnownMonikers.StatusWarning);
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12835

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The Solution Explorer is typically a narrow width compared to the width of VS toolbars. Therefore, InfoBars in the Solution Explorer don't really benefit from a columnar layout. Adding actions (hyperlink) to the collection will utilize a columnar layout, so to avoid that, I've added the hyperlink to the text controls. This way, the hyperlink flows with the other text and wraps more naturally.

I've tested several widths to ensure the link is legible and works in each configuration:

![image](https://github.com/NuGet/NuGet.Client/assets/49205731/551c8c65-a0f6-43e6-8954-8046d7d4b7ad)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - see manual test screenshots above
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
