### PR TITLE
disable OptProf pipeline for release-6.0.x branch.

### DIFF
--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -12,7 +12,7 @@ resources:
         - dev
         - release-*
         exclude:
-        -  release-6.0.x
+        - release-6.0.x
   - pipeline: DartLab
     source: DartLab
     branch: main

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -8,8 +8,11 @@ resources:
     source: NuGet.Client-Official
     trigger:
       branches:
+        include:
         - dev
         - release-*
+        exclude:
+        -  release-6.0.x
   - pipeline: DartLab
     source: DartLab
     branch: main
@@ -142,7 +145,7 @@ stages:
         arguments: -BootstrapperInfoJsonURI '$(Pipeline.Workspace)\ComponentBuildUnderTest\MicroBuildOutputs\BootstrapperInfo.json' -VSBranch '$(VSBranch)' -OutVariableName 'VisualStudio.InstallationUnderTest.BootstrapperURL'
     # Remove this step hook and it's task if you don't want LKG support
     prePublishOptimizationInputsDropStepList:
-    # Set parameter for PreviousOptimizationInputsDropName 
+    # Set parameter for PreviousOptimizationInputsDropName
     - powershell: |
         try {
           $artifactName = 'OptProf'
@@ -155,7 +158,7 @@ stages:
 
           Write-Host "The content of the metadata.json file was $json"
           $dropname = $json.OptimizationData
-          
+
           Write-Host "PreviousOptimizationInputsDropName: $dropname"
           Set-AzurePipelinesVariable 'PreviousOptimizationInputsDropName' $dropname
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2662

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Disable OptProf pipeline for release-6.0.x branch because the corresponding VS version is out of support. Added more details in the linked issue. Followed this [doc](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/pipeline-triggers?view=azure-devops#branch-filters) to edit the yaml pipeline.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A