### PR TITLE
Filter out transitive packages with no origins when deciding if to show vulnerabilities warning on Installed tab

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1010,9 +1010,9 @@ namespace NuGet.PackageManagement.UI
             }
             else
             {
-                IInstalledAndTransitivePackages installedAndTransitivePackages = await PackageCollection.GetInstalledAndTransitivePackagesAsync(loadContext.ServiceBroker, loadContext.Projects, includeTransitiveOrigins: false, token);
+                IInstalledAndTransitivePackages installedAndTransitivePackages = await PackageCollection.GetInstalledAndTransitivePackagesAsync(loadContext.ServiceBroker, loadContext.Projects, includeTransitiveOrigins: true, token);
                 installedPackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.InstalledPackages);
-                PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.TransitivePackages);
+                PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.TransitivePackages.Where(p => p.TransitiveOrigins.Any()));
                 IEnumerable<PackageVulnerabilityMetadataContextInfo>[] transitivePackageVulnerabilities = await Task.WhenAll(transitivePackageCollection.Select(p => _packageVulnerabilityService.GetVulnerabilityInfoAsync(p, token)));
 
                 foreach (IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfo in transitivePackageVulnerabilities)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13068

Regression? Last working version: N/A

## Description
Vulnerabilities for Transitive Dependencies fetched Installed and Transitive Dependencies when loading or refreshing the PM UI so it can show a warning indicator if a project has transitive vulnerabilities. The issue is that if a project depends on another project and the parent project has any package dependencies, the dependent project considers all those package dependencies to be transitive dependencies, and the way to differentiate them between transitive packages that are because of a project dependency vs. transitive packages that are because of a top-level package that is installed to that project is by checking if it has any transitive origins.

This fix calculates transitive origins for transitive packages and filters out any transitive packages that have no transitive origins, which means they come from a dependent project, so the vulnerability indicator only shows if the project brings in the transitive packages with vulnerabilities, not when the project it depends on does.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

Manually tested with a solution that contains two projects. ProjectA has transitive vulnerabilities, and ProjectB depends on ProjectA. ProjectB has no packages installed. Opened PM UI for ProjectB to verify that the warning indicator does not show up next to the Installed tab. Verified ProjectA does have the indicator.

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
