### PR TITLE
Always set ProjectPath in restore log messages, avoiding unnecessary assets file writes

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -227,6 +227,7 @@ namespace NuGet.SolutionRestoreManager
                 {
                     var restoreLogMessage = RestoreLogMessage.CreateError(NuGetLogCode.NU1105, string.Format(CultureInfo.CurrentCulture, Resources.NU1105, projectNames.ShortName, e.Message));
                     restoreLogMessage.ProjectPath = projectUniqueName;
+                    restoreLogMessage.FilePath = projectUniqueName;
 
                     nominationErrors = new List<IAssetsLogMessage>()
                     {

--- a/src/NuGet.Core/NuGet.Build.Tasks/CheckForDuplicateNuGetItemsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/CheckForDuplicateNuGetItemsTask.cs
@@ -65,6 +65,7 @@ namespace NuGet.Build.Tasks
                         duplicateItemsFormatted))
                 {
                     FilePath = MSBuildProjectFullPath,
+                    ProjectPath = MSBuildProjectFullPath,
                 });
 
                 // Set Output

--- a/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildLogger.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildLogger.cs
@@ -68,7 +68,8 @@ namespace NuGet.Build
                         logMessage = new RestoreLogMessage(message.Level, message.Message)
                         {
                             Code = message.Code,
-                            FilePath = message.ProjectPath
+                            FilePath = message.ProjectPath,
+                            ProjectPath = message.ProjectPath,
                         };
                     }
                     LogForNonMono(logMessage);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/RestoreCollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/RestoreCollectorLogger.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -134,9 +133,14 @@ namespace NuGet.Commands
                 // if the message is not suppressed then check if it needs to be upgraded to an error
                 UpgradeWarningToErrorIfNeeded(message);
 
+                if (string.IsNullOrEmpty(message.ProjectPath))
+                {
+                    message.ProjectPath = ProjectPath;
+                }
+
                 if (string.IsNullOrEmpty(message.FilePath))
                 {
-                    message.FilePath = message.ProjectPath ?? ProjectPath;
+                    message.FilePath = message.ProjectPath;
                 }
 
                 if (CollectMessage(message.Level))
@@ -162,6 +166,11 @@ namespace NuGet.Commands
                 if (string.IsNullOrEmpty(message.FilePath))
                 {
                     message.FilePath = message.ProjectPath ?? ProjectPath;
+                }
+
+                if (string.IsNullOrEmpty(message.ProjectPath))
+                {
+                    message.ProjectPath = ProjectPath;
                 }
 
                 if (CollectMessage(message.Level))

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
@@ -126,7 +126,6 @@ namespace NuGet.Commands.Restore.Utility
             {
                 var messageText = string.Format(Strings.Error_VulnerabilityDataFetch, exception.Message);
                 RestoreLogMessage logMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1900, messageText);
-                logMessage.ProjectPath = _projectFullPath;
                 _logger.Log(logMessage);
             }
         }
@@ -166,7 +165,6 @@ namespace NuGet.Commands.Restore.Utility
                             message,
                             package.Id,
                             affectedGraphs.OrderBy(s => s).ToArray());
-                        restoreLogMessage.ProjectPath = _projectFullPath;
                         _logger.Log(restoreLogMessage);
                     }
                 }
@@ -384,7 +382,6 @@ namespace NuGet.Commands.Restore.Utility
 
             string messageText = string.Format(Strings.Error_InvalidNuGetAuditLevelValue, auditLevel, "low, moderate, high, critical");
             RestoreLogMessage message = RestoreLogMessage.CreateError(NuGetLogCode.NU1014, messageText);
-            message.ProjectPath = _projectFullPath;
             _logger.Log(message);
             return 0;
         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -420,6 +420,7 @@ namespace NuGet.Commands
             var text = string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedProject, path);
             var message = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1503, text);
             message.FilePath = path;
+            message.ProjectPath = path;
 
             return message;
         }
@@ -429,6 +430,7 @@ namespace NuGet.Commands
             var text = string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedProject, path);
             var message = new RestoreLogMessage(LogLevel.Information, text);
             message.FilePath = path;
+            message.ProjectPath = path;
 
             return message;
         }

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace NuGet.Common
 {

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/AssetsLogMessage.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/AssetsLogMessage.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using NuGet.Common;
 using NuGet.Shared;
 

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -444,6 +444,8 @@ namespace NuGet.ProjectModel
                         assetsLogMessage.WarningLevel = (WarningLevel)Enum.ToObject(typeof(WarningLevel), warningLevelJson.Value<int>());
                     }
 
+                    assetsLogMessage.ProjectPath = projectPath;
+
                     if (filePathJson != null)
                     {
                         assetsLogMessage.FilePath = filePathJson.Value<string>();
@@ -452,9 +454,6 @@ namespace NuGet.ProjectModel
                     {
                         assetsLogMessage.FilePath = projectPath;
                     }
-
-                    assetsLogMessage.ProjectPath = projectPath; // TODO NK - Should we ever use ProjectPath? ReferenceNearest sets it, so I think it was intended, but reference nearest doesn't undergo round tripping.
-                    // MSBuild logger depends on it, so do we have issues reporting errors/warnings?
 
                     if (startLineNumberJson != null)
                     {

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -453,6 +453,9 @@ namespace NuGet.ProjectModel
                         assetsLogMessage.FilePath = projectPath;
                     }
 
+                    assetsLogMessage.ProjectPath = projectPath; // TODO NK - Should we ever use ProjectPath? ReferenceNearest sets it, so I think it was intended, but reference nearest doesn't undergo round tripping.
+                    // MSBuild logger depends on it, so do we have issues reporting errors/warnings?
+
                     if (startLineNumberJson != null)
                     {
                         assetsLogMessage.StartLineNumber = startLineNumberJson.Value<int>();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -11427,9 +11427,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 Version = "1.0.0"
             };
 
-            // Add 1.0.0
             projectA.AddPackageToAllFrameworks(packageX);
-            // But create only 2.0.0 on the server.
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageX);
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -11453,7 +11451,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             // Assert
             result.Success.Should().BeTrue(because: result.AllOutput);
 
-            // Is there a thing that's always guaranteed to have a $(User)
             projectA.AssetsFile.PackageFolders.Should().HaveCountGreaterThan(0);
             var globalPackagesFolder = projectA.AssetsFile.PackageFolders[0]; // the package folders are always in priority and gpf is always first.
 

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -877,6 +877,8 @@ namespace NuGet.SolutionRestoreManager.Test
             // Assert
             var additionalMessage = Assert.Single(additionalMessages);
             Assert.Equal(NuGetLogCode.NU1105, additionalMessage.Code);
+            Assert.Equal(projectFullPath, additionalMessage.ProjectPath);
+            Assert.Equal(projectFullPath, additionalMessage.FilePath);
             Assert.Contains(string.Format(CultureInfo.CurrentCulture, Resources.PropertyDoesNotHaveSingleValue, "PackageId", "PackageId.net46, PackageId.netcoreapp1.0"), additionalMessage.Message);
         }
 

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -1374,5 +1374,65 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             var packagePath = Path.Combine(pathContext.UserPackagesFolder, packageX.Id, packageX.Version, PackagingCoreConstants.NupkgMetadataFileExtension);
             File.Exists(packagePath).Should().BeTrue();
         }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task MsbuildRestore_ProjectWithWarnings_SkipsWritingAssetsFileWhenUpToDate()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+
+                var project = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("net472"));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.5.0"
+                };
+
+                project.AddPackageToAllFrameworks(new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                });
+                solution.Projects.Add(project);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX);
+
+                // Pre-Conditions
+                var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {project.ProjectPath}", ignoreExitCode: true);
+                result.Success.Should().BeTrue(because: result.AllOutput);
+                DateTime assetsFileWriteTime = GetFileLastWriteTime(project.AssetsFileOutputPath);
+                var logMessages = project.AssetsFile.LogMessages;
+                logMessages.Should().HaveCount(1);
+                logMessages[0].Code.Should().Be(NuGetLogCode.NU1603);
+
+                // Act
+                result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore /p:RestoreForce=true {project.ProjectPath}", ignoreExitCode: true);
+
+                // Assert
+                result.Success.Should().BeTrue();
+                var currentWriteTime = GetFileLastWriteTime(project.AssetsFileOutputPath);
+                currentWriteTime.Should().Be(assetsFileWriteTime);
+            }
+
+            static DateTime GetFileLastWriteTime(string path)
+            {
+                var fileInfo = new FileInfo(path);
+                fileInfo.Exists.Should().BeTrue();
+                return fileInfo.LastWriteTimeUtc;
+            }
+        }
+
+        
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/CollectorLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/CollectorLoggerTests.cs
@@ -7,18 +7,15 @@ using Moq;
 using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.ProjectModel;
-using Test.Utility;
 using Xunit;
 
 namespace NuGet.Commands.Test
 {
     public class RestoreCollectorLoggerTests
     {
-
         [Fact]
         public void CollectorLogger_DoesNotPassLogMessagesToInnerLoggerByDefault()
         {
-
             // Arrange
             var innerLogger = new Mock<ILogger>();
             var collector = new RestoreCollectorLogger(innerLogger.Object, LogLevel.Debug, hideWarningsAndErrors: false);
@@ -105,9 +102,8 @@ namespace NuGet.Commands.Test
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Never());
         }
 
-
         [Fact]
-        public void CollectorLogger_DoesNotPassLogCallsToInnerLoggerByDefaultWithFilePath()
+        public void CollectorLogger_DoesNotPassLogCallsToInnerLoggerByDefaultWithFilePathAndProjectPath()
         {
             // Arrange
             var projectPath = @"kung/fu/fighting.csproj";
@@ -130,11 +126,11 @@ namespace NuGet.Commands.Test
             collector.Log(LogLevel.Error, "Error");
 
             // Assert
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Once(), filePath: projectPath);
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Verbose, "Verbose", Times.Once(), filePath: projectPath);
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once(), filePath: projectPath);
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Once(), filePath: projectPath);
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once(), filePath: projectPath);
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Once(), filePath: projectPath, projectPath: projectPath);
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Verbose, "Verbose", Times.Once(), filePath: projectPath, projectPath: projectPath);
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once(), filePath: projectPath, projectPath: projectPath);
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Once(), filePath: projectPath, projectPath: projectPath);
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once(), filePath: projectPath, projectPath: projectPath);
         }
 
         [Fact]
@@ -1060,13 +1056,14 @@ namespace NuGet.Commands.Test
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
         }
 
-        private void VerifyInnerLoggerCalls(Mock<ILogger> innerLogger, LogLevel messageLevel, string message, Times times, NuGetLogCode code = NuGetLogCode.Undefined, string filePath = null)
+        private void VerifyInnerLoggerCalls(Mock<ILogger> innerLogger, LogLevel messageLevel, string message, Times times, NuGetLogCode code = NuGetLogCode.Undefined, string filePath = null, string projectPath = null)
         {
             innerLogger.Verify(x => x.Log(It.Is<RestoreLogMessage>(l =>
             l.Level == messageLevel &&
             l.Message == message &&
             (code == NuGetLogCode.Undefined || l.Code == code) &&
-            (filePath == null || filePath == l.FilePath))),
+            filePath == l.FilePath &&
+            projectPath == l.ProjectPath)),
             times);
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -3209,9 +3209,56 @@ namespace NuGet.Commands.Test.RestoreCommandTests
             }
         }
 
-        private static PackageSpec GetPackageSpec(string projectName, string testDirectory, string referenceSpec)
+        [Fact]
+        public async Task ExecuteAsync_ProjectWithWarnings_SkipsWritingAssetsFileWhenUpToDate()
         {
-            return JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, testDirectory).WithTestRestoreMetadata();
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            var projectName = "TestProject";
+            var projectPath = Path.Combine(pathContext.SolutionRoot, projectName);
+            PackageSpec packageSpec = ProjectTestHelpers.GetPackageSpec(projectName, pathContext.SolutionRoot, "net472", "a");
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                new SimpleTestPackageContext("a", "1.5.0"));
+
+            var logger = new TestLogger();
+
+            // Pre-Conditions
+            var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
+            var restoreCommand = new RestoreCommand(request);
+            RestoreResult result = await restoreCommand.ExecuteAsync();
+            result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+            await result.CommitAsync(logger, CancellationToken.None);
+            var logMessages = result.LogMessages;
+            logMessages.Should().HaveCount(1);
+            logMessages[0].Code.Should().Be(NuGetLogCode.NU1603);
+            DateTime assetsFileWriteTime = GetFileLastWriteTime(result.LockFilePath);
+
+            // Act
+            var forceRequest = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
+            forceRequest.AllowNoOp = false;
+            var forceRestoreCommand = new RestoreCommand(forceRequest);
+            RestoreResult forceResult = await forceRestoreCommand.ExecuteAsync();
+            await forceResult.CommitAsync(logger, CancellationToken.None);
+
+            // Assert
+            forceResult.Success.Should().BeTrue(because: logger.ShowMessages());
+            logMessages = forceResult.LogMessages;
+            logMessages.Should().HaveCount(1);
+            logMessages[0].Code.Should().Be(NuGetLogCode.NU1603);
+
+            var currentWriteTime = GetFileLastWriteTime(result.LockFilePath);
+            currentWriteTime.Should().Be(assetsFileWriteTime);
+
+            static DateTime GetFileLastWriteTime(string path)
+            {
+                var fileInfo = new FileInfo(path);
+                fileInfo.Exists.Should().BeTrue();
+                return fileInfo.LastWriteTimeUtc;
+            }
         }
 
         private static TargetFrameworkInformation CreateTargetFrameworkInformation(List<LibraryDependency> dependencies, List<CentralPackageVersion> centralVersionsDependencies, NuGetFramework framework = null)

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/Utility/AuditUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/Utility/AuditUtilityTests.cs
@@ -76,7 +76,6 @@ public class AuditUtilityTests
         // Assert
         context.Log.LogMessages.Count.Should().Be(2);
         context.Log.LogMessages.All(m => m.Code == NuGetLogCode.NU1900).Should().BeTrue();
-        context.Log.LogMessages.All(m => m.ProjectPath == context.ProjectFullPath).Should().BeTrue();
         context.Log.LogMessages.Where(m => m.Message.Contains("404")).Should().ContainSingle();
         context.Log.LogMessages.Where(m => m.Message.Contains("401")).Should().ContainSingle();
         context.Log.LogMessages.All(m => m.Level == LogLevel.Warning).Should().BeTrue();
@@ -227,7 +226,6 @@ public class AuditUtilityTests
             message.Message.Should().Contain("1.0.0", "Message doesn't contain package version");
             message.Message.Should().Contain(CveUrl.OriginalString, "Message doesn't contain CVE URL");
             message.Code.Should().Be(expectedCode);
-            message.ProjectPath.Should().Be(context.ProjectFullPath);
             message.LibraryId.Should().Be(packageId);
             message.TargetGraphs.Should().BeEquivalentTo(new[] { "net6.0" });
         }
@@ -357,7 +355,6 @@ public class AuditUtilityTests
             context.Log.Messages.Count.Should().Be(1);
             RestoreLogMessage message = (RestoreLogMessage)context.Log.LogMessages.Single();
             message.Message.Should().Contain(vulnerablePackage).And.Contain(vulnerableVersion);
-            message.ProjectPath.Should().Be(context.ProjectFullPath);
         }
         else
         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13098

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

When reading log messages from the assets file, we didn't set the project path. In some of the errors raised from within restore, we do set the project path. 

This lead to assets file writes that did not change anything.

To ensure consistency, we now set the project path in restore collector logger. That means the errors raised within the core of restore itself do not need to set the project path. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
