### PR TITLE
Control embedding Restore files in binlog

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -1098,9 +1098,12 @@ namespace NuGet.Build.Tasks.Console
         /// <param name="dependencyGraphSpec"></param>
         private void LogFilesToEmbedInBinlog(DependencyGraphSpec dependencyGraphSpec, IReadOnlyDictionary<string, string> options)
         {
-            // If the MSBuildBinaryLoggerEnabled environment variable is not set, don't log the paths to the files.
-            if (!string.Equals(Environment.GetEnvironmentVariable("MSBUILDBINARYLOGGERENABLED"), bool.TrueString, StringComparison.OrdinalIgnoreCase)
-                || !IsOptionTrue(nameof(RestoreTaskEx.EmbedRestoreFilesInBinlog), options))
+            // Determines what the user wants embedded in the binary log where 0 or false disables embedding anything, 2 embeds everything, and 1 or true embeds just the assets file, g.props, and g.targets.
+            options.TryGetValue(nameof(RestoreTaskEx.EmbedFilesInBinlog), out string embedFilesInBinlog);
+
+            int embedInBinlogSelection = BuildTasksUtility.GetFilesToEmbedInBinlogValue(embedFilesInBinlog);
+
+            if (embedInBinlogSelection == 0)
             {
                 return;
             }
@@ -1112,13 +1115,14 @@ namespace NuGet.Build.Tasks.Console
                 if (project.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference)
                 {
                     LoggingQueue.Enqueue(new ConsoleOutLogEmbedInBinlog(Path.Combine(project.RestoreMetadata.OutputPath, LockFileFormat.AssetsFileName)));
-                    if (IsOptionTrue(nameof(RestoreTaskEx.EmbedDGSpecInBinlog), options))
+                    LoggingQueue.Enqueue(new ConsoleOutLogEmbedInBinlog(BuildAssetsUtils.GetMSBuildFilePathForPackageReferenceStyleProject(project, BuildAssetsUtils.PropsExtension)));
+                    LoggingQueue.Enqueue(new ConsoleOutLogEmbedInBinlog(BuildAssetsUtils.GetMSBuildFilePathForPackageReferenceStyleProject(project, BuildAssetsUtils.TargetsExtension)));
+
+                    // Only include the dgspec if the user wants everything embedded in the binlog.
+                    if (embedInBinlogSelection == 2)
                     {
                         LoggingQueue.Enqueue(new ConsoleOutLogEmbedInBinlog(Path.Combine(project.RestoreMetadata.OutputPath, DependencyGraphSpec.GetDGSpecFileName(Path.GetFileName(project.RestoreMetadata.ProjectPath)))));
                     }
-
-                    LoggingQueue.Enqueue(new ConsoleOutLogEmbedInBinlog(BuildAssetsUtils.GetMSBuildFilePathForPackageReferenceStyleProject(project, BuildAssetsUtils.PropsExtension)));
-                    LoggingQueue.Enqueue(new ConsoleOutLogEmbedInBinlog(BuildAssetsUtils.GetMSBuildFilePathForPackageReferenceStyleProject(project, BuildAssetsUtils.TargetsExtension)));
                 }
                 else if (project.RestoreMetadata.ProjectStyle == ProjectStyle.PackagesConfig)
                 {

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -755,5 +755,47 @@ namespace NuGet.Build.Tasks
 
             return null;
         }
+
+        /// <summary>
+        /// Gets an integer indicating what files should be embedded in the MSBuild binary log based on the user-specified value:
+        ///  - "0" or "false" = Do not embed any files
+        ///  - "2" = Embed dgspec, project.assets.json, g.props, and g.targets
+        /// Any other value embeds project.assets.json, g.props, and g.targets
+        /// </summary>
+        /// <param name="value">The user supplied value indicating what files to embed in the binary log.</param>
+        /// <returns>An integer representing what to embed in the binary log.</returns>
+        public static int GetFilesToEmbedInBinlogValue(string value)
+        {
+            return GetFilesToEmbedInBinlogValue(value, EnvironmentVariableWrapper.Instance);
+        }
+
+        internal static int GetFilesToEmbedInBinlogValue(string value, IEnvironmentVariableReader environmentVariableReader)
+        {
+            if (!string.Equals(environmentVariableReader.GetEnvironmentVariable("MSBUILDBINARYLOGGERENABLED"), bool.TrueString, StringComparison.OrdinalIgnoreCase))
+            {
+                return 0;
+            }
+
+            if (value == null)
+            {
+                return 1;
+            }
+
+            string trimmed = value.Trim();
+
+            if (string.Equals(bool.FalseString, trimmed, StringComparison.OrdinalIgnoreCase) || string.Equals("0", trimmed, StringComparison.OrdinalIgnoreCase))
+            {
+                return 0;
+            }
+
+            if (string.Equals("2", trimmed, StringComparison.OrdinalIgnoreCase))
+            {
+                return 2;
+            }
+
+            return 1;
+        }
+
     }
 }
+

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
@@ -33,7 +33,9 @@ Copyright (c) .NET Foundation. All rights reserved.
         SolutionPath="$(SolutionPath)"
         ProcessFileName="$(NuGetConsoleProcessFileName)"
         SerializeGlobalProperties="$(RestoreSerializeGlobalProperties)"
-        MSBuildStartupDirectory="$(MSBuildStartupDirectory)">
+        MSBuildStartupDirectory="$(MSBuildStartupDirectory)"
+        EmbedRestoreFilesInBinlog="$(EmbedRestoreFilesInBinlog)"
+        EmbedDGSpecInBinlog="$(EmbedDGSpecInBinlog)">
       <Output TaskParameter="EmbedInBinlog" ItemName="EmbedInBinlog" />
     </RestoreTaskEx>
   </Target>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
@@ -34,8 +34,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         ProcessFileName="$(NuGetConsoleProcessFileName)"
         SerializeGlobalProperties="$(RestoreSerializeGlobalProperties)"
         MSBuildStartupDirectory="$(MSBuildStartupDirectory)"
-        EmbedRestoreFilesInBinlog="$(EmbedRestoreFilesInBinlog)"
-        EmbedDGSpecInBinlog="$(EmbedDGSpecInBinlog)">
+        EmbedFilesInBinlog="$(RestoreEmbedFilesInBinlog)">
       <Output TaskParameter="EmbedInBinlog" ItemName="EmbedInBinlog" />
     </RestoreTaskEx>
   </Target>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -177,7 +177,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       HideWarningsAndErrors="$(HideWarningsAndErrors)"
       Interactive="$(NuGetInteractive)"
       RestoreForceEvaluate="$(RestoreForceEvaluate)"
-      RestorePackagesConfig="$(RestorePackagesConfig)">
+      RestorePackagesConfig="$(RestorePackagesConfig)"
+      EmbedRestoreFilesInBinlog="$(EmbedRestoreFilesInBinlog)"
+      EmbedDGSpecInBinlog="$(EmbedDGSpecInBinlog)">
       <Output TaskParameter="EmbedInBinlog" ItemName="EmbedInBinlog" />
     </RestoreTask>
   </Target>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -178,8 +178,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       Interactive="$(NuGetInteractive)"
       RestoreForceEvaluate="$(RestoreForceEvaluate)"
       RestorePackagesConfig="$(RestorePackagesConfig)"
-      EmbedRestoreFilesInBinlog="$(EmbedRestoreFilesInBinlog)"
-      EmbedDGSpecInBinlog="$(EmbedDGSpecInBinlog)">
+      EmbedFilesInBinlog="$(RestoreEmbedFilesInBinlog)">
       <Output TaskParameter="EmbedInBinlog" ItemName="EmbedInBinlog" />
     </RestoreTask>
   </Target>

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
@@ -65,16 +65,9 @@ namespace NuGet.Build.Tasks
         public bool RestorePackagesConfig { get; set; }
 
         /// <summary>
-        /// Controls whether to embed files produced by the Restore task in the binlog.
-        /// Defaults to true.
+        /// Gets or sets a value indicating whether to embed files produced by restore in the MSBuild binary logger.
         /// </summary>
-        public bool EmbedRestoreFilesInBinlog { get; set; } = true;
-
-        /// <summary>
-        /// Controls whether to embed .nuget.dgspec.json files in the binlog.
-        /// Defaults to true.
-        /// </summary>
-        public bool EmbedDGSpecInBinlog { get; set; } = true;
+        public string EmbedFilesInBinlog { get; set; }
 
         protected override string DebugEnvironmentVariableName => "DEBUG_RESTORE_TASK_EX";
 
@@ -92,8 +85,10 @@ namespace NuGet.Build.Tasks
             options[nameof(NoCache)] = NoCache.ToString();
             options[nameof(NoHttpCache)] = NoHttpCache.ToString();
             options[nameof(RestorePackagesConfig)] = RestorePackagesConfig.ToString();
-            options[nameof(EmbedRestoreFilesInBinlog)] = EmbedRestoreFilesInBinlog.ToString();
-            options[nameof(EmbedDGSpecInBinlog)] = EmbedDGSpecInBinlog.ToString();
+            if (!string.IsNullOrWhiteSpace(EmbedFilesInBinlog))
+            {
+                options[nameof(EmbedFilesInBinlog)] = EmbedFilesInBinlog;
+            }
 
             return options;
         }

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTaskEx.cs
@@ -64,6 +64,18 @@ namespace NuGet.Build.Tasks
         /// </summary>
         public bool RestorePackagesConfig { get; set; }
 
+        /// <summary>
+        /// Controls whether to embed files produced by the Restore task in the binlog.
+        /// Defaults to true.
+        /// </summary>
+        public bool EmbedRestoreFilesInBinlog { get; set; } = true;
+
+        /// <summary>
+        /// Controls whether to embed .nuget.dgspec.json files in the binlog.
+        /// Defaults to true.
+        /// </summary>
+        public bool EmbedDGSpecInBinlog { get; set; } = true;
+
         protected override string DebugEnvironmentVariableName => "DEBUG_RESTORE_TASK_EX";
 
         protected override Dictionary<string, string> GetOptions()
@@ -80,6 +92,8 @@ namespace NuGet.Build.Tasks
             options[nameof(NoCache)] = NoCache.ToString();
             options[nameof(NoHttpCache)] = NoHttpCache.ToString();
             options[nameof(RestorePackagesConfig)] = RestorePackagesConfig.ToString();
+            options[nameof(EmbedRestoreFilesInBinlog)] = EmbedRestoreFilesInBinlog.ToString();
+            options[nameof(EmbedDGSpecInBinlog)] = EmbedDGSpecInBinlog.ToString();
 
             return options;
         }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/BuildTasksUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/BuildTasksUtilityTests.cs
@@ -2,10 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using FluentAssertions;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Test.Utility;
+using Test.Utility;
 using Xunit;
 
 namespace NuGet.Build.Tasks.Console.Test
@@ -130,6 +133,31 @@ namespace NuGet.Build.Tasks.Console.Test
                 // Assert
                 effectiveSources.Should().BeEquivalentTo(new[] { Path.Combine(startupDirectory, relativePath) });
             }
+        }
+
+        [Theory]
+        [InlineData("0", "false", 0)]
+        [InlineData("0", "true", 0)]
+        [InlineData("false", "false", 0)]
+        [InlineData("false", "true", 0)]
+        [InlineData(" 2 ", "false", 0)]
+        [InlineData(" 2 ", "true", 2)]
+        [InlineData("true", "false", 0)]
+        [InlineData("true", "true", 1)]
+        [InlineData(" 1 ", "false", 0)]
+        [InlineData(" 1 ", "true", 1)]
+        [InlineData("", "false", 0)]
+        [InlineData("", "true", 1)]
+        [InlineData(null, "false", 0)]
+        [InlineData(null, "true", 1)]
+        public void GetFilesToEmbedInBinlogValue_WithValue_ReturnsExpectedValue(string value, string binaryLoggerEnabled, int expected)
+        {
+            IEnvironmentVariableReader environmentVariableReader = new TestEnvironmentVariableReader(new Dictionary<string, string>
+            {
+                ["MSBUILDBINARYLOGGERENABLED"] = binaryLoggerEnabled
+            });
+
+            BuildTasksUtility.GetFilesToEmbedInBinlogValue(value, environmentVariableReader).Should().Be(expected);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
@@ -25,7 +25,71 @@ namespace NuGet.Build.Tasks.Test
             }
         }
 
-        [Fact]
+        [Theory]
+        [InlineData("something", true)]
+        [InlineData("  ", false)]
+        [InlineData(null, false)]
+        public void GetCommandLineArguments_WhenEmbedFilesInBinlogSpecified_CorrectValuesReturned(string embedFilesInBinlogValue, bool expectedToBeSet)
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                string msbuildBinPath = Path.Combine(testDirectory, "MSBuild", "Current", "Bin");
+                string projectPath = Path.Combine(testDirectory, "src", "project1", "project1.csproj");
+
+                var globalProperties = new Dictionary<string, string>();
+
+                var buildEngine = new TestBuildEngine(globalProperties);
+
+                using (var task = new RestoreTaskEx
+                {
+                    BuildEngine = buildEngine,
+                    DisableParallel = true,
+                    Force = true,
+                    ForceEvaluate = true,
+                    HideWarningsAndErrors = true,
+                    IgnoreFailedSources = true,
+                    Interactive = true,
+                    MSBuildBinPath = msbuildBinPath,
+                    NoCache = true,
+                    NoHttpCache = true,
+                    ProjectFullPath = projectPath,
+                    Recursive = true,
+                    RestorePackagesConfig = true,
+                    MSBuildStartupDirectory = testDirectory,
+                    EmbedFilesInBinlog = embedFilesInBinlogValue
+                })
+                {
+                    string arguments = task.GetCommandLineArguments(globalProperties);
+
+                    arguments.Should().Be(StaticGraphRestoreTaskBase.CreateArgumentString(GetExpectedArguments(msbuildBinPath, projectPath)));
+                }
+            }
+
+            IEnumerable<string> GetExpectedArguments(string msbuildBinPath, string projectPath)
+            {
+#if IS_CORECLR
+                yield return Path.ChangeExtension(typeof(RestoreTaskEx).Assembly.Location, ".Console.dll");
+#endif
+                if (expectedToBeSet)
+                {
+                    yield return "Recursive=True;CleanupAssetsForUnsupportedProjects=True;DisableParallel=True;Force=True;ForceEvaluate=True;HideWarningsAndErrors=True;IgnoreFailedSources=True;Interactive=True;NoCache=True;NoHttpCache=True;RestorePackagesConfig=True;EmbedFilesInBinlog=" + embedFilesInBinlogValue.ToString();
+                }
+                else
+                {
+                    yield return "Recursive=True;CleanupAssetsForUnsupportedProjects=True;DisableParallel=True;Force=True;ForceEvaluate=True;HideWarningsAndErrors=True;IgnoreFailedSources=True;Interactive=True;NoCache=True;NoHttpCache=True;RestorePackagesConfig=True";
+                }
+#if IS_CORECLR
+                yield return Path.Combine(msbuildBinPath, "MSBuild.dll");
+#else
+                yield return Path.Combine(msbuildBinPath, "MSBuild.exe");
+#endif
+                yield return projectPath;
+
+                yield return $"";
+            }
+        }
+
+            [Fact]
         public void GetCommandLineArguments_WhenOptionsSpecified_CorrectValuesReturned()
         {
             using (var testDirectory = TestDirectory.Create())
@@ -70,7 +134,7 @@ namespace NuGet.Build.Tasks.Test
 #if IS_CORECLR
                 yield return Path.ChangeExtension(typeof(RestoreTaskEx).Assembly.Location, ".Console.dll");
 #endif
-                yield return "Recursive=True;CleanupAssetsForUnsupportedProjects=True;DisableParallel=True;Force=True;ForceEvaluate=True;HideWarningsAndErrors=True;IgnoreFailedSources=True;Interactive=True;NoCache=True;NoHttpCache=True;RestorePackagesConfig=True;EmbedRestoreFilesInBinlog=True;EmbedDGSpecInBinlog=True";
+                yield return "Recursive=True;CleanupAssetsForUnsupportedProjects=True;DisableParallel=True;Force=True;ForceEvaluate=True;HideWarningsAndErrors=True;IgnoreFailedSources=True;Interactive=True;NoCache=True;NoHttpCache=True;RestorePackagesConfig=True";
 #if IS_CORECLR
                 yield return Path.Combine(msbuildBinPath, "MSBuild.dll");
 #else

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
@@ -89,7 +89,7 @@ namespace NuGet.Build.Tasks.Test
             }
         }
 
-            [Fact]
+        [Fact]
         public void GetCommandLineArguments_WhenOptionsSpecified_CorrectValuesReturned()
         {
             using (var testDirectory = TestDirectory.Create())

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/RestoreTaskExTests.cs
@@ -70,7 +70,7 @@ namespace NuGet.Build.Tasks.Test
 #if IS_CORECLR
                 yield return Path.ChangeExtension(typeof(RestoreTaskEx).Assembly.Location, ".Console.dll");
 #endif
-                yield return "Recursive=True;CleanupAssetsForUnsupportedProjects=True;DisableParallel=True;Force=True;ForceEvaluate=True;HideWarningsAndErrors=True;IgnoreFailedSources=True;Interactive=True;NoCache=True;NoHttpCache=True;RestorePackagesConfig=True";
+                yield return "Recursive=True;CleanupAssetsForUnsupportedProjects=True;DisableParallel=True;Force=True;ForceEvaluate=True;HideWarningsAndErrors=True;IgnoreFailedSources=True;Interactive=True;NoCache=True;NoHttpCache=True;RestorePackagesConfig=True;EmbedRestoreFilesInBinlog=True;EmbedDGSpecInBinlog=True";
 #if IS_CORECLR
                 yield return Path.Combine(msbuildBinPath, "MSBuild.dll");
 #else


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12957

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This changes allows users to specify what level of files to embed in the MSBuild binary log.

| Value | Files to embed |
|---|---|
| `0` or `false` | Do not embed any files
| `2` | Embed everything (dgspec, assets file, g.props, and g.targets) |
| Any other value | Embed assets file, g.props, and g.targets |

Users can specify what get embedded via the MSBuild property `RestoreEmbedFilesInBinlog`:

For example, to disable the functionality:
```
/p:RestoreEmbedFilesInBinlog=false
```

Or to opt into embedding everything:
```
/p:RestoreEmbedFilesInBinlog=2
```

Any other value embeds just the default (assets file, g.props, and g.targets)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
