### PR TITLE
Switch from ConcurrentDictionary to Dictionary with lock to avoid rep…

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -36,11 +35,11 @@ namespace NuGet.Commands
         private bool _isFallbackFolderSource;
         private bool _useLegacyAssetTargetFallbackBehavior;
 
-        private readonly ConcurrentDictionary<LibraryRangeCacheKey, AsyncLazy<LibraryDependencyInfo>> _dependencyInfoCache
-            = new ConcurrentDictionary<LibraryRangeCacheKey, AsyncLazy<LibraryDependencyInfo>>();
+        private readonly Dictionary<LibraryRangeCacheKey, Task<LibraryDependencyInfo>> _dependencyInfoCache
+            = new Dictionary<LibraryRangeCacheKey, Task<LibraryDependencyInfo>>();
 
-        private readonly ConcurrentDictionary<LibraryRange, AsyncLazy<LibraryIdentity>> _libraryMatchCache
-            = new ConcurrentDictionary<LibraryRange, AsyncLazy<LibraryIdentity>>();
+        private readonly Dictionary<LibraryRange, Task<LibraryIdentity>> _libraryMatchCache
+            = new Dictionary<LibraryRange, Task<LibraryIdentity>>();
 
         // Limiting concurrent requests to limit the amount of files open at a time.
         private readonly static SemaphoreSlim _throttle = GetThrottleSemaphoreSlim(EnvironmentVariableWrapper.Instance);
@@ -205,20 +204,7 @@ namespace NuGet.Commands
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-
-            AsyncLazy<LibraryIdentity> result = null;
-
-            var action = new AsyncLazy<LibraryIdentity>(async () =>
-                await FindLibraryCoreAsync(libraryRange, cacheContext, logger, cancellationToken));
-
-            if (cacheContext.RefreshMemoryCache)
-            {
-                result = _libraryMatchCache.AddOrUpdate(libraryRange, action, (k, v) => action);
-            }
-            else
-            {
-                result = _libraryMatchCache.GetOrAdd(libraryRange, action);
-            }
+            Task<LibraryIdentity> result = FindLibraryIdentityAsync(libraryRange, cacheContext);
 
             try
             {
@@ -237,6 +223,32 @@ namespace NuGet.Commands
                 }
             }
             return null;
+
+            Task<LibraryIdentity> FindLibraryIdentityAsync(LibraryRange libraryRange, SourceCacheContext cacheContext)
+            {
+                Task<LibraryIdentity> result;
+                if (cacheContext.RefreshMemoryCache)
+                {
+                    lock (_libraryMatchCache)
+                    {
+                        result = FindLibraryCoreAsync(libraryRange, cacheContext, logger, cancellationToken);
+                        _libraryMatchCache[libraryRange] = result;
+                    }
+                }
+                else
+                {
+                    lock (_libraryMatchCache)
+                    {
+                        if (!_libraryMatchCache.TryGetValue(libraryRange, out result))
+                        {
+                            result = FindLibraryCoreAsync(libraryRange, cacheContext, logger, cancellationToken);
+                            _libraryMatchCache[libraryRange] = result;
+                        }
+                    }
+                }
+
+                return result;
+            }
         }
 
         private async Task<LibraryIdentity> FindLibraryCoreAsync(
@@ -322,7 +334,7 @@ namespace NuGet.Commands
         /// is either <see langword="null" /> or empty.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
-        public async Task<LibraryDependencyInfo> GetDependenciesAsync(
+        public Task<LibraryDependencyInfo> GetDependenciesAsync(
             LibraryIdentity libraryIdentity,
             NuGetFramework targetFramework,
             SourceCacheContext cacheContext,
@@ -351,23 +363,32 @@ namespace NuGet.Commands
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            AsyncLazy<LibraryDependencyInfo> result = null;
-
-            var action = new AsyncLazy<LibraryDependencyInfo>(async () =>
-                await GetDependenciesCoreAsync(libraryIdentity, targetFramework, cacheContext, logger, cancellationToken));
+            Task<LibraryDependencyInfo> result;
 
             var key = new LibraryRangeCacheKey(libraryIdentity, targetFramework);
 
             if (cacheContext.RefreshMemoryCache)
             {
-                result = _dependencyInfoCache.AddOrUpdate(key, action, (k, v) => action);
+                lock (_dependencyInfoCache)
+                {
+                    result = GetDependenciesCoreAsync(libraryIdentity, targetFramework, cacheContext, logger, cancellationToken);
+                    _dependencyInfoCache[key] = result;
+
+                }
             }
             else
             {
-                result = _dependencyInfoCache.GetOrAdd(key, action);
+                lock (_dependencyInfoCache)
+                {
+                    if (!_dependencyInfoCache.TryGetValue(key, out result))
+                    {
+                        result = GetDependenciesCoreAsync(libraryIdentity, targetFramework, cacheContext, logger, cancellationToken);
+                        _dependencyInfoCache[key] = result;
+                    }
+                }
             }
 
-            return await result;
+            return result;
         }
 
         private async Task<LibraryDependencyInfo> GetDependenciesCoreAsync(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -231,7 +231,7 @@ namespace NuGet.Commands
                 {
                     lock (_libraryMatchCache)
                     {
-                        result = FindLibraryCoreAsync(libraryRange, cacheContext, logger, cancellationToken);
+                        result = Task.Run(() => FindLibraryCoreAsync(libraryRange, cacheContext, logger, cancellationToken), cancellationToken);
                         _libraryMatchCache[libraryRange] = result;
                     }
                 }
@@ -241,7 +241,7 @@ namespace NuGet.Commands
                     {
                         if (!_libraryMatchCache.TryGetValue(libraryRange, out result))
                         {
-                            result = FindLibraryCoreAsync(libraryRange, cacheContext, logger, cancellationToken);
+                            result = Task.Run(() => FindLibraryCoreAsync(libraryRange, cacheContext, logger, cancellationToken), cancellationToken);
                             _libraryMatchCache[libraryRange] = result;
                         }
                     }
@@ -257,7 +257,6 @@ namespace NuGet.Commands
             ILogger logger,
             CancellationToken cancellationToken)
         {
-
             await EnsureResource();
 
             if (libraryRange.VersionRange?.MinVersion != null && libraryRange.VersionRange.IsMinInclusive && !libraryRange.VersionRange.IsFloating)


### PR DESCRIPTION
…eated closure allocations.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Related: https://github.com/NuGet/Home/issues/12748

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Switches from usage of `ConcurrentDictionary` to `Dictionary` used within a lock. Empirically, it appears that this lock is unlikely to suffer from significant contention, and the allocation overhead from using `ConcurrentDictionary` ends up being significant.

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
