### PR TITLE
Add the possibility to replace a nuget source (force dotnet nuget add)

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SourcesCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SourcesCommand.cs
@@ -36,6 +36,8 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "SourcesCommandFormatDescription")]
         public SourcesListFormat Format { get; set; }
 
+        [Option(typeof(NuGetCommand), "SourcesCommandAddForceDescription")]
+        public bool Force { get; set; }
 
         public override void ExecuteCommand()
         {
@@ -61,7 +63,7 @@ namespace NuGet.CommandLine
             switch (action)
             {
                 case SourcesAction.Add:
-                    var addArgs = new AddSourceArgs() { Name = Name, Source = Source, Username = Username, Password = Password, StorePasswordInClearText = StorePasswordInClearText, ValidAuthenticationTypes = ValidAuthenticationTypes, Configfile = ConfigFile, ProtocolVersion = ProtocolVersion };
+                    var addArgs = new AddSourceArgs() { Name = Name, Source = Source, Username = Username, Password = Password, StorePasswordInClearText = StorePasswordInClearText, ValidAuthenticationTypes = ValidAuthenticationTypes, Configfile = ConfigFile, ProtocolVersion = ProtocolVersion, Force = Force };
                     AddSourceRunner.Run(addArgs, () => Console);
                     break;
                 case SourcesAction.Update:

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -1729,6 +1729,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Applies to the add action. Replaces the source if it already exists..
+        /// </summary>
+        internal static string SourcesCommandAddForceDescription {
+            get {
+                return ResourceManager.GetString("SourcesCommandAddForceDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Provides the ability to manage list of sources located in NuGet.config files..
         /// </summary>
         internal static string SourcesCommandDescription {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -931,4 +931,7 @@ nuget client-certs List</value>
   <data name="SourcesCommandProtocolVersionDescription" xml:space="preserve">
     <value>The NuGet server protocol version to be used. Currently supported versions are 2 and 3. See https://learn.microsoft.com/nuget/api/overview for information about the version 3 protocol. Defaults to 2 if not specified.</value>
   </data>
+  <data name="SourcesCommandAddForceDescription" xml:space="preserve">
+    <value>Applies to the add action. Replaces the source if it already exists.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Commands.xml
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Commands.xml
@@ -13,6 +13,7 @@
       <SingleValueOption Name="valid-Authentication-Types" Help="SourcesCommandValidAuthenticationTypesDescription" />
       <SingleValueOption Name="protocol-Version" Help="SourcesCommandProtocolVersionDescription"/>
       <SingleValueOption Name="configfile" Help="Option_ConfigFile" />
+      <SwitchOption Name="force" Help="SourcesCommandAddForceDescription"/>
       <Example Title="Add `nuget.org` as a source:" Command="dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org" />
       <Example Title="Add `c:\packages` as a local source:" Command="dotnet nuget add source c:\packages" />
       <Example Title="Add a source that needs authentication:" Command="dotnet nuget add source https://contoso.com/litware -n myTeam -u myUsername -p myPassword --store-password-in-clear-text" />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Verbs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Verbs.cs
@@ -51,6 +51,10 @@ namespace NuGet.CommandLine.XPlat
                         "--configfile",
                         Strings.Option_ConfigFile,
                         CommandOptionType.SingleValue);
+                    CommandOption force = SourceCmd.Option(
+                        "--force",
+                        Strings.SourcesCommandAddForceDescription,
+                        CommandOptionType.NoValue);
                     SourceCmd.HelpOption("-h|--help");
                     SourceCmd.Description = Strings.AddSourceCommandDescription;
                     SourceCmd.OnExecute(() =>
@@ -65,6 +69,7 @@ namespace NuGet.CommandLine.XPlat
                             ValidAuthenticationTypes = validAuthenticationTypes.Value(),
                             ProtocolVersion = protocolVersion.Value(),
                             Configfile = configfile.Value(),
+                            Force = force.HasValue(),
                         };
 
                         AddSourceRunner.Run(args, getLogger);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -1845,6 +1845,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Replaces the source if it already exists..
+        /// </summary>
+        internal static string SourcesCommandAddForceDescription {
+            get {
+                return ResourceManager.GetString("SourcesCommandAddForceDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The format of the list command output: `Detailed` (the default) and `Short`..
         /// </summary>
         internal static string SourcesCommandFormatDescription {
@@ -1922,15 +1931,6 @@ namespace NuGet.CommandLine.XPlat {
         internal static string SourcesCommandValidProtocolVersion {
             get {
                 return ResourceManager.GetString("SourcesCommandValidProtocolVersion", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to .
-        /// </summary>
-        internal static string String1 {
-            get {
-                return ResourceManager.GetString("String1", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -741,9 +741,6 @@ The search is a case-insensitive string comparison using the supplied value, whi
   <data name="Error_TrustFingerPrintAlreadyExist" xml:space="preserve">
     <value>The certificate finger you're trying to add is already in the certificate fingerprint list.</value>
   </data>
-  <data name="String1" xml:space="preserve">
-    <value />
-  </data>
   <data name="Warning_HttpServerUsage" xml:space="preserve">
     <value>You are running the '{0}' operation with an 'HTTP' source, '{1}'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.</value>
     <comment>0 - The command name. Ex. Push/Delete. 1 - server uri.</comment>
@@ -911,5 +908,9 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
   </data>
   <data name="ConfigGetCommandDescription" xml:space="preserve">
     <value>Gets the NuGet configuration settings that will be applied.</value>
+  </data>
+</root>
+  <data name="SourcesCommandAddForceDescription" xml:space="preserve">
+    <value>Replaces the source if it already exists.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/CommandArgs/VerbArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandArgs/VerbArgs.cs
@@ -21,6 +21,7 @@ namespace NuGet.Commands
         public string ValidAuthenticationTypes { get; set; }
         public string ProtocolVersion { get; set; }
         public string Configfile { get; set; }
+        public bool Force { get; set; }
     }
 
     public partial class AddClientCertArgs
@@ -97,5 +98,4 @@ namespace NuGet.Commands
         public bool Force { get; set; }
         public string Configfile { get; set; }
     }
-
 }

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ NuGet.Commands.ResolvedDependencyKey.Equals(NuGet.Commands.ResolvedDependencyKey
 NuGet.Commands.ResolvedDependencyKey.ResolvedDependencyKey() -> void
 static NuGet.Commands.ResolvedDependencyKey.operator !=(NuGet.Commands.ResolvedDependencyKey left, NuGet.Commands.ResolvedDependencyKey right) -> bool
 static NuGet.Commands.ResolvedDependencyKey.operator ==(NuGet.Commands.ResolvedDependencyKey left, NuGet.Commands.ResolvedDependencyKey right) -> bool
+NuGet.Commands.AddSourceArgs.Force.get -> bool
+NuGet.Commands.AddSourceArgs.Force.set -> void

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ NuGet.Commands.ResolvedDependencyKey.Equals(NuGet.Commands.ResolvedDependencyKey
 NuGet.Commands.ResolvedDependencyKey.ResolvedDependencyKey() -> void
 static NuGet.Commands.ResolvedDependencyKey.operator !=(NuGet.Commands.ResolvedDependencyKey left, NuGet.Commands.ResolvedDependencyKey right) -> bool
 static NuGet.Commands.ResolvedDependencyKey.operator ==(NuGet.Commands.ResolvedDependencyKey left, NuGet.Commands.ResolvedDependencyKey right) -> bool
+NuGet.Commands.AddSourceArgs.Force.get -> bool
+NuGet.Commands.AddSourceArgs.Force.set -> void

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -4,3 +4,5 @@ NuGet.Commands.ResolvedDependencyKey.ResolvedDependencyKey() -> void
 static NuGet.Commands.ResolvedDependencyKey.operator !=(NuGet.Commands.ResolvedDependencyKey left, NuGet.Commands.ResolvedDependencyKey right) -> bool
 static NuGet.Commands.ResolvedDependencyKey.operator ==(NuGet.Commands.ResolvedDependencyKey left, NuGet.Commands.ResolvedDependencyKey right) -> bool
 ~static NuGet.Commands.MSBuildRestoreUtility.GetCentralPackageManagementSettings(NuGet.Commands.IMSBuildItem projectSpecItem, NuGet.ProjectModel.ProjectStyle projectStyle) -> (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled)
+NuGet.Commands.AddSourceArgs.Force.get -> bool
+NuGet.Commands.AddSourceArgs.Force.set -> void

--- a/src/NuGet.Core/NuGet.Commands/SourcesCommands/SourceRunners.cs
+++ b/src/NuGet.Core/NuGet.Commands/SourcesCommands/SourceRunners.cs
@@ -52,13 +52,31 @@ namespace NuGet.Commands
             var existingSourceWithName = sourceProvider.GetPackageSourceByName(args.Name);
             if (existingSourceWithName != null)
             {
-                throw new CommandException(Strings.SourcesCommandUniqueName);
+                if (args.Force)
+                {
+                    getLogger().LogWarning(
+                        string.Format(CultureInfo.CurrentCulture,
+                        Strings.SourcesCommandUniqueNameWithForce));
+                }
+                else
+                {
+                    throw new CommandException(Strings.SourcesCommandUniqueName);
+                }
             }
 
             var existingSourceWithSource = sourceProvider.GetPackageSourceBySource(args.Source);
             if (existingSourceWithSource != null)
             {
-                throw new CommandException(Strings.SourcesCommandUniqueSource);
+                if (args.Force)
+                {
+                    getLogger().LogWarning(
+                        string.Format(CultureInfo.CurrentCulture,
+                        Strings.SourcesCommandUniqueSourceWithForce));
+                }
+                else
+                {
+                    throw new CommandException(Strings.SourcesCommandUniqueSource);
+                }
             }
 
             var newPackageSource = new Configuration.PackageSource(args.Source, args.Name);

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -2105,7 +2105,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The name specified has already been added to the list of available package sources. Provide a unique name..
+        ///   Looks up a localized string similar to The name specified already exists in the list of available package sources. Provide a unique name or use -Force option..
         /// </summary>
         internal static string SourcesCommandUniqueName {
             get {
@@ -2114,7 +2114,16 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The source specified has already been added to the list of available package sources. Provide a unique source..
+        ///   Looks up a localized string similar to The name specified already exists in the list of available package sources and will be overwritten..
+        /// </summary>
+        internal static string SourcesCommandUniqueNameWithForce {
+            get {
+                return ResourceManager.GetString("SourcesCommandUniqueNameWithForce", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The source specified already exists in the list of available package sources. Provide a unique source or use -Force option..
         /// </summary>
         internal static string SourcesCommandUniqueSource {
             get {
@@ -2122,6 +2131,15 @@ namespace NuGet.Commands {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to The source specified already exists in the list of available package sources and will be overwritten..
+        /// </summary>
+        internal static string SourcesCommandUniqueSourceWithForce {
+            get {
+                return ResourceManager.GetString("SourcesCommandUniqueSourceWithForce", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Package source &quot;{0}&quot; was successfully updated..
         /// </summary>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -828,10 +828,10 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <value>The source specified is invalid. Provide a valid source.</value>
   </data>
   <data name="SourcesCommandUniqueName" xml:space="preserve">
-    <value>The name specified has already been added to the list of available package sources. Provide a unique name.</value>
+    <value>The name specified already exists in the list of available package sources. Provide a unique name or use -Force option.</value>
   </data>
   <data name="SourcesCommandUniqueSource" xml:space="preserve">
-    <value>The source specified has already been added to the list of available package sources. Provide a unique source.</value>
+    <value>The source specified already exists in the list of available package sources. Provide a unique source or use -Force option.</value>
   </data>
   <data name="SourcesCommandSourceAddedSuccessfully" xml:space="preserve">
     <value>Package source with Name: {0} added successfully.</value>
@@ -1098,5 +1098,11 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
   </data>
   <data name="SourcesCommandValidProtocolVersion" xml:space="preserve">
     <value>The protocol version specified is invalid. Valid protocol versions are from {0} to {1}.</value>
+  </data>
+  <data name="SourcesCommandUniqueNameWithForce" xml:space="preserve">
+    <value>The name specified already exists in the list of available package sources and will be overwritten.</value>
+  </data>
+  <data name="SourcesCommandUniqueSourceWithForce" xml:space="preserve">
+    <value>The source specified already exists in the list of available package sources and will be overwritten.</value>
   </data>
 </root>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSourcesTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSourcesTests.cs
@@ -356,7 +356,7 @@ warn : Non-HTTPS access will be removed in a future version. Consider migrating 
 
                 Assert.Equal("test_source", source.Name);
                 Assert.Equal("http://source.test", source.Source);
-                Assert.True(result.Output.Contains("warn : You are running the 'enable source' operation with an 'HTTP' source, 'http://source.test'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source."));
+                Assert.Contains("warn : You are running the 'enable source' operation with an 'HTTP' source, 'http://source.test'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.", result.Output);
             }
         }
 
@@ -419,7 +419,7 @@ warn : Non-HTTPS access will be removed in a future version. Consider migrating 
 
                 Assert.Equal("test_source", source.Name);
                 Assert.Equal("http://source.test", source.Source);
-                Assert.False(result.Output.Contains("warn :"));
+                Assert.DoesNotContain("warn :", result.Output);
             }
         }
 
@@ -643,7 +643,7 @@ warn : Non-HTTPS access will be removed in a future version. Consider migrating 
                 {
                     // Assert error message
                     string expectedErrorMessage = "The protocol version specified is invalid.";
-                    Assert.True(result.Output.Contains(expectedErrorMessage), "Expected error is " + expectedErrorMessage + ". Actual error is " + result.Output);
+                    Assert.Contains(expectedErrorMessage, result.Output);
                 }
             }
         }
@@ -1169,7 +1169,7 @@ warn : Non-HTTPS access will be removed in a future version. Consider migrating 
                 var result = _fixture.RunDotnetExpectSuccess(workingPath, string.Join(" ", args));
 
                 // Assert
-                Assert.True(result.Output.StartsWith("Registered Sources:"));
+                Assert.StartsWith("Registered Sources:", result.Output);
                 Assert.Contains("encyclopaedia [Enabled]", result.Output);
                 Assert.Contains("encyclopædia [Enabled]", result.Output);
                 Assert.DoesNotContain("Encyclopaedia", result.Output);
@@ -1193,7 +1193,7 @@ warn : Non-HTTPS access will be removed in a future version. Consider migrating 
 
                 // Break the test if no proper command is found
                 if (commandSplit.Length < 1 || string.IsNullOrEmpty(commandSplit[0]))
-                    Assert.True(false, "command not found");
+                    Assert.Fail("command not found");
 
                 // 0th - "nuget"
                 // 1st - "source"
@@ -1216,7 +1216,7 @@ warn : Non-HTTPS access will be removed in a future version. Consider migrating 
                     invalidMessage = ": Unrecognized command";
                 }
 
-                Assert.True(result.Output.Contains(invalidMessage), "Expected error is " + invalidMessage + ". Actual error is " + result.Output);
+                Assert.Contains(invalidMessage, result.Output);
                 // Verify traits of help message in stdout
                 Assert.Contains("Specify --help for a list of available options and commands.", result.Output);
             }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchResultTablePrinterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchResultTablePrinterTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace NuGet.CommandLine.Xplat.Tests
 {
+    [UseCulture("en-US")] // We are asserting English culture formatted numbers
     public class PackageSearchResultTablePrinterTests
     {
         [Theory]

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
@@ -14,6 +14,7 @@ using System.Threading;
 
 namespace NuGet.CommandLine.Xplat.Tests
 {
+    [UseCulture("en-US")] // We are asserting English culture formatted numbers
     public class PackageSearchRunnerTests : PackageSearchTestInitializer, IClassFixture<PackageSearchRunnerFixture>
     {
         PackageSearchRunnerFixture _fixture;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12537

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
- add `force` option to `nuget sources add` command
- improve test failure messages by replacing `Assert.True`/`Assert.False` with a more fitting Asserts in `DotnetSourcesTests.cs`
- fix tests failing when run on non-english culture machines in `PackageSearchResultTablePrinterTests.cs` and `PackageSearchRunnerTests.cs`

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
