### PR TITLE
disable OptProf pipeline for release-6.3.x branch

### DIFF
--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -6,13 +6,6 @@ resources:
   pipelines:
   - pipeline: ComponentBuildUnderTest
     source: NuGet.Client-Official
-    trigger: 
-      branches:
-        include: 
-        - dev
-        - release-*
-        exclude:
-        - refs/heads/release-6.3.x
   - pipeline: DartLab
     source: DartLab
     branch: main

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -6,13 +6,13 @@ resources:
   pipelines:
   - pipeline: ComponentBuildUnderTest
     source: NuGet.Client-Official
-    trigger:
+    trigger: 
       branches:
-       include:
+        include: 
         - dev
         - release-*
-       exclude:
-        - release-6.3.x
+        exclude:
+        - refs/heads/release-6.3.x
   - pipeline: DartLab
     source: DartLab
     branch: main
@@ -145,7 +145,7 @@ stages:
         arguments: -BootstrapperInfoJsonURI '$(Pipeline.Workspace)\ComponentBuildUnderTest\MicroBuildOutputs\BootstrapperInfo.json' -VSBranch '$(VSBranch)' -OutVariableName 'VisualStudio.InstallationUnderTest.BootstrapperURL'
     # Remove this step hook and it's task if you don't want LKG support
     prePublishOptimizationInputsDropStepList:
-    # Set parameter for PreviousOptimizationInputsDropName 
+    # Set parameter for PreviousOptimizationInputsDropName
     - powershell: |
         try {
           $artifactName = 'OptProf'
@@ -158,7 +158,7 @@ stages:
 
           Write-Host "The content of the metadata.json file was $json"
           $dropname = $json.OptimizationData
-          
+
           Write-Host "PreviousOptimizationInputsDropName: $dropname"
           Set-AzurePipelinesVariable 'PreviousOptimizationInputsDropName' $dropname
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Tracking: https://github.com/NuGet/Client.Engineering/issues/2362

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

We already excluded the release-6.3.x branch from triggering the pipeline in [PR #5282](https://github.com/NuGet/NuGet.Client/pull/5282), but I noticed it was ineffective. The [OptProf pipeline](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8952995&view=results) was still triggered when the [scheduled official build succeeded for `release-6.3.x` branch](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8952919&view=results). Consequently, I've removed the trigger entirely in this PR to ensure that the OptProf pipeline will not be triggered.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A
