### PR TITLE
Output a more debuggable message if a single value isn't specified

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
@@ -226,6 +226,15 @@ namespace NuGet.SolutionRestoreManager {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The property {0} was expected to have a single value across all target frameworks, but instead had the following values: {1}.
+        /// </summary>
+        internal static string PropertyDoesNotHaveSingleValue {
+            get {
+                return ResourceManager.GetString("PropertyDoesNotHaveSingleValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;globalPackagesFolder&apos; from nuget.config file or the environment variable is &apos;{0}&apos;, a relative path and the solution is not saved. Please save your solution or configure a &apos;globalPackagesFolder&apos; which is a full path..
         /// </summary>
         internal static string RelativeGlobalPackagesFolder {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
@@ -190,4 +190,7 @@ To prevent NuGet from restoring packages during build, open the Visual Studio Op
   <data name="SolutionIsNotSaved" xml:space="preserve">
     <value>Solution is not saved. Please save your solution before managing NuGet packages.</value>
   </data>
+  <data name="PropertyDoesNotHaveSingleValue" xml:space="preserve">
+    <value>The property {0} was expected to have a single value across all target frameworks, but instead had the following values: {1}</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -369,7 +369,23 @@ namespace NuGet.SolutionRestoreManager
             string propertyName,
             Func<string, TValue> valueFactory)
         {
-            return GetNonEvaluatedPropertyOrNull(values, propertyName, valueFactory).SingleOrDefault();
+            var distinctValues = GetNonEvaluatedPropertyOrNull(values, propertyName, valueFactory).ToList();
+
+            if (distinctValues.Count == 0)
+            {
+                return default(TValue);
+            }
+            else if (distinctValues.Count == 1)
+            {
+                return distinctValues[0];
+            }
+            else
+            {
+                distinctValues.Sort();
+                var distinctValueStrings = string.Join(", ", distinctValues);
+                var message = string.Format(CultureInfo.CurrentCulture, Resources.PropertyDoesNotHaveSingleValue, propertyName, distinctValueStrings);
+                throw new InvalidOperationException(message);
+            }
         }
 
         /// <summary>

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -839,6 +839,48 @@ namespace NuGet.SolutionRestoreManager.Test
         }
 
         [Fact]
+        public async Task DifferingPackageIdsFailsWithUsableErrorMessage()
+        {
+            var cps = NewCpsProject("{ }");
+            var projectFullPath = cps.ProjectFullPath;
+            var pri = cps.Builder
+                .WithTargetFrameworkInfo(
+                    new VsTargetFrameworkInfo2(
+                        "netcoreapp1.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("PackageId", "PackageId.netcoreapp1.0") }))
+                .WithTargetFrameworkInfo(
+                    new VsTargetFrameworkInfo2(
+                        "net46",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("PackageId", "PackageId.net46") }))
+                .ProjectRestoreInfo2;
+
+            var cache = Mock.Of<IProjectSystemCache>();
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+            var vsSolution2 = Mock.Of<IVsSolution2>();
+            var asyncLazySolution2 = new Microsoft.VisualStudio.Threading.AsyncLazy<IVsSolution2>(() => Task.FromResult(vsSolution2));
+            var telemetryProvider = Mock.Of<INuGetTelemetryProvider>();
+
+            var service = new VsSolutionRestoreService(
+                cache, restoreWorker, NuGet.Common.NullLogger.Instance, asyncLazySolution2, telemetryProvider);
+
+            // Act
+            var additionalMessages = await CaptureAdditionalMessagesAsync(projectFullPath, pri);
+
+            // Assert
+            var additionalMessage = Assert.Single(additionalMessages);
+            Assert.Equal(NuGetLogCode.NU1105, additionalMessage.Code);
+            Assert.Contains(string.Format(CultureInfo.CurrentCulture, Resources.PropertyDoesNotHaveSingleValue, "PackageId", "PackageId.net46, PackageId.netcoreapp1.0"), additionalMessage.Message);
+        }
+
+        [Fact]
         public async Task NominateProjectAsync_VerifySourcesAreCombinedAcrossFrameworks()
         {
             var cps = NewCpsProject(@"{ }");


### PR DESCRIPTION
A number of places call GetSingleNonEvaluatedPropertyOrNull to get the single value that spans all TFMs -- if that's not distinct though the failure that would bubble up to the user wouldn't point to the underlying issue. This makes the failure easier.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/8749

Regression? No.

## Description
This adds a better exception message than simply calling SingleOrDefault(). The test changes mostly involve extracting out a helper function for other tests doing the same thing.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
