### PR TITLE
Fix missing transitive dependency tree nodes in some multi-targeting projects

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/AssetsFileDependenciesTreeSearchProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/AssetsFileDependenciesTreeSearchProvider.cs
@@ -70,7 +70,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
 
             foreach ((_, AssetsFileTarget target) in snapshot.DataByTarget)
             {
-                ConfiguredProject? configuredProject = await FindConfiguredProjectAsync(target.TargetFrameworkMoniker);
+                ConfiguredProject? configuredProject = await FindConfiguredProjectAsync(target.TargetAlias);
 
                 if (configuredProject == null)
                 {
@@ -109,7 +109,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
 
                 continue;
 
-                async Task<ConfiguredProject?> FindConfiguredProjectAsync(string tfm)
+                async Task<ConfiguredProject?> FindConfiguredProjectAsync(string targetAlias)
                 {
                     foreach (ConfiguredProject configuredProject in configuredProjects)
                     {
@@ -122,7 +122,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
 
                         if (subscriptionUpdate.CurrentState.TryGetValue(NuGetRestoreRule.SchemaName, out IProjectRuleSnapshot nuGetRestoreSnapshot) &&
                             nuGetRestoreSnapshot.Properties.TryGetValue(NuGetRestoreRule.NuGetTargetMonikerProperty, out string nuGetTargetMoniker) &&
-                            StringComparer.OrdinalIgnoreCase.Equals(nuGetTargetMoniker, tfm))
+                            StringComparer.OrdinalIgnoreCase.Equals(nuGetTargetMoniker, targetAlias))
                         {
                             // Assets file 'target' string matches the configured project's NuGetTargetMoniker property value
                             return configuredProject;
@@ -131,14 +131,14 @@ namespace NuGet.VisualStudio.SolutionExplorer
                         if (subscriptionUpdate.CurrentState.TryGetValue(ConfigurationGeneralRule.SchemaName, out IProjectRuleSnapshot configurationGeneralSnapshot))
                         {
                             if (configurationGeneralSnapshot.Properties.TryGetValue(ConfigurationGeneralRule.TargetFrameworkMonikerProperty, out string targetFrameworkMoniker) &&
-                                StringComparer.OrdinalIgnoreCase.Equals(targetFrameworkMoniker, tfm))
+                                StringComparer.OrdinalIgnoreCase.Equals(targetFrameworkMoniker, targetAlias))
                             {
                                 // Assets file 'target' string matches the configured project's TargetFrameworkMoniker property value
                                 return configuredProject;
                             }
 
                             if (configurationGeneralSnapshot.Properties.TryGetValue(ConfigurationGeneralRule.TargetFrameworkProperty, out string targetFramework) &&
-                                StringComparer.OrdinalIgnoreCase.Equals(targetFramework, tfm))
+                                StringComparer.OrdinalIgnoreCase.Equals(targetFramework, targetAlias))
                             {
                                 // Assets file 'target' string matches the configured project's TargetFramework property value
                                 return configuredProject;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileTarget.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileTarget.cs
@@ -19,9 +19,12 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
     internal sealed class AssetsFileTarget
     {
         /// <summary>
-        /// Gets the target framework moniker, such as <c>.NETFramework,Version=v4.8</c> or <c>.NETStandard,Version=v1.3</c>.
+        /// Gets the target framework alias, which is the string from the project file.
+        /// Target framework aliases may be arbitrary strings, so this value should not be parsed.
+        /// It is used here to join attached nodes in Solution Explorer under the correct target
+        /// node in multi-target projects.
         /// </summary>
-        public string TargetFrameworkMoniker { get; }
+        public string TargetAlias { get; }
 
         /// <summary>
         /// Gets diagnostic messages for this target. Often empty.
@@ -49,14 +52,14 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
         /// </summary>
         private readonly Dictionary<(string LibraryName, string? Version), ImmutableArray<AssetsFileTargetLibrary>> _dependenciesByNameAndVersion = new Dictionary<(string LibraryName, string? Version), ImmutableArray<AssetsFileTargetLibrary>>();
 
-        public AssetsFileTarget(AssetsFileDependenciesSnapshot snapshot, string targetFrameworkMoniker, ImmutableArray<AssetsFileLogMessage> logs, ImmutableDictionary<string, AssetsFileTargetLibrary> libraryByName)
+        public AssetsFileTarget(AssetsFileDependenciesSnapshot snapshot, string targetAlias, ImmutableArray<AssetsFileLogMessage> logs, ImmutableDictionary<string, AssetsFileTargetLibrary> libraryByName)
         {
             Requires.NotNull(snapshot, nameof(snapshot));
-            Requires.NotNullOrWhiteSpace(targetFrameworkMoniker, nameof(targetFrameworkMoniker));
+            Requires.NotNullOrWhiteSpace(targetAlias, nameof(targetAlias));
             Requires.Argument(!logs.IsDefault, nameof(logs), "Must not be default");
             Requires.NotNull(libraryByName, nameof(libraryByName));
 
-            TargetFrameworkMoniker = targetFrameworkMoniker;
+            TargetAlias = targetAlias;
             _snapshot = snapshot;
             Logs = logs;
             LibraryByName = libraryByName;
@@ -181,7 +184,7 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
         public override string ToString()
         {
             var s = new StringBuilder();
-            s.Append("Target \"").Append(TargetFrameworkMoniker).Append("\" ");
+            s.Append("Target \"").Append(TargetAlias).Append("\" ");
             s.Append(LibraryByName.Count).Append(LibraryByName.Count == 1 ? " library" : " libraries");
             s.Append(Logs.Length).Append(Logs.Length == 1 ? " log" : " logs");
             return s.ToString();


### PR DESCRIPTION
The "target name" used in the project model can take different forms. For example, both `net8.0` and `.NETFramework,Version=v4.8.1` are valid values. The dependencies tree uses the "target alias" for its target nodes, in multi-target projects. This is because two different aliases can resolve to the same TFM, for example, yet attached items may differ.

This change digs the alias out of the lock file and uses that value throughout. It also renames a property and fixes the documentation on it so as to avoid confusion.

![image](https://github.com/NuGet/NuGet.Client/assets/350947/8b266000-acd9-4744-968f-4a4009bc4dfc)

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes https://github.com/dotnet/project-system/issues/6832

Regression? Last working version: I think we broke this in 16.9.

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
