### PR TITLE
switch dictionary reference to no longer use Add to avoid concurrent …

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagService.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Microsoft.Internal.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Shell;
 using NuGet.Common;
 
@@ -44,8 +45,11 @@ namespace NuGet.VisualStudio
             {
                 var featureFlagService = await _ivsFeatureFlags.GetValueAsync();
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                featureEnabled = featureFlagService.IsFeatureEnabled(featureFlag.Name, defaultValue: featureFlag.DefaultState);
-                _featureFlagCache[featureFlag.Name] = featureEnabled;
+                if (!_featureFlagCache.TryGetValue(featureFlag.Name, out featureEnabled))
+                {
+                    featureEnabled = featureFlagService.IsFeatureEnabled(featureFlag.Name, defaultValue: featureFlag.DefaultState);
+                    _featureFlagCache.TryAdd(featureFlag.Name, featureEnabled);
+                }
             }
             return !isFeatureForcedDisabled && (isFeatureForcedEnabled || featureEnabled);
         }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagService.cs
@@ -45,7 +45,7 @@ namespace NuGet.VisualStudio
                 var featureFlagService = await _ivsFeatureFlags.GetValueAsync();
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 featureEnabled = featureFlagService.IsFeatureEnabled(featureFlag.Name, defaultValue: featureFlag.DefaultState);
-                _featureFlagCache.Add(featureFlag.Name, featureEnabled);
+                _featureFlagCache[featureFlag.Name] = featureEnabled;
             }
             return !isFeatureForcedDisabled && (isFeatureForcedEnabled || featureEnabled);
         }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagService.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Microsoft.Internal.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Shell;
 using NuGet.Common;
 
@@ -48,7 +47,7 @@ namespace NuGet.VisualStudio
                 if (!_featureFlagCache.TryGetValue(featureFlag.Name, out featureEnabled))
                 {
                     featureEnabled = featureFlagService.IsFeatureEnabled(featureFlag.Name, defaultValue: featureFlag.DefaultState);
-                    _featureFlagCache.TryAdd(featureFlag.Name, featureEnabled);
+                    _featureFlagCache[featureFlag.Name] = featureEnabled;
                 }
             }
             return !isFeatureForcedDisabled && (isFeatureForcedEnabled || featureEnabled);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13067
Feedback Ticket: https://developercommunity.visualstudio.com/t/Error-reading-git-repository-information/10525656

Regression? Last working version: 

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
When checking if a feature is enabled the NuGetFeatureFlagService was using the ".Add" function. We received DevCom feedback showing that a user was getting an error because the key already existed in the dictionary. 
## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
