### PR TITLE
Avoid creating the capture class for calls to WithExtension

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -722,12 +722,24 @@ namespace NuGet.Commands
 
         private static IEnumerable<LockFileItem> WithExtension(this IList<LockFileItem> items, string extension)
         {
-            if (items == null)
+            if (items == null || items.Count == 0)
             {
                 return Enumerable.Empty<LockFileItem>();
             }
 
-            return items.Where(c => extension.Equals(Path.GetExtension(c.Path), StringComparison.OrdinalIgnoreCase));
+            return FilterExtensions(items, extension);
+
+            static IEnumerable<LockFileItem> FilterExtensions(IList<LockFileItem> items, string extension)
+            {
+                for (int i = 0; i < items.Count; ++i)
+                {
+                    var item = items[i];
+                    if (extension.Equals(Path.GetExtension(item.Path), StringComparison.OrdinalIgnoreCase))
+                    {
+                        yield return item;
+                    }
+                }
+            }
         }
 
         private static string GetMatchingFrameworkStrings(PackageSpec spec, NuGetFramework framework)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Related: https://github.com/NuGet/Home/issues/12748

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Calls to `WithExtension()` created a closure object to capture the extension string being passed in. We can avoid this by unrolling the LINQ.

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
