### PR TITLE
Unroll Linq in GetFlags

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
@@ -641,13 +641,23 @@ namespace NuGet.Packaging
 
             // PERF: Avoid Linq on hot paths
             var splitFlags = flags.Split(CommaArray, StringSplitOptions.RemoveEmptyEntries);
+
+#if NETSTANDARD2_0
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+#elif NET472_OR_GREATER || NET5_0_OR_GREATER
             var set = new HashSet<string>(splitFlags.Length, StringComparer.OrdinalIgnoreCase);
-            for (int i = 0; i < splitFlags.Length; ++i)
+#endif
+            foreach (string flag in splitFlags)
             {
-                set.Add(splitFlags[i].Trim());
+                set.Add(flag.Trim());
             }
 
-            var result = set.ToList();
+            var result = new List<string>(set.Count);
+            foreach (var s in set)
+            {
+                result.Add(s);
+            }
+
             result.Sort(StringComparer.OrdinalIgnoreCase);
 
             return result;

--- a/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
@@ -639,12 +639,18 @@ namespace NuGet.Packaging
                 return EmptyList;
             }
 
-            var set = new HashSet<string>(
-                flags.Split(CommaArray, StringSplitOptions.RemoveEmptyEntries)
-                    .Select(flag => flag.Trim()),
-                StringComparer.OrdinalIgnoreCase);
+            // PERF: Avoid Linq on hot paths
+            var splitFlags = flags.Split(CommaArray, StringSplitOptions.RemoveEmptyEntries);
+            var set = new HashSet<string>(splitFlags.Length, StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < splitFlags.Length; ++i)
+            {
+                set.Add(splitFlags[i].Trim());
+            }
 
-            return set.OrderBy(s => s, StringComparer.OrdinalIgnoreCase).ToList();
+            var result = set.ToList();
+            result.Sort(StringComparer.OrdinalIgnoreCase);
+
+            return result;
         }
 
         private HashSet<PackageDependency> GetPackageDependencies(IEnumerable<XElement> nodes, bool useStrictVersionCheck)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Related: https://github.com/NuGet/Home/issues/12748

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Avoids some allocations due to LINQ usage. Also creates a new list that is sorted in place rather than using `OrderBy`, which internally allocates a buffer for all the items, and then calling `ToList()` which allocates a list again.

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
