### PR TITLE
Further reduce allocations in CreateGraphNodeAsync

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphNode.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphNode.cs
@@ -62,9 +62,13 @@ namespace NuGet.DependencyResolver
         /// <param name="additionalSpace">The count of additional items that will be added.</param>
         internal void EnsureInnerNodeCapacity(int additionalSpace)
         {
-            if (InnerNodes is List<GraphNode<TItem>> innerList && innerList.Capacity < innerList.Count + additionalSpace)
+            if (InnerNodes is List<GraphNode<TItem>> innerList)
             {
-                innerList.Capacity = innerList.Count + additionalSpace;
+                int requiredCapacity = innerList.Count + additionalSpace;
+                if (innerList.Capacity < requiredCapacity)
+                {
+                    innerList.Capacity = requiredCapacity;
+                }
             }
         }
 

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphNode.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphNode.cs
@@ -55,6 +55,19 @@ namespace NuGet.DependencyResolver
             return true;
         }
 
+        /// <summary>
+        /// Ensures that <see cref="InnerNodes"/> has the capacity to add
+        /// <paramref name="additionalSpace"/> more items.
+        /// </summary>
+        /// <param name="additionalSpace">The count of additional items that will be added.</param>
+        internal void EnsureInnerNodeCapacity(int additionalSpace)
+        {
+            if (InnerNodes is List<GraphNode<TItem>> innerList && innerList.Capacity < innerList.Count + additionalSpace)
+            {
+                innerList.Capacity = innerList.Count + additionalSpace;
+            }
+        }
+
         public override string ToString()
         {
             return (Item?.Key ?? Key) + " " + Disposition;

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -101,6 +101,7 @@ namespace NuGet.DependencyResolver
 
             LightweightList<ValueTask<GraphNode<RemoteResolveResult>>> tasks = EvaluateDependencies(libraryRange, framework, runtimeName, runtimeGraph, predicate, outerEdge, transitiveCentralPackageVersions, node);
 
+            node.EnsureInnerNodeCapacity(tasks.Count);
             foreach (var task in tasks)
             {
                 var dependencyNode = await task;
@@ -186,7 +187,7 @@ namespace NuGet.DependencyResolver
                 // HACK(davidfowl): This is making runtime.json support package redirects
 
                 // Look up any additional dependencies for this package
-                foreach (var runtimeDependency in runtimeGraph.FindRuntimeDependencies(runtimeName, libraryRange.Name))
+                foreach (var runtimeDependency in runtimeGraph.FindRuntimeDependencies(runtimeName, libraryRange.Name).NoAllocEnumerate())
                 {
                     var libraryDependency = new LibraryDependency
                     {
@@ -557,14 +558,22 @@ namespace NuGet.DependencyResolver
 
     internal struct LightweightList<T>
     {
-        private const int Fields = 4;
+        private const int Fields = 10;
         private int _count;
         private T _firstItem;
         private T _secondItem;
         private T _thirdItem;
         private T _fourthItem;
+        private T _fifthItem;
+        private T _sixthItem;
+        private T _seventhItem;
+        private T _eighthItem;
+        private T _ninthItem;
+        private T _tenthItem;
 
         private List<T> _additionalItems;
+
+        public readonly int Count => _count;
 
         public void Add(T task)
         {
@@ -583,6 +592,30 @@ namespace NuGet.DependencyResolver
             else if (_count == 3)
             {
                 _fourthItem = task;
+            }
+            else if (_count == 4)
+            {
+                _fifthItem = task;
+            }
+            else if (_count == 5)
+            {
+                _sixthItem = task;
+            }
+            else if (_count == 6)
+            {
+                _seventhItem = task;
+            }
+            else if (_count == 7)
+            {
+                _eighthItem = task;
+            }
+            else if (_count == 8)
+            {
+                _ninthItem = task;
+            }
+            else if (_count == 9)
+            {
+                _tenthItem = task;
             }
             else
             {
@@ -630,6 +663,30 @@ namespace NuGet.DependencyResolver
                     else if (_index == 3)
                     {
                         _current = _itemList._fourthItem;
+                    }
+                    else if (_index == 4)
+                    {
+                        _current = _itemList._fifthItem;
+                    }
+                    else if (_index == 5)
+                    {
+                        _current = _itemList._sixthItem;
+                    }
+                    else if (_index == 6)
+                    {
+                        _current = _itemList._seventhItem;
+                    }
+                    else if (_index == 7)
+                    {
+                        _current = _itemList._eighthItem;
+                    }
+                    else if (_index == 8)
+                    {
+                        _current = _itemList._ninthItem;
+                    }
+                    else if (_index == 9)
+                    {
+                        _current = _itemList._tenthItem;
                     }
                     else
                     {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Related: https://github.com/NuGet/Home/issues/12748

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This PR makes additional changes to reduce allocations in `CreateGraphNodeAsync()` by addressing three issues highlighted in this trace:

![image](https://github.com/NuGet/NuGet.Client/assets/60519722/2e241c67-0261-4d9c-a1be-609de5153cdf)

A `LightweightList` was introduced in a previous PR to reduce the need to allocate a `List<T>` in the cases where the number of items was 4 or fewer. This value was chosen because it was seen as a safe starting point since it's the default size for `List<T>` as well as the 80th percentile in telemetry data

50 - 2,
70 - 3,
80 - 4
90 - 7
95 - 9

This trace indicates that there are still significant allocations occurring and this change allows `LightweightList` to contain up to 10 items before needing to allocate a `List<T>`. 

The second change introduces a helper method on `GraphNode` that enables callers to ensure that `InnerNodes` has sufficient capacity to add additional items to minimize resizing.

Finally, `FindRuntimeDependencies()` often returns a `List<T>` wrapped by the `IEnumerable<T>` interface which was resulting in boxing of the `List<T>.Enumerator`.  The existing `NoAllocEnumerate()` helper can be used here to avoid the boxing.

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
