### PR TITLE
Try to fix MockServer_RestorePCVerifySessionId

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetMockServerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetMockServerTests.cs
@@ -2,11 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
 using NuGet.Frameworks;
+using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Test.Utility;
 using Xunit;
@@ -15,63 +16,43 @@ namespace NuGet.CommandLine.Test
 {
     public class NuGetMockServerTests
     {
-        [Fact]
-        public void MockServer_RestorePRVerifySessionId()
+        [Theory]
+        [InlineData(ProjectStyle.PackageReference)]
+        [InlineData(ProjectStyle.PackagesConfig)]
+        public void MockServer_VerifySessionId(ProjectStyle projectStyle)
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
             {
-                var nugetexe = Util.GetNuGetExePath();
-
                 var packageA = new FileInfo(Util.CreateTestPackage("a", "1.0.0", pathContext.PackageSource));
                 var packageB = new FileInfo(Util.CreateTestPackage("b", "1.0.0", pathContext.PackageSource));
 
-                var project = SimpleTestProjectContext.CreateNETCore("proj", pathContext.SolutionRoot, NuGetFramework.Parse("net46"));
+                string inputPath = null;
 
-                project.AddPackageToAllFrameworks(new SimpleTestPackageContext("a", "1.0.0"));
-                project.AddPackageToAllFrameworks(new SimpleTestPackageContext("b", "1.0.0"));
-
-                project.Save();
-
-                var ids = new List<string>();
-
-                using (var server = Util.CreateMockServer(new[] { packageA, packageB }))
+                switch (projectStyle)
                 {
-                    server.RequestObserver = context =>
-                    {
-                        ids.Add(context.Request.Headers.Get(ProtocolConstants.SessionId));
-                    };
-
-                    server.Start();
-
-                    var result = Util.Restore(pathContext, project.ProjectPath, 0, "-Source", server.Uri + "nuget");
-
-                    result.Success.Should().BeTrue();
-
-                    ids.Distinct().Count().Should().Be(1, "all requests should be in the same session");
-                    ids.All(s => !string.IsNullOrEmpty(s) && Guid.TryParse(s, out var r)).Should().BeTrue("the values should guids");
-                }
-            }
-        }
-
-        [Fact]
-        public void MockServer_RestorePCVerifySessionId()
-        {
-            // Arrange
-            using (var pathContext = new SimpleTestPathContext())
-            {
-                var nugetexe = Util.GetNuGetExePath();
-
-                var packageA = new FileInfo(Util.CreateTestPackage("a", "1.0.0", pathContext.PackageSource));
-                var packageB = new FileInfo(Util.CreateTestPackage("b", "1.0.0", pathContext.PackageSource));
-
-                Util.CreateFile(pathContext.SolutionRoot, "packages.config",
+                    case ProjectStyle.PackagesConfig:
+                        inputPath = Util.CreateFile(
+                            pathContext.SolutionRoot,
+                            "packages.config",
 @"<packages>
   <package id=""a"" version=""1.0.0"" targetFramework=""net45"" />
   <package id=""b"" version=""1.0.0"" targetFramework=""net45"" />
 </packages>");
+                        break;
 
-                var ids = new List<string>();
+                    case ProjectStyle.PackageReference:
+                        var project = SimpleTestProjectContext.CreateNETCore("proj", pathContext.SolutionRoot, NuGetFramework.Parse("net46"));
+
+                        project.AddPackageToAllFrameworks(new SimpleTestPackageContext("a", "1.0.0"), new SimpleTestPackageContext("b", "1.0.0"));
+
+                        project.Save();
+
+                        inputPath = project.ProjectPath;
+                        break;
+                }
+
+                var ids = new ConcurrentBag<string>();
 
                 using (var server = Util.CreateMockServer(new[] { packageA, packageB }))
                 {
@@ -82,13 +63,11 @@ namespace NuGet.CommandLine.Test
 
                     server.Start();
 
-                    var result = Util.Restore(pathContext, Path.Combine(pathContext.SolutionRoot, "packages.config"), 0, "-Source", server.Uri + "nuget");
+                    var result = Util.Restore(pathContext, inputPath, 0, "-Source", server.Uri + "nuget");
 
                     result.Success.Should().BeTrue();
-
-                    // Not all ids will be in the same session, this is due to how cache contexts are shared for packages.config
-                    ids.Distinct().Count().Should().BeLessThan(ids.Count(), "Verify some requests share the same cache context and session id.");
                     ids.All(s => !string.IsNullOrEmpty(s) && Guid.TryParse(s, out var r)).Should().BeTrue("the values should guids");
+                    ids.GroupBy(i => i).Any(i => i.Count() > 1).Should().BeTrue("At least one session should have been reused");
                 }
             }
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -316,15 +316,15 @@ namespace NuGet.CommandLine.Test
         /// <param name="directory">The directory of the created file.</param>
         /// <param name="fileName">The name of the created file.</param>
         /// <param name="fileContent">The content of the created file.</param>
-        public static void CreateFile(string directory, string fileName, string fileContent)
+        public static string CreateFile(string directory, string fileName, string fileContent)
         {
-            if (!Directory.Exists(directory))
-            {
-                Directory.CreateDirectory(directory);
-            }
+            var fileInfo = new FileInfo(Path.Combine(directory, fileName));
 
-            var fileFullName = Path.Combine(directory, fileName);
-            CreateFile(fileFullName, fileContent);
+            fileInfo.Directory.Create();
+
+            CreateFile(fileInfo.FullName, fileContent);
+
+            return fileInfo.FullName;
         }
 
         public static void CreateFile(string fileFullName, string fileContent)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2623

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This test has failed a few times this month because it expects to send multiple HTTP requests and at least one session be reused.  I've refactored the test to be a `Theory` to reuse code from the same test that checks PackageReference and used a GroupBy() to make the test easier to understand.  I also tried using a `ConcurrentBag<T>` instead of a `List<T>` in case the problem is concurrency.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
