### PR TITLE
Use string.Contains instead of IEnumerable.Contains

### DIFF
--- a/src/NuGet.Core/NuGet.Versioning/VersionRangeFactory.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRangeFactory.cs
@@ -204,7 +204,7 @@ namespace NuGet.Versioning
 #if NETCOREAPP2_1_OR_GREATER
                 if (allowFloating && minVersionString.Contains('*', StringComparison.Ordinal))
 #else
-                if (allowFloating && minVersionString.Contains('*'))
+                if (allowFloating && minVersionString.Contains("*"))
 #endif
                 {
                     // single floating version


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13124

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This code was mistakenly using the `Enumerable.Contains()` overload which ends up allocating an enumerator. Using `string.Contains()` avoids this allocation and is faster. Example benchmark over 100 invocations:

| Method              | Count | Mean      | Error     | StdDev    | Gen0   | Allocated |
|-------------------- |------ |----------:|----------:|----------:|-------:|----------:|
| Enumerable.Contains | 100   | 29.830 us | 0.0658 us | 0.0583 us | 0.3662 |    2003 B |
| string.Contains     | 100   |  5.516 us | 0.0105 us | 0.0082 us |      - |         - |


## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
