### PR TITLE
Reduce number of Dataflow updates through dependency tree code

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/AssetsFileDependenciesDataSource.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/AssetsFileDependenciesDataSource.cs
@@ -128,7 +128,7 @@ namespace NuGet.VisualStudio.SolutionExplorer
 
                 if (lastSnapshot is null)
                 {
-                    lastSnapshot ??= AssetsFileDependenciesSnapshot.Empty;
+                    lastSnapshot = AssetsFileDependenciesSnapshot.Empty;
                     yield return new ProjectVersionedValue<AssetsFileDependenciesSnapshot>(lastSnapshot, update.DataSourceVersions);
                 }
             }


### PR DESCRIPTION
The provision of transitive dependency tree nodes uses Dataflow to propagate project data from producer to consumer.

This change converts a TransformBlock into a TransformManyBlock, such that we can return zero items when there's no real change to propagate. This reduces the work done by consumers, who were previously wasting resources in response to such no-op updates.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13019

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A Dataflow is notoriously difficult to test and we hardly ever do so in the project system

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
