### PR TITLE
[Draft] Add Owner and Contributors to PM UI Packages List

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -301,6 +301,7 @@ namespace NuGet.PackageManagement.UI
                     Version = metadata.Identity.Version,
                     IconUrl = metadata.IconUrl,
                     Owner = metadata.Owners,
+                    IsTrustedOwner = !string.IsNullOrWhiteSpace(metadata.Owners),
                     Author = metadata.Authors,
                     DownloadCount = metadata.DownloadCount,
                     Summary = metadata.Summary,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -300,6 +300,7 @@ namespace NuGet.PackageManagement.UI
                     Id = metadata.Identity.Id,
                     Version = metadata.Identity.Version,
                     IconUrl = metadata.IconUrl,
+                    Owner = metadata.Owners,
                     Author = metadata.Authors,
                     DownloadCount = metadata.DownloadCount,
                     Summary = metadata.Summary,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1854,7 +1854,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to contributors: {0}.
+        ///   Looks up a localized string similar to by {0}.
         /// </summary>
         public static string Text_ByAuthor {
             get {
@@ -1863,7 +1863,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to by: {0}.
+        ///   Looks up a localized string similar to by {0}.
         /// </summary>
         public static string Text_ByOwner {
             get {
@@ -2300,6 +2300,15 @@ namespace NuGet.PackageManagement.UI {
         public static string ToolTip_TransitiveDependencyVersion {
             get {
                 return ResourceManager.GetString("ToolTip_TransitiveDependencyVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Owner according to nuget.org.
+        /// </summary>
+        public static string ToolTip_TrustedOwnerIndicator {
+            get {
+                return ResourceManager.GetString("ToolTip_TrustedOwnerIndicator", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1854,11 +1854,20 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to by {0}.
+        ///   Looks up a localized string similar to contributors: {0}.
         /// </summary>
         public static string Text_ByAuthor {
             get {
                 return ResourceManager.GetString("Text_ByAuthor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to by: {0}.
+        /// </summary>
+        public static string Text_ByOwner {
+            get {
+                return ResourceManager.GetString("Text_ByOwner", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -387,7 +387,7 @@
     <value>The package at '{0}' failed to uninstall. Restart Visual Studio to finish the process.</value>
   </data>
   <data name="Text_ByAuthor" xml:space="preserve">
-    <value>by {0}</value>
+    <value>contributors: {0}</value>
   </data>
   <data name="Text_Downloads" xml:space="preserve">
     <value>{0} downloads</value>
@@ -1041,5 +1041,8 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Error_SourceMapping_GPF_NotEnabled" xml:space="preserve">
     <value>The package `{0}` is available in the Global packages folder, but the source it came from `{1}` is not one of the configured sources.</value>
     <comment>{0} is the package ID. {1} is the URI of the package source found in the Global packages folder.</comment>
+  </data>
+  <data name="Text_ByOwner" xml:space="preserve">
+    <value>by: {0}</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -387,7 +387,7 @@
     <value>The package at '{0}' failed to uninstall. Restart Visual Studio to finish the process.</value>
   </data>
   <data name="Text_ByAuthor" xml:space="preserve">
-    <value>contributors: {0}</value>
+    <value>by {0}</value>
   </data>
   <data name="Text_Downloads" xml:space="preserve">
     <value>{0} downloads</value>
@@ -1043,6 +1043,9 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <comment>{0} is the package ID. {1} is the URI of the package source found in the Global packages folder.</comment>
   </data>
   <data name="Text_ByOwner" xml:space="preserve">
-    <value>by: {0}</value>
+    <value>by {0}</value>
+  </data>
+  <data name="ToolTip_TrustedOwnerIndicator" xml:space="preserve">
+    <value>Owner according to nuget.org</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -99,7 +99,7 @@ namespace NuGet.PackageManagement.UI
         {
             get
             {
-                return _owner != null ? string.Format(CultureInfo.CurrentCulture, Resx.Text_ByOwner, _owner) : null;
+                return !string.IsNullOrWhiteSpace(_owner) ? string.Format(CultureInfo.CurrentCulture, Resx.Text_ByOwner, _owner) : null;
             }
         }
 
@@ -107,7 +107,7 @@ namespace NuGet.PackageManagement.UI
         {
             get
             {
-                return _author != null ? string.Format(CultureInfo.CurrentCulture, Resx.Text_ByAuthor, _author) : null;
+                return !string.IsNullOrWhiteSpace(_author) ? string.Format(CultureInfo.CurrentCulture, Resx.Text_ByAuthor, _author) : null;
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -64,6 +64,22 @@ namespace NuGet.PackageManagement.UI
 
         public bool IncludePrerelease { get; set; }
 
+        private string _owner;
+
+        public string Owner
+        {
+            get
+            {
+                return _owner;
+            }
+            set
+            {
+                _owner = value;
+                OnPropertyChanged(nameof(Owner));
+                OnPropertyChanged(nameof(ByOwner));
+            }
+        }
+
         private string _author;
         public string Author
         {
@@ -76,6 +92,14 @@ namespace NuGet.PackageManagement.UI
                 _author = value;
                 OnPropertyChanged(nameof(Author));
                 OnPropertyChanged(nameof(ByAuthor));
+            }
+        }
+
+        public string ByOwner
+        {
+            get
+            {
+                return _owner != null ? string.Format(CultureInfo.CurrentCulture, Resx.Text_ByOwner, _owner) : null;
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -111,6 +111,14 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
+        public string ByOwnerOrAuthor
+        {
+            get
+            {
+                return ByOwner ?? ByAuthor;
+            }
+        }
+
         /// <summary>
         /// The installed version of the package.
         /// </summary>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -64,6 +64,8 @@ namespace NuGet.PackageManagement.UI
 
         public bool IncludePrerelease { get; set; }
 
+        public bool IsTrustedOwner { get; set; }
+
         private string _owner;
 
         public string Owner

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/AuthorAndDownloadCount.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/AuthorAndDownloadCount.xaml
@@ -3,6 +3,9 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
+             xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"  
+             xmlns:nuget="clr-namespace:NuGet.PackageManagement.UI"
              mc:Ignorable="d"
              x:Name="_self"
              d:DesignHeight="300" d:DesignWidth="300">
@@ -10,22 +13,31 @@
 
     <!-- text "by owner" is shown here -->
     <TextBlock
-      x:Name="_textBlockOwner"
-      Visibility="Collapsed"/>
+        x:Name="_textBlockOwner"
+        Visibility="Collapsed"/>
 
     <!-- text "by author" is shown here when owner is unavailable -->
     <TextBlock 
-      x:Name="_textBlockAuthor" 
-      Visibility="Collapsed"/>
-    
+        x:Name="_textBlockAuthor" 
+        Visibility="Collapsed"/>
+
+    <imaging:CrispImage
+        x:Name="_trustedOwnerIndicator"
+        Margin="0"
+        VerticalAlignment="Top"
+        Visibility="{Binding IsTrustedOwner, Converter={StaticResource BooleanToVisibilityConverter}}"
+        ToolTip="{x:Static nuget:Resources.ToolTip_TrustedOwnerIndicator}"
+        AutomationProperties.Name="{x:Static nuget:Resources.ToolTip_TrustedOwnerIndicator}"
+        Moniker="{x:Static catalog:KnownMonikers.NuGet}" />
+
     <TextBlock 
-      x:Name="_separator" 
-      xml:space="preserve" 
-      Visibility="Collapsed">, </TextBlock>
+        x:Name="_separator" 
+        xml:space="preserve" 
+        Visibility="Collapsed">, </TextBlock>
     
     <!-- the download count -->
     <TextBlock 
-      x:Name="_textBlockDownloadCount" 
-      Visibility="Collapsed"/>
+        x:Name="_textBlockDownloadCount" 
+        Visibility="Collapsed"/>
   </StackPanel>
 </UserControl>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/AuthorAndDownloadCount.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/AuthorAndDownloadCount.xaml
@@ -1,14 +1,19 @@
-﻿<UserControl x:Class="NuGet.PackageManagement.UI.AuthorAndDownloadCount"
+<UserControl x:Class="NuGet.PackageManagement.UI.AuthorAndDownloadCount"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:local="clr-namespace:NuGet.PackageManagement.UI"
              mc:Ignorable="d"
              x:Name="_self"
              d:DesignHeight="300" d:DesignWidth="300">
   <StackPanel Orientation="Horizontal">
-    <!-- text "by author" is shown here -->
+
+    <!-- text "by owner" is shown here -->
+    <TextBlock
+      x:Name="_textBlockOwner"
+      Visibility="Collapsed"/>
+
+    <!-- text "by author" is shown here when owner is unavailable -->
     <TextBlock 
       x:Name="_textBlockAuthor" 
       Visibility="Collapsed"/>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/AuthorAndDownloadCount.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/AuthorAndDownloadCount.xaml.cs
@@ -18,6 +18,13 @@ namespace NuGet.PackageManagement.UI
     /// </summary>
     public partial class AuthorAndDownloadCount : UserControl, INotifyPropertyChanged
     {
+        public static readonly DependencyProperty OwnerProperty =
+            DependencyProperty.Register(
+                nameof(Owner),
+                typeof(string),
+                typeof(AuthorAndDownloadCount),
+                new PropertyMetadata(OnPropertyChanged));
+
         public static readonly DependencyProperty AuthorProperty =
             DependencyProperty.Register(
                 nameof(Author),
@@ -32,9 +39,36 @@ namespace NuGet.PackageManagement.UI
                 typeof(AuthorAndDownloadCount),
                 new PropertyMetadata(OnPropertyChanged));
 
+
         public AuthorAndDownloadCount()
         {
             InitializeComponent();
+        }
+
+        public string Owner
+        {
+            get
+            {
+                return GetValue(OwnerProperty) as string;
+            }
+            set
+            {
+                SetValue(OwnerProperty, value);
+                UpdateControl();
+            }
+        }
+
+        public string Author
+        {
+            get
+            {
+                return GetValue(AuthorProperty) as string;
+            }
+            set
+            {
+                SetValue(AuthorProperty, value);
+                UpdateControl();
+            }
         }
 
         public long? DownloadCount
@@ -58,19 +92,6 @@ namespace NuGet.PackageManagement.UI
             control?.UpdateControl();
         }
 
-        public string Author
-        {
-            get
-            {
-                return GetValue(AuthorProperty) as string;
-            }
-            set
-            {
-                SetValue(AuthorProperty, value);
-                UpdateControl();
-            }
-        }
-
         public event PropertyChangedEventHandler PropertyChanged;
 
         private void OnPropertyChanged(string propertyName)
@@ -83,14 +104,25 @@ namespace NuGet.PackageManagement.UI
 
         private void UpdateControl()
         {
-            if (!string.IsNullOrEmpty(Author))
+            if (!string.IsNullOrEmpty(Owner))
             {
-                _textBlockAuthor.Text = Author;
-                _textBlockAuthor.Visibility = Visibility.Visible;
+                _textBlockOwner.Text = Owner;
+                _textBlockOwner.Visibility = Visibility.Visible;
+                _textBlockAuthor.Visibility = Visibility.Collapsed;
             }
             else
             {
-                _textBlockAuthor.Visibility = Visibility.Collapsed;
+                _textBlockOwner.Visibility = Visibility.Collapsed;
+
+                if (!string.IsNullOrEmpty(Author))
+                {
+                    _textBlockAuthor.Text = Author;
+                    _textBlockAuthor.Visibility = Visibility.Visible;
+                }
+                else
+                {
+                    _textBlockAuthor.Visibility = Visibility.Collapsed;
+                }
             }
 
             // Generate the textbox for download count.
@@ -129,9 +161,9 @@ namespace NuGet.PackageManagement.UI
                 _textBlockDownloadCount.Visibility = Visibility.Collapsed;
             }
 
-            // set the visiblity of the separator.
-            if (_textBlockAuthor.Visibility == Visibility.Visible &&
-                _textBlockDownloadCount.Visibility == Visibility.Visible)
+            // set the visibility of the separator.
+            if ((_textBlockOwner.Visibility == Visibility.Visible || _textBlockAuthor.Visibility == Visibility.Visible)
+                && _textBlockDownloadCount.Visibility == Visibility.Visible)
             {
                 _separator.Visibility = Visibility.Visible;
             }
@@ -141,7 +173,8 @@ namespace NuGet.PackageManagement.UI
             }
 
             // set the visibility of the control itself.
-            if (_textBlockAuthor.Visibility == Visibility.Collapsed &&
+            if (_textBlockOwner.Visibility == Visibility.Collapsed &&
+                _textBlockAuthor.Visibility == Visibility.Collapsed &&
                 _textBlockDownloadCount.Visibility == Visibility.Collapsed)
             {
                 _self.Visibility = Visibility.Collapsed;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -183,6 +183,7 @@
           <!-- author and download count -->
           <nuget:AuthorAndDownloadCount
                         Margin="5,4,0,0"
+                        Owner="{Binding ByOwner, Mode=OneTime}"
                         Author="{Binding ByAuthor, Mode=OneTime}"
                         DownloadCount="{Binding DownloadCount}" />
         </StackPanel>
@@ -213,7 +214,7 @@
                         Style="{StaticResource TooltipStyle}">
                         <Run
                           Text="{Binding Id}"
-                          FontWeight="Bold" /> <Run Text="{Binding ByAuthor, Mode=OneTime}"/>
+                          FontWeight="Bold" /> <Run Text="{Binding ByOwner, Mode=OneTime}"/> <Run Text="{Binding ByAuthor, Mode=OneTime}"/>
                         <LineBreak />
                         <Run FontWeight="Bold">
                           <Run.Style>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -214,7 +214,7 @@
                         Style="{StaticResource TooltipStyle}">
                         <Run
                           Text="{Binding Id}"
-                          FontWeight="Bold" /> <Run Text="{Binding ByOwner, Mode=OneTime}"/> <Run Text="{Binding ByAuthor, Mode=OneTime}"/>
+                          FontWeight="Bold" /> <Run Text="{Binding ByOwnerOrAuthor, Mode=OneTime}"/>
                         <LineBreak />
                         <Run FontWeight="Bold">
                           <Run.Style>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -5,7 +5,7 @@
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"  
-  xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"  
+  xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
   x:Name="_self"
   mc:Ignorable="d"
   xmlns:nuget="clr-namespace:NuGet.PackageManagement.UI"

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/TransitivePackageSearchMetadata.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/TransitivePackageSearchMetadata.cs
@@ -39,6 +39,8 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         public DateTimeOffset? Published => _packageSearchMetadata.Published;
 
+        public IEnumerable<string> OwnersEnumerable => _packageSearchMetadata.OwnersEnumerable;
+
         public string Owners => _packageSearchMetadata.Owners;
 
         public bool RequireLicenseAcceptance => _packageSearchMetadata.RequireLicenseAcceptance;

--- a/src/NuGet.Core/NuGet.Protocol/Model/IPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/IPackageSearchMetadata.cs
@@ -27,6 +27,7 @@ namespace NuGet.Protocol.Core.Types
         Uri ReportAbuseUrl { get; }
         Uri PackageDetailsUrl { get; }
         DateTimeOffset? Published { get; }
+        IEnumerable<string> OwnersEnumerable { get; }
         string Owners { get; }
         bool RequireLicenseAcceptance { get; }
         string Summary { get; }

--- a/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
@@ -42,6 +42,8 @@ namespace NuGet.Protocol
 
         public Uri LicenseUrl => Convert(_nuspec.GetLicenseUrl());
 
+        public IEnumerable<string> OwnersEnumerable => null;
+
         public string Owners => _nuspec.GetOwners();
 
         public Uri ProjectUrl => Convert(_nuspec.GetProjectUrl());

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
@@ -63,8 +63,9 @@ namespace NuGet.Protocol
         public Uri LicenseUrl { get; private set; }
 
         [JsonProperty(PropertyName = JsonProperties.Owners)]
-        [JsonConverter(typeof(MetadataFieldConverter))]
-        public string Owners { get; private set; }
+        public IEnumerable<string> OwnersEnumerable { get; private set; }
+
+        public string Owners => OwnersEnumerable != null ? string.Join(", ", OwnersEnumerable.Where(s => !string.IsNullOrWhiteSpace(s))) : null;
 
         [JsonProperty(PropertyName = JsonProperties.PackageId)]
         public string PackageId { get; private set; }

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataBuilder.cs
@@ -35,6 +35,7 @@ namespace NuGet.Protocol.Core.Types
             public Uri IconUrl { get; set; }
             public PackageIdentity Identity { get; set; }
             public Uri LicenseUrl { get; set; }
+            public IEnumerable<string> OwnersEnumerable { get; set; }
             public string Owners { get; set; }
             public Uri ProjectUrl { get; set; }
             public DateTimeOffset? Published { get; set; }
@@ -92,6 +93,7 @@ namespace NuGet.Protocol.Core.Types
                 IconUrl = _metadata.IconUrl,
                 Identity = _metadata.Identity,
                 LicenseUrl = _metadata.LicenseUrl,
+                OwnersEnumerable = _metadata.OwnersEnumerable,
                 Owners = _metadata.Owners,
                 ProjectUrl = _metadata.ProjectUrl,
                 Published = _metadata.Published,

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -84,6 +83,8 @@ namespace NuGet.Protocol
         public PackageIdentity Identity => new PackageIdentity(PackageId, Version);
 
         public Uri LicenseUrl { get; private set; }
+
+        public IEnumerable<string> OwnersEnumerable => null;
 
         public string Owners { get; private set; }
 

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+~NuGet.Protocol.Core.Types.IPackageSearchMetadata.OwnersEnumerable.get -> System.Collections.Generic.IEnumerable<string>
+~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersEnumerable.get -> System.Collections.Generic.IEnumerable<string>
+~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersEnumerable.set -> void
+~NuGet.Protocol.LocalPackageSearchMetadata.OwnersEnumerable.get -> System.Collections.Generic.IEnumerable<string>
+~NuGet.Protocol.PackageSearchMetadata.OwnersEnumerable.get -> System.Collections.Generic.IEnumerable<string>
+~NuGet.Protocol.PackageSearchMetadataV2Feed.OwnersEnumerable.get -> System.Collections.Generic.IEnumerable<string>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+~NuGet.Protocol.Core.Types.IPackageSearchMetadata.OwnersEnumerable.get -> System.Collections.Generic.IEnumerable<string>
+~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersEnumerable.get -> System.Collections.Generic.IEnumerable<string>
+~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersEnumerable.set -> void
+~NuGet.Protocol.LocalPackageSearchMetadata.OwnersEnumerable.get -> System.Collections.Generic.IEnumerable<string>
+~NuGet.Protocol.PackageSearchMetadata.OwnersEnumerable.get -> System.Collections.Generic.IEnumerable<string>
+~NuGet.Protocol.PackageSearchMetadataV2Feed.OwnersEnumerable.get -> System.Collections.Generic.IEnumerable<string>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+~NuGet.Protocol.Core.Types.IPackageSearchMetadata.OwnersEnumerable.get -> System.Collections.Generic.IEnumerable<string>
+~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersEnumerable.get -> System.Collections.Generic.IEnumerable<string>
+~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersEnumerable.set -> void
+~NuGet.Protocol.LocalPackageSearchMetadata.OwnersEnumerable.get -> System.Collections.Generic.IEnumerable<string>
+~NuGet.Protocol.PackageSearchMetadata.OwnersEnumerable.get -> System.Collections.Generic.IEnumerable<string>
+~NuGet.Protocol.PackageSearchMetadataV2Feed.OwnersEnumerable.get -> System.Collections.Generic.IEnumerable<string>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12501

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

In the Packages List, a distinction is made between package owner and author:

- **"by:"** refers to the **owner**
  - Always shown when available
  - I added the colon (:) to for parity with nuget.org
  - The prefix reserved indicator will still be shown to the left, just like it is on nuget.org. Note that prefix reservation is not required for an owner to be specified in the metadata. (ex: [NuGet Gallery | GraphQL.NewtonsoftJson 7.6.1](https://www.nuget.org/packages/GraphQL.NewtonsoftJson))

- **"contributors:"** refers to the **authors**
  - Only shown if owner is not available
  - Another option would be "authors:" but I wonder if is still misleading, since at a glance, it may seem that the author is the responsible party for owning the package. This confusion is exactly what we're trying to address, so I think a new term makes sense. GitHub uses the term "contributors" so I chose that.

The **Tooltip** when hovering over a package item **will show both** pieces of metadata (when available).
That is, after the package ID, both the owner "by: <owners>", and the authors, "contributors: <authors>" are shown, in that order. Owners are always first.

### Example of owners now shown in PM UI:
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/4d536dbf-e473-49f1-9c21-321d59eac2a9)

### Example of owners shown as "by: <owners> from nuget.org:
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/8cbcfde8-8d1a-4e8c-b6e1-c6ec5f7d6ab1)

### Example of authors shown when owners are not available on the feed in PM UI:
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/74145614-b2df-4c66-8e72-99a795a26e11)


## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
