### PR TITLE
Show Errors for package sources that fail to complete a search operation

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchRunner.cs
@@ -95,20 +95,20 @@ namespace NuGet.CommandLine.XPlat
                     // search
                     // Throws FatalProtocolException for JSON parsing errors as fatal metadata issues.
                     // Throws FatalProtocolException for HTTP request issues indicating critical source(v2/v3) problems.
-                    packageSearchResultRenderer.Add(source, new PackageSearchProblem(PackageSearchProblemType.Warning, ex.Message));
+                    packageSearchResultRenderer.Add(source, new PackageSearchProblem(PackageSearchProblemType.Error, ex.Message));
                     searchRequests.Remove(completedTask);
                     continue;
                 }
                 catch (OperationCanceledException ex)
                 {
-                    packageSearchResultRenderer.Add(source, new PackageSearchProblem(PackageSearchProblemType.Warning, ex.Message));
+                    packageSearchResultRenderer.Add(source, new PackageSearchProblem(PackageSearchProblemType.Error, ex.Message));
                     searchRequests.Remove(completedTask);
                     continue;
                 }
                 catch (InvalidOperationException ex)
                 {
                     // Thrown for a local package with an invalid source destination.
-                    packageSearchResultRenderer.Add(source, new PackageSearchProblem(PackageSearchProblemType.Warning, ex.Message));
+                    packageSearchResultRenderer.Add(source, new PackageSearchProblem(PackageSearchProblemType.Error, ex.Message));
                     searchRequests.Remove(completedTask);
                     continue;
                 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
@@ -472,7 +472,7 @@ namespace NuGet.CommandLine.Xplat.Tests
 
             // Assert
             Assert.Equal(0, exitCode);
-            Assert.Contains(expectedError, StoredWarningMessage);
+            Assert.Contains(expectedError, StoredErrorMessage);
         }
 
         [Fact]
@@ -509,7 +509,7 @@ namespace NuGet.CommandLine.Xplat.Tests
 
             // Assert
             Assert.Equal(0, exitCode);
-            Assert.Contains(expectedError, StoredWarningMessage);
+            Assert.Contains(expectedError, StoredErrorMessage);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13163

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This PR removes warnings from the following scenarios and prints out Error level problems in replacement.
- when a search service index for a source is not available
- when a search operation times out because of the source
- when a local search source has an invalid destination
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
