### PR TITLE
Unset NUGET_PACKAGES in our CI environment

### DIFF
--- a/configure.cmd
+++ b/configure.cmd
@@ -1,5 +1,4 @@
 @echo off
-SET NUGET_PACKAGES=
 powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -Command "%~dpn0.ps1" -SkipDotnetInfo %*
 IF ERRORLEVEL 1 (
   EXIT /B %ERRORLEVEL%

--- a/configure.ps1
+++ b/configure.ps1
@@ -37,12 +37,6 @@ $ErrorActionPreference = 'Stop'
 
 Trace-Log "Configuring NuGet.Client build environment"
 
-if ($env:CI -eq "true") {
-    [Environment]::SetEnvironmentVariable("NUGET_PACKAGES", $null, "Machine")
-} else {
-    $Env:NUGET_PACKAGES=""
-}
-
 $BuildErrors = @()
 
 if ($ProcDump -eq $true -Or $env:CI -eq "true")

--- a/configure.sh
+++ b/configure.sh
@@ -50,7 +50,6 @@ fi
 export DOTNET_ROOT="$CLI_DIR"
 export DOTNET_MULTILEVEL_LOOKUP="0"
 export "PATH=$CLI_DIR:$PATH"
-export NUGET_PACKAGES=
 
 if [ "$CI" == "true" ]; then
     echo "##vso[task.setvariable variable=DOTNET_ROOT;isOutput=false;issecret=false;]$CLI_DIR"

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -152,6 +152,7 @@ stages:
       VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
       BuildRTM: "false"
       SemanticVersion: $[stageDependencies.Initialize.GetSemanticVersion.outputs['setsemanticversion.SemanticVersion']]
+      NUGET_PACKAGES:
     pool:
       name: VSEngSS-MicroBuild2022-1ES
     steps:
@@ -174,6 +175,7 @@ stages:
       VsTargetChannelForTests: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannelForTests']]
       VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
       BuildRTM: "true"
+      NUGET_PACKAGES:
     pool:
       name: VSEngSS-MicroBuild2022-1ES
     steps:
@@ -222,6 +224,7 @@ stages:
       FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
        # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
       MSBuildEnableWorkloadResolver: false
+      NUGET_PACKAGES:
     condition: "and(succeeded(), ne(variables['RunFunctionalTestsOnWindows'], 'false'))"
     pool:
       name: VSEngSS-MicroBuild2022-1ES
@@ -243,6 +246,7 @@ stages:
       # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
       MSBuildEnableWorkloadResolver: false
       DOTNET_NUGET_SIGNATURE_VERIFICATION: true
+      NUGET_PACKAGES:
     condition: "and(succeeded(), ne(variables['RunTestsOnLinux'], 'false'))"
     pool:
       vmImage: ubuntu-latest
@@ -265,6 +269,7 @@ stages:
       MSBUILDDISABLENODEREUSE: 1
       # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
       MSBuildEnableWorkloadResolver: false
+      NUGET_PACKAGES:
     condition: "and(succeeded(), ne(variables['RunTestsOnMac'], 'false'))"
     pool:
       vmImage: macos-latest
@@ -286,6 +291,7 @@ stages:
     variables:
       BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
       FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+      NUGET_PACKAGES:
     pool:
       vmImage: windows-latest
     steps:
@@ -306,6 +312,7 @@ stages:
       MSBuildEnableWorkloadResolver: false
       TestRunDisplayName: "Mono Tests"
       TestRunCommandLineArguments: "--mono-tests"
+      NUGET_PACKAGES:
     pool:
       vmImage: macos-latest
     steps:


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Client.Engineering/issues/2616

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
My fix yesterday wasn't reliable, presumably because the environment variable is already set for the running process.  This sets it before the hosted build agent process runs and seems to fix the issue.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
