### PR TITLE
disable vs bootstrapper step, and dartlab steps for release-6.0.x

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -38,14 +38,15 @@ steps:
 - task: MicroBuildSwixPlugin@1
   displayName: "Install Swix Plugin"
 
-- task: MicroBuildOptProfPlugin@6
-  displayName: 'OptProfV2:  install the plugin'
-  inputs:
-    getDropNameByDrop: true
-    optimizationInputsDropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
-    ShouldSkipOptimize: $(ShouldSkipOptimize)
-    AccessToken: $(System.AccessToken)
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+# disable for release-6.0.x
+# - task: MicroBuildOptProfPlugin@6
+#   displayName: 'OptProfV2:  install the plugin'
+#   inputs:
+#     getDropNameByDrop: true
+#     optimizationInputsDropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
+#     ShouldSkipOptimize: $(ShouldSkipOptimize)
+#     AccessToken: $(System.AccessToken)
+#   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
 # NuGet.Client's official repo is on github, hence the source link metadata should use the github URL.
 # However, our official builds are built from a mirror in Azure DevOps, hence without any extra help, the SourceLink.GitHub package
@@ -296,39 +297,40 @@ steps:
     arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.655 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-- task: MicroBuildBuildVSBootstrapper@3
-  displayName: 'Build a Visual Studio bootstrapper'
-  inputs:
-    channelName: "$(VsTargetChannel)"
-    vsMajorVersion: "$(VsTargetMajorVersion)"
-    manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
-    outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+# disable for release-6.0.x
+# - task: MicroBuildBuildVSBootstrapper@3
+#   displayName: 'Build a Visual Studio bootstrapper'
+#   inputs:
+#     channelName: "$(VsTargetChannel)"
+#     vsMajorVersion: "$(VsTargetMajorVersion)"
+#     manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
+#     outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
+#   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish BootstrapperInfo.json as a build artifact'
-  inputs:
-    PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
-    ArtifactName: MicroBuildOutputs
-    ArtifactType: Container
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+# - task: PublishBuildArtifacts@1
+#   displayName: 'Publish BootstrapperInfo.json as a build artifact'
+#   inputs:
+#     PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
+#     ArtifactName: MicroBuildOutputs
+#     ArtifactType: Container
+#   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-- task: PowerShell@1
-  displayName: "Set Bootstrapper URL variable"
-  name: "vsbootstrapper"
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      try {
-        $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
-        $bootstrapperUrl = $json[0].bootstrapperUrl;
-        Write-Host "Bootstrapper URL: $bootstrapperUrl"
-        Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
-      } catch {
-        Write-Host "##vso[task.LogIssue type=error;]Unable to set bootstrapperUrl: $_"
-        exit 1
-      }
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+# - task: PowerShell@1
+#   displayName: "Set Bootstrapper URL variable"
+#   name: "vsbootstrapper"
+#   inputs:
+#     scriptType: "inlineScript"
+#     inlineScript: |
+#       try {
+#         $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
+#         $bootstrapperUrl = $json[0].bootstrapperUrl;
+#         Write-Host "Bootstrapper URL: $bootstrapperUrl"
+#         Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
+#       } catch {
+#         Write-Host "##vso[task.LogIssue type=error;]Unable to set bootstrapperUrl: $_"
+#         exit 1
+#       }
+#   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1
   displayName: 'Generate .runsettings files'

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -181,65 +181,66 @@ stages:
     steps:
     - template: Tests_On_Mac.yml
 
+# disable for release-6.0.x
 # Dartlab's template defines this in its own stage
-- template: End_To_End_Tests_On_Windows.yml
-  parameters:
-    stageName: VS_EndToEnd_Part1
-    stageDisplayName: VS EndToEnd Tests Part 1
-    condition: "and(succeeded(), eq(variables['RunEndToEndTests'], 'true'))"
-    dependsOn:
-    - Initialize
-    - Build_Insertable
-    testExecutionJobTimeoutInMinutes: 100
-    bootstrapperUrl: $(VsBootstrapperUrl)
-    runSettingsURI:  https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
-    DartLabEnvironment: ${{parameters.DartLabEnvironment}}
-    variables:
-    - name: VsBootstrapperUrl
-      value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
-    - name: GitHubStatusName
-      value: End_To_End_Tests_On_Windows Part1
-    part: "InstallPackageTest.ps1,UninstallPackageTest.ps1,UpdatePackageTest.ps1,PackageRestoreTest.ps1"
-    testMachineCleanUpStrategy: ${{parameters.E2EPart1AgentCleanup}}
+# - template: End_To_End_Tests_On_Windows.yml
+#   parameters:
+#     stageName: VS_EndToEnd_Part1
+#     stageDisplayName: VS EndToEnd Tests Part 1
+#     condition: "and(succeeded(), eq(variables['RunEndToEndTests'], 'true'))"
+#     dependsOn:
+#     - Initialize
+#     - Build_Insertable
+#     testExecutionJobTimeoutInMinutes: 100
+#     bootstrapperUrl: $(VsBootstrapperUrl)
+#     runSettingsURI:  https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
+#     DartLabEnvironment: ${{parameters.DartLabEnvironment}}
+#     variables:
+#     - name: VsBootstrapperUrl
+#       value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
+#     - name: GitHubStatusName
+#       value: End_To_End_Tests_On_Windows Part1
+#     part: "InstallPackageTest.ps1,UninstallPackageTest.ps1,UpdatePackageTest.ps1,PackageRestoreTest.ps1"
+#     testMachineCleanUpStrategy: ${{parameters.E2EPart1AgentCleanup}}
 
 # Dartlab's template defines this in its own stage
-- template: End_To_End_Tests_On_Windows.yml
-  parameters:
-    stageName: VS_EndToEnd_Part2
-    stageDisplayName: VS EndToEnd Tests Part 2
-    condition: "and(succeeded(), eq(variables['RunEndToEndTests'], 'true'))"
-    dependsOn:
-    - Initialize
-    - Build_Insertable
-    testExecutionJobTimeoutInMinutes: 100
-    bootstrapperUrl: $(VsBootstrapperUrl)
-    runSettingsURI:  https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
-    DartLabEnvironment: ${{parameters.DartLabEnvironment}}
-    variables:
-    - name: VsBootstrapperUrl
-      value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
-    - name: GitHubStatusName
-      value: End_To_End_Tests_On_Windows Part2
-    part: "A-TopDownloadedPackages.ps1,BuildIntegratedTest.ps1,ExecuteInitScriptTest.ps1,FindPackageTest.ps1,GetPackageTest.ps1,GetProjectTest.ps1,LegacyPackageRefProjectTest.ps1,NativeProjectTest.ps1,NetCoreProjectTest.ps1,PackTest.ps1,ProjectRetargeting.ps1,ServicesTest.ps1,Settings.ps1,SyncPackageTest.ps1,TabExpansionTest.ps1,UniversalWindowsProjectTest.ps1"
-    testMachineCleanUpStrategy: ${{parameters.E2EPart2AgentCleanup}}
+# - template: End_To_End_Tests_On_Windows.yml
+#   parameters:
+#     stageName: VS_EndToEnd_Part2
+#     stageDisplayName: VS EndToEnd Tests Part 2
+#     condition: "and(succeeded(), eq(variables['RunEndToEndTests'], 'true'))"
+#     dependsOn:
+#     - Initialize
+#     - Build_Insertable
+#     testExecutionJobTimeoutInMinutes: 100
+#     bootstrapperUrl: $(VsBootstrapperUrl)
+#     runSettingsURI:  https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
+#     DartLabEnvironment: ${{parameters.DartLabEnvironment}}
+#     variables:
+#     - name: VsBootstrapperUrl
+#       value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
+#     - name: GitHubStatusName
+#       value: End_To_End_Tests_On_Windows Part2
+#     part: "A-TopDownloadedPackages.ps1,BuildIntegratedTest.ps1,ExecuteInitScriptTest.ps1,FindPackageTest.ps1,GetPackageTest.ps1,GetProjectTest.ps1,LegacyPackageRefProjectTest.ps1,NativeProjectTest.ps1,NetCoreProjectTest.ps1,PackTest.ps1,ProjectRetargeting.ps1,ServicesTest.ps1,Settings.ps1,SyncPackageTest.ps1,TabExpansionTest.ps1,UniversalWindowsProjectTest.ps1"
+#     testMachineCleanUpStrategy: ${{parameters.E2EPart2AgentCleanup}}
 
 # Dartlab's template defines this in its own stage
-- template: Apex_Tests_On_Windows.yml
-  parameters:
-    stageName: Visual_Studio_Apex_Tests
-    stageDisplayName: Apex Tests On Windows
-    condition: "and(succeeded(), eq(variables['RunApexTests'], 'true'))"
-    dependsOn:
-      - Initialize
-      - Build_Insertable
-    variables:
-      - name: VsBootstrapperUrl
-        value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
-      - name: GitHubStatusName
-        value: Apex Tests On Windows
-    isOfficialBuild: ${{parameters.isOfficialBuild}}
-    runSettingsURI: https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
-    dartLabEnvironment: ${{parameters.DartLabEnvironment}}
-    testExecutionJobTimeoutInMinutes: 150
-    bootstrapperUrl: $(VsBootstrapperUrl)
-    testMachineCleanUpStrategy: ${{parameters.ApexAgentCleanup}}
+# - template: Apex_Tests_On_Windows.yml
+#   parameters:
+#     stageName: Visual_Studio_Apex_Tests
+#     stageDisplayName: Apex Tests On Windows
+#     condition: "and(succeeded(), eq(variables['RunApexTests'], 'true'))"
+#     dependsOn:
+#       - Initialize
+#       - Build_Insertable
+#     variables:
+#       - name: VsBootstrapperUrl
+#         value: $[stageDependencies.Build_Insertable.Build_and_UnitTest_NonRTM.outputs['vsbootstrapper.bootstrapperUrl']]
+#       - name: GitHubStatusName
+#         value: Apex Tests On Windows
+#     isOfficialBuild: ${{parameters.isOfficialBuild}}
+#     runSettingsURI: https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId);NuGet.Tests.Apex.runsettings
+#     dartLabEnvironment: ${{parameters.DartLabEnvironment}}
+#     testExecutionJobTimeoutInMinutes: 150
+#     bootstrapperUrl: $(VsBootstrapperUrl)
+#     testMachineCleanUpStrategy: ${{parameters.ApexAgentCleanup}}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Related: https://github.com/NuGet/Client.Engineering/issues/2654

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
release-6.0.x is no longer supported in VS but it is in .NET SDK, this change enables running the CI without problems.

We followed same approach as release-6.3.x branch https://github.com/NuGet/NuGet.Client/commit/1ff5433f8f1d1b2eafc8d2fa366db5e19f916397


## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
