### PR TITLE
Fix conditional package updating in update all scenarios, add more tests for conditional package operations

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedProjectAction.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedProjectAction.cs
@@ -1,10 +1,11 @@
+#nullable enable
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NuGet.Commands;
-using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
@@ -38,13 +39,18 @@ namespace NuGet.PackageManagement
         /// <summary>
         /// Original user actions.
         /// </summary>
+        [Obsolete("The internal ActionAndContextList property should be used.")]
         public IReadOnlyList<NuGetProjectAction> OriginalActions { get; }
 
         /// <summary>
         /// The context necessary for installing a package.
         /// </summary>
+        [Obsolete("The internal ActionAndContextList property should be used.")]
         public BuildIntegratedInstallationContext InstallationContext { get; }
 
+        internal IReadOnlyList<(NuGetProjectAction, BuildIntegratedInstallationContext)> ActionAndContextList { get; }
+
+        [Obsolete("This type is not expected to be created externally.")]
         public BuildIntegratedProjectAction(NuGetProject project,
             PackageIdentity packageIdentity,
             NuGetProjectActionType nuGetProjectActionType,
@@ -57,6 +63,7 @@ namespace NuGet.PackageManagement
         {
         }
 
+        [Obsolete("This type is not expected to be created externally.")]
         public BuildIntegratedProjectAction(NuGetProject project,
             PackageIdentity packageIdentity,
             NuGetProjectActionType nuGetProjectActionType,
@@ -65,9 +72,14 @@ namespace NuGet.PackageManagement
             IReadOnlyList<SourceRepository> sources,
             IReadOnlyList<NuGetProjectAction> originalActions,
             BuildIntegratedInstallationContext installationContext,
-            VersionRange versionRange)
+            VersionRange? versionRange)
             : base(packageIdentity, nuGetProjectActionType, project, sourceRepository: null, versionRange)
         {
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
             if (packageIdentity == null)
             {
                 throw new ArgumentNullException(nameof(packageIdentity));
@@ -90,12 +102,12 @@ namespace NuGet.PackageManagement
 
             if (originalActions == null)
             {
-                throw new ArgumentNullException(nameof(sources));
+                throw new ArgumentNullException(nameof(originalActions));
             }
 
             if (installationContext == null)
             {
-                throw new ArgumentNullException(nameof(sources));
+                throw new ArgumentNullException(nameof(installationContext));
             }
 
             OriginalLockFile = originalLockFile;
@@ -104,6 +116,63 @@ namespace NuGet.PackageManagement
             Sources = sources;
             OriginalActions = originalActions;
             InstallationContext = installationContext;
+            ActionAndContextList = originalActions.Select(e => (e, installationContext)).ToList();
+        }
+
+        internal BuildIntegratedProjectAction(NuGetProject project,
+            PackageIdentity packageIdentity,
+            NuGetProjectActionType nuGetProjectActionType,
+            LockFile originalLockFile,
+            RestoreResultPair restoreResultPair,
+            IReadOnlyList<SourceRepository> sources,
+            IReadOnlyList<(NuGetProjectAction, BuildIntegratedInstallationContext)> originalActionsAndInstallationContexts,
+            VersionRange versionRange)
+            : base(packageIdentity, nuGetProjectActionType, project, sourceRepository: null, versionRange)
+        {
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            if (packageIdentity == null)
+            {
+                throw new ArgumentNullException(nameof(packageIdentity));
+            }
+
+            if (originalLockFile == null)
+            {
+                throw new ArgumentNullException(nameof(originalLockFile));
+            }
+
+            if (restoreResultPair == null)
+            {
+                throw new ArgumentNullException(nameof(restoreResultPair));
+            }
+
+            if (sources == null)
+            {
+                throw new ArgumentNullException(nameof(sources));
+            }
+
+            if (originalActionsAndInstallationContexts == null)
+            {
+                throw new ArgumentNullException(nameof(originalActionsAndInstallationContexts));
+            }
+
+            if (originalActionsAndInstallationContexts.Count < 1)
+            {
+                throw new ArgumentException("Must contain at least 1 element.", nameof(originalActionsAndInstallationContexts));
+            }
+
+            OriginalLockFile = originalLockFile;
+            RestoreResult = restoreResultPair.Result;
+            RestoreResultPair = restoreResultPair;
+            Sources = sources;
+            ActionAndContextList = originalActionsAndInstallationContexts;
+#pragma warning disable CS0618 // Type or member is obsolete
+            OriginalActions = originalActionsAndInstallationContexts.Select(e => e.Item1).ToList();
+            InstallationContext = originalActionsAndInstallationContexts[0].Item2;
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public IReadOnlyList<NuGetProjectAction> GetProjectActions()
@@ -117,12 +186,12 @@ namespace NuGet.PackageManagement
 
                 foreach (var package in removed)
                 {
-                    actions.Add(NuGetProjectAction.CreateUninstallProjectAction(package, Project));
+                    actions.Add(CreateUninstallProjectAction(package, Project));
                 }
 
                 foreach (var package in added)
                 {
-                    actions.Add(NuGetProjectAction.CreateInstallProjectAction(package, sourceRepository: null, project: Project));
+                    actions.Add(CreateInstallProjectAction(package, sourceRepository: null, project: Project));
                 }
             }
 

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedProjectAction.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedProjectAction.cs
@@ -1,6 +1,7 @@
-#nullable enable
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
 
 using System;
 using System.Collections.Generic;

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -3115,8 +3115,8 @@ namespace NuGet.PackageManagement
                 if (nuGetProjectActions.Length == 1 &&
                     firstAction.NuGetProjectActionType == NuGetProjectActionType.Install &&
                     !restoreResult.Result.Success &&
-                    successfulFrameworks.Any() &&
-                    unsuccessfulFrameworks.Any() &&
+                    successfulFrameworks.Count > 0 &&
+                    unsuccessfulFrameworks.Count > 0 &&
                     !PackageSpecOperations.HasPackage(originalPackageSpec, firstAction.PackageIdentity.Id))
                 {
                     updatedPackageSpec = originalPackageSpec.Clone();

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -24,6 +24,7 @@ using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Resolver;
+using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.PackageManagement
@@ -833,10 +834,7 @@ namespace NuGet.PackageManagement
 
             if (packageIdentities.Count == 0 && packageId == null)
             {
-                // Update-Package  all
-
-                //TODO: need to consider whether Update ALL simply does nothing for Build Integrated projects
-
+                // Update All
                 var lowLevelActions = new List<NuGetProjectAction>();
 
                 foreach (var installedPackage in projectInstalledPackageReferences)
@@ -3063,8 +3061,7 @@ namespace NuGet.PackageManagement
 
             foreach (var buildIntegratedProject in buildIntegratedProjects)
             {
-                var nuGetProjectActions = nugetProjectActionsLookup[buildIntegratedProject.MSBuildProjectPath];
-                var nuGetProjectActionsList = nuGetProjectActions;
+                NuGetProjectAction[] nuGetProjectActions = nugetProjectActionsLookup[buildIntegratedProject.MSBuildProjectPath];
                 var updatedPackageSpec = updatedNugetPackageSpecLookup[buildIntegratedProject.MSBuildProjectPath];
                 var originalPackageSpec = originalNugetPackageSpecLookup[buildIntegratedProject.MSBuildProjectPath];
                 var originalLockFile = lockFileLookup[buildIntegratedProject.MSBuildProjectPath];
@@ -3090,20 +3087,36 @@ namespace NuGet.PackageManagement
                     .Distinct()
                     .ToList();
 
-                var successfulFrameworks = allFrameworks
-                    .Except(unsuccessfulFrameworks)
-                    .ToList();
+                var originalFrameworks = updatedPackageSpec
+                    .TargetFrameworks
+                    .ToDictionary(x => x.FrameworkName, x => x.TargetAlias);
 
-                var firstAction = nuGetProjectActionsList[0];
+                List<(NuGetProjectAction, BuildIntegratedInstallationContext)> projectActionsAndInstallationContexts = new(nuGetProjectActions.Length);
+
+                foreach (var action in nuGetProjectActions)
+                {
+                    PackageSpec referencePackageSpec = null;
+                    referencePackageSpec = action.NuGetProjectActionType switch
+                    {
+                        NuGetProjectActionType.Install or NuGetProjectActionType.Update => restoreResult.Result.LockFile.PackageSpec,
+                        NuGetProjectActionType.Uninstall => originalPackageSpec,
+                        _ => throw new InvalidOperationException("Unknown NuGetProjectActionType"),
+                    };
+                    BuildIntegratedInstallationContext installationContext = CreateInstallationContextForPackageId(action.PackageIdentity.Id, referencePackageSpec, unsuccessfulFrameworks, originalFrameworks);
+                    projectActionsAndInstallationContexts.Add((action, installationContext));
+                }
+
+                var firstInstallationAndProjectContext = projectActionsAndInstallationContexts[0];
+                var firstAction = firstInstallationAndProjectContext.Item1;
+                var successfulFrameworks = firstInstallationAndProjectContext.Item2.SuccessfulFrameworks.AsList();
 
                 // If the restore failed and this was a single package install, try to install the package to a subset of
                 // the target frameworks.
-                if (nuGetProjectActionsList.Length == 1 &&
+                if (nuGetProjectActions.Length == 1 &&
                     firstAction.NuGetProjectActionType == NuGetProjectActionType.Install &&
                     !restoreResult.Result.Success &&
                     successfulFrameworks.Any() &&
                     unsuccessfulFrameworks.Any() &&
-                    // Exclude upgrades, for now we take the simplest case.
                     !PackageSpecOperations.HasPackage(originalPackageSpec, firstAction.PackageIdentity.Id))
                 {
                     updatedPackageSpec = originalPackageSpec.Clone();
@@ -3134,16 +3147,6 @@ namespace NuGet.PackageManagement
                     await MSBuildRestoreUtility.ReplayWarningsAndErrorsAsync(restoreResult.Result.LockFile?.LogMessages, logger);
                 }
 
-                // Build the installation context
-                var originalFrameworks = updatedPackageSpec
-                    .TargetFrameworks
-                    .ToDictionary(x => x.FrameworkName, x => x.TargetAlias);
-
-                var installationContext = new BuildIntegratedInstallationContext(
-                    successfulFrameworks,
-                    unsuccessfulFrameworks,
-                    originalFrameworks);
-
                 InstallationCompatibility.EnsurePackageCompatibility(
                     buildIntegratedProject,
                     pathContext,
@@ -3166,8 +3169,7 @@ namespace NuGet.PackageManagement
                     originalLockFile,
                     restoreResult,
                     sources.ToList(),
-                    nuGetProjectActionsList,
-                    installationContext,
+                    projectActionsAndInstallationContexts,
                     versionRange);
 
                 result.Add(new ResolvedAction(buildIntegratedProject, nugetProjectAction));
@@ -3187,6 +3189,35 @@ namespace NuGet.PackageManagement
             TelemetryActivity.EmitTelemetryEvent(actionTelemetryEvent);
 
             return result;
+        }
+
+        /// <summary>
+        /// Build a context for package given package id.
+        /// The "successful" frameworks are the ones that contain the package and are not part of the failed list.
+        /// The "unsuccessful" frameworks are the ones that never had the package or are part of the unsuccessful list.
+        /// </summary>>
+        internal static BuildIntegratedInstallationContext CreateInstallationContextForPackageId(string packageIdentityId, PackageSpec packageSpec, List<NuGetFramework> unsuccessfulFrameworks, Dictionary<NuGetFramework, string> originalFrameworks)
+        {
+            var frameworksWithResultingPackage = packageSpec
+                                .TargetFrameworks
+                                .Where(e => e.Dependencies.Any(a => a.Name == packageIdentityId))
+                                .Select(e => e.FrameworkName)
+                                .Distinct();
+
+            var frameworksWithoutResultingPackage = packageSpec
+                .TargetFrameworks
+                .Where(e => !e.Dependencies.Any(a => a.Name == packageIdentityId))
+                .Select(e => e.FrameworkName)
+                .Distinct();
+
+            var successfulFrameworksWithPackage = frameworksWithResultingPackage
+                .Except(unsuccessfulFrameworks)
+                .ToList();
+
+            return new BuildIntegratedInstallationContext(
+                successfulFrameworksWithPackage,
+                unsuccessfulFrameworks.Union(frameworksWithoutResultingPackage).Distinct(),
+                originalFrameworks);
         }
 
         /// <summary>
@@ -3259,7 +3290,7 @@ namespace NuGet.PackageManagement
                 var ignoreActions = new HashSet<NuGetProjectAction>();
                 var installedIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-                foreach (var action in projectAction.OriginalActions.Reverse())
+                foreach ((var action, _) in projectAction.ActionAndContextList.Reverse())
                 {
                     if (action.NuGetProjectActionType == NuGetProjectActionType.Install)
                     {
@@ -3275,8 +3306,9 @@ namespace NuGet.PackageManagement
                     projectAction.RestoreResult.LockFile.PackageSpec.RestoreMetadata.PackagesPath,
                     projectAction.RestoreResult.LockFile.PackageSpec.RestoreMetadata.FallbackFolders);
 
-                foreach (var originalAction in projectAction.OriginalActions.Where(e => !ignoreActions.Contains(e)))
+                foreach ((var originalAction, var installationContext) in projectAction.ActionAndContextList.Where(e => !ignoreActions.Contains(e.Item1)))
                 {
+                    // This is where we calculate what goes into CPSPackageReferenceProject
                     if (originalAction.NuGetProjectActionType == NuGetProjectActionType.Install)
                     {
                         if (buildIntegratedProject.ProjectStyle == ProjectStyle.PackageReference)
@@ -3286,12 +3318,12 @@ namespace NuGet.PackageManagement
                                 pathResolver,
                                 originalAction.PackageIdentity);
 
-                            var framework = projectAction.InstallationContext.SuccessfulFrameworks.FirstOrDefault();
+                            var framework = installationContext.SuccessfulFrameworks.FirstOrDefault();
                             var resolvedAction = projectAction.RestoreResult.LockFile.PackageSpec.TargetFrameworks.FirstOrDefault(fm => fm.FrameworkName.Equals(framework))
                                 .Dependencies.First(dependency => dependency.Name.Equals(originalAction.PackageIdentity.Id, StringComparison.OrdinalIgnoreCase));
 
-                            projectAction.InstallationContext.SuppressParent = resolvedAction.SuppressParent;
-                            projectAction.InstallationContext.IncludeType = resolvedAction.IncludeType;
+                            installationContext.SuppressParent = resolvedAction.SuppressParent;
+                            installationContext.IncludeType = resolvedAction.IncludeType;
                         }
 
                         // Install the package to the project
@@ -3299,7 +3331,7 @@ namespace NuGet.PackageManagement
                             originalAction.PackageIdentity.Id,
                             originalAction.VersionRange ?? new VersionRange(originalAction.PackageIdentity.Version),
                             nuGetProjectContext,
-                            projectAction.InstallationContext,
+                            installationContext,
                             token: token);
                     }
                     else if (originalAction.NuGetProjectActionType == NuGetProjectActionType.Uninstall)
@@ -3640,12 +3672,6 @@ namespace NuGet.PackageManagement
             {
                 packageWithDirectoriesToBeDeleted.Add(packageIdentity);
             }
-
-            // TODO: Consider using CancelEventArgs instead of a regular EventArgs??
-            //if (packageOperationEventArgs.Cancel)
-            //{
-            //    return;
-            //}
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Shipped.txt
@@ -22,15 +22,15 @@ NuGet.PackageManagement.ActionsTelemetryEvent
 NuGet.PackageManagement.ActionsTelemetryEvent.OperationType.get -> NuGet.PackageManagement.NuGetProjectActionType
 NuGet.PackageManagement.AssetsFileMissingStatusChanged
 NuGet.PackageManagement.BuildIntegratedProjectAction
-~NuGet.PackageManagement.BuildIntegratedProjectAction.BuildIntegratedProjectAction(NuGet.ProjectManagement.NuGetProject project, NuGet.Packaging.Core.PackageIdentity packageIdentity, NuGet.PackageManagement.NuGetProjectActionType nuGetProjectActionType, NuGet.ProjectModel.LockFile originalLockFile, NuGet.Commands.RestoreResultPair restoreResultPair, System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Core.Types.SourceRepository> sources, System.Collections.Generic.IReadOnlyList<NuGet.PackageManagement.NuGetProjectAction> originalActions, NuGet.ProjectManagement.BuildIntegratedInstallationContext installationContext) -> void
-~NuGet.PackageManagement.BuildIntegratedProjectAction.BuildIntegratedProjectAction(NuGet.ProjectManagement.NuGetProject project, NuGet.Packaging.Core.PackageIdentity packageIdentity, NuGet.PackageManagement.NuGetProjectActionType nuGetProjectActionType, NuGet.ProjectModel.LockFile originalLockFile, NuGet.Commands.RestoreResultPair restoreResultPair, System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Core.Types.SourceRepository> sources, System.Collections.Generic.IReadOnlyList<NuGet.PackageManagement.NuGetProjectAction> originalActions, NuGet.ProjectManagement.BuildIntegratedInstallationContext installationContext, NuGet.Versioning.VersionRange versionRange) -> void
-~NuGet.PackageManagement.BuildIntegratedProjectAction.GetProjectActions() -> System.Collections.Generic.IReadOnlyList<NuGet.PackageManagement.NuGetProjectAction>
-~NuGet.PackageManagement.BuildIntegratedProjectAction.InstallationContext.get -> NuGet.ProjectManagement.BuildIntegratedInstallationContext
-~NuGet.PackageManagement.BuildIntegratedProjectAction.OriginalActions.get -> System.Collections.Generic.IReadOnlyList<NuGet.PackageManagement.NuGetProjectAction>
-~NuGet.PackageManagement.BuildIntegratedProjectAction.OriginalLockFile.get -> NuGet.ProjectModel.LockFile
-~NuGet.PackageManagement.BuildIntegratedProjectAction.RestoreResult.get -> NuGet.Commands.RestoreResult
-~NuGet.PackageManagement.BuildIntegratedProjectAction.RestoreResultPair.get -> NuGet.Commands.RestoreResultPair
-~NuGet.PackageManagement.BuildIntegratedProjectAction.Sources.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Core.Types.SourceRepository>
+NuGet.PackageManagement.BuildIntegratedProjectAction.BuildIntegratedProjectAction(NuGet.ProjectManagement.NuGetProject! project, NuGet.Packaging.Core.PackageIdentity! packageIdentity, NuGet.PackageManagement.NuGetProjectActionType nuGetProjectActionType, NuGet.ProjectModel.LockFile! originalLockFile, NuGet.Commands.RestoreResultPair! restoreResultPair, System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Core.Types.SourceRepository!>! sources, System.Collections.Generic.IReadOnlyList<NuGet.PackageManagement.NuGetProjectAction!>! originalActions, NuGet.ProjectManagement.BuildIntegratedInstallationContext! installationContext) -> void
+NuGet.PackageManagement.BuildIntegratedProjectAction.BuildIntegratedProjectAction(NuGet.ProjectManagement.NuGetProject! project, NuGet.Packaging.Core.PackageIdentity! packageIdentity, NuGet.PackageManagement.NuGetProjectActionType nuGetProjectActionType, NuGet.ProjectModel.LockFile! originalLockFile, NuGet.Commands.RestoreResultPair! restoreResultPair, System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Core.Types.SourceRepository!>! sources, System.Collections.Generic.IReadOnlyList<NuGet.PackageManagement.NuGetProjectAction!>! originalActions, NuGet.ProjectManagement.BuildIntegratedInstallationContext! installationContext, NuGet.Versioning.VersionRange? versionRange) -> void
+NuGet.PackageManagement.BuildIntegratedProjectAction.GetProjectActions() -> System.Collections.Generic.IReadOnlyList<NuGet.PackageManagement.NuGetProjectAction!>!
+NuGet.PackageManagement.BuildIntegratedProjectAction.InstallationContext.get -> NuGet.ProjectManagement.BuildIntegratedInstallationContext!
+NuGet.PackageManagement.BuildIntegratedProjectAction.OriginalActions.get -> System.Collections.Generic.IReadOnlyList<NuGet.PackageManagement.NuGetProjectAction!>!
+NuGet.PackageManagement.BuildIntegratedProjectAction.OriginalLockFile.get -> NuGet.ProjectModel.LockFile!
+NuGet.PackageManagement.BuildIntegratedProjectAction.RestoreResult.get -> NuGet.Commands.RestoreResult!
+NuGet.PackageManagement.BuildIntegratedProjectAction.RestoreResultPair.get -> NuGet.Commands.RestoreResultPair!
+NuGet.PackageManagement.BuildIntegratedProjectAction.Sources.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Core.Types.SourceRepository!>!
 NuGet.PackageManagement.BuildIntegratedRestoreUtility
 NuGet.PackageManagement.DependencyGraphRestoreUtility
 NuGet.PackageManagement.ExceptionUtility

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedProjectActionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedProjectActionTests.cs
@@ -1,0 +1,297 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Moq;
+using NuGet.Commands;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.PackageManagement.Test.BuildIntegration
+{
+    public class BuildIntegratedProjectActionTests
+    {
+        private readonly NuGetProject _nuGetProject = Mock.Of<NuGetProject>();
+        private readonly PackageIdentity _packageIdentity = new("a", new NuGetVersion(1, 0, 0));
+        private readonly LockFile _lockFile = Mock.Of<LockFile>();
+        private readonly RestoreResultPair _restoreResultPair = new(null, null);
+        private readonly BuildIntegratedInstallationContext _installationContext = new(null, null, null);
+        private readonly VersionRange _versionRange = new(new NuGetVersion(1, 0, 0));
+        private readonly List<(NuGetProjectAction, BuildIntegratedInstallationContext)> _originalActionAndProjectContexts = new();
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        [Fact]
+        public void Constructor_WithNullProjectIdentity_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new BuildIntegratedProjectAction(
+                project: null,
+                packageIdentity: _packageIdentity,
+                nuGetProjectActionType: NuGetProjectActionType.Install,
+                originalLockFile: _lockFile,
+                restoreResultPair: _restoreResultPair,
+                sources: new List<SourceRepository>(),
+                originalActions: new List<NuGetProjectAction>(),
+                installationContext: _installationContext,
+                versionRange: _versionRange));
+            exception.ParamName.Should().Be("project");
+        }
+
+        [Fact]
+        public void Constructor_WithNullPackageIdentity_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new BuildIntegratedProjectAction(
+                project: _nuGetProject,
+                packageIdentity: null,
+                nuGetProjectActionType: NuGetProjectActionType.Install,
+                originalLockFile: _lockFile,
+                restoreResultPair: _restoreResultPair,
+                sources: new List<SourceRepository>(),
+                originalActions: new List<NuGetProjectAction>(),
+                installationContext: _installationContext,
+                versionRange: _versionRange));
+            exception.ParamName.Should().Be("packageIdentity");
+        }
+
+        [Fact]
+        public void Constructor_WithNullLockFile_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new BuildIntegratedProjectAction(
+                project: _nuGetProject,
+                packageIdentity: _packageIdentity,
+                nuGetProjectActionType: NuGetProjectActionType.Install,
+                originalLockFile: null,
+                restoreResultPair: _restoreResultPair,
+                sources: new List<SourceRepository>(),
+                originalActions: new List<NuGetProjectAction>(),
+                installationContext: _installationContext,
+                versionRange: _versionRange));
+            exception.ParamName.Should().Be("originalLockFile");
+        }
+
+        [Fact]
+        public void Constructor_WithNullRestoreResultPair_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new BuildIntegratedProjectAction(
+                project: _nuGetProject,
+                packageIdentity: _packageIdentity,
+                nuGetProjectActionType: NuGetProjectActionType.Install,
+                originalLockFile: _lockFile,
+                restoreResultPair: null,
+                sources: new List<SourceRepository>(),
+                originalActions: new List<NuGetProjectAction>(),
+                installationContext: _installationContext,
+                versionRange: _versionRange));
+            exception.ParamName.Should().Be("restoreResultPair");
+        }
+
+        [Fact]
+        public void Constructor_WithNullSources_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new BuildIntegratedProjectAction(
+                project: _nuGetProject,
+                packageIdentity: _packageIdentity,
+                nuGetProjectActionType: NuGetProjectActionType.Install,
+                originalLockFile: _lockFile,
+                restoreResultPair: _restoreResultPair,
+                sources: null,
+                originalActions: new List<NuGetProjectAction>(),
+                installationContext: _installationContext,
+                versionRange: _versionRange));
+            exception.ParamName.Should().Be("sources");
+        }
+
+        [Fact]
+        public void Constructor_WithNullOriginalActions_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new BuildIntegratedProjectAction(
+                project: _nuGetProject,
+                packageIdentity: _packageIdentity,
+                nuGetProjectActionType: NuGetProjectActionType.Install,
+                originalLockFile: _lockFile,
+                restoreResultPair: _restoreResultPair,
+                sources: new List<SourceRepository>(),
+                originalActions: null,
+                installationContext: _installationContext,
+                versionRange: _versionRange));
+            exception.ParamName.Should().Be("originalActions");
+        }
+
+        [Fact]
+        public void Constructor_WithNullInstallationContext_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new BuildIntegratedProjectAction(
+                project: _nuGetProject,
+                packageIdentity: _packageIdentity,
+                nuGetProjectActionType: NuGetProjectActionType.Install,
+                originalLockFile: _lockFile,
+                restoreResultPair: _restoreResultPair,
+                sources: new List<SourceRepository>(),
+                originalActions: new List<NuGetProjectAction>(),
+                installationContext: null,
+                versionRange: _versionRange));
+            exception.ParamName.Should().Be("installationContext");
+        }
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        [Fact]
+        public void Constructor_WithActionAndContextList_WithNullProjectIdentity_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new BuildIntegratedProjectAction(
+                project: null,
+                packageIdentity: _packageIdentity,
+                nuGetProjectActionType: NuGetProjectActionType.Install,
+                originalLockFile: _lockFile,
+                restoreResultPair: _restoreResultPair,
+                sources: new List<SourceRepository>(),
+                originalActionsAndInstallationContexts: _originalActionAndProjectContexts,
+                versionRange: _versionRange));
+            exception.ParamName.Should().Be("project");
+        }
+
+        [Fact]
+        public void Constructor_WithActionAndContextList_WithNullPackageIdentity_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new BuildIntegratedProjectAction(
+                project: _nuGetProject,
+                packageIdentity: null,
+                nuGetProjectActionType: NuGetProjectActionType.Install,
+                originalLockFile: _lockFile,
+                restoreResultPair: _restoreResultPair,
+                sources: new List<SourceRepository>(),
+                originalActionsAndInstallationContexts: _originalActionAndProjectContexts,
+                versionRange: _versionRange));
+            exception.ParamName.Should().Be("packageIdentity");
+        }
+
+        [Fact]
+        public void Constructor_WithActionAndContextList_WithNullLockFile_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new BuildIntegratedProjectAction(
+                project: _nuGetProject,
+                packageIdentity: _packageIdentity,
+                nuGetProjectActionType: NuGetProjectActionType.Install,
+                originalLockFile: null,
+                restoreResultPair: _restoreResultPair,
+                sources: new List<SourceRepository>(),
+                originalActionsAndInstallationContexts: _originalActionAndProjectContexts,
+                versionRange: _versionRange));
+            exception.ParamName.Should().Be("originalLockFile");
+        }
+
+        [Fact]
+        public void Constructor_WithActionAndContextList_WithNullRestoreResultPair_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new BuildIntegratedProjectAction(
+                project: _nuGetProject,
+                packageIdentity: _packageIdentity,
+                nuGetProjectActionType: NuGetProjectActionType.Install,
+                originalLockFile: _lockFile,
+                restoreResultPair: null,
+                sources: new List<SourceRepository>(),
+                originalActionsAndInstallationContexts: _originalActionAndProjectContexts,
+                versionRange: _versionRange));
+            exception.ParamName.Should().Be("restoreResultPair");
+        }
+
+        [Fact]
+        public void Constructor_WithActionAndContextList_WithNullSources_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new BuildIntegratedProjectAction(
+                project: _nuGetProject,
+                packageIdentity: _packageIdentity,
+                nuGetProjectActionType: NuGetProjectActionType.Install,
+                originalLockFile: _lockFile,
+                restoreResultPair: _restoreResultPair,
+                sources: null,
+                originalActionsAndInstallationContexts: _originalActionAndProjectContexts,
+                versionRange: _versionRange));
+            exception.ParamName.Should().Be("sources");
+        }
+
+        [Fact]
+        public void Constructor_WithActionAndContextList_WithNullOriginalActionsAndInstallationContexts_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new BuildIntegratedProjectAction(
+                project: _nuGetProject,
+                packageIdentity: _packageIdentity,
+                nuGetProjectActionType: NuGetProjectActionType.Install,
+                originalLockFile: _lockFile,
+                restoreResultPair: _restoreResultPair,
+                sources: new List<SourceRepository>(),
+                originalActionsAndInstallationContexts: null,
+                versionRange: _versionRange));
+            exception.ParamName.Should().Be("originalActionsAndInstallationContexts");
+        }
+
+        [Fact]
+        public void Constructor_WithActionAndContextList_WithEmptyOriginalActionsAndInstallationContexts_Throws()
+        {
+            ArgumentException exception = Assert.Throws<ArgumentException>(() => new BuildIntegratedProjectAction(
+                project: _nuGetProject,
+                packageIdentity: _packageIdentity,
+                nuGetProjectActionType: NuGetProjectActionType.Install,
+                originalLockFile: _lockFile,
+                restoreResultPair: _restoreResultPair,
+                sources: new List<SourceRepository>(),
+                originalActionsAndInstallationContexts: new List<(NuGetProjectAction, BuildIntegratedInstallationContext)>(),
+                versionRange: _versionRange));
+            exception.ParamName.Should().Be("originalActionsAndInstallationContexts");
+        }
+
+        [Fact]
+        public void Constructor_WithActionAndContextList_SetsOriginalActionsAndInstallationContextToFirst()
+        {
+            var firstProjectAction = NuGetProjectAction.CreateInstallProjectAction(_packageIdentity, Mock.Of<SourceRepository>(), _nuGetProject);
+            var firstInstallationContext = new BuildIntegratedInstallationContext(null, null, null);
+            var actionsAndContextsList = new List<(NuGetProjectAction, BuildIntegratedInstallationContext)>
+            {
+                (firstProjectAction, firstInstallationContext),
+                (NuGetProjectAction.CreateUninstallProjectAction(_packageIdentity, _nuGetProject), new BuildIntegratedInstallationContext(null, null, null))
+            };
+
+            var action = new BuildIntegratedProjectAction(
+                project: _nuGetProject,
+                packageIdentity: _packageIdentity,
+                nuGetProjectActionType: NuGetProjectActionType.Install,
+                originalLockFile: _lockFile,
+                restoreResultPair: _restoreResultPair,
+                sources: new List<SourceRepository>(),
+                originalActionsAndInstallationContexts: actionsAndContextsList,
+                versionRange: _versionRange);
+
+            action.ActionAndContextList.Should().HaveCount(2);
+#pragma warning disable CS0618 // Type or member is obsolete
+            action.OriginalActions.Should().HaveCount(2);
+            action.OriginalActions[0].Should().Be(firstProjectAction);
+            action.InstallationContext.Should().Be(firstInstallationContext);
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        [Fact]
+        public void Constructor_SetsOriginalActionsAndInstallationContextsList()
+        {
+            var firstProjectAction = NuGetProjectAction.CreateInstallProjectAction(_packageIdentity, Mock.Of<SourceRepository>(), _nuGetProject);
+#pragma warning disable CS0618 // Type or member is obsolete
+            var action = new BuildIntegratedProjectAction(
+                project: _nuGetProject,
+                packageIdentity: _packageIdentity,
+                nuGetProjectActionType: NuGetProjectActionType.Install,
+                originalLockFile: _lockFile,
+                restoreResultPair: _restoreResultPair,
+                sources: new List<SourceRepository>(),
+                originalActions: new List<NuGetProjectAction>() { firstProjectAction },
+                installationContext: _installationContext,
+                versionRange: _versionRange);
+#pragma warning restore CS0618 // Type or member is obsolete
+            action.ActionAndContextList.Should().HaveCount(1);
+            action.ActionAndContextList[0].Item1.Should().Be(firstProjectAction);
+            action.ActionAndContextList[0].Item2.Should().Be(_installationContext);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerUtilityTests.cs
@@ -14,6 +14,7 @@ namespace NuGet.PackageManagement.Test
         [Fact]
         public void CreateInstallationContextForPackageId_WithCompleteOperation_ReturnsCorrectValue()
         {
+            // Arrange
             string referenceSpec = @"
                 {
                     ""frameworks"": {
@@ -38,7 +39,10 @@ namespace NuGet.PackageManagement.Test
 
             var originalPackageSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project", @"C:\", referenceSpec);
 
+            // Act
             var buildIntegrationInstallationContext = NuGetPackageManager.CreateInstallationContextForPackageId(packageIdentityId: "a", originalPackageSpec, unsuccessfulFrameworks: new(), originalFrameworks);
+
+            // Assert
             buildIntegrationInstallationContext.OriginalFrameworks.Should().Equal(originalFrameworks);
             buildIntegrationInstallationContext.SuccessfulFrameworks.Should().HaveCount(2);
             buildIntegrationInstallationContext.UnsuccessfulFrameworks.Should().HaveCount(0);
@@ -49,6 +53,7 @@ namespace NuGet.PackageManagement.Test
         [Fact]
         public void CreateInstallationContextForPackageId_WithConditionalOperation_ReturnsCorrectValue()
         {
+            // Arrange
             string referenceSpec = @"
                 {
                     ""frameworks"": {
@@ -73,7 +78,10 @@ namespace NuGet.PackageManagement.Test
 
             var originalPackageSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project", @"C:\", referenceSpec);
 
+            // Act
             var buildIntegrationInstallationContext = NuGetPackageManager.CreateInstallationContextForPackageId(packageIdentityId: "a", originalPackageSpec, unsuccessfulFrameworks: new(), originalFrameworks);
+
+            // Assert
             buildIntegrationInstallationContext.OriginalFrameworks.Should().Equal(originalFrameworks);
             buildIntegrationInstallationContext.SuccessfulFrameworks.Should().HaveCount(1);
             buildIntegrationInstallationContext.UnsuccessfulFrameworks.Should().HaveCount(1);
@@ -84,6 +92,7 @@ namespace NuGet.PackageManagement.Test
         [Fact]
         public void CreateInstallationContextForPackageId_WithFailedConditionalOperation_ReturnsCorrectValue()
         {
+            // Arrange
             string referenceSpec = @"
                 {
                     ""frameworks"": {
@@ -107,7 +116,10 @@ namespace NuGet.PackageManagement.Test
 
             var originalPackageSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project", @"C:\", referenceSpec);
 
+            // Act
             var buildIntegrationInstallationContext = NuGetPackageManager.CreateInstallationContextForPackageId(packageIdentityId: "a", originalPackageSpec, unsuccessfulFrameworks: new() { FrameworkConstants.CommonFrameworks.Net472 }, originalFrameworks);
+
+            // Assert
             buildIntegrationInstallationContext.OriginalFrameworks.Should().Equal(originalFrameworks);
             buildIntegrationInstallationContext.SuccessfulFrameworks.Should().HaveCount(0);
             buildIntegrationInstallationContext.UnsuccessfulFrameworks.Should().HaveCount(2);
@@ -118,6 +130,7 @@ namespace NuGet.PackageManagement.Test
         [Fact]
         public void CreateInstallationContextForPackageId_WithFailedCompleteOperation_ReturnsCorrectValue()
         {
+            // Arrange
             string referenceSpec = @"
                 {
                     ""frameworks"": {
@@ -142,7 +155,10 @@ namespace NuGet.PackageManagement.Test
 
             var originalPackageSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project", @"C:\", referenceSpec);
 
+            // Act
             var buildIntegrationInstallationContext = NuGetPackageManager.CreateInstallationContextForPackageId(packageIdentityId: "a", originalPackageSpec, unsuccessfulFrameworks: new() { FrameworkConstants.CommonFrameworks.Net50 }, originalFrameworks);
+
+            // Assert
             buildIntegrationInstallationContext.OriginalFrameworks.Should().Equal(originalFrameworks);
             buildIntegrationInstallationContext.SuccessfulFrameworks.Should().HaveCount(1);
             buildIntegrationInstallationContext.UnsuccessfulFrameworks.Should().HaveCount(1);

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerUtilityTests.cs
@@ -1,0 +1,153 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using FluentAssertions;
+using NuGet.Commands.Test;
+using NuGet.Frameworks;
+using Xunit;
+
+namespace NuGet.PackageManagement.Test
+{
+    public class NuGetPackageManagerUtilityTests
+    {
+        [Fact]
+        public void CreateInstallationContextForPackageId_WithCompleteOperation_ReturnsCorrectValue()
+        {
+            string referenceSpec = @"
+                {
+                    ""frameworks"": {
+                        ""net472"": {
+                            ""dependencies"": {
+                                ""b"" : ""2.0.0"",
+                                ""a"" : ""1.0.0"" 
+                            }
+                        },
+                        ""net5.0"": {
+                            ""dependencies"": {
+                                ""a"" : ""1.0.0"" 
+                            }
+                        }
+                    }
+                }";
+            Dictionary<NuGetFramework, string> originalFrameworks = new()
+            {
+                { FrameworkConstants.CommonFrameworks.Net472, "net472" },
+                { FrameworkConstants.CommonFrameworks.Net50, "net50" }
+            };
+
+            var originalPackageSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project", @"C:\", referenceSpec);
+
+            var buildIntegrationInstallationContext = NuGetPackageManager.CreateInstallationContextForPackageId(packageIdentityId: "a", originalPackageSpec, unsuccessfulFrameworks: new(), originalFrameworks);
+            buildIntegrationInstallationContext.OriginalFrameworks.Should().Equal(originalFrameworks);
+            buildIntegrationInstallationContext.SuccessfulFrameworks.Should().HaveCount(2);
+            buildIntegrationInstallationContext.UnsuccessfulFrameworks.Should().HaveCount(0);
+            buildIntegrationInstallationContext.SuccessfulFrameworks.Should().Contain(FrameworkConstants.CommonFrameworks.Net50);
+            buildIntegrationInstallationContext.SuccessfulFrameworks.Should().Contain(FrameworkConstants.CommonFrameworks.Net472);
+        }
+
+        [Fact]
+        public void CreateInstallationContextForPackageId_WithConditionalOperation_ReturnsCorrectValue()
+        {
+            string referenceSpec = @"
+                {
+                    ""frameworks"": {
+                        ""net472"": {
+                            ""dependencies"": {
+                                ""b"" : ""2.0.0"",
+                                ""a"" : ""1.0.0"" 
+                            }
+                        },
+                        ""net5.0"": {
+                            ""dependencies"": {
+                                ""b"" : ""2.0.0"",
+                            }
+                        }
+                    }
+                }";
+            Dictionary<NuGetFramework, string> originalFrameworks = new()
+            {
+                { FrameworkConstants.CommonFrameworks.Net472, "net472" },
+                { FrameworkConstants.CommonFrameworks.Net50, "net50" }
+            };
+
+            var originalPackageSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project", @"C:\", referenceSpec);
+
+            var buildIntegrationInstallationContext = NuGetPackageManager.CreateInstallationContextForPackageId(packageIdentityId: "a", originalPackageSpec, unsuccessfulFrameworks: new(), originalFrameworks);
+            buildIntegrationInstallationContext.OriginalFrameworks.Should().Equal(originalFrameworks);
+            buildIntegrationInstallationContext.SuccessfulFrameworks.Should().HaveCount(1);
+            buildIntegrationInstallationContext.UnsuccessfulFrameworks.Should().HaveCount(1);
+            buildIntegrationInstallationContext.UnsuccessfulFrameworks.Should().Contain(FrameworkConstants.CommonFrameworks.Net50);
+            buildIntegrationInstallationContext.SuccessfulFrameworks.Should().Contain(FrameworkConstants.CommonFrameworks.Net472);
+        }
+
+        [Fact]
+        public void CreateInstallationContextForPackageId_WithFailedConditionalOperation_ReturnsCorrectValue()
+        {
+            string referenceSpec = @"
+                {
+                    ""frameworks"": {
+                        ""net472"": {
+                            ""dependencies"": {
+                                ""b"" : ""2.0.0"",
+                                ""a"" : ""1.0.0"" 
+                            }
+                        },
+                        ""net5.0"": {
+                            ""dependencies"": {
+                            }
+                        }
+                    }
+                }";
+            Dictionary<NuGetFramework, string> originalFrameworks = new()
+            {
+                { FrameworkConstants.CommonFrameworks.Net472, "net472" },
+                { FrameworkConstants.CommonFrameworks.Net50, "net50" }
+            };
+
+            var originalPackageSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project", @"C:\", referenceSpec);
+
+            var buildIntegrationInstallationContext = NuGetPackageManager.CreateInstallationContextForPackageId(packageIdentityId: "a", originalPackageSpec, unsuccessfulFrameworks: new() { FrameworkConstants.CommonFrameworks.Net472 }, originalFrameworks);
+            buildIntegrationInstallationContext.OriginalFrameworks.Should().Equal(originalFrameworks);
+            buildIntegrationInstallationContext.SuccessfulFrameworks.Should().HaveCount(0);
+            buildIntegrationInstallationContext.UnsuccessfulFrameworks.Should().HaveCount(2);
+            buildIntegrationInstallationContext.UnsuccessfulFrameworks.Should().Contain(FrameworkConstants.CommonFrameworks.Net50);
+            buildIntegrationInstallationContext.UnsuccessfulFrameworks.Should().Contain(FrameworkConstants.CommonFrameworks.Net472);
+        }
+
+        [Fact]
+        public void CreateInstallationContextForPackageId_WithFailedCompleteOperation_ReturnsCorrectValue()
+        {
+            string referenceSpec = @"
+                {
+                    ""frameworks"": {
+                        ""net472"": {
+                            ""dependencies"": {
+                                ""b"" : ""2.0.0"",
+                                ""a"" : ""1.0.0"" 
+                            }
+                        },
+                        ""net5.0"": {
+                            ""dependencies"": {
+                                ""a"" : ""1.0.0"" 
+                            }
+                        }
+                    }
+                }";
+            Dictionary<NuGetFramework, string> originalFrameworks = new()
+            {
+                { FrameworkConstants.CommonFrameworks.Net472, "net472" },
+                { FrameworkConstants.CommonFrameworks.Net50, "net50" }
+            };
+
+            var originalPackageSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project", @"C:\", referenceSpec);
+
+            var buildIntegrationInstallationContext = NuGetPackageManager.CreateInstallationContextForPackageId(packageIdentityId: "a", originalPackageSpec, unsuccessfulFrameworks: new() { FrameworkConstants.CommonFrameworks.Net50 }, originalFrameworks);
+            buildIntegrationInstallationContext.OriginalFrameworks.Should().Equal(originalFrameworks);
+            buildIntegrationInstallationContext.SuccessfulFrameworks.Should().HaveCount(1);
+            buildIntegrationInstallationContext.UnsuccessfulFrameworks.Should().HaveCount(1);
+            buildIntegrationInstallationContext.UnsuccessfulFrameworks.Should().Contain(FrameworkConstants.CommonFrameworks.Net50);
+            buildIntegrationInstallationContext.SuccessfulFrameworks.Should().Contain(FrameworkConstants.CommonFrameworks.Net472);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageReferenceBasedNuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageReferenceBasedNuGetPackageManagerTests.cs
@@ -21,13 +21,14 @@ using NuGet.Versioning;
 using NuGet.VisualStudio;
 using Test.Utility;
 using Xunit;
+using static NuGet.Frameworks.FrameworkConstants;
 
 namespace NuGet.PackageManagement.Test
 {
     public class PackageReferenceBasedNuGetPackageManagerTests
     {
         [Fact]
-        public async Task PreviewInstallPackageAsync_WithMultiTargettedPackageReferenceProjectAndConditionalPackages_UpdatesOnlyConditionalPackages()
+        public async Task PreviewInstallPackageAsync_WithMultiTargettedPackageReferenceProjectAndPartiallyCompatiblePackage_InstallsConditionalPackage()
         {
             // Arrange
             using SimpleTestPathContext pathContext = new();
@@ -52,9 +53,11 @@ namespace NuGet.PackageManagement.Test
             NuGetProject buildIntegratedProject = CreateBuildIntegratedProjectAndAddToSolutionManager(solutionManager, settings, referenceSpec);
 
             var packageID = "A";
-            var packageToInstall = new PackageIdentity(packageID, new NuGetVersion(1, 0, 0));
+            var packageContext = new SimpleTestPackageContext(packageID, "1.0.0");
+            packageContext.AddFile("lib/net472/a.dll");
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource,
-                packageToInstall);
+                packageContext);
+            var packageToInstall = packageContext.Identity;
 
             // Main Act
             var result = (await nuGetPackageManager.PreviewInstallPackageAsync(
@@ -75,6 +78,16 @@ namespace NuGet.PackageManagement.Test
 
             buildIntegratedAction.OriginalLockFile.Libraries.Should().HaveCount(0);
 
+            buildIntegratedAction.ActionAndContextList.Should().HaveCount(1);
+            (var originalAction, var installationContext) = buildIntegratedAction.ActionAndContextList[0];
+            originalAction.PackageIdentity.Should().Be(packageToInstall);
+            originalAction.NuGetProjectActionType.Should().Be(NuGetProjectActionType.Install);
+            installationContext.Should().NotBeNull();
+            installationContext.UnsuccessfulFrameworks.Should().HaveCount(1);
+            installationContext.UnsuccessfulFrameworks.Should().Contain(CommonFrameworks.Net50);
+            installationContext.SuccessfulFrameworks.Should().HaveCount(1);
+            installationContext.SuccessfulFrameworks.Should().Contain(CommonFrameworks.Net472);
+
             var assetsFile = buildIntegratedAction.RestoreResult.LockFile;
             assetsFile.Libraries.Should().HaveCount(1);
             assetsFile.Libraries[0].Name.Should().Be(packageToInstall.Id);
@@ -85,9 +98,7 @@ namespace NuGet.PackageManagement.Test
             net472Target.Libraries.Should().HaveCount(1);
             net472Target.Libraries[0].Name.Should().Be(packageToInstall.Id);
             net472Target.Libraries[0].Version.Should().Be(packageToInstall.Version);
-            net50Target.Libraries.Should().HaveCount(1);
-            net50Target.Libraries[0].Name.Should().Be(packageToInstall.Id);
-            net50Target.Libraries[0].Version.Should().Be(packageToInstall.Version);
+            net50Target.Libraries.Should().HaveCount(0);
         }
 
         [Fact]
@@ -142,6 +153,16 @@ namespace NuGet.PackageManagement.Test
 
             buildIntegratedAction.OriginalLockFile.Libraries[0].Name.Should().Be(before.Id);
             buildIntegratedAction.OriginalLockFile.Libraries[0].Version.Should().Be(before.Version);
+
+            buildIntegratedAction.ActionAndContextList.Should().HaveCount(1);
+            (var originalAction, var installationContext) = buildIntegratedAction.ActionAndContextList[0];
+            originalAction.PackageIdentity.Should().Be(after);
+            originalAction.NuGetProjectActionType.Should().Be(NuGetProjectActionType.Install);
+            installationContext.Should().NotBeNull();
+            installationContext.UnsuccessfulFrameworks.Should().HaveCount(1);
+            installationContext.UnsuccessfulFrameworks.Should().Contain(CommonFrameworks.Net50);
+            installationContext.SuccessfulFrameworks.Should().HaveCount(1);
+            installationContext.SuccessfulFrameworks.Should().Contain(CommonFrameworks.Net472);
 
             var assetsFile = buildIntegratedAction.RestoreResult.LockFile;
             assetsFile.Libraries.Should().HaveCount(1);
@@ -210,6 +231,16 @@ namespace NuGet.PackageManagement.Test
             buildIntegratedAction.OriginalLockFile.Libraries[0].Name.Should().Be(before.Id);
             buildIntegratedAction.OriginalLockFile.Libraries[0].Version.Should().Be(before.Version);
 
+            buildIntegratedAction.ActionAndContextList.Should().HaveCount(1);
+            (var originalAction, var installationContext) = buildIntegratedAction.ActionAndContextList[0];
+            originalAction.PackageIdentity.Should().Be(after);
+            originalAction.NuGetProjectActionType.Should().Be(NuGetProjectActionType.Install);
+            installationContext.Should().NotBeNull();
+            installationContext.UnsuccessfulFrameworks.Should().HaveCount(0);
+            installationContext.SuccessfulFrameworks.Should().HaveCount(2);
+            installationContext.SuccessfulFrameworks.Should().Contain(CommonFrameworks.Net472);
+            installationContext.SuccessfulFrameworks.Should().Contain(CommonFrameworks.Net50);
+
             var assetsFile = buildIntegratedAction.RestoreResult.LockFile;
             assetsFile.Libraries.Should().HaveCount(1);
             assetsFile.Libraries[0].Name.Should().Be(after.Id);
@@ -223,6 +254,102 @@ namespace NuGet.PackageManagement.Test
             net50Target.Libraries.Should().HaveCount(1);
             net50Target.Libraries[0].Name.Should().Be(after.Id);
             net50Target.Libraries[0].Version.Should().Be(after.Version);
+        }
+
+        [Fact]
+        public async Task PreviewUpdatePackagesAsync_WithMultiTargettedPackageReferenceProject_UpdatesAllConditionalPackages()
+        {
+            // Arrange
+            using SimpleTestPathContext pathContext = new();
+            using var solutionManager = new TestSolutionManager(pathContext);
+            SourceRepositoryProvider sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(pathContext.PackageSource));
+            var settings = Settings.LoadDefaultSettings(solutionManager.SolutionDirectory);
+            var nuGetPackageManager = new NuGetPackageManager(sourceRepositoryProvider, settings, solutionManager, new TestDeleteOnRestartManager());
+
+            string referenceSpec = @"
+                {
+                    ""frameworks"": {
+                        ""net472"": {
+                            ""dependencies"": {
+                                ""A"" : ""1.0.0""
+                            }
+                        },
+                        ""net5.0"": {
+                            ""dependencies"": {
+                                ""B"" : ""1.0.0""
+                            }
+                        }
+                    }
+                }";
+            NuGetProject buildIntegratedProject = CreateBuildIntegratedProjectAndAddToSolutionManager(solutionManager, settings, referenceSpec);
+
+            var packageA = "A";
+            var packageB = "B";
+            var a100 = new PackageIdentity(packageA, new NuGetVersion(1, 0, 0));
+            var a200 = new PackageIdentity(packageA, new NuGetVersion(2, 0, 0));
+            var b100 = new PackageIdentity(packageB, new NuGetVersion(1, 0, 0));
+            var b200 = new PackageIdentity(packageB, new NuGetVersion(2, 0, 0));
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource,
+                a100,
+                a200,
+                b100,
+                b200);
+
+            // Main Act
+            var result = (await nuGetPackageManager.PreviewUpdatePackagesAsync(
+                new List<NuGetProject> { buildIntegratedProject },
+                new ResolutionContext(DependencyBehavior.Lowest, false, false, VersionConstraints.None),
+                new TestNuGetProjectContext(),
+                sourceRepositoryProvider.GetRepositories(),
+                sourceRepositoryProvider.GetRepositories(),
+                CancellationToken.None)).ToList();
+
+            // Assert
+            result.Should().HaveCount(1);
+
+            result[0].NuGetProjectActionType.Should().Be(NuGetProjectActionType.Install);
+            result[0].PackageIdentity.Should().Be(a200);
+            var buildIntegratedAction = (BuildIntegratedProjectAction)result[0];
+            buildIntegratedAction.RestoreResult.Success.Should().BeTrue(because: string.Join(",", buildIntegratedAction.RestoreResult.LogMessages.Select(e => e.Message)));
+
+            buildIntegratedAction.OriginalLockFile.Libraries[0].Name.Should().Be(a100.Id);
+            buildIntegratedAction.OriginalLockFile.Libraries[0].Version.Should().Be(a100.Version);
+            buildIntegratedAction.OriginalLockFile.Libraries[1].Name.Should().Be(b100.Id);
+            buildIntegratedAction.OriginalLockFile.Libraries[1].Version.Should().Be(b100.Version);
+
+            buildIntegratedAction.ActionAndContextList.Should().HaveCount(2);
+            (var originalActionA, var installationContextA) = buildIntegratedAction.ActionAndContextList[0];
+            originalActionA.PackageIdentity.Should().Be(a200);
+            originalActionA.NuGetProjectActionType.Should().Be(NuGetProjectActionType.Install);
+            installationContextA.Should().NotBeNull();
+            installationContextA.UnsuccessfulFrameworks.Should().HaveCount(1);
+            installationContextA.SuccessfulFrameworks.Should().HaveCount(1);
+            installationContextA.SuccessfulFrameworks.Should().Contain(CommonFrameworks.Net472);
+            installationContextA.UnsuccessfulFrameworks.Should().Contain(CommonFrameworks.Net50);
+
+            (var originalActionB, var installationContextB) = buildIntegratedAction.ActionAndContextList[1];
+            originalActionB.PackageIdentity.Should().Be(b200);
+            originalActionB.NuGetProjectActionType.Should().Be(NuGetProjectActionType.Install);
+            installationContextB.Should().NotBeNull();
+            installationContextB.UnsuccessfulFrameworks.Should().HaveCount(1);
+            installationContextB.SuccessfulFrameworks.Should().HaveCount(1);
+            installationContextB.UnsuccessfulFrameworks.Should().Contain(CommonFrameworks.Net472);
+            installationContextB.SuccessfulFrameworks.Should().Contain(CommonFrameworks.Net50);
+
+            var assetsFile = buildIntegratedAction.RestoreResult.LockFile;
+            assetsFile.Libraries.Should().HaveCount(2);
+            assetsFile.Libraries[0].Name.Should().Be(a200.Id);
+            assetsFile.Libraries[0].Version.Should().Be(a200.Version);
+            assetsFile.Libraries[1].Name.Should().Be(b200.Id);
+            assetsFile.Libraries[1].Version.Should().Be(b200.Version); assetsFile.Targets.Should().HaveCount(2);
+            var net472Target = assetsFile.Targets.Single(e => e.TargetFramework.Equals(NuGetFramework.Parse("net472")));
+            var net50Target = assetsFile.Targets.Single(e => e.TargetFramework.Equals(NuGetFramework.Parse("net50")));
+            net472Target.Libraries.Should().HaveCount(1);
+            net472Target.Libraries[0].Name.Should().Be(a200.Id);
+            net472Target.Libraries[0].Version.Should().Be(a200.Version);
+            net50Target.Libraries.Should().HaveCount(1);
+            net50Target.Libraries[0].Name.Should().Be(b200.Id);
+            net50Target.Libraries[0].Version.Should().Be(b200.Version);
         }
 
         private static NuGetProject CreateBuildIntegratedProjectAndAddToSolutionManager(TestSolutionManager solutionManager, ISettings settings, string referenceSpec)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/4681

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Conditional package updating was previously fixed in https://github.com/NuGet/NuGet.Client/commit/fed7892af6c079015431389d7cf7a7f630e22bbd. 

This PR fixes the `update all` scenario, ensuring all packages are updated instead of just 1. 
This PR also improves the tests cases for the scenarios.

Some technical details to help with the review of this PR: 

- BuildIntegratedProjectAction is always the result for a project action on a PackageReference project, even if there are multiple packages being updated. Note that this is not something we're adding in this PR. 
- For each package being updated as part of an action, the compatible frameworks should be consider with that package id in mind. That allows, Newtonsoft.Json to be updated for net472, but NuGet.Common to be updated for net5.0.
- BuildIntegratedProjectAction types are not expected to be used outside of the NuGet.PackageManagement, and given how overexposed are APIs are, I'm adding these as internal. This is probably not  the best design, but it avoids adding future work for us. An alternative would be to complete break the type.
- Added nullable annotation for BuildIntegratedProjectAction 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added, will also add manual tests.
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
