### PR TITLE
Mark method that gets properties via DTE as obsolete

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
@@ -338,7 +338,10 @@ namespace NuGet.PackageManagement.VisualStudio
         private bool IsCentralPackageManagementVersionsEnabled()
         {
             ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning disable CS0618 // Type or member is obsolete
+            // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
             return MSBuildStringUtility.IsTrue(_vsProjectAdapter.BuildProperties.GetPropertyValueWithDteFallback(ProjectBuildProperties.ManagePackageVersionsCentrally));
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         private class ProjectReference

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs
@@ -82,6 +82,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return null;
         }
 
+        [Obsolete("New properties should use GetPropertyValue instead. Ideally we should migrate existing properties to stop using DTE as well.")]
         public string GetPropertyValueWithDteFallback(string propertyName)
         {
             ThreadHelper.ThrowIfNotOnUIThread();

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
@@ -136,7 +136,10 @@ namespace NuGet.PackageManagement.VisualStudio
             // it into the project.
             // Other exceptions are 'web.config' and 'app.config'
             var fileName = Path.GetFileName(path);
+#pragma warning disable CS0618 // Type or member is obsolete
+            // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
             var lockFileFullPath = PackagesConfigLockFileUtility.GetPackagesLockFilePath(ProjectFullPath, GetPropertyValue("NuGetLockFilePath")?.ToString(), ProjectName);
+#pragma warning restore CS0618 // Type or member is obsolete
             if (File.Exists(Path.Combine(ProjectFullPath, path))
                 && !fileExistsInProject
                 && !fileName.Equals(ProjectManagement.Constants.PackageReferenceFile, StringComparison.Ordinal)
@@ -399,6 +402,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 });
         }
 
+        [Obsolete("New properties should use IVsProjectBuildProperties.GetPropertyValue instead. Ideally we should migrate existing properties to stop using DTE as well.")]
         public virtual dynamic GetPropertyValue(string propertyName)
         {
             return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/WebSiteProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/WebSiteProjectSystem.cs
@@ -168,13 +168,18 @@ namespace NuGet.PackageManagement.VisualStudio
             return false;
         }
 
+#pragma warning disable CS0672 // Member overrides obsolete member
+        // Website project properties are only available via DTE.
         public override dynamic GetPropertyValue(string propertyName)
+#pragma warning restore CS0672 // Member overrides obsolete member
         {
             if (propertyName.Equals(RootNamespace, StringComparison.OrdinalIgnoreCase))
             {
                 return DefaultNamespace;
             }
+#pragma warning disable CS0618 // Type or member is obsolete
             return base.GetPropertyValue(propertyName);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public override IEnumerable<string> GetDirectories(string path)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/WixProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/WixProjectSystem.cs
@@ -36,6 +36,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return false;
         }
 
+        [Obsolete("New properties should use IVsProjectBuildProperties.GetPropertyValue instead. Ideally we should migrate existing properties to stop using DTE as well.")]
         public override dynamic GetPropertyValue(string propertyName)
         {
             if (propertyName.Equals(RootNamespace, StringComparison.OrdinalIgnoreCase))

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
@@ -76,7 +76,10 @@ namespace NuGet.PackageManagement.VisualStudio
             var buildProperties = vsProject.BuildProperties;
 
             // read MSBuild property RestoreProjectStyle
+#pragma warning disable CS0618 // Type or member is obsolete
+            // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
             var restoreProjectStyle = buildProperties.GetPropertyValueWithDteFallback(ProjectBuildProperties.RestoreProjectStyle);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // check for RestoreProjectStyle property is set and if not set to PackageReference then return false
             if (!(string.IsNullOrEmpty(restoreProjectStyle) ||

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -260,6 +260,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return msbuildProjectExtensionsPath;
         }
 
+        [Obsolete("New properties should use IVsProjectBuildProperties.GetPropertyValue instead. Ideally we should migrate existing properties to stop using DTE as well.")]
         private static string GetPropertySafe(IVsProjectBuildProperties projectBuildProperties, string propertyName)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
@@ -276,7 +277,10 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
+#pragma warning disable CS0618 // Type or member is obsolete
+            // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
             var packagePath = GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.RestorePackagesPath);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             if (string.IsNullOrWhiteSpace(packagePath))
             {
@@ -290,7 +294,10 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
+#pragma warning disable CS0618 // Type or member is obsolete
+            // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
             var sources = MSBuildStringUtility.Split(GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.RestoreSources)).AsEnumerable();
+#pragma warning restore CS0618 // Type or member is obsolete
 
             if (ShouldReadFromSettings(sources))
             {
@@ -302,7 +309,10 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             // Add additional sources
+#pragma warning disable CS0618 // Type or member is obsolete
+            // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
             sources = sources.Concat(MSBuildStringUtility.Split(GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.RestoreAdditionalProjectSources)));
+#pragma warning restore CS0618 // Type or member is obsolete
 
             return sources.Select(e => new PackageSource(UriUtility.GetAbsolutePathFromFile(ProjectFullPath, e))).ToList();
         }
@@ -311,7 +321,10 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
+#pragma warning disable CS0618 // Type or member is obsolete
+            // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
             var fallbackFolders = MSBuildStringUtility.Split(GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.RestoreFallbackFolders)).AsEnumerable();
+#pragma warning restore CS0618 // Type or member is obsolete
 
             if (ShouldReadFromSettings(fallbackFolders))
             {
@@ -323,7 +336,10 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             // Add additional fallback folders
+#pragma warning disable CS0618 // Type or member is obsolete
+            // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
             fallbackFolders = fallbackFolders.Concat(MSBuildStringUtility.Split(GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.RestoreAdditionalProjectFallbackFolders)));
+#pragma warning restore CS0618 // Type or member is obsolete
 
             return fallbackFolders.Select(e => UriUtility.GetAbsolutePathFromFile(ProjectFullPath, e)).ToList();
         }
@@ -356,6 +372,8 @@ namespace NuGet.PackageManagement.VisualStudio
                 .GetPackageReferencesAsync(targetFramework, CancellationToken.None))
                 .ToList();
 
+#pragma warning disable CS0618 // Type or member is obsolete
+            // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
             var packageTargetFallback = MSBuildStringUtility.Split(GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.PackageTargetFallback))
                 .Select(NuGetFramework.Parse)
                 .ToList();
@@ -363,6 +381,7 @@ namespace NuGet.PackageManagement.VisualStudio
             var assetTargetFallback = MSBuildStringUtility.Split(GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.AssetTargetFallback))
                 .Select(NuGetFramework.Parse)
                 .ToList();
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var projectTfi = new TargetFrameworkInformation
             {
@@ -370,7 +389,10 @@ namespace NuGet.PackageManagement.VisualStudio
                 Dependencies = packageReferences,
             };
 
+#pragma warning disable CS0618 // Type or member is obsolete
+            // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
             bool isCpvmEnabled = MSBuildStringUtility.IsTrue(GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.ManagePackageVersionsCentrally));
+#pragma warning restore CS0618 // Type or member is obsolete
             if (isCpvmEnabled)
             {
                 // Add the central version information and merge the information to the package reference dependencies
@@ -383,10 +405,13 @@ namespace NuGet.PackageManagement.VisualStudio
 
             // Build up runtime information.
 
+#pragma warning disable CS0618 // Type or member is obsolete
+            // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
             var runtimes = GetRuntimeIdentifiers(
                 GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.RuntimeIdentifier),
                 GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.RuntimeIdentifiers));
             var supports = GetRuntimeSupports(GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.RuntimeSupports));
+#pragma warning restore CS0618 // Type or member is obsolete
             var runtimeGraph = new RuntimeGraph(runtimes, supports);
 
             // In legacy CSProj, we only have one target framework per project
@@ -394,7 +419,10 @@ namespace NuGet.PackageManagement.VisualStudio
 
             var projectName = ProjectName ?? ProjectUniqueName;
 
+#pragma warning disable CS0618 // Type or member is obsolete
+            // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
             string specifiedPackageId = _vsProjectAdapter.BuildProperties.GetPropertyValueWithDteFallback(ProjectBuildProperties.PackageId);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             if (!string.IsNullOrWhiteSpace(specifiedPackageId))
             {
@@ -402,7 +430,10 @@ namespace NuGet.PackageManagement.VisualStudio
             }
             else
             {
+#pragma warning disable CS0618 // Type or member is obsolete
+                // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
                 string specifiedAssemblyName = _vsProjectAdapter.BuildProperties.GetPropertyValueWithDteFallback(ProjectBuildProperties.AssemblyName);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 if (!string.IsNullOrWhiteSpace(specifiedAssemblyName))
                 {
@@ -423,6 +454,21 @@ namespace NuGet.PackageManagement.VisualStudio
                 : null;
 
             var msbuildProjectExtensionsPath = await GetMSBuildProjectExtensionsPathAsync();
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            // Do not add new properties here. Use BuildProperties.GetPropertyValue instead, without DTE fallback.
+            string treatWarningsAsErrors = GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.TreatWarningsAsErrors);
+            string noWarn = GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.NoWarn);
+            string warningsAsErrors = GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.WarningsAsErrors);
+            string warningsNotAsErrors = GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.WarningsNotAsErrors);
+            string restorePackagesWithLockFile = GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.RestorePackagesWithLockFile);
+            string nugetLockFilePath = GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.NuGetLockFilePath);
+            string restoreLockedMode = GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.RestoreLockedMode);
+            string centralPackageVersionOverrideDisabled = GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.CentralPackageVersionOverrideEnabled);
+            string centralPackageTransitivePinningEnabled = GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.CentralPackageTransitivePinningEnabled);
+            // Do not add new properties here. Use BuildProperties.GetPropertyValue instead, without DTE fallback.
+#pragma warning restore CS0618 // Type or member is obsolete
+
             return new PackageSpec(tfis)
             {
                 Name = projectName,
@@ -453,18 +499,18 @@ namespace NuGet.PackageManagement.VisualStudio
                     FallbackFolders = GetFallbackFolders(settings),
                     ConfigFilePaths = GetConfigFilePaths(settings),
                     ProjectWideWarningProperties = WarningProperties.GetWarningProperties(
-                        treatWarningsAsErrors: GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.TreatWarningsAsErrors),
-                        noWarn: GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.NoWarn),
-                        warningsAsErrors: GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.WarningsAsErrors),
-                        warningsNotAsErrors: GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.WarningsNotAsErrors)),
+                        treatWarningsAsErrors,
+                        noWarn,
+                        warningsAsErrors,
+                        warningsNotAsErrors),
                     RestoreLockProperties = new RestoreLockProperties(
-                        GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.RestorePackagesWithLockFile),
-                        GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.NuGetLockFilePath),
-                        MSBuildStringUtility.IsTrue(GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.RestoreLockedMode))),
+                        restorePackagesWithLockFile,
+                        nugetLockFilePath,
+                        MSBuildStringUtility.IsTrue(restoreLockedMode)),
                     CentralPackageVersionsEnabled = isCpvmEnabled,
-                    CentralPackageVersionOverrideDisabled = GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.CentralPackageVersionOverrideEnabled).EqualsFalse(),
+                    CentralPackageVersionOverrideDisabled = centralPackageVersionOverrideDisabled.EqualsFalse(),
                     CentralPackageFloatingVersionsEnabled = MSBuildStringUtility.IsTrue(_vsProjectAdapter.BuildProperties.GetPropertyValue(ProjectBuildProperties.CentralPackageFloatingVersionsEnabled)),
-                    CentralPackageTransitivePinningEnabled = MSBuildStringUtility.IsTrue(GetPropertySafe(_vsProjectAdapter.BuildProperties, ProjectBuildProperties.CentralPackageTransitivePinningEnabled)),
+                    CentralPackageTransitivePinningEnabled = MSBuildStringUtility.IsTrue(centralPackageTransitivePinningEnabled),
                     RestoreAuditProperties = auditProperties,
                 }
             };

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProjectProvider.cs
@@ -94,8 +94,11 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             // Check for RestoreProjectStyle property
+#pragma warning disable CS0618 // Type or member is obsolete
+            // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
             var restoreProjectStyle = vsProjectAdapter.BuildProperties.GetPropertyValueWithDteFallback(
                 ProjectBuildProperties.RestoreProjectStyle);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // For legacy csproj, either the RestoreProjectStyle must be set to PackageReference or
             // project has atleast one package dependency defined as PackageReference

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -34,7 +34,10 @@ namespace NuGet.PackageManagement.VisualStudio
         public string GetMSBuildProjectExtensionsPath()
         {
             ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning disable CS0618 // Type or member is obsolete
+            // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
             var msbuildProjectExtensionsPath = BuildProperties.GetPropertyValueWithDteFallback(ProjectBuildProperties.MSBuildProjectExtensionsPath);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             if (string.IsNullOrEmpty(msbuildProjectExtensionsPath))
             {
@@ -88,11 +91,17 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 ThreadHelper.ThrowIfNotOnUIThread();
 
+#pragma warning disable CS0618 // Type or member is obsolete
+                // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
                 var packageVersion = BuildProperties.GetPropertyValueWithDteFallback(ProjectBuildProperties.PackageVersion);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 if (string.IsNullOrEmpty(packageVersion))
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
+                    // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
                     packageVersion = BuildProperties.GetPropertyValueWithDteFallback(ProjectBuildProperties.Version);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     if (string.IsNullOrEmpty(packageVersion))
                     {
@@ -230,6 +239,8 @@ namespace NuGet.PackageManagement.VisualStudio
             await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             var projectPath = FullName;
+#pragma warning disable CS0618 // Type or member is obsolete
+            // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
             var platformIdentifier = BuildProperties.GetPropertyValueWithDteFallback(
                 ProjectBuildProperties.TargetPlatformIdentifier);
             var platformVersion = BuildProperties.GetPropertyValueWithDteFallback(
@@ -238,6 +249,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 ProjectBuildProperties.TargetPlatformMinVersion);
             var targetFrameworkMoniker = BuildProperties.GetPropertyValueWithDteFallback(
                 ProjectBuildProperties.TargetFrameworkMoniker);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // Projects supporting TargetFramework and TargetFrameworks are detected before
             // this check. The values can be passed as null here.

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectJsonNuGetProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectJsonNuGetProject.cs
@@ -43,7 +43,10 @@ namespace NuGet.PackageManagement.VisualStudio
         protected override async Task<string> GetMSBuildProjectExtensionsPathAsync()
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+#pragma warning disable CS0618 // Type or member is obsolete
+            // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
             var msbuildProjectExtensionsPath = _vsProjectAdapter.BuildProperties.GetPropertyValueWithDteFallback(ProjectBuildProperties.MSBuildProjectExtensionsPath);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             if (string.IsNullOrEmpty(msbuildProjectExtensionsPath))
             {
@@ -72,17 +75,23 @@ namespace NuGet.PackageManagement.VisualStudio
                 var jsonTargetFramework = targetFramework as NuGetFramework;
                 if (IsUAPFramework(jsonTargetFramework))
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
+                    // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
                     var platformMinVersionString = _vsProjectAdapter
                         .BuildProperties
                         .GetPropertyValueWithDteFallback(ProjectBuildProperties.TargetPlatformMinVersion);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     var platformMinVersion = !string.IsNullOrEmpty(platformMinVersionString)
                         ? new Version(platformMinVersionString)
                         : null;
 
+#pragma warning disable CS0618 // Type or member is obsolete
+                    // Need to validate no project systems get this property via DTE, and if so, switch to GetPropertyValue
                     var targetFrameworkMonikerString = _vsProjectAdapter
                         .BuildProperties
                         .GetPropertyValueWithDteFallback(ProjectBuildProperties.TargetFrameworkMoniker);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     var targetFrameworkMoniker = !string.IsNullOrWhiteSpace(targetFrameworkMonikerString)
                         ? NuGetFramework.Parse(targetFrameworkMonikerString)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectBuildProperties.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectBuildProperties.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace NuGet.VisualStudio
 {
     public interface IVsProjectBuildProperties
@@ -15,6 +17,7 @@ namespace NuGet.VisualStudio
         /// <returns>The value of the property, if defined by the project. Otherwise, null</returns>
         /// <remarks>This method should not be used for anything new, as an exception is thrown and caught internally
         /// when no value is defined, which harms performance.</remarks>
+        [Obsolete("New properties should use GetPropertyValue instead. Ideally we should migrate existing properties to stop using DTE as well.")]
         string GetPropertyValueWithDteFallback(string propertyName);
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -291,6 +291,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var projectBuildProperties = new Mock<IVsProjectBuildProperties>();
                 var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 projectBuildProperties
                     .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestorePackagesPath))))
                     .Returns(restorePackagesPath);
@@ -302,6 +303,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 projectBuildProperties
                     .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreFallbackFolders))))
                     .Returns(fallbackFolders);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 var projectServices = new TestProjectSystemServices();
 
@@ -355,6 +357,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var projectBuildProperties = new Mock<IVsProjectBuildProperties>();
                 var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 projectBuildProperties
                     .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestorePackagesPath))))
                     .Returns(restorePackagesPath);
@@ -366,6 +369,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 projectBuildProperties
                     .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreFallbackFolders))))
                     .Returns(fallbackFolders);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 var projectServices = new TestProjectSystemServices();
 
@@ -415,9 +419,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var projectBuildProperties = new Mock<IVsProjectBuildProperties>();
                 var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 projectBuildProperties
                     .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.PackageTargetFallback))))
                     .Returns("portable-net45+win8;dnxcore50");
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 var testProject = new LegacyPackageReferenceProject(
                     projectAdapter,
@@ -761,6 +767,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var projectBuildProperties = new Mock<IVsProjectBuildProperties>();
                 var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 projectBuildProperties
                     .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestorePackagesWithLockFile))))
                     .Returns(restorePackagesWithLockFile);
@@ -772,6 +779,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 projectBuildProperties
                     .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreLockedMode))))
                     .Returns(restoreLockedMode.ToString());
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 var projectServices = new TestProjectSystemServices();
 
@@ -1455,6 +1463,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var projectBuildProperties = new Mock<IVsProjectBuildProperties>();
                 var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 projectBuildProperties
                     .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RuntimeIdentifier))))
                     .Returns(runtimeIdentifier);
@@ -1466,6 +1475,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 projectBuildProperties
                     .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RuntimeSupports))))
                     .Returns(runtimeSupports);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 var projectServices = new TestProjectSystemServices();
 
@@ -1527,6 +1537,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var projectBuildProperties = new Mock<IVsProjectBuildProperties>();
             var projectAdapter = CreateProjectAdapter(testDirectory, projectBuildProperties);
 
+#pragma warning disable CS0618 // Type or member is obsolete
             projectBuildProperties
                 .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.NoWarn))))
                 .Returns("NU1504");
@@ -1539,6 +1550,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             projectBuildProperties
                 .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.WarningsAsErrors))))
                 .Returns("NU1803");
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var projectServices = new TestProjectSystemServices();
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
@@ -51,6 +51,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             _isCentralPackageVersionOverrideEnabled = isCentralPackageVersionOverrideEnabled;
             _CentralPackageTransitivePinningEnabled = CentralPackageTransitivePinningEnabled;
 
+#pragma warning disable CS0618 // Type or member is obsolete
             Mock.Get(BuildProperties)
                 .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.ManagePackageVersionsCentrally))))
                 .Returns(_isCPVMEnabled.ToString());
@@ -74,6 +75,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Mock.Get(BuildProperties)
                 .Setup(x => x.GetPropertyValueWithDteFallback(It.Is<string>(x => x.Equals(ProjectBuildProperties.RestoreLockedMode))))
                 .Returns(_restoreLockedMode.ToString());
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public string GetMSBuildProjectExtensionsPath()


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2664

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Visual Studio's performance tests count the number of exceptions thrown (even if caught) and flag a regression if the number increases. DTE thrown an exception when a project doesn't have a value for a property. Therefore, we get flagged every time we add a new property and use the API that falls back to DTE when the newer API doesn't return a value.

So, mark the API as obsolete, and suppress all instances of the API where it's currently being called. Hopefully this discourages new features from using the API that uses DTE.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
