### PR TITLE
Add ESProj guid to recognized projects in Visual Studio

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ProjectType.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ProjectType.cs
@@ -27,6 +27,7 @@ namespace NuGet.VisualStudio
             VsProjectTypes.DeploymentProjectTypeGuid,
             VsProjectTypes.CosmosProjectTypeGuid,
             VsProjectTypes.ManagementPackProjectTypeGuid,
+            VsProjectTypes.ESProjTypeGuid,
         };
 
         private static readonly HashSet<string> Unsupported = new HashSet<string>(StringComparer.OrdinalIgnoreCase)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/VsProjectTypes.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/VsProjectTypes.cs
@@ -31,6 +31,7 @@ namespace NuGet.VisualStudio
         public const string SilverlightProjectTypeGuid = "{A1591282-1198-4647-A2B1-27E5FF5F6F3B}";
         public const string LightSwitchCsharpProjectTypeGuid = "{8BB0C5E8-0616-4F60-8E55-A43933E57E9C}";
         public const string LightSwitchLsxtProjectTypeGuid = "{581633EB-B896-402F-8E60-36F3DA191C85}";
+        public const string ESProjTypeGuid = "{54a90642-561a-4bb1-a94e-469adee60c69}";
 
         // Copied from EnvDTE.Constants since that type can't be embedded
         public const string VsProjectItemKindPhysicalFile = "{6BB5F8EE-4483-11D3-8BCF-00C04F8EC28C}";


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12986

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

NuGet does not recognize esproj in VisualStudio and as such fails all scenarios for esproj. 
The reasoning for this is that esproj while an SDK based project, it doesn't support CPS based restore like .NET SDK based projects.

By recognizing these projects, we allow restore equivalence in commandline and VS.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - There's no esproj available for E2E testing. We also do recognize various project types that are not extensively testable because commandline they're just "another project"
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
