### PR TITLE
dotnet list package prompts only once for authentication even though there are multiple projects in a solution

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -53,6 +53,9 @@ namespace NuGet.CommandLine.XPlat
                         listPackageArgs.Path));
                 return (GenericFailureExitCode, listPackageReportModel);
             }
+
+            PopulateSourceRepositoryCache(listPackageArgs);
+
             //If the given file is a solution, get the list of projects
             //If not, then it's a project, which is put in a list
             var projectsPaths = Path.GetExtension(listPackageArgs.Path).Equals(".sln", PathUtility.GetStringComparisonBasedOnOS()) ?
@@ -127,7 +130,6 @@ namespace NuGet.CommandLine.XPlat
                     {
                         if (listPackageArgs.ReportType != ReportType.Default)  // generic list package is offline -- no server lookups
                         {
-                            PopulateSourceRepositoryCache(listPackageArgs);
                             WarnForHttpSources(listPackageArgs, projectModel);
                             var metadata = await GetPackageMetadataAsync(frameworks, listPackageArgs);
                             await UpdatePackagesWithSourceMetadata(frameworks, metadata, listPackageArgs);

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -203,6 +203,7 @@ namespace NuGet.XPlat.FuncTest
             await RestoreProjectsAsync(pathContext, projectA, projectB);
 
             // Act
+            var logger = new TestLogger();
             ListPackageCommandRunner listPackageCommandRunner = new();
             var packageRefArgs = new ListPackageArgs(
                                         path: Path.Combine(pathContext.SolutionRoot, "solution.sln"),
@@ -214,13 +215,13 @@ namespace NuGet.XPlat.FuncTest
                                         prerelease: false,
                                         highestPatch: false,
                                         highestMinor: false,
-                                        logger: NullLogger.Instance,
+                                        logger: logger,
                                         cancellationToken: CancellationToken.None);
 
             int result = await listPackageCommandRunner.ExecuteCommandAsync(packageRefArgs);
 
             // Assert
-            Assert.Equal(0, result);
+            Assert.True(result == 0, userMessage: logger.ShowMessages());
             // GetCredentialsAsync should be called once during restore
             mockedCredentialService.Verify(x => x.GetCredentialsAsync(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<CredentialRequestType>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
             // TryGetLastKnownGoodCredentialsFromCache should be called twice during restore and once during list package.Hence total 3 times.

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -273,10 +273,12 @@ namespace NuGet.XPlat.FuncTest
                 project.GlobalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(settings);
                 project.Save();
 
-                var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, NullLogger.Instance, project.PackageSpec));
+                var logger = new TestLogger();
+
+                var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project.PackageSpec));
                 var restoreResult = await command.ExecuteAsync(CancellationToken.None);
-                await restoreResult.CommitAsync(NullLogger.Instance, CancellationToken.None);
-                Assert.True(restoreResult.Success);
+                await restoreResult.CommitAsync(logger, CancellationToken.None);
+                Assert.True(restoreResult.Success, userMessage: logger.ShowMessages());
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -273,10 +273,12 @@ namespace NuGet.XPlat.FuncTest
                 project.GlobalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(settings);
                 project.Save();
 
-                var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, NullLogger.Instance, project.PackageSpec));
+                TestLogger logger = new();
+
+                var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project.PackageSpec));
                 var restoreResult = await command.ExecuteAsync(CancellationToken.None);
-                await restoreResult.CommitAsync(NullLogger.Instance, CancellationToken.None);
-                Assert.True(restoreResult.Success);
+                await restoreResult.CommitAsync(logger, CancellationToken.None);
+                Assert.True(restoreResult.Success, logger.ShowErrors());
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -21,12 +21,15 @@ using NuGet.Protocol;
 using NuGet.Test.Utility;
 using Test.Utility;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.XPlat.FuncTest
 {
     [Collection("NuGet XPlat Test Collection")]
-    public class ListPackageTests
+    public class ListPackageTests(ITestOutputHelper output)
     {
+        private readonly TestLogger _logger = new(output);
+
         [Fact]
         public void BasicListPackageParsing_Interactive()
         {
@@ -248,7 +251,7 @@ namespace NuGet.XPlat.FuncTest
                     });
             }
 
-            static async Task RestoreProjectsAsync(SimpleTestPathContext pathContext, SimpleTestProjectContext projectA, SimpleTestProjectContext projectB)
+            async Task RestoreProjectsAsync(SimpleTestPathContext pathContext, SimpleTestProjectContext projectA, SimpleTestProjectContext projectB)
             {
                 var settings = Settings.LoadDefaultSettings(Path.GetDirectoryName(pathContext.NuGetConfig), Path.GetFileName(pathContext.NuGetConfig), null);
                 var packageSourceProvider = new PackageSourceProvider(settings);
@@ -261,7 +264,7 @@ namespace NuGet.XPlat.FuncTest
                 await RestoreProjectAsync(settings, pathContext, projectB, sources, fallbackFolders, globalPackagesFolder);
             }
 
-            static async Task RestoreProjectAsync(ISettings settings,
+            async Task RestoreProjectAsync(ISettings settings,
                 SimpleTestPathContext pathContext,
                 SimpleTestProjectContext project,
                 IEnumerable<PackageSource> packageSources,
@@ -273,12 +276,10 @@ namespace NuGet.XPlat.FuncTest
                 project.GlobalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(settings);
                 project.Save();
 
-                TestLogger logger = new();
-
-                var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project.PackageSpec));
+                var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, _logger, project.PackageSpec));
                 var restoreResult = await command.ExecuteAsync(CancellationToken.None);
-                await restoreResult.CommitAsync(logger, CancellationToken.None);
-                Assert.True(restoreResult.Success, logger.ShowErrors());
+                await restoreResult.CommitAsync(_logger, CancellationToken.None);
+                Assert.True(restoreResult.Success, _logger.ShowMessages());
             }
         }
 

--- a/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
@@ -205,7 +205,7 @@ namespace NuGet.Commands.Test
 
             return new TestRestoreRequest(projectToRestore, sources, pathContext.UserPackagesFolder, logger)
             {
-                LockFilePath = Path.Combine(projectToRestore.FilePath, LockFileFormat.AssetsFileName),
+                LockFilePath = Path.Combine(projectToRestore.BaseDirectory, "obj", LockFileFormat.AssetsFileName),
                 DependencyGraphSpec = dgSpec,
                 ExternalProjects = externalClosure,
             };

--- a/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
@@ -205,7 +205,7 @@ namespace NuGet.Commands.Test
 
             return new TestRestoreRequest(projectToRestore, sources, pathContext.UserPackagesFolder, logger)
             {
-                LockFilePath = Path.Combine(projectToRestore.BaseDirectory, "obj", LockFileFormat.AssetsFileName),
+                LockFilePath = Path.Combine(projectToRestore.BaseDirectory, projectToRestore.RestoreMetadata.OutputPath, LockFileFormat.AssetsFileName),
                 DependencyGraphSpec = dgSpec,
                 ExternalProjects = externalClosure,
             };

--- a/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
@@ -205,7 +205,7 @@ namespace NuGet.Commands.Test
 
             return new TestRestoreRequest(projectToRestore, sources, pathContext.UserPackagesFolder, logger)
             {
-                LockFilePath = Path.Combine(projectToRestore.BaseDirectory, projectToRestore.RestoreMetadata.OutputPath, LockFileFormat.AssetsFileName),
+                LockFilePath = Path.Combine(projectToRestore.RestoreMetadata.OutputPath, LockFileFormat.AssetsFileName),
                 DependencyGraphSpec = dgSpec,
                 ExternalProjects = externalClosure,
             };

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -258,7 +258,7 @@ namespace NuGet.Test.Utility
                 _packageSpec.RestoreMetadata.TargetFrameworks = Frameworks
                     .Select(f => new ProjectRestoreMetadataFrameworkInfo(f.Framework))
                     .ToList();
-                _packageSpec.RestoreMetadata.Sources = Sources.ToList();
+                _packageSpec.RestoreMetadata.Sources = Sources?.ToList();
                 _packageSpec.RestoreMetadata.PackagesPath = GlobalPackagesFolder;
                 _packageSpec.RestoreMetadata.FallbackFolders = FallbackFolders;
                 if (Type == ProjectStyle.ProjectJson)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12456

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->


**Problem:**  `dotnet list package --interactive --vulnerable/--outdated` prompts for authentication once for every project when executed on a solution. If there are "n" projects in a solution, then there will be "n" number of authentication prompts.

**Root cause:** In the current implementation, the `ListPackageCommandRunner.GetReportDataAsync()` method incorrectly invokes `PopulateSourceRepositoryCache()` for each project in the solution. This is problematic because source repositories are intended to be singletons for the entire operation. Updating the source repositories for every project, especially when accessing private feeds, results in NuGet invoking the Credential Provider with `isRetry = true`. Specifically for the Azure DevOps Credential Provider, this leads to the local cache being invalidated, which may prompt users to enter their credentials again, an unnecessary step.

**Solution:** This Pull Request resolves the issue by ensuring that users are prompted for authentication only once. It achieves this by calling the `PopulateSourceRepositoryCache()` method a single time, rather than for each project. This approach allows credentials to be reused while accessing the private feed, avoiding cache invalidation and repeated credential prompts. If authentication is successful, there should be no further need for authentication to access the feed during the command's execution.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added - I tested the changes manually on the patched SDK also.
  
<details>
  <summary> Current behavior which displays authentication prompt for every project (Click to expand!) </summary>
  
dotnet list package --vulnerable --interactive
    [CredentialProvider]DeviceFlow: https://org.pkgs.vs.com/org/_packaging/feedname/nuget/v3/index.json
    [CredentialProvider]ATTENTION: User interaction required.
 
    **********************************************************************
 
    To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code {CODE} to authenticate.
 
    **********************************************************************
    [CredentialProvider]DeviceFlow: https://org.pkgs.vs.com/org/_packaging/feedname/nuget/v3/index.json
    [CredentialProvider]ATTENTION: User interaction required.
 
    **********************************************************************
 
    To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code {CODE} to authenticate.
 
    **********************************************************************
 
The following sources were used:
https://org.pkgs.vs.com/org/_packaging/feedname/nuget/v3/index.json
 
The given project `authentication-demo` has no vulnerable packages given the current sources.
The given project `ClassLibrary1` has no vulnerable packages given the current sources.

</details>

<details>
  <summary> New behavior which displays only one authentication prompt irrespective of number of projects (Click to expand!) </summary>
  
dotnet list package --vulnerable --interactive
    [CredentialProvider]DeviceFlow: https://org.pkgs.vs.com/org/_packaging/feedname/nuget/v3/index.json
    [CredentialProvider]ATTENTION: User interaction required.
 
    **********************************************************************
 
    To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code {CODE} to authenticate.
 
    **********************************************************************
 
The following sources were used:
https://org.pkgs.vs.com/org/_packaging/feedname/nuget/v3/index.json
 
The given project `authentication-demo` has no vulnerable packages given the current sources.
The given project `ClassLibrary1` has no vulnerable packages given the current sources.

</details>

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A
