### PR TITLE
Revert "Add option to enable floating versions in CPM (#5440)"

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -459,7 +459,6 @@ namespace NuGet.PackageManagement.VisualStudio
                         MSBuildStringUtility.IsTrue(GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.RestoreLockedMode))),
                     CentralPackageVersionsEnabled = isCpvmEnabled,
                     CentralPackageVersionOverrideDisabled = GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.CentralPackageVersionOverrideEnabled).EqualsFalse(),
-                    CentralPackageFloatingVersionsEnabled = MSBuildStringUtility.IsTrue(GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.CentralPackageFloatingVersionsEnabled)),
                     CentralPackageTransitivePinningEnabled = MSBuildStringUtility.IsTrue(GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.CentralPackageTransitivePinningEnabled)),
                     RestoreAuditProperties = auditProperties,
                 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -297,11 +297,6 @@ namespace NuGet.SolutionRestoreManager
             return GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.CentralPackageVersionOverrideEnabled, (value) => value.EqualsFalse());
         }
 
-        internal static bool IsCentralPackageFloatingVersionsEnabled(IEnumerable tfms)
-        {
-            return GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.CentralPackageFloatingVersionsEnabled, MSBuildStringUtility.IsTrue);
-        }
-
         internal static bool IsCentralPackageTransitivePinningEnabled(IEnumerable tfms)
         {
             return GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.CentralPackageTransitivePinningEnabled, MSBuildStringUtility.IsTrue);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -348,7 +348,6 @@ namespace NuGet.SolutionRestoreManager
                     CacheFilePath = NoOpRestoreUtilities.GetProjectCacheFilePath(cacheRoot: outputPath),
                     RestoreLockProperties = VSNominationUtilities.GetRestoreLockProperties(TargetFrameworks),
                     CentralPackageVersionsEnabled = cpvmEnabled,
-                    CentralPackageFloatingVersionsEnabled = VSNominationUtilities.IsCentralPackageFloatingVersionsEnabled(TargetFrameworks),
                     CentralPackageVersionOverrideDisabled = VSNominationUtilities.IsCentralPackageVersionOverrideDisabled(TargetFrameworks),
                     CentralPackageTransitivePinningEnabled = VSNominationUtilities.IsCentralPackageTransitivePinningEnabled(TargetFrameworks),
                     RestoreAuditProperties = VSNominationUtilities.GetRestoreAuditProperties(TargetFrameworks),

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -808,7 +808,7 @@ namespace NuGet.Build.Tasks.Console
 
             ProjectStyle? projectStyleOrNull = BuildTasksUtility.GetProjectRestoreStyleFromProjectProperty(project.GetProperty("RestoreProjectStyle"));
 
-            (bool isCentralPackageManagementEnabled, bool isCentralPackageVersionOverrideDisabled, bool isCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled) = MSBuildRestoreUtility.GetCentralPackageManagementSettings(project, projectStyleOrNull);
+            (bool isCentralPackageManagementEnabled, bool isCentralPackageVersionOverrideDisabled, bool isCentralPackageTransitivePinningEnabled) = GetCentralPackageManagementSettings(project, projectStyleOrNull);
 
             RestoreAuditProperties auditProperties = MSBuildRestoreUtility.GetRestoreAuditProperties(project);
 
@@ -854,7 +854,6 @@ namespace NuGet.Build.Tasks.Console
                     SkipContentFileWrite = IsLegacyProject(project),
                     ValidateRuntimeAssets = project.IsPropertyTrue("ValidateRuntimeIdentifierCompatibility"),
                     CentralPackageVersionsEnabled = isCentralPackageManagementEnabled && projectStyle == ProjectStyle.PackageReference,
-                    CentralPackageFloatingVersionsEnabled = isCentralPackageFloatingVersionsEnabled,
                     CentralPackageVersionOverrideDisabled = isCentralPackageVersionOverrideDisabled,
                     CentralPackageTransitivePinningEnabled = isCentralPackageTransitivePinningEnabled,
                     RestoreAuditProperties = auditProperties
@@ -1024,6 +1023,22 @@ namespace NuGet.Build.Tasks.Console
 
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Determines the current settings for central package management for the specified project.
+        /// </summary>
+        /// <param name="project">The <see cref="IMSBuildProject" /> to get the central package management settings for.</param>
+        /// <param name="projectStyle">The <see cref="ProjectStyle?" /> of the specified project.  Specify <see langword="null" /> when the project does not define a restore style.</param>
+        /// <returns>A <see cref="Tuple{T1, T2}" /> containing values indicating whether or not central package management is enabled and if the ability to override a package version is disabled.</returns>
+        internal static (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled) GetCentralPackageManagementSettings(IMSBuildProject project, ProjectStyle? projectStyle)
+        {
+            if (!projectStyle.HasValue || (projectStyle.Value == ProjectStyle.PackageReference))
+            {
+                return (project.IsPropertyTrue("_CentralPackageVersionsEnabled"), project.IsPropertyFalse("CentralPackageVersionOverrideEnabled"), project.IsPropertyTrue("CentralPackageTransitivePinningEnabled"));
+            }
+
+            return (false, false, false);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -862,7 +862,6 @@ Copyright (c) .NET Foundation. All rights reserved.
         <NuGetLockFilePath>$(NuGetLockFilePath)</NuGetLockFilePath>
         <RestoreLockedMode>$(RestoreLockedMode)</RestoreLockedMode>
         <_CentralPackageVersionsEnabled>$(_CentralPackageVersionsEnabled)</_CentralPackageVersionsEnabled>
-        <CentralPackageFloatingVersionsEnabled>$(CentralPackageFloatingVersionsEnabled)</CentralPackageFloatingVersionsEnabled>
         <CentralPackageVersionOverrideEnabled>$(CentralPackageVersionOverrideEnabled)</CentralPackageVersionOverrideEnabled>
         <CentralPackageTransitivePinningEnabled>$(CentralPackageTransitivePinningEnabled)</CentralPackageTransitivePinningEnabled>
         <NuGetAudit>$(NuGetAudit)</NuGetAudit>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -164,15 +164,11 @@ namespace NuGet.CommandLine.XPlat
                 packageReferenceArgs.Logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageVersions_MissingPackageVersion, string.Join(";", packageReferencedDependenciesWithoutCentralVersionDefined.Select(d => d.Name))));
                 return false;
             }
-
-            if (!packageSpec.RestoreMetadata.CentralPackageFloatingVersionsEnabled)
+            var floatingVersionDependencies = packageSpec.TargetFrameworks.SelectMany(tfm => tfm.CentralPackageVersions.Values).Where(cpv => cpv.VersionRange.IsFloating);
+            if (floatingVersionDependencies.Any())
             {
-                var floatingVersionDependencies = packageSpec.TargetFrameworks.SelectMany(tfm => tfm.CentralPackageVersions.Values).Where(cpv => cpv.VersionRange.IsFloating);
-                if (floatingVersionDependencies.Any())
-                {
-                    packageReferenceArgs.Logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageVersions_FloatingVersionsAreNotAllowed));
-                    return false;
-                }
+                packageReferenceArgs.Logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageVersions_FloatingVersionsAreNotAllowed));
+                return false;
             }
 
             // PackageVersion should not be defined outside the project file.

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 #nullable enable
-~static NuGet.Commands.MSBuildRestoreUtility.GetCentralPackageManagementSettings(NuGet.Commands.IMSBuildItem projectSpecItem, NuGet.ProjectModel.ProjectStyle? projectStyle) -> (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled)

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 #nullable enable
-~static NuGet.Commands.MSBuildRestoreUtility.GetCentralPackageManagementSettings(NuGet.Commands.IMSBuildItem projectSpecItem, NuGet.ProjectModel.ProjectStyle? projectStyle) -> (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled)

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 #nullable enable
-~static NuGet.Commands.MSBuildRestoreUtility.GetCentralPackageManagementSettings(NuGet.Commands.IMSBuildItem projectSpecItem, NuGet.ProjectModel.ProjectStyle? projectStyle) -> (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -598,17 +598,12 @@ namespace NuGet.Commands
                 await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1010, string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageVersions_MissingPackageVersion, string.Join(";", packageReferencedDependenciesWithoutCentralVersionDefined.Select(d => d.Name)))));
                 return false;
             }
-
-            if (!restoreRequest.Project.RestoreMetadata.CentralPackageFloatingVersionsEnabled)
+            var floatingVersionDependencies = _request.Project.TargetFrameworks.SelectMany(tfm => tfm.CentralPackageVersions.Values).Where(cpv => cpv.VersionRange.IsFloating);
+            if (floatingVersionDependencies.Any())
             {
-                var floatingVersionDependencies = _request.Project.TargetFrameworks.SelectMany(tfm => tfm.CentralPackageVersions.Values).Where(cpv => cpv.VersionRange.IsFloating);
-                if (floatingVersionDependencies.Any())
-                {
-                    await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1011, Strings.Error_CentralPackageVersions_FloatingVersionsAreNotAllowed));
-                    return false;
-                }
+                await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1011, Strings.Error_CentralPackageVersions_FloatingVersionsAreNotAllowed));
+                return false;
             }
-
             return true;
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -161,7 +161,7 @@ namespace NuGet.Commands
             {
                 ProjectStyle restoreType = GetProjectStyle(specItem);
 
-                (bool isCentralPackageManagementEnabled, bool isCentralPackageVersionOverrideDisabled, bool isCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled) = GetCentralPackageManagementSettings(specItem, restoreType);
+                (bool isCentralPackageManagementEnabled, bool isCentralPackageVersionOverrideDisabled, bool isCentralPackageTransitivePinningEnabled) = GetCentralPackageManagementSettings(specItem, restoreType);
 
                 // Get base spec
                 if (restoreType == ProjectStyle.ProjectJson)
@@ -296,7 +296,6 @@ namespace NuGet.Commands
 
                 result.RestoreMetadata.CentralPackageVersionsEnabled = isCentralPackageManagementEnabled;
                 result.RestoreMetadata.CentralPackageVersionOverrideDisabled = isCentralPackageVersionOverrideDisabled;
-                result.RestoreMetadata.CentralPackageFloatingVersionsEnabled = isCentralPackageFloatingVersionsEnabled;
                 result.RestoreMetadata.CentralPackageTransitivePinningEnabled = isCentralPackageTransitivePinningEnabled;
             }
 
@@ -958,7 +957,7 @@ namespace NuGet.Commands
             return s;
         }
 
-        internal static bool IsPropertyFalse(IMSBuildItem item, string propertyName, bool defaultValue = false)
+        private static bool IsPropertyFalse(IMSBuildItem item, string propertyName, bool defaultValue = false)
         {
             string value = item.GetProperty(propertyName);
 
@@ -970,7 +969,7 @@ namespace NuGet.Commands
             return string.Equals(value, bool.FalseString, StringComparison.OrdinalIgnoreCase);
         }
 
-        internal static bool IsPropertyTrue(IMSBuildItem item, string propertyName, bool defaultValue = false)
+        private static bool IsPropertyTrue(IMSBuildItem item, string propertyName, bool defaultValue = false)
         {
             string value = item.GetProperty(propertyName);
 
@@ -1056,23 +1055,11 @@ namespace NuGet.Commands
             return restoreType;
         }
 
-        /// <summary>
-        /// Determines the current settings for central package management for the specified project.
-        /// </summary>
-        /// <param name="projectSpecItem">The <see cref="IMSBuildItem" /> to get the central package management settings from.</param>
-        /// <param name="projectStyle">The <see cref="ProjectStyle?" /> of the specified project.  Specify <see langword="null" /> when the project does not define a restore style.</param>
-        /// <returns>A <see cref="Tuple{T1, T2, T3, T4}" /> containing values indicating whether or not central package management is enabled, if the ability to override a package version 
-        public static (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled) GetCentralPackageManagementSettings(IMSBuildItem projectSpecItem, ProjectStyle? projectStyle)
+        internal static (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled) GetCentralPackageManagementSettings(IMSBuildItem projectSpecItem, ProjectStyle projectStyle)
         {
-            if (!projectStyle.HasValue || (projectStyle.Value == ProjectStyle.PackageReference))
-            {
-                return (IsPropertyTrue(projectSpecItem, "_CentralPackageVersionsEnabled") && projectStyle == ProjectStyle.PackageReference,
+            return (IsPropertyTrue(projectSpecItem, "_CentralPackageVersionsEnabled") && projectStyle == ProjectStyle.PackageReference,
                 IsPropertyFalse(projectSpecItem, "CentralPackageVersionOverrideEnabled"),
-                IsPropertyTrue(projectSpecItem, "CentralPackageTransitivePinningEnabled"),
-                IsPropertyTrue(projectSpecItem, "CentralPackageFloatingVersionsEnabled"));
-            }
-
-            return (false, false, false, false);
+                IsPropertyTrue(projectSpecItem, "CentralPackageTransitivePinningEnabled"));
         }
 
         private static void AddCentralPackageVersions(PackageSpec spec, IEnumerable<IMSBuildItem> items)

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
@@ -59,6 +59,5 @@ namespace NuGet.ProjectManagement
         public const string NuGetAudit = nameof(NuGetAudit);
         public const string NuGetAuditLevel = nameof(NuGetAuditLevel);
         public const string NuGetAuditMode = nameof(NuGetAuditMode);
-        public const string CentralPackageFloatingVersionsEnabled = nameof(CentralPackageFloatingVersionsEnabled);
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 #nullable enable
-~const NuGet.ProjectManagement.ProjectBuildProperties.CentralPackageFloatingVersionsEnabled = "CentralPackageFloatingVersionsEnabled" -> string

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -902,7 +902,6 @@ namespace NuGet.ProjectModel
         private static void ReadMSBuildMetadata(JsonTextReader jsonReader, PackageSpec packageSpec)
         {
             var centralPackageVersionsManagementEnabled = false;
-            var centralPackageFloatingVersionsEnabled = false;
             var centralPackageVersionOverrideDisabled = false;
             var CentralPackageTransitivePinningEnabled = false;
             List<string> configFilePaths = null;
@@ -934,10 +933,6 @@ namespace NuGet.ProjectModel
                 {
                     case "centralPackageVersionsManagementEnabled":
                         centralPackageVersionsManagementEnabled = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);
-                        break;
-
-                    case "centralPackageFloatingVersionsEnabled":
-                        centralPackageFloatingVersionsEnabled = ReadNextTokenAsBoolOrFalse(jsonReader, packageSpec.FilePath);
                         break;
 
                     case "centralPackageVersionOverrideDisabled":
@@ -1136,7 +1131,6 @@ namespace NuGet.ProjectModel
             }
 
             msbuildMetadata.CentralPackageVersionsEnabled = centralPackageVersionsManagementEnabled;
-            msbuildMetadata.CentralPackageFloatingVersionsEnabled = centralPackageFloatingVersionsEnabled;
             msbuildMetadata.CentralPackageVersionOverrideDisabled = centralPackageVersionOverrideDisabled;
             msbuildMetadata.CentralPackageTransitivePinningEnabled = CentralPackageTransitivePinningEnabled;
             msbuildMetadata.RestoreAuditProperties = auditProperties;

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -176,7 +176,6 @@ namespace NuGet.ProjectModel
             SetValueIfTrue(writer, "validateRuntimeAssets", msbuildMetadata.ValidateRuntimeAssets);
             SetValueIfTrue(writer, "skipContentFileWrite", msbuildMetadata.SkipContentFileWrite);
             SetValueIfTrue(writer, "centralPackageVersionsManagementEnabled", msbuildMetadata.CentralPackageVersionsEnabled);
-            SetValueIfTrue(writer, "centralPackageFloatingVersionsEnabled", msbuildMetadata.CentralPackageFloatingVersionsEnabled);
             SetValueIfTrue(writer, "centralPackageVersionOverrideDisabled", msbuildMetadata.CentralPackageVersionOverrideDisabled);
             SetValueIfTrue(writer, "CentralPackageTransitivePinningEnabled", msbuildMetadata.CentralPackageTransitivePinningEnabled);
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -123,11 +123,6 @@ namespace NuGet.ProjectModel
         /// </summary>
         public bool CentralPackageVersionOverrideDisabled { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value indicating whether or not floating versions are allowed when using central package management (CPM).
-        /// </summary>
-        public bool CentralPackageFloatingVersionsEnabled { get; set; }
-
         public bool CentralPackageTransitivePinningEnabled { get; set; }
 
         public RestoreAuditProperties RestoreAuditProperties { get; set; }
@@ -158,7 +153,6 @@ namespace NuGet.ProjectModel
             hashCode.AddObject(ProjectWideWarningProperties);
             hashCode.AddObject(RestoreLockProperties);
             hashCode.AddObject(CentralPackageVersionsEnabled);
-            hashCode.AddObject(CentralPackageFloatingVersionsEnabled);
             hashCode.AddObject(CentralPackageVersionOverrideDisabled);
             hashCode.AddObject(CentralPackageTransitivePinningEnabled);
             hashCode.AddObject(RestoreAuditProperties);
@@ -204,7 +198,6 @@ namespace NuGet.ProjectModel
                    EqualityUtility.EqualsWithNullCheck(ProjectWideWarningProperties, other.ProjectWideWarningProperties) &&
                    EqualityUtility.EqualsWithNullCheck(RestoreLockProperties, other.RestoreLockProperties) &&
                    EqualityUtility.EqualsWithNullCheck(CentralPackageVersionsEnabled, other.CentralPackageVersionsEnabled) &&
-                   EqualityUtility.EqualsWithNullCheck(CentralPackageFloatingVersionsEnabled, other.CentralPackageFloatingVersionsEnabled) &&
                    EqualityUtility.EqualsWithNullCheck(CentralPackageVersionOverrideDisabled, other.CentralPackageVersionOverrideDisabled) &&
                    EqualityUtility.EqualsWithNullCheck(CentralPackageTransitivePinningEnabled, other.CentralPackageTransitivePinningEnabled) &&
                    RestoreAuditProperties == other.RestoreAuditProperties;
@@ -240,7 +233,6 @@ namespace NuGet.ProjectModel
             clone.ProjectWideWarningProperties = ProjectWideWarningProperties?.Clone();
             clone.RestoreLockProperties = RestoreLockProperties?.Clone();
             clone.CentralPackageVersionsEnabled = CentralPackageVersionsEnabled;
-            clone.CentralPackageFloatingVersionsEnabled = CentralPackageFloatingVersionsEnabled;
             clone.CentralPackageVersionOverrideDisabled = CentralPackageVersionOverrideDisabled;
             clone.CentralPackageTransitivePinningEnabled = CentralPackageTransitivePinningEnabled;
             clone.RestoreAuditProperties = RestoreAuditProperties?.Clone();

--- a/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-NuGet.ProjectModel.ProjectRestoreMetadata.CentralPackageFloatingVersionsEnabled.get -> bool
-NuGet.ProjectModel.ProjectRestoreMetadata.CentralPackageFloatingVersionsEnabled.set -> void

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -1967,7 +1967,7 @@ namespace NuGet.SolutionRestoreManager.Test
         public void ToPackageSpec_CentralVersions_AreAddedToThePackageSpecIfCPVMIsEnabled()
         {
             // Arrange
-            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "projectC", Guid.NewGuid().ToString());
+            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "prjectC", Guid.NewGuid().ToString());
             var emptyReferenceItems = Array.Empty<VsReferenceItem>();
 
             var targetFrameworks = new VsTargetFrameworkInfo3[] { new VsTargetFrameworkInfo3(
@@ -2009,7 +2009,7 @@ namespace NuGet.SolutionRestoreManager.Test
         public void ToPackageSpec_CentralVersions_CPVMIsEnabled_NoPackageVersions()
         {
             // Arrange
-            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "projectC", Guid.NewGuid().ToString());
+            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "prjectC", Guid.NewGuid().ToString());
             var emptyReferenceItems = Array.Empty<VsReferenceItem>();
 
             var targetFrameworks = new VsTargetFrameworkInfo3[] { new VsTargetFrameworkInfo3(
@@ -2042,7 +2042,7 @@ namespace NuGet.SolutionRestoreManager.Test
         public void ToPackageSpec_CentralVersions_AreNotAddedToThePackageSpecIfCPVMIsNotEnabled(string packRefVersion, string managePackageVersionsCentrally)
         {
             // Arrange
-            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "projectC", Guid.NewGuid().ToString());
+            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "prjectC", Guid.NewGuid().ToString());
             var emptyReferenceItems = Array.Empty<VsReferenceItem>();
             var packageReferenceProperties = packRefVersion == null ?
                 new VsReferenceProperties() :
@@ -2090,7 +2090,7 @@ namespace NuGet.SolutionRestoreManager.Test
         public void ToPackageSpec_CentralVersionOverride_CanBeDisabled(string isCentralPackageVersionOverrideEnabled, bool expected)
         {
             // Arrange
-            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "projectC", Guid.NewGuid().ToString());
+            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "prjectC", Guid.NewGuid().ToString());
             var emptyReferenceItems = Array.Empty<VsReferenceItem>();
 
             var targetFrameworks = new VsTargetFrameworkInfo3[] { new VsTargetFrameworkInfo3(
@@ -2151,7 +2151,7 @@ namespace NuGet.SolutionRestoreManager.Test
         public void ToPackageSpec_TransitiveDependencyPinning_CanBeEnabled(string CentralPackageTransitivePinningEnabled, bool expected)
         {
             // Arrange
-            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "projectC", Guid.NewGuid().ToString());
+            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "prjectC", Guid.NewGuid().ToString());
             var emptyReferenceItems = Array.Empty<VsReferenceItem>();
 
             var targetFrameworks = new VsTargetFrameworkInfo3[] { new VsTargetFrameworkInfo3(
@@ -2180,49 +2180,6 @@ namespace NuGet.SolutionRestoreManager.Test
             else
             {
                 Assert.False(result.RestoreMetadata.CentralPackageTransitivePinningEnabled);
-            }
-        }
-
-        [Theory]
-        [InlineData(null, false)]
-        [InlineData("", false)]
-        [InlineData(" ", false)]
-        [InlineData("invalid", false)]
-        [InlineData("false", false)]
-        [InlineData("true", true)]
-        [InlineData("           true    ", true)]
-        public void ToPackageSpec_CentralPackageFloatingVersions_CanBeEnabled(string centralPackageFloatingVersionsEnabled, bool expected)
-        {
-            // Arrange
-            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "projectC", Guid.NewGuid().ToString());
-            var emptyReferenceItems = Array.Empty<VsReferenceItem>();
-
-            var targetFrameworks = new VsTargetFrameworkInfo3[] { new VsTargetFrameworkInfo3(
-                targetFrameworkMoniker: CommonFrameworks.NetStandard20.ToString(),
-                packageReferences: new[] { new VsReferenceItem("foo", new VsReferenceProperties()) },
-                projectReferences: emptyReferenceItems,
-                packageDownloads: emptyReferenceItems,
-                frameworkReferences: emptyReferenceItems,
-                projectProperties: ProjectRestoreInfoBuilder.GetTargetFrameworkProperties(CommonFrameworks.NetStandard20).Concat(new VsProjectProperty[]
-                {
-                    new VsProjectProperty(ProjectBuildProperties.ManagePackageVersionsCentrally, "true"),
-                    new VsProjectProperty(ProjectBuildProperties.CentralPackageFloatingVersionsEnabled, centralPackageFloatingVersionsEnabled),
-                }),
-                centralPackageVersions: Array.Empty<IVsReferenceItem>())
-            };
-
-            // Act
-            PackageSpec result = VsSolutionRestoreService.ToPackageSpec(projectName, targetFrameworks, CommonFrameworks.NetStandard20.ToString(), string.Empty);
-
-            // Assert
-
-            if (expected)
-            {
-                Assert.True(result.RestoreMetadata.CentralPackageFloatingVersionsEnabled);
-            }
-            else
-            {
-                Assert.False(result.RestoreMetadata.CentralPackageFloatingVersionsEnabled);
             }
         }
 
@@ -2276,7 +2233,7 @@ namespace NuGet.SolutionRestoreManager.Test
         public void ToPackageSpec_TargetFrameworkWithAlias_DefinesAliasCorrectly()
         {
             // Arrange
-            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "projectC", Guid.NewGuid().ToString());
+            ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "prjectC", Guid.NewGuid().ToString());
             var emptyReferenceItems = Array.Empty<VsReferenceItem>();
             var packageReferenceProperties = new VsReferenceProperties();
 

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
@@ -762,7 +762,7 @@ namespace NuGet.Build.Tasks.Console.Test
             });
 
             // Act
-            var result = MSBuildRestoreUtility.GetCentralPackageManagementSettings(project, projectStyle).IsEnabled;
+            var result = MSBuildStaticGraphRestore.GetCentralPackageManagementSettings(project, projectStyle).IsEnabled;
 
             // Assert
             Assert.Equal(expected, result);
@@ -786,7 +786,7 @@ namespace NuGet.Build.Tasks.Console.Test
                 });
 
             // Act
-            var result = MSBuildRestoreUtility.GetCentralPackageManagementSettings(project, ProjectStyle.PackageReference).IsVersionOverrideDisabled;
+            var result = MSBuildStaticGraphRestore.GetCentralPackageManagementSettings(project, ProjectStyle.PackageReference).IsVersionOverrideDisabled;
 
             // Assert
             Assert.Equal(disabled, result);
@@ -810,7 +810,7 @@ namespace NuGet.Build.Tasks.Console.Test
                 });
 
             // Act
-            var result = MSBuildRestoreUtility.GetCentralPackageManagementSettings(project, ProjectStyle.PackageReference).IsCentralPackageTransitivePinningEnabled;
+            var result = MSBuildStaticGraphRestore.GetCentralPackageManagementSettings(project, ProjectStyle.PackageReference).IsCentralPackageTransitivePinningEnabled;
 
             // Assert
             Assert.Equal(enabled, result);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -3725,9 +3725,11 @@ namespace NuGet.Commands.Test
         [Theory]
         [InlineData(null, false)]
         [InlineData("", false)]
+        [InlineData("                     ", false)]
         [InlineData("true", false)]
         [InlineData("invalid", false)]
         [InlineData("false", true)]
+        [InlineData("           false    ", true)]
         public void MSBuildRestoreUtility_GetPackageSpec_CPVM_VersionOverrideCanBeDisabled(string isCentralPackageVersionOverrideEnabled, bool disabled)
         {
             var projectName = "alegacycpvm";
@@ -3823,111 +3825,6 @@ namespace NuGet.Commands.Test
                 else
                 {
                     Assert.False(project1Spec.RestoreMetadata.CentralPackageVersionOverrideDisabled);
-                }
-            }
-        }
-
-        [Theory]
-        [InlineData(null, false)]
-        [InlineData("                     ", false)]
-        [InlineData("false", false)]
-        [InlineData("invalid", false)]
-        [InlineData("true", true)]
-        public void MSBuildRestoreUtility_GetPackageSpec_CPVM_FloatingVersionsCanBeEnabled(string isCentralPackageFloatingVersionsEnabled, bool enabled)
-        {
-            var projectName = "alegacycpvm";
-            using (var workingDir = TestDirectory.Create())
-            {
-                // Arrange
-                var projectUniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
-                var project1Root = Path.Combine(workingDir, projectName);
-                var project1Path = Path.Combine(project1Root, $"{projectName}.csproj");
-
-                var items = new List<IDictionary<string, string>>();
-
-                items.Add(new Dictionary<string, string>()
-                {
-                    { "Type", "ProjectSpec" },
-                    { "ProjectName", projectName },
-                    { "ProjectStyle", "PackageReference" },
-                    { "ProjectUniqueName", projectUniqueName },
-                    { "ProjectPath", project1Path },
-                    { "_CentralPackageVersionsEnabled", "true"},
-                    { "CentralPackageFloatingVersionsEnabled", isCentralPackageFloatingVersionsEnabled }
-                });
-
-                items.Add(new Dictionary<string, string>()
-                {
-                    { "Type", "TargetFrameworkInformation" },
-                    { "AssetTargetFallback", "" },
-                    { "PackageTargetFallback", "" },
-                    { "ProjectUniqueName", projectUniqueName },
-                    { "TargetFramework", "net472" },
-                    { "TargetFrameworkIdentifier", ".NETFramework" },
-                    { "TargetFrameworkVersion", "v4.7.2" },
-                    { "TargetFrameworkMoniker", ".NETFramework,Version=v4.7.2" },
-                    { "TargetPlatformIdentifier", "" },
-                    { "TargetPlatformMoniker", "" },
-                    { "TargetPlatformVersion", "" },
-                });
-
-                // Package reference
-                // No TargetFrameworks metadata
-                items.Add(new Dictionary<string, string>()
-                {
-                    { "Type", "Dependency" },
-                    { "ProjectUniqueName", projectUniqueName },
-                    { "Id", "x" },
-                    { "IncludeAssets", "build;compile" },
-                    { "CrossTargeting", "true" },
-                });
-
-
-                // Central Version for the package above and another one for a package y
-                items.Add(new Dictionary<string, string>()
-                {
-                    { "Type", "CentralPackageVersion" },
-                    { "ProjectUniqueName", projectUniqueName },
-                    { "Id", "x" },
-                    { "VersionRange", "1.0.0" },
-                });
-                items.Add(new Dictionary<string, string>()
-                {
-                    { "Type", "CentralPackageVersion" },
-                    { "ProjectUniqueName", projectUniqueName },
-                    { "Id", "y" },
-                    { "VersionRange", "2.0.0" },
-                });
-
-                var wrappedItems = items.Select(CreateItems).ToList();
-
-                // Act
-                var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
-                var project1Spec = dgSpec.Projects.Single(e => e.Name == projectName);
-
-                // Assert
-                Assert.Equal(1, project1Spec.TargetFrameworks.Count());
-                Assert.Equal(1, project1Spec.TargetFrameworks.First().Dependencies.Count);
-                Assert.Equal(2, project1Spec.TargetFrameworks.First().CentralPackageVersions.Count);
-
-                Assert.Equal("[1.0.0, )", project1Spec.TargetFrameworks.First().Dependencies[0].LibraryRange.VersionRange.ToNormalizedString());
-                Assert.Equal(LibraryIncludeFlags.Compile | LibraryIncludeFlags.Build, project1Spec.TargetFrameworks.First().Dependencies[0].IncludeType);
-
-                Assert.Equal("x", project1Spec.TargetFrameworks.First().CentralPackageVersions["x"].Name);
-                Assert.Equal("[1.0.0, )", project1Spec.TargetFrameworks.First().CentralPackageVersions["x"].VersionRange.ToNormalizedString());
-
-                Assert.Equal("y", project1Spec.TargetFrameworks.First().CentralPackageVersions["y"].Name);
-                Assert.Equal("[2.0.0, )", project1Spec.TargetFrameworks.First().CentralPackageVersions["y"].VersionRange.ToNormalizedString());
-
-                Assert.True(project1Spec.RestoreMetadata.CentralPackageVersionsEnabled);
-
-                if (enabled)
-                {
-                    Assert.True(project1Spec.RestoreMetadata.CentralPackageFloatingVersionsEnabled);
-                }
-                else
-                {
-                    Assert.False(project1Spec.RestoreMetadata.CentralPackageFloatingVersionsEnabled);
                 }
             }
         }
@@ -4695,47 +4592,6 @@ namespace NuGet.Commands.Test
                 net60Framework.FrameworkName.Profile.Should().Be(profile);
                 net60Framework.FrameworkName.HasPlatform.Should().BeFalse();
             }
-        }
-
-        [Theory]
-        [InlineData(null, false)]
-        [InlineData("", false)]
-        [InlineData("                     ", false)]
-        [InlineData("false", false)]
-        [InlineData("invalid", false)]
-        [InlineData("true", true)]
-        [InlineData("           true    ", true)]
-        public void IsPropertyTrue_ReturnsExpectedValue(string value, bool expected)
-        {
-            const string propertyName = "Property1";
-
-            MSBuildItem item = new("Item1", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                [propertyName] = value
-            });
-
-            MSBuildRestoreUtility.IsPropertyTrue(item, propertyName).Should().Be(expected);
-        }
-
-        [Theory]
-        [InlineData(null, false)]
-        [InlineData("", false)]
-        [InlineData("                     ", false)]
-        [InlineData("false", true)]
-        [InlineData("   false     ", true)]
-        [InlineData("invalid", false)]
-        [InlineData("true", false)]
-        [InlineData("           true    ", false)]
-        public void IsPropertyFalse_ReturnsExpectedValue(string value, bool expected)
-        {
-            const string propertyName = "Property1";
-
-            MSBuildItem item = new("Item1", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                [propertyName] = value
-            });
-
-            MSBuildRestoreUtility.IsPropertyFalse(item, propertyName).Should().Be(expected);
         }
 
         private static IDictionary<string, string> CreateProject(string root, string uniqueName)

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -2996,48 +2996,6 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CentralPackageVersionsEnabled);
         }
 
-        [Theory]
-        [InlineData(null, false)]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void GetPackageSpec_WhenCentralPackageFloatingVersionsEnabledValueIsValid_ReturnsCentralPackageFloatingVersionsEnabled(
-            bool? value,
-            bool expectedValue)
-        {
-            var json = $"{{\"restore\":{{\"centralPackageFloatingVersionsEnabled\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
-
-            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CentralPackageFloatingVersionsEnabled);
-        }
-
-        [Theory]
-        [InlineData(null, false)]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void GetPackageSpec_WhenCentralPackageVersionOverrideDisabledValueIsValid_ReturnsCentralPackageVersionOverrideDisabled(
-            bool? value,
-            bool expectedValue)
-        {
-            var json = $"{{\"restore\":{{\"centralPackageVersionOverrideDisabled\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
-
-            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CentralPackageVersionOverrideDisabled);
-        }
-
-        [Theory]
-        [InlineData(null, false)]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void GetPackageSpec_WhenCentralPackageTransitivePinningEnabledValueIsValid_ReturnsCentralPackageTransitivePinningEnabled(
-            bool? value,
-            bool expectedValue)
-        {
-            var json = $"{{\"restore\":{{\"CentralPackageTransitivePinningEnabled\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
-
-            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CentralPackageTransitivePinningEnabled);
-        }
-
         [Fact]
         public void GetPackageSpec_WhenSourcesValueIsEmptyObject_ReturnsEmptySources()
         {

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTests.cs
@@ -109,7 +109,7 @@ namespace NuGet.ProjectModel.Test
             Assert.NotEqual(originalPackOptions, clone);
             Assert.Equal(originalPackageName, clone.PackageType[0].Name);
 
-            // Arrange again
+            // Set Up again
             originalPackOptions.Mappings.Add("randomString", files);
 
             // Act again
@@ -229,7 +229,7 @@ namespace NuGet.ProjectModel.Test
         //[InlineData("ModifyRestoreSettings", true)] = Not really included in the equals and hash code comparisons
         public void PackageSpecCloneTest(string methodName, bool validateJson)
         {
-            // Arrange
+            // Set up
             var packageSpec = CreatePackageSpec();
             var clonedPackageSpec = packageSpec.Clone();
 
@@ -407,7 +407,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataCloneTest()
         {
-            // Arrange
+            // Set up
             var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
             // Act
 
@@ -421,7 +421,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataCloneChangeSourcesTest()
         {
-            // Arrange
+            // Set up
             var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
 
             // Preconditions
@@ -438,85 +438,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Fact]
-        public void ProjectRestoreMetadataCloneChangeCentralPackageVersionsEnabledTest()
-        {
-            // Arrange
-            var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
-
-            // Preconditions
-            var happyClone = originalProjectRestoreMetadata.Clone();
-            Assert.Equal(originalProjectRestoreMetadata, happyClone);
-            Assert.False(object.ReferenceEquals(originalProjectRestoreMetadata, happyClone));
-
-            // Act
-            originalProjectRestoreMetadata.CentralPackageVersionsEnabled = !originalProjectRestoreMetadata.CentralPackageVersionsEnabled;
-
-            // Assert
-            Assert.NotEqual(originalProjectRestoreMetadata, happyClone);
-            Assert.Equal(originalProjectRestoreMetadata.CentralPackageVersionsEnabled, !happyClone.CentralPackageVersionsEnabled);
-        }
-
-        [Fact]
-        public void ProjectRestoreMetadataCloneChangeCentralPackageFloatingVersionsEnabledTest()
-        {
-            // Arrange
-            var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
-
-            // Preconditions
-            var happyClone = originalProjectRestoreMetadata.Clone();
-            Assert.Equal(originalProjectRestoreMetadata, happyClone);
-            Assert.False(object.ReferenceEquals(originalProjectRestoreMetadata, happyClone));
-
-            // Act
-            originalProjectRestoreMetadata.CentralPackageFloatingVersionsEnabled = !originalProjectRestoreMetadata.CentralPackageFloatingVersionsEnabled;
-
-            // Assert
-            Assert.NotEqual(originalProjectRestoreMetadata, happyClone);
-            Assert.Equal(originalProjectRestoreMetadata.CentralPackageFloatingVersionsEnabled, !happyClone.CentralPackageFloatingVersionsEnabled);
-        }
-
-        [Fact]
-        public void ProjectRestoreMetadataCloneChangeCentralPackageVersionOverrideDisabledTest()
-        {
-            // Arrange
-            var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
-
-            // Preconditions
-            var happyClone = originalProjectRestoreMetadata.Clone();
-            Assert.Equal(originalProjectRestoreMetadata, happyClone);
-            Assert.False(object.ReferenceEquals(originalProjectRestoreMetadata, happyClone));
-
-            // Act
-            originalProjectRestoreMetadata.CentralPackageVersionOverrideDisabled = !originalProjectRestoreMetadata.CentralPackageVersionOverrideDisabled;
-
-            // Assert
-            Assert.NotEqual(originalProjectRestoreMetadata, happyClone);
-            Assert.Equal(originalProjectRestoreMetadata.CentralPackageVersionOverrideDisabled, !happyClone.CentralPackageVersionOverrideDisabled);
-        }
-
-        [Fact]
-        public void ProjectRestoreMetadataCloneChangeCentralPackageTransitivePinningEnabledTest()
-        {
-            // Arrange
-            var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
-
-            // Preconditions
-            var happyClone = originalProjectRestoreMetadata.Clone();
-            Assert.Equal(originalProjectRestoreMetadata, happyClone);
-            Assert.False(object.ReferenceEquals(originalProjectRestoreMetadata, happyClone));
-
-            // Act
-            originalProjectRestoreMetadata.CentralPackageTransitivePinningEnabled = !originalProjectRestoreMetadata.CentralPackageTransitivePinningEnabled;
-
-            // Assert
-            Assert.NotEqual(originalProjectRestoreMetadata, happyClone);
-            Assert.Equal(originalProjectRestoreMetadata.CentralPackageTransitivePinningEnabled, !happyClone.CentralPackageTransitivePinningEnabled);
-        }
-
-        [Fact]
         public void ProjectRestoreMetadataCloneChangeFallbackFoldersTest()
         {
-            // Arrange
+            // Set up
             var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
 
             // Preconditions
@@ -535,7 +459,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataCloneChangeConfigFilePathsTest()
         {
-            // Arrange
+            // Set up
             var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
 
             // Preconditions
@@ -554,7 +478,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataCloneChangeOriginalTargetFrameworksTest()
         {
-            // Arrange
+            // Set up
             var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
 
             // Preconditions
@@ -573,7 +497,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataCloneChangeFilesTest()
         {
-            // Arrange
+            // Set up
             var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
 
             // Preconditions
@@ -592,7 +516,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataCloneChangeProjectWideWarningPropertiesTest()
         {
-            // Arrange
+            // Set up
             var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
 
             // Preconditions
@@ -601,7 +525,7 @@ namespace NuGet.ProjectModel.Test
             Assert.False(object.ReferenceEquals(originalProjectRestoreMetadata, happyClone));
 
             // Act
-            originalProjectRestoreMetadata.ProjectWideWarningProperties.AllWarningsAsErrors = false;
+            originalProjectRestoreMetadata.ProjectWideWarningProperties.AllWarningsAsErrors = false; ;
 
             // Assert
             Assert.NotEqual(originalProjectRestoreMetadata, happyClone);
@@ -611,7 +535,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataFileCloneTest()
         {
-            // Arrange
+            // Set up
             var originalProjectRestoreMetadataFile = new ProjectRestoreMetadataFile("packagePath", "absolutePath");
 
             // Act
@@ -655,7 +579,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreReferenceCloneTest()
         {
-            // Arrange
+            // Set up
             var originalProjectRestoreReference = new ProjectRestoreReference();
             originalProjectRestoreReference.ProjectPath = "Path";
             originalProjectRestoreReference.ProjectUniqueName = "ProjectUniqueName";
@@ -681,7 +605,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreSettingsCloneTest()
         {
-            // Arrange
+            // Set up
             var originalProjectRestoreSettings = CreateProjectRestoreSettings();
 
             // Act
@@ -725,7 +649,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void TargetFrameworkInformationCloneTest()
         {
-            // Arrange
+            // Set up
             var originalTargetFrameworkInformation = CreateTargetFrameworkInformation();
 
             // Act
@@ -807,7 +731,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void WarningPropertiesCloneTest()
         {
-            // Arrange
+            // Set up
             var allWarningsAsErrors = false;
             var noWarn = new HashSet<NuGetLogCode>() { NuGetLogCode.NU1000, NuGetLogCode.NU1500 };
             var warningsAsErrors = new HashSet<NuGetLogCode>() { NuGetLogCode.NU1001, NuGetLogCode.NU1501 };

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreMetadataTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreMetadataTests.cs
@@ -334,60 +334,6 @@ namespace NuGet.ProjectModel.Test
         [InlineData(true, false, false)]
         [InlineData(false, true, false)]
         [InlineData(false, false, true)]
-        public void Equals_WithCentralPackageFloatingVersionsEnabled(bool left, bool right, bool expected)
-        {
-            var leftSide = new ProjectRestoreMetadata
-            {
-                CentralPackageFloatingVersionsEnabled = left
-            };
-            var rightSide = new ProjectRestoreMetadata
-            {
-                CentralPackageFloatingVersionsEnabled = right
-            };
-            AssertEquality(expected, leftSide, rightSide);
-        }
-
-        [Theory]
-        [InlineData(true, true, true)]
-        [InlineData(true, false, false)]
-        [InlineData(false, true, false)]
-        [InlineData(false, false, true)]
-        public void Equals_WithCentralPackageVersionOverrideDisabled(bool left, bool right, bool expected)
-        {
-            var leftSide = new ProjectRestoreMetadata
-            {
-                CentralPackageVersionOverrideDisabled = left
-            };
-            var rightSide = new ProjectRestoreMetadata
-            {
-                CentralPackageVersionOverrideDisabled = right
-            };
-            AssertEquality(expected, leftSide, rightSide);
-        }
-
-        [Theory]
-        [InlineData(true, true, true)]
-        [InlineData(true, false, false)]
-        [InlineData(false, true, false)]
-        [InlineData(false, false, true)]
-        public void Equals_WithCentralPackageTransitivePinningEnabled(bool left, bool right, bool expected)
-        {
-            var leftSide = new ProjectRestoreMetadata
-            {
-                CentralPackageTransitivePinningEnabled = left
-            };
-            var rightSide = new ProjectRestoreMetadata
-            {
-                CentralPackageTransitivePinningEnabled = right
-            };
-            AssertEquality(expected, leftSide, rightSide);
-        }
-
-        [Theory]
-        [InlineData(true, true, true)]
-        [InlineData(true, false, false)]
-        [InlineData(false, true, false)]
-        [InlineData(false, false, true)]
         public void Equals_WithSkipContentFileWrite(bool left, bool right, bool expected)
         {
             var leftSide = new ProjectRestoreMetadata
@@ -633,41 +579,6 @@ namespace NuGet.ProjectModel.Test
         [InlineData(true, false, false)]
         [InlineData(false, true, false)]
         [InlineData(false, false, true)]
-        public void HashCode_WithCentralPackageVersionOverrideDisabled(bool left, bool right, bool expected)
-        {
-            var leftSide = new ProjectRestoreMetadata
-            {
-                CentralPackageVersionOverrideDisabled = left
-            };
-            var rightSide = new ProjectRestoreMetadata
-            {
-                CentralPackageVersionOverrideDisabled = right
-            };
-            AssertHashCode(expected, leftSide, rightSide);
-        }
-        [Theory]
-        [InlineData(true, true, true)]
-        [InlineData(true, false, false)]
-        [InlineData(false, true, false)]
-        [InlineData(false, false, true)]
-        public void HashCode_WithCentralPackageTransitivePinningEnabled(bool left, bool right, bool expected)
-        {
-            var leftSide = new ProjectRestoreMetadata
-            {
-                CentralPackageTransitivePinningEnabled = left
-            };
-            var rightSide = new ProjectRestoreMetadata
-            {
-                CentralPackageTransitivePinningEnabled = right
-            };
-            AssertHashCode(expected, leftSide, rightSide);
-        }
-
-        [Theory]
-        [InlineData(true, true, true)]
-        [InlineData(true, false, false)]
-        [InlineData(false, true, false)]
-        [InlineData(false, false, true)]
         public void HashCode_WithCentralPackageVersionsEnabled(bool left, bool right, bool expected)
         {
             var leftSide = new ProjectRestoreMetadata
@@ -677,24 +588,6 @@ namespace NuGet.ProjectModel.Test
             var rightSide = new ProjectRestoreMetadata
             {
                 CentralPackageVersionsEnabled = right
-            };
-            AssertHashCode(expected, leftSide, rightSide);
-        }
-
-        [Theory]
-        [InlineData(true, true, true)]
-        [InlineData(true, false, false)]
-        [InlineData(false, true, false)]
-        [InlineData(false, false, true)]
-        public void HashCode_WithCentralPackageFloatingVersionsEnabled(bool left, bool right, bool expected)
-        {
-            var leftSide = new ProjectRestoreMetadata
-            {
-                CentralPackageFloatingVersionsEnabled = left
-            };
-            var rightSide = new ProjectRestoreMetadata
-            {
-                CentralPackageFloatingVersionsEnabled = right
             };
             AssertHashCode(expected, leftSide, rightSide);
         }


### PR DESCRIPTION
This reverts commit 8bc8c9a2d55b13d033b14482c2beb4722f636c5b.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2592

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This reverts https://github.com/NuGet/NuGet.Client/pull/5440 because during VS insertion DDRITs is flagging that there are new `ArgumentException`s being thrown.  I believe its because this change does not explicitly set the `CentralPackageFloatingVersionsEnabled` property and the [EnvDTE.Properties.Item()](https://learn.microsoft.com/en-us/dotnet/api/envdte.properties.item?view=visualstudiosdk-2022#remarks) method then throws an [ArgumentException](https://github.com/NuGet/NuGet.Client/blob/39ea8e8081541fb1eb4702a5546e12f81fcad34d/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs#L114-L117)which we catch and treat as `null`.

If this unblocks insertions, I can bring the change back by either updating the baseline during insertion or explicitly setting a value in for the `CentralPackageFloatingVersionsEnabled` property in `NuGet.props`.


```
>git revert 8bc8c9a2d55b13d033b14482c2beb4722f636c5b
Auto-merging src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
Auto-merging src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
Auto-merging test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
[dev-jeffkl-revert-8bc8c9a2d55b13d033b14482c2beb4722f636c5b b5f308e2c] Revert "Add option to enable floating versions in CPM (#5440)"
 24 files changed, 75 insertions(+), 543 deletions(-)
```
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
