### PR TITLE
Improve VS project API telemetry to include property name

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs
@@ -75,7 +75,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             if (result == VSConstants.S_OK && !string.IsNullOrWhiteSpace(output))
             {
-                _buildPropertiesTelemetry.OnPropertyStorageUsed(_projectTypeGuids);
+                _buildPropertiesTelemetry.OnPropertyStorageUsed(propertyName, _projectTypeGuids);
                 return output;
             }
 
@@ -97,7 +97,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 if (result == VSConstants.S_OK && !string.IsNullOrWhiteSpace(output))
                 {
-                    _buildPropertiesTelemetry.OnPropertyStorageUsed(_projectTypeGuids);
+                    _buildPropertiesTelemetry.OnPropertyStorageUsed(propertyName, _projectTypeGuids);
                     return output;
                 }
             }
@@ -109,7 +109,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     _project = _dteProject.Value;
                 }
                 var property = _project.Properties.Item(propertyName);
-                _buildPropertiesTelemetry.OnDteUsed(_projectTypeGuids);
+                _buildPropertiesTelemetry.OnDteUsed(propertyName, _projectTypeGuids);
                 return property?.Value as string;
             }
             catch (ArgumentException)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/IVsProjectBuildPropertiesTelemetry.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/IVsProjectBuildPropertiesTelemetry.cs
@@ -1,11 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace NuGet.PackageManagement.VisualStudio.Telemetry
 {
     internal interface IVsProjectBuildPropertiesTelemetry
     {
-        void OnPropertyStorageUsed(string[] projectTypeGuids);
-        void OnDteUsed(string[] projectTypeGuids);
+        void OnPropertyStorageUsed(string propertyName, string[] projectTypeGuids);
+        void OnDteUsed(string propertyName, string[] projectTypeGuids);
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -106,7 +106,7 @@ namespace NuGet.VisualStudio
                 var hr = aggregatableProject.GetAggregateProjectTypeGuids(out projectTypeGuids);
                 ErrorHandler.ThrowOnFailure(hr);
 
-                return projectTypeGuids.Split(';');
+                return projectTypeGuids.Split([';'], StringSplitOptions.RemoveEmptyEntries);
             }
 
             if (ErrorHandler.Succeeded(hierarchy.GetGuidProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_TypeGuid, out Guid pguid)))

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VsProjectBuildPropertiesTelemetryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VsProjectBuildPropertiesTelemetryTests.cs
@@ -18,10 +18,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var target = new VsProjectBuildPropertiesTelemetry();
 
             Guid projectType1 = Guid.NewGuid();
-            target.OnPropertyStorageUsed(new[] { projectType1.ToString() });
+            target.OnPropertyStorageUsed("Property1", [projectType1.ToString()]);
+            target.OnPropertyStorageUsed("Property2", [projectType1.ToString()]);
 
             Guid projectType2 = Guid.NewGuid();
-            target.OnDteUsed(new[] { projectType2.ToString() });
+            target.OnDteUsed("Property1", [projectType2.ToString()]);
 
             var telemetryEvent = new TelemetryEvent("test");
 
@@ -31,7 +32,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Assert
             object data = Assert.Contains("ProjectBuildProperties", telemetryEvent.ComplexData);
             IList list = Assert.IsAssignableFrom<IList>(data);
-            Assert.Equal(2, list.Count);
+            Assert.Equal(3, list.Count);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2670

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The previously telemetry only told us if at least 1 property per project system used the ProjectBuildProperties or DTE APIs, but not which properties used which API.  This API gives us the info per property (and still per project system), so we'll know which properties we can migrate to the new API exclusively.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
