### PR TITLE
APIs to read auditSources from nuget.config files

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <clear />
@@ -8,11 +8,10 @@
     <add key="myget-legacy@Local" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy%40Local/nuget/v3/index.json" />
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
     <add key="vside" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/nuget/v3/index.json" />
-    <add key="default" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <clear />
-    <packageSource key="dotnet-public">
+    <packageSource key = "dotnet-public">
       <package pattern="ben.demystifier" />
       <package pattern="castle.core" />
       <package pattern="fluentassertions" />
@@ -41,14 +40,14 @@
       <package pattern="xunit.*" />
       <package pattern="xunitxml.testlogger" />
     </packageSource>
-    <packageSource key="dotnet-eng">
+    <packageSource key = "dotnet-eng">
       <package pattern="microsoft.*" />
     </packageSource>
-    <packageSource key="nuget-build">
+    <packageSource key = "nuget-build">
       <package pattern="nuget.client.endtoend.testdata" />
       <package pattern="nugetvalidator" />
     </packageSource>
-    <packageSource key="vside">
+    <packageSource key = "vside">
       <package pattern="envdte" />
       <package pattern="envdte100" />
       <package pattern="envdte80" />
@@ -73,13 +72,13 @@
       <package pattern="vslangproj90" />
       <package pattern="vswebsite.interop" />
     </packageSource>
-    <packageSource key="myget-legacy@Local">
+    <packageSource key = "myget-legacy@Local">
       <package pattern="microsoft.*" />
     </packageSource>
-    <packageSource key="VS">
+    <packageSource key = "VS">
       <package pattern="Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks" />
     </packageSource>
-    <packageSource key="dotnet-libraries">
+    <packageSource key = "dotnet-libraries">
       <package pattern="System.CommandLine" />
     </packageSource>
   </packageSourceMapping>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <clear />
@@ -8,10 +8,11 @@
     <add key="myget-legacy@Local" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy%40Local/nuget/v3/index.json" />
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
     <add key="vside" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/nuget/v3/index.json" />
+    <add key="default" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <clear />
-    <packageSource key = "dotnet-public">
+    <packageSource key="dotnet-public">
       <package pattern="ben.demystifier" />
       <package pattern="castle.core" />
       <package pattern="fluentassertions" />
@@ -40,14 +41,14 @@
       <package pattern="xunit.*" />
       <package pattern="xunitxml.testlogger" />
     </packageSource>
-    <packageSource key = "dotnet-eng">
+    <packageSource key="dotnet-eng">
       <package pattern="microsoft.*" />
     </packageSource>
-    <packageSource key = "nuget-build">
+    <packageSource key="nuget-build">
       <package pattern="nuget.client.endtoend.testdata" />
       <package pattern="nugetvalidator" />
     </packageSource>
-    <packageSource key = "vside">
+    <packageSource key="vside">
       <package pattern="envdte" />
       <package pattern="envdte100" />
       <package pattern="envdte80" />
@@ -72,13 +73,13 @@
       <package pattern="vslangproj90" />
       <package pattern="vswebsite.interop" />
     </packageSource>
-    <packageSource key = "myget-legacy@Local">
+    <packageSource key="myget-legacy@Local">
       <package pattern="microsoft.*" />
     </packageSource>
-    <packageSource key = "VS">
+    <packageSource key="VS">
       <package pattern="Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks" />
     </packageSource>
-    <packageSource key = "dotnet-libraries">
+    <packageSource key="dotnet-libraries">
       <package pattern="System.CommandLine" />
     </packageSource>
   </packageSourceMapping>

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/IPackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/IPackageSourceProvider.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 
@@ -15,12 +17,18 @@ namespace NuGet.Configuration
         IEnumerable<PackageSource> LoadPackageSources();
 
         /// <summary>
+        /// Gets a list of all of the audit sources
+        /// </summary>
+        /// <returns>Read only list of all of the audit sources</returns>
+        IReadOnlyList<PackageSource> LoadAuditSources();
+
+        /// <summary>
         /// Gets the source that matches a given name.
         /// </summary>
         /// <param name="name">Name of source to be searched for</param>
         /// <returns>PackageSource that matches the given name. Null if none was found</returns>
         /// <throws>ArgumentException when <paramref name="name"/> is null or empty.</throws>
-        PackageSource GetPackageSourceByName(string name);
+        PackageSource? GetPackageSourceByName(string name);
 
         /// <summary>
         /// Gets the source that matches a given source url.
@@ -29,12 +37,12 @@ namespace NuGet.Configuration
         /// <returns>PackageSource that matches the given source. Null if none was found</returns>
         /// <throws>ArgumentException when <paramref name="source"/> is null or empty.</throws>
         /// <remarks>There may be multiple sources that match a given url. This method will return the first.</remarks>
-        PackageSource GetPackageSourceBySource(string source);
+        PackageSource? GetPackageSourceBySource(string source);
 
         /// <summary>
         /// Event raised when the package sources have been changed.
         /// </summary>
-        event EventHandler PackageSourcesChanged;
+        event EventHandler? PackageSourcesChanged;
 
         /// <summary>
         /// Removes the package source that matches the given name
@@ -86,12 +94,12 @@ namespace NuGet.Configuration
         /// <summary>
         /// Gets the name of the active PackageSource
         /// </summary>
-        string ActivePackageSourceName { get; }
+        string? ActivePackageSourceName { get; }
 
         /// <summary>
         /// Gets the Default push source
         /// </summary>
-        string DefaultPushSource { get; }
+        string? DefaultPushSource { get; }
 
         /// <summary>
         /// Updates the active package source with the given source.

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -716,7 +716,7 @@ namespace NuGet.Configuration
             }
             catch (ArgumentException e)
             {
-                AddItem duplicatedKey = existingDisabledSources
+                AddItem duplicatedKey = existingDisabledSources!
                     .GroupBy(s => s.Key, StringComparer.OrdinalIgnoreCase)
                     .Where(g => g.Count() > 1)
                     .Select(g => g.First())

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -15,12 +17,10 @@ namespace NuGet.Configuration
 
         internal const int MaxSupportedProtocolVersion = 3;
         private readonly IReadOnlyList<PackageSource> _configurationDefaultSources;
+        private readonly IReadOnlyList<PackageSource> _configurationDefaultAuditSources;
 
         public PackageSourceProvider(
-          ISettings settings)
-#pragma warning disable CS0618 // Type or member is obsolete
-            : this(settings, ConfigurationDefaults.Instance.DefaultPackageSources, enablePackageSourcesChangedEvent: true)
-#pragma warning restore CS0618 // Type or member is obsolete
+          ISettings settings) : this(settings, ConfigurationDefaults.Instance.DefaultPackageSources, ConfigurationDefaults.Instance.DefaultAuditSources, enablePackageSourcesChangedEvent: true)
         {
         }
 
@@ -28,16 +28,14 @@ namespace NuGet.Configuration
         public PackageSourceProvider(
           ISettings settings,
           bool enablePackageSourcesChangedEvent)
-            : this(settings, ConfigurationDefaults.Instance.DefaultPackageSources, enablePackageSourcesChangedEvent)
+            : this(settings, ConfigurationDefaults.Instance.DefaultPackageSources, ConfigurationDefaults.Instance.DefaultAuditSources, enablePackageSourcesChangedEvent)
         {
         }
 
         public PackageSourceProvider(
             ISettings settings,
             IEnumerable<PackageSource> configurationDefaultSources)
-#pragma warning disable CS0618 // Type or member is obsolete
-            : this(settings, configurationDefaultSources, enablePackageSourcesChangedEvent: true)
-#pragma warning restore CS0618 // Type or member is obsolete
+            : this(settings, configurationDefaultSources, ConfigurationDefaults.Instance.DefaultAuditSources, enablePackageSourcesChangedEvent: true)
         {
         }
 
@@ -45,6 +43,31 @@ namespace NuGet.Configuration
         public PackageSourceProvider(
             ISettings settings,
             IEnumerable<PackageSource> configurationDefaultSources,
+            bool enablePackageSourcesChangedEvent)
+            : this(settings, configurationDefaultSources, ConfigurationDefaults.Instance.DefaultAuditSources, enablePackageSourcesChangedEvent)
+        {
+        }
+
+        public PackageSourceProvider(
+            ISettings settings,
+            ConfigurationDefaults configurationDefaults)
+            : this(settings, configurationDefaults.DefaultPackageSources, configurationDefaults.DefaultAuditSources, enablePackageSourcesChangedEvent: true)
+        {
+        }
+
+        [Obsolete("https://github.com/NuGet/Home/issues/8479")]
+        public PackageSourceProvider(
+            ISettings settings,
+            ConfigurationDefaults configurationDefaults,
+            bool enablePackageSourcesChangedEvent)
+            : this(settings, configurationDefaults.DefaultPackageSources, configurationDefaults.DefaultAuditSources, enablePackageSourcesChangedEvent)
+        {
+        }
+
+        private PackageSourceProvider(
+            ISettings settings,
+            IEnumerable<PackageSource> configurationDefaultSources,
+            IReadOnlyList<PackageSource> configurationDefaultAuditSources,
             bool enablePackageSourcesChangedEvent)
         {
             Settings = settings ?? throw new ArgumentNullException(nameof(settings));
@@ -57,6 +80,11 @@ namespace NuGet.Configuration
                 throw new ArgumentNullException(nameof(configurationDefaultSources));
             }
             _configurationDefaultSources = LoadConfigurationDefaultSources(configurationDefaultSources);
+            if (configurationDefaultAuditSources is null)
+            {
+                throw new ArgumentNullException(nameof(configurationDefaultAuditSources));
+            }
+            _configurationDefaultAuditSources = LoadConfigurationDefaultSources(configurationDefaultAuditSources);
         }
 
         private static IReadOnlyList<PackageSource> LoadConfigurationDefaultSources(IEnumerable<PackageSource> configurationDefaultSources)
@@ -84,14 +112,17 @@ namespace NuGet.Configuration
             return defaultSources.AsReadOnly();
         }
 
-        private static List<PackageSource> GetPackageSourceFromSettings(ISettings settings)
+        private static List<PackageSource> GetPackageSourceFromSettings(ISettings settings, string sectionName)
         {
-            var packageSourcesSection = settings.GetSection(ConfigurationConstants.PackageSources);
+            var packageSourcesSection = settings.GetSection(sectionName);
             var sourcesItems = packageSourcesSection?.Items.OfType<SourceItem>();
 
             // Order the list so that the closer to the user appear first
             IList<string> configFilePaths = settings.GetConfigFilePaths();
+#pragma warning disable CS8604 // Possible null reference argument.
+            // netfx and netstandard BCLs are missing nullability annotations.
             var sources = sourcesItems?.OrderBy(i => configFilePaths.IndexOf(i.Origin?.ConfigFilePath)); //lower index => higher priority => closer to user.
+#pragma warning restore CS8604 // Possible null reference argument.
 
             List<PackageSource> packageSources;
 
@@ -133,7 +164,12 @@ namespace NuGet.Configuration
         /// </summary>
         public IEnumerable<PackageSource> LoadPackageSources()
         {
-            return LoadPackageSources(Settings, _configurationDefaultSources);
+            return LoadPackageSources(Settings, ConfigurationConstants.PackageSources, _configurationDefaultSources);
+        }
+
+        public IReadOnlyList<PackageSource> LoadAuditSources()
+        {
+            return LoadPackageSources(Settings, ConfigurationConstants.AuditSources, _configurationDefaultAuditSources);
         }
 
         /// <summary>
@@ -141,16 +177,16 @@ namespace NuGet.Configuration
         /// </summary>
         public static IEnumerable<PackageSource> LoadPackageSources(ISettings settings)
         {
-            return LoadPackageSources(settings, ConfigurationDefaults.Instance.DefaultPackageSources);
+            return LoadPackageSources(settings, ConfigurationConstants.PackageSources, ConfigurationDefaults.Instance.DefaultPackageSources);
         }
 
-        private static List<PackageSource> LoadPackageSources(ISettings settings, IEnumerable<PackageSource> defaultPackageSources)
+        private static List<PackageSource> LoadPackageSources(ISettings settings, string sectionName, IEnumerable<PackageSource> defaultSources)
         {
-            List<PackageSource> loadedPackageSources = GetPackageSourceFromSettings(settings);
+            List<PackageSource> loadedPackageSources = GetPackageSourceFromSettings(settings, sectionName);
 
-            if (defaultPackageSources != null && defaultPackageSources.Any())
+            if (defaultSources != null && defaultSources.Any())
             {
-                AddDefaultPackageSources(loadedPackageSources, defaultPackageSources);
+                AddDefaultPackageSources(loadedPackageSources, defaultSources);
             }
 
             return loadedPackageSources;
@@ -254,7 +290,7 @@ namespace NuGet.Configuration
             }
         }
 
-        private static PackageSourceCredential ReadCredential(string sourceName, ISettings settings)
+        private static PackageSourceCredential? ReadCredential(string sourceName, ISettings settings)
         {
             var environmentCredentials = ReadCredentialFromEnvironment(sourceName);
 
@@ -279,7 +315,7 @@ namespace NuGet.Configuration
             return null;
         }
 
-        private static PackageSourceCredential ReadCredentialFromEnvironment(string sourceName)
+        private static PackageSourceCredential? ReadCredentialFromEnvironment(string sourceName)
         {
             var rawCredentials = Environment.GetEnvironmentVariable("NuGetPackageSourceCredentials_" + sourceName);
             if (string.IsNullOrEmpty(rawCredentials))
@@ -301,14 +337,14 @@ namespace NuGet.Configuration
                 validAuthenticationTypesText: match.Groups["authTypes"].Value);
         }
 
-        public PackageSource GetPackageSourceByName(string name)
+        public PackageSource? GetPackageSourceByName(string name)
         {
             if (string.IsNullOrEmpty(name))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(name));
             }
 
-            List<PackageSource> packageSources = LoadPackageSources(Settings, _configurationDefaultSources);
+            List<PackageSource> packageSources = LoadPackageSources(Settings, ConfigurationConstants.PackageSources, _configurationDefaultSources);
 
             foreach (var packageSource in packageSources)
             {
@@ -325,7 +361,7 @@ namespace NuGet.Configuration
         {
             var names = new HashSet<string>();
 
-            List<PackageSource> packageSources = LoadPackageSources(Settings, _configurationDefaultSources);
+            List<PackageSource> packageSources = LoadPackageSources(Settings, ConfigurationConstants.PackageSources, _configurationDefaultSources);
             foreach (PackageSource packageSource in packageSources)
             {
                 if (packageSource.Name.StartsWith(namePrefix, StringComparison.OrdinalIgnoreCase))
@@ -337,14 +373,14 @@ namespace NuGet.Configuration
             return names;
         }
 
-        public PackageSource GetPackageSourceBySource(string source)
+        public PackageSource? GetPackageSourceBySource(string source)
         {
             if (string.IsNullOrEmpty(source))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(source));
             }
 
-            List<PackageSource> packageSources = LoadPackageSources(Settings, _configurationDefaultSources);
+            List<PackageSource> packageSources = LoadPackageSources(Settings, ConfigurationConstants.PackageSources, _configurationDefaultSources);
 
             foreach (var packageSource in packageSources)
             {
@@ -449,9 +485,9 @@ namespace NuGet.Configuration
             {
                 try
                 {
-                    if (sourceSetting.Origin != null)
+                    if (sourceSetting.Origin != null && Settings is Settings castSettings)
                     {
-                        (Settings as Settings).AddOrUpdate(sourceSetting.Origin, ConfigurationConstants.DisabledPackageSources, new AddItem(name, "true"));
+                        castSettings.AddOrUpdate(sourceSetting.Origin, ConfigurationConstants.DisabledPackageSources, new AddItem(name, "true"));
                         isDirty = true;
                         addedInSameFileAsCurrentSource = true;
                     }
@@ -522,8 +558,8 @@ namespace NuGet.Configuration
 
             if (sourceToUpdate != null)
             {
-                AddItem disabledSourceItem = null;
-                CredentialsItem credentialsSettingsItem = null;
+                AddItem? disabledSourceItem = null;
+                CredentialsItem? credentialsSettingsItem = null;
 
                 if (updateEnabled)
                 {
@@ -557,8 +593,8 @@ namespace NuGet.Configuration
         private void UpdatePackageSource(
             PackageSource newSource,
             PackageSource existingSource,
-            AddItem existingDisabledSourceItem,
-            CredentialsItem existingCredentialsItem,
+            AddItem? existingDisabledSourceItem,
+            CredentialsItem? existingCredentialsItem,
             bool updateEnabled,
             bool updateCredentials,
             bool shouldSkipSave,
@@ -672,7 +708,7 @@ namespace NuGet.Configuration
 
             var disabledSourcesSection = Settings.GetSection(ConfigurationConstants.DisabledPackageSources);
             var existingDisabledSources = disabledSourcesSection?.Items.OfType<AddItem>();
-            Dictionary<string, AddItem> existingDisabledSourcesLookup = null;
+            Dictionary<string, AddItem>? existingDisabledSourcesLookup = null;
 
             try
             {
@@ -694,14 +730,13 @@ namespace NuGet.Configuration
 
             foreach (var source in sources)
             {
-                AddItem existingDisabledSourceItem = null;
-                SourceItem existingSourceItem = null;
-                CredentialsItem existingCredentialsItem = null;
+                AddItem? existingDisabledSourceItem = null;
+                SourceItem? existingSourceItem = null;
+                CredentialsItem? existingCredentialsItem = null;
 
                 var existingSourceIsEnabled = existingDisabledSourcesLookup == null || existingDisabledSourcesLookup.TryGetValue(source.Name, out existingDisabledSourceItem);
 
-                if (existingSettingsLookup != null &&
-                    existingSettingsLookup.TryGetValue(source.Name, out existingSourceItem))
+                if (existingSettingsLookup.TryGetValue(source.Name, out existingSourceItem))
                 {
                     var oldPackageSource = ReadPackageSource(existingSourceItem, existingSourceIsEnabled, Settings);
 
@@ -764,8 +799,8 @@ namespace NuGet.Configuration
 
         private Dictionary<string, SourceItem> GetExistingSettingsLookup()
         {
-            var sourcesSection = Settings.GetSection(ConfigurationConstants.PackageSources);
-            var existingSettings = sourcesSection?.Items.OfType<SourceItem>().Where(
+            SettingSection? sourcesSection = Settings.GetSection(ConfigurationConstants.PackageSources);
+            List<SourceItem>? existingSettings = sourcesSection?.Items.OfType<SourceItem>().Where(
                 c => !(c.Origin == null || c.Origin.IsReadOnly || c.Origin.IsMachineWide))
                 .ToList();
 
@@ -796,7 +831,7 @@ namespace NuGet.Configuration
             PackageSourcesChanged?.Invoke(this, EventArgs.Empty);
         }
 
-        public string DefaultPushSource
+        public string? DefaultPushSource
         {
             get
             {
@@ -840,7 +875,7 @@ namespace NuGet.Configuration
         /// <summary>
         /// Gets the name of the ActivePackageSource from NuGet.Config
         /// </summary>
-        public string ActivePackageSourceName
+        public string? ActivePackageSourceName
         {
             get
             {
@@ -885,11 +920,11 @@ namespace NuGet.Configuration
 
         private class IndexedPackageSource
         {
-            public int Index { get; set; }
+            public required int Index { get; init; }
 
-            public PackageSource PackageSource { get; set; }
+            public required PackageSource PackageSource { get; set; }
         }
 
-        public event EventHandler PackageSourcesChanged;
+        public event EventHandler? PackageSourcesChanged;
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -220,7 +220,7 @@ namespace NuGet.Configuration
             loadedPackageSources.InsertRange(defaultSourcesInsertIndex, defaultPackageSourcesToBeAdded);
         }
 
-        private static PackageSource ReadPackageSource(SourceItem setting, bool isEnabled, ISettings settings)
+        internal static PackageSource ReadPackageSource(SourceItem setting, bool isEnabled, ISettings settings)
         {
             var name = setting.Key;
             var packageSource = new PackageSource(setting.GetValueAsPath(), name, isEnabled)

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
@@ -29,9 +29,9 @@ NuGet.Configuration.ClientCertificateProvider
 ~NuGet.Configuration.ClientCertificateProvider.Remove(System.Collections.Generic.IReadOnlyList<NuGet.Configuration.ClientCertItem> items) -> void
 NuGet.Configuration.ConfigurationConstants
 NuGet.Configuration.ConfigurationDefaults
-~NuGet.Configuration.ConfigurationDefaults.DefaultPackageRestoreConsent.get -> string
-~NuGet.Configuration.ConfigurationDefaults.DefaultPackageSources.get -> System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource>
-~NuGet.Configuration.ConfigurationDefaults.DefaultPushSource.get -> string
+NuGet.Configuration.ConfigurationDefaults.DefaultPackageRestoreConsent.get -> string?
+NuGet.Configuration.ConfigurationDefaults.DefaultPackageSources.get -> System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource!>!
+NuGet.Configuration.ConfigurationDefaults.DefaultPushSource.get -> string?
 NuGet.Configuration.CredentialRequestType
 NuGet.Configuration.CredentialRequestType.Forbidden = 2 -> NuGet.Configuration.CredentialRequestType
 NuGet.Configuration.CredentialRequestType.Proxy = 0 -> NuGet.Configuration.CredentialRequestType
@@ -401,7 +401,7 @@ override NuGet.Configuration.UnknownItem.IsEmpty() -> bool
 ~override NuGet.Configuration.VirtualSettingSection.Clone() -> NuGet.Configuration.SettingBase
 ~override sealed NuGet.Configuration.AddItem.Equals(object other) -> bool
 override sealed NuGet.Configuration.AddItem.GetHashCode() -> int
-~static NuGet.Configuration.ConfigurationDefaults.Instance.get -> NuGet.Configuration.ConfigurationDefaults
+static NuGet.Configuration.ConfigurationDefaults.Instance.get -> NuGet.Configuration.ConfigurationDefaults!
 ~static NuGet.Configuration.EncryptionUtility.DecryptString(string encryptedString) -> string
 ~static NuGet.Configuration.EncryptionUtility.EncryptString(string value) -> string
 ~static NuGet.Configuration.NuGetPathContext.Create(NuGet.Configuration.ISettings settings) -> NuGet.Configuration.NuGetPathContext

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
@@ -69,20 +69,20 @@ NuGet.Configuration.IExtensionLocator
 NuGet.Configuration.IMachineWideSettings
 ~NuGet.Configuration.IMachineWideSettings.Settings.get -> NuGet.Configuration.ISettings
 NuGet.Configuration.IPackageSourceProvider
-~NuGet.Configuration.IPackageSourceProvider.ActivePackageSourceName.get -> string
-~NuGet.Configuration.IPackageSourceProvider.AddPackageSource(NuGet.Configuration.PackageSource source) -> void
-~NuGet.Configuration.IPackageSourceProvider.DefaultPushSource.get -> string
-~NuGet.Configuration.IPackageSourceProvider.DisablePackageSource(string name) -> void
-~NuGet.Configuration.IPackageSourceProvider.EnablePackageSource(string name) -> void
-~NuGet.Configuration.IPackageSourceProvider.GetPackageSourceByName(string name) -> NuGet.Configuration.PackageSource
-~NuGet.Configuration.IPackageSourceProvider.GetPackageSourceBySource(string source) -> NuGet.Configuration.PackageSource
-~NuGet.Configuration.IPackageSourceProvider.IsPackageSourceEnabled(string name) -> bool
-~NuGet.Configuration.IPackageSourceProvider.LoadPackageSources() -> System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource>
-NuGet.Configuration.IPackageSourceProvider.PackageSourcesChanged -> System.EventHandler
-~NuGet.Configuration.IPackageSourceProvider.RemovePackageSource(string name) -> void
-~NuGet.Configuration.IPackageSourceProvider.SaveActivePackageSource(NuGet.Configuration.PackageSource source) -> void
-~NuGet.Configuration.IPackageSourceProvider.SavePackageSources(System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource> sources) -> void
-~NuGet.Configuration.IPackageSourceProvider.UpdatePackageSource(NuGet.Configuration.PackageSource source, bool updateCredentials, bool updateEnabled) -> void
+NuGet.Configuration.IPackageSourceProvider.ActivePackageSourceName.get -> string?
+NuGet.Configuration.IPackageSourceProvider.AddPackageSource(NuGet.Configuration.PackageSource! source) -> void
+NuGet.Configuration.IPackageSourceProvider.DefaultPushSource.get -> string?
+NuGet.Configuration.IPackageSourceProvider.DisablePackageSource(string! name) -> void
+NuGet.Configuration.IPackageSourceProvider.EnablePackageSource(string! name) -> void
+NuGet.Configuration.IPackageSourceProvider.GetPackageSourceByName(string! name) -> NuGet.Configuration.PackageSource?
+NuGet.Configuration.IPackageSourceProvider.GetPackageSourceBySource(string! source) -> NuGet.Configuration.PackageSource?
+NuGet.Configuration.IPackageSourceProvider.IsPackageSourceEnabled(string! name) -> bool
+NuGet.Configuration.IPackageSourceProvider.LoadPackageSources() -> System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource!>!
+NuGet.Configuration.IPackageSourceProvider.PackageSourcesChanged -> System.EventHandler?
+NuGet.Configuration.IPackageSourceProvider.RemovePackageSource(string! name) -> void
+NuGet.Configuration.IPackageSourceProvider.SaveActivePackageSource(NuGet.Configuration.PackageSource! source) -> void
+NuGet.Configuration.IPackageSourceProvider.SavePackageSources(System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource!>! sources) -> void
+NuGet.Configuration.IPackageSourceProvider.UpdatePackageSource(NuGet.Configuration.PackageSource! source, bool updateCredentials, bool updateEnabled) -> void
 NuGet.Configuration.IProxyCache
 ~NuGet.Configuration.IProxyCache.Add(System.Net.IWebProxy proxy) -> void
 ~NuGet.Configuration.IProxyCache.GetProxy(System.Uri uri) -> System.Net.IWebProxy
@@ -186,28 +186,28 @@ NuGet.Configuration.PackageSourceMappingSourceItem
 ~NuGet.Configuration.PackageSourceMappingSourceItem.Patterns.get -> System.Collections.Generic.IList<NuGet.Configuration.PackagePatternItem>
 ~NuGet.Configuration.PackageSourceMappingSourceItem.SetKey(string value) -> void
 NuGet.Configuration.PackageSourceProvider
-~NuGet.Configuration.PackageSourceProvider.ActivePackageSourceName.get -> string
-~NuGet.Configuration.PackageSourceProvider.AddPackageSource(NuGet.Configuration.PackageSource source) -> void
-~NuGet.Configuration.PackageSourceProvider.DefaultPushSource.get -> string
-~NuGet.Configuration.PackageSourceProvider.DisablePackageSource(NuGet.Configuration.PackageSource source) -> void
-~NuGet.Configuration.PackageSourceProvider.DisablePackageSource(string name) -> void
-~NuGet.Configuration.PackageSourceProvider.EnablePackageSource(string name) -> void
-~NuGet.Configuration.PackageSourceProvider.GetPackageSourceByName(string name) -> NuGet.Configuration.PackageSource
-~NuGet.Configuration.PackageSourceProvider.GetPackageSourceBySource(string source) -> NuGet.Configuration.PackageSource
-~NuGet.Configuration.PackageSourceProvider.GetPackageSourceNamesMatchingNamePrefix(string namePrefix) -> System.Collections.Generic.HashSet<string>
-~NuGet.Configuration.PackageSourceProvider.IsPackageSourceEnabled(NuGet.Configuration.PackageSource source) -> bool
-~NuGet.Configuration.PackageSourceProvider.IsPackageSourceEnabled(string name) -> bool
-~NuGet.Configuration.PackageSourceProvider.LoadPackageSources() -> System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource>
-~NuGet.Configuration.PackageSourceProvider.PackageSourceProvider(NuGet.Configuration.ISettings settings) -> void
-~NuGet.Configuration.PackageSourceProvider.PackageSourceProvider(NuGet.Configuration.ISettings settings, System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource> configurationDefaultSources) -> void
-~NuGet.Configuration.PackageSourceProvider.PackageSourceProvider(NuGet.Configuration.ISettings settings, System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource> configurationDefaultSources, bool enablePackageSourcesChangedEvent) -> void
-~NuGet.Configuration.PackageSourceProvider.PackageSourceProvider(NuGet.Configuration.ISettings settings, bool enablePackageSourcesChangedEvent) -> void
-NuGet.Configuration.PackageSourceProvider.PackageSourcesChanged -> System.EventHandler
-~NuGet.Configuration.PackageSourceProvider.RemovePackageSource(string name) -> void
-~NuGet.Configuration.PackageSourceProvider.SaveActivePackageSource(NuGet.Configuration.PackageSource source) -> void
-~NuGet.Configuration.PackageSourceProvider.SavePackageSources(System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource> sources) -> void
-~NuGet.Configuration.PackageSourceProvider.Settings.get -> NuGet.Configuration.ISettings
-~NuGet.Configuration.PackageSourceProvider.UpdatePackageSource(NuGet.Configuration.PackageSource source, bool updateCredentials, bool updateEnabled) -> void
+NuGet.Configuration.PackageSourceProvider.ActivePackageSourceName.get -> string?
+NuGet.Configuration.PackageSourceProvider.AddPackageSource(NuGet.Configuration.PackageSource! source) -> void
+NuGet.Configuration.PackageSourceProvider.DefaultPushSource.get -> string?
+NuGet.Configuration.PackageSourceProvider.DisablePackageSource(NuGet.Configuration.PackageSource! source) -> void
+NuGet.Configuration.PackageSourceProvider.DisablePackageSource(string! name) -> void
+NuGet.Configuration.PackageSourceProvider.EnablePackageSource(string! name) -> void
+NuGet.Configuration.PackageSourceProvider.GetPackageSourceByName(string! name) -> NuGet.Configuration.PackageSource?
+NuGet.Configuration.PackageSourceProvider.GetPackageSourceBySource(string! source) -> NuGet.Configuration.PackageSource?
+NuGet.Configuration.PackageSourceProvider.GetPackageSourceNamesMatchingNamePrefix(string! namePrefix) -> System.Collections.Generic.HashSet<string!>!
+NuGet.Configuration.PackageSourceProvider.IsPackageSourceEnabled(NuGet.Configuration.PackageSource! source) -> bool
+NuGet.Configuration.PackageSourceProvider.IsPackageSourceEnabled(string! name) -> bool
+NuGet.Configuration.PackageSourceProvider.LoadPackageSources() -> System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource!>!
+NuGet.Configuration.PackageSourceProvider.PackageSourceProvider(NuGet.Configuration.ISettings! settings) -> void
+NuGet.Configuration.PackageSourceProvider.PackageSourceProvider(NuGet.Configuration.ISettings! settings, System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource!>! configurationDefaultSources) -> void
+NuGet.Configuration.PackageSourceProvider.PackageSourceProvider(NuGet.Configuration.ISettings! settings, System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource!>! configurationDefaultSources, bool enablePackageSourcesChangedEvent) -> void
+NuGet.Configuration.PackageSourceProvider.PackageSourceProvider(NuGet.Configuration.ISettings! settings, bool enablePackageSourcesChangedEvent) -> void
+NuGet.Configuration.PackageSourceProvider.PackageSourcesChanged -> System.EventHandler?
+NuGet.Configuration.PackageSourceProvider.RemovePackageSource(string! name) -> void
+NuGet.Configuration.PackageSourceProvider.SaveActivePackageSource(NuGet.Configuration.PackageSource! source) -> void
+NuGet.Configuration.PackageSourceProvider.SavePackageSources(System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource!>! sources) -> void
+NuGet.Configuration.PackageSourceProvider.Settings.get -> NuGet.Configuration.ISettings!
+NuGet.Configuration.PackageSourceProvider.UpdatePackageSource(NuGet.Configuration.PackageSource! source, bool updateCredentials, bool updateEnabled) -> void
 NuGet.Configuration.ProxyCache
 ~NuGet.Configuration.ProxyCache.Add(System.Net.IWebProxy proxy) -> void
 ~NuGet.Configuration.ProxyCache.GetCredential(System.Uri proxyAddress, string authType) -> System.Net.NetworkCredential
@@ -409,7 +409,7 @@ static NuGet.Configuration.ConfigurationDefaults.Instance.get -> NuGet.Configura
 ~static NuGet.Configuration.NullSettings.Instance.get -> NuGet.Configuration.NullSettings
 ~static NuGet.Configuration.PackageSourceCredential.FromUserInput(string source, string username, string password, bool storePasswordInClearText, string validAuthenticationTypesText) -> NuGet.Configuration.PackageSourceCredential
 static NuGet.Configuration.PackageSourceMapping.GetPackageSourceMapping(NuGet.Configuration.ISettings! settings) -> NuGet.Configuration.PackageSourceMapping!
-~static NuGet.Configuration.PackageSourceProvider.LoadPackageSources(NuGet.Configuration.ISettings settings) -> System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource>
+static NuGet.Configuration.PackageSourceProvider.LoadPackageSources(NuGet.Configuration.ISettings! settings) -> System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource!>!
 ~static NuGet.Configuration.ProxyCache.Instance.get -> NuGet.Configuration.ProxyCache
 ~static NuGet.Configuration.Settings.ApplyEnvironmentTransform(string value) -> string
 ~static NuGet.Configuration.Settings.GetFileNameAndItsRoot(string root, string settingsPath) -> System.Tuple<string, string>

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -1,5 +1,8 @@
 #nullable enable
+NuGet.Configuration.ConfigurationDefaults.DefaultAuditSources.get -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSource!>!
+NuGet.Configuration.SettingElementType.AuditSources = 20 -> NuGet.Configuration.SettingElementType
 ~NuGet.Configuration.SettingElement.ConfigPath.get -> string
 ~NuGet.Configuration.SettingItem.GetAttributes() -> System.Collections.Generic.IReadOnlyDictionary<string, string>
 ~NuGet.Configuration.Settings.GetAllSettingSections() -> System.Collections.Generic.IEnumerable<string>
 ~static NuGet.Configuration.ConfigurationConstants.GetConfigKeys() -> System.Collections.Generic.IReadOnlyList<string>
+~static readonly NuGet.Configuration.ConfigurationConstants.AuditSources -> string

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -1,5 +1,9 @@
 #nullable enable
 NuGet.Configuration.ConfigurationDefaults.DefaultAuditSources.get -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSource!>!
+NuGet.Configuration.IPackageSourceProvider.LoadAuditSources() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSource!>!
+NuGet.Configuration.PackageSourceProvider.LoadAuditSources() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSource!>!
+NuGet.Configuration.PackageSourceProvider.PackageSourceProvider(NuGet.Configuration.ISettings! settings, NuGet.Configuration.ConfigurationDefaults! configurationDefaults) -> void
+NuGet.Configuration.PackageSourceProvider.PackageSourceProvider(NuGet.Configuration.ISettings! settings, NuGet.Configuration.ConfigurationDefaults! configurationDefaults, bool enablePackageSourcesChangedEvent) -> void
 NuGet.Configuration.SettingElementType.AuditSources = 20 -> NuGet.Configuration.SettingElementType
 ~NuGet.Configuration.SettingElement.ConfigPath.get -> string
 ~NuGet.Configuration.SettingItem.GetAttributes() -> System.Collections.Generic.IReadOnlyDictionary<string, string>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ConfigurationDefaults.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ConfigurationDefaults.cs
@@ -50,6 +50,11 @@ namespace NuGet.Configuration
             // This way, administrator will become aware of the failures when the ConfigurationDefaults file is not valid or permissions are not set properly
         }
 
+        internal ConfigurationDefaults(ISettings settingsManager)
+        {
+            _settingsManager = settingsManager ?? throw new ArgumentNullException(nameof(settingsManager));
+        }
+
         public static ConfigurationDefaults Instance { get; } = InitializeInstance();
 
         private IReadOnlyList<PackageSource> GetSourceItems(string sectionName)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ConfigurationDefaults.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ConfigurationDefaults.cs
@@ -70,11 +70,10 @@ namespace NuGet.Configuration
             List<PackageSource> sources = new();
             foreach (var source in sourceItems)
             {
-                // In a SettingValue representing a package source, the Key represents the name of the package source and the Value its source
-                sources.Add(new PackageSource(source.GetValueAsPath(),
-                    source.Key,
-                    isEnabled: !disabledPackageSources.Any(p => p.Key.Equals(source.Key, StringComparison.OrdinalIgnoreCase)),
-                    isOfficial: true));
+                bool isEnabled = !disabledPackageSources.Any(p => p.Key.Equals(source.Key, StringComparison.OrdinalIgnoreCase));
+                PackageSource packageSource = PackageSourceProvider.ReadPackageSource(source, isEnabled, _settingsManager);
+                packageSource.IsOfficial = true;
+                sources.Add(packageSource);
             }
 
             return sources;

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ConfigurationDefaults.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ConfigurationDefaults.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -13,8 +15,9 @@ namespace NuGet.Configuration
     {
         private ISettings _settingsManager = NullSettings.Instance;
         private bool _defaultPackageSourceInitialized;
-        private List<PackageSource> _defaultPackageSources;
-        private string _defaultPushSource;
+        private IReadOnlyList<PackageSource>? _defaultPackageSources;
+        private IReadOnlyList<PackageSource>? _defaultAuditSources;
+        private string? _defaultPushSource;
 
         private static ConfigurationDefaults InitializeInstance()
         {
@@ -49,32 +52,54 @@ namespace NuGet.Configuration
 
         public static ConfigurationDefaults Instance { get; } = InitializeInstance();
 
+        private IReadOnlyList<PackageSource> GetSourceItems(string sectionName)
+        {
+            IEnumerable<SourceItem>? sourceItems = _settingsManager.GetSection(sectionName)?.Items.OfType<SourceItem>();
+            if (sourceItems == null)
+            {
+                return Array.Empty<PackageSource>();
+            }
+
+            var disabledPackageSources = _settingsManager.GetSection(ConfigurationConstants.DisabledPackageSources)?.Items.OfType<AddItem>() ?? Enumerable.Empty<AddItem>();
+
+            List<PackageSource> sources = new();
+            foreach (var source in sourceItems)
+            {
+                // In a SettingValue representing a package source, the Key represents the name of the package source and the Value its source
+                sources.Add(new PackageSource(source.GetValueAsPath(),
+                    source.Key,
+                    isEnabled: !disabledPackageSources.Any(p => p.Key.Equals(source.Key, StringComparison.OrdinalIgnoreCase)),
+                    isOfficial: true));
+            }
+
+            return sources;
+        }
+
         public IEnumerable<PackageSource> DefaultPackageSources
         {
             get
             {
                 if (_defaultPackageSources == null)
                 {
-                    List<PackageSource> defaultPackageSources = new();
-                    var disabledPackageSources = _settingsManager.GetSection(ConfigurationConstants.DisabledPackageSources)?.Items.OfType<AddItem>() ?? Enumerable.Empty<AddItem>();
-                    var packageSources = _settingsManager.GetSection(ConfigurationConstants.PackageSources)?.Items.OfType<SourceItem>() ?? Enumerable.Empty<SourceItem>();
-
-                    foreach (var source in packageSources)
-                    {
-                        // In a SettingValue representing a package source, the Key represents the name of the package source and the Value its source
-                        defaultPackageSources.Add(new PackageSource(source.GetValueAsPath(),
-                            source.Key,
-                            isEnabled: !disabledPackageSources.Any(p => p.Key.Equals(source.Key, StringComparison.OrdinalIgnoreCase)),
-                            isOfficial: true));
-                    }
-
-                    _defaultPackageSources = defaultPackageSources;
+                    _defaultPackageSources = GetSourceItems(ConfigurationConstants.PackageSources);
                 }
                 return _defaultPackageSources;
             }
         }
 
-        public string DefaultPushSource
+        public IReadOnlyList<PackageSource> DefaultAuditSources
+        {
+            get
+            {
+                if (_defaultAuditSources is null)
+                {
+                    _defaultAuditSources = GetSourceItems(ConfigurationConstants.AuditSources);
+                }
+                return _defaultAuditSources;
+            }
+        }
+
+        public string? DefaultPushSource
         {
             get
             {
@@ -89,6 +114,6 @@ namespace NuGet.Configuration
             }
         }
 
-        public string DefaultPackageRestoreConsent => SettingsUtility.GetValueForAddItem(_settingsManager, ConfigurationConstants.PackageRestore, ConfigurationConstants.Enabled);
+        public string? DefaultPackageRestoreConsent => SettingsUtility.GetValueForAddItem(_settingsManager, ConfigurationConstants.PackageRestore, ConfigurationConstants.Enabled);
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingElementType.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingElementType.cs
@@ -43,12 +43,12 @@ namespace NuGet.Configuration
 
         StoreCert,
 
-        /** Package Source Mapping **/
-
         PackageSourceMapping,
 
         PackageSource,
 
         Package,
+
+        AuditSources,
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -43,6 +43,7 @@ namespace NuGet.Configuration
                         return new CredentialsItem(element, origin);
 
                     case SettingElementType.PackageSources:
+                    case SettingElementType.AuditSources:
                         if (elementType == SettingElementType.Add)
                         {
                             return new SourceItem(element, origin);

--- a/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -17,6 +17,8 @@ namespace NuGet.Configuration
 
         public static readonly string ApiKeys = "apikeys";
 
+        public static readonly string AuditSources = "auditSources";
+
         public static readonly string Author = "author";
 
         public static readonly string BeginIgnoreMarker = "NUGET: BEGIN LICENSE TEXT";

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TestPackageSourceProvider.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TestPackageSourceProvider.cs
@@ -21,6 +21,8 @@ namespace NuGet.Commands.Test
 
         public IEnumerable<PackageSource> LoadPackageSources() => PackageSources;
 
+        public IReadOnlyList<PackageSource> LoadAuditSources() => Array.Empty<PackageSource>();
+
         public event EventHandler PackageSourcesChanged;
 
         public void SavePackageSources(IEnumerable<PackageSource> sources)

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/ClientCertificateProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/ClientCertificateProviderTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Configuration.Test
                                                                              testInfo.ConfigFile));
 
                 // Assert
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
                 Assert.Equal(1, packageSourceList.Count);
                 Assert.Equal(1, packageSourceList[0].ClientCertificates.Count);
@@ -57,7 +57,7 @@ namespace NuGet.Configuration.Test
                                                                               testInfo.CertificateFindBy));
 
                 // Assert
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
                 Assert.Equal(1, packageSourceList.Count);
                 Assert.Equal(1, packageSourceList[0].ClientCertificates.Count);

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/ConfigurationDefaultsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/ConfigurationDefaultsTests.cs
@@ -1,10 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using FluentAssertions;
 using NuGet.Test.Utility;
 using Xunit;
 
@@ -49,12 +52,13 @@ namespace NuGet.Configuration
                 //Act
                 ConfigurationDefaults configDefaults = new ConfigurationDefaults(nugetConfigFileFolder, nugetConfigFile);
                 IEnumerable<PackageSource> defaultSourcesFromConfigFile = configDefaults.DefaultPackageSources;
-                string packageRestore = configDefaults.DefaultPackageRestoreConsent;
-                string packagePushSource = configDefaults.DefaultPushSource;
+                string? packageRestore = configDefaults.DefaultPackageRestoreConsent;
+                string? packagePushSource = configDefaults.DefaultPushSource;
 
                 //Assert
                 VerifyPackageSource(defaultSourcesFromConfigFile, 2, new string[] { name1, name2 }, new string[] { feed1, feed2 });
                 Assert.Equal(feed2, packagePushSource);
+                Assert.NotNull(packageRestore);
                 Assert.Equal("true", packageRestore.ToLowerInvariant());
             }
         }
@@ -340,6 +344,77 @@ namespace NuGet.Configuration
                 Assert.Equal(1, packageSources.Count());
                 Assert.Equal("v2", packageSources[0].Name);
                 Assert.Equal("http://www.nuget.org/api/v2/", packageSources[0].Source);
+            }
+        }
+
+        [Fact]
+        public void DefaultAuditSources_ConfigWithoutAuditSources_ReturnsEmptyList()
+        {
+            // Arrange
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
+            {
+                const string configurationDefaultsContent = @"<configuration />";
+                ConfigurationDefaults configurationDefaults = GetConfigurationDefaults(configurationDefaultsContent, mockBaseDirectory);
+
+                // Act
+                var defaultAuditSources = configurationDefaults.DefaultAuditSources;
+
+                // Assert
+                Assert.NotNull(defaultAuditSources);
+                Assert.Empty(defaultAuditSources);
+            }
+        }
+
+        [Fact]
+        public void DefaultAuditSources_ConfigWithAuditSources_ReturnsNonEmptyList()
+        {
+            // Arrange
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
+            {
+                const string configurationDefaultsContent = @"<configuration>
+  <auditSources>
+    <add key=""contoso"" value=""https://contoso.text/nuget/v3/index.json"" />
+  </auditSources>
+</configuration>";
+                ConfigurationDefaults configurationDefaults = GetConfigurationDefaults(configurationDefaultsContent, mockBaseDirectory);
+
+                // Act
+                var defaultAuditSources = configurationDefaults.DefaultAuditSources;
+
+                // Assert
+                Assert.NotNull(defaultAuditSources);
+                var auditSource = Assert.Single(defaultAuditSources);
+                auditSource.Source.Should().Be("https://contoso.text/nuget/v3/index.json");
+                auditSource.Name.Should().Be("contoso");
+                auditSource.IsEnabled.Should().BeTrue();
+            }
+        }
+
+        [Fact]
+        public void DefaultAuditSources_ConfigWithDisabledAuditSources_ReturnsEmptyList()
+        {
+            // Arrange
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
+            {
+                const string configurationDefaultsContent = @"<configuration>
+  <auditSources>
+    <add key=""contoso"" value=""https://contoso.text/nuget/v3/index.json"" />
+  </auditSources>
+  <disabledPackageSources>
+    <add key=""contoso"" value=""true"" />
+  </disabledPackageSources>
+</configuration>";
+                ConfigurationDefaults configurationDefaults = GetConfigurationDefaults(configurationDefaultsContent, mockBaseDirectory);
+
+                // Act
+                var defaultAuditSources = configurationDefaults.DefaultAuditSources;
+
+                // Assert
+                Assert.NotNull(defaultAuditSources);
+                var auditSource = Assert.Single(defaultAuditSources);
+                auditSource.Source.Should().Be("https://contoso.text/nuget/v3/index.json");
+                auditSource.Name.Should().Be("contoso");
+                auditSource.IsEnabled.Should().BeFalse();
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Configuration.Test
 
                 var settings = new Settings(directory, "nuget.Config");
 
-                var before = new PackageSourceProvider(settings);
+                var before = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 Assert.Equal(NuGetConstants.FeedName, before.ActivePackageSourceName);
 
                 before.SaveActivePackageSource(new PackageSource(NuGetConstants.V3FeedUrl, NuGetConstants.FeedName));
@@ -53,7 +53,7 @@ namespace NuGet.Configuration.Test
                 File.WriteAllText(nugetConfigFilePath, text);
 
                 var settings = new Settings(directory, "nuget.config");
-                var before = new PackageSourceProvider(settings);
+                var before = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 Assert.Null(before.ActivePackageSourceName);
 
                 before.SaveActivePackageSource(new PackageSource(NuGetConstants.V3FeedUrl, NuGetConstants.FeedName));
@@ -77,7 +77,7 @@ namespace NuGet.Configuration.Test
                 File.WriteAllText(nugetConfigFilePath, fileContents);
 
                 var settings = new Settings(directory, "nuget.Config");
-                var before = new PackageSourceProvider(settings);
+                var before = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 Assert.Null(before.ActivePackageSourceName);
 
                 before.SaveActivePackageSource(new PackageSource(NuGetConstants.V3FeedUrl, NuGetConstants.FeedName));
@@ -85,10 +85,8 @@ namespace NuGet.Configuration.Test
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void LoadPackageSources_LoadsCredentials(bool useStaticMethod)
+        [Fact]
+        public void LoadPackageSources_LoadsCredentials()
         {
             // Arrange
             var nugetConfigFilePath = "NuGet.Config";
@@ -152,7 +150,7 @@ namespace NuGet.Configuration.Test
                 var settings = new Settings(directory);
 
                 // Act
-                List<PackageSource> sources = LoadPackageSources(useStaticMethod, settings);
+                List<PackageSource> sources = LoadPackageSources(settings);
 
                 // Assert
                 sources.Count.Should().Be(6);
@@ -161,16 +159,14 @@ namespace NuGet.Configuration.Test
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void TestNoPackageSourcesAreReturnedIfUserSettingsIsEmpty(bool useStaticMethod)
+        [Fact]
+        public void TestNoPackageSourcesAreReturnedIfUserSettingsIsEmpty()
         {
             // Arrange
             var settings = new Mock<ISettings>();
 
             // Act
-            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+            List<PackageSource> values = LoadPackageSources(settings.Object);
 
             // Assert
             Assert.Equal(0, values.Count);
@@ -189,7 +185,7 @@ namespace NuGet.Configuration.Test
             {
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigFilePath, directory, configContent);
                 var settings = new Settings(directory);
-                var provider = new PackageSourceProvider(settings);
+                var provider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
 
                 // Act
                 provider.SavePackageSources(
@@ -254,7 +250,7 @@ namespace NuGet.Configuration.Test
                     machineWideSettings: null,
                     loadUserWideSettings: false,
                     useTestingGlobalPath: false);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
 
                 // Act
@@ -298,7 +294,7 @@ namespace NuGet.Configuration.Test
                     machineWideSettings: null,
                     loadUserWideSettings: false,
                     useTestingGlobalPath: false);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
 
                 // Act
@@ -347,7 +343,7 @@ namespace NuGet.Configuration.Test
                     machineWideSettings: null,
                     loadUserWideSettings: false,
                     useTestingGlobalPath: false);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
 
                 // act
@@ -400,7 +396,7 @@ namespace NuGet.Configuration.Test
                     machineWideSettings: null,
                     loadUserWideSettings: false,
                     useTestingGlobalPath: false);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
 
                 // act
@@ -452,7 +448,7 @@ namespace NuGet.Configuration.Test
                     machineWideSettings: null,
                     loadUserWideSettings: false,
                     useTestingGlobalPath: false);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
 
                 // act
@@ -508,7 +504,7 @@ namespace NuGet.Configuration.Test
                     loadUserWideSettings: false,
                     useTestingGlobalPath: false);
 
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
 
                 // act
@@ -574,7 +570,7 @@ namespace NuGet.Configuration.Test
 
                 var expectedDisabledSources = disabledPackagesSection?.Items.ToList();
 
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
 
                 // Act
@@ -638,7 +634,7 @@ namespace NuGet.Configuration.Test
                 Assert.Equal("Microsoft and .NET", disabledSources[0].Key);
                 Assert.Equal("b", disabledSources[1].Key);
 
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
 
                 Assert.Equal(2, packageSourceList.Count);
@@ -666,7 +662,7 @@ namespace NuGet.Configuration.Test
                 Assert.Equal(1, disabledSources.Count);
                 Assert.Equal("Microsoft and .NET", disabledSources[0].Key);
 
-                packageSourceList = PackageSourceProvider.LoadPackageSources(newSettings).ToList();
+                packageSourceList = new PackageSourceProvider(newSettings, TestConfigurationDefaults.NullInstance).LoadPackageSources().ToList();
 
                 Assert.Equal(2, packageSourceList.Count);
                 Assert.Equal("a", packageSourceList[0].Name);
@@ -676,10 +672,8 @@ namespace NuGet.Configuration.Test
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void LoadPackageSourcesReturnCorrectDataFromSettings(bool useStaticMethod)
+        [Fact]
+        public void LoadPackageSourcesReturnCorrectDataFromSettings()
         {
             // Arrange
             var settings = new Mock<ISettings>(MockBehavior.Strict);
@@ -704,7 +698,7 @@ namespace NuGet.Configuration.Test
                     .Returns(new VirtualSettingSection("clientCertificates"));
 
             // Act
-            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+            List<PackageSource> values = LoadPackageSources(settings.Object);
 
             // Assert
             Assert.Equal(3, values.Count);
@@ -713,10 +707,8 @@ namespace NuGet.Configuration.Test
             AssertPackageSource(values[2], "three", "threesource", isEnabled: true);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void LoadPackageSourcesReturnCorrectDataFromSettingsWhenSomePackageSourceIsDisabled(bool useStaticMethod)
+        [Fact]
+        public void LoadPackageSourcesReturnCorrectDataFromSettingsWhenSomePackageSourceIsDisabled()
         {
             // Arrange
             var settings = new Mock<ISettings>(MockBehavior.Strict);
@@ -744,7 +736,7 @@ namespace NuGet.Configuration.Test
                 .Returns(new VirtualSettingSection("clientCertificates"));
 
             // Act
-            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+            List<PackageSource> values = LoadPackageSources(settings.Object);
 
             // Assert
             Assert.Equal(3, values.Count);
@@ -753,10 +745,8 @@ namespace NuGet.Configuration.Test
             AssertPackageSource(values[2], "three", "threesource", isEnabled: true);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void LoadPackageSources_ReadsSourcesWithProtocolVersionFromPackageSourceSections(bool useStaticMethod)
+        [Fact]
+        public void LoadPackageSources_ReadsSourcesWithProtocolVersionFromPackageSourceSections()
         {
             // Arrange
             var settings = new Mock<ISettings>();
@@ -784,7 +774,7 @@ namespace NuGet.Configuration.Test
             settings.Setup(s => s.GetConfigFilePaths())
                 .Returns(new List<string>());
             // Act
-            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+            List<PackageSource> values = LoadPackageSources(settings.Object);
 
             // Assert
             Assert.Collection(values,
@@ -822,10 +812,8 @@ namespace NuGet.Configuration.Test
                     });
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void LoadPackageSources_ReadsSourcesWithNullAllowInsecureConnectionsFromPackageSourceSections_LoadsDefault(bool useStaticMethod)
+        [Fact]
+        public void LoadPackageSources_ReadsSourcesWithNullAllowInsecureConnectionsFromPackageSourceSections_LoadsDefault()
         {
             // Arrange
             var settings = new Mock<ISettings>();
@@ -839,7 +827,7 @@ namespace NuGet.Configuration.Test
                 .Returns(new List<string>());
 
             // Act
-            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+            List<PackageSource> values = LoadPackageSources(settings.Object);
 
             // Assert
             var loadedSource = values.Single();
@@ -848,10 +836,8 @@ namespace NuGet.Configuration.Test
             Assert.Equal(PackageSource.DefaultAllowInsecureConnections, loadedSource.AllowInsecureConnections);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void LoadPackageSources_ReadsSourcesWithInvalidAllowInsecureConnectionsFromPackageSourceSections_LoadsDefault(bool useStaticMethod)
+        [Fact]
+        public void LoadPackageSources_ReadsSourcesWithInvalidAllowInsecureConnectionsFromPackageSourceSections_LoadsDefault()
         {
             // Arrange
             var settings = new Mock<ISettings>();
@@ -865,7 +851,7 @@ namespace NuGet.Configuration.Test
                 .Returns(new List<string>());
 
             // Act
-            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+            List<PackageSource> values = LoadPackageSources(settings.Object);
 
             // Assert
             var loadedSource = values.Single();
@@ -875,13 +861,11 @@ namespace NuGet.Configuration.Test
         }
 
         [Theory]
-        [InlineData(true, "true")]
-        [InlineData(true, "TRUE")]
-        [InlineData(true, "false")]
-        [InlineData(false, "false")]
-        [InlineData(false, "fALSE")]
-        [InlineData(false, "true")]
-        public void LoadPackageSources_ReadsSourcesWithNotNullAllowInsecureConnectionsFromPackageSourceSections_LoadsValue(bool useStaticMethod, string allowInsecureConnections)
+        [InlineData("true")]
+        [InlineData("TRUE")]
+        [InlineData("false")]
+        [InlineData("fALSE")]
+        public void LoadPackageSources_ReadsSourcesWithNotNullAllowInsecureConnectionsFromPackageSourceSections_LoadsValue(string allowInsecureConnections)
         {
             // Arrange
             var settings = new Mock<ISettings>();
@@ -895,7 +879,7 @@ namespace NuGet.Configuration.Test
                 .Returns(new List<string>());
 
             // Act
-            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+            List<PackageSource> values = LoadPackageSources(settings.Object);
 
             // Assert
             var loadedSource = values.Single();
@@ -940,10 +924,8 @@ namespace NuGet.Configuration.Test
             Assert.False(isEnabled);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void LoadPackageSources_ReadsCredentialPairsFromSettings(bool useStaticMethod)
+        [Fact]
+        public void LoadPackageSources_ReadsCredentialPairsFromSettings()
         {
             // Arrange
             var encryptedPassword = Guid.NewGuid().ToString();
@@ -965,7 +947,7 @@ namespace NuGet.Configuration.Test
                     ));
 
             // Act
-            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+            List<PackageSource> values = LoadPackageSources(settings.Object);
 
             // Assert
             Assert.Equal(3, values.Count);
@@ -973,10 +955,8 @@ namespace NuGet.Configuration.Test
             AssertCredentials(values[1].Credentials, "two", "user1", encryptedPassword, isPasswordClearText: false);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void LoadPackageSources_WithSpaceInName_ReadsCredentialPairsFromSettings(bool useStaticMethod)
+        [Fact]
+        public void LoadPackageSources_WithSpaceInName_ReadsCredentialPairsFromSettings()
         {
             // Arrange
             var encryptedPassword = Guid.NewGuid().ToString();
@@ -998,7 +978,7 @@ namespace NuGet.Configuration.Test
             settings.Setup(s => s.GetConfigFilePaths())
                 .Returns(new List<string>());
             // Act
-            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+            List<PackageSource> values = LoadPackageSources(settings.Object);
 
             // Assert
             Assert.Equal(3, values.Count);
@@ -1006,10 +986,8 @@ namespace NuGet.Configuration.Test
             AssertCredentials(values[1].Credentials, "two source", "user1", encryptedPassword, isPasswordClearText: false);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void LoadPackageSources_ReadsClearTextCredentialPairsFromSettings(bool useStaticMethod)
+        [Fact]
+        public void LoadPackageSources_ReadsClearTextCredentialPairsFromSettings()
         {
             // Arrange
             const string clearTextPassword = "topsecret";
@@ -1031,7 +1009,7 @@ namespace NuGet.Configuration.Test
             settings.Setup(s => s.GetConfigFilePaths())
                 .Returns(new List<string>());
             // Act
-            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+            List<PackageSource> values = LoadPackageSources(settings.Object);
 
             // Assert
             Assert.Equal(3, values.Count);
@@ -1039,10 +1017,8 @@ namespace NuGet.Configuration.Test
             AssertCredentials(values[1].Credentials, "two", "user1", clearTextPassword);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void LoadPackageSources_WhenEnvironmentCredentialsAreMalformed_FallsbackToSettingsCredentials(bool useStaticMethod)
+        [Fact]
+        public void LoadPackageSources_WhenEnvironmentCredentialsAreMalformed_FallsbackToSettingsCredentials()
         {
             // Arrange
             var settings = new Mock<ISettings>();
@@ -1062,7 +1038,7 @@ namespace NuGet.Configuration.Test
             settings.Setup(s => s.GetConfigFilePaths())
                 .Returns(new List<string>());
             // Act
-            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+            List<PackageSource> values = LoadPackageSources(settings.Object);
 
             // Assert
             Assert.Equal(3, values.Count);
@@ -1082,7 +1058,7 @@ namespace NuGet.Configuration.Test
 
                 File.WriteAllText(Path.Combine(directory.Path, "NuGet.Config"), configContents);
                 var settings = new Settings(directory);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var sources = new[] { new PackageSource("one"), new PackageSource("two"), new PackageSource("three") };
 
                 // Act
@@ -1122,7 +1098,7 @@ namespace NuGet.Configuration.Test
 
                 File.WriteAllText(Path.Combine(directory.Path, "NuGet.Config"), configContents);
                 var settings = new Settings(directory);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var sources = new[]
                     {
                     new PackageSource("Source1", "Source1-Name"),
@@ -1161,7 +1137,7 @@ namespace NuGet.Configuration.Test
 
                 File.WriteAllText(Path.Combine(directory.Path, "NuGet.Config"), configContents);
                 var settings = new Settings(directory);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var sources = new[] { new PackageSource("one"), new PackageSource("two", "two", isEnabled: false), new PackageSource("three") };
 
                 // Act
@@ -1204,7 +1180,7 @@ namespace NuGet.Configuration.Test
 
                 File.WriteAllText(Path.Combine(directory.Path, "NuGet.Config"), configContents);
                 var settings = new Settings(directory);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var encryptedPassword = Guid.NewGuid().ToString();
                 var credentials = new PackageSourceCredential("twoname", "User", encryptedPassword, isPasswordClearText: false, validAuthenticationTypesText: null);
 
@@ -1260,7 +1236,7 @@ namespace NuGet.Configuration.Test
 
                 File.WriteAllText(Path.Combine(directory.Path, "NuGet.Config"), configContents);
                 var settings = new Settings(directory);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var credentials = new PackageSourceCredential("twoname", "User", "password", isPasswordClearText: true, validAuthenticationTypesText: null);
 
                 var sources = new[]
@@ -1303,10 +1279,8 @@ namespace NuGet.Configuration.Test
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void LoadPackageSourcesWithDisabledPackageSourceIsUpperCase(bool useStaticMethod)
+        [Fact]
+        public void LoadPackageSourcesWithDisabledPackageSourceIsUpperCase()
         {
             // Arrange
             var settings = new Mock<ISettings>(MockBehavior.Strict);
@@ -1329,7 +1303,7 @@ namespace NuGet.Configuration.Test
             settings.Setup(s => s.GetSection("clientCertificates"))
                 .Returns(new VirtualSettingSection("clientCertificates"));
             // Act
-            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+            List<PackageSource> values = LoadPackageSources(settings.Object);
 
             // Assert
             Assert.Equal(3, values.Count);
@@ -1340,10 +1314,8 @@ namespace NuGet.Configuration.Test
 
         // Test that a source added in a high priority config file is not
         // disabled by <disabledPackageSources> in a low priority file.
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void HighPrioritySourceDisabled(bool useStaticMethod)
+        [Fact]
+        public void HighPrioritySourceDisabled()
         {
             // Arrange
             using (var directory = TestDirectory.Create())
@@ -1368,7 +1340,7 @@ namespace NuGet.Configuration.Test
                     useTestingGlobalPath: false);
 
                 // Act
-                List<PackageSource> values = LoadPackageSources(useStaticMethod, settings);
+                List<PackageSource> values = LoadPackageSources(settings);
 
                 // Assert
                 Assert.Equal(1, values.Count);
@@ -1380,10 +1352,8 @@ namespace NuGet.Configuration.Test
 
         // Test that a source added in a low priority config file is disabled
         // if it's listed in <disabledPackageSources> in a high priority file.
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void LowPrioritySourceDisabled(bool useStaticMethod)
+        [Fact]
+        public void LowPrioritySourceDisabled()
         {
             // Arrange
             using (var directory = TestDirectory.Create())
@@ -1408,7 +1378,7 @@ namespace NuGet.Configuration.Test
                     useTestingGlobalPath: false);
 
                 // Act
-                List<PackageSource> values = LoadPackageSources(useStaticMethod, settings);
+                List<PackageSource> values = LoadPackageSources(settings);
 
                 // Assert
                 Assert.Equal(1, values.Count);
@@ -1418,10 +1388,8 @@ namespace NuGet.Configuration.Test
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void V2NotDisabled(bool useStaticMethod)
+        [Fact]
+        public void V2NotDisabled()
         {
             // Arrange
             using (var directory = TestDirectory.Create())
@@ -1441,7 +1409,7 @@ namespace NuGet.Configuration.Test
                     useTestingGlobalPath: false);
 
                 // Act
-                List<PackageSource> values = LoadPackageSources(useStaticMethod, settings);
+                List<PackageSource> values = LoadPackageSources(settings);
 
                 // Assert
                 Assert.True(values.Single(p => p.Name.Equals("nuget.org", StringComparison.OrdinalIgnoreCase)).IsEnabled);
@@ -1470,7 +1438,7 @@ namespace NuGet.Configuration.Test
                    machineWideSettings: null,
                    loadUserWideSettings: true,
                    useTestingGlobalPath: false);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
 
                 // Act
                 var sources = packageSourceProvider.LoadPackageSources().ToList();
@@ -1519,7 +1487,7 @@ namespace NuGet.Configuration.Test
                     machineWideSettings: null,
                     loadUserWideSettings: false,
                     useTestingGlobalPath: false);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
 
                 // Act - 1
                 var sources = packageSourceProvider.LoadPackageSources();
@@ -1585,7 +1553,7 @@ namespace NuGet.Configuration.Test
                     machineWideSettings: null,
                     loadUserWideSettings: false,
                     useTestingGlobalPath: false);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
 
                 // Act - 1
                 var sources = packageSourceProvider.LoadPackageSources();
@@ -1656,7 +1624,7 @@ namespace NuGet.Configuration.Test
                     machineWideSettings: null,
                     loadUserWideSettings: false,
                     useTestingGlobalPath: false);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
 
                 // Act - 1
                 var sources = packageSourceProvider.LoadPackageSources().ToList();
@@ -1723,7 +1691,7 @@ namespace NuGet.Configuration.Test
                     machineWideSettings: null,
                     loadUserWideSettings: false,
                     useTestingGlobalPath: false);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
 
                 // Act - 1
                 var sources = packageSourceProvider.LoadPackageSources().ToList();
@@ -1799,7 +1767,7 @@ namespace NuGet.Configuration.Test
                     machineWideSettings: m.Object,
                     loadUserWideSettings: true,
                     useTestingGlobalPath: true);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var sources = packageSourceProvider.LoadPackageSources().ToList();
 
                 // Act
@@ -1854,7 +1822,7 @@ namespace NuGet.Configuration.Test
                     machineWideSettings: m.Object,
                     loadUserWideSettings: true,
                     useTestingGlobalPath: true);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var sources = packageSourceProvider.LoadPackageSources().ToList();
 
 
@@ -1872,10 +1840,8 @@ namespace NuGet.Configuration.Test
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void DisabledMachineWideSourceByDefaultWithNull(bool useStaticMethod)
+        [Fact]
+        public void DisabledMachineWideSourceByDefaultWithNull()
         {
             using (var directory = TestDirectory.Create())
             {
@@ -1889,17 +1855,15 @@ namespace NuGet.Configuration.Test
                     useTestingGlobalPath: true);
 
                 // Act
-                List<PackageSource> sources = LoadPackageSources(useStaticMethod, settings);
+                List<PackageSource> sources = LoadPackageSources(settings);
 
                 // Assert
                 Assert.Equal(0, sources.Count);
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void LoadPackageSourceEmptyConfigFileOnUserMachine(bool useStaticMethod)
+        [Fact]
+        public void LoadPackageSourceEmptyConfigFileOnUserMachine()
         {
             using (var directory = TestDirectory.Create())
             {
@@ -1920,17 +1884,15 @@ namespace NuGet.Configuration.Test
                                   useTestingGlobalPath: true);
 
                 // Act
-                List<PackageSource> sources = LoadPackageSources(useStaticMethod, settings);
+                List<PackageSource> sources = LoadPackageSources(settings);
 
                 // Assert
                 Assert.Equal(0, sources.Count);
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void LoadPackageSourceLocalConfigFileOnUserMachine(bool useStaticMethod)
+        [Fact]
+        public void LoadPackageSourceLocalConfigFileOnUserMachine()
         {
             using (var directory = TestDirectory.Create())
             {
@@ -1952,7 +1914,7 @@ namespace NuGet.Configuration.Test
                                   useTestingGlobalPath: true);
 
                 // Act
-                List<PackageSource> sources = LoadPackageSources(useStaticMethod, settings);
+                List<PackageSource> sources = LoadPackageSources(settings);
 
                 // Assert
                 Assert.Equal(1, sources.Count);
@@ -1983,7 +1945,7 @@ namespace NuGet.Configuration.Test
                                   machineWideSettings: null,
                                   loadUserWideSettings: true,
                                   useTestingGlobalPath: true);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
 
                 // Act
                 var sources = packageSourceProvider.LoadPackageSources().ToList();
@@ -2028,7 +1990,7 @@ namespace NuGet.Configuration.Test
                         machineWideSettings: null,
                         loadUserWideSettings: true,
                         useTestingGlobalPath: true);
-                    var packageSourceProvider = new PackageSourceProvider(settings);
+                    var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
 
                     // Act
                     var sources = packageSourceProvider.LoadPackageSources().ToList();
@@ -2081,8 +2043,8 @@ namespace NuGet.Configuration.Test
                    loadUserWideSettings: true,
                    useTestingGlobalPath: false);
 
-                var packageSourceProviderWithDefault = new PackageSourceProvider(settingsWithDefault);
-                var packageSourceProviderWithoutDefault = new PackageSourceProvider(settingsWithoutDefault);
+                var packageSourceProviderWithDefault = new PackageSourceProvider(settingsWithDefault, TestConfigurationDefaults.NullInstance);
+                var packageSourceProviderWithoutDefault = new PackageSourceProvider(settingsWithoutDefault, TestConfigurationDefaults.NullInstance);
 
                 // Act
                 var defaultPushSourceWithDefault = packageSourceProviderWithDefault.DefaultPushSource;
@@ -2120,7 +2082,7 @@ namespace NuGet.Configuration.Test
                                   machineWideSettings: null,
                                   loadUserWideSettings: false,
                                   useTestingGlobalPath: false);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
 
                 // Act
                 var sources = packageSourceProvider.LoadPackageSources().ToList();
@@ -2171,7 +2133,7 @@ namespace NuGet.Configuration.Test
                     machineWideSettings: null,
                     loadUserWideSettings: true,
                     useTestingGlobalPath: true);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
 
                 // Act
                 var sources = packageSourceProvider.LoadPackageSources().ToList();
@@ -2209,7 +2171,7 @@ namespace NuGet.Configuration.Test
                    loadUserWideSettings: true,
                    useTestingGlobalPath: false);
 
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
 
                 // Act
                 var packageSources = packageSourceProvider.LoadPackageSources();
@@ -2241,7 +2203,7 @@ namespace NuGet.Configuration.Test
                    loadUserWideSettings: true,
                    useTestingGlobalPath: false);
 
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
 
                 // Act
                 var packageSources = packageSourceProvider.LoadPackageSources();
@@ -2289,10 +2251,9 @@ namespace NuGet.Configuration.Test
             File.WriteAllText(path, contents);
 
             Settings settings = new Settings(testDirectory.Path);
-            var machineDefaultSources = Array.Empty<PackageSource>();
 
             // Act
-            PackageSourceProvider psp = new PackageSourceProvider(settings, machineDefaultSources);
+            PackageSourceProvider psp = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
             PackageSource source = psp.GetPackageSourceBySource(sourceUrl);
 
             // Assert
@@ -2310,10 +2271,9 @@ namespace NuGet.Configuration.Test
             File.WriteAllText(path, contents);
 
             Settings settings = new Settings(testDirectory.Path);
-            var machineDefaultSources = Array.Empty<PackageSource>();
 
             // Act
-            PackageSourceProvider psp = new PackageSourceProvider(settings, machineDefaultSources);
+            PackageSourceProvider psp = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
             IReadOnlyList<PackageSource> auditSources = psp.LoadAuditSources();
 
             // Assert
@@ -2335,10 +2295,9 @@ namespace NuGet.Configuration.Test
             File.WriteAllText(path, contents);
 
             Settings settings = new Settings(testDirectory.Path);
-            var machineDefaultSources = Array.Empty<PackageSource>();
 
             // Act
-            PackageSourceProvider psp = new PackageSourceProvider(settings, machineDefaultSources);
+            PackageSourceProvider psp = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
             IReadOnlyList<PackageSource> auditSources = psp.LoadAuditSources();
 
             // Assert
@@ -2368,10 +2327,9 @@ namespace NuGet.Configuration.Test
             File.WriteAllText(path, contents);
 
             Settings settings = new Settings(testDirectory.Path);
-            var machineDefaultSources = Array.Empty<PackageSource>();
 
             // Act
-            PackageSourceProvider psp = new PackageSourceProvider(settings, machineDefaultSources);
+            PackageSourceProvider psp = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
             IReadOnlyList<PackageSource> auditSources = psp.LoadAuditSources();
 
             // Assert
@@ -2410,17 +2368,11 @@ namespace NuGet.Configuration.Test
             return nugetConfig;
         }
 
-        private List<PackageSource> LoadPackageSources(bool useStaticMethod, ISettings settings)
+        private List<PackageSource> LoadPackageSources(ISettings settings)
         {
-            if (useStaticMethod)
-            {
-                return PackageSourceProvider.LoadPackageSources(settings).ToList();
-            }
-            else
-            {
-                var provider = new PackageSourceProvider(settings);
-                return provider.LoadPackageSources().ToList();
-            }
+            var configurationDefaults = TestConfigurationDefaults.NullInstance;
+            var provider = new PackageSourceProvider(settings, configurationDefaults);
+            return provider.LoadPackageSources().ToList();
         }
 
         private void AssertPackageSource(PackageSource ps, string name, string source, bool isEnabled, bool isMachineWide = false, bool isOfficial = false)

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/TestConfigurationDefaults.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/TestConfigurationDefaults.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Configuration.Test
+{
+    internal static class TestConfigurationDefaults
+    {
+        public static ConfigurationDefaults NullInstance { get; } = new ConfigurationDefaults(NullSettings.Instance);
+    }
+}

--- a/test/TestUtilities/Test.Utility/SourceRepository/TestSourceRepositoryUtility.cs
+++ b/test/TestUtilities/Test.Utility/SourceRepository/TestSourceRepositoryUtility.cs
@@ -96,6 +96,8 @@ namespace Test.Utility
 
         public IEnumerable<PackageSource> LoadPackageSources() => PackageSources;
 
+        public IReadOnlyList<PackageSource> LoadAuditSources() => Array.Empty<PackageSource>();
+
         public event EventHandler PackageSourcesChanged;
 
         public void SavePackageSources(IEnumerable<PackageSource> sources)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13211

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Make `ConfigurationDefaults` be able to load audit sources from `NuGetDefaults.config`
* Add `LoadAuditSources()` to `IPackageSourceProvider` and `PackageSource`Provider`
* `#nullable enable` in several files
* Fix a bunch of tests that fail when your machine has a `NuGetDefaults.config` with at least one package source defined. Tests should not depend on machine state.

The only functionality proposed at the moment is to read the config, not to add/modify/delete `auditSources`, so no APIs have been added for those actions yet.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled: https://github.com/NuGet/docs.microsoft.com-nuget/issues/3226
  - **OR**
  - [ ] N/A
