### PR TITLE
Add three apex test cases for verify packages can be restored by “Restore NuGet Packages” or "building solution"

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -853,7 +853,7 @@ namespace NuGet.Tests.Apex
         [DataRow(ProjectTemplate.NetCoreConsoleApp)]
         [DataRow(ProjectTemplate.ConsoleApplication)]
         [Timeout(DefaultTimeout)]
-        public async Task VerifyRestorePackageByRestoreNuGetPackages(ProjectTemplate projectTemplate)
+        public async Task VerifyRestorePackageByRestoreNuGetPackagesContextMenu(ProjectTemplate projectTemplate)
         {
             // Arrange
             string packageFolderPath;
@@ -893,9 +893,8 @@ namespace NuGet.Tests.Apex
             Directory.Exists(packageFolderPath).Should().BeFalse();
             CommonUtility.RestoreNuGetPackages(VisualStudio, Logger);
 
-            // Assert (It takes some time for the package folder to be back after the solution is restored.)
-            Thread.Sleep(200);
-            Directory.Exists(installedPackageFolderPath).Should().BeTrue();
+            // Assert
+            CommonUtility.WaitForDirectoryExists(installedPackageFolderPath);
         }
 
         [DataTestMethod]

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NuGet.Test.Utility;
@@ -845,6 +847,87 @@ namespace NuGet.Tests.Apex
             CommonUtility.AssertPackageReferenceDoesNotExist(VisualStudio, project, transitivePackageName, Logger);
             uiwindow.AssertPackageNameAndType(TestPackageName, NuGet.VisualStudio.PackageLevel.TopLevel);
             uiwindow.AssertPackageNameAndType(transitivePackageName, NuGet.VisualStudio.PackageLevel.Transitive);
+        }
+
+        [TestMethod]
+        [DataRow(ProjectTemplate.NetCoreConsoleApp)]
+        [DataRow(ProjectTemplate.ConsoleApplication)]
+        [Timeout(DefaultTimeout)]
+        public async Task VerifyRestorePackageByRestoreNuGetPackages(ProjectTemplate projectTemplate)
+        {
+            // Arrange
+            string packageFolderPath;
+            string installedPackageFolderPath;
+
+            await CommonUtility.CreatePackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1);
+
+            NuGetApexTestService nugetTestService = GetNuGetTestService();
+
+            var solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
+            var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, "TestProject");
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
+
+            var uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI(TestPackageName, TestPackageVersionV1);
+            solutionService.Build();
+
+            if (projectTemplate.Equals(ProjectTemplate.NetCoreConsoleApp))
+            {
+                packageFolderPath = _pathContext.UserPackagesFolder;
+                installedPackageFolderPath = Path.Combine(packageFolderPath, TestPackageName);
+            }
+            else
+            {
+                packageFolderPath = _pathContext.PackagesV2;
+                installedPackageFolderPath = Path.Combine(packageFolderPath, "Contoso.A.1.0.0");
+            }
+
+            Directory.Exists(installedPackageFolderPath).Should().BeTrue();
+
+            // Act
+            Directory.Delete(packageFolderPath, true);
+            Directory.Exists(packageFolderPath).Should().BeFalse();
+            CommonUtility.RestoreNuGetPackages(VisualStudio, Logger);
+
+            // Assert (It takes some time for the package folder to be back after the solution is restored.)
+            Thread.Sleep(200);
+            Directory.Exists(installedPackageFolderPath).Should().BeTrue();
+        }
+
+        [DataTestMethod]
+        [Timeout(DefaultTimeout)]
+        public async Task VerifyRestorePackageByBuilding()
+        {
+            // Arrange
+            await CommonUtility.CreatePackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1);
+
+            NuGetApexTestService nugetTestService = GetNuGetTestService();
+
+            SolutionService solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
+            ProjectTestExtension project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V48, "TestProject");
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
+            NuGetUIProjectTestExtension uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI(TestPackageName, TestPackageVersionV1);
+
+            var packageFolderPath = _pathContext.PackagesV2;
+            var installedPackageFolderPath = Path.Combine(packageFolderPath, "Contoso.A.1.0.0");
+            Directory.Exists(installedPackageFolderPath).Should().BeTrue();
+
+            // Act
+            Directory.Delete(packageFolderPath, true);
+            Directory.Exists(packageFolderPath).Should().BeFalse();
+            solutionService.Build();
+
+            // Assert
+            Directory.Exists(installedPackageFolderPath).Should().BeTrue();
         }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
@@ -332,6 +332,13 @@ namespace NuGet.Tests.Apex
             visualStudio.Dte.ExecuteCommand("Project.ManageNuGetPackages");
         }
 
+        internal static void RestoreNuGetPackages(VisualStudioHost visualStudio, ITestLogger logger)
+        {
+            visualStudio.ObjectModel.Solution.WaitForOperationsInProgress(TimeSpan.FromMinutes(3));
+            WaitForCommandAvailable(visualStudio, "ProjectAndSolutionContextMenus.Solution.RestoreNuGetPackages", TimeSpan.FromMinutes(1), logger);
+            visualStudio.Dte.ExecuteCommand("ProjectAndSolutionContextMenus.Solution.RestoreNuGetPackages");
+        }
+
         private static void WaitForCommandAvailable(VisualStudioHost visualStudio, string commandName, TimeSpan timeout, ITestLogger logger)
         {
             WaitForCommandAvailable(visualStudio.Dte.Commands.Item(commandName), timeout, logger);

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
@@ -458,6 +458,15 @@ namespace NuGet.Tests.Apex
                 $"{file.FullName} still existed after {Timeout}.");
         }
 
+        public static void WaitForDirectoryExists(string directoryPath)
+        {
+            Omni.Common.WaitFor.IsTrue(
+                () => !Directory.Exists(directoryPath),
+                Timeout,
+                Interval,
+                $"{directoryPath} still existed after {Timeout}.");
+        }
+
         public static void UIInvoke(Action action)
         {
             var jtf = NuGetUIThreadHelper.JoinableTaskFactory;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2611

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
We want to add below three apex test cases for verify packages can be restored:

1. The first and second test cases is that verify packages can be restored with context menu “Restore NuGet Packages” in an SDK/non-SDK style project.

2. The third case is that verify packages can be restored through building a solution in non-SDK style project.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [X] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [X] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
