### PR TITLE
Avoid some allocations in GetCompatibilityData

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
@@ -455,20 +455,35 @@ namespace NuGet.Commands
         {
             // Use data from the current lock file if it exists.
             LockFileTargetLibrary targetLibrary = null;
-            var target = _lockFile.Targets.FirstOrDefault(t => Equals(t.TargetFramework, graph.Framework) && string.Equals(t.RuntimeIdentifier, graph.RuntimeIdentifier, StringComparison.Ordinal));
-            if (target != null)
+
+            for (int i = 0; i < _lockFile.Targets.Count; ++i)
             {
-                targetLibrary = target.Libraries
-                    .FirstOrDefault(t => t.Name.Equals(libraryId.Name, StringComparison.OrdinalIgnoreCase) && t.Version.Equals(libraryId.Version));
+                var target = _lockFile.Targets[i];
+                if (Equals(target.TargetFramework, graph.Framework) && string.Equals(target.RuntimeIdentifier, graph.RuntimeIdentifier, StringComparison.Ordinal))
+                {
+                    for (int j = 0; j < target.Libraries.Count; ++j)
+                    {
+                        var library = target.Libraries[j];
+                        if (library.Name.Equals(libraryId.Name, StringComparison.OrdinalIgnoreCase) && library.Version.Equals(libraryId.Version))
+                        {
+                            targetLibrary = library;
+                            break;
+                        }
+                    }
+
+                    break;
+                }
             }
 
             IEnumerable<string> files = null;
-            var lockFileLibrary = _lockFile.Libraries
-                .FirstOrDefault(l => l.Name.Equals(libraryId.Name, StringComparison.OrdinalIgnoreCase) && l.Version.Equals(libraryId.Version));
-
-            if (lockFileLibrary != null)
+            for (var i = 0; i < _lockFile.Libraries.Count; i++)
             {
-                files = lockFileLibrary.Files;
+                LockFileLibrary library = _lockFile.Libraries[i];
+                if (library.Name.Equals(libraryId.Name, StringComparison.OrdinalIgnoreCase) && library.Version.Equals(libraryId.Version))
+                {
+                    files = library.Files;
+                    break;
+                }
             }
 
             if (files == null || targetLibrary == null)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Related: https://github.com/NuGet/Home/issues/12748

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Calls to GetCompatibilityData were boxing enumerators and creating closure objects. This change avoids these allocations.

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
