### PR TITLE
Static graph restore should work with packages.config only solution

### DIFF
--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -29,8 +29,10 @@ namespace Msbuild.Integration.Test
             _msbuildFixture = fixture;
         }
 
-        [PlatformFact(Platform.Windows)]
-        public async Task MsbuildRestore_PackagesConfigDependencyAsync()
+        [PlatformTheory(Platform.Windows)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task MsbuildRestore_PackagesConfigDependencyAsync(bool useStaticGraphRestore)
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -70,7 +72,8 @@ namespace Msbuild.Integration.Test
                     packageX);
 
                 // Act
-                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true", ignoreExitCode: true);
+                string args = $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true /p:RestoreUseStaticGraphEvaluation={useStaticGraphRestore}";
+                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, args, ignoreExitCode: true);
 
 
                 // Assert
@@ -79,8 +82,10 @@ namespace Msbuild.Integration.Test
             }
         }
 
-        [PlatformFact(Platform.Windows)]
-        public async Task MsbuildRestore_PackagesConfigIsOptInAsync()
+        [PlatformTheory(Platform.Windows)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task MsbuildRestore_PackagesConfigIsOptInAsync(bool useStaticGraphRestore)
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -120,7 +125,8 @@ namespace Msbuild.Integration.Test
                     packageX);
 
                 // Act
-                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot}", ignoreExitCode: true);
+                string args = $"/t:restore {pathContext.SolutionRoot} /p:RestoreUseStaticGraphEvaluation={useStaticGraphRestore}";
+                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, args, ignoreExitCode: true);
 
 
                 // Assert
@@ -1130,8 +1136,10 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             }
         }
 
-        [PlatformFact(Platform.Windows)]
-        public async Task MsbuildRestore_PackagesConfigDependency_WithHttpSource_Warns()
+        [PlatformTheory(Platform.Windows)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task MsbuildRestore_PackagesConfigDependency_WithHttpSource_Warns(bool useStaticGraphEvaluation)
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -1173,8 +1181,8 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                     packageX);
 
                 // Act
-                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true", ignoreExitCode: true);
-
+                string args = $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true /p:RestoreUseStaticGraphEvaluation={useStaticGraphEvaluation}";
+                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, args, ignoreExitCode: true);
 
                 // Assert
                 Assert.True(result.ExitCode == 0, result.AllOutput);

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -82,10 +82,8 @@ namespace Msbuild.Integration.Test
             }
         }
 
-        [PlatformTheory(Platform.Windows)]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task MsbuildRestore_PackagesConfigIsOptInAsync(bool useStaticGraphRestore)
+        [PlatformFact(Platform.Windows)]
+        public async Task MsbuildRestore_PackagesConfigIsOptInAsync()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -125,8 +123,7 @@ namespace Msbuild.Integration.Test
                     packageX);
 
                 // Act
-                string args = $"/t:restore {pathContext.SolutionRoot} /p:RestoreUseStaticGraphEvaluation={useStaticGraphRestore}";
-                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, args, ignoreExitCode: true);
+                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot}", ignoreExitCode: true);
 
 
                 // Assert


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13109

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Static graph restore has an early exit that "normal" restore doesn't, in order to provide a different error message. However, the early exist code assumed there'd be at least 1 PackageReference project. While it probably doesn't make much sense to use static graph restore with a packages.config only solution, IMO it shouldn't have such a behaviour difference.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
