### PR TITLE
Add three apex tests for verify commonly used commands in PMC

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -964,7 +964,7 @@ namespace NuGet.Tests.Apex
                 Assert.IsTrue(nugetConsole.IsMessageFoundInPMC("Install.ps1"), "The Install.ps1 script in TestProject was not executed when the Entityframework.sqlservercompact package was installed.");
             }
         }
-        
+
         [DataTestMethod]
         [DynamicData(nameof(GetNetCoreTemplates), DynamicDataSourceType.Method)]
         [Timeout(DefaultTimeout)]
@@ -1052,7 +1052,7 @@ namespace NuGet.Tests.Apex
                 PMCText.Should().Contain(testContext.Project.FullPath);
             }
         }
-        
+
         public static IEnumerable<object[]> GetNetCoreTemplates()
         {
             yield return new object[] { ProjectTemplate.NetCoreConsoleApp };

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -991,8 +991,9 @@ namespace NuGet.Tests.Apex
                     nugetConsole.Execute($"find-package {PackageName} -ExactMatch");
 
                     // Assert
-                    Assert.IsTrue(nugetConsole.IsMessageFoundInPMC(PackageName), $"The package name {PackageName} doesn't show correctly in PMC.");
-                    Assert.IsTrue(nugetConsole.IsMessageFoundInPMC(v100), $"The package version {v100} doesn't show correctly in PMC.");
+                    string PMCText = nugetConsole.GetText();
+                    PMCText.Should().Contain(PackageName);
+                    PMCText.Should().Contain(v100);
                 }
             }
         }
@@ -1027,7 +1028,8 @@ namespace NuGet.Tests.Apex
                     nugetConsole.Execute("get-package -update");
 
                     // Assert
-                    Assert.IsTrue(nugetConsole.IsMessageFoundInPMC(v200), $"The latest package version {v200} doesn't show correctly in PMC.");
+                    string PMCText = nugetConsole.GetText();
+                    PMCText.Should().Contain(v200);
                 }
             }
         }
@@ -1048,9 +1050,10 @@ namespace NuGet.Tests.Apex
                 nugetConsole.Execute("Get-Project");
 
                 // Assert
-                Assert.IsTrue(nugetConsole.IsMessageFoundInPMC(testContext.Project.Name), "Fail to find the ProjectName in PMC");
-                Assert.IsTrue(nugetConsole.IsMessageFoundInPMC("C#"), "Fail to find the project type in PMC");
-                Assert.IsTrue(nugetConsole.IsMessageFoundInPMC(testContext.Project.FullPath), "Fail to find the project's FullName in PMC");
+                string PMCText = nugetConsole.GetText();
+                PMCText.Should().Contain(testContext.Project.Name);
+                PMCText.Should().Contain("C#");
+                PMCText.Should().Contain(testContext.Project.FullPath);
             }
         }
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -966,9 +966,8 @@ namespace NuGet.Tests.Apex
         }
 
         [DataTestMethod]
-        [DynamicData(nameof(GetNetCoreTemplates), DynamicDataSourceType.Method)]
         [Timeout(DefaultTimeout)]
-        public async Task VerifyCmdFindPackageExactMatchInPMC(ProjectTemplate projectTemplate)
+        public async Task VerifyCmdFindPackageExactMatchInPMC()
         {
             EnsureVisualStudioHost();
             using (var simpleTestPathContext = new SimpleTestPathContext())
@@ -978,7 +977,7 @@ namespace NuGet.Tests.Apex
                 var v100 = "1.0.0";
                 await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, PackageName, v100);
 
-                using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, addNetStandardFeeds: true, simpleTestPathContext: simpleTestPathContext))
+                using (var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCoreConsoleApp, Logger, addNetStandardFeeds: true, simpleTestPathContext: simpleTestPathContext))
                 {
                     SolutionService solutionService = VisualStudio.Get<SolutionService>();
                     var nugetConsole = GetConsole(testContext.Project);
@@ -995,9 +994,8 @@ namespace NuGet.Tests.Apex
         }
 
         [DataTestMethod]
-        [DynamicData(nameof(GetNetCoreTemplates), DynamicDataSourceType.Method)]
         [Timeout(DefaultTimeout)]
-        public async Task VerifyCmdGetPackageUpdateInPMC(ProjectTemplate projectTemplate)
+        public async Task VerifyCmdGetPackageUpdateInPMC()
         {
             EnsureVisualStudioHost();
             using (var simpleTestPathContext = new SimpleTestPathContext())
@@ -1009,7 +1007,7 @@ namespace NuGet.Tests.Apex
                 await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, v100);
                 await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, v200);
 
-                using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, addNetStandardFeeds: true, simpleTestPathContext: simpleTestPathContext))
+                using (var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCoreConsoleApp, Logger, addNetStandardFeeds: true, simpleTestPathContext: simpleTestPathContext))
                 {
                     // Arrange
                     SolutionService solutionService = VisualStudio.Get<SolutionService>();
@@ -1031,12 +1029,11 @@ namespace NuGet.Tests.Apex
         }
 
         [DataTestMethod]
-        [DynamicData(nameof(GetPackagesConfigTemplates), DynamicDataSourceType.Method)]
         [Timeout(DefaultTimeout)]
-        public void VerifyCmdGetProjectInPMC(ProjectTemplate projectTemplate)
+        public void VerifyCmdGetProjectInPMC()
         {
             EnsureVisualStudioHost();
-            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))
+            using (var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.ClassLibrary, Logger))
             {
                 // Arrange
                 SolutionService solutionService = VisualStudio.Get<SolutionService>();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2591

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
We want to add below three APEX test cases for verify common commands in PMC:

1. Verify that the package name and latest package version are displayed correctly in PMC after running the command `"find-package -ExactMatch"`.

2. Verify that the latest package versions is show correctly in PMC after running the command `“get-package -update”`.

3. Verify that the project name, project type and project full path are show correctly in PMC after running the command `“get-project”`.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
