### PR TITLE
Use Macros when writing the assets file to avoid updates due to user profile changes

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -253,8 +253,7 @@ namespace NuGet.ProjectModel
                         case "projects":
                             jsonReader.ReadObject(projectsPropertyName =>
                             {
-                                PackageSpec packageSpec = JsonPackageSpecReader.GetPackageSpec(jsonReader, path);
-
+                                PackageSpec packageSpec = JsonPackageSpecReader.GetPackageSpec(jsonReader, name: null, path, EnvironmentVariableWrapper.Instance);
                                 dgspec._projects.Add(projectsPropertyName, packageSpec);
                             });
                             break;
@@ -308,7 +307,7 @@ namespace NuGet.ProjectModel
             }
         }
 
-        private void Write(RuntimeModel.IObjectWriter writer, bool hashing, Action<PackageSpec, RuntimeModel.IObjectWriter, bool> writeAction)
+        private void Write(RuntimeModel.IObjectWriter writer, bool hashing, Action<PackageSpec, RuntimeModel.IObjectWriter, bool, IEnvironmentVariableReader> writeAction)
         {
             writer.WriteObjectStart();
             writer.WriteNameValue("format", Version);
@@ -332,7 +331,7 @@ namespace NuGet.ProjectModel
                 var project = pair.Value;
 
                 writer.WriteObjectStart(project.RestoreMetadata.ProjectUniqueName);
-                writeAction.Invoke(project, writer, hashing);
+                writeAction.Invoke(project, writer, hashing, EnvironmentVariableWrapper.Instance);
                 writer.WriteObjectEnd();
             }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -981,19 +981,19 @@ namespace NuGet.ProjectModel
                         break;
 
                     case "outputPath":
-                        outputPath = ExtractMacro(jsonReader.ReadNextTokenAsString(), userSettingsDirectory, useMacros);
+                        outputPath = jsonReader.ReadNextTokenAsString();
                         break;
 
                     case "packagesConfigPath":
-                        packagesConfigPath = ExtractMacro(jsonReader.ReadNextTokenAsString(), userSettingsDirectory, useMacros); ;
+                        packagesConfigPath = jsonReader.ReadNextTokenAsString();
                         break;
 
                     case "packagesPath":
-                        packagesPath = ExtractMacro(jsonReader.ReadNextTokenAsString(), userSettingsDirectory, useMacros); ;
+                        packagesPath = ExtractMacro(jsonReader.ReadNextTokenAsString(), userSettingsDirectory, useMacros);
                         break;
 
                     case "projectJsonPath":
-                        projectJsonPath = ExtractMacro(jsonReader.ReadNextTokenAsString(), userSettingsDirectory, useMacros); ;
+                        projectJsonPath = jsonReader.ReadNextTokenAsString();
                         break;
 
                     case "projectName":
@@ -1001,7 +1001,7 @@ namespace NuGet.ProjectModel
                         break;
 
                     case "projectPath":
-                        projectPath = ExtractMacro(jsonReader.ReadNextTokenAsString(), userSettingsDirectory, useMacros); ;
+                        projectPath = jsonReader.ReadNextTokenAsString();
                         break;
 
                     case "projectStyle":

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -60,7 +60,7 @@ namespace NuGet.ProjectModel
             using (var streamReader = new StreamReader(stream))
             using (var jsonReader = new JsonTextReader(streamReader))
             {
-                return GetPackageSpec(jsonReader, name, packageSpecPath, snapshotValue);
+                return GetPackageSpec(jsonReader, name, packageSpecPath, EnvironmentVariableWrapper.Instance, snapshotValue);
             }
         }
 
@@ -70,16 +70,11 @@ namespace NuGet.ProjectModel
             using (var stringReader = new StringReader(rawPackageSpec.ToString()))
             using (var jsonReader = new JsonTextReader(stringReader))
             {
-                return GetPackageSpec(jsonReader, name, packageSpecPath, snapshotValue);
+                return GetPackageSpec(jsonReader, name, packageSpecPath, EnvironmentVariableWrapper.Instance, snapshotValue);
             }
         }
 
-        internal static PackageSpec GetPackageSpec(JsonTextReader jsonReader, string packageSpecPath)
-        {
-            return GetPackageSpec(jsonReader, name: null, packageSpecPath, snapshotValue: null);
-        }
-
-        private static PackageSpec GetPackageSpec(JsonTextReader jsonReader, string name, string packageSpecPath, string snapshotValue)
+        internal static PackageSpec GetPackageSpec(JsonTextReader jsonReader, string name, string packageSpecPath, IEnvironmentVariableReader environmentVariableReader, string snapshotValue = null)
         {
             var packageSpec = new PackageSpec();
 
@@ -156,7 +151,7 @@ namespace NuGet.ProjectModel
 #pragma warning restore CS0612 // Type or member is obsolete
 
                     case "restore":
-                        ReadMSBuildMetadata(jsonReader, packageSpec);
+                        ReadMSBuildMetadata(jsonReader, packageSpec, environmentVariableReader);
                         break;
 
                     case "runtimes":
@@ -899,7 +894,7 @@ namespace NuGet.ProjectModel
             }
         }
 
-        private static void ReadMSBuildMetadata(JsonTextReader jsonReader, PackageSpec packageSpec)
+        private static void ReadMSBuildMetadata(JsonTextReader jsonReader, PackageSpec packageSpec, IEnvironmentVariableReader environmentVariableReader)
         {
             var centralPackageVersionsManagementEnabled = false;
             var centralPackageFloatingVersionsEnabled = false;
@@ -927,6 +922,8 @@ namespace NuGet.ProjectModel
             var validateRuntimeAssets = false;
             WarningProperties warningProperties = null;
             RestoreAuditProperties auditProperties = null;
+            bool useMacros = MSBuildStringUtility.IsTrue(environmentVariableReader.GetEnvironmentVariable(MacroStringsUtility.NUGET_ENABLE_EXPERIMENTAL_MACROS));
+            var userSettingsDirectory = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
 
             jsonReader.ReadObject(propertyName =>
             {
@@ -950,6 +947,7 @@ namespace NuGet.ProjectModel
 
                     case "configFilePaths":
                         configFilePaths = jsonReader.ReadStringArrayAsList();
+                        ExtractMacros(configFilePaths, userSettingsDirectory, useMacros);
                         break;
 
                     case "crossTargeting":
@@ -958,6 +956,7 @@ namespace NuGet.ProjectModel
 
                     case "fallbackFolders":
                         fallbackFolders = jsonReader.ReadStringArrayAsList();
+                        ExtractMacros(fallbackFolders, userSettingsDirectory, useMacros);
                         break;
 
                     case "files":
@@ -982,19 +981,19 @@ namespace NuGet.ProjectModel
                         break;
 
                     case "outputPath":
-                        outputPath = jsonReader.ReadNextTokenAsString();
+                        outputPath = ExtractMacro(jsonReader.ReadNextTokenAsString(), userSettingsDirectory, useMacros);
                         break;
 
                     case "packagesConfigPath":
-                        packagesConfigPath = jsonReader.ReadNextTokenAsString();
+                        packagesConfigPath = ExtractMacro(jsonReader.ReadNextTokenAsString(), userSettingsDirectory, useMacros); ;
                         break;
 
                     case "packagesPath":
-                        packagesPath = jsonReader.ReadNextTokenAsString();
+                        packagesPath = ExtractMacro(jsonReader.ReadNextTokenAsString(), userSettingsDirectory, useMacros); ;
                         break;
 
                     case "projectJsonPath":
-                        projectJsonPath = jsonReader.ReadNextTokenAsString();
+                        projectJsonPath = ExtractMacro(jsonReader.ReadNextTokenAsString(), userSettingsDirectory, useMacros); ;
                         break;
 
                     case "projectName":
@@ -1002,7 +1001,7 @@ namespace NuGet.ProjectModel
                         break;
 
                     case "projectPath":
-                        projectPath = jsonReader.ReadNextTokenAsString();
+                        projectPath = ExtractMacro(jsonReader.ReadNextTokenAsString(), userSettingsDirectory, useMacros); ;
                         break;
 
                     case "projectStyle":
@@ -1016,7 +1015,7 @@ namespace NuGet.ProjectModel
                         break;
 
                     case "projectUniqueName":
-                        projectUniqueName = jsonReader.ReadNextTokenAsString();
+                        projectUniqueName = ExtractMacro(jsonReader.ReadNextTokenAsString(), userSettingsDirectory, useMacros);
                         break;
 
                     case "restoreLockProperties":
@@ -1203,6 +1202,23 @@ namespace NuGet.ProjectModel
             }
 
             packageSpec.RestoreMetadata = msbuildMetadata;
+        }
+
+        private static string ExtractMacro(string value, string userSettingsDirectory, bool useMacros)
+        {
+            if (useMacros)
+            {
+                return MacroStringsUtility.ExtractMacro(value, userSettingsDirectory, MacroStringsUtility.UserMacro);
+            }
+            return value;
+        }
+
+        private static void ExtractMacros(List<string> paths, string userSettingsDirectory, bool useMacros)
+        {
+            if (useMacros)
+            {
+                MacroStringsUtility.ExtractMacros(paths, userSettingsDirectory, MacroStringsUtility.UserMacro);
+            }
         }
 
         private static bool ReadNextTokenAsBoolOrFalse(JsonTextReader jsonReader, string filePath)

--- a/src/NuGet.Core/NuGet.ProjectModel/MacroStringsUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/MacroStringsUtility.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.ProjectModel
+{
+    // Add JsonPackageReader and PackageSpecWriter tests.
+    internal static class MacroStringsUtility
+    {
+        internal const string NUGET_ENABLE_EXPERIMENTAL_MACROS = nameof(NUGET_ENABLE_EXPERIMENTAL_MACROS);
+        internal const string UserMacro = "$(User)";
+
+        /// <summary>
+        /// Applies macros in place to every string in the list.
+        /// Macros are applied only at the beginning of a string.
+        /// </summary>
+        /// <param name="list">The list of elements to apply the macro on.</param>
+        /// <param name="macroValue">The macro value that'll need to match from the strings.</param>
+        /// <param name="macroName">The macro that'll replace the value within the string.</param>
+        /// <param name="stringComparison">The comparer to use. Normally these strings are paths, so the comparer should be OS aware.</param>
+        internal static void ApplyMacros(IList<string> list, string macroValue, string macroName, StringComparison stringComparison)
+        {
+            if (list != null)
+            {
+                for (int i = 0; i < list.Count; i++)
+                {
+                    var result = ApplyMacro(list[i], macroValue, macroName, stringComparison);
+                    list[i] = result;
+                }
+            }
+        }
+
+        internal static void ExtractMacros(List<string> list, string macroValue, string macroName)
+        {
+            if (list != null)
+            {
+                for (int i = 0; i < list.Count; i++)
+                {
+                    var result = ExtractMacro(list[i], macroValue, macroName);
+                    list[i] = result;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Applies macro to the string in the list.
+        /// </summary>
+        /// <param name="originalString">The string to apply the macro on.</param>
+        /// <param name="macroValue">The macro value that'll need to match from the string.</param>
+        /// <param name="macroName">The macro that'll replace the value within the string.</param>
+        /// <param name="stringComparison">The comparer to use. Normally these strings are paths, so the comparer should be OS aware.</param>
+        internal static string ApplyMacro(string originalString, string macroValue, string macroName, StringComparison stringComparison)
+        {
+            if (!string.IsNullOrEmpty(originalString) && !string.IsNullOrEmpty(macroValue) && originalString.StartsWith(macroValue, stringComparison))
+            {
+                return macroName + originalString.Substring(macroValue.Length);
+            }
+            return originalString;
+        }
+
+        internal static string ExtractMacro(string originalString, string macroValue, string macroName)
+        {
+            if (!string.IsNullOrEmpty(originalString) && !string.IsNullOrEmpty(macroName) && originalString.StartsWith(macroName, StringComparison.Ordinal))
+            {
+                return macroValue + originalString.Substring(macroName.Length);
+            }
+            return originalString;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -137,12 +137,12 @@ namespace NuGet.ProjectModel
 
             writer.WriteObjectStart(JsonPackageSpecReader.RestoreOptions);
 
-            SetValue(writer, "projectUniqueName", ApplyMacro(msbuildMetadata.ProjectUniqueName, userSettingsDirectory, useMacros));
+            SetValue(writer, "projectUniqueName", msbuildMetadata.ProjectUniqueName);
             SetValue(writer, "projectName", msbuildMetadata.ProjectName);
-            SetValue(writer, "projectPath", ApplyMacro(msbuildMetadata.ProjectPath, userSettingsDirectory, useMacros));
-            SetValue(writer, "projectJsonPath", ApplyMacro(msbuildMetadata.ProjectJsonPath, userSettingsDirectory, useMacros));
+            SetValue(writer, "projectPath", msbuildMetadata.ProjectPath);
+            SetValue(writer, "projectJsonPath", msbuildMetadata.ProjectJsonPath);
             SetValue(writer, "packagesPath", ApplyMacro(msbuildMetadata.PackagesPath, userSettingsDirectory, useMacros));
-            SetValue(writer, "outputPath", ApplyMacro(msbuildMetadata.OutputPath, userSettingsDirectory, useMacros));
+            SetValue(writer, "outputPath", msbuildMetadata.OutputPath);
 
             if (msbuildMetadata.ProjectStyle != ProjectStyle.Unknown)
             {
@@ -264,7 +264,7 @@ namespace NuGet.ProjectModel
                         {
                             writer.WriteObjectStart(project.ProjectUniqueName);
 
-                            writer.WriteNameValue("projectPath", project.ProjectPath); // Do the project references (?)
+                            writer.WriteNameValue("projectPath", project.ProjectPath);
 
                             if (project.IncludeAssets != LibraryIncludeFlags.All)
                             {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -9,7 +9,6 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.Frameworks;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -11462,7 +11462,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             var configFilePaths = configList.Select(e => e.Value<string>()).ToList();
 
 
-            configFilePaths.Should().Contain(("$(User)\\NuGet.Config"));
+            configFilePaths.Should().Contain(("$(User)" + Path.DirectorySeparatorChar + "NuGet.Config"));
         }
 
         /// <summary>

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -3699,12 +3699,12 @@ namespace NuGet.ProjectModel.Test
             // Arrange
             var json = @"{  
                             ""restore"": {
-    ""projectUniqueName"": ""$(User)source\\code\\project.csproj"",
+    ""projectUniqueName"": ""C:\\users\\me\\source\\code\\project.csproj"",
     ""projectName"": ""project"",
-    ""projectPath"": ""$(User)source\\code\\project.csproj"",
-    ""projectJsonPath"": ""$(User)source\\code\\project.json"",
+    ""projectPath"": ""C:\\users\\me\\source\\code\\project.csproj"",
+    ""projectJsonPath"": ""C:\\users\\me\\source\\code\\project.json"",
     ""packagesPath"": ""$(User).nuget\\packages"",
-    ""outputPath"": ""$(User)source\\code\\obj"",
+    ""outputPath"": ""C:\\users\\me\\source\\code\\obj"",
     ""projectStyle"": ""PackageReference"",
     ""crossTargeting"": true,
     ""configFilePaths"": [
@@ -3733,11 +3733,7 @@ namespace NuGet.ProjectModel.Test
             var userSettingsDirectory = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
 
             Assert.NotNull(metadata);
-            metadata.ProjectUniqueName.Should().Be(@$"{userSettingsDirectory}source\code\project.csproj");
-            metadata.ProjectPath.Should().Be(@$"{userSettingsDirectory}source\code\project.csproj");
-            metadata.ProjectJsonPath.Should().Be(@$"{userSettingsDirectory}source\code\project.json");
             metadata.PackagesPath.Should().Be(@$"{userSettingsDirectory}.nuget\packages");
-            metadata.OutputPath.Should().Be(@$"{userSettingsDirectory}source\code\obj");
 
             metadata.ConfigFilePaths.Should().Contain(@$"{userSettingsDirectory}source\code\NuGet.Config");
             metadata.ConfigFilePaths.Should().Contain(@"C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.config");

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/MacroStringsUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/MacroStringsUtilityTests.cs
@@ -1,0 +1,106 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    public class MacroStringsUtilityTests
+    {
+        [Theory]
+        [InlineData("C:\\Users\\me", "C:\\Users\\me", "$(UserProfile)", "$(UserProfile)")]
+        [InlineData("C:\\Users\\me\\path", "C:\\Users\\me", "$(UserProfile)", "$(UserProfile)\\path")]
+        [InlineData("C:\\Users\\me\\.nuget\\packages", "C:\\Users\\me", "$(UserProfile)", "$(UserProfile)\\.nuget\\packages")]
+        [InlineData("C:\\Users\\Me\\.nuget\\packages", "C:\\Users\\me", "$(UserProfile)", "C:\\Users\\Me\\.nuget\\packages")]
+        [InlineData("C:\\Users\\me\\.nuget\\packages", "C:\\Users\\Me", "$(UserProfile)", "C:\\Users\\me\\.nuget\\packages")]
+        public void ApplyMacro_VariousTestCases(string testString, string macroValue, string macroName, string expected)
+        {
+            var actual = MacroStringsUtility.ApplyMacro(testString, macroValue, macroName, StringComparison.Ordinal);
+            actual.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("C:\\Users\\me", "C:\\Users\\me", "$(UserProfile)", "$(UserProfile)")]
+        [InlineData("C:\\Users\\me\\path", "C:\\Users\\me", "$(UserProfile)", "$(UserProfile)\\path")]
+        [InlineData("C:\\Users\\me\\.nuget\\packages", "C:\\Users\\me", "$(UserProfile)", "$(UserProfile)\\.nuget\\packages")]
+        [InlineData("C:\\Users\\Me\\.nuget\\packages", "C:\\Users\\me", "$(UserProfile)", "C:\\Users\\Me\\.nuget\\packages")]
+        [InlineData("C:\\Users\\me\\.nuget\\packages", "C:\\Users\\Me", "$(UserProfile)", "C:\\Users\\me\\.nuget\\packages")]
+        public void Extract_VariousTestCases(string expected, string macroValue, string macroName, string testString)
+        {
+            var actual = MacroStringsUtility.ExtractMacro(testString, macroValue, macroName);
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void ApplyMacros_AppliesEachMacroIndividually()
+        {
+            List<string> testStrings = new()
+            {
+                "C:\\Users\\me",
+                "C:\\Users\\me\\path",
+                "C:\\Users\\me\\.nuget\\packages",
+                "C:\\Users\\Me\\.nuget\\packages",
+            };
+
+            List<string> expected = new()
+            {
+                "$(UserProfile)",
+                "$(UserProfile)\\path",
+                "$(UserProfile)\\.nuget\\packages",
+                "C:\\Users\\Me\\.nuget\\packages",
+            };
+
+            MacroStringsUtility.ApplyMacros(testStrings, "C:\\Users\\me", "$(UserProfile)", StringComparison.Ordinal);
+            testStrings.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void ExtractMacros_ExtractsEachMacroIndividually()
+        {
+            List<string> testStrings = new()
+            {
+                "$(UserProfile)",
+                "$(UserProfile)\\path",
+                "$(UserProfile)\\.nuget\\packages",
+                "C:\\Users\\Me\\.nuget\\packages",
+            };
+
+            List<string> expected = new()
+            {
+                "C:\\Users\\me",
+                "C:\\Users\\me\\path",
+                "C:\\Users\\me\\.nuget\\packages",
+                "C:\\Users\\Me\\.nuget\\packages",
+            };
+
+            MacroStringsUtility.ExtractMacros(testStrings, "C:\\Users\\me", "$(UserProfile)");
+            testStrings.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void ApplyMacros_WithIgnoreCaseComparer_AppliesEachMacroIndividually()
+        {
+            List<string> testStrings = new()
+            {
+                "C:\\Users\\me",
+                "C:\\Users\\me\\path",
+                "C:\\Users\\me\\.nuget\\packages",
+                "C:\\Users\\Me\\.nuget\\packages",
+            };
+
+            List<string> expected = new()
+            {
+                "$(UserProfile)",
+                "$(UserProfile)\\path",
+                "$(UserProfile)\\.nuget\\packages",
+                "$(UserProfile)\\.nuget\\packages",
+            };
+
+            MacroStringsUtility.ApplyMacros(testStrings, "c:\\users\\me", "$(UserProfile)", StringComparison.OrdinalIgnoreCase);
+            testStrings.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -727,19 +727,18 @@ namespace NuGet.ProjectModel.Test
             VerifyJsonPackageSpecRoundTrip(json);
         }
 
-        // The roundtrip effectively tests both the reader & writer.
         [Fact]
         public void RestoreMetadataWithMacros_RoundTrips()
         {
             // Arrange
             var json = @"{  
                             ""restore"": {
-    ""projectUniqueName"": ""$(User)source\\code\\project.csproj"",
+    ""projectUniqueName"": ""C:\\users\\me\\source\\code\\project.csproj"",
     ""projectName"": ""project"",
-    ""projectPath"": ""$(User)source\\code\\project.csproj"",
-    ""projectJsonPath"": ""$(User)source\\code\\project.json"",
+    ""projectPath"": ""C:\\users\\me\\source\\code\\project.csproj"",
+    ""projectJsonPath"": ""C:\\users\\me\\source\\code\\project.json"",
     ""packagesPath"": ""$(User).nuget\\packages"",
-    ""outputPath"": ""$(User)source\\code\\obj"",
+    ""outputPath"": ""C:\\users\\me\\source\\code\\obj"",
     ""projectStyle"": ""PackageReference"",
     ""crossTargeting"": true,
     ""fallbackFolders"": [
@@ -761,17 +760,16 @@ namespace NuGet.ProjectModel.Test
                     { MacroStringsUtility.NUGET_ENABLE_EXPERIMENTAL_MACROS, "true" }
             });
 
+            // Act
             var actual = PackageSpecTestUtility.RoundTripJson(json, environmentReader);
+
+            // Assert
 
             var metadata = actual.RestoreMetadata;
             var userSettingsDirectory = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
 
             Assert.NotNull(metadata);
-            metadata.ProjectUniqueName.Should().Be(@$"{userSettingsDirectory}source\code\project.csproj");
-            metadata.ProjectPath.Should().Be(@$"{userSettingsDirectory}source\code\project.csproj");
-            metadata.ProjectJsonPath.Should().Be(@$"{userSettingsDirectory}source\code\project.json");
             metadata.PackagesPath.Should().Be(@$"{userSettingsDirectory}.nuget\packages");
-            metadata.OutputPath.Should().Be(@$"{userSettingsDirectory}source\code\obj");
 
             metadata.ConfigFilePaths.Should().Contain(@$"{userSettingsDirectory}source\code\NuGet.Config");
             metadata.ConfigFilePaths.Should().Contain(@"C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.config");

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using FluentAssertions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
@@ -12,6 +13,7 @@ using NuGet.LibraryModel;
 using NuGet.RuntimeModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
+using Test.Utility;
 using Xunit;
 
 namespace NuGet.ProjectModel.Test
@@ -723,6 +725,61 @@ namespace NuGet.ProjectModel.Test
 
             // Act & Assert
             VerifyJsonPackageSpecRoundTrip(json);
+        }
+
+        // The roundtrip effectively tests both the reader & writer.
+        [Fact]
+        public void RestoreMetadataWithMacros_RoundTrips()
+        {
+            // Arrange
+            var json = @"{  
+                            ""restore"": {
+    ""projectUniqueName"": ""$(User)source\\code\\project.csproj"",
+    ""projectName"": ""project"",
+    ""projectPath"": ""$(User)source\\code\\project.csproj"",
+    ""projectJsonPath"": ""$(User)source\\code\\project.json"",
+    ""packagesPath"": ""$(User).nuget\\packages"",
+    ""outputPath"": ""$(User)source\\code\\obj"",
+    ""projectStyle"": ""PackageReference"",
+    ""crossTargeting"": true,
+    ""fallbackFolders"": [
+        ""C:\\Program Files\\dotnet\\sdk\\NuGetFallbackFolder"",
+        ""$(User)fallbackFolder""
+
+
+    ],
+    ""configFilePaths"": [
+        ""$(User)source\\code\\NuGet.Config"",
+        ""$(User)AppData\\Roaming\\NuGet\\NuGet.Config"",
+        ""C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config"",
+        ""C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config""
+    ]
+  }
+}";
+            var environmentReader = new TestEnvironmentVariableReader(new Dictionary<string, string>()
+                {
+                    { MacroStringsUtility.NUGET_ENABLE_EXPERIMENTAL_MACROS, "true" }
+            });
+
+            var actual = PackageSpecTestUtility.RoundTripJson(json, environmentReader);
+
+            var metadata = actual.RestoreMetadata;
+            var userSettingsDirectory = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
+
+            Assert.NotNull(metadata);
+            metadata.ProjectUniqueName.Should().Be(@$"{userSettingsDirectory}source\code\project.csproj");
+            metadata.ProjectPath.Should().Be(@$"{userSettingsDirectory}source\code\project.csproj");
+            metadata.ProjectJsonPath.Should().Be(@$"{userSettingsDirectory}source\code\project.json");
+            metadata.PackagesPath.Should().Be(@$"{userSettingsDirectory}.nuget\packages");
+            metadata.OutputPath.Should().Be(@$"{userSettingsDirectory}source\code\obj");
+
+            metadata.ConfigFilePaths.Should().Contain(@$"{userSettingsDirectory}source\code\NuGet.Config");
+            metadata.ConfigFilePaths.Should().Contain(@"C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.config");
+            metadata.ConfigFilePaths.Should().Contain(@"C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config");
+            metadata.ConfigFilePaths.Should().Contain(@$"{userSettingsDirectory}AppData\Roaming\NuGet\NuGet.Config");
+
+            metadata.FallbackFolders.Should().Contain(@"C:\Program Files\dotnet\sdk\NuGetFallbackFolder");
+            metadata.FallbackFolders.Should().Contain(@$"{userSettingsDirectory}fallbackFolder");
         }
 
         private static string GetJsonString(PackageSpec packageSpec)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2178

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Many properties within the PackageSpec, and by extension, the lock file, are paths.
These paths can often contain the user profile, the home path etc. Paths are user specific.

The assets file itself isn't designed to be shared across machines cleanly, but there are things that one can do to allow that to be a thing.
For example, specifying the same global packages folder, putting the code in the same location etc. 
If when writing the assets file, we convert paths like UserProfile to a macro, we can allow the assets file to be shared across machines. 

* Write `$(User)` where the user settings directory is a part of the path. 
* Extract `$(User)` macro at assets file read, effectively only change what's written on disk, but nothing changes for the rest of  code.
* At this point, this behavior is hidden behind an environment variable. We can decide whether to enable it for everyone at a later point.
* As of now, only the paths that have been found to cause issues for the devbox are being changed. This should minimize the overhead of the change.

* To enable the feature, the `NUGET_ENABLE_EXPERIMENTAL_MACROS` environment variable needs to be set to `true`.  

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
