### PR TITLE
when accessing a private feed, try last known valid credentials before invoking credential providers.

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -158,8 +158,12 @@ namespace NuGet.Protocol
             }
         }
 
-        private async Task<ICredentials> AcquireCredentialsAsync(HttpStatusCode statusCode, Guid credentialsVersion, ILogger log,
-            bool areLastKnownGoodCredentialsTried, CancellationToken cancellationToken)
+        private async Task<ICredentials> AcquireCredentialsAsync(
+            HttpStatusCode statusCode,
+            Guid credentialsVersion,
+            ILogger log,
+            bool areLastKnownGoodCredentialsTried,
+            CancellationToken cancellationToken)
         {
             // Only one request may prompt and attempt to auth at a time
             await _httpClientLock.WaitAsync(cancellationToken);
@@ -206,6 +210,7 @@ namespace NuGet.Protocol
                 ICredentials promptCredentials = default;
                 if (!areLastKnownGoodCredentialsTried)
                 {
+                    // isProxy is false because the previous if statement allows only Unauthorized or Forbidden types, not Proxy.
                     _ = _credentialService.TryGetLastKnownGoodCredentialsFromCache(uri: _packageSource.SourceUri, isProxy: false, out promptCredentials);
                 }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
@@ -137,7 +137,7 @@ namespace NuGet.Protocol.FuncTest
                     _ = await source.GetAsync(request, ProcessResponse, logger.Object, cancellationToken);
 
                     request = new HttpSourceCachedRequest(packageUrl, "2", httpSourceCacheContext);
-                    _ = await source.GetAsync(request, ProcessResponse, logger.Object, cancellationToken);                    
+                    _ = await source.GetAsync(request, ProcessResponse, logger.Object, cancellationToken);
                 }
                 finally
                 {

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
@@ -150,7 +150,7 @@ namespace NuGet.Protocol.FuncTest
                 // Following the 401 response, NuGet attempts to acquire the necessary credentials.
                 // These credentials are then used for subsequent requests to the feed.
                 // Note: If 'HttpClientHandler.PreAuthenticate' is set to true, this behavior might differ as 
-                // credentials would be sent preemptively with the initial request.
+                // credentials would be sent preemptively after the initial request.
 
                 // In this test, the expected number of requests is 4, but it turns out to be 5. This discrepancy occurs because 
                 // we initialize _credentials =  new HttpSourceCredentials() in the HttpSourceAuthenticationHandler constructor.

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
@@ -152,11 +152,14 @@ namespace NuGet.Protocol.FuncTest
                 // Note: If 'HttpClientHandler.PreAuthenticate' is set to true, this behavior might differ as 
                 // credentials would be sent preemptively after the initial request.
 
-                // In this test, the expected number of requests is 4, but it turns out to be 5. This discrepancy occurs because 
-                // we initialize _credentials =  new HttpSourceCredentials() in the HttpSourceAuthenticationHandler constructor.
-                // The HttpHandler pipeline operates under the assumption that credentials have already been set, although they have not.
-                // As a result, NuGet initially sends 2 requests to the server without credentials when accessing the private feed for the first time
-                // and then invokes the credential service.
+                // In this test, 2 requests are sent from the test's perspective, and the previous paragraph's explanation will
+                // make you believe the server should see 4, but it turns out to be 5. This discrepancy occurs because 
+                // HttpSourceCredentials is only initialized with credentials if the PackageSource object has credentials set.
+                // In other words, if there are creds in nuget.config or the appropriate environment variable. However, if the
+                // package source uses a credential provider, the provider is not asked for credentials until after the first 401
+                // response. After the auth handler requests HttpClientHandler to make a second request, it will again make
+                // an unautheticated request, and then finally obtain the credentials and send an authenticated request from
+                // what the server sees as the 3rd request.
 
                 // Request flow while accessing index.json
                 // NuGet -> Server (No Credentials) - 1st request

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
@@ -179,7 +179,6 @@ namespace NuGet.Protocol.FuncTest
                 server.Requests.Should().HaveCount(5);
                 // This should have been 2, but is 3 because of the reason mentioned above.
                 server.Requests.Count(RequestWithoutAuthorizationHeader).Should().Be(3);
-                server.Requests.Any(r => r.Url!.OriginalString == serviceIndexUrl).Should().BeTrue();
 
                 server.CapturedCredentials.Should().HaveCount(2);
                 foreach (var creds in server.CapturedCredentials)

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
@@ -159,7 +159,7 @@ namespace NuGet.Protocol.Tests
                 InnerHandler = GetLambdaMessageHandler(HttpStatusCode.Forbidden)
             };
 
-            var request = new HttpRequestMessage(HttpMethod.Get, "http://foo");
+            var request = new HttpRequestMessage(HttpMethod.Get, PackageSourceUrl);
             request.SetConfiguration(new HttpRequestMessageConfiguration(promptOn403: false));
 
             // Act
@@ -563,7 +563,7 @@ namespace NuGet.Protocol.Tests
                 for (int i = 0; i < HttpSourceAuthenticationHandler.MaxAuthRetries + 1; i++)
                 {
                     // Act
-                    var response = await client.SendAsync(request: new HttpRequestMessage(HttpMethod.Get, "http://foo"), CancellationToken.None);
+                    var response = await client.SendAsync(request: new HttpRequestMessage(HttpMethod.Get, PackageSourceUrl), CancellationToken.None);
 
                     // Assert
                     Assert.NotNull(response);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
@@ -416,6 +416,7 @@ namespace NuGet.Protocol.Tests
 
             using var client = new HttpClient(handler);
 
+            // Act
             // Send 3 requests to the feed which succeed only if initial credentials are used.
             await SendAsync(client, 3);
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
@@ -21,10 +21,12 @@ namespace NuGet.Protocol.Tests
     [Collection(nameof(NotThreadSafeResourceCollection))]
     public class HttpSourceAuthenticationHandlerTests
     {
+        private const string PackageSourceUrl = "http://package.source.test";
+
         [Fact]
         public void Constructor_WithSourceCredentials_InitializesClientHandler()
         {
-            var packageSource = new PackageSource("http://package.source.test", "source")
+            var packageSource = new PackageSource(PackageSourceUrl, "source")
             {
                 Credentials = new PackageSourceCredential("source", "user", "password", isPasswordClearText: true, validAuthenticationTypesText: null)
             };
@@ -44,7 +46,7 @@ namespace NuGet.Protocol.Tests
         [Fact]
         public async Task SendAsync_WithUnauthenticatedSource_PassesThru()
         {
-            var packageSource = new PackageSource("http://package.source.test");
+            var packageSource = new PackageSource(PackageSourceUrl);
             var clientHandler = new HttpClientHandler();
 
             var credentialService = new Mock<ICredentialService>(MockBehavior.Strict);
@@ -64,7 +66,7 @@ namespace NuGet.Protocol.Tests
         [Fact]
         public async Task SendAsync_WithAcquiredCredentialsOn401_RetriesRequest()
         {
-            var packageSource = new PackageSource("http://package.source.test");
+            var packageSource = new PackageSource(PackageSourceUrl);
             var clientHandler = new HttpClientHandler();
 
             var credentialService = Mock.Of<ICredentialService>();
@@ -104,7 +106,7 @@ namespace NuGet.Protocol.Tests
         public async Task SendAsync_WithAcquiredCredentialsOn403_RetriesRequest()
         {
             // Arrange
-            var packageSource = new PackageSource("http://package.source.test");
+            var packageSource = new PackageSource(PackageSourceUrl);
             var clientHandler = new HttpClientHandler();
 
             var credentialService = Mock.Of<ICredentialService>();
@@ -146,7 +148,7 @@ namespace NuGet.Protocol.Tests
         public async Task SendAsync_With403PromptDisabled_Returns403()
         {
             // Arrange
-            var packageSource = new PackageSource("http://package.source.test");
+            var packageSource = new PackageSource(PackageSourceUrl);
             var clientHandler = new HttpClientHandler();
 
             var credentialService = new Mock<ICredentialService>(MockBehavior.Strict);
@@ -172,7 +174,7 @@ namespace NuGet.Protocol.Tests
         public async Task SendAsync_WhenTaskCanceledExceptionThrownDuringAcquiringCredentials_Throws()
         {
             // Arrange
-            var packageSource = new PackageSource("http://package.source.test");
+            var packageSource = new PackageSource(PackageSourceUrl);
             var clientHandler = new HttpClientHandler();
 
             var credentialService = Mock.Of<ICredentialService>();
@@ -218,7 +220,7 @@ namespace NuGet.Protocol.Tests
         public async Task SendAsync_WhenOperationCanceledExceptionThrownDuringAcquiringCredentials_Throws()
         {
             // Arrange
-            var packageSource = new PackageSource("http://package.source.test");
+            var packageSource = new PackageSource(PackageSourceUrl);
             var clientHandler = new HttpClientHandler();
 
             var cts = new CancellationTokenSource();
@@ -267,7 +269,7 @@ namespace NuGet.Protocol.Tests
         public async Task SendAsync_WithWrongCredentials_StopsRetryingAfter3Times()
         {
             // Arrange
-            var packageSource = new PackageSource("http://package.source.test");
+            var packageSource = new PackageSource(PackageSourceUrl);
             var clientHandler = new HttpClientHandler();
 
             var credentialService = Mock.Of<ICredentialService>();
@@ -316,7 +318,7 @@ namespace NuGet.Protocol.Tests
         public async Task SendAsync_EveryRequestForCredentialsInvokesCacheFirstAndCredentialProvidersIfNeeded_SucceedsAsync()
         {
             // Arrange
-            var packageSource = new PackageSource("http://package.source.test");
+            var packageSource = new PackageSource(PackageSourceUrl);
             var credentialServiceMock = new Mock<ICredentialService>();
             var clientHandler = new HttpClientHandler();
             NetworkCredential credentialsReturnedByAProvider = new NetworkCredential(userName: "user", password: "password");
@@ -390,7 +392,7 @@ namespace NuGet.Protocol.Tests
         public async Task SendAsync_CachedCredentialsAreUsedUntilTheyAreExpiredThenCredentialProvidersAreInvoked_SucceedsAsync()
         {
             // Arrange
-            var packageSource = new PackageSource("http://package.source.test");
+            var packageSource = new PackageSource(PackageSourceUrl);
             var credentialServiceMock = new Mock<ICredentialService>();
             bool isUnAuthorized = true;
             var clientHandler = new HttpClientHandler();
@@ -490,7 +492,7 @@ namespace NuGet.Protocol.Tests
         {
             for (int i = 0; i < count; i++)
             {
-                await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "http://foo"), CancellationToken.None);
+                await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, PackageSourceUrl), CancellationToken.None);
             }
         }
 
@@ -498,7 +500,7 @@ namespace NuGet.Protocol.Tests
         public async Task SendAsync_WithMissingCredentials_Returns401()
         {
             // Arrange
-            var packageSource = new PackageSource("http://package.source.test");
+            var packageSource = new PackageSource(PackageSourceUrl);
             var clientHandler = new HttpClientHandler();
 
             var credentialService = Mock.Of<ICredentialService>();
@@ -538,7 +540,7 @@ namespace NuGet.Protocol.Tests
         public async Task SendAsync_WhenCredentialServiceReturnsNullThenTheHandlerAllowsRetriesUpToMaxAuthRetriesValue_Returns401Async()
         {
             // Arrange
-            var packageSource = new PackageSource("http://package.source.test");
+            var packageSource = new PackageSource(PackageSourceUrl);
             var clientHandler = new HttpClientHandler();
 
             var credentialService = Mock.Of<ICredentialService>();
@@ -587,7 +589,7 @@ namespace NuGet.Protocol.Tests
         public async Task SendAsync_WhenCredentialServiceThrows_Returns401()
         {
             // Arrange
-            var packageSource = new PackageSource("http://package.source.test");
+            var packageSource = new PackageSource(PackageSourceUrl);
             var clientHandler = new HttpClientHandler();
 
             var credentialService = Mock.Of<ICredentialService>();
@@ -635,7 +637,7 @@ namespace NuGet.Protocol.Tests
         [Fact]
         public async Task SendAsync_WithProtocolDiagnosticsStopwatches_PausesStopwatches()
         {
-            var packageSource = new PackageSource("http://package.source.test");
+            var packageSource = new PackageSource(PackageSourceUrl);
             Stopwatch stopwatch = Stopwatch.StartNew();
             var clientHandler = new HttpClientHandler();
 
@@ -678,7 +680,7 @@ namespace NuGet.Protocol.Tests
         [Fact]
         public async Task SendAsync_RetryWithClonedGetRequest()
         {
-            var packageSource = new PackageSource("http://package.source.test");
+            var packageSource = new PackageSource(PackageSourceUrl);
             var clientHandler = new HttpClientHandler();
 
             var credentialService = Mock.Of<ICredentialService>();
@@ -730,7 +732,7 @@ namespace NuGet.Protocol.Tests
         [MemberData(nameof(GetHttpContent))]
         public async Task SendAsync_RetryWithClonedPostRequest(HttpContent httpContent)
         {
-            var packageSource = new PackageSource("http://package.source.test");
+            var packageSource = new PackageSource(PackageSourceUrl);
             var clientHandler = new HttpClientHandler();
 
             var credentialService = Mock.Of<ICredentialService>();
@@ -758,7 +760,7 @@ namespace NuGet.Protocol.Tests
                     })
             };
 
-            var response = await SendAsync(handler, new HttpRequestMessage(HttpMethod.Post, "http://package.source.test") { Content = httpContent });
+            var response = await SendAsync(handler, new HttpRequestMessage(HttpMethod.Post, PackageSourceUrl) { Content = httpContent });
 
             Assert.True(requests > 1, "No retries");
             Assert.NotNull(response);
@@ -769,7 +771,7 @@ namespace NuGet.Protocol.Tests
         public async Task Dispose_CalledMultipleTimes_DisposesInstanceAsync()
         {
             // Arrange
-            var packageSource = new PackageSource("http://package.source.test");
+            var packageSource = new PackageSource(PackageSourceUrl);
             var clientHandler = new HttpClientHandler();
             var credentialService = Mock.Of<ICredentialService>();
             Mock.Get(credentialService)
@@ -803,7 +805,7 @@ namespace NuGet.Protocol.Tests
         public async Task Dispose_CalledInMultipleObjectsConcurrently_NoLocksAsync()
         {
             // Arrange
-            var packageSource = new PackageSource("http://package.source.test");
+            var packageSource = new PackageSource(PackageSourceUrl);
             var clientHandler = new HttpClientHandler();
             var credentialService = Mock.Of<ICredentialService>();
             Mock.Get(credentialService)
@@ -885,7 +887,7 @@ namespace NuGet.Protocol.Tests
         public async Task SendAsync_AfterDispose_ThrowsAsync()
         {
             // Arrange
-            var packageSource = new PackageSource("http://package.source.test");
+            var packageSource = new PackageSource(PackageSourceUrl);
             var clientHandler = new HttpClientHandler();
 
             var handler = new HttpSourceAuthenticationHandler(packageSource, clientHandler, credentialService: null);
@@ -917,7 +919,7 @@ namespace NuGet.Protocol.Tests
         {
             using (var client = new HttpClient(handler))
             {
-                return await client.SendAsync(request ?? new HttpRequestMessage(HttpMethod.Get, "http://foo"), cancellationToken);
+                return await client.SendAsync(request ?? new HttpRequestMessage(HttpMethod.Get, PackageSourceUrl), cancellationToken);
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
@@ -440,6 +440,7 @@ namespace NuGet.Protocol.Tests
             // Send 2 more requests to the feed which succeed only if new credentials are used.
             await SendAsync(client, 2);
 
+            // Assert
             Assert.Equal(11, retryCount);
             credentialServiceMock.Verify(x => x.TryGetLastKnownGoodCredentialsFromCache(packageSource.SourceUri, It.IsAny<bool>(), out It.Ref<ICredentials>.IsAny), Times.Exactly(5));
             credentialServiceMock.Verify(x => x.GetCredentialsAsync(packageSource.SourceUri, It.IsAny<IWebProxy>(), CredentialRequestType.Unauthorized, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(2));


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/11210

Regression? Last working version: No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The [documentation](https://docs.microsoft.com/en-us/nuget/reference/extensibility/nuget-credential-providers-for-visual-studio#creating-a-nuget-credential-provider-for-visual-studio) for NuGet credential providers for Visual Studio specifies that the value of the isRetry parameter should be set to true `if credentials were previously requested for this URI, but the supplied credentials did not allow authorized access.` However, credential providers are initially invoked with `isRetry = false` for the first operation, and then with `isRetry = true` for all subsequent operations.

In the case of the `Azure Artifacts Credential Provider`, the `isRetry` value has a different meaning: If set to false or unset, cached credentials are returned to the caller. The caller must validate these returned credentials, and if found invalid, should call the credential provider again with -IsRetry set. If set to true, the credential provider will obtain new credentials instead of returning potentially invalid ones from the cache.

This behavior could impact the MSBuild server feature, as discussed in this [issue comment](https://github.com/microsoft/artifacts-credprovider/issues/347#issuecomment-1363093587).

With the changes proposed in this PR, the NuGet Client would first verify if the cached credentials are effective before invoking credential providers with `isRetry` set to true. The proposed changes will potentially reduce the number of prompts in Visual Studio and also decrease the frequency of cache invalidation in .NET CLI.

Andy clearly explained the old (current) behavior in [this issue comment](https://github.com/NuGet/Home/issues/11210#issuecomment-1132240645). I have attempted to describe the new behavior that will be implemented once this PR is merged, as follows:

```mermaid

sequenceDiagram
  autonumber
  actor Customer
  participant CredProvider
  participant CredentialService
  participant NuGet
  participant Server
  NuGet->>Server: no auth header
  Server->>NuGet: HTTP 401
  NuGet->> CredentialService: Check for cached credentials
  CredentialService->>NuGet: No cached credentials
  NuGet->> CredentialService: Acquire credentials from providers
  CredentialService->>CredProvider: isRetry: false
  CredProvider->>CredProvider: Check for cached token
  CredProvider->>Customer: Prompt for username/password
  Customer->>CredProvider: Enters CorrectAccount, correct password
  CredProvider->>NuGet: HTTP BASIC Combo1
NuGet->>Server: Auth: HTTP BASIC Combo1
  Server->>NuGet: HTTP 200
  NuGet->>Server: Auth: no auth header
  Server->>NuGet: HTTP 401
  NuGet->> CredentialService: Check for cached credentials
  CredentialService->>NuGet: Returns cached credentials
  NuGet->>Server: Auth: HTTP BASIC Combo1
  Server->>NuGet: HTTP 200
  NuGet->>Server: Auth: no auth header
  Server->>NuGet: HTTP 401
  NuGet->> CredentialService: Check for cached credentials
  CredentialService->>NuGet: Returns cached credentials
  NuGet->>Server: Auth: HTTP BASIC Combo1
  Server->>NuGet: HTTP 401 (cached tokens expired)
  NuGet->> CredentialService: Acquire credentials from providers
  CredentialService->>CredProvider: isRetry: true
  CredProvider->>Customer: Prompt for username/password
  Customer->>CredProvider: Enters CorrectAccount, correct password
  CredProvider->>NuGet: HTTP BASIC Combo2
  NuGet->>Server: Auth: HTTP BASIC Combo2
  Server->>NuGet: HTTP 200
```

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
 
- **Documentation**
  - [x] N/A
