### PR TITLE
Allow authentication on subsequent attempts when the credential provider returns a 'message not found' message for a previous request.

### DIFF
--- a/src/NuGet.Core/NuGet.Credentials/SecurePluginCredentialProvider.cs
+++ b/src/NuGet.Core/NuGet.Credentials/SecurePluginCredentialProvider.cs
@@ -210,6 +210,10 @@ namespace NuGet.Credentials
 
                 taskResponse = new CredentialResponse(result);
             }
+            else if (credentialResponse.ResponseCode == MessageResponseCode.NotFound)
+            {
+                taskResponse = new CredentialResponse(CredentialStatus.UserCanceled);
+            }
             else
             {
                 taskResponse = new CredentialResponse(CredentialStatus.ProviderNotApplicable);

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -256,17 +256,11 @@ namespace NuGet.Protocol
                 promptCredentials = await _credentialService
                     .GetCredentialsAsync(_packageSource.SourceUri, proxy, type, message, token);
 
-                if (promptCredentials == null)
-                {
-                    // If this is the case, this means none of the credential providers were able to
-                    // handle the credential request or no credentials were available for the
-                    // endpoint.
-                    authState.Block();
-                }
-                else
-                {
-                    authState.Increment();
-                }
+                // If promptCredentials == null means none of the credential providers were able to
+                // handle the credential request or no credentials were available for the
+                // endpoint, a retry might fix the issue so we increment the authState.
+
+                authState.Increment();
             }
             catch (OperationCanceledException)
             {

--- a/test/NuGet.Core.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderTests.cs
@@ -391,7 +391,7 @@ namespace NuGet.Credentials.Test
                 var credentialResponse = await provider.GetAsync(_uri, proxy, credType, message, isRetry, isInteractive, token);
 
                 Assert.True(credentialResponse.Status == CredentialStatus.UserCanceled);
-                Assert.Null(credentialResponse.Credentials);                
+                Assert.Null(credentialResponse.Credentials);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
@@ -360,7 +360,7 @@ namespace NuGet.Protocol.Tests
             var clientHandler = new HttpClientHandler();
 
             var credentialService = Mock.Of<ICredentialService>();
-            
+
             int retryCount = 0;
             var innerHandler = new LambdaMessageHandler(
                 _ =>
@@ -384,8 +384,8 @@ namespace NuGet.Protocol.Tests
                     // Assert
                     Assert.NotNull(response);
                     Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-                }                
-            }            
+                }
+            }
 
             // Assert
             Assert.Equal(HttpSourceAuthenticationHandler.MaxAuthRetries + 1, retryCount);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12540

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

When accessing a private Azure DevOps (AzDO) feed in the .NET CLI, for instance, during the execution of `dotnet restore --interactive`, the Azure Artifacts credentials provider displays a device code login prompt in the console. If the user fails to respond in time, the credentials provider returns a [credentials not found message](https://github.com/microsoft/artifacts-credprovider/blob/d6aba72dd317a31f9d041268919fd148a2be6155/CredentialProvider.Microsoft/RequestHandlers/GetAuthenticationCredentialsRequestHandler.cs#L111-L117). However, the NuGet protocol implementation treats this scenario as an error and subsequently blocks any attempts to authenticate with that feed. Even though I mentioned the AzDO credential provider in the above description, this issue is applicable to any credential provider that returns a `MessageNotFound` message.

Updated the implementation to ensure that if the credentials provider returns null response for any reason, then any subsequent attempts to authenticate with that feed will succeed until the [maximum retry attempts are](https://github.com/NuGet/NuGet.Client/blob/2a234707a663f731e4de93cba4014ed1a8259def/src/NuGet.Core/NuGet.Protocol/HttpSource/AmbientAuthenticationState.cs#L11) reached.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added

- **Documentation**
  - [x] N/A
