### PR TITLE
Refactor VMs to listen to Settings being changed and notify the View to update

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Windows.Data;
 using Microsoft.ServiceHub.Framework;
+using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuGet.VisualStudio;
@@ -26,8 +27,9 @@ namespace NuGet.PackageManagement.UI
             IServiceBroker serviceBroker,
             INuGetSolutionManagerService solutionManager,
             IEnumerable<IProjectContextInfo> projects,
-            INuGetUI uiController)
-            : base(serviceBroker, projects, uiController)
+            INuGetUI uiController,
+            ISettings settings)
+            : base(serviceBroker, projects, uiController, settings)
         {
             _solutionManager = solutionManager;
             _solutionManager.ProjectUpdated += ProjectChanged;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Shell;
+using NuGet.Configuration;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.ProjectModel;
 using NuGet.Versioning;
@@ -36,8 +37,9 @@ namespace NuGet.PackageManagement.UI
         private PackageSolutionDetailControlModel(
             IServiceBroker serviceBroker,
             IEnumerable<IProjectContextInfo> projects,
-            INuGetUI uiController)
-            : base(serviceBroker, projects, uiController)
+            INuGetUI uiController,
+            ISettings settings)
+            : base(serviceBroker, projects, uiController, settings)
         {
             IsRequestedVisible = projects.Any(p => p.ProjectStyle == ProjectStyle.PackageReference);
         }
@@ -69,9 +71,10 @@ namespace NuGet.PackageManagement.UI
             INuGetSolutionManagerService solutionManager,
             IEnumerable<IProjectContextInfo> projects,
             INuGetUI uiController,
+            ISettings settings,
             CancellationToken cancellationToken)
         {
-            var packageSolutionDetailControlModel = new PackageSolutionDetailControlModel(serviceBroker, projects, uiController);
+            var packageSolutionDetailControlModel = new PackageSolutionDetailControlModel(serviceBroker, projects, uiController, settings);
             await packageSolutionDetailControlModel.InitializeAsync(solutionManager, cancellationToken);
             return packageSolutionDetailControlModel;
         }
@@ -81,9 +84,10 @@ namespace NuGet.PackageManagement.UI
             IEnumerable<IProjectContextInfo> projects,
             IServiceBroker serviceBroker,
             INuGetUI uiController,
+            ISettings settings,
             CancellationToken cancellationToken)
         {
-            var packageSolutionDetailControlModel = new PackageSolutionDetailControlModel(serviceBroker, projects, uiController);
+            var packageSolutionDetailControlModel = new PackageSolutionDetailControlModel(serviceBroker, projects, uiController, settings);
             await packageSolutionDetailControlModel.InitializeAsync(solutionManager, cancellationToken);
             return packageSolutionDetailControlModel;
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -104,6 +104,7 @@ namespace NuGet.PackageManagement.UI
                     Model.Context.SolutionManagerService,
                     Model.Context.Projects,
                     Model.UIController,
+                    Settings,
                     CancellationToken.None);
             }
             else
@@ -112,7 +113,8 @@ namespace NuGet.PackageManagement.UI
                     Model.Context.ServiceBroker,
                     Model.Context.SolutionManagerService,
                     Model.Context.Projects,
-                    Model.UIController);
+                    Model.UIController,
+                    Settings);
             }
 
             if (_windowSearchHostFactory != null)
@@ -184,14 +186,6 @@ namespace NuGet.PackageManagement.UI
             }
 
             _missingPackageStatus = false;
-
-            Settings.SettingsChanged += Settings_SettingsChanged;
-        }
-
-        private void Settings_SettingsChanged(object sender, EventArgs e)
-        {
-            _detailModel.PackageSourceMappingViewModel.SettingsChanged();
-            _detailModel.SetInstalledOrUpdateButtonIsEnabled();
         }
 
         public PackageRestoreBar RestoreBar { get; private set; }
@@ -1207,7 +1201,7 @@ namespace NuGet.PackageManagement.UI
         {
             var timeSpan = GetTimeSinceLastRefreshAndRestart();
 
-            _detailModel.PackageSourceMappingViewModel.SettingsChanged();
+            _detailModel.PackageSourceMappingViewModel.UpdateState();
 
             if (_dontStartNewSearch || !_initialized)
             {
@@ -1540,8 +1534,6 @@ namespace NuGet.PackageManagement.UI
             Model.Context.ProjectActionsExecuted -= OnProjectActionsExecuted;
 
             Model.Context.SourceService.PackageSourcesChanged -= PackageSourcesChanged;
-
-            Settings.SettingsChanged -= Settings_SettingsChanged;
 
             Model.Dispose();
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/LocalDetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/LocalDetailControlModelTests.cs
@@ -9,7 +9,7 @@ using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Sdk.TestFramework;
 using Microsoft.VisualStudio.Threading;
 using Moq;
-using NuGet.PackageManagement.UI.Utility;
+using NuGet.Configuration;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using NuGet.VisualStudio;
@@ -54,7 +54,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 Mock.Of<IServiceBroker>(),
                 solutionManager: solMgr.Object,
                 projects: new List<IProjectContextInfo>(),
-                uiController: Mock.Of<INuGetUI>());
+                uiController: Mock.Of<INuGetUI>(),
+                settings: Mock.Of<ISettings>());
 
             _testInstance.SetCurrentPackageAsync(
                 _testViewModel,
@@ -83,7 +84,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 Mock.Of<IServiceBroker>(),
                 Mock.Of<INuGetSolutionManagerService>(),
                 projects: new[] { project.Object },
-                uiController: Mock.Of<INuGetUI>());
+                uiController: Mock.Of<INuGetUI>(),
+                settings: Mock.Of<ISettings>());
 
             Assert.False(model.Options.ShowClassicOptions);
         }
@@ -100,7 +102,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 Mock.Of<IServiceBroker>(),
                 Mock.Of<INuGetSolutionManagerService>(),
                 projects: new[] { project.Object },
-                uiController: Mock.Of<INuGetUI>());
+                uiController: Mock.Of<INuGetUI>(),
+                settings: Mock.Of<ISettings>());
 
             Assert.True(model.Options.ShowClassicOptions);
         }
@@ -112,7 +115,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 Mock.Of<IServiceBroker>(),
                 Mock.Of<INuGetSolutionManagerService>(),
                 Enumerable.Empty<IProjectContextInfo>(),
-                uiController: Mock.Of<INuGetUI>());
+                uiController: Mock.Of<INuGetUI>(),
+                settings: Mock.Of<ISettings>());
 
             Assert.Null(model.SelectedVersion);
             Assert.Null(model.InstalledVersion);
@@ -126,7 +130,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 Mock.Of<IServiceBroker>(),
                 Mock.Of<INuGetSolutionManagerService>(),
                 Enumerable.Empty<IProjectContextInfo>(),
-                uiController: Mock.Of<INuGetUI>());
+                uiController: Mock.Of<INuGetUI>(),
+                settings: Mock.Of<ISettings>());
 
             NuGetVersion installedVersion = NuGetVersion.Parse("1.0.0");
 
@@ -158,7 +163,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 Mock.Of<IServiceBroker>(),
                 Mock.Of<INuGetSolutionManagerService>(),
                 Enumerable.Empty<IProjectContextInfo>(),
-                uiController: Mock.Of<INuGetUI>());
+                uiController: Mock.Of<INuGetUI>(),
+                settings: Mock.Of<ISettings>());
 
             NuGetVersion installedVersion = NuGetVersion.Parse("1.0.0");
 
@@ -206,6 +212,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
                     projects: new List<IProjectContextInfo>(),
                     serviceBroker: serviceBroker.Object,
                     uiController: Mock.Of<INuGetUI>(),
+                    settings: Mock.Of<ISettings>(),
                     CancellationToken.None);
             });
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/TestDetailControlModel.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/TestDetailControlModel.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ServiceHub.Framework;
 using Moq;
+using NuGet.Configuration;
 using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.PackageManagement.UI.Test
@@ -19,7 +20,7 @@ namespace NuGet.PackageManagement.UI.Test
         public override bool IsSolution => throw new NotImplementedException();
 
         public TestDetailControlModel(IServiceBroker serviceBroker, IEnumerable<IProjectContextInfo> projects)
-            : base(serviceBroker, projects, uiController: Mock.Of<INuGetUI>())
+            : base(serviceBroker, projects, uiController: Mock.Of<INuGetUI>(), settings: Mock.Of<ISettings>())
         {
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
@@ -16,7 +16,6 @@ using Microsoft.VisualStudio.Shell.ServiceBroker;
 using Moq;
 using NuGet.Configuration;
 using NuGet.Frameworks;
-using NuGet.PackageManagement.UI.Utility;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -166,7 +165,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 _mockServiceBroker.Object,
                 solutionManager: solMgr.Object,
                 Array.Empty<IProjectContextInfo>(),
-                uiController: _mockNuGetUI.Object);
+                uiController: _mockNuGetUI.Object,
+                settings: Mock.Of<ISettings>());
             _testInstance.SetCurrentPackageAsync(
                 _testViewModel,
                 ItemFilter.All,
@@ -667,7 +667,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 mockServiceBroker.Object,
                 solutionManager: new Mock<INuGetSolutionManagerService>().Object,
                 projects: new[] { project.Object },
-                uiController: _mockNuGetUI.Object);
+                uiController: _mockNuGetUI.Object,
+                settings: Mock.Of<ISettings>());
 
             // Arrange
             List<VersionInfoContextInfo> testVersions = includePrerelease ? ExpectedVersionsList_IncludePrerelease() : ExpectedVersionsList();
@@ -776,7 +777,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 mockServiceBroker.Object,
                 solutionManager: new Mock<INuGetSolutionManagerService>().Object,
                 projects: new[] { project.Object },
-                uiController: _mockNuGetUI.Object);
+                uiController: _mockNuGetUI.Object,
+                settings: Mock.Of<ISettings>());
 
             // Arrange
             List<VersionInfoContextInfo> testVersions = includePrerelease ? ExpectedVersionsList_IncludePrerelease() : ExpectedVersionsList();
@@ -898,7 +900,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 mockServiceBroker.Object,
                 solutionManager: new Mock<INuGetSolutionManagerService>().Object,
                 projects: new[] { project.Object },
-                uiController: _mockNuGetUI.Object);
+                uiController: _mockNuGetUI.Object,
+                settings: Mock.Of<ISettings>());
 
             // Arrange
             List<VersionInfoContextInfo> testVersions = includePrerelease ? ExpectedVersionsList_IncludePrerelease() : ExpectedVersionsList();
@@ -1107,7 +1110,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 mockServiceBroker.Object,
                 solutionManager: new Mock<INuGetSolutionManagerService>().Object,
                 projects: new[] { project.Object },
-                uiController: _mockNuGetUI.Object);
+                uiController: _mockNuGetUI.Object,
+                settings: Mock.Of<ISettings>());
 
             // Arrange
             List<VersionInfoContextInfo> testVersions = includePrerelease ? ExpectedVersionsList_IncludePrerelease() : ExpectedVersionsList();
@@ -1210,7 +1214,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 mockServiceBroker.Object,
                 solutionManager: new Mock<INuGetSolutionManagerService>().Object,
                 projects: new[] { project.Object },
-                uiController: _mockNuGetUI.Object);
+                uiController: _mockNuGetUI.Object,
+                settings: Mock.Of<ISettings>());
 
             // Arrange
             List<VersionInfoContextInfo> testVersions = includePrerelease ? ExpectedVersionsList_IncludePrerelease() : ExpectedVersionsList();
@@ -1313,7 +1318,8 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 mockServiceBroker.Object,
                 solutionManager: new Mock<INuGetSolutionManagerService>().Object,
                 projects: new[] { project.Object },
-                uiController: _mockNuGetUI.Object);
+                uiController: _mockNuGetUI.Object,
+                settings: Mock.Of<ISettings>());
 
             // Arrange
             List<VersionInfoContextInfo> testVersions = includePrerelease ? ExpectedVersionsList_IncludePrerelease() : ExpectedVersionsList();
@@ -1433,6 +1439,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
                     projects: new List<IProjectContextInfo>(),
                     serviceBroker: _mockServiceBroker.Object,
                     uiController: _mockNuGetUI.Object,
+                    settings: Mock.Of<ISettings>(),
                     CancellationToken.None);
 
                 await _testInstance.SetCurrentPackageAsync(

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/UserInterfaceService/NuGetUITests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/UserInterfaceService/NuGetUITests.cs
@@ -174,7 +174,7 @@ namespace NuGet.PackageManagement.UI.Test
             Mock<PackageSourceMapping> mockPackageSourceMapping = new(patterns);
             NuGetUI nuGetUI = CreateNuGetUI(Mock.Of<INuGetUILogger>(), Mock.Of<INuGetUILogger>(), currentTab, isSolution, mockPackageSourceMapping);
 
-            var packageSourceMappingActionViewModel = PackageSourceMappingActionViewModel.Create(nuGetUI);
+            var packageSourceMappingActionViewModel = PackageSourceMappingActionViewModel.Create(nuGetUI, Mock.Of<ISettings>());
 
             // Act
             nuGetUI.LaunchNuGetOptionsDialog(packageSourceMappingActionViewModel);
@@ -205,7 +205,7 @@ namespace NuGet.PackageManagement.UI.Test
             bool isSolution = false;
             NuGetUI nuGetUI = CreateNuGetUI(Mock.Of<INuGetUILogger>(), Mock.Of<INuGetUILogger>(), currentTab, isSolution, mockPackageSourceMapping);
 
-            var packageSourceMappingActionViewModel = PackageSourceMappingActionViewModel.Create(nuGetUI);
+            var packageSourceMappingActionViewModel = PackageSourceMappingActionViewModel.Create(nuGetUI, Mock.Of<ISettings>());
 
             // Act
             nuGetUI.LaunchNuGetOptionsDialog(packageSourceMappingActionViewModel);
@@ -236,7 +236,7 @@ namespace NuGet.PackageManagement.UI.Test
             bool isSolution = true;
             NuGetUI nuGetUI = CreateNuGetUI(Mock.Of<INuGetUILogger>(), Mock.Of<INuGetUILogger>(), currentTab, isSolution, mockPackageSourceMapping);
 
-            var packageSourceMappingActionViewModel = PackageSourceMappingActionViewModel.Create(nuGetUI);
+            var packageSourceMappingActionViewModel = PackageSourceMappingActionViewModel.Create(nuGetUI, Mock.Of<ISettings>());
             packageSourceMappingActionViewModel.PackageId = packageId;
             var _ = packageSourceMappingActionViewModel.IsPackageMapped; // Emulate the View binding to this property by invoking the getter which initializes the Property's backing field.
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageSourceMappingActionViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageSourceMappingActionViewModelTests.cs
@@ -21,7 +21,17 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
-                PackageSourceMappingActionViewModel.Create(uiController: null);
+                PackageSourceMappingActionViewModel.Create(uiController: null, settings: Mock.Of<ISettings>());
+            });
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                PackageSourceMappingActionViewModel.Create(uiController: Mock.Of<INuGetUI>(), settings: null);
+            });
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                PackageSourceMappingActionViewModel.Create(uiController: null, settings: null);
             });
         }
 
@@ -29,7 +39,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
         public void PackageSourceMappingActionViewModel_WithNullMappingObject_PropertiesSetToDefaults()
         {
             var mockUiController = new Mock<INuGetUI>();
-            var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object);
+            var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object, Mock.Of<ISettings>());
 
             Assert.Equal(mockUiController.Object, target.UIController);
             Assert.Equal(false, target.IsPackageSourceMappingEnabled);
@@ -60,7 +70,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             mockUiController.Setup(uiController => uiController.UIContext).Returns(mockUIContext.Object);
 
             // Act
-            var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object);
+            var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object, Mock.Of<ISettings>());
             string targetPackageIdBeforeSelecting = target.PackageId;
             target.PackageId = packageId;
 
@@ -93,7 +103,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             mockUiController.Setup(uiController => uiController.UIContext).Returns(mockUIContext.Object);
 
             // Act
-            var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object);
+            var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object, Mock.Of<ISettings>());
             target.PackageId = packageId;
 
             // Assert
@@ -130,7 +140,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             mockUiController.Setup(uiController => uiController.ActivePackageSourceMoniker).Returns(aggregatePackageSourceMoniker);
 
             // Act
-            var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object);
+            var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object, Mock.Of<ISettings>());
             target.PackageId = packageId;
 
             // Assert
@@ -165,7 +175,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             mockUiController.Setup(uiController => uiController.ActivePackageSourceMoniker).Returns(singlePackageSourceMoniker);
 
             // Act
-            var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object);
+            var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object, Mock.Of<ISettings>());
             target.PackageId = packageId;
 
             // Assert
@@ -216,7 +226,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             mockUiController.Setup(uiController => uiController.ActivePackageSourceMoniker).Returns(singlePackageSourceMoniker);
 
             // Act
-            var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object);
+            var target = PackageSourceMappingActionViewModel.Create(mockUiController.Object, Mock.Of<ISettings>());
             target.PackageId = packageId;
 
             // Assert


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13044

Regression? Last working version: N/A

## Description
This refactor puts the responsibility of listening for changes to Settings on the ViewModel objects that care about when the settings are updated and moves it away from the PackageManagerControl View which previously was listening to changes on Settings so it could instruct the ViewModels when to send property change notifications to the View. By removing the extra coordination from the PackageManagerControl, we end up with ViewModels that more closely follow the MVVM pattern, encapsulate their interaction with Settings, and whose dependencies are better expressed by the arguments they take in the constructor.

This change represents the implementation of PR feedback I provided here: https://github.com/NuGet/NuGet.Client/pull/5166#discussion_r1198459461 and created draft PR to demonstrate the requested change: https://github.com/NuGet/NuGet.Client/pull/5173. There are opportunities for further improvement, but this refactor is limited to moving the responsibility of listening for changes to Settings from the PackageManagerControl to the ViewModels that need to react when Settings change.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->
As a refactor, no additional tests were added, but I updated existing tests.

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
