### PR TITLE
Unroll several LINQ calls

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,4 +1,3 @@
 #nullable enable
-~static NuGet.Commands.MSBuildRestoreItemGroup.Create(string rootName, int position) -> NuGet.Commands.MSBuildRestoreItemGroup
 ~static NuGet.Commands.MSBuildRestoreUtility.GetCentralPackageManagementSettings(NuGet.Commands.IMSBuildItem projectSpecItem, NuGet.ProjectModel.ProjectStyle? projectStyle) -> (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled)
 ~static NuGet.Commands.MSBuildRestoreUtility.GetMessageForUnsupportedProject(string path) -> NuGet.Common.RestoreLogMessage

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
+~static NuGet.Commands.MSBuildRestoreItemGroup.Create(string rootName, int position) -> NuGet.Commands.MSBuildRestoreItemGroup
 ~static NuGet.Commands.MSBuildRestoreUtility.GetCentralPackageManagementSettings(NuGet.Commands.IMSBuildItem projectSpecItem, NuGet.ProjectModel.ProjectStyle? projectStyle) -> (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled)
 ~static NuGet.Commands.MSBuildRestoreUtility.GetMessageForUnsupportedProject(string path) -> NuGet.Common.RestoreLogMessage

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/MSBuildRestoreItemGroup.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/MSBuildRestoreItemGroup.cs
@@ -50,7 +50,7 @@ namespace NuGet.Commands
             }
         }
 
-        public static MSBuildRestoreItemGroup Create(
+        internal static MSBuildRestoreItemGroup Create(
             string rootName,
             int position)
         {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/MSBuildRestoreItemGroup.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/MSBuildRestoreItemGroup.cs
@@ -52,6 +52,18 @@ namespace NuGet.Commands
 
         public static MSBuildRestoreItemGroup Create(
             string rootName,
+            int position)
+        {
+            var group = new MSBuildRestoreItemGroup();
+
+            group.RootName = rootName;
+            group.Position = position;
+
+            return group;
+        }
+
+        public static MSBuildRestoreItemGroup Create(
+            string rootName,
             IEnumerable<XElement> items,
             int position,
             IEnumerable<string> conditions)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -511,11 +511,11 @@ namespace NuGet.Commands
                 }
 
                 // build/ {packageId}.targets
-                var buildTargetsGroup = GenerateBuildGroup(repositoryRoot, sortedPackages);
+                var buildTargetsGroup = GenerateBuildGroup(repositoryRoot, sortedPackages, TargetsExtension);
                 targets.AddRange(GenerateGroupsWithConditions(buildTargetsGroup, isMultiTargeting, frameworkConditions));
 
                 // props/ {packageId}.props
-                MSBuildRestoreItemGroup buildPropsGroup = GenerateBuildGroup(repositoryRoot, sortedPackages);
+                MSBuildRestoreItemGroup buildPropsGroup = GenerateBuildGroup(repositoryRoot, sortedPackages, PropsExtension);
                 props.AddRange(GenerateGroupsWithConditions(buildPropsGroup, isMultiTargeting, frameworkConditions));
 
                 // Create an empty PropertyGroup for package properties
@@ -563,11 +563,11 @@ namespace NuGet.Commands
                 if (isMultiTargeting)
                 {
                     // buildMultiTargeting/ {packageId}.targets
-                    var buildCrossTargetsGroup = GenerateMultiTargetingGroup(repositoryRoot, sortedPackages, multiTargetingImportsAdded);
+                    var buildCrossTargetsGroup = GenerateMultiTargetingGroup(repositoryRoot, sortedPackages, multiTargetingImportsAdded, TargetsExtension);
                     targets.AddRange(GenerateGroupsWithConditions(buildCrossTargetsGroup, isMultiTargeting, CrossTargetingCondition));
 
                     // buildMultiTargeting/ {packageId}.props
-                    var buildCrossPropsGroup = GenerateMultiTargetingGroup(repositoryRoot, sortedPackages, multiTargetingImportsAdded);
+                    var buildCrossPropsGroup = GenerateMultiTargetingGroup(repositoryRoot, sortedPackages, multiTargetingImportsAdded, PropsExtension);
                     props.AddRange(GenerateGroupsWithConditions(buildCrossPropsGroup, isMultiTargeting, CrossTargetingCondition));
                 }
 
@@ -635,7 +635,7 @@ namespace NuGet.Commands
 
             return files;
 
-            static MSBuildRestoreItemGroup GenerateBuildGroup(string repositoryRoot, List<KeyValuePair<LockFileTargetLibrary, Lazy<LocalPackageSourceInfo>>> sortedPackages)
+            static MSBuildRestoreItemGroup GenerateBuildGroup(string repositoryRoot, List<KeyValuePair<LockFileTargetLibrary, Lazy<LocalPackageSourceInfo>>> sortedPackages, string extension)
             {
                 var buildGroup = new MSBuildRestoreItemGroup();
                 buildGroup.RootName = MSBuildRestoreItemGroup.ImportGroup;
@@ -645,7 +645,7 @@ namespace NuGet.Commands
                 {
                     if (pkg.Value.Exists())
                     {
-                        foreach (LockFileItem lockFileItem in pkg.Key.Build.WithExtension(TargetsExtension))
+                        foreach (LockFileItem lockFileItem in pkg.Key.Build.WithExtension(extension))
                         {
                             var absolutePath = pkg.Value.GetAbsolutePath(lockFileItem);
                             var pathWithMacros = GetPathWithMacros(absolutePath, repositoryRoot);
@@ -658,7 +658,7 @@ namespace NuGet.Commands
                 return buildGroup;
             }
 
-            static MSBuildRestoreItemGroup GenerateMultiTargetingGroup(string repositoryRoot, List<KeyValuePair<LockFileTargetLibrary, Lazy<LocalPackageSourceInfo>>> sortedPackages, HashSet<string> multiTargetingImportsAdded)
+            static MSBuildRestoreItemGroup GenerateMultiTargetingGroup(string repositoryRoot, List<KeyValuePair<LockFileTargetLibrary, Lazy<LocalPackageSourceInfo>>> sortedPackages, HashSet<string> multiTargetingImportsAdded, string extension)
             {
                 var buildCrossTargetsGroup = new MSBuildRestoreItemGroup();
                 buildCrossTargetsGroup.RootName = MSBuildRestoreItemGroup.ImportGroup;
@@ -668,7 +668,7 @@ namespace NuGet.Commands
                 {
                     if (pkg.Value.Exists())
                     {
-                        foreach (var e in pkg.Key.BuildMultiTargeting.WithExtension(TargetsExtension))
+                        foreach (var e in pkg.Key.BuildMultiTargeting.WithExtension(extension))
                         {
                             var path = pkg.Value.GetAbsolutePath(e);
                             if (multiTargetingImportsAdded.Add(path))

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -579,7 +579,7 @@ namespace NuGet.Commands
                     foreach (var pkg in sortedPackages)
                     {
                         var lockContentFiles = new List<LockFileContentFile>(pkg.Key.ContentFiles.Count);
-                        foreach (var contentFile in pkg.Key.ContentFiles)
+                        foreach (var contentFile in pkg.Key.ContentFiles.NoAllocEnumerate())
                         {
                             if (pkg.Value.Exists())
                             {
@@ -623,7 +623,7 @@ namespace NuGet.Commands
             var targetsXML = GenerateMSBuildFile(targets, request.ProjectStyle);
 
             // Return all files to write out or delete.
-            var files = new List<MSBuildOutputFile>(2)
+            var files = new List<MSBuildOutputFile>(capacity: 2)
             {
                 new MSBuildOutputFile(propsPath, propsXML),
                 new MSBuildOutputFile(targetsPath, targetsXML)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Related: https://github.com/NuGet/Home/issues/12748

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
There are multiple delegates and closure objects that get created in calls to `GetMSBuildOutputFiles()` which can be avoided by switching away from LINQ. Just some of the delegate, closure, and LINQ type allocations in this path:

![image](https://github.com/NuGet/NuGet.Client/assets/60519722/31f2c80a-be77-460f-b773-804e19caff5f)
![image](https://github.com/NuGet/NuGet.Client/assets/60519722/93ac993a-16f7-4831-85e7-766516447ec2)


## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
