### PR TITLE
Remove unused `GetDeprecationMetadataAsync` from Search Service

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -332,13 +332,6 @@ namespace NuGet.PackageManagement.UI
             return listItemViewModels.ToArray();
         }
 
-        private async Task<PackageDeprecationMetadataContextInfo> GetDeprecationMetadataAsync(PackageIdentity identity)
-        {
-            Assumes.NotNull(identity);
-
-            return await _searchService.GetDeprecationMetadataAsync(identity, _packageSources, _includePrerelease, CancellationToken.None);
-        }
-
         private async Task<IReadOnlyCollection<VersionInfoContextInfo>> GetVersionInfoAsync(PackageIdentity identity)
         {
             Assumes.NotNull(identity);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/NuGetSearchServiceReconnector.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/NuGetSearchServiceReconnector.cs
@@ -141,11 +141,6 @@ namespace NuGet.PackageManagement.UI.Utility
                 return _parent._service.GetAllPackagesAsync(projectContextInfos, packageSources, targetFrameworks, searchFilter, itemFilter, isSolution, cancellationToken);
             }
 
-            public ValueTask<PackageDeprecationMetadataContextInfo> GetDeprecationMetadataAsync(PackageIdentity identity, IReadOnlyCollection<PackageSourceContextInfo> packageSources, bool includePrerelease, CancellationToken cancellationToken)
-            {
-                return _parent._service.GetDeprecationMetadataAsync(identity, packageSources, includePrerelease, cancellationToken);
-            }
-
             public ValueTask<(PackageSearchMetadataContextInfo, PackageDeprecationMetadataContextInfo)> GetPackageMetadataAsync(PackageIdentity identity, IReadOnlyCollection<PackageSourceContextInfo> packageSources, bool includePrerelease, CancellationToken cancellationToken)
             {
                 return _parent._service.GetPackageMetadataAsync(identity, packageSources, includePrerelease, cancellationToken);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
@@ -235,34 +235,6 @@ namespace NuGet.PackageManagement.VisualStudio
             return await cacheEntry.AllVersionsContextInfo;
         }
 
-
-        public async ValueTask<PackageDeprecationMetadataContextInfo?> GetDeprecationMetadataAsync(
-            PackageIdentity identity,
-            IReadOnlyCollection<PackageSourceContextInfo> packageSources,
-            bool includePrerelease,
-            CancellationToken cancellationToken)
-        {
-            Assumes.NotNull(identity);
-            Assumes.NotNullOrEmpty(packageSources);
-
-            string cacheId = PackageSearchMetadataCacheItem.GetCacheId(identity.Id, includePrerelease, packageSources);
-            PackageSearchMetadataCacheItem? backgroundDataCache = PackageSearchMetadataMemoryCache.Get(cacheId) as PackageSearchMetadataCacheItem;
-            if (backgroundDataCache != null)
-            {
-                PackageSearchMetadataCacheItemEntry cacheItem = await backgroundDataCache.GetPackageSearchMetadataCacheVersionedItemAsync(identity, cancellationToken);
-                return await cacheItem.PackageDeprecationMetadataContextInfo;
-            }
-
-            IPackageMetadataProvider packageMetadataProvider = await GetPackageMetadataProviderAsync(packageSources, cancellationToken);
-            IPackageSearchMetadata packageMetadata = await packageMetadataProvider.GetPackageMetadataAsync(identity, includePrerelease, cancellationToken);
-            PackageDeprecationMetadata deprecationMetadata = await packageMetadata.GetDeprecationMetadataAsync();
-            if (deprecationMetadata == null)
-            {
-                return null;
-            }
-            return PackageDeprecationMetadataContextInfo.Create(deprecationMetadata);
-        }
-
         public async ValueTask<SearchResultContextInfo> RefreshSearchAsync(CancellationToken cancellationToken)
         {
             Assumes.NotNull(_searchObject);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetSearchService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetSearchService.cs
@@ -67,12 +67,6 @@ namespace NuGet.VisualStudio.Internal.Contracts
             bool isTransitive,
             CancellationToken cancellationToken);
 
-        ValueTask<PackageDeprecationMetadataContextInfo?> GetDeprecationMetadataAsync(
-            PackageIdentity identity,
-            IReadOnlyCollection<PackageSourceContextInfo> packageSources,
-            bool includePrerelease,
-            CancellationToken cancellationToken);
-
         ValueTask<IReadOnlyCollection<PackageSearchMetadataContextInfo>> GetPackageMetadataListAsync(
             string id,
             IReadOnlyCollection<PackageSourceContextInfo> packageSources,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
@@ -78,14 +78,6 @@ namespace NuGet.PackageManagement.UI.Test.Models
                     It.IsAny<CancellationToken>()))
                 .Returns(new ValueTask<IReadOnlyCollection<PackageSearchMetadataContextInfo>>(packageSearchMetadata));
 
-            mockSearchService.Setup(x =>
-                x.GetDeprecationMetadataAsync(
-                    It.IsAny<PackageIdentity>(),
-                    It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(),
-                    It.IsAny<bool>(),
-                    It.IsAny<CancellationToken>()))
-                .Returns(null);
-
             mockSearchService.Setup(x => x.GetPackageMetadataAsync(
                     It.IsAny<PackageIdentity>(),
                     It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(),
@@ -162,14 +154,6 @@ namespace NuGet.PackageManagement.UI.Test.Models
                     It.IsAny<bool>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(new ValueTask<IReadOnlyCollection<PackageSearchMetadataContextInfo>>(packageSearchMetadata));
-
-            mockSearchService.Setup(x =>
-                x.GetDeprecationMetadataAsync(
-                    It.IsAny<PackageIdentity>(),
-                    It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(),
-                    It.IsAny<bool>(),
-                    It.IsAny<CancellationToken>()))
-                .Returns(null);
 
             mockSearchService.Setup(x => x.GetPackageMetadataAsync(
                     It.IsAny<PackageIdentity>(),

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
@@ -203,23 +203,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async Task GetDeprecationMetadataAsync_WhenDeprecationMetadataExists_ReturnsDeprecationMetadata()
-        {
-            using (NuGetPackageSearchService searchService = SetupSearchService())
-            {
-                PackageDeprecationMetadataContextInfo deprecationMetadata = await searchService.GetDeprecationMetadataAsync(
-                    new PackageIdentity("microsoft.extensions.logging.abstractions", new Versioning.NuGetVersion("5.0.0-rc.2.20475.5")),
-                    new List<PackageSourceContextInfo> { PackageSourceContextInfo.Create(_sourceRepository.PackageSource) },
-                    includePrerelease: true,
-                    CancellationToken.None);
-
-                Assert.NotNull(deprecationMetadata);
-                Assert.Equal("This is deprecated.", deprecationMetadata.Message);
-                Assert.Equal("Legacy", deprecationMetadata.Reasons.First());
-            }
-        }
-
-        [Fact]
         public async Task GetPackageVersionsAsync_WhenPackageVersionsExist_ReturnsPackageVersions()
         {
             using (NuGetPackageSearchService searchService = SetupSearchService())


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13007

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
There are no references, and I'm thinking I won't need a separate method since deprecation information exists in search results.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
