### PR TITLE
PMC should close text view on dispose

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsole.cs
+++ b/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsole.cs
@@ -746,6 +746,12 @@ namespace NuGetConsole.Implementation.Console
                 {
                     disposable.Dispose();
                 }
+
+                if (_view is not null)
+                {
+                    _view.CloseView();
+                    _view = null;
+                }
             }
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13104

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Close the VS text view on dispose, so that underlying resources can be cleaned up correctly.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: This class doesn't have any tests, and is tightly coupled to VS components (and WPF?), so can't (easily?) be tested
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
