### PR TITLE
Unroll Linq usage in FilterDependencyProvidersForLibrary

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteWalkContext.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteWalkContext.cs
@@ -73,7 +73,21 @@ namespace NuGet.DependencyResolver
                     return Array.Empty<IRemoteDependencyProvider>();
                 }
 
-                return RemoteLibraryProviders.Where(p => sources.Contains(p.Source.Name)).AsList();
+                // PERF: Avoid Linq in hot paths.
+                var filteredLibraryProviders = new List<IRemoteDependencyProvider>();
+                for (int i = 0; i < RemoteLibraryProviders.Count; ++i)
+                {
+                    var current = RemoteLibraryProviders[i];
+                    for (int j = 0; j < sources.Count; ++j)
+                    {
+                        if (StringComparer.Ordinal.Equals(sources[j], current.Source.Name))
+                        {
+                            filteredLibraryProviders.Add(current);
+                            break;
+                        }
+                    }
+                }
+                return filteredLibraryProviders;
             }
             return RemoteLibraryProviders;
         }

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteWalkContext.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteWalkContext.cs
@@ -74,7 +74,7 @@ namespace NuGet.DependencyResolver
                 }
 
                 // PERF: Avoid Linq in hot paths.
-                var filteredLibraryProviders = new List<IRemoteDependencyProvider>();
+                var filteredLibraryProviders = new List<IRemoteDependencyProvider>(sources.Count);
                 for (int i = 0; i < RemoteLibraryProviders.Count; ++i)
                 {
                     var current = RemoteLibraryProviders[i];


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Related: https://github.com/NuGet/Home/issues/12748

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
There are some easily avoidable allocations that were happening in `FilterDependencyProvidersForLibrary` due to closure and delegate allocations caused by Linq usage. I swapped the implementation and added a comment.

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
