### PR TITLE
Make PMUI packages browse page to allow loading additional packages

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -738,8 +738,7 @@ namespace NuGet.PackageManagement.UI
                 var first = _scrollViewer.VerticalOffset;
                 var last = _scrollViewer.ViewportHeight + first;
 
-                // Minus one to account for the loading indicator
-                if (_scrollViewer.ViewportHeight > 0 && last >= Items.Count - 1)
+                if (_scrollViewer.ViewportHeight > 0 && last >= PackageItems.Count())
                 {
                     NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() =>
                         LoadItemsAsync(selectedPackageItem: null, token: CancellationToken.None)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -375,7 +375,6 @@ namespace NuGet.PackageManagement.UI
                     else
                     {
                         Items.Remove(_loadingStatusIndicator);
-                        Items.Remove(_loadingVulnerabilitiesStatusIndicator);
                     }
                 }
             }
@@ -734,11 +733,23 @@ namespace NuGet.PackageManagement.UI
 
         private void ScrollViewer_ScrollChanged(object sender, ScrollChangedEventArgs e)
         {
+            int packagesCount = Items.Count;
+
+            if (Items.Contains(_loadingStatusIndicator))
+            {
+                packagesCount--;
+            }
+
+            if (Items.Contains(_loadingVulnerabilitiesStatusIndicator))
+            {
+                packagesCount--;
+            }
+
             if (_loader?.State.LoadingStatus == LoadingStatus.Ready)
             {
                 var first = _scrollViewer.VerticalOffset;
                 var last = _scrollViewer.ViewportHeight + first;
-                if (_scrollViewer.ViewportHeight > 0 && last >= Items.Count)
+                if (_scrollViewer.ViewportHeight > 0 && last >= packagesCount)
                 {
                     NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() =>
                         LoadItemsAsync(selectedPackageItem: null, token: CancellationToken.None)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -375,6 +375,7 @@ namespace NuGet.PackageManagement.UI
                     else
                     {
                         Items.Remove(_loadingStatusIndicator);
+                        Items.Remove(_loadingVulnerabilitiesStatusIndicator);
                     }
                 }
             }
@@ -738,7 +739,7 @@ namespace NuGet.PackageManagement.UI
                 var first = _scrollViewer.VerticalOffset;
                 var last = _scrollViewer.ViewportHeight + first;
 
-                if (_scrollViewer.ViewportHeight > 0 && last >= PackageItems.Count())
+                if (_scrollViewer.ViewportHeight > 0 && last >= Items.Count)
                 {
                     NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() =>
                         LoadItemsAsync(selectedPackageItem: null, token: CancellationToken.None)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -737,7 +737,9 @@ namespace NuGet.PackageManagement.UI
             {
                 var first = _scrollViewer.VerticalOffset;
                 var last = _scrollViewer.ViewportHeight + first;
-                if (_scrollViewer.ViewportHeight > 0 && last >= Items.Count)
+
+                // Minus one to account for the loading indicator
+                if (_scrollViewer.ViewportHeight > 0 && last >= Items.Count - 1)
                 {
                     NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() =>
                         LoadItemsAsync(selectedPackageItem: null, token: CancellationToken.None)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -738,7 +738,6 @@ namespace NuGet.PackageManagement.UI
             {
                 var first = _scrollViewer.VerticalOffset;
                 var last = _scrollViewer.ViewportHeight + first;
-
                 if (_scrollViewer.ViewportHeight > 0 && last >= Items.Count)
                 {
                     NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() =>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13063

Regression? Last working version: https://github.com/NuGet/NuGet.Client/commit/0dd5a1ea536201af94725353e4bc711d7560b246

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

When trying to browse for packages it only returns the first page and won’t refresh when scrolling down to the bottom of the page. 
- This is because the refreshing the list of packages is not triggered.
- The reason it is not triggered is because `Items` contains `_loadingVulnerabilitiesStatusIndicator` which would make `Items.count` 1 more than it should be. 
- I added a fix that makes sure that more packages are loaded based on the number of packages present not Items.count.

#### Before

![before](https://github.com/NuGet/NuGet.Client/assets/59111203/6a642b9a-4b91-4d2f-8669-3614925d8038)

#### After
![Aftrt](https://github.com/NuGet/NuGet.Client/assets/59111203/95d82bf4-26f7-4aae-ad0e-fee2b10e2b7a)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
