### PR TITLE
Run Component Governance task after restore (5.11.x)

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -85,13 +85,6 @@ steps:
       }
   condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
-- task: NuGetCommand@2
-  displayName: "Add Apex Feed Source"
-  inputs:
-    command: "custom"
-    arguments: "sources add -Name ApexFeed -Source $(ApexPackageFeedUrl) -UserName $(ApexPackageFeedUsername) -Password $(ApexPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\\NuGet.config"
-  condition: " and(succeeded(), eq(variables['AddApexFeedSource'], 'true'))"
-
 - task: MSBuild@1
   displayName: "Restore for VS2019"
   inputs:
@@ -99,6 +92,9 @@ steps:
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=$(BuildRTM) /v:m /p:IncludeApex=true"
     maximumCpuCount: true
+
+- task: ComponentGovernanceComponentDetection@0
+  displayName: 'Component Detection'
 
 - task: MSBuild@1
   displayName: "Build for VS2019"
@@ -265,10 +261,6 @@ steps:
     WhiteListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
     WhiteListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
   condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))  #skip this task for nonRTM in private build
-
-- task: ComponentGovernanceComponentDetection@0
-  displayName: 'Component Detection'
-  condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
 
 - task: PublishPipelineArtifact@1
   displayName: "Publish nupkgs"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2555

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

CG must run on all jobs in the pipeline, so when it's not run explicitly, it runs automatically as the last task in the job. Hence, I removed the condition so it's explicit on both the "RTM" and "nonRTM" jobs.  I also moved it to after restore, so that it does not detect the packages that our pipeline creates, since those are out of scope for what CG is intended for.

Finally, I noticed that we had an old "add apex feed" task, which is no longer relevant, so I deleted it at the same time.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
