### PR TITLE
Avoid boxing HashSet Enumerator in IsBestVerion

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/Tracker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/Tracker.cs
@@ -44,7 +44,7 @@ namespace NuGet.DependencyResolver
             {
                 var version = item.Key.Version;
 
-                foreach (var known in entry.Items)
+                foreach (var known in entry.Items.NoAllocEnumerate())
                 {
                     if (version < known.Key.Version)
                     {

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/NoAllocEnumerateExtensionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/NoAllocEnumerateExtensionsTests.cs
@@ -19,6 +19,26 @@ public class NoAllocEnumerateExtensionsTests
     }
 
     [Fact]
+    public void NoAllocEnumerate_IEnumerable_HashSet()
+    {
+        var testSet = new HashSet<int> { 0, 1, 2, 3 };
+        var newSet = new HashSet<int>(testSet.Count);
+        foreach (int i in testSet.NoAllocEnumerate())
+        {
+            // ensure we got something that was actually in the original set
+            Assert.True(testSet.Contains(i));
+
+            // ensure we don't get duplicates
+            Assert.True(newSet.Add(i));
+        }
+
+        // If every item we get from the enumerator exists in the source set
+        // and we didn't add any duplicates, we know we enumerated over the same set
+        // of items if the counts are equal.
+        Assert.Equal(testSet.Count, newSet.Count);
+    }
+
+    [Fact]
     public void NoAllocEnumerate_IEnumerable_ImmutableList()
     {
         ValidateIEnumerable(ImmutableList.Create(0, 1, 2, 3));


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13146

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

This change updates `NoAllocEnumerate()` to handle `HashSet<T>` to avoid these allocations.

![image](https://github.com/NuGet/NuGet.Client/assets/60519722/6e0fa825-7685-4b58-be2d-a215dd5e2174)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
