### PR TITLE
NuGetAudit must not cause restore to fail

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/VulnerabilityInformationProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/VulnerabilityInformationProvider.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -35,23 +36,31 @@ namespace NuGet.Commands
 
         private async Task<GetVulnerabilityInfoResult?> GetVulnerabilityInfoAsync()
         {
-            IVulnerabilityInfoResource vulnerabilityInfoResource =
-                await _source.GetResourceAsync<IVulnerabilityInfoResource>(CancellationToken.None);
-            if (vulnerabilityInfoResource is null)
+            try
             {
-                return null;
-            }
+                IVulnerabilityInfoResource vulnerabilityInfoResource =
+                    await _source.GetResourceAsync<IVulnerabilityInfoResource>(CancellationToken.None);
+                if (vulnerabilityInfoResource is null)
+                {
+                    return null;
+                }
 
-            // Don't re-use a SourceCacheContext from whatever triggered this, because installing packages
-            // (and a few other scenarios, look at everything that calls SourceCacheContext.MaxAge's setter)
-            // will ignore the http cache, because it wants to allow newly published packages to be installable.
-            // However, in VS, when a new project template installs packages, we don't want to force a re-download
-            // of the vulnerability data. Firstly, from a customer point of view, it's not necessary. The reason
-            // we bust the cache for package install doesn't apply to vulnerability data. Secondly, it triggers
-            // regressions in VS's performance tests.
-            using SourceCacheContext cacheContext = new();
-            GetVulnerabilityInfoResult result = await vulnerabilityInfoResource.GetVulnerabilityInfoAsync(cacheContext, _logger, CancellationToken.None);
-            return result;
+                // Don't re-use a SourceCacheContext from whatever triggered this, because installing packages
+                // (and a few other scenarios, look at everything that calls SourceCacheContext.MaxAge's setter)
+                // will ignore the http cache, because it wants to allow newly published packages to be installable.
+                // However, in VS, when a new project template installs packages, we don't want to force a re-download
+                // of the vulnerability data. Firstly, from a customer point of view, it's not necessary. The reason
+                // we bust the cache for package install doesn't apply to vulnerability data. Secondly, it triggers
+                // regressions in VS's performance tests.
+                using SourceCacheContext cacheContext = new();
+                GetVulnerabilityInfoResult result = await vulnerabilityInfoResource.GetVulnerabilityInfoAsync(cacheContext, _logger, CancellationToken.None);
+                return result;
+            }
+            catch (Exception e)
+            {
+                GetVulnerabilityInfoResult result = new(knownVulnerabilities: null, exceptions: new(e));
+                return result;
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/AuditUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/AuditUtility.cs
@@ -137,13 +137,22 @@ namespace NuGet.PackageManagement
 
             static async Task<GetVulnerabilityInfoResult?> GetVulnerabilityInfoAsync(SourceRepository source, SourceCacheContext cacheContext, ILogger logger)
             {
-                IVulnerabilityInfoResource vulnerabilityInfoResource =
-                    await source.GetResourceAsync<IVulnerabilityInfoResource>(CancellationToken.None);
-                if (vulnerabilityInfoResource is null)
+                try
                 {
-                    return null;
+                    IVulnerabilityInfoResource vulnerabilityInfoResource =
+                        await source.GetResourceAsync<IVulnerabilityInfoResource>(CancellationToken.None);
+                    if (vulnerabilityInfoResource is null)
+                    {
+                        return null;
+                    }
+                    return await vulnerabilityInfoResource.GetVulnerabilityInfoAsync(cacheContext, logger, CancellationToken.None);
                 }
-                return await vulnerabilityInfoResource.GetVulnerabilityInfoAsync(cacheContext, logger, CancellationToken.None);
+                catch (Exception exception)
+                {
+                    AggregateException aggregateException = new(exception);
+                    GetVulnerabilityInfoResult result = new(knownVulnerabilities: null, exceptions: aggregateException);
+                    return result;
+                }
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/VulnerabilityInformationProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/VulnerabilityInformationProviderTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Moq;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -45,6 +46,29 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
             // Assert
             vulnerabilityResource.Verify(x => x.GetVulnerabilityInfoAsync(It.IsAny<SourceCacheContext>(), It.IsAny<ILogger>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        // While IVulnerabilityInfoResource.GetVulnerabilityInfoAsync is designed to never throw, the provider needs to get the resource from the service index
+        // and that can throw. Normally it would throw when resolving the graph, but if all packages are already in the global packages folder, then the
+        // SourceRepository instances haven't yet attempted to load the service index. This test ensures that the provider does not throw if the service index
+        // cannot be retrieved, which might happen for reasons like the DNS lookup failed, the service index itself returns an HTTP 404 or 401, network is down, etc.
+        [Fact]
+        public async Task GetVulnerabilityInformationAsync_SourceWithInvalidHostname_DoesNotThrow()
+        {
+            // Arrange
+            // .test is a reserved TLD, so we know it will never exist.
+            var packageSource = new PackageSource("https://nuget.test/v3/index.json");
+            SourceRepository source = Repository.Factory.GetCoreV3(packageSource);
+            var logger = NullLogger.Instance;
+            var provider = new VulnerabilityInformationProvider(source, logger);
+
+            // Act
+            var result = await provider.GetVulnerabilityInformationAsync(CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result!.KnownVulnerabilities.Should().BeNull();
+            result.Exceptions.Should().NotBeNull();
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/AuditUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/AuditUtilityTests.cs
@@ -520,6 +520,25 @@ namespace NuGet.PackageManagement.Test
         }
 
         [Fact]
+        public async Task GetAllVulnerabilityDataAsync_SourceWithInvalidHost_ReturnResultWithException()
+        {
+            // Arrange
+            // .test is a reserved TLD, so we know it will never exist
+            var packageSource = new PackageSource("https://nuget.test/v3/index.json");
+            SourceRepository source = Repository.Factory.GetCoreV3(packageSource);
+            List<SourceRepository> sourceRepositories = new List<SourceRepository>() { source };
+            using SourceCacheContext cacheContext = new();
+
+            // Act
+            GetVulnerabilityInfoResult? result = await AuditUtility.GetAllVulnerabilityDataAsync(sourceRepositories, cacheContext, NullLogger.Instance, CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result!.KnownVulnerabilities.Should().BeNull();
+            result.Exceptions.Should().NotBeNull();
+        }
+
+        [Fact]
         public void CreateWarningsForPackagesWithVulnerabilities_CreatesWarningsForAllVulnerabilities()
         {
             var packageA = new PackageIdentity("A", new NuGetVersion(1, 0, 0));


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13085

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

While the vulnerability info resource is designed to fail gracefully (not throw, return a result object with an exception), if restore didn't need to talk to any sources before running audit, then getting the service index, or getting the vulnerability resource from the service index can throw. This needs to be guarded because Audit should never cause a build to fail (unless customers opt into warnings as errors)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
