### PR TITLE
Hide vulnerabilities filter for Solution Browse tab

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -135,7 +135,6 @@ namespace NuGet.PackageManagement.UI
             if (_topPanel.IsSolution)
             {
                 _topPanel.CreateAndAddConsolidateTab();
-                _topPanel.CheckBoxVulnerabilities.Visibility = Visibility.Hidden;
             }
 
             _settingsKey = await GetSettingsKeyAsync(CancellationToken.None);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -135,6 +135,7 @@ namespace NuGet.PackageManagement.UI
             if (_topPanel.IsSolution)
             {
                 _topPanel.CreateAndAddConsolidateTab();
+                _topPanel.CheckBoxVulnerabilities.Visibility = Visibility.Hidden;
             }
 
             _settingsKey = await GetSettingsKeyAsync(CancellationToken.None);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
@@ -244,7 +244,7 @@
           VerticalContentAlignment="Center"
           Checked="_checkboxVulnerabilities_Checked"
           Unchecked="_checkboxVulnerabilities_Unchecked"
-          Visibility="Visible"
+          Visibility="Hidden"
           IsChecked="False">
           <TextBlock Text="{x:Static nuget:Resources.Checkbox_Show_Vulnerable_Only}" />
         </CheckBox>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12974

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
PM UI remembers the last tab you had open before closing it. If you open Solution PM UI, change to Browse tab and close it. Next time you open Solution PM UI it will be in the Browse tab, current implementation of the filter is not considering this.

I changed the Filter to be hidden by default and change according to the current tab. The funcitons that handles the visibility of the filter is `TabsPackageManagement_SelectionChanged` which is called when the UI is created and when we change tab.

When creating the UI `CheckBoxVulnerabilities`, the filter, is null so we cannot change the visibility here, so we rely on `TabsPackageManagement_SelectionChanged` being called again to update the visibility. Fortunately (or unfortunately) when the Tab is not Browse, `TabsPackageManagement_SelectionChanged` is called twice because first we create the UI with the tab selected to Browse and then switch the selection to the actual Tab.
 
![vulnerabilities-filter-12974](https://github.com/NuGet/NuGet.Client/assets/43253759/60a9a9b1-0d06-4f06-9f8f-3e6ca6489f52)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. --> UI

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
