### PR TITLE
Add --format --verbosity and --configfile options to `dotnet package search`

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/IPackageSearchResultPackage.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/IPackageSearchResultPackage.cs
@@ -1,0 +1,9 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.CommandLine.XPlat
+{
+    internal interface IPackageSearchResultPackage
+    {
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchArgs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchArgs.cs
@@ -24,15 +24,15 @@ namespace NuGet.CommandLine.XPlat
 
         public PackageSearchArgs(string skip, string take, string format, string verbosity)
         {
-            Skip = VerifyInt(skip, DefaultSkip);
-            Take = VerifyInt(take, DefaultTake);
+            Skip = VerifyInt(skip, DefaultSkip, "--skip");
+            Take = VerifyInt(take, DefaultTake, "--take");
             JsonFormat = VerifyFormat(format);
             Verbosity = VerifyVerbosity(verbosity);
         }
 
         public PackageSearchArgs() { }
 
-        public int VerifyInt(string number, int defaultValue)
+        public int VerifyInt(string number, int defaultValue, string option)
         {
             if (string.IsNullOrEmpty(number))
             {
@@ -44,14 +44,25 @@ namespace NuGet.CommandLine.XPlat
                 return verifiedNumber;
             }
 
-            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_invalid_number, number));
+            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_invalidOptionValue, number, option));
         }
 
         public bool VerifyFormat(string format)
         {
             if (!string.IsNullOrEmpty(format))
             {
-                return string.Equals(format, "json", StringComparison.CurrentCultureIgnoreCase);
+                if (string.Equals(format, "json", StringComparison.CurrentCultureIgnoreCase))
+                {
+                    return true;
+                }
+                else if (string.Equals(format, "table", StringComparison.CurrentCultureIgnoreCase))
+                {
+                    return false;
+                }
+                else
+                {
+                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_invalidOptionValue, format, "--format"));
+                }
             }
 
             return false;
@@ -59,14 +70,24 @@ namespace NuGet.CommandLine.XPlat
 
         private PackageSearchVerbosity VerifyVerbosity(string verbosity)
         {
-            if (string.IsNullOrEmpty(verbosity) || string.Equals(verbosity, nameof(PackageSearchVerbosity.Detailed), StringComparison.CurrentCultureIgnoreCase))
+            if (verbosity != null)
             {
-                return PackageSearchVerbosity.Detailed;
-            }
-
-            if (string.Equals(verbosity, nameof(PackageSearchVerbosity.Minimal), StringComparison.CurrentCultureIgnoreCase))
-            {
-                return PackageSearchVerbosity.Minimal;
+                if (string.Equals(verbosity, nameof(PackageSearchVerbosity.Detailed), StringComparison.CurrentCultureIgnoreCase))
+                {
+                    return PackageSearchVerbosity.Detailed;
+                }
+                else if (string.Equals(verbosity, nameof(PackageSearchVerbosity.Normal), StringComparison.CurrentCultureIgnoreCase))
+                {
+                    return PackageSearchVerbosity.Normal;
+                }
+                else if (string.Equals(verbosity, nameof(PackageSearchVerbosity.Minimal), StringComparison.CurrentCultureIgnoreCase))
+                {
+                    return PackageSearchVerbosity.Minimal;
+                }
+                else
+                {
+                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_invalidOptionValue, verbosity, "--verbosity"));
+                }
             }
 
             return PackageSearchVerbosity.Normal;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchArgs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchArgs.cs
@@ -19,11 +19,15 @@ namespace NuGet.CommandLine.XPlat
         public bool Interactive { get; set; }
         public ILoggerWithColor Logger { get; set; }
         public string SearchTerm { get; set; }
+        public PackageSearchVerbosity Verbosity { get; set; } = PackageSearchVerbosity.Normal;
+        public bool JsonFormat { get; set; } = false;
 
-        public PackageSearchArgs(string skip, string take)
+        public PackageSearchArgs(string skip, string take, string format, string verbosity)
         {
             Skip = VerifyInt(skip, DefaultSkip);
             Take = VerifyInt(take, DefaultTake);
+            JsonFormat = VerifyFormat(format);
+            Verbosity = VerifyVerbosity(verbosity);
         }
 
         public PackageSearchArgs() { }
@@ -41,6 +45,31 @@ namespace NuGet.CommandLine.XPlat
             }
 
             throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_invalid_number, number));
+        }
+
+        public bool VerifyFormat(string format)
+        {
+            if (!string.IsNullOrEmpty(format))
+            {
+                return string.Equals(format, "json", StringComparison.CurrentCultureIgnoreCase);
+            }
+
+            return false;
+        }
+
+        private PackageSearchVerbosity VerifyVerbosity(string verbosity)
+        {
+            if (string.IsNullOrEmpty(verbosity) || string.Equals(verbosity, nameof(PackageSearchVerbosity.Detailed), StringComparison.CurrentCultureIgnoreCase))
+            {
+                return PackageSearchVerbosity.Detailed;
+            }
+
+            if (string.Equals(verbosity, nameof(PackageSearchVerbosity.Minimal), StringComparison.CurrentCultureIgnoreCase))
+            {
+                return PackageSearchVerbosity.Minimal;
+            }
+
+            return PackageSearchVerbosity.Normal;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResult.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResult.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace NuGet.CommandLine.XPlat
+{
+    /// <summary>
+    /// Represents the result of a package search for a specific source.
+    /// </summary>
+    internal class PackageSearchResult
+    {
+        [JsonProperty("sourceName")]
+        public string SourceName { get; set; }
+
+        [JsonProperty("packages")]
+        public List<IPackageSearchResultPackage> Packages { get; set; }
+
+        public PackageSearchResult(string source)
+        {
+            SourceName = source;
+            Packages = new List<IPackageSearchResultPackage>();
+        }
+
+        public void AddPackage(IPackageSearchResultPackage package)
+        {
+            Packages.Add(package);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultJsonPrinter.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultJsonPrinter.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using NuGet.Configuration;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.CommandLine.XPlat
+{
+    internal class PackageSearchResultJsonPrinter : IPackageSearchResultRenderer
+    {
+        private ILoggerWithColor _logger;
+        private const int LineSeparatorLength = 40;
+        private static readonly string SourceSeparator = new('*', LineSeparatorLength);
+        private PackageSearchVerbosity _verbosity;
+        private List<PackageSearchResult> _packageSearchResults;
+
+        public PackageSearchResultJsonPrinter(ILoggerWithColor loggerWithColor, PackageSearchVerbosity verbosity)
+        {
+            _logger = loggerWithColor;
+            _verbosity = verbosity;
+        }
+        public async void Add(PackageSource source, IEnumerable<IPackageSearchMetadata> completedSearch)
+        {
+            PackageSearchResult packageSearchResult = new PackageSearchResult(source.Name);
+
+            foreach (IPackageSearchMetadata metadata in completedSearch)
+            {
+
+                if (_verbosity == PackageSearchVerbosity.Minimal)
+                {
+                    packageSearchResult.AddPackage(new PackageSearchResultPackageMinimal(metadata));
+                }
+                else if (_verbosity == PackageSearchVerbosity.Detailed)
+                {
+                    PackageDeprecationMetadata packageDeprecationMetadata = await metadata.GetDeprecationMetadataAsync();
+                    packageSearchResult.AddPackage(new PackageSearchResultPackageDetailed(metadata, packageDeprecationMetadata?.Message));
+                }
+                else
+                {
+                    packageSearchResult.AddPackage(new PackageSearchResultPackageNormal(metadata));
+                }
+            }
+            _packageSearchResults.Add(packageSearchResult);
+        }
+
+        public void Add(PackageSource source, string error)
+        {
+            _logger.LogMinimal(SourceSeparator);
+            _logger.LogMinimal($"Source: {source.Name} ({source.SourceUri})");
+            _logger.LogError(error);
+        }
+
+        public void Finish()
+        {
+            var json = JsonConvert.SerializeObject(_packageSearchResults, Formatting.Indented);
+            _logger.LogMinimal(SourceSeparator);
+            _logger.LogMinimal("Search Result");
+            _logger.LogMinimal(json);
+        }
+
+        public void Start()
+        {
+            _packageSearchResults = new List<PackageSearchResult>();
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultJsonPrinter.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultJsonPrinter.cs
@@ -28,7 +28,6 @@ namespace NuGet.CommandLine.XPlat
 
             foreach (IPackageSearchMetadata metadata in completedSearch)
             {
-
                 if (_verbosity == PackageSearchVerbosity.Minimal)
                 {
                     packageSearchResult.AddPackage(new PackageSearchResultPackageMinimal(metadata));
@@ -43,6 +42,7 @@ namespace NuGet.CommandLine.XPlat
                     packageSearchResult.AddPackage(new PackageSearchResultPackageNormal(metadata));
                 }
             }
+
             _packageSearchResults.Add(packageSearchResult);
         }
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultPackageDetailed.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultPackageDetailed.cs
@@ -29,10 +29,12 @@ namespace NuGet.CommandLine.XPlat
         public PackageSearchResultPackageDetailed(IPackageSearchMetadata packageSearchMetadata, string deprecation) : base(packageSearchMetadata)
         {
             Description = packageSearchMetadata.Description;
+
             if (packageSearchMetadata.Vulnerabilities != null && packageSearchMetadata.Vulnerabilities.Any())
             {
                 Vulnerable = true;
             }
+
             Deprecation = deprecation;
             ProjectUrl = packageSearchMetadata.ProjectUrl;
         }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultPackageDetailed.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultPackageDetailed.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Newtonsoft.Json;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.CommandLine.XPlat
+{
+    internal class PackageSearchResultPackageDetailed : PackageSearchResultPackageNormal
+    {
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("vulnerable")]
+        public bool? Vulnerable { get; set; }
+
+        [JsonProperty("deprecation")]
+        public string Deprecation { get; set; }
+
+        [JsonProperty("projectUrl")]
+        public Uri ProjectUrl { get; set; }
+
+        public PackageSearchResultPackageDetailed(IPackageSearchMetadata packageSearchMetadata, string deprecation) : base(packageSearchMetadata)
+        {
+            Description = packageSearchMetadata.Description;
+            if (packageSearchMetadata.Vulnerabilities != null && packageSearchMetadata.Vulnerabilities.Any())
+            {
+                Vulnerable = true;
+            }
+            Deprecation = deprecation;
+            ProjectUrl = packageSearchMetadata.ProjectUrl;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultPackageDetailed.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultPackageDetailed.cs
@@ -22,6 +22,10 @@ namespace NuGet.CommandLine.XPlat
         [JsonProperty("projectUrl")]
         public Uri ProjectUrl { get; set; }
 
+        public PackageSearchResultPackageDetailed() : base()
+        {
+        }
+
         public PackageSearchResultPackageDetailed(IPackageSearchMetadata packageSearchMetadata, string deprecation) : base(packageSearchMetadata)
         {
             Description = packageSearchMetadata.Description;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultPackageMinimal.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultPackageMinimal.cs
@@ -14,6 +14,8 @@ namespace NuGet.CommandLine.XPlat
         [JsonProperty("latestVersion")]
         public string LatestVersion { get; set; }
 
+        public PackageSearchResultPackageMinimal() { }
+
         public PackageSearchResultPackageMinimal(IPackageSearchMetadata packageSearchMetadata)
         {
             PackageId = packageSearchMetadata.Identity.Id;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultPackageMinimal.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultPackageMinimal.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.CommandLine.XPlat
+{
+    internal class PackageSearchResultPackageMinimal : IPackageSearchResultPackage
+    {
+        [JsonProperty("packageId")]
+        public string PackageId { get; set; }
+
+        [JsonProperty("latestVersion")]
+        public string LatestVersion { get; set; }
+
+        public PackageSearchResultPackageMinimal(IPackageSearchMetadata packageSearchMetadata)
+        {
+            PackageId = packageSearchMetadata.Identity.Id;
+            LatestVersion = packageSearchMetadata.Identity.Version.ToString();
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultPackageNormal.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultPackageNormal.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.CommandLine.XPlat
+{
+    internal class PackageSearchResultPackageNormal : PackageSearchResultPackageMinimal
+    {
+        [JsonProperty("downloads")]
+        public long? Downloads { get; set; }
+
+        [JsonProperty("authors")]
+        public string Authors { get; set; }
+
+        public PackageSearchResultPackageNormal(IPackageSearchMetadata packageSearchMetadata) : base(packageSearchMetadata)
+        {
+            Downloads = packageSearchMetadata.DownloadCount;
+            Authors = packageSearchMetadata.Authors;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultPackageNormal.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultPackageNormal.cs
@@ -14,6 +14,8 @@ namespace NuGet.CommandLine.XPlat
         [JsonProperty("authors")]
         public string Authors { get; set; }
 
+        public PackageSearchResultPackageNormal() : base() { }
+
         public PackageSearchResultPackageNormal(IPackageSearchMetadata packageSearchMetadata) : base(packageSearchMetadata)
         {
             Downloads = packageSearchMetadata.DownloadCount;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultTablePrinter.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultTablePrinter.cs
@@ -3,7 +3,9 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using NuGet.Configuration;
+using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 
 namespace NuGet.CommandLine.XPlat
@@ -14,18 +16,70 @@ namespace NuGet.CommandLine.XPlat
         private ILoggerWithColor _loggerWithColor;
         private const int LineSeparatorLength = 40;
         private static readonly string SourceSeparator = new('*', LineSeparatorLength);
+        private PackageSearchVerbosity _verbosity;
+        private bool _exactMatch;
 
-        public PackageSearchResultTablePrinter(string searchTerm, ILoggerWithColor loggerWithColor)
+        private readonly string[] _minimalVerbosityTableHeader = { "Package ID", "Latest Version" };
+        private readonly string[] _minimalVerbosityTableHeaderForExactMatch = { "Package ID", "Version" };
+        private readonly int[] _minimalColumnsToHighlight = { 0 };
+
+        private readonly string[] _normalVerbosityTableHeader = { "Package ID", "Latest Version", "Authors", "Downloads" };
+        private readonly string[] _normalVerbosityTableHeaderForExactMatch = { "Package ID", "Version", "Authors", "Downloads" };
+        private readonly int[] _normalColumnsToHighlight = { 0, 2 };
+
+        private readonly string[] _detailedVerbosityTableHeader = { "Package ID", "Latest Version", "Authors", "Downloads", "Vulnerable", "Deprecation", "Project URL", "Description" };
+        private readonly string[] _detailedVerbosityTableHeaderForExactMatch = { "Package ID", "Version", "Authors", "Downloads", "Vulnerable", "Deprecation", "Project URL", "Description" };
+        private readonly int[] _detailedColumnsToHighlight = { 0, 2, 6, 7 };
+
+        public PackageSearchResultTablePrinter(string searchTerm, ILoggerWithColor loggerWithColor, PackageSearchVerbosity verbosity, bool exactMatch)
         {
             _searchTerm = searchTerm;
             _loggerWithColor = loggerWithColor;
+            _verbosity = verbosity;
+            _exactMatch = exactMatch;
         }
 
         public void Add(PackageSource source, IEnumerable<IPackageSearchMetadata> completedSearch)
         {
             _loggerWithColor.LogMinimal(SourceSeparator);
             _loggerWithColor.LogMinimal($"Source: {source.Name} ({source.SourceUri})");
-            var table = new Table(new[] { 0, 2 }, "Package ID", "Latest Version", "Authors", "Downloads");
+
+            Table table;
+
+            if (_verbosity == PackageSearchVerbosity.Minimal)
+            {
+                if (_exactMatch)
+                {
+                    table = new Table(_minimalColumnsToHighlight, _minimalVerbosityTableHeaderForExactMatch);
+                }
+                else
+                {
+                    table = new Table(_minimalColumnsToHighlight, _minimalVerbosityTableHeader);
+                }
+            }
+            else if (_verbosity == PackageSearchVerbosity.Detailed)
+            {
+                if (_exactMatch)
+                {
+                    table = new Table(_detailedColumnsToHighlight, _detailedVerbosityTableHeaderForExactMatch);
+                }
+                else
+                {
+                    table = new Table(_detailedColumnsToHighlight, _detailedVerbosityTableHeader);
+                }
+            }
+            else
+            {
+                if (_exactMatch)
+                {
+                    table = new Table(_normalColumnsToHighlight, _normalVerbosityTableHeaderForExactMatch);
+                }
+                else
+                {
+                    table = new Table(_normalColumnsToHighlight, _normalVerbosityTableHeader);
+                }
+            }
+
             PopulateTableWithResults(completedSearch, table);
             table.PrintResult(_searchTerm, _loggerWithColor);
         }
@@ -52,7 +106,7 @@ namespace NuGet.CommandLine.XPlat
         /// </summary>
         /// <param name="results">An enumerable of package search metadata to be processed and added to the table.</param>
         /// <param name="table">The table where the results will be added as rows.</param>
-        private static void PopulateTableWithResults(IEnumerable<IPackageSearchMetadata> results, Table table)
+        private async void PopulateTableWithResults(IEnumerable<IPackageSearchMetadata> results, Table table)
         {
             CultureInfo culture = CultureInfo.CurrentCulture;
             NumberFormatInfo nfi = (NumberFormatInfo)culture.NumberFormat.Clone();
@@ -70,7 +124,46 @@ namespace NuGet.CommandLine.XPlat
                     downloads = string.Format(nfi, "{0:N}", result.DownloadCount);
                 }
 
-                table.AddRow(packageId, version, authors, downloads);
+                if (_verbosity == PackageSearchVerbosity.Minimal)
+                {
+                    table.AddRow(packageId, version);
+                }
+                else if (_verbosity == PackageSearchVerbosity.Detailed)
+                {
+                    PackageDeprecationMetadata packageDeprecationMetadata = await result.GetDeprecationMetadataAsync();
+                    string vulnerable = "N/A";
+                    string projectUri = "N/A";
+                    string deprecation = "N/A";
+
+                    if (result.Vulnerabilities != null && result.Vulnerabilities.Any())
+                    {
+                        vulnerable = "True";
+                    }
+
+                    if (result.ProjectUrl != null)
+                    {
+                        projectUri = result.ProjectUrl.ToString();
+                    }
+
+                    if (packageDeprecationMetadata != null)
+                    {
+                        deprecation = packageDeprecationMetadata.Message;
+                    }
+
+                    table.AddRow(
+                        packageId,
+                        version,
+                        authors,
+                        downloads,
+                        vulnerable,
+                        deprecation,
+                        projectUri,
+                        result.Description);
+                }
+                else
+                {
+                    table.AddRow(packageId, version, authors, downloads);
+                }
             }
         }
     }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Enums/PackageSearchVerbosity.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Enums/PackageSearchVerbosity.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.CommandLine.XPlat
+{
+    internal enum PackageSearchVerbosity
+    {
+        Minimal,
+        Normal,
+        Detailed
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -448,20 +448,20 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} is not a valid integer..
-        /// </summary>
-        internal static string Error_invalid_number {
-            get {
-                return ResourceManager.GetString("Error_invalid_number", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Invalid culture identifier in {0} environment variable. Value read is &apos;{1}&apos;.
         /// </summary>
         internal static string Error_InvalidCultureInfo {
             get {
                 return ResourceManager.GetString("Error_InvalidCultureInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid value `{0}` for option {1}..
+        /// </summary>
+        internal static string Error_invalidOptionValue {
+            get {
+                return ResourceManager.GetString("Error_invalidOptionValue", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -493,6 +493,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No package sources found..
+        /// </summary>
+        internal static string Error_NoSource {
+            get {
+                return ResourceManager.GetString("Error_NoSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The project `{0}` uses package.config for NuGet packages, while the command works only with package reference projects..
         /// </summary>
         internal static string Error_NotPRProject {
@@ -1310,6 +1319,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The path to a NuGet config file to use..
+        /// </summary>
+        internal static string pkgSearch_ConfigFileDescription {
+            get {
+                return ResourceManager.GetString("pkgSearch_ConfigFileDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Searches one or more package sources for packages that match a search term. If no sources are specified, all sources defined in the NuGet.Config are used..
         /// </summary>
         internal static string pkgSearch_Description {
@@ -1324,6 +1342,15 @@ namespace NuGet.CommandLine.XPlat {
         internal static string pkgSearch_ExactMatchDescription {
             get {
                 return ResourceManager.GetString("pkgSearch_ExactMatchDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Format the output accordingly. Either `table`, or `json`. The default value is `table`..
+        /// </summary>
+        internal static string pkgSearch_FormatDescription {
+            get {
+                return ResourceManager.GetString("pkgSearch_FormatDescription", resourceCulture);
             }
         }
         
@@ -1378,6 +1405,15 @@ namespace NuGet.CommandLine.XPlat {
         internal static string pkgSearch_termDescription {
             get {
                 return ResourceManager.GetString("pkgSearch_termDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Display this amount of details in the output: `normal`, `minimal`, `detailed`. The default is `normal`..
+        /// </summary>
+        internal static string pkgSearch_VerbosityDescription {
+            get {
+                return ResourceManager.GetString("pkgSearch_VerbosityDescription", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -844,7 +844,7 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
   </data>
   <data name="Error_invalidOptionValue" xml:space="preserve">
     <value>Invalid value `{0}` for option {1}.</value>
-    <comment>0 - The invalid value. 1- the option.</comment>
+    <comment>0 - The invalid value. 1 - the option.</comment>
   </data>
   <data name="Error_InvalidSource" xml:space="preserve">
     <value>The specified source '{0}' is invalid. Provide a valid source.</value>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -842,9 +842,9 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
   <data name="pkgSearch_termDescription" xml:space="preserve">
     <value>Search term to filter package names, descriptions, and tags. Used as a literal value. Example: `dotnet package search some.package`. See also `--exact-match`.</value>
   </data>
-  <data name="Error_invalid_number" xml:space="preserve">
-    <value>{0} is not a valid integer.</value>
-    <comment>0 - The invalid number.</comment>
+  <data name="Error_invalidOptionValue" xml:space="preserve">
+    <value>Invalid value `{0}` for option {1}.</value>
+    <comment>0 - The invalid value. 1- the option.</comment>
   </data>
   <data name="Error_InvalidSource" xml:space="preserve">
     <value>The specified source '{0}' is invalid. Provide a valid source.</value>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -853,4 +853,18 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
   <data name="Error_CannotObtainSearchSource" xml:space="preserve">
     <value>Failed to obtain a search resource.</value>
   </data>
+  <data name="pkgSearch_FormatDescription" xml:space="preserve">
+    <value>Format the output accordingly. Either `table`, or `json`. The default value is `table`.</value>
+    <comment>Please don't translate `table`, `json`.</comment>
+  </data>
+  <data name="pkgSearch_VerbosityDescription" xml:space="preserve">
+    <value>Display this amount of details in the output: `normal`, `minimal`, `detailed`. The default is `normal`.</value>
+    <comment>Please don't translate `minimal`, `normal`, `detailed`</comment>
+  </data>
+  <data name="pkgSearch_ConfigFileDescription" xml:space="preserve">
+    <value>The path to a NuGet config file to use.</value>
+  </data>
+  <data name="Error_NoSource" xml:space="preserve">
+    <value>No package sources found.</value>
+  </data>
 </root>

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchCommandTests.cs
@@ -113,6 +113,87 @@ namespace NuGet.CommandLine.Xplat.Tests
             Assert.Equal(int.Parse(take), CapturedArgs.Take);
         }
 
+        [Theory]
+        [InlineData("table")]
+        [InlineData("json")]
+        public void Register_withFormatOption_SetsFormat(string format)
+        {
+            // Arrange
+            Register(App, GetLogger, SetupSettingsAndRunSearchAsync);
+
+            // Act
+            App.Execute(new[] { "search", "--format", format });
+
+            // Assert
+            if (format == "json")
+            {
+                Assert.True(CapturedArgs.JsonFormat);
+            }
+            else
+            {
+                Assert.False(CapturedArgs.JsonFormat);
+            }
+        }
+
+        [Fact]
+        public void Register_withInvalidFormattingOption_ShowsErrorMessage()
+        {
+            // Arrange
+            Register(App, GetLogger, SetupSettingsAndRunSearchAsync);
+            string invalidFormat = "invalid";
+            string expectedError = string.Format(CultureInfo.CurrentCulture, Strings.Error_invalidOptionValue, invalidFormat, "--format");
+
+            // Act
+            var exitCode = App.Execute(new[] { "search", "--format", invalidFormat });
+
+            // Assert
+            Assert.Equal(1, exitCode);
+            Assert.Contains(expectedError, StoredErrorMessage);
+        }
+
+        [Theory]
+        [InlineData("minimal")]
+        [InlineData("normal")]
+        [InlineData("detailed")]
+        public void Register_withVerbosityOption_SetsFormat(string verbosity)
+        {
+            // Arrange
+            Register(App, GetLogger, SetupSettingsAndRunSearchAsync);
+
+            // Act
+            App.Execute(new[] { "search", "--verbosity", verbosity });
+
+            // Assert
+            if (verbosity == "minimal")
+            {
+                Assert.Equal(PackageSearchVerbosity.Minimal, CapturedArgs.Verbosity);
+            }
+            else if (verbosity == "detailed")
+            {
+                Assert.Equal(PackageSearchVerbosity.Detailed, CapturedArgs.Verbosity);
+            }
+            else
+            {
+                Assert.Equal(PackageSearchVerbosity.Normal, CapturedArgs.Verbosity);
+            }
+        }
+
+        [Fact]
+        public void Register_withInvalidVerbosityOption_ShowsErrorMessage()
+        {
+            // Arrange
+            Register(App, GetLogger, SetupSettingsAndRunSearchAsync);
+            string invalidFormat = "invalid";
+            string expectedError = string.Format(CultureInfo.CurrentCulture, Strings.Error_invalidOptionValue, invalidFormat, "--verbosity");
+
+            // Act
+            var exitCode = App.Execute(new[] { "search", "--verbosity", invalidFormat });
+
+            // Assert
+            Assert.Equal(1, exitCode);
+            Assert.Contains(expectedError, StoredErrorMessage);
+        }
+
         [Fact]
         public void Register_withSkipOption_SetsSkip()
         {
@@ -135,7 +216,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             Register(App, GetLogger, SetupSettingsAndRunSearchAsync);
             string searchTerm = "nuget";
             string take = "invalid";
-            string expectedError = string.Format(CultureInfo.CurrentCulture, Strings.Error_invalid_number, take);
+            string expectedError = string.Format(CultureInfo.CurrentCulture, Strings.Error_invalidOptionValue, take, "--take");
 
             // Act
             var exitCode = App.Execute(new[] { "search", searchTerm, "--take", take });
@@ -152,7 +233,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             Register(App, GetLogger, SetupSettingsAndRunSearchAsync);
             string searchTerm = "nuget";
             string skip = "invalid";
-            string expectedError = string.Format(CultureInfo.CurrentCulture, Strings.Error_invalid_number, skip);
+            string expectedError = string.Format(CultureInfo.CurrentCulture, Strings.Error_invalidOptionValue, skip, "--skip");
 
             // Act
             var exitCode = App.Execute(new[] { "search", searchTerm, "--skip", skip });

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchResultJsonPrinterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchResultJsonPrinterTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Moq;
+using NuGet.CommandLine.XPlat;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.CommandLine.Xplat.Tests
+{
+    public class PackageSearchResultJsonPrinterTests
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void Add_MultiplePackageSearchMetadata_RendersCorrectNumberOfPackages(int numberOfPackages)
+        {
+            // Arrange
+            var mockLoggerWithColor = new Mock<ILoggerWithColor>();
+            var printer = new PackageSearchResultJsonPrinter(mockLoggerWithColor.Object, PackageSearchVerbosity.Normal);
+            var mockSource = new Mock<PackageSource>("http://mocksource", "MockSource");
+            var completedSearch = new List<IPackageSearchMetadata>();
+            var mockMetadata = new Mock<IPackageSearchMetadata>();
+            var packageIdentity = new PackageIdentity("NuGet.Versioning", new NuGetVersion("4.3.0"));
+
+            mockMetadata.Setup(m => m.Identity).Returns(packageIdentity);
+            mockMetadata.Setup(m => m.Authors).Returns("Microsoft");
+            mockMetadata.Setup(m => m.DownloadCount).Returns(123456);
+            printer.Start();
+
+            for (int i = 0; i < numberOfPackages; i++)
+            {
+                completedSearch.Add(mockMetadata.Object);
+            }
+
+            // Act
+            printer.Add(mockSource.Object, completedSearch);
+            printer.Finish();
+
+            // Assert
+            var expectedZeroJson = $@"[
+  {{
+    ""sourceName"": ""MockSource"",
+    ""packages"": []
+  }}
+]";
+            var expectedOneJson = $@"[
+  {{
+    ""sourceName"": ""MockSource"",
+    ""packages"": [
+      {{
+        ""downloads"": 123456,
+        ""authors"": ""Microsoft"",
+        ""packageId"": ""NuGet.Versioning"",
+        ""latestVersion"": ""4.3.0""
+      }}
+    ]
+  }}
+]";
+
+            var expectedTwoJson = $@"[
+  {{
+    ""sourceName"": ""MockSource"",
+    ""packages"": [
+      {{
+        ""downloads"": 123456,
+        ""authors"": ""Microsoft"",
+        ""packageId"": ""NuGet.Versioning"",
+        ""latestVersion"": ""4.3.0""
+      }},
+      {{
+        ""downloads"": 123456,
+        ""authors"": ""Microsoft"",
+        ""packageId"": ""NuGet.Versioning"",
+        ""latestVersion"": ""4.3.0""
+      }}
+    ]
+  }}
+]";
+
+            if (numberOfPackages == 2)
+            {
+                mockLoggerWithColor.Verify(x => x.LogMinimal(expectedTwoJson), Times.Exactly(1));
+            }
+            else if (numberOfPackages == 0)
+            {
+                mockLoggerWithColor.Verify(x => x.LogMinimal(expectedZeroJson), Times.Exactly(1));
+            }
+            else
+            {
+                mockLoggerWithColor.Verify(x => x.LogMinimal(expectedOneJson), Times.Exactly(1));
+            }
+        }
+
+        [Fact]
+        public void Add_Error_ShouldLogError()
+        {
+            // Arrange
+            var mockLoggerWithColor = new Mock<ILoggerWithColor>();
+            var printer = new PackageSearchResultJsonPrinter(mockLoggerWithColor.Object, PackageSearchVerbosity.Minimal);
+            Mock<PackageSource> mockSource = new Mock<PackageSource>("http://errorsource", "ErrorTestSource");
+            string errorMessage = "An error occurred";
+
+            // Act
+            printer.Add(mockSource.Object, errorMessage);
+
+            // Assert
+            mockLoggerWithColor.Verify(x => x.LogMinimal("****************************************"), Times.Once);
+            mockLoggerWithColor.Verify(x => x.LogMinimal($"Source: ErrorTestSource (http://errorsource/)"), Times.Once);
+            mockLoggerWithColor.Verify(x => x.LogError(errorMessage), Times.Once);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchResultJsonPrinterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchResultJsonPrinterTests.cs
@@ -49,6 +49,7 @@ namespace NuGet.CommandLine.Xplat.Tests
     ""packages"": []
   }}
 ]";
+
             var expectedOneJson = $@"[
   {{
     ""sourceName"": ""MockSource"",

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchResultTablePrinterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchResultTablePrinterTests.cs
@@ -24,7 +24,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             // Arrange
             var searchTerm = "TestPackage";
             Mock<ILoggerWithColor> mockLoggerWithColor = new Mock<ILoggerWithColor>();
-            PackageSearchResultTablePrinter renderer = new PackageSearchResultTablePrinter(searchTerm, mockLoggerWithColor.Object);
+            PackageSearchResultTablePrinter renderer = new PackageSearchResultTablePrinter(searchTerm, mockLoggerWithColor.Object, PackageSearchVerbosity.Normal, false);
             Mock<PackageSource> mockSource = new Mock<PackageSource>("http://mysource", "TestSource");
             var packageIdentity = new PackageIdentity("NuGet.Versioning", new NuGetVersion("4.3.0"));
             var completedSearch = new List<IPackageSearchMetadata>();
@@ -69,7 +69,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             // Arrange
             var searchTerm = "ErrorPackage";
             Mock<ILoggerWithColor> mockLoggerWithColor = new Mock<ILoggerWithColor>();
-            PackageSearchResultTablePrinter renderer = new PackageSearchResultTablePrinter(searchTerm, mockLoggerWithColor.Object);
+            PackageSearchResultTablePrinter renderer = new PackageSearchResultTablePrinter(searchTerm, mockLoggerWithColor.Object, PackageSearchVerbosity.Normal, false);
             Mock<PackageSource> mockSource = new Mock<PackageSource>("http://errorsource", "ErrorTestSource");
             string errorMessage = "Error retrieving data";
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerFixture.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerFixture.cs
@@ -10,6 +10,9 @@ namespace NuGet.CommandLine.Xplat.Tests
         public string SinglePackageQueryResponse { get; private set; }
         public string ExactMatchMetadataResponse { get; private set; }
         public MockServer ServerWithMultipleEndpoints { get; private set; }
+        internal string ExpectedSearchResultDetailed { get; set; }
+        internal string ExpectedSearchResultNormal { get; set; }
+        internal string ExpectedSearchResultMinimal { get; set; }
 
         public PackageSearchRunnerFixture()
         {
@@ -32,7 +35,12 @@ namespace NuGet.CommandLine.Xplat.Tests
                         ""title"": ""Json.NET"",
                         ""iconUrl"": ""https://api.nuget.org/v3-flatcontainer/newtonsoft.json/12.0.3/icon"",
                         ""licenseUrl"": ""https://www.nuget.org/packages/Newtonsoft.Json/12.0.3/license"",
-
+                        ""projectUrl"": ""http://myuri"",
+                        ""deprecation"": {{
+                            ""message"": ""This package has been deprecated"",
+                            ""reasons"": [ ] }},
+                        ""vulnerabilities"": [],
+                        ""description"": ""My description."",
                         ""tags"": [
                             ""json""
                         ],
@@ -135,6 +143,57 @@ namespace NuGet.CommandLine.Xplat.Tests
                     }}
                 }}";
 
+            string detailedJson = $@"
+[
+  {{
+    ""sourceName"": ""{ServerWithMultipleEndpoints.Uri}v3/index.json"",
+    ""packages"": [
+      {{
+        ""description"": ""My description."",
+        ""vulnerable"": null,
+        ""deprecation"": ""This package has been deprecated"",
+        ""projectUrl"": ""http://myuri"",
+        ""downloads"": 531607259,
+        ""authors"": ""James Newton-King"",
+        ""packageId"": ""Fake.Newtonsoft.Json"",
+        ""latestVersion"": ""12.0.3""
+      }}
+    ]
+  }}
+]";
+
+            string normalJson = $@"
+[
+  {{
+    ""sourceName"": ""{ServerWithMultipleEndpoints.Uri}v3/index.json"",
+    ""packages"": [
+      {{
+        ""downloads"": 531607259,
+        ""authors"": ""James Newton-King"",
+        ""packageId"": ""Fake.Newtonsoft.Json"",
+        ""latestVersion"": ""12.0.3""
+      }}
+    ]
+  }}
+]";
+
+            string minimalJson = $@"
+[
+  {{
+    ""sourceName"": ""{ServerWithMultipleEndpoints.Uri}v3/index.json"",
+    ""packages"": [
+      {{
+        ""packageId"": ""Fake.Newtonsoft.Json"",
+        ""latestVersion"": ""12.0.3""
+      }}
+    ]
+  }}
+]";
+
+            ExpectedSearchResultDetailed = NormalizeNewlines(detailedJson);
+            ExpectedSearchResultMinimal = NormalizeNewlines(minimalJson);
+            ExpectedSearchResultNormal = NormalizeNewlines(normalJson);
+
             ServerWithMultipleEndpoints.Get.Add("/v3/index.json", r => index);
             ServerWithMultipleEndpoints.Get.Add("/v3/indexWithNoSearchResource.json", r => indexWithNoSearchResource);
             ServerWithMultipleEndpoints.Get.Add($"/search/query?q=json&skip=0&take=10&prerelease=true&semVerLevel=2.0.0", r => SinglePackageQueryResponse);
@@ -143,6 +202,11 @@ namespace NuGet.CommandLine.Xplat.Tests
             ServerWithMultipleEndpoints.Get.Add($"/search/query?q=json&skip=10&take=20&prerelease=false&semVerLevel=2.0.0", r => SinglePackageQueryResponse);
             ServerWithMultipleEndpoints.Get.Add($"/v3/registration5-semver1/fake.newtonsoft.json/index.json", r => ExactMatchMetadataResponse);
             ServerWithMultipleEndpoints.Start();
+        }
+
+        internal string NormalizeNewlines(string input)
+        {
+            return input.Replace("\r\n", "\n").Replace("\r", "\n");
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
@@ -95,18 +95,18 @@ namespace NuGet.CommandLine.Xplat.Tests
             var expectedValues = new List<string>
             {
                 "| Package ID           ",
-                "| Latest Version ",
+                "| Version ",
                 "| Authors           ",
                 "| Downloads   ",
                 "|----------------------",
-                "|----------------",
+                "|---------",
                 "|-------------------",
                 "|-------------",
                 "| ",
                 "",
                 "",
                 " ",
-                "| 12.0.3         ",
+                "| 12.0.3  ",
                 "| James Newton-King ",
                 "| 531,607,259 ",
             };

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
@@ -28,7 +28,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         [InlineData(0, 20, false)]
         [InlineData(5, 10, true)]
         [InlineData(10, 20, false)]
-        public async Task PackageSearchRunner_SearchAPIWithVariousSkipTakePrereleaseOptionsValuesReturnsOnePackage_OnePackageTableOutputted(int skip, int take, bool prerelease)
+        public async Task PackageSearchRunner_TableFormatNormalVerbosity_OnePackageTableOutputted(int skip, int take, bool prerelease)
         {
             // Arrange
             ISettings settings = Settings.LoadDefaultSettings(
@@ -57,6 +57,14 @@ namespace NuGet.CommandLine.Xplat.Tests
                 "| 531,607,259 ",
             };
 
+            var notExpectedValues = new List<string>
+            {
+                "| Vulnerable ",
+                "| Deprecation                      ",
+                "| Project URL   ",
+                "| Description     ",
+            };
+
             PackageSearchArgs packageSearchArgs = new()
             {
                 Skip = skip,
@@ -65,7 +73,157 @@ namespace NuGet.CommandLine.Xplat.Tests
                 ExactMatch = false,
                 Logger = GetLogger(),
                 SearchTerm = "json",
-                Sources = new List<string> { $"{_fixture.ServerWithMultipleEndpoints.Uri}v3/index.json" }
+                Sources = new List<string> { $"{_fixture.ServerWithMultipleEndpoints.Uri}v3/index.json" },
+                Verbosity = PackageSearchVerbosity.Normal,
+                JsonFormat = false
+            };
+
+            // Act
+            await PackageSearchRunner.RunAsync(
+                sourceProvider: sourceProvider,
+                packageSearchArgs,
+                cancellationToken: System.Threading.CancellationToken.None);
+
+            // Assert
+            foreach (var expected in expectedValues)
+            {
+                Assert.Contains(expected, ColoredMessage.Select(tuple => tuple.Item1));
+            }
+
+            foreach (var notExpected in notExpectedValues)
+            {
+                Assert.DoesNotContain(notExpected, ColoredMessage.Select(tuple => tuple.Item1));
+            }
+
+            Assert.Contains(Tuple.Create("Json", ConsoleColor.Red), ColoredMessage);
+        }
+
+        [Theory]
+        [InlineData(0, 10, true)]
+        [InlineData(0, 20, false)]
+        [InlineData(5, 10, true)]
+        [InlineData(10, 20, false)]
+        public async Task PackageSearchRunner_TableFormatMinimalVerbosity_OnePackageTableOutputted(int skip, int take, bool prerelease)
+        {
+            // Arrange
+            ISettings settings = Settings.LoadDefaultSettings(
+                Directory.GetCurrentDirectory(),
+                configFileName: null,
+                machineWideSettings: new XPlatMachineWideSetting());
+            PackageSourceProvider sourceProvider = new PackageSourceProvider(settings);
+            var expectedValues = new List<string>
+            {
+                "| Package ID           ",
+                "| Latest Version ",
+                "|----------------------",
+                "|----------------",
+                "| ",
+                "",
+                "Fake.Newtonsoft.",
+                "Json",
+                "",
+                " ",
+                "| 12.0.3         ",
+            };
+
+            var notExpectedValues = new List<string>
+            {
+                "| Authors           ",
+                "| Downloads   ",
+                "| Vulnerable ",
+                "| Deprecation                      ",
+                "| Project URL   ",
+                "| Description     ",
+            };
+
+            PackageSearchArgs packageSearchArgs = new()
+            {
+                Skip = skip,
+                Take = take,
+                Prerelease = prerelease,
+                ExactMatch = false,
+                Logger = GetLogger(),
+                SearchTerm = "json",
+                Sources = new List<string> { $"{_fixture.ServerWithMultipleEndpoints.Uri}v3/index.json" },
+                Verbosity = PackageSearchVerbosity.Minimal,
+                JsonFormat = false
+            };
+
+            // Act
+            await PackageSearchRunner.RunAsync(
+                sourceProvider: sourceProvider,
+                packageSearchArgs,
+                cancellationToken: System.Threading.CancellationToken.None);
+
+            // Assert
+            foreach (var expected in expectedValues)
+            {
+                Assert.Contains(expected, ColoredMessage.Select(tuple => tuple.Item1));
+            }
+
+            foreach (var notExpected in notExpectedValues)
+            {
+                Assert.DoesNotContain(notExpected, ColoredMessage.Select(tuple => tuple.Item1));
+            }
+
+            Assert.Contains(Tuple.Create("Json", ConsoleColor.Red), ColoredMessage);
+        }
+
+        [Theory]
+        [InlineData(0, 10, true)]
+        [InlineData(0, 20, false)]
+        [InlineData(5, 10, true)]
+        [InlineData(10, 20, false)]
+        public async Task PackageSearchRunner_TableFormatDetailedVerbosity_OnePackageTableOutputted(int skip, int take, bool prerelease)
+        {
+            // Arrange
+            ISettings settings = Settings.LoadDefaultSettings(
+                Directory.GetCurrentDirectory(),
+                configFileName: null,
+                machineWideSettings: new XPlatMachineWideSetting());
+            PackageSourceProvider sourceProvider = new PackageSourceProvider(settings);
+            var expectedValues = new List<string>
+                {
+                    "| Package ID           ",
+                    "| Latest Version ",
+                    "| Authors           ",
+                    "| Downloads   ",
+                    "| Vulnerable ",
+                    "| Deprecation                      ",
+                    "| Project URL   ",
+                    "| Description     ",
+                    "|----------------------",
+                    "|----------------",
+                    "|-------------------",
+                    "|-------------",
+                    "|------------",
+                    "|----------------------------------",
+                    "|---------------",
+                    "|-----------------",
+                    " ",
+                    "Fake.Newtonsoft.",
+                    " ",
+                    " ",
+                    "| 12.0.3         ",
+                    "| James Newton-King ",
+                    "| 531,607,259 ",
+                    "| N/A        ",
+                    "| This package has been deprecated ",
+                    "| http://myuri/ ",
+                    "| My description. "
+                };
+
+            PackageSearchArgs packageSearchArgs = new()
+            {
+                Skip = skip,
+                Take = take,
+                Prerelease = prerelease,
+                ExactMatch = false,
+                Logger = GetLogger(),
+                SearchTerm = "json",
+                Sources = new List<string> { $"{_fixture.ServerWithMultipleEndpoints.Uri}v3/index.json" },
+                Verbosity = PackageSearchVerbosity.Detailed,
+                JsonFormat = false
             };
 
             // Act
@@ -81,6 +239,120 @@ namespace NuGet.CommandLine.Xplat.Tests
             }
 
             Assert.Contains(Tuple.Create("Json", ConsoleColor.Red), ColoredMessage);
+        }
+
+        [Theory]
+        [InlineData(0, 10, true)]
+        [InlineData(0, 20, false)]
+        [InlineData(5, 10, true)]
+        [InlineData(10, 20, false)]
+        public async Task PackageSearchRunner_JsonFormatNormalVerbosity_OnePackageJsonOutputted(int skip, int take, bool prerelease)
+        {
+            // Arrange
+            ISettings settings = Settings.LoadDefaultSettings(
+                Directory.GetCurrentDirectory(),
+                configFileName: null,
+                machineWideSettings: new XPlatMachineWideSetting());
+            PackageSourceProvider sourceProvider = new PackageSourceProvider(settings);
+
+            PackageSearchArgs packageSearchArgs = new()
+            {
+                Skip = skip,
+                Take = take,
+                Prerelease = prerelease,
+                ExactMatch = false,
+                Logger = GetLogger(),
+                SearchTerm = "json",
+                Sources = new List<string> { $"{_fixture.ServerWithMultipleEndpoints.Uri}v3/index.json" },
+                Verbosity = PackageSearchVerbosity.Normal,
+                JsonFormat = true
+            };
+
+            // Act
+            await PackageSearchRunner.RunAsync(
+                sourceProvider: sourceProvider,
+                packageSearchArgs,
+                cancellationToken: System.Threading.CancellationToken.None);
+
+            // Assert
+            string message = _fixture.NormalizeNewlines(Message);
+            Assert.Contains(_fixture.ExpectedSearchResultNormal, message);
+        }
+
+        [Theory]
+        [InlineData(0, 10, true)]
+        [InlineData(0, 20, false)]
+        [InlineData(5, 10, true)]
+        [InlineData(10, 20, false)]
+        public async Task PackageSearchRunner_JsonFormatMinimalVerbosity_OnePackageJsonOutputted(int skip, int take, bool prerelease)
+        {
+            // Arrange
+            ISettings settings = Settings.LoadDefaultSettings(
+                Directory.GetCurrentDirectory(),
+                configFileName: null,
+                machineWideSettings: new XPlatMachineWideSetting());
+            PackageSourceProvider sourceProvider = new PackageSourceProvider(settings);
+
+            PackageSearchArgs packageSearchArgs = new()
+            {
+                Skip = skip,
+                Take = take,
+                Prerelease = prerelease,
+                ExactMatch = false,
+                Logger = GetLogger(),
+                SearchTerm = "json",
+                Sources = new List<string> { $"{_fixture.ServerWithMultipleEndpoints.Uri}v3/index.json" },
+                Verbosity = PackageSearchVerbosity.Minimal,
+                JsonFormat = true
+            };
+
+            // Act
+            await PackageSearchRunner.RunAsync(
+                sourceProvider: sourceProvider,
+                packageSearchArgs,
+                cancellationToken: System.Threading.CancellationToken.None);
+
+            // Assert
+            string message = _fixture.NormalizeNewlines(Message);
+            Assert.Contains(_fixture.ExpectedSearchResultMinimal, message);
+        }
+
+        [Theory]
+        [InlineData(0, 10, true)]
+        [InlineData(0, 20, false)]
+        [InlineData(5, 10, true)]
+        [InlineData(10, 20, false)]
+        public async Task PackageSearchRunner_JsonFormatDetailedVerbosity_OnePackageJsonOutputted(int skip, int take, bool prerelease)
+        {
+            // Arrange
+            ISettings settings = Settings.LoadDefaultSettings(
+                Directory.GetCurrentDirectory(),
+                configFileName: null,
+                machineWideSettings: new XPlatMachineWideSetting());
+            PackageSourceProvider sourceProvider = new PackageSourceProvider(settings);
+
+            PackageSearchArgs packageSearchArgs = new()
+            {
+                Skip = skip,
+                Take = take,
+                Prerelease = prerelease,
+                ExactMatch = false,
+                Logger = GetLogger(),
+                SearchTerm = "json",
+                Sources = new List<string> { $"{_fixture.ServerWithMultipleEndpoints.Uri}v3/index.json" },
+                Verbosity = PackageSearchVerbosity.Detailed,
+                JsonFormat = true
+            };
+
+            // Act
+            await PackageSearchRunner.RunAsync(
+                sourceProvider: sourceProvider,
+                packageSearchArgs,
+                cancellationToken: System.Threading.CancellationToken.None);
+
+            // Assert
+            string message = _fixture.NormalizeNewlines(Message);
+            Assert.Contains(_fixture.ExpectedSearchResultDetailed, message);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchTestInitializer.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchTestInitializer.cs
@@ -18,6 +18,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         internal Func<PackageSearchArgs, string, Task<int>> SetupSettingsAndRunSearchAsync { get; set; }
         internal string StoredErrorMessage { get; set; }
         internal List<Tuple<string, ConsoleColor>> ColoredMessage { get; set; }
+        internal string Message { get; set; }
 
         public PackageSearchTestInitializer()
         {
@@ -30,6 +31,10 @@ namespace NuGet.CommandLine.Xplat.Tests
 
             loggerWithColorMock.Setup(x => x.LogMinimal(It.IsAny<string>(), It.IsAny<ConsoleColor>()))
                 .Callback<string, ConsoleColor>((message, color) => { ColoredMessage.Add(Tuple.Create(message, color)); });
+
+            loggerWithColorMock.Setup(x => x.LogMinimal(It.IsAny<string>()))
+                .Callback<string>((message) => { Message += message + "\n"; });
+
             GetLogger = () => loggerWithColorMock.Object;
 
             CapturedArgs = null;

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchTestInitializer.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchTestInitializer.cs
@@ -15,7 +15,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         internal CommandLineApplication App { get; set; }
         internal Func<ILoggerWithColor> GetLogger { get; set; }
         internal PackageSearchArgs CapturedArgs { get; set; }
-        internal Func<PackageSearchArgs, Task<int>> SetupSettingsAndRunSearchAsync { get; set; }
+        internal Func<PackageSearchArgs, string, Task<int>> SetupSettingsAndRunSearchAsync { get; set; }
         internal string StoredErrorMessage { get; set; }
         internal List<Tuple<string, ConsoleColor>> ColoredMessage { get; set; }
 
@@ -34,7 +34,7 @@ namespace NuGet.CommandLine.Xplat.Tests
 
             CapturedArgs = null;
 
-            SetupSettingsAndRunSearchAsync = async (PackageSearchArgs args) =>
+            SetupSettingsAndRunSearchAsync = async (PackageSearchArgs args, string configFile) =>
             {
                 CapturedArgs = args;
                 await Task.CompletedTask;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12978

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This PR adds three new options to `dotnet package search`
- `--format`, `--verbosity` , `--configfile`
- In addition. it modifies the `--exact-match` option to list all version of a package rather than the latest version.
Spec: https://github.com/NuGet/Home/pull/12970

### Screenshots
- `dotnet package search nuget --verbosity minimal`
![image](https://github.com/NuGet/NuGet.Client/assets/59111203/6338920a-1963-4166-9220-032e8f4f03e6)
- `dotnet package search nuget --verbosity normal`
![image](https://github.com/NuGet/NuGet.Client/assets/59111203/aeaa15f9-9857-4ddb-a175-1fab1e6b19e4)
- `dotnet package search nuget --verbosity detailed`
![image](https://github.com/NuGet/NuGet.Client/assets/59111203/aace6f18-0e43-4692-8f5a-74de28964651)
- `dotnet package search nuget --verbosity minimal --format json`
![image](https://github.com/NuGet/NuGet.Client/assets/59111203/7e9dcf91-99e1-4090-b001-38b73902fb2d)



## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
