### PR TITLE
Shorten source-build inner clone paths

### DIFF
--- a/eng/pipelines/templates/Source_Build.yml
+++ b/eng/pipelines/templates/Source_Build.yml
@@ -12,7 +12,7 @@ steps:
   condition: "or(failed(), eq(variables['System.debug'], 'true'))"
   continueOnError: true
   inputs:
-    PathToPublish: "artifacts/sb/s/log/source-build.binlog"
+    PathToPublish: "artifacts/sb/log/source-build.binlog"
     ArtifactName: "Source-build log"
     ArtifactType: Container
 

--- a/eng/pipelines/templates/Source_Build.yml
+++ b/eng/pipelines/templates/Source_Build.yml
@@ -12,7 +12,7 @@ steps:
   condition: "or(failed(), eq(variables['System.debug'], 'true'))"
   continueOnError: true
   inputs:
-    PathToPublish: "artifacts/source-build/self/log/source-build.binlog"
+    PathToPublish: "artifacts/sb/s/log/source-build.binlog"
     ArtifactName: "Source-build log"
     ArtifactType: Container
 

--- a/eng/source-build/build.sh
+++ b/eng/source-build/build.sh
@@ -85,7 +85,7 @@ ReadGlobalVersion Microsoft.DotNet.Arcade.Sdk
 export ARCADE_VERSION=$_ReadGlobalVersion
 
 if [ -z "$DotNetBuildFromSourceFlavor" ] || [ "$DotNetBuildFromSourceFlavor" != "Product" ]; then
-  export NUGET_PACKAGES=$scriptroot/../../artifacts/sb/s/package-cache/
+  export NUGET_PACKAGES=$scriptroot/../../artifacts/sb/package-cache/
 fi
 
-"$DOTNET" msbuild "$scriptroot/source-build.proj" /p:Configuration=$configuration /p:DotNetBuildFromSource=true /p:ArcadeBuildFromSource=true "/p:RepoRoot=$scriptroot/../../" "/bl:$scriptroot/../../artifacts/sb/s/log/source-build.binlog" $args
+"$DOTNET" msbuild "$scriptroot/source-build.proj" /p:Configuration=$configuration /p:DotNetBuildFromSource=true /p:ArcadeBuildFromSource=true "/p:RepoRoot=$scriptroot/../../" "/bl:$scriptroot/../../artifacts/sb/log/source-build.binlog" $args

--- a/eng/source-build/build.sh
+++ b/eng/source-build/build.sh
@@ -85,7 +85,7 @@ ReadGlobalVersion Microsoft.DotNet.Arcade.Sdk
 export ARCADE_VERSION=$_ReadGlobalVersion
 
 if [ -z "$DotNetBuildFromSourceFlavor" ] || [ "$DotNetBuildFromSourceFlavor" != "Product" ]; then
-  export NUGET_PACKAGES=$scriptroot/../../artifacts/source-build/self/package-cache/
+  export NUGET_PACKAGES=$scriptroot/../../artifacts/sb/s/package-cache/
 fi
 
-"$DOTNET" msbuild "$scriptroot/source-build.proj" /p:Configuration=$configuration /p:DotNetBuildFromSource=true /p:ArcadeBuildFromSource=true "/p:RepoRoot=$scriptroot/../../" "/bl:$scriptroot/../../artifacts/source-build/self/log/source-build.binlog" $args
+"$DOTNET" msbuild "$scriptroot/source-build.proj" /p:Configuration=$configuration /p:DotNetBuildFromSource=true /p:ArcadeBuildFromSource=true "/p:RepoRoot=$scriptroot/../../" "/bl:$scriptroot/../../artifacts/sb/s/log/source-build.binlog" $args


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/3791

Related changes in Arcade: https://github.com/dotnet/arcade/pull/14292

This PR changes the source build inner clone path from `source-build/self` to `sb`
