### PR TITLE
Do not allocate unnecessary lists of no warn log codes in LibraryDependency

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
@@ -204,7 +204,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private static LibraryDependency ToPackageLibraryDependency(PackageReference reference, bool isCpvmEnabled)
         {
             // Get warning suppressions
-            List<NuGetLogCode> noWarn = MSBuildStringUtility.GetNuGetLogCodes(GetReferenceMetadataValue(reference, ProjectItemProperties.NoWarn)).ToList();
+            IList<NuGetLogCode> noWarn = MSBuildStringUtility.GetNuGetLogCodes(GetReferenceMetadataValue(reference, ProjectItemProperties.NoWarn));
 
             var dependency = new LibraryDependency(noWarn)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
@@ -203,7 +203,10 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private static LibraryDependency ToPackageLibraryDependency(PackageReference reference, bool isCpvmEnabled)
         {
-            var dependency = new LibraryDependency
+            // Get warning suppressions
+            List<NuGetLogCode> noWarn = MSBuildStringUtility.GetNuGetLogCodes(GetReferenceMetadataValue(reference, ProjectItemProperties.NoWarn)).ToList();
+
+            var dependency = new LibraryDependency(noWarn)
             {
                 AutoReferenced = MSBuildStringUtility.IsTrue(GetReferenceMetadataValue(reference, ProjectItemProperties.IsImplicitlyDefined)),
                 GeneratePathProperty = MSBuildStringUtility.IsTrue(GetReferenceMetadataValue(reference, ProjectItemProperties.GeneratePathProperty)),
@@ -212,7 +215,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 LibraryRange = new LibraryRange(
                     name: reference.Name,
                     versionRange: ToVersionRange(reference.Version, isCpvmEnabled),
-                    typeConstraint: LibraryDependencyTarget.Package)
+                    typeConstraint: LibraryDependencyTarget.Package),
             };
 
             MSBuildRestoreUtility.ApplyIncludeFlags(
@@ -220,13 +223,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 GetReferenceMetadataValue(reference, ProjectItemProperties.IncludeAssets),
                 GetReferenceMetadataValue(reference, ProjectItemProperties.ExcludeAssets),
                 GetReferenceMetadataValue(reference, ProjectItemProperties.PrivateAssets));
-
-
-            // Add warning suppressions
-            foreach (var code in MSBuildStringUtility.GetNuGetLogCodes(GetReferenceMetadataValue(reference, ProjectItemProperties.NoWarn)))
-            {
-                dependency.NoWarn.Add(code);
-            }
 
             return dependency;
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -167,7 +167,7 @@ namespace NuGet.PackageManagement.VisualStudio
             BuildIntegratedInstallationContext __,
             CancellationToken token)
         {
-            var dependency = new LibraryDependency
+            var dependency = new LibraryDependency(noWarn: Array.Empty<NuGetLogCode>())
             {
                 LibraryRange = new LibraryRange(
                     name: packageId,

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -229,9 +229,9 @@ namespace NuGet.SolutionRestoreManager
         {
             return WarningProperties.GetWarningProperties(
                         treatWarningsAsErrors: GetSingleOrDefaultPropertyValue(targetFrameworks, ProjectBuildProperties.TreatWarningsAsErrors, e => e),
-                        warningsAsErrors: GetSingleOrDefaultNuGetLogCodes(targetFrameworks, ProjectBuildProperties.WarningsAsErrors, e => MSBuildStringUtility.GetNuGetLogCodes(e)),
-                        noWarn: GetSingleOrDefaultNuGetLogCodes(targetFrameworks, ProjectBuildProperties.NoWarn, e => MSBuildStringUtility.GetNuGetLogCodes(e)),
-                        warningsNotAsErrors: GetSingleOrDefaultNuGetLogCodes(targetFrameworks, ProjectBuildProperties.WarningsNotAsErrors, e => MSBuildStringUtility.GetNuGetLogCodes(e)));
+                        warningsAsErrors: GetSingleOrDefaultNuGetLogCodes(targetFrameworks, ProjectBuildProperties.WarningsAsErrors, MSBuildStringUtility.GetNuGetLogCodes),
+                        noWarn: GetSingleOrDefaultNuGetLogCodes(targetFrameworks, ProjectBuildProperties.NoWarn, MSBuildStringUtility.GetNuGetLogCodes),
+                        warningsNotAsErrors: GetSingleOrDefaultNuGetLogCodes(targetFrameworks, ProjectBuildProperties.WarningsNotAsErrors, MSBuildStringUtility.GetNuGetLogCodes));
         }
 
         /// <summary>
@@ -420,7 +420,7 @@ namespace NuGet.SolutionRestoreManager
             TryGetVersionRange(item, "VersionOverride", out VersionRange versionOverrideRange);
 
             // Get warning suppressions
-            List<NuGetLogCode> noWarn = MSBuildStringUtility.GetNuGetLogCodes(GetPropertyValueOrNull(item, ProjectBuildProperties.NoWarn)).ToList();
+            IList<NuGetLogCode> noWarn = MSBuildStringUtility.GetNuGetLogCodes(GetPropertyValueOrNull(item, ProjectBuildProperties.NoWarn));
 
             var dependency = new LibraryDependency(noWarn)
             {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -419,7 +419,10 @@ namespace NuGet.SolutionRestoreManager
 
             TryGetVersionRange(item, "VersionOverride", out VersionRange versionOverrideRange);
 
-            var dependency = new LibraryDependency
+            // Get warning suppressions
+            List<NuGetLogCode> noWarn = MSBuildStringUtility.GetNuGetLogCodes(GetPropertyValueOrNull(item, ProjectBuildProperties.NoWarn)).ToList();
+
+            var dependency = new LibraryDependency(noWarn)
             {
                 LibraryRange = new LibraryRange(
                     name: item.Name,
@@ -432,12 +435,6 @@ namespace NuGet.SolutionRestoreManager
                 Aliases = GetPropertyValueOrNull(item, "Aliases"),
                 VersionOverride = versionOverrideRange
             };
-
-            // Add warning suppressions
-            foreach (var code in MSBuildStringUtility.GetNuGetLogCodes(GetPropertyValueOrNull(item, ProjectBuildProperties.NoWarn)))
-            {
-                dependency.NoWarn.Add(code);
-            }
 
             MSBuildRestoreUtility.ApplyIncludeFlags(
                 dependency,

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -70,7 +69,7 @@ namespace NuGet.Commands
                 {
                     Dependencies = new List<LibraryDependency>
                     {
-                        new LibraryDependency
+                        new LibraryDependency(noWarn: Array.Empty<NuGetLogCode>())
                         {
                             LibraryRange = new LibraryRange(
                                 libraryIdentity.Name,

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -305,7 +305,7 @@ namespace NuGet.Build.Tasks.Console
 
                 string versionOverride = packageReferenceItem.GetProperty("VersionOverride");
 
-                libraryDependencies.Add(new LibraryDependency
+                libraryDependencies.Add(new LibraryDependency(MSBuildStringUtility.GetNuGetLogCodes(packageReferenceItem.GetProperty("NoWarn")).ToList())
                 {
                     AutoReferenced = packageReferenceItem.IsPropertyTrue("IsImplicitlyDefined"),
                     GeneratePathProperty = packageReferenceItem.IsPropertyTrue("GeneratePathProperty"),
@@ -315,7 +315,6 @@ namespace NuGet.Build.Tasks.Console
                         packageReferenceItem.Identity,
                         string.IsNullOrWhiteSpace(version) ? isCentralPackageVersionManagementEnabled ? null : VersionRange.All : VersionRange.Parse(version),
                         LibraryDependencyTarget.Package),
-                    NoWarn = MSBuildStringUtility.GetNuGetLogCodes(packageReferenceItem.GetProperty("NoWarn")).ToList(),
                     SuppressParent = GetLibraryIncludeFlags(packageReferenceItem.GetProperty("PrivateAssets"), LibraryIncludeFlagUtils.DefaultSuppressParent),
                     VersionOverride = string.IsNullOrWhiteSpace(versionOverride) ? null : VersionRange.Parse(versionOverride),
                 });

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -305,7 +305,9 @@ namespace NuGet.Build.Tasks.Console
 
                 string versionOverride = packageReferenceItem.GetProperty("VersionOverride");
 
-                libraryDependencies.Add(new LibraryDependency(MSBuildStringUtility.GetNuGetLogCodes(packageReferenceItem.GetProperty("NoWarn")).ToList())
+                IList<NuGetLogCode> noWarn = MSBuildStringUtility.GetNuGetLogCodes(packageReferenceItem.GetProperty("NoWarn"));
+
+                libraryDependencies.Add(new LibraryDependency(noWarn)
                 {
                     AutoReferenced = packageReferenceItem.IsPropertyTrue("IsImplicitlyDefined"),
                     GeneratePathProperty = packageReferenceItem.IsPropertyTrue("GeneratePathProperty"),

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -889,7 +889,7 @@ namespace NuGet.Build.Tasks.Pack
                     //   https://github.com/NuGet/Home/issues/3891
                     //
                     // For now, assume the project reference is a package dependency.
-                    var projectDependency = new LibraryDependency
+                    var projectDependency = new LibraryDependency(noWarn: Array.Empty<NuGetLogCode>())
                     {
                         LibraryRange = new LibraryRange(
                             targetLibrary.Name,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -49,7 +49,7 @@ namespace NuGet.CommandLine.XPlat
                     versionRange = VersionRange.Parse(packageReferenceArgs.PackageVersion);
                 }
 
-                var libraryDependency = new LibraryDependency
+                var libraryDependency = new LibraryDependency(noWarn: Array.Empty<NuGetLogCode>())
                 {
                     LibraryRange = new LibraryRange(
                         name: packageReferenceArgs.PackageId,
@@ -329,7 +329,7 @@ namespace NuGet.CommandLine.XPlat
                 }
             }
 
-            return new LibraryDependency
+            return new LibraryDependency(noWarn: Array.Empty<NuGetLogCode>())
             {
                 LibraryRange = new LibraryRange(
                     name: packageReferenceArgs.PackageId,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Globalization;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Credentials;
 using NuGet.LibraryModel;
 using NuGet.Versioning;
@@ -21,7 +23,7 @@ namespace NuGet.CommandLine.XPlat
             //Setup the Credential Service - This allows the msbuild sdk resolver to auth if needed.
             DefaultCredentialServiceUtility.SetupDefaultCredentialService(packageReferenceArgs.Logger, !packageReferenceArgs.Interactive);
 
-            var libraryDependency = new LibraryDependency
+            var libraryDependency = new LibraryDependency(noWarn: Array.Empty<NuGetLogCode>())
             {
                 LibraryRange = new LibraryRange(
                     name: packageReferenceArgs.PackageId,

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -1252,7 +1252,7 @@ namespace NuGet.Commands
                 if (!newVersionRange.Equals(VersionRange.None))
                 {
                     list.Remove(matchingDependency);
-                    list.Add(new LibraryDependency()
+                    list.Add(new LibraryDependency(noWarn: Array.Empty<NuGetLogCode>())
                     {
                         LibraryRange = new LibraryRange(matchingDependency.Name, newVersionRange, LibraryDependencyTarget.All),
                         IncludeType = dependency.IncludeType & matchingDependency.IncludeType,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -550,7 +550,7 @@ namespace NuGet.Commands
                     // If all assets are suppressed then the dependency should not be added
                     if (suppressParent != LibraryIncludeFlags.All)
                     {
-                        yield return new LibraryDependency()
+                        yield return new LibraryDependency(noWarn: Array.Empty<NuGetLogCode>())
                         {
                             LibraryRange = new LibraryRange(centralPackageVersion.Name, centralPackageVersion.VersionRange, LibraryDependencyTarget.Package),
                             ReferenceType = LibraryDependencyReferenceType.Transitive,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -639,7 +639,7 @@ namespace NuGet.Commands
             foreach (var item in GetItemByType(items, "Dependency"))
             {
                 // Get warning suppressions
-                List<NuGetLogCode> noWarn = MSBuildStringUtility.GetNuGetLogCodes(item.GetProperty("NoWarn")).ToList();
+                IList<NuGetLogCode> noWarn = MSBuildStringUtility.GetNuGetLogCodes(item.GetProperty("NoWarn"));
 
                 var dependency = new LibraryDependency(noWarn)
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -638,7 +638,10 @@ namespace NuGet.Commands
         {
             foreach (var item in GetItemByType(items, "Dependency"))
             {
-                var dependency = new LibraryDependency
+                // Get warning suppressions
+                List<NuGetLogCode> noWarn = MSBuildStringUtility.GetNuGetLogCodes(item.GetProperty("NoWarn")).ToList();
+
+                var dependency = new LibraryDependency(noWarn)
                 {
                     LibraryRange = new LibraryRange(
                         name: item.GetProperty("Id"),
@@ -650,12 +653,6 @@ namespace NuGet.Commands
                     Aliases = item.GetProperty("Aliases"),
                     VersionOverride = GetVersionRange(item, defaultValue: null, "VersionOverride")
                 };
-
-                // Add warning suppressions
-                foreach (var code in MSBuildStringUtility.GetNuGetLogCodes(item.GetProperty("NoWarn")))
-                {
-                    dependency.NoWarn.Add(code);
-                }
 
                 ApplyIncludeFlags(dependency, item);
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
@@ -38,7 +39,7 @@ namespace NuGet.Commands
                         FrameworkName = framework,
                         Dependencies = new List<LibraryDependency>
                         {
-                            new LibraryDependency
+                            new LibraryDependency(noWarn: Array.Empty<NuGetLogCode>())
                             {
                                 LibraryRange = new LibraryRange(id, versionRange, LibraryDependencyTarget.Package)
                             }

--- a/src/NuGet.Core/NuGet.Common/MsBuildStringUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/MsBuildStringUtility.cs
@@ -85,19 +85,32 @@ namespace NuGet.Common
         }
 
         /// <summary>
-        /// Splits and parses a ; or , delimited list of log codes.
-        /// Ignores codes that are unknown.
+        /// Parses the specified string as a comma or semicolon delimited list of NuGet log codes and ignores unknown codes.
         /// </summary>
-        public static IEnumerable<NuGetLogCode> GetNuGetLogCodes(string s)
+        /// <param name="s">A comma or semicolon delimited list of NuGet log codes.</param>
+        /// <returns>An <see cref="IList{T}" /> containing the <see cref="NuGetLogCode" /> values that were successfully parsed from the specified string.</returns>
+        public static IList<NuGetLogCode> GetNuGetLogCodes(string s)
         {
-            foreach (var item in MSBuildStringUtility.Split(s, ';', ','))
+            // The Split() method already checks for an empty string and returns Array.Empty<string>().
+            string[] split = MSBuildStringUtility.Split(s, ';', ',');
+
+            if (split.Length == 0)
             {
-                if (item.StartsWith("NU", StringComparison.OrdinalIgnoreCase) &&
-                    Enum.TryParse<NuGetLogCode>(value: item, ignoreCase: true, result: out var result))
+                return Array.Empty<NuGetLogCode>();
+            }
+
+            List<NuGetLogCode> logCodes = new List<NuGetLogCode>(capacity: split.Length);
+
+            for (int i = 0; i < split.Length; i++)
+            {
+                if (split[i].StartsWith("NU", StringComparison.OrdinalIgnoreCase) &&
+                    Enum.TryParse(value: split[i], ignoreCase: true, out NuGetLogCode logCode))
                 {
-                    yield return result;
+                    logCodes.Add(logCode);
                 }
             }
+
+            return logCodes;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Common/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI.Shipped.txt
@@ -567,7 +567,6 @@ static NuGet.Common.LoggingExtensions.TryGetName(this NuGet.Common.NuGetLogCode 
 static NuGet.Common.MSBuildStringUtility.Convert(string? value) -> string?
 static NuGet.Common.MSBuildStringUtility.GetBooleanOrNull(string? value) -> bool?
 static NuGet.Common.MSBuildStringUtility.GetDistinctNuGetLogCodesOrDefault(System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<NuGet.Common.NuGetLogCode>!>! nugetLogCodeLists) -> System.Collections.Generic.IEnumerable<NuGet.Common.NuGetLogCode>!
-static NuGet.Common.MSBuildStringUtility.GetNuGetLogCodes(string! s) -> System.Collections.Generic.IEnumerable<NuGet.Common.NuGetLogCode>!
 static NuGet.Common.MSBuildStringUtility.IsTrue(string? value) -> bool
 static NuGet.Common.MSBuildStringUtility.IsTrueOrEmpty(string? value) -> bool
 static NuGet.Common.MSBuildStringUtility.Split(string! s) -> string![]!

--- a/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static NuGet.Common.MSBuildStringUtility.GetNuGetLogCodes(string! s) -> System.Collections.Generic.IList<NuGet.Common.NuGetLogCode>!

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/PackagingUtility.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/PackagingUtility.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using NuGet.Common;
 using NuGet.LibraryModel;
 
 namespace NuGet.DependencyResolver
@@ -31,7 +33,7 @@ namespace NuGet.DependencyResolver
 
             // Create the library
             // Nuspec references cannot contain suppress parent flags
-            var libraryDependency = new LibraryDependency
+            var libraryDependency = new LibraryDependency(noWarn: Array.Empty<NuGetLogCode>())
             {
                 LibraryRange = new LibraryRange
                 {

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Packaging;
@@ -188,7 +189,7 @@ namespace NuGet.DependencyResolver
                 // Look up any additional dependencies for this package
                 foreach (var runtimeDependency in runtimeGraph.FindRuntimeDependencies(runtimeName, libraryRange.Name))
                 {
-                    var libraryDependency = new LibraryDependency
+                    var libraryDependency = new LibraryDependency(noWarn: Array.Empty<NuGetLogCode>())
                     {
                         LibraryRange = new LibraryRange()
                         {

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using NuGet.Common;
@@ -50,8 +51,16 @@ namespace NuGet.LibraryModel
         /// <summary>Initializes a new instance of the LibraryDependency class.</summary>
         /// <remarks>Required properties must be set when using this constructor.</remarks>
         public LibraryDependency()
+            : this(new List<NuGetLogCode>())
         {
-            NoWarn = new List<NuGetLogCode>();
+        }
+
+        /// <summary>Initializes a new instance of the LibraryDependency class with the specified NoWarn codes.</summary>
+        /// <param name="noWarn">Specifies a <see cref="List{T}" /> containing <see cref="NuGetLogCode" /> values.</param>
+        /// <remarks>Required properties must be set when using this constructor.</remarks>
+        public LibraryDependency(IList<NuGetLogCode> noWarn)
+        {
+            NoWarn = noWarn;
         }
 
         /// <summary>Initializes a new instance of the LibraryDependency class.</summary>

--- a/src/NuGet.Core/NuGet.LibraryModel/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.LibraryModel/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+NuGet.LibraryModel.LibraryDependency.LibraryDependency(System.Collections.Generic.IList<NuGet.Common.NuGetLogCode>! noWarn) -> void

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -350,7 +350,7 @@ namespace NuGet.ProjectModel
                     var dependencyIncludeFlagsValue = LibraryIncludeFlags.All;
                     var dependencyExcludeFlagsValue = LibraryIncludeFlags.None;
                     var suppressParentFlagsValue = LibraryIncludeFlagUtils.DefaultSuppressParent;
-                    List<NuGetLogCode> noWarn = null;
+                    IList<NuGetLogCode> noWarn = Array.Empty<NuGetLogCode>();
 
                     // This method handles both the dependencies and framework assembly sections.
                     // Framework references should be limited to references.
@@ -484,7 +484,7 @@ namespace NuGet.ProjectModel
 
                     // the dependency flags are: Include flags - Exclude flags
                     var includeFlags = dependencyIncludeFlagsValue & ~dependencyExcludeFlagsValue;
-                    var libraryDependency = new LibraryDependency()
+                    var libraryDependency = new LibraryDependency(noWarn)
                     {
                         LibraryRange = new LibraryRange()
                         {
@@ -503,11 +503,6 @@ namespace NuGet.ProjectModel
                         ReferenceType = LibraryDependencyReferenceType.Direct,
                         VersionOverride = versionOverride
                     };
-
-                    if (noWarn != null)
-                    {
-                        libraryDependency.NoWarn = noWarn;
-                    }
 
                     results.Add(libraryDependency);
                 }
@@ -616,7 +611,7 @@ namespace NuGet.ProjectModel
 
                     // the dependency flags are: Include flags - Exclude flags
                     var includeFlags = dependencyIncludeFlagsValue & ~dependencyExcludeFlagsValue;
-                    var libraryDependency = new LibraryDependency()
+                    var libraryDependency = new LibraryDependency(noWarn: Array.Empty<NuGetLogCode>())
                     {
                         LibraryRange = new LibraryRange()
                         {
@@ -1252,9 +1247,9 @@ namespace NuGet.ProjectModel
             }
         }
 
-        private static List<NuGetLogCode> ReadNuGetLogCodesList(JsonTextReader jsonReader)
+        private static IList<NuGetLogCode> ReadNuGetLogCodesList(JsonTextReader jsonReader)
         {
-            List<NuGetLogCode> items = null;
+            IList<NuGetLogCode> items = null;
 
             if (jsonReader.ReadNextToken() && jsonReader.TokenType == JsonToken.StartArray)
             {
@@ -1269,7 +1264,7 @@ namespace NuGet.ProjectModel
                 }
             }
 
-            return items;
+            return items ?? Array.Empty<NuGetLogCode>();
         }
 
         private static void ReadPackageTypes(PackageSpec packageSpec, JsonTextReader jsonReader)

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecOperations.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecOperations.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
@@ -234,7 +235,7 @@ namespace NuGet.ProjectModel
             VersionRange range,
             bool centralPackageVersionsEnabled)
         {
-            var dependency = new LibraryDependency
+            var dependency = new LibraryDependency(noWarn: Array.Empty<NuGetLogCode>())
             {
                 LibraryRange = new LibraryRange(packageId, range, LibraryDependencyTarget.Package),
                 VersionCentrallyManaged = centralPackageVersionsEnabled

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -249,7 +249,7 @@ namespace NuGet.ProjectModel
                         }
                     }
 
-                    var dependency = new LibraryDependency()
+                    var dependency = new LibraryDependency(noWarn: Array.Empty<NuGetLogCode>())
                     {
                         IncludeType = (reference.IncludeAssets & ~reference.ExcludeAssets),
                         SuppressParent = reference.PrivateAssets,
@@ -306,7 +306,7 @@ namespace NuGet.ProjectModel
                 // Note: Only add in dependencies that are in the filtered list to avoid getting the wrong TxM
                 dependencies.AddRange(childReferences
                     .Where(reference => filteredExternalDependencies.Contains(reference.ProjectName))
-                    .Select(reference => new LibraryDependency
+                    .Select(reference => new LibraryDependency(noWarn: Array.Empty<NuGetLogCode>())
                     {
                         LibraryRange = new LibraryRange
                         {
@@ -350,7 +350,7 @@ namespace NuGet.ProjectModel
                     var dependencyNamesSet = new HashSet<string>(targetFrameworkInfo.Dependencies.Select(d => d.Name), StringComparer.OrdinalIgnoreCase);
                     dependencies.AddRange(targetFrameworkInfo.CentralPackageVersions
                         .Where(item => !dependencyNamesSet.Contains(item.Key))
-                        .Select(item => new LibraryDependency()
+                        .Select(item => new LibraryDependency(noWarn: Array.Empty<NuGetLogCode>())
                         {
                             LibraryRange = new LibraryRange(item.Value.Name, item.Value.VersionRange, LibraryDependencyTarget.Package),
                             VersionCentrallyManaged = true,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13184

Regression? No Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
The `LibraryDependency` class hold a collection of NoWarn codes and initializes it as a `List<T>` which allocates.  Some code paths then parse the user specified codes and then adds them to the list while other code paths simply replace the list allocated at the time of construction.  This change adds an overload to the constructor that accepts an `IList<NuGetLogCode>` so that callers can specify the exact list they want.  In some code paths the callers now specify `Array,Empty<NuGetLogCode>()` to avoid allocations.

I also refactored `MSBuildStringUtility.Split()` to return an `IList<T>` instead of `IEnumerable<T>` so that callers don't have to call `.ToList()` on it.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Existing tests cover this refactoring
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
