### PR TITLE
Enable central package management implicitly when Directory.Packages.props exists

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -91,6 +91,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="..\..\NuGet.Core\NuGet.Build.Tasks\NuGet.props">
+      <Link>NuGet.props</Link>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="..\..\NuGet.Core\NuGet.Build.Tasks\NuGet.targets">
       <Link>NuGet.targets</Link>
       <SubType>Designer</SubType>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.props
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.props
@@ -9,33 +9,32 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
-
 <Project>
-
   <!--
-      Import 'Directory.Packages.props' which will contain centralized packages for all the projects and solutions under
-      the directory in which the file is present. This is similar to 'Directory.Build.props/targets' logic which is present
-      in the common props/targets which serve a similar purpose.
+    Determine the path to the 'Directory.Packages.props' file, if the user did not:
+      1. Set $(ManagePackageVersionsCentrally) to false
+      2. Set $(ImportDirectoryPackagesProps) to false
+      3. Already specify the path to a 'Directory.Packages.props' file via $(DirectoryPackagesPropsPath)
   -->
-
-  <PropertyGroup>
-    <ImportDirectoryPackagesProps Condition="'$(ImportDirectoryPackagesProps)' == ''">true</ImportDirectoryPackagesProps>
-  </PropertyGroup>
-
-  <!--
-      Determine the path to the 'Directory.Packages.props' file, if the user did not disable $(ImportDirectoryPackagesProps) and
-      they did not already specify an absolute path to use via $(DirectoryPackagesPropsPath)
-  -->
-  <PropertyGroup Condition="'$(ImportDirectoryPackagesProps)' == 'true' and '$(DirectoryPackagesPropsPath)' == ''">
+  <PropertyGroup Condition="'$(ManagePackageVersionsCentrally)' != 'false' And '$(ImportDirectoryPackagesProps)' != 'false' And '$(DirectoryPackagesPropsPath)' == ''">
     <_DirectoryPackagesPropsFile Condition="'$(_DirectoryPackagesPropsFile)' == ''">Directory.Packages.props</_DirectoryPackagesPropsFile>
     <_DirectoryPackagesPropsBasePath Condition="'$(_DirectoryPackagesPropsBasePath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(MSBuildProjectDirectory)', '$(_DirectoryPackagesPropsFile)'))</_DirectoryPackagesPropsBasePath>
     <DirectoryPackagesPropsPath Condition="'$(_DirectoryPackagesPropsBasePath)' != '' and '$(_DirectoryPackagesPropsFile)' != ''">$([MSBuild]::NormalizePath('$(_DirectoryPackagesPropsBasePath)', '$(_DirectoryPackagesPropsFile)'))</DirectoryPackagesPropsPath>
   </PropertyGroup>
 
-  <Import Project="$(DirectoryPackagesPropsPath)" Condition="'$(ImportDirectoryPackagesProps)' == 'true' and '$(DirectoryPackagesPropsPath)' != '' and Exists('$(DirectoryPackagesPropsPath)')"/>
-
-  <PropertyGroup Condition="'$(ImportDirectoryPackagesProps)' == 'true' and '$(DirectoryPackagesPropsPath)' != '' and Exists('$(DirectoryPackagesPropsPath)')">
-    <CentralPackageVersionsFileImported>true</CentralPackageVersionsFileImported>
+  <!--
+    Default $(ManagePackageVersionsCentrally) to true, import Directory.Packages.props, and set $(CentralPackageVersionsFileImported) to true if the user did not:
+      1. Set $(ManagePackageVersionsCentrally) to false
+      2. Set $(ImportDirectoryPackagesProps) to false
+      3. The path specified in $(DirectoryPackagesPropsPath) exists
+  -->
+  <PropertyGroup Condition="'$(ManagePackageVersionsCentrally)' != 'false' And '$(ImportDirectoryPackagesProps)' != 'false' And Exists('$(DirectoryPackagesPropsPath)')">
+    <ManagePackageVersionsCentrally Condition="'$(ManagePackageVersionsCentrally)' == ''">true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
+  <Import Project="$(DirectoryPackagesPropsPath)" Condition="'$(ManagePackageVersionsCentrally)' != 'false' And '$(ImportDirectoryPackagesProps)' != 'false' And Exists('$(DirectoryPackagesPropsPath)')" />
+
+  <PropertyGroup Condition="'$(ManagePackageVersionsCentrally)' != 'false' And '$(ImportDirectoryPackagesProps)' != 'false' And Exists('$(DirectoryPackagesPropsPath)')">
+    <CentralPackageVersionsFileImported>true</CentralPackageVersionsFileImported>
+  </PropertyGroup>
 </Project>

--- a/test/EndToEnd/Directory.Packages.props
+++ b/test/EndToEnd/Directory.Packages.props
@@ -1,1 +1,5 @@
-<Project />
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -9184,7 +9184,6 @@ namespace NuGet.CommandLine.Test
                    "a",
                    pathContext.SolutionRoot,
                    NuGetFramework.Parse("net46"));
-                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
 
@@ -9269,7 +9268,6 @@ namespace NuGet.CommandLine.Test
                    "a",
                    pathContext.SolutionRoot,
                    NuGetFramework.Parse("net46"));
-                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
 
@@ -9352,7 +9350,6 @@ namespace NuGet.CommandLine.Test
                    "a",
                    pathContext.SolutionRoot,
                    NuGetFramework.Parse("net46"));
-                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
 
@@ -9426,7 +9423,6 @@ namespace NuGet.CommandLine.Test
                    "a",
                    pathContext.SolutionRoot,
                    NuGetFramework.Parse("net46"));
-                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
 
@@ -9500,7 +9496,6 @@ namespace NuGet.CommandLine.Test
                    "a",
                    pathContext.SolutionRoot,
                    NuGetFramework.Parse("net46"));
-                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
 
@@ -9573,7 +9568,6 @@ namespace NuGet.CommandLine.Test
                    "a",
                    pathContext.SolutionRoot,
                    NuGetFramework.Parse("net46"));
-                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
 
@@ -9676,19 +9670,16 @@ namespace NuGet.CommandLine.Test
                     "a",
                     pathContext.SolutionRoot,
                     netcoreapp2);
-                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
 
                 var projectB = SimpleTestProjectContext.CreateNETCore(
                     "b",
                     pathContext.SolutionRoot,
                     netcoreapp2);
-                projectB.Properties.Add("ManagePackageVersionsCentrally", "true");
 
                 var projectC = SimpleTestProjectContext.CreateNETCore(
                     "c",
                     pathContext.SolutionRoot,
                     netcoreapp2);
-                projectC.Properties.Add("ManagePackageVersionsCentrally", "true");
 
                 var packageX100 = new SimpleTestPackageContext()
                 {
@@ -9821,8 +9812,7 @@ namespace NuGet.CommandLine.Test
                    "projectA",
                    pathContext.SolutionRoot,
                    NuGetFramework.Parse("netcoreapp2.0"));
-                projectA.Properties.Add(ProjectBuildProperties.ManagePackageVersionsCentrally, "true");
-                projectA.Properties.Add(ProjectBuildProperties.CentralPackageTransitivePinningEnabled, "true");
+                projectA.Properties.Add(ProjectBuildProperties.CentralPackageTransitivePinningEnabled, bool.TrueString);
 
                 // the package references defined in the project should not have version
                 var packageBNoVersion = createTestPackage("B", null, packagesForProject);
@@ -10072,7 +10062,6 @@ namespace NuGet.CommandLine.Test
                    "projectA",
                    pathContext.SolutionRoot,
                    framework);
-                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
 
                 // the package references defined in the project should not have version
                 var packageBNoVersion = createTestPackage("B", null, packagesForProject);
@@ -10248,8 +10237,6 @@ namespace NuGet.CommandLine.Test
 
                 var projectA = SimpleTestProjectContext.CreateNETCore("projectA", pathContext.SolutionRoot, framework);
 
-                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
-
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(
                    pathContext.PackageSource,
                    new[]
@@ -10329,7 +10316,6 @@ namespace NuGet.CommandLine.Test
 
                 var projectA = SimpleTestProjectContext.CreateNETCore("projectA", pathContext.SolutionRoot, framework);
 
-                projectA.Properties.Add(ProjectBuildProperties.ManagePackageVersionsCentrally, bool.TrueString);
                 projectA.Properties.Add(ProjectBuildProperties.CentralPackageVersionOverrideEnabled, bool.FalseString);
 
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(
@@ -11330,11 +11316,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 
                 var xml = projectA.GetXML();
 
-                ProjectFileUtils.AddProperty(
-                    xml,
-                    "ManagePackageVersionsCentrally",
-                    "true");
-
                 ProjectFileUtils.AddItem(
                                     xml,
                                     "PackageReference",
@@ -11494,7 +11475,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                     pathContext.SolutionRoot,
                     "net472");
 
-                projectContext.Properties.Add("ManagePackageVersionsCentrally", "true");
                 projectContext.Properties.Add("CentralPackageTransitivePinningEnabled", centralPackageTransitivePinningEnabled.ToString());
 
                 if (referencedProject != null)

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -693,12 +693,7 @@ namespace Dotnet.Integration.Test
                     packageX100,
                     packageX200);
 
-            var propsFile = @$"<Project>
-                                <PropertyGroup>
-                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                </PropertyGroup>
-                            </Project>
-                            ";
+            var propsFile = @$"<Project />";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -741,12 +736,7 @@ namespace Dotnet.Integration.Test
                     packageX100,
                     packageX200);
 
-            var propsFile = @$"<Project>
-                                <PropertyGroup>
-                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                </PropertyGroup>
-                            </Project>
-                            ";
+            var propsFile = @$"<Project />";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -787,14 +777,10 @@ namespace Dotnet.Integration.Test
                     packageX200);
 
             var propsFile = @$"<Project>
-                                <PropertyGroup>
-                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                </PropertyGroup>
-                                <ItemGroup>
-                                <PackageVersion Include=""X"" Version=""1.0.0"" />
-                                </ItemGroup>
-                            </Project>
-                            ";
+  <ItemGroup>
+    <PackageVersion Include=""X"" Version=""1.0.0"" />
+  </ItemGroup>
+</Project>";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -838,14 +824,10 @@ namespace Dotnet.Integration.Test
                     packageX200);
 
             var propsFile = @$"<Project>
-                                <PropertyGroup>
-                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                </PropertyGroup>
-                                <ItemGroup>
-                                <PackageVersion Include=""X"" Version=""1.0.0"" />
-                                </ItemGroup>
-                            </Project>
-                            ";
+  <ItemGroup>
+    <PackageVersion Include=""X"" Version=""1.0.0"" />
+  </ItemGroup>
+</Project>";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -888,9 +870,6 @@ namespace Dotnet.Integration.Test
                     packageX100);
 
             var propsFile = @$"<Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
   <ItemGroup>
     <Content Include=""SomeFile"" />
   </ItemGroup>
@@ -945,12 +924,7 @@ namespace Dotnet.Integration.Test
                     packageX100,
                     packageX200);
 
-            var propsFile = @$"<Project>
-                                <PropertyGroup>
-                                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                </PropertyGroup>
-                            </Project>
-                            ";
+            var propsFile = @$"<Project />";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1007,12 +981,7 @@ namespace Dotnet.Integration.Test
                     packageX100,
                     packageX200);
 
-            var propsFile = @$"<Project>
-                                <PropertyGroup>
-                                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                </PropertyGroup>
-                            </Project>
-                            ";
+            var propsFile = @$"<Project />";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1070,14 +1039,10 @@ namespace Dotnet.Integration.Test
                     packageX200);
 
             var propsFile = @$"<Project>
-                                <PropertyGroup>
-                                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                    <ItemGroup>
-                                        <PackageVersion Include=""X"" Version=""1.0.0"" />
-                                    </ItemGroup>
-                                </PropertyGroup>
-                            </Project>
-                            ";
+    <ItemGroup>
+        <PackageVersion Include=""X"" Version=""1.0.0"" />
+    </ItemGroup>
+</Project>";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1099,13 +1064,11 @@ namespace Dotnet.Integration.Test
             File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "projectA", "projectA.csproj"), projectContent);
 
             //Act
-            var result = _fixture.RunDotnetExpectFailure(projectADirectory, $"add {projectA.ProjectPath} package {packageX} ");
+            var result = _fixture.RunDotnetExpectSuccess(projectADirectory, $"add {projectA.ProjectPath} package {packageX} ");
 
             // Assert
             Assert.DoesNotContain("error: Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion items: X", result.Output);
-            Assert.Contains(@$"<ItemGroup>
-                                        <PackageVersion Include=""X"" Version=""1.0.0"" />
-                                    </ItemGroup>", File.ReadAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props")));
+            Assert.Contains(@$"<PackageVersion Include=""{packageX}"" Version=""{version1}"" />", File.ReadAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props")));
             Assert.Contains(@$"<ItemGroup>
         <PackageReference Include=""X"" />
     </ItemGroup>", File.ReadAllText(Path.Combine(projectADirectory, "projectA.csproj")));
@@ -1135,14 +1098,10 @@ namespace Dotnet.Integration.Test
                     packageX200);
 
             var propsFile = @$"<Project>
-                                <PropertyGroup>
-                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                </PropertyGroup>
-                                <ItemGroup>
-                                <PackageVersion Include=""X"" Version=""1.0.0"" />
-                                </ItemGroup>
-                            </Project>
-                            ";
+  <ItemGroup>
+    <PackageVersion Include=""X"" Version=""1.0.0"" />
+  </ItemGroup>
+</Project>";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1195,12 +1154,7 @@ namespace Dotnet.Integration.Test
                     packageX100,
                     packageX200);
 
-            var propsFile = @$"<Project>
-                                <PropertyGroup>
-                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                </PropertyGroup>
-                            </Project>
-                            ";
+            var propsFile = @$"<Project />";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1257,12 +1211,7 @@ namespace Dotnet.Integration.Test
                     packageX100,
                     packageX200);
 
-            var propsFile = @$"<Project>
-                                <PropertyGroup>
-                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                </PropertyGroup>
-                            </Project>
-                            ";
+            var propsFile = @$"<Project />";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1319,14 +1268,10 @@ namespace Dotnet.Integration.Test
                     packageX200);
 
             var propsFile = @$"<Project>
-                                <PropertyGroup>
-                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                </PropertyGroup>
-                                <ItemGroup>
-                                <PackageVersion Include=""X"" Version=""1.0.0"" />
-                                </ItemGroup>
-                            </Project>
-                            ";
+  <ItemGroup>
+    <PackageVersion Include=""X"" Version=""1.0.0"" />
+  </ItemGroup>
+</Project>";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1352,9 +1297,7 @@ namespace Dotnet.Integration.Test
 
             // Assert
             Assert.DoesNotContain("error: Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion items: X", result.Output);
-            Assert.Contains(@$"<ItemGroup>
-                                <PackageVersion Include=""X"" Version=""1.0.0"" />
-                                </ItemGroup>", File.ReadAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props")));
+            Assert.Contains(@$"<PackageVersion Include=""X"" Version=""1.0.0"" />", File.ReadAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props")));
             Assert.Contains(@$"<ItemGroup>
         <PackageReference Include=""X"" VersionOverride=""1.0.0""/>
     </ItemGroup>", File.ReadAllText(Path.Combine(projectADirectory, "projectA.csproj")));
@@ -1384,14 +1327,10 @@ namespace Dotnet.Integration.Test
                     packageX200);
 
             var propsFile = @$"<Project>
-                                <PropertyGroup>
-                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                </PropertyGroup>
-                                <ItemGroup>
-                                <PackageVersion Include=""X"" Version=""1.0.0"" />
-                                </ItemGroup>
-                            </Project>
-                            ";
+  <ItemGroup>
+    <PackageVersion Include=""X"" Version=""1.0.0"" />
+  </ItemGroup>
+</Project>";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1448,14 +1387,10 @@ namespace Dotnet.Integration.Test
                     packageX200);
 
             var propsFile = @$"<Project>
-                                <PropertyGroup>
-                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                </PropertyGroup>
-                                <ItemGroup>
-                                <PackageVersion Include=""X"" Version=""1.0.0"" />
-                                </ItemGroup>
-                            </Project>
-                            ";
+  <ItemGroup>
+    <PackageVersion Include=""X"" Version=""1.0.0"" />
+  </ItemGroup>
+</Project>";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1512,15 +1447,11 @@ namespace Dotnet.Integration.Test
                     packageX200);
 
             var propsFile = @$"<Project>
-                                    <PropertyGroup>
-                                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                    </PropertyGroup>
-                                    <ItemGroup>
-                                    <PackageVersion Include=""X"" Version=""1.0.0"" />
-                                    <PackageReference Include=""X"" VersionOverride=""1.0.0""/>
-                                    </ItemGroup>
-                                </Project>
-                                ";
+  <ItemGroup>
+    <PackageVersion Include=""X"" Version=""1.0.0"" />
+    <PackageReference Include=""X"" VersionOverride=""1.0.0""/>
+  </ItemGroup>
+</Project>";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1572,12 +1503,7 @@ namespace Dotnet.Integration.Test
                     packageX100,
                     packageX200);
 
-            var propsFile = @$"<Project>
-                                    <PropertyGroup>
-                                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                    </PropertyGroup>
-                                </Project>
-                                ";
+            var propsFile = @$"<Project />";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1634,12 +1560,7 @@ namespace Dotnet.Integration.Test
                     packageX100,
                     packageX200);
 
-            var propsFile = @$"<Project>
-                                    <PropertyGroup>
-                                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                    </PropertyGroup>
-                                </Project>
-                                ";
+            var propsFile = @$"<Project />";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -100,10 +100,7 @@ namespace Dotnet.Integration.Test
 
                 var propsFile =
 @$"<Project>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    </PropertyGroup>
-    <ItemGroup>
+   <ItemGroup>
         <PackageVersion Include=""X"" Version=""[0.1.0,)"" />
     </ItemGroup>
 </Project>";
@@ -152,9 +149,6 @@ namespace Dotnet.Integration.Test
 
                 var propsFile =
 @$"<Project>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include=""X"" Version=""2.0.0"" />
     </ItemGroup>
@@ -202,9 +196,6 @@ namespace Dotnet.Integration.Test
 
                 var propsFile =
 @$"<Project>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    </PropertyGroup>
     <ItemGroup>
         <GlobalPackageReference Include=""X"" Version=""0.1.0"" />
     </ItemGroup>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -1758,10 +1758,6 @@ EndGlobal";
                 using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
                 {
                     var xml = XDocument.Load(stream);
-                    ProjectFileUtils.AddProperty(
-                        xml,
-                        "ManagePackageVersionsCentrally",
-                        "true");
 
                     ProjectFileUtils.AddItem(
                          xml,
@@ -2305,10 +2301,6 @@ EndGlobal";
                 using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
                 {
                     var xml = XDocument.Load(stream);
-                    ProjectFileUtils.AddProperty(
-                        xml,
-                        "ManagePackageVersionsCentrally",
-                        "true");
 
                     ProjectFileUtils.AddItem(
                          xml,
@@ -2491,7 +2483,6 @@ EndGlobal";
                 {
                     var xml = XDocument.Load(stream);
                     ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", Constants.DefaultTargetFramework.GetShortFolderName());
-                    ProjectFileUtils.AddProperty(xml, "ManagePackageVersionsCentrally", "true");
 
                     ProjectFileUtils.AddItem(
                         xml,

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -5202,10 +5202,10 @@ namespace ClassLibrary
         }
 
         [PlatformTheory(Platform.Windows)]
-        [InlineData("false")]
-        [InlineData("true")]
+        [InlineData(false)]
+        [InlineData(true)]
         [InlineData(null)]
-        public void PackCommand_PackProjectWithCentralTransitiveDependencies(string CentralPackageTransitivePinningEnabled)
+        public void PackCommand_PackProjectWithCentralTransitiveDependencies(bool? centralPackageTransitivePinningEnabled)
         {
             using (var testDirectory = msbuildFixture.CreateTestDirectory())
             {
@@ -5228,20 +5228,19 @@ namespace ClassLibrary
                         new Dictionary<string, string>(),
                         new Dictionary<string, string>());
 
-                    if (CentralPackageTransitivePinningEnabled != null)
+                    if (centralPackageTransitivePinningEnabled.HasValue)
                     {
                         ProjectFileUtils.AddProperty(
                             xml,
                             ProjectBuildProperties.CentralPackageTransitivePinningEnabled,
-                            CentralPackageTransitivePinningEnabled);
+                            centralPackageTransitivePinningEnabled.ToString());
                     }
 
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
 
                 // The test depends on the presence of these packages and their versions.
-                // Change to Directory.Packages.props when new cli that supports NuGet.props will be downloaded
-                var directoryPackagesPropsName = Path.Combine(workingDirectory, $"Directory.Packages.props");
+                var directoryPackagesPropsName = Path.Combine(workingDirectory, "Directory.Packages.props");
                 var directoryPackagesPropsContent = @"<Project>
                         <ItemGroup>
                             <PackageVersion Include=""Moq"" Version=""4.10.0""/>
@@ -5267,7 +5266,7 @@ namespace ClassLibrary
                     Assert.Equal(1, dependencyGroups.Count);
                     Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard20, dependencyGroups[0].TargetFramework);
                     var packages = dependencyGroups[0].Packages.ToList();
-                    if (CentralPackageTransitivePinningEnabled == "true")
+                    if (centralPackageTransitivePinningEnabled == true)
                     {
                         Assert.Equal(2, packages.Count);
                         var moqPackage = packages.Where(p => p.Id.Equals("Moq", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -5228,11 +5228,6 @@ namespace ClassLibrary
                         new Dictionary<string, string>(),
                         new Dictionary<string, string>());
 
-                    ProjectFileUtils.AddProperty(
-                        xml,
-                        ProjectBuildProperties.ManagePackageVersionsCentrally,
-                        "true");
-
                     if (CentralPackageTransitivePinningEnabled != null)
                     {
                         ProjectFileUtils.AddProperty(
@@ -5246,15 +5241,12 @@ namespace ClassLibrary
 
                 // The test depends on the presence of these packages and their versions.
                 // Change to Directory.Packages.props when new cli that supports NuGet.props will be downloaded
-                var directoryPackagesPropsName = Path.Combine(workingDirectory, $"Directory.Build.props");
+                var directoryPackagesPropsName = Path.Combine(workingDirectory, $"Directory.Packages.props");
                 var directoryPackagesPropsContent = @"<Project>
                         <ItemGroup>
-                            <PackageVersion Include = ""Moq"" Version = ""4.10.0""/>
-                            <PackageVersion Include = ""Castle.Core"" Version = ""4.4.0""/>
+                            <PackageVersion Include=""Moq"" Version=""4.10.0""/>
+                            <PackageVersion Include=""Castle.Core"" Version=""4.4.0""/>
                         </ItemGroup>
-                        <PropertyGroup>
-	                        <CentralPackageVersionsFileImported>true</CentralPackageVersionsFileImported>
-                        </PropertyGroup>
                     </Project>";
                 File.WriteAllText(directoryPackagesPropsName, directoryPackagesPropsContent);
 

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -1292,9 +1292,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             File.WriteAllText(
                 Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props"),
                 @$"<Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
   <ItemGroup>
     <GlobalPackageReference Include=""PackageA"" Version=""1.2.3"" />
     <GlobalPackageReference Include=""PackageB"" Version=""4.5.6"" />

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
@@ -44,13 +44,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                 ProjectCollection = projectCollection
             };
 
-            var propsFile =
-@$"<Project>
-    <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    </PropertyGroup>
-</Project>";
-            File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);
+            File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), @$"<Project />");
 
             string projectContent =
 @$"<Project Sdk=""Microsoft.NET.Sdk"">    
@@ -204,13 +198,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             };
 
             // Arrange Directory.Packages.props file
-            var propsFile =
-@$"<Project>
-    <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    </PropertyGroup>
-</Project>";
-            File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);
+            File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), "<Project />");
 
             // Arrange project file
             string projectContent =
@@ -271,11 +259,8 @@ namespace NuGet.CommandLine.Xplat.Tests
             // Arrange Directory.Packages.props file
             var propsFile =
 @$"<Project>
-    <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    </PropertyGroup>
     <ItemGroup>
-    <PackageVersion Include=""X"" Version=""1.0.0"" />
+        <PackageVersion Include=""X"" Version=""1.0.0"" />
     </ItemGroup>
 </Project>";
             File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);
@@ -340,11 +325,8 @@ namespace NuGet.CommandLine.Xplat.Tests
             // Arrange Directory.Packages.props file
             var propsFile =
 @$"<Project>
-    <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    </PropertyGroup>
     <ItemGroup>
-    <PackageVersion Include=""X"" Version=""1.0.0"" />
+        <PackageVersion Include=""X"" Version=""1.0.0"" />
     </ItemGroup>
 </Project>";
             File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);
@@ -409,11 +391,8 @@ namespace NuGet.CommandLine.Xplat.Tests
             // Arrange Directory.Packages.props file
             var propsFile =
 @$"<Project>
-    <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    </PropertyGroup>
     <ItemGroup>
-    <PackageVersion Include=""X"" Version=""1.0.0"" />
+        <PackageVersion Include=""X"" Version=""1.0.0"" />
     </ItemGroup>
 </Project>";
             File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);

--- a/test/TestUtilities/Test.Utility/CentralPackageVersionsManagementFile.cs
+++ b/test/TestUtilities/Test.Utility/CentralPackageVersionsManagementFile.cs
@@ -17,7 +17,7 @@ namespace NuGet.Test.Utility
     {
         private const string DirectoryPackagesProps = "Directory.Packages.props";
 
-        private readonly bool _managePackageVersionsCentrally;
+        private readonly bool? _managePackageVersionsCentrally;
 
         private readonly Dictionary<string, string> _packageVersions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -25,7 +25,7 @@ namespace NuGet.Test.Utility
 
         private readonly FileInfo _path;
 
-        private CentralPackageVersionsManagementFile(string directoryPath, bool managePackageVersionsCentrally)
+        private CentralPackageVersionsManagementFile(string directoryPath, bool? managePackageVersionsCentrally)
         {
             _path = new FileInfo(Path.Combine(directoryPath, DirectoryPackagesProps));
             _managePackageVersionsCentrally = managePackageVersionsCentrally;
@@ -47,7 +47,7 @@ namespace NuGet.Test.Utility
         /// <param name="directoryPath">The path to a directory to create the central package management in.</param>
         /// <param name="managePackageVersionsCentrally"><see langword="true" /> to enable central package management (default), or <see langword="false" /> to disable it.</param>
         /// <returns></returns>
-        public static CentralPackageVersionsManagementFile Create(string directoryPath, bool managePackageVersionsCentrally = true)
+        public static CentralPackageVersionsManagementFile Create(string directoryPath, bool? managePackageVersionsCentrally = null)
         {
             return new CentralPackageVersionsManagementFile(directoryPath, managePackageVersionsCentrally);
         }
@@ -59,6 +59,11 @@ namespace NuGet.Test.Utility
         /// <returns>The current <see cref="CentralPackageVersionsManagementFile" />.</returns>
         public CentralPackageVersionsManagementFile RemovePackageVersion(string packageId)
         {
+            if (_managePackageVersionsCentrally == false)
+            {
+                return this;
+            }
+
             _packageVersions.Remove(packageId);
 
             IsDirty = true;
@@ -71,10 +76,13 @@ namespace NuGet.Test.Utility
         /// </summary>
         public void Save()
         {
+            XElement managePackageVersionsCentrallyProperty = _managePackageVersionsCentrally is null
+                ? null
+                : new XElement("PropertyGroup", new XElement(ProjectBuildProperties.ManagePackageVersionsCentrally, new XText(_managePackageVersionsCentrally.ToString())));
+
             XDocument directoryPackagesPropsXml = new XDocument(
                 new XElement("Project",
-                    new XElement("PropertyGroup",
-                        new XElement(ProjectBuildProperties.ManagePackageVersionsCentrally, new XText(_managePackageVersionsCentrally.ToString()))),
+                    managePackageVersionsCentrallyProperty,
                     new XElement("ItemGroup", _packageVersions.Select(i => new XElement("PackageVersion", new XAttribute("Include", i.Key), new XAttribute("Version", i.Value)))),
                     new XElement("ItemGroup", _globalPackageReferences.Select(i => new XElement("GlobalPackageReference", new XAttribute("Include", i.Key), new XAttribute("Version", i.Value))))));
 
@@ -91,6 +99,11 @@ namespace NuGet.Test.Utility
         /// <returns>The current <see cref="CentralPackageVersionsManagementFile" />.</returns>
         public CentralPackageVersionsManagementFile SetPackageVersion(string packageId, string packageVersion)
         {
+            if (_managePackageVersionsCentrally == false)
+            {
+                return this;
+            }
+
             _packageVersions[packageId] = packageVersion;
 
             IsDirty = true;
@@ -100,6 +113,11 @@ namespace NuGet.Test.Utility
 
         public CentralPackageVersionsManagementFile SetGlobalPackageReference(string packageId, string packageVersion)
         {
+            if (_managePackageVersionsCentrally == false)
+            {
+                return this;
+            }
+
             _globalPackageReferences[packageId] = packageVersion;
 
             IsDirty = true;

--- a/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
@@ -194,7 +194,7 @@ SDKs found: {string.Join(", ", Directory.EnumerateDirectories(SdkDirSource).Sele
 
         private static void CopyRestoreArtifacts(string artifactsDirectory, string pathToSdkInCli, string configuration)
         {
-            var fileExtensions = new[] { ".dll", ".pdb", ".targets" };
+            var fileExtensions = new[] { ".dll", ".pdb", ".targets", ".props" };
 
             var sdkDependencies = new List<string> { "NuGet.Build.Tasks.Console", "NuGet.CommandLine.XPlat" };
 

--- a/test/TestUtilities/Test.Utility/TestFileSystemUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestFileSystemUtility.cs
@@ -54,7 +54,13 @@ namespace NuGet.Test.Utility
                     File.WriteAllText(Path.Combine(testDirectory.FullName, "Directory.Build.props"), "<Project />");
                     File.WriteAllText(Path.Combine(testDirectory.FullName, "Directory.Build.targets"), "<Project />");
                     File.WriteAllText(Path.Combine(testDirectory.FullName, "Directory.Build.rsp"), string.Empty);
-                    File.WriteAllText(Path.Combine(testDirectory.FullName, "Directory.Packages.props"), "<Project />");
+                    File.WriteAllText(
+                        Path.Combine(testDirectory.FullName, "Directory.Packages.props"),
+                        @"<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>");
                 }
                 catch (Exception)
                 {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11834

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This change makes it so the presence of a `Directory.Packages.props` means that central package management is implicitly on.  I've had countless people ask over the last year why you have to have the file and explicitly set `ManagePackageVersionsCentrally` to `true`.  The logic now assumes if `Directory.Packages.props` exists then `ManagePackageVersionsCentrally` should be `true` unless the user has already set that property to a value, including if its set in `Directory.Packages.props`.  This will make it easier for customers to onboard.  


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
