### PR TITLE
Add `disableTLSCertificateValidation` property to nuget.config

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSourcesService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSourcesService.cs
@@ -94,6 +94,7 @@ namespace NuGet.PackageManagement.VisualStudio
                         && packageSource.Source.Equals(packageSourceContextInfo.Source, StringComparison.InvariantCulture)
                         && packageSource.ProtocolVersion == packageSourceContextInfo.ProtocolVersion
                         && packageSource.AllowInsecureConnections == packageSourceContextInfo.AllowInsecureConnections
+                        && packageSource.DisableTLSCertificateValidation == packageSourceContextInfo.DisableTLSCertificateValidation
                         && packageSource.IsEnabled == packageSourceContextInfo.IsEnabled)
                     {
                         newPackageSources.Add(packageSource);
@@ -113,6 +114,7 @@ namespace NuGet.PackageManagement.VisualStudio
                             Description = packageSource.Description,
                             ProtocolVersion = packageSourceContextInfo.ProtocolVersion,
                             AllowInsecureConnections = packageSourceContextInfo.AllowInsecureConnections,
+                            DisableTLSCertificateValidation = packageSourceContextInfo.DisableTLSCertificateValidation,
                             MaxHttpRequestsPerSource = packageSource.MaxHttpRequestsPerSource,
                         };
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSourceContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSourceContextInfo.cs
@@ -33,7 +33,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         }
 
         public PackageSourceContextInfo(string source, string name, bool isEnabled, int protocolVersion, bool allowInsecureConnections)
-            : this(name, source, isEnabled, protocolVersion, allowInsecureConnections, disableTLSCertificateValidation: false)
+            : this(source, name, isEnabled, protocolVersion, allowInsecureConnections, disableTLSCertificateValidation: false)
         {
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSourceContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSourceContextInfo.cs
@@ -33,6 +33,11 @@ namespace NuGet.VisualStudio.Internal.Contracts
         }
 
         public PackageSourceContextInfo(string source, string name, bool isEnabled, int protocolVersion, bool allowInsecureConnections)
+            : this(name, source, isEnabled, protocolVersion, allowInsecureConnections, disableTLSCertificateValidation: false)
+        {
+        }
+
+        public PackageSourceContextInfo(string source, string name, bool isEnabled, int protocolVersion, bool allowInsecureConnections, bool disableTLSCertificateValidation)
         {
             Assumes.NotNullOrEmpty(name);
             Assumes.NotNullOrEmpty(source);
@@ -42,12 +47,14 @@ namespace NuGet.VisualStudio.Internal.Contracts
             IsEnabled = isEnabled;
             ProtocolVersion = protocolVersion;
             AllowInsecureConnections = allowInsecureConnections;
+            DisableTLSCertificateValidation = disableTLSCertificateValidation;
 
             var hash = new HashCodeCombiner();
             hash.AddStringIgnoreCase(Name);
             hash.AddStringIgnoreCase(Source);
             hash.AddObject(ProtocolVersion);
             hash.AddObject(AllowInsecureConnections);
+            hash.AddObject(DisableTLSCertificateValidation);
             _hashCode = hash.CombinedHash;
             OriginalHashCode = _hashCode;
         }
@@ -56,6 +63,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         public string Source { get; set; }
         public int ProtocolVersion { get; set; }
         public bool AllowInsecureConnections { get; set; }
+        public bool DisableTLSCertificateValidation { get; set; }
         public bool IsMachineWide { get; internal set; }
         public bool IsEnabled { get; set; }
         public string? Description { get; internal set; }
@@ -94,7 +102,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         public PackageSourceContextInfo Clone()
         {
-            return new PackageSourceContextInfo(Source, Name, IsEnabled, ProtocolVersion, AllowInsecureConnections)
+            return new PackageSourceContextInfo(Source, Name, IsEnabled, ProtocolVersion, AllowInsecureConnections, DisableTLSCertificateValidation)
             {
                 IsMachineWide = IsMachineWide,
                 Description = Description,
@@ -104,7 +112,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         public static PackageSourceContextInfo Create(PackageSource packageSource)
         {
-            return new PackageSourceContextInfo(packageSource.Source, packageSource.Name, packageSource.IsEnabled, packageSource.ProtocolVersion, packageSource.AllowInsecureConnections)
+            return new PackageSourceContextInfo(packageSource.Source, packageSource.Name, packageSource.IsEnabled, packageSource.ProtocolVersion, packageSource.AllowInsecureConnections, packageSource.DisableTLSCertificateValidation)
             {
                 IsMachineWide = packageSource.IsMachineWide,
                 Description = packageSource.Description,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceContextInfoFormatter.cs
@@ -14,6 +14,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         private const string IsEnabledPropertyName = "isenabled";
         private const string ProtocolVersionPropertyName = "protocolversion";
         private const string AllowInsecureConnectionsPropertyName = "allowInsecureConnections";
+        private const string DisableTLSCertificateValidationPropertyName = "disableTLSCertificateValidation";
         private const string IsMachineWidePropertyName = "ismachinewide";
         private const string NamePropertyName = "name";
         private const string DescriptionPropertyName = "description";
@@ -35,6 +36,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             int originalHashCode = 0;
             int protocolVersion = PackageSource.DefaultProtocolVersion;
             bool allowInsecureConnections = false;
+            bool disableTLSCertificateValidation = false;
 
             int propertyCount = reader.ReadMapHeader();
             for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
@@ -65,6 +67,9 @@ namespace NuGet.VisualStudio.Internal.Contracts
                     case AllowInsecureConnectionsPropertyName:
                         allowInsecureConnections = reader.ReadBoolean();
                         break;
+                    case DisableTLSCertificateValidationPropertyName:
+                        disableTLSCertificateValidation = reader.ReadBoolean();
+                        break;
                     default:
                         reader.Skip();
                         break;
@@ -74,7 +79,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             Assumes.NotNullOrEmpty(source);
             Assumes.NotNullOrEmpty(name);
 
-            return new PackageSourceContextInfo(source, name, isEnabled, protocolVersion, allowInsecureConnections)
+            return new PackageSourceContextInfo(source, name, isEnabled, protocolVersion, allowInsecureConnections, disableTLSCertificateValidation)
             {
                 IsMachineWide = isMachineWide,
                 Description = description,
@@ -84,13 +89,15 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         protected override void SerializeCore(ref MessagePackWriter writer, PackageSourceContextInfo value, MessagePackSerializerOptions options)
         {
-            writer.WriteMapHeader(count: 8);
+            writer.WriteMapHeader(count: 9);
             writer.Write(SourcePropertyName);
             writer.Write(value.Source);
             writer.Write(ProtocolVersionPropertyName);
             writer.Write(value.ProtocolVersion);
             writer.Write(AllowInsecureConnectionsPropertyName);
             writer.Write(value.AllowInsecureConnections);
+            writer.Write(DisableTLSCertificateValidationPropertyName);
+            writer.Write(value.DisableTLSCertificateValidation);
             writer.Write(IsEnabledPropertyName);
             writer.Write(value.IsEnabled);
             writer.Write(IsMachineWidePropertyName);

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -21,6 +21,7 @@ namespace NuGet.Configuration
         public const int MaxProtocolVersion = 3;
 
         internal const bool DefaultAllowInsecureConnections = false;
+        internal const bool DefaultDisableTLSCertificateValidation = false;
 
         private int _hashCode;
         private string _source;
@@ -109,6 +110,11 @@ namespace NuGet.Configuration
         /// </summary>
         public bool AllowInsecureConnections { get; set; } = DefaultAllowInsecureConnections;
 
+        ///<summary>
+        /// Gets or sets disableTLSCertificateValidation of the source. Defaults to false.
+        ///</summary>
+        public bool DisableTLSCertificateValidation { get; set; } = DefaultDisableTLSCertificateValidation;
+
         /// <summary>
         /// Whether the source is using the HTTP protocol, including HTTPS.
         /// </summary>
@@ -162,11 +168,16 @@ namespace NuGet.Configuration
             }
 
             string? allowInsecureConnections = null;
+            string? disableTLSCertificateValidation = null;
             if (AllowInsecureConnections != DefaultAllowInsecureConnections)
             {
                 allowInsecureConnections = $"{AllowInsecureConnections}";
             }
-            return new SourceItem(Name, Source, protocolVersion, allowInsecureConnections);
+            if (DisableTLSCertificateValidation != DefaultDisableTLSCertificateValidation)
+            {
+                disableTLSCertificateValidation = $"{DisableTLSCertificateValidation}";
+            }
+            return new SourceItem(Name, Source, protocolVersion, allowInsecureConnections, disableTLSCertificateValidation);
         }
 
         public bool Equals(PackageSource? other)
@@ -204,6 +215,7 @@ namespace NuGet.Configuration
                 IsMachineWide = IsMachineWide,
                 ProtocolVersion = ProtocolVersion,
                 AllowInsecureConnections = AllowInsecureConnections,
+                DisableTLSCertificateValidation = DisableTLSCertificateValidation,
             };
         }
     }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -200,6 +200,7 @@ namespace NuGet.Configuration
 
             packageSource.ProtocolVersion = ReadProtocolVersion(setting);
             packageSource.AllowInsecureConnections = ReadAllowInsecureConnections(setting);
+            packageSource.DisableTLSCertificateValidation = ReadDisableTLSCertificateValidation(setting);
 
             return packageSource;
         }
@@ -212,6 +213,16 @@ namespace NuGet.Configuration
             }
 
             return PackageSource.DefaultProtocolVersion;
+        }
+
+        private static bool ReadDisableTLSCertificateValidation(SourceItem setting)
+        {
+            if (bool.TryParse(setting.DisableTLSCertificateValidation, out var disableTLSCertificateValidation))
+            {
+                return disableTLSCertificateValidation;
+            }
+
+            return PackageSource.DefaultDisableTLSCertificateValidation;
         }
 
         private static bool ReadAllowInsecureConnections(SourceItem setting)

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+NuGet.Configuration.PackageSource.DisableTLSCertificateValidation.get -> bool
+NuGet.Configuration.PackageSource.DisableTLSCertificateValidation.set -> void
+~NuGet.Configuration.SourceItem.DisableTLSCertificateValidation.get -> string
+~NuGet.Configuration.SourceItem.DisableTLSCertificateValidation.set -> void
+~NuGet.Configuration.SourceItem.SourceItem(string key, string value, string protocolVersion, string allowInsecureConnections, string disableTLSCertificateValidation) -> void
+~static readonly NuGet.Configuration.ConfigurationConstants.DisableTLSCertificateValidation -> string

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
@@ -60,7 +60,7 @@ namespace NuGet.Configuration
         }
 
         public SourceItem(string key, string value, string protocolVersion, string allowInsecureConnections)
-            : this(key, value, protocolVersion, allowInsecureConnections: "", disableTLSCertificateValidation: "")
+            : this(key, value, protocolVersion, allowInsecureConnections, disableTLSCertificateValidation: "")
         {
         }
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
@@ -35,17 +35,36 @@ namespace NuGet.Configuration
             set => AddOrUpdateAttribute(ConfigurationConstants.AllowInsecureConnections, value);
         }
 
+        public string DisableTLSCertificateValidation
+        {
+            get
+            {
+                if (Attributes.TryGetValue(ConfigurationConstants.DisableTLSCertificateValidation, out var attribute))
+                {
+                    return Settings.ApplyEnvironmentTransform(attribute);
+                }
+
+                return null;
+            }
+            set => AddOrUpdateAttribute(ConfigurationConstants.DisableTLSCertificateValidation, value);
+        }
+
         public SourceItem(string key, string value)
-            : this(key, value, protocolVersion: "", allowInsecureConnections: "")
+            : this(key, value, protocolVersion: "", allowInsecureConnections: "", disableTLSCertificateValidation: "")
         {
         }
 
         public SourceItem(string key, string value, string protocolVersion)
-            : this(key, value, protocolVersion, allowInsecureConnections: "")
+            : this(key, value, protocolVersion, allowInsecureConnections: "", disableTLSCertificateValidation: "")
         {
         }
 
         public SourceItem(string key, string value, string protocolVersion, string allowInsecureConnections)
+            : this(key, value, protocolVersion, allowInsecureConnections: "", disableTLSCertificateValidation: "")
+        {
+        }
+
+        public SourceItem(string key, string value, string protocolVersion, string allowInsecureConnections, string disableTLSCertificateValidation)
             : base(key, value)
         {
             if (!string.IsNullOrEmpty(protocolVersion))
@@ -56,6 +75,10 @@ namespace NuGet.Configuration
             {
                 AllowInsecureConnections = allowInsecureConnections;
             }
+            if (!string.IsNullOrEmpty(disableTLSCertificateValidation))
+            {
+                DisableTLSCertificateValidation = disableTLSCertificateValidation;
+            }
         }
 
         internal SourceItem(XElement element, SettingsFile origin)
@@ -65,7 +88,7 @@ namespace NuGet.Configuration
 
         public override SettingBase Clone()
         {
-            var newSetting = new SourceItem(Key, Value, ProtocolVersion, AllowInsecureConnections);
+            var newSetting = new SourceItem(Key, Value, ProtocolVersion, AllowInsecureConnections, DisableTLSCertificateValidation);
 
             if (Origin != null)
             {

--- a/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -49,6 +49,8 @@ namespace NuGet.Configuration
 
         public static readonly string DisabledPackageSources = "disabledPackageSources";
 
+        public static readonly string DisableTLSCertificateValidation = "disableTLSCertificateValidation";
+
         public static readonly string DoNotShowPackageManagementSelectionKey = "disabled";
 
         public static readonly string Enabled = "enabled";

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSourceContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSourceContextInfoFormatterTests.cs
@@ -19,6 +19,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
 
         public static TheoryData TestData => new TheoryData<PackageSourceContextInfo>
             {
+                { new PackageSourceContextInfo("source", "name", isEnabled: true, protocolVersion: 3, allowInsecureConnections: true, disableTLSCertificateValidation: true) },
                 { new PackageSourceContextInfo("source", "name", isEnabled: true, protocolVersion: 3, allowInsecureConnections: true) },
                 { new PackageSourceContextInfo("source", "name", isEnabled: true, protocolVersion: 3) },
                 { new PackageSourceContextInfo("source", "name", isEnabled: true) },

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -904,6 +904,88 @@ namespace NuGet.Configuration.Test
             Assert.Equal(bool.Parse(allowInsecureConnections), loadedSource.AllowInsecureConnections);
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LoadPackageSources_ReadsSourcesWithNullDisableTLSCertificateVerificationFromPackageSourceSections_LoadsDefault(bool useStaticMethod)
+        {
+            // Arrange
+            var settings = new Mock<ISettings>();
+            var sourceItem = new SourceItem("Source", "https://some-source.test", protocolVersion: null, allowInsecureConnections: null, disableTLSCertificateValidation: null);
+
+            settings.Setup(s => s.GetSection("packageSources"))
+                .Returns(new VirtualSettingSection("packageSources",
+                    sourceItem));
+
+            settings.Setup(s => s.GetConfigFilePaths())
+                .Returns(new List<string>());
+
+            // Act
+            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+
+            // Assert
+            var loadedSource = values.Single();
+            Assert.Equal("Source", loadedSource.Name);
+            Assert.Equal("https://some-source.test", loadedSource.Source);
+            Assert.Equal(PackageSource.DefaultDisableTLSCertificateValidation, loadedSource.DisableTLSCertificateValidation);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LoadPackageSources_ReadsSourcesWithInvalidDisableTLSCertificateVerificationFromPackageSourceSections_LoadsDefault(bool useStaticMethod)
+        {
+            // Arrange
+            var settings = new Mock<ISettings>();
+            var sourceItem = new SourceItem("Source", "https://some-source.test", protocolVersion: null, allowInsecureConnections: null, disableTLSCertificateValidation: "invalidValue");
+
+            settings.Setup(s => s.GetSection("packageSources"))
+                .Returns(new VirtualSettingSection("packageSources",
+                    sourceItem));
+
+            settings.Setup(s => s.GetConfigFilePaths())
+                .Returns(new List<string>());
+
+            // Act
+            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+
+            // Assert
+            var loadedSource = values.Single();
+            Assert.Equal("Source", loadedSource.Name);
+            Assert.Equal("https://some-source.test", loadedSource.Source);
+            Assert.Equal(PackageSource.DefaultDisableTLSCertificateValidation, loadedSource.DisableTLSCertificateValidation);
+        }
+
+        [Theory]
+        [InlineData(true, "true")]
+        [InlineData(true, "TRUE")]
+        [InlineData(true, "false")]
+        [InlineData(false, "false")]
+        [InlineData(false, "fALSE")]
+        [InlineData(false, "true")]
+        public void LoadPackageSources_ReadsSourcesWithNotNullDisableTLSCertificateVerificationFromPackageSourceSections_LoadsValue(bool useStaticMethod, string disableTLSCertificateValidation)
+        {
+            // Arrange
+            var settings = new Mock<ISettings>();
+            var sourceItem = new SourceItem("Source", "https://some-source.test", protocolVersion: null, allowInsecureConnections: null, disableTLSCertificateValidation: disableTLSCertificateValidation);
+
+            settings.Setup(s => s.GetSection("packageSources"))
+                .Returns(new VirtualSettingSection("packageSources",
+                    sourceItem));
+
+            settings.Setup(s => s.GetConfigFilePaths())
+                .Returns(new List<string>());
+
+            // Act
+            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+
+            // Assert
+            var loadedSource = values.Single();
+            Assert.Equal("Source", loadedSource.Name);
+            Assert.Equal("https://some-source.test", loadedSource.Source);
+            Assert.Equal(bool.Parse(disableTLSCertificateValidation), loadedSource.DisableTLSCertificateValidation);
+        }
+
         [Fact]
         public void DisablePackageSourceAddEntryToSettings()
         {

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
@@ -18,7 +18,8 @@ namespace NuGet.Configuration.Test
             {
                 Credentials = credentials,
                 ProtocolVersion = 43,
-                AllowInsecureConnections = true
+                AllowInsecureConnections = true,
+                DisableTLSCertificateValidation = true
             };
 
             // Act
@@ -32,6 +33,7 @@ namespace NuGet.Configuration.Test
             Assert.Equal(source.IsEnabled, result.IsEnabled);
             Assert.Equal(source.ProtocolVersion, result.ProtocolVersion);
             Assert.Equal(source.AllowInsecureConnections, result.AllowInsecureConnections);
+            Assert.Equal(source.DisableTLSCertificateValidation, result.DisableTLSCertificateValidation);
 
             // source credential
             result.Credentials.Should().NotBeNull();
@@ -46,11 +48,12 @@ namespace NuGet.Configuration.Test
             var source = new PackageSource("Source", "SourceName", isEnabled: false)
             {
                 ProtocolVersion = 43,
-                AllowInsecureConnections = true
+                AllowInsecureConnections = true,
+                DisableTLSCertificateValidation = true
             };
             var result = source.AsSourceItem();
 
-            var expectedItem = new SourceItem("SourceName", "Source", "43", "True");
+            var expectedItem = new SourceItem("SourceName", "Source", "43", "True", "True");
 
             SettingsTestUtils.DeepEquals(result, expectedItem).Should().BeTrue();
         }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
@@ -59,9 +59,9 @@ namespace NuGet.Configuration.Test
         <add key='nuget3' value='http://serviceIndex.test3/api/index.json' protocolVersion='3' ALLOWInsecureConnections='true' />
         <add key='nuget4' value='http://serviceIndex.test4/api/index.json' allowInsecureConnections='true' />
         <add key='nuget5' value='http://serviceIndex.test5/api/index.json' allowInsecureConnections='false' protocolVersion='2' />
-        <add key='nuget6' value='http://serviceIndex.test3/api/index.json' protocolVersion='3' ALLOWInsecureConnections='true' DiSaBleTLSCertificateValidation='true'/>
-        <add key='nuget7' value='http://serviceIndex.test4/api/index.json' allowInsecureConnections='true' disableTLSCertificateValidation='false'/>
-        <add key='nuget8' value='http://serviceIndex.test5/api/index.json' allowInsecureConnections='false' protocolVersion='2' disableTLSCertificateValidation='true'/>
+        <add key='nuget6' value='http://serviceIndex.test6/api/index.json' protocolVersion='3' ALLOWInsecureConnections='true' DiSaBleTLSCertificateValidation='true'/>
+        <add key='nuget7' value='http://serviceIndex.test7/api/index.json' allowInsecureConnections='true' disableTLSCertificateValidation='false'/>
+        <add key='nuget8' value='http://serviceIndex.test8/api/index.json' allowInsecureConnections='false' protocolVersion='2' disableTLSCertificateValidation='true'/>
     </packageSources>
 </configuration>";
 
@@ -72,9 +72,9 @@ namespace NuGet.Configuration.Test
                 new SourceItem("nuget3","http://serviceIndex.test3/api/index.json", protocolVersion: "3", allowInsecureConnections: "true" ),
                 new SourceItem("nuget4","http://serviceIndex.test4/api/index.json", protocolVersion: null, allowInsecureConnections: "true"  ),
                 new SourceItem("nuget5","http://serviceIndex.test5/api/index.json", protocolVersion: "2", allowInsecureConnections: "false"),
-                new SourceItem("nuget6","http://serviceIndex.test3/api/index.json", protocolVersion: "3", allowInsecureConnections: "true", disableTLSCertificateValidation: "true"),
-                new SourceItem("nuget7","http://serviceIndex.test4/api/index.json", protocolVersion: null, allowInsecureConnections: "true", disableTLSCertificateValidation: "false"),
-                new SourceItem("nuget8","http://serviceIndex.test5/api/index.json", protocolVersion: "2", allowInsecureConnections: "false", disableTLSCertificateValidation: "true"),
+                new SourceItem("nuget6","http://serviceIndex.test6/api/index.json", protocolVersion: "3", allowInsecureConnections: "true", disableTLSCertificateValidation: "true"),
+                new SourceItem("nuget7","http://serviceIndex.test7/api/index.json", protocolVersion: null, allowInsecureConnections: "true", disableTLSCertificateValidation: "false"),
+                new SourceItem("nuget8","http://serviceIndex.test8/api/index.json", protocolVersion: "2", allowInsecureConnections: "false", disableTLSCertificateValidation: "true"),
             };
 
             var nugetConfigPath = "NuGet.Config";
@@ -92,7 +92,7 @@ namespace NuGet.Configuration.Test
                 var children = section.Items.Cast<SourceItem>().ToList();
 
                 children.Should().NotBeEmpty();
-                children.Count.Should().Be(5);
+                children.Count.Should().Be(8);
 
                 for (var i = 0; i < children.Count; i++)
                 {
@@ -115,9 +115,9 @@ namespace NuGet.Configuration.Test
                     new SourceItem("nuget2", "http://serviceIndex.test2/api/index.json", protocolVersion: "2", allowInsecureConnections: "false"),
                     new SourceItem("nuget3", "http://serviceIndex.test3/api/index.json", protocolVersion: null, allowInsecureConnections: "true"),
                     new SourceItem("nuget4", "http://serviceIndex.test4/api/index.json", protocolVersion: "3"),
-                    new SourceItem("nuget5", "http://serviceIndex.test1/api/index.json", protocolVersion: "3", allowInsecureConnections: "true", disableTLSCertificateValidation: "false"),
-                    new SourceItem("nuget6", "http://serviceIndex.test2/api/index.json", protocolVersion: "2", allowInsecureConnections: "false", disableTLSCertificateValidation: "false"),
-                    new SourceItem("nuget7", "http://serviceIndex.test3/api/index.json", protocolVersion: null, allowInsecureConnections: "true", disableTLSCertificateValidation: "true")));
+                    new SourceItem("nuget5", "http://serviceIndex.test5/api/index.json", protocolVersion: "3", allowInsecureConnections: "true", disableTLSCertificateValidation: "false"),
+                    new SourceItem("nuget6", "http://serviceIndex.test6/api/index.json", protocolVersion: "2", allowInsecureConnections: "false", disableTLSCertificateValidation: "false"),
+                    new SourceItem("nuget7", "http://serviceIndex.test7/api/index.json", protocolVersion: null, allowInsecureConnections: "true", disableTLSCertificateValidation: "true")));
             var resultXml = SettingsTestUtils.RemoveWhitespace(configuration.AsXNode().ToString());
 
             var expectedXNode = new XElement("configuration",
@@ -142,19 +142,20 @@ namespace NuGet.Configuration.Test
                         new XAttribute("protocolVersion", "3")),
                     new XElement("add",
                         new XAttribute("key", "nuget5"),
-                        new XAttribute("value", "http://serviceIndex.test2/api/index.json"),
+                        new XAttribute("value", "http://serviceIndex.test5/api/index.json"),
+                        new XAttribute("protocolVersion", "3"),
+                        new XAttribute("allowInsecureConnections", "true"),
+                        new XAttribute("disableTLSCertificateValidation", "false")),
+                    new XElement("add",
+                        new XAttribute("key", "nuget6"),
+                        new XAttribute("value", "http://serviceIndex.test6/api/index.json"),
                         new XAttribute("protocolVersion", "2"),
                         new XAttribute("allowInsecureConnections", "false"),
                         new XAttribute("disableTLSCertificateValidation", "false")),
                     new XElement("add",
-                        new XAttribute("key", "nuget6"),
-                        new XAttribute("value", "http://serviceIndex.test3/api/index.json"),
-                        new XAttribute("allowInsecureConnections", "true"),
-                        new XAttribute("disableTLSCertificateValidation", "false")),
-                    new XElement("add",
                         new XAttribute("key", "nuget7"),
-                        new XAttribute("value", "http://serviceIndex.test4/api/index.json"),
-                        new XAttribute("protocolVersion", "3"),
+                        new XAttribute("value", "http://serviceIndex.test7/api/index.json"),
+                        new XAttribute("allowInsecureConnections", "true"),
                         new XAttribute("disableTLSCertificateValidation", "true"))));
             var expectedXml = SettingsTestUtils.RemoveWhitespace(expectedXNode.ToString());
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
@@ -59,6 +59,9 @@ namespace NuGet.Configuration.Test
         <add key='nuget3' value='http://serviceIndex.test3/api/index.json' protocolVersion='3' ALLOWInsecureConnections='true' />
         <add key='nuget4' value='http://serviceIndex.test4/api/index.json' allowInsecureConnections='true' />
         <add key='nuget5' value='http://serviceIndex.test5/api/index.json' allowInsecureConnections='false' protocolVersion='2' />
+        <add key='nuget6' value='http://serviceIndex.test3/api/index.json' protocolVersion='3' ALLOWInsecureConnections='true' DiSaBleTLSCertificateValidation='true'/>
+        <add key='nuget7' value='http://serviceIndex.test4/api/index.json' allowInsecureConnections='true' disableTLSCertificateValidation='false'/>
+        <add key='nuget8' value='http://serviceIndex.test5/api/index.json' allowInsecureConnections='false' protocolVersion='2' disableTLSCertificateValidation='true'/>
     </packageSources>
 </configuration>";
 
@@ -69,6 +72,9 @@ namespace NuGet.Configuration.Test
                 new SourceItem("nuget3","http://serviceIndex.test3/api/index.json", protocolVersion: "3", allowInsecureConnections: "true" ),
                 new SourceItem("nuget4","http://serviceIndex.test4/api/index.json", protocolVersion: null, allowInsecureConnections: "true"  ),
                 new SourceItem("nuget5","http://serviceIndex.test5/api/index.json", protocolVersion: "2", allowInsecureConnections: "false"),
+                new SourceItem("nuget6","http://serviceIndex.test3/api/index.json", protocolVersion: "3", allowInsecureConnections: "true", disableTLSCertificateValidation: "true"),
+                new SourceItem("nuget7","http://serviceIndex.test4/api/index.json", protocolVersion: null, allowInsecureConnections: "true", disableTLSCertificateValidation: "false"),
+                new SourceItem("nuget8","http://serviceIndex.test5/api/index.json", protocolVersion: "2", allowInsecureConnections: "false", disableTLSCertificateValidation: "true"),
             };
 
             var nugetConfigPath = "NuGet.Config";
@@ -95,6 +101,7 @@ namespace NuGet.Configuration.Test
                     children[i].Value.Should().Be(expectedValues[i].Value, because: $"SourceItem[{i}].Value is {children[i].Value}, but it's expected to be {expectedValues[i].Value}");
                     children[i].ProtocolVersion.Should().Be(expectedValues[i].ProtocolVersion, because: $"SourceItem[{i}].ProtocolVersion is {children[i].ProtocolVersion}, but it's expected to be {expectedValues[i].ProtocolVersion}");
                     children[i].AllowInsecureConnections.Should().Be(expectedValues[i].AllowInsecureConnections, because: $"SourceItem[{i}].AllowInsecureConnections is {children[i].AllowInsecureConnections}, but it's expected to be {expectedValues[i].AllowInsecureConnections}");
+                    children[i].DisableTLSCertificateValidation.Should().Be(expectedValues[i].DisableTLSCertificateValidation, because: $"SourceItem[{i}].DisableTLSCertificateValidation is {children[i].DisableTLSCertificateValidation}, but it's expected to be {expectedValues[i].DisableTLSCertificateValidation}");
                 }
             }
         }
@@ -107,7 +114,10 @@ namespace NuGet.Configuration.Test
                     new SourceItem("nuget1", "http://serviceIndex.test1/api/index.json", protocolVersion: "3", allowInsecureConnections: "true"),
                     new SourceItem("nuget2", "http://serviceIndex.test2/api/index.json", protocolVersion: "2", allowInsecureConnections: "false"),
                     new SourceItem("nuget3", "http://serviceIndex.test3/api/index.json", protocolVersion: null, allowInsecureConnections: "true"),
-                    new SourceItem("nuget4", "http://serviceIndex.test4/api/index.json", protocolVersion: "3")));
+                    new SourceItem("nuget4", "http://serviceIndex.test4/api/index.json", protocolVersion: "3"),
+                    new SourceItem("nuget5", "http://serviceIndex.test1/api/index.json", protocolVersion: "3", allowInsecureConnections: "true", disableTLSCertificateValidation: "false"),
+                    new SourceItem("nuget6", "http://serviceIndex.test2/api/index.json", protocolVersion: "2", allowInsecureConnections: "false", disableTLSCertificateValidation: "false"),
+                    new SourceItem("nuget7", "http://serviceIndex.test3/api/index.json", protocolVersion: null, allowInsecureConnections: "true", disableTLSCertificateValidation: "true")));
             var resultXml = SettingsTestUtils.RemoveWhitespace(configuration.AsXNode().ToString());
 
             var expectedXNode = new XElement("configuration",
@@ -129,7 +139,23 @@ namespace NuGet.Configuration.Test
                     new XElement("add",
                         new XAttribute("key", "nuget4"),
                         new XAttribute("value", "http://serviceIndex.test4/api/index.json"),
-                        new XAttribute("protocolVersion", "3"))));
+                        new XAttribute("protocolVersion", "3")),
+                    new XElement("add",
+                        new XAttribute("key", "nuget5"),
+                        new XAttribute("value", "http://serviceIndex.test2/api/index.json"),
+                        new XAttribute("protocolVersion", "2"),
+                        new XAttribute("allowInsecureConnections", "false"),
+                        new XAttribute("disableTLSCertificateValidation", "false")),
+                    new XElement("add",
+                        new XAttribute("key", "nuget6"),
+                        new XAttribute("value", "http://serviceIndex.test3/api/index.json"),
+                        new XAttribute("allowInsecureConnections", "true"),
+                        new XAttribute("disableTLSCertificateValidation", "false")),
+                    new XElement("add",
+                        new XAttribute("key", "nuget7"),
+                        new XAttribute("value", "http://serviceIndex.test4/api/index.json"),
+                        new XAttribute("protocolVersion", "3"),
+                        new XAttribute("disableTLSCertificateValidation", "true"))));
             var expectedXml = SettingsTestUtils.RemoveWhitespace(expectedXNode.ToString());
 
             resultXml.Should().Be(expectedXml, because: resultXml);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug 

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12996

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
We need to add a `disableTLSCertificateValidation` property into `packageSources` section in NuGet.Config files, as below:
```
<!-- Disables certification validation on a specific https source -->
<packageSources>
    <add key="Contoso" value="https://contoso.com/packages/" disableTLSCertificateValidation="true" />
</packageSources>
```
spec : https://github.com/NuGet/Home/blob/dev/proposed/2023/InsecureConnectionsDisableCertificateValidation.md#package-source-nuget-config 
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled : 
  - **OR**
  - [x] N/A
