### PR TITLE
Stop enumerating MSBuild item metadata names in static graph-based restore

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildItemBase.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildItemBase.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using NuGet.Commands;
 
 namespace NuGet.Build.Tasks.Console
@@ -15,7 +17,15 @@ namespace NuGet.Build.Tasks.Console
         public virtual string Identity { get; }
 
         /// <inheritdoc cref="IMSBuildItem.Properties" />
-        public virtual IReadOnlyList<string> Properties { get; }
+        public IReadOnlyList<string> Properties
+        {
+            get
+            {
+                Debug.Fail("This property should not be accessed.  Calculating the names of the item metadata allocates a new list and can cause performance issues.  Use GetProperty(string) instead and check if the value is null or whitespace.");
+
+                return Array.Empty<string>();
+            }
+        }
 
         /// <inheritdoc cref="IMSBuildItem.GetProperty(string)" />
         public string GetProperty(string property)

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildItemBase.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildItemBase.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using NuGet.Commands;
 
 namespace NuGet.Build.Tasks.Console
@@ -16,16 +15,9 @@ namespace NuGet.Build.Tasks.Console
         /// <inheritdoc cref="IMSBuildItem.Identity" />
         public virtual string Identity { get; }
 
+        [Obsolete("This property should not be accessed.  Calculating the names of the item metadata allocates a new list and can cause performance issues.  Use GetProperty(string) instead and check if the value is null or whitespace.")]
         /// <inheritdoc cref="IMSBuildItem.Properties" />
-        public IReadOnlyList<string> Properties
-        {
-            get
-            {
-                Debug.Fail("This property should not be accessed.  Calculating the names of the item metadata allocates a new list and can cause performance issues.  Use GetProperty(string) instead and check if the value is null or whitespace.");
-
-                return Array.Empty<string>();
-            }
-        }
+        public IReadOnlyList<string> Properties => throw new NotSupportedException();
 
         /// <inheritdoc cref="IMSBuildItem.GetProperty(string)" />
         public string GetProperty(string property)

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildProjectItemInstance.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildProjectItemInstance.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Build.Execution;
 
 namespace NuGet.Build.Tasks.Console
@@ -18,8 +16,6 @@ namespace NuGet.Build.Tasks.Console
         /// </summary>
         private readonly ProjectItemInstance _projectItemInstance;
 
-        private readonly IReadOnlyList<string> _metadataNames;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MSBuildProjectItemInstance" /> class.
         /// </summary>
@@ -27,12 +23,9 @@ namespace NuGet.Build.Tasks.Console
         public MSBuildProjectItemInstance(ProjectItemInstance projectItemInstance)
         {
             _projectItemInstance = projectItemInstance ?? throw new ArgumentNullException(nameof(projectItemInstance));
-            _metadataNames = _projectItemInstance.MetadataNames.ToList();
         }
 
         public override string Identity => _projectItemInstance.EvaluatedInclude;
-
-        public override IReadOnlyList<string> Properties => _metadataNames;
 
         /// <inheritdoc cref="MSBuildItemBase.GetPropertyValue(string)" />
         protected override string GetPropertyValue(string name) => _projectItemInstance.GetMetadataValue(name);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13049

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
The `MSBuildItemBase` object is just an implementation of `IMSBuildItem` which is supposed to implement the `Properties` property.  However, this code path does not need access to the list of item metadata so it's causing unnecessary allocation.  I also added a `Debug.Fail()` to prevent usage of it since its required to implement the member.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - No need to test this since its not actually used but the constructor is
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
