### PR TITLE
Include path to GPF package on `InvalidDataException` from `nupkg.metadata` files

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
@@ -57,6 +57,11 @@ namespace NuGet.Packaging
                     Strings.Error_LoadingHashFile,
                     path, ex.Message));
 
+                if (!string.IsNullOrEmpty(path) && ex is InvalidDataException)
+                {
+                    throw new InvalidDataException(message: path, innerException: ex);
+                }
+
                 throw;
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NupkgMetadataFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NupkgMetadataFileFormatTests.cs
@@ -107,6 +107,8 @@ namespace NuGet.Packaging.Test
             // Assert
             Assert.Equal(1, logger.Messages.Count);
             Assert.Contains(path, exception.Message);
+            Assert.NotNull(exception.InnerException);
+            Assert.IsType<InvalidDataException>(exception.InnerException);
         }
 
         [Fact]
@@ -126,6 +128,8 @@ namespace NuGet.Packaging.Test
             // Assert
             Assert.Equal(1, logger.Messages.Count);
             Assert.Contains(path, exception.Message);
+            Assert.NotNull(exception.InnerException);
+            Assert.IsType<InvalidDataException>(exception.InnerException);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NupkgMetadataFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NupkgMetadataFileFormatTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using System.Linq;
 using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -93,16 +94,38 @@ namespace NuGet.Packaging.Test
         public void Read_ContentsNotAnObject_ThrowsException(string contents)
         {
             // Arrange
+            var path = "from memory";
             var logger = new TestLogger();
+            InvalidDataException exception;
 
             // Act
             using (var stringReader = new StringReader(contents))
             {
-                Assert.Throws<InvalidDataException>(() => NupkgMetadataFileFormat.Read(stringReader, logger, "from memory"));
+                exception = Assert.Throws<InvalidDataException>(() => NupkgMetadataFileFormat.Read(stringReader, logger, path));
             }
 
             // Assert
             Assert.Equal(1, logger.Messages.Count);
+            Assert.Contains(path, exception.Message);
+        }
+
+        [Fact]
+        public void Read_ContentsMissing_ThrowsInvalidDataExceptionWithFilePath()
+        {
+            // Arrange
+            var path = "from memory";
+            var logger = new TestLogger();
+            InvalidDataException exception;
+
+            // Act
+            using (var stringReader = new StringReader(string.Empty))
+            {
+                exception = Assert.Throws<InvalidDataException>(() => NupkgMetadataFileFormat.Read(stringReader, logger, path));
+            }
+
+            // Assert
+            Assert.Equal(1, logger.Messages.Count);
+            Assert.Contains(path, exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12997

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

When any `InvalidDataException` is thrown, rethrow the exception with the message set as the `path` to the `nupkg.metadata` file. By including the path in the output, it should be easier for customers to self-address the issue, or for the team to more quickly understand the output from restore when customers report this problem to us.

_Screenshots show behavior **before** (left side) / **after** (right side). 
NuGet Version: 6.7.0.127 was used as the testing control / before behavior_

### Test nuget.exe with Invalid `nupkg.metadata` (content is "1")

#### Show Stack Trace OFF
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/c5fc8f32-299d-4604-927d-23cd284fa678)

#### Show Stack Trace ON
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/976f75d4-0204-4b0e-a99b-1dca3b62aa7c)

### Test nuget.exe with Empty `nupkg.metadata`

#### Show Stack Trace OFF

![image](https://github.com/NuGet/NuGet.Client/assets/49205731/39f5b736-9353-49a5-a7e8-95af2629af8a)

#### Show Stack Trace ON

![image](https://github.com/NuGet/NuGet.Client/assets/49205731/266a737d-a6e5-489b-88aa-1a1ea3b43405)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
