### PR TITLE
Clear NUGET_PACKAGES in the CI environment to unblock tests

### DIFF
--- a/configure.cmd
+++ b/configure.cmd
@@ -1,4 +1,5 @@
 @echo off
+SET NUGET_PACKAGES=
 powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -Command "%~dpn0.ps1" -SkipDotnetInfo %*
 IF ERRORLEVEL 1 (
   EXIT /B %ERRORLEVEL%

--- a/configure.ps1
+++ b/configure.ps1
@@ -37,6 +37,12 @@ $ErrorActionPreference = 'Stop'
 
 Trace-Log "Configuring NuGet.Client build environment"
 
+if ($env:CI -eq "true") {
+    [Environment]::SetEnvironmentVariable("NUGET_PACKAGES", $null, "Machine")
+} else {
+    $Env:NUGET_PACKAGES=""
+}
+
 $BuildErrors = @()
 
 if ($ProcDump -eq $true -Or $env:CI -eq "true")

--- a/configure.sh
+++ b/configure.sh
@@ -50,6 +50,7 @@ fi
 export DOTNET_ROOT="$CLI_DIR"
 export DOTNET_MULTILEVEL_LOOKUP="0"
 export "PATH=$CLI_DIR:$PATH"
+export NUGET_PACKAGES=
 
 if [ "$CI" == "true" ]; then
     echo "##vso[task.setvariable variable=DOTNET_ROOT;isOutput=false;issecret=false;]$CLI_DIR"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2616

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Some of our tests expect to get a value for the global packages folder from a config but our CI environment now sets `NUGET_PACKAGES` effectively breaking the tests.  This clears the environment variable in CI for now until we have time to make our tests more robust.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
