### PR TITLE
CI: Run CG after restore and stop pushing packages (6.6.x)

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -415,16 +415,6 @@ steps:
     artifactName: "localizationArtifacts"
   condition: "and(eq(variables['BuildRTM'], 'false'), or(eq(variables['OverridePublishLocalizationArtifact'], 'true'), and(succeededOrFailed(), eq(variables['IsOfficialBuild'], 'true'))))"
 
-- task: NuGetCommand@2
-  displayName: Publish public Nuget packages to nuget-build
-  inputs:
-    command: push
-    packagesToPush: 'artifacts\nupkgs\*.nupkg;!artifacts\nupkgs\*.symbols.nupkg'
-    nuGetFeedType: external
-    allowPackageConflicts: true
-    publishFeedCredentials : nuget-build-dnceng-public-feed
-  condition: " and(succeeded(),eq(variables['PublishArtifactsToMyGet'], 'true'), eq(variables['BuildRTM'], 'false')) "
-
 - task: MSBuild@1
   displayName: "Collect Build Symbols"
   inputs:

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -115,6 +115,9 @@ steps:
         exit 1
       }
 
+- task: ComponentGovernanceComponentDetection@0
+  displayName: 'Component Detection'
+
 - task: MSBuild@1
   displayName: "Build"
   inputs:
@@ -273,9 +276,6 @@ steps:
     TargetFolders: '$(Build.Repository.LocalPath)\\artifacts\\VS15'
     ApprovalListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
     ApprovalListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
-
-- task: ComponentGovernanceComponentDetection@0
-  displayName: 'Component Detection'
 
 - task: PublishPipelineArtifact@1
   displayName: "Publish nupkgs"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: N/A

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Cherry picks https://github.com/NuGet/NuGet.Client/pull/5473 and https://github.com/NuGet/NuGet.Client/pull/5454 to bring CI improvements to supported release branches

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
