### PR TITLE
Eliminate obsolete API warnings/errors in product source-build

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Exceptions/PackageSourceException.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Exceptions/PackageSourceException.cs
@@ -14,6 +14,9 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
+#endif
         protected PackageSourceException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/src/NuGet.Core/NuGet.Commands/Common/CommandException.cs
+++ b/src/NuGet.Core/NuGet.Commands/Common/CommandException.cs
@@ -29,6 +29,9 @@ namespace NuGet.Commands
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
+#endif
         protected CommandException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/NuGet.Core/NuGet.Configuration/Exceptions/NuGetConfigurationException.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Exceptions/NuGetConfigurationException.cs
@@ -22,6 +22,9 @@ namespace NuGet.Configuration
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
+#endif
         protected NuGetConfigurationException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkException.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkException.cs
@@ -14,6 +14,9 @@ namespace NuGet.Frameworks
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
+#endif
         protected FrameworkException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/src/NuGet.Core/NuGet.Packaging/Licenses/NuGetLicenseExpressionParsingException.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Licenses/NuGetLicenseExpressionParsingException.cs
@@ -18,6 +18,9 @@ namespace NuGet.Packaging.Licenses
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
+#endif
         protected NuGetLicenseExpressionParsingException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/src/NuGet.Core/NuGet.Protocol/Exceptions/FatalProtocolException.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Exceptions/FatalProtocolException.cs
@@ -18,6 +18,9 @@ namespace NuGet.Protocol.Core.Types
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
+#endif
         protected FatalProtocolException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/src/NuGet.Core/NuGet.Protocol/Exceptions/InvalidCacheProtocolException.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Exceptions/InvalidCacheProtocolException.cs
@@ -23,6 +23,9 @@ namespace NuGet.Protocol
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
+#endif
         protected InvalidCacheProtocolException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/src/NuGet.Core/NuGet.Protocol/Exceptions/NuGetProtocolException.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Exceptions/NuGetProtocolException.cs
@@ -22,6 +22,9 @@ namespace NuGet.Protocol.Core.Types
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
+#endif
         protected NuGetProtocolException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/src/NuGet.Core/NuGet.Protocol/Exceptions/RetriableProtocolException.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Exceptions/RetriableProtocolException.cs
@@ -17,6 +17,9 @@ namespace NuGet.Protocol.Core.Types
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
+#endif
         protected RetriableProtocolException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginException.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginException.cs
@@ -31,6 +31,9 @@ namespace NuGet.Protocol.Plugins
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
+#endif
         private PluginException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/ProtocolException.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/ProtocolException.cs
@@ -31,6 +31,9 @@ namespace NuGet.Protocol.Plugins
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
+#endif
         private ProtocolException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/src/NuGet.Core/NuGet.Resolver/Exceptions/NuGetResolverConstraintException.cs
+++ b/src/NuGet.Core/NuGet.Resolver/Exceptions/NuGetResolverConstraintException.cs
@@ -17,6 +17,9 @@ namespace NuGet.Resolver
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
+#endif
         protected NuGetResolverConstraintException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/src/NuGet.Core/NuGet.Resolver/Exceptions/NuGetResolverException.cs
+++ b/src/NuGet.Core/NuGet.Resolver/Exceptions/NuGetResolverException.cs
@@ -14,6 +14,9 @@ namespace NuGet.Resolver
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
+#endif
         protected NuGetResolverException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/src/NuGet.Core/NuGet.Resolver/Exceptions/NuGetResolverInputException.cs
+++ b/src/NuGet.Core/NuGet.Resolver/Exceptions/NuGetResolverInputException.cs
@@ -17,6 +17,9 @@ namespace NuGet.Resolver
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
+#endif
         protected NuGetResolverInputException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12988

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

When building nuget.client repo in full product source-build we see the following error:

`
/vmr/src/nuget-client/src/NuGet.Core/NuGet.Frameworks/FrameworkException.cs(17,88): error SYSLIB0051: 'Exception.Exception(SerializationInfo, StreamingContext)' is obsolete: 'This API supports obsolete formatter-based serialization. It should not be called or extended by application code.' (https://aka.ms/dotnet-warnings/SYSLIB0051) [/vmr/src/nuget-client/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj::TargetFramework=net8.0]
`

To work around this, source-build process have been modifying `Directory.Build.props` during build to add a nowarn for SYSLIB0051. We are moving away from modifying sources during source-build and this needs to be fixed in the repo.

This PR adds the conditional `Obsolete` attribute to all affected APIs. Attribute is applicable on .NET 8.0+.
