### PR TITLE
Parse the assets file with System.Text.Json

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -253,7 +253,7 @@ namespace NuGet.ProjectModel
                             jsonReader.ReadObject(projectsPropertyName =>
                             {
 #pragma warning disable CS0612 // Type or member is obsolete
-                                PackageSpec packageSpec = JsonPackageSpecReader.GetPackageSpec(jsonReader, name: null, path, snapshotValue: null, EnvironmentVariableWrapper.Instance);
+                                PackageSpec packageSpec = JsonPackageSpecReader.GetPackageSpec(jsonReader, name: null, path, EnvironmentVariableWrapper.Instance);
 #pragma warning restore CS0612 // Type or member is obsolete
                                 dgspec._projects.Add(projectsPropertyName, packageSpec);
                             });

--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.Packaging;
 
@@ -253,7 +252,9 @@ namespace NuGet.ProjectModel
                         case "projects":
                             jsonReader.ReadObject(projectsPropertyName =>
                             {
-                                PackageSpec packageSpec = JsonPackageSpecReader.GetPackageSpec(jsonReader, name: null, path, EnvironmentVariableWrapper.Instance);
+#pragma warning disable CS0612 // Type or member is obsolete
+                                PackageSpec packageSpec = JsonPackageSpecReader.GetPackageSpec(jsonReader, name: null, path, snapshotValue: null, EnvironmentVariableWrapper.Instance);
+#pragma warning restore CS0612 // Type or member is obsolete
                                 dgspec._projects.Add(projectsPropertyName, packageSpec);
                             });
                             break;

--- a/src/NuGet.Core/NuGet.ProjectModel/FileFormatException.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/FileFormatException.cs
@@ -85,6 +85,18 @@ namespace NuGet.ProjectModel
             return ex.WithFilePath(path).WithLineInfo(line, column);
         }
 
+        internal static FileFormatException Create(Exception exception, string path)
+        {
+            var message = string.Format(CultureInfo.CurrentCulture,
+                Strings.Log_ErrorReadingProjectJson,
+                path,
+                exception.Message);
+
+            var ex = new FileFormatException(message, exception);
+
+            return ex.WithFilePath(path);
+        }
+
         public static FileFormatException Create(string message, JToken value, string path)
         {
             var lineInfo = (IJsonLineInfo)value;
@@ -101,32 +113,24 @@ namespace NuGet.ProjectModel
             return ex.WithFilePath(path).WithLineInfo(line, column);
         }
 
-        internal static FileFormatException Create(Exception exception, string path)
+        internal static FileFormatException Create(JsonReaderException exception, string path)
         {
-            var jex = exception as JsonReaderException;
-
             string message;
-            if (jex == null)
-            {
-                message = string.Format(CultureInfo.CurrentCulture,
-                    Strings.Log_ErrorReadingProjectJson,
-                    path,
-                    exception.Message);
+            message = string.Format(CultureInfo.CurrentCulture,
+                Strings.Log_ErrorReadingProjectJsonWithLocation,
+                path, exception.LineNumber,
+                exception.LinePosition,
+                exception.Message);
 
-                return new FileFormatException(message, exception).WithFilePath(path);
-            }
-            else
-            {
-                message = string.Format(CultureInfo.CurrentCulture,
-                    Strings.Log_ErrorReadingProjectJsonWithLocation,
-                    path, jex.LineNumber,
-                    jex.LinePosition,
-                    exception.Message);
+            return new FileFormatException(message, exception)
+                .WithFilePath(path)
+                .WithLineInfo(exception);
+        }
 
-                return new FileFormatException(message, exception)
-                    .WithFilePath(path)
-                    .WithLineInfo(jex);
-            }
+        internal static FileFormatException Create(string message, string path)
+        {
+            return new FileFormatException(message)
+                .WithFilePath(path);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
@@ -1,0 +1,1822 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.Packaging.Core;
+using NuGet.RuntimeModel;
+using NuGet.Versioning;
+
+namespace NuGet.ProjectModel
+{
+    public partial class JsonPackageSpecReader
+    {
+        private static readonly byte[] AuthorsPropertyName = Encoding.UTF8.GetBytes("authors");
+        private static readonly byte[] BuildOptionsPropertyName = Encoding.UTF8.GetBytes("buildOptions");
+        private static readonly byte[] ContentFilesPropertyName = Encoding.UTF8.GetBytes("contentFiles");
+        private static readonly byte[] CopyrightPropertyName = Encoding.UTF8.GetBytes("copyright");
+        private static readonly byte[] DependenciesPropertyName = Encoding.UTF8.GetBytes("dependencies");
+        private static readonly byte[] DescriptionPropertyName = Encoding.UTF8.GetBytes("description");
+        private static readonly byte[] LanguagePropertyName = Encoding.UTF8.GetBytes("language");
+        private static readonly byte[] PackIncludePropertyName = Encoding.UTF8.GetBytes("packInclude");
+        private static readonly byte[] PackOptionsPropertyName = Encoding.UTF8.GetBytes("packOptions");
+        private static readonly byte[] ScriptsPropertyName = Encoding.UTF8.GetBytes("scripts");
+        private static readonly byte[] FrameworksPropertyName = Encoding.UTF8.GetBytes("frameworks");
+        private static readonly byte[] RestorePropertyName = Encoding.UTF8.GetBytes("restore");
+        private static readonly byte[] RuntimesPropertyName = Encoding.UTF8.GetBytes("runtimes");
+        private static readonly byte[] SupportsPropertyName = Encoding.UTF8.GetBytes("supports");
+        private static readonly byte[] TitlePropertyName = Encoding.UTF8.GetBytes("title");
+        private static readonly byte[] VersionPropertyName = Encoding.UTF8.GetBytes("version");
+        private static readonly byte[] OutputNamePropertyName = Encoding.UTF8.GetBytes("outputName");
+        private static readonly byte[] AutoReferencedPropertyName = Encoding.UTF8.GetBytes("autoReferenced");
+        private static readonly byte[] ExcludePropertyName = Encoding.UTF8.GetBytes("exclude");
+        private static readonly byte[] GeneratePathPropertyPropertyName = Encoding.UTF8.GetBytes("generatePathProperty");
+        private static readonly byte[] IncludePropertyName = Encoding.UTF8.GetBytes("include");
+        private static readonly byte[] NoWarnPropertyName = Encoding.UTF8.GetBytes("noWarn");
+        private static readonly byte[] SuppressParentPropertyName = Encoding.UTF8.GetBytes("suppressParent");
+        private static readonly byte[] TargetPropertyName = Encoding.UTF8.GetBytes("target");
+        private static readonly byte[] VersionOverridePropertyName = Encoding.UTF8.GetBytes("versionOverride");
+        private static readonly byte[] VersionCentrallyManagedPropertyName = Encoding.UTF8.GetBytes("versionCentrallyManaged");
+        private static readonly byte[] AliasesPropertyName = Encoding.UTF8.GetBytes("aliases");
+        private static readonly byte[] NamePropertyName = Encoding.UTF8.GetBytes("name");
+        private static readonly byte[] PrivateAssetsPropertyName = Encoding.UTF8.GetBytes("privateAssets");
+        private static readonly byte[] ExcludeFilesPropertyName = Encoding.UTF8.GetBytes("excludeFiles");
+        private static readonly byte[] IncludeFilesPropertyName = Encoding.UTF8.GetBytes("includeFiles");
+        private static readonly byte[] CentralPackageVersionsManagementEnabledPropertyName = Encoding.UTF8.GetBytes("centralPackageVersionsManagementEnabled");
+        private static readonly byte[] CentralPackageVersionOverrideDisabledPropertyName = Encoding.UTF8.GetBytes("centralPackageVersionOverrideDisabled");
+        private static readonly byte[] CentralPackageTransitivePinningEnabledPropertyName = Encoding.UTF8.GetBytes("CentralPackageTransitivePinningEnabled");
+        private static readonly byte[] ConfigFilePathsPropertyName = Encoding.UTF8.GetBytes("configFilePaths");
+        private static readonly byte[] CrossTargetingPropertyName = Encoding.UTF8.GetBytes("crossTargeting");
+        private static readonly byte[] FallbackFoldersPropertyName = Encoding.UTF8.GetBytes("fallbackFolders");
+        private static readonly byte[] FilesPropertyName = Encoding.UTF8.GetBytes("files");
+        private static readonly byte[] LegacyPackagesDirectoryPropertyName = Encoding.UTF8.GetBytes("legacyPackagesDirectory");
+        private static readonly byte[] OriginalTargetFrameworksPropertyName = Encoding.UTF8.GetBytes("originalTargetFrameworks");
+        private static readonly byte[] OutputPathPropertyName = Encoding.UTF8.GetBytes("outputPath");
+        private static readonly byte[] PackagesConfigPathPropertyName = Encoding.UTF8.GetBytes("packagesConfigPath");
+        private static readonly byte[] PackagesPathPropertyName = Encoding.UTF8.GetBytes("packagesPath");
+        private static readonly byte[] ProjectJsonPathPropertyName = Encoding.UTF8.GetBytes("projectJsonPath");
+        private static readonly byte[] ProjectNamePropertyName = Encoding.UTF8.GetBytes("projectName");
+        private static readonly byte[] ProjectPathPropertyName = Encoding.UTF8.GetBytes("projectPath");
+        private static readonly byte[] ProjectStylePropertyName = Encoding.UTF8.GetBytes("projectStyle");
+        private static readonly byte[] ProjectUniqueNamePropertyName = Encoding.UTF8.GetBytes("projectUniqueName");
+        private static readonly byte[] RestoreLockPropertiesPropertyName = Encoding.UTF8.GetBytes("restoreLockProperties");
+        private static readonly byte[] NuGetLockFilePathPropertyName = Encoding.UTF8.GetBytes("nuGetLockFilePath");
+        private static readonly byte[] RestoreLockedModePropertyName = Encoding.UTF8.GetBytes("restoreLockedMode");
+        private static readonly byte[] RestorePackagesWithLockFilePropertyName = Encoding.UTF8.GetBytes("restorePackagesWithLockFile");
+        private static readonly byte[] RestoreAuditPropertiesPropertyName = Encoding.UTF8.GetBytes("restoreAuditProperties");
+        private static readonly byte[] EnableAuditPropertyName = Encoding.UTF8.GetBytes("enableAudit");
+        private static readonly byte[] AuditLevelPropertyName = Encoding.UTF8.GetBytes("auditLevel");
+        private static readonly byte[] AuditModePropertyName = Encoding.UTF8.GetBytes("auditMode");
+        private static readonly byte[] SkipContentFileWritePropertyName = Encoding.UTF8.GetBytes("skipContentFileWrite");
+        private static readonly byte[] SourcesPropertyName = Encoding.UTF8.GetBytes("sources");
+        private static readonly byte[] ValidateRuntimeAssetsPropertyName = Encoding.UTF8.GetBytes("validateRuntimeAssets");
+        private static readonly byte[] WarningPropertiesPropertyName = Encoding.UTF8.GetBytes("warningProperties");
+        private static readonly byte[] AllWarningsAsErrorsPropertyName = Encoding.UTF8.GetBytes("allWarningsAsErrors");
+        private static readonly byte[] WarnAsErrorPropertyName = Encoding.UTF8.GetBytes("warnAsError");
+        private static readonly byte[] WarnNotAsErrorPropertyName = Encoding.UTF8.GetBytes("warnNotAsError");
+        private static readonly byte[] ExcludeAssetsPropertyName = Encoding.UTF8.GetBytes("excludeAssets");
+        private static readonly byte[] IncludeAssetsPropertyName = Encoding.UTF8.GetBytes("includeAssets");
+        private static readonly byte[] TargetAliasPropertyName = Encoding.UTF8.GetBytes("targetAlias");
+        private static readonly byte[] AssetTargetFallbackPropertyName = Encoding.UTF8.GetBytes("assetTargetFallback");
+        private static readonly byte[] SecondaryFrameworkPropertyName = Encoding.UTF8.GetBytes("secondaryFramework");
+        private static readonly byte[] CentralPackageVersionsPropertyName = Encoding.UTF8.GetBytes("centralPackageVersions");
+        private static readonly byte[] DownloadDependenciesPropertyName = Encoding.UTF8.GetBytes("downloadDependencies");
+        private static readonly byte[] FrameworkAssembliesPropertyName = Encoding.UTF8.GetBytes("frameworkAssemblies");
+        private static readonly byte[] FrameworkReferencesPropertyName = Encoding.UTF8.GetBytes("frameworkReferences");
+        private static readonly byte[] ImportsPropertyName = Encoding.UTF8.GetBytes("imports");
+        private static readonly byte[] RuntimeIdentifierGraphPathPropertyName = Encoding.UTF8.GetBytes("runtimeIdentifierGraphPath");
+        private static readonly byte[] WarnPropertyName = Encoding.UTF8.GetBytes("warn");
+        private static readonly byte[] IconUrlPropertyName = Encoding.UTF8.GetBytes("iconUrl");
+        private static readonly byte[] LicenseUrlPropertyName = Encoding.UTF8.GetBytes("licenseUrl");
+        private static readonly byte[] OwnersPropertyName = Encoding.UTF8.GetBytes("owners");
+        private static readonly byte[] PackageTypePropertyName = Encoding.UTF8.GetBytes("packageType");
+        private static readonly byte[] ProjectUrlPropertyName = Encoding.UTF8.GetBytes("projectUrl");
+        private static readonly byte[] ReleaseNotesPropertyName = Encoding.UTF8.GetBytes("releaseNotes");
+        private static readonly byte[] RequireLicenseAcceptancePropertyName = Encoding.UTF8.GetBytes("requireLicenseAcceptance");
+        private static readonly byte[] SummaryPropertyName = Encoding.UTF8.GetBytes("summary");
+        private static readonly byte[] TagsPropertyName = Encoding.UTF8.GetBytes("tags");
+        private static readonly byte[] MappingsPropertyName = Encoding.UTF8.GetBytes("mappings");
+        private static readonly byte[] HashTagImportPropertyName = Encoding.UTF8.GetBytes("#import");
+        private static readonly byte[] ProjectReferencesPropertyName = Encoding.UTF8.GetBytes("projectReferences");
+        private static readonly byte[] EmptyStringPropertyName = Encoding.UTF8.GetBytes(string.Empty);
+
+        internal static PackageSpec GetPackageSpecUtf8JsonStreamReader(Stream stream, string name, string packageSpecPath, string snapshotValue)
+        {
+            var reader = new Utf8JsonStreamReader(stream);
+            PackageSpec packageSpec;
+            packageSpec = GetPackageSpec(ref reader, name, packageSpecPath, snapshotValue);
+
+            if (!string.IsNullOrEmpty(name))
+            {
+                packageSpec.Name = name;
+                if (!string.IsNullOrEmpty(packageSpecPath))
+                {
+                    packageSpec.FilePath = Path.GetFullPath(packageSpecPath);
+
+                }
+            }
+            return packageSpec;
+        }
+
+        internal static PackageSpec GetPackageSpec(ref Utf8JsonStreamReader jsonReader, string name, string packageSpecPath, string snapshotValue)
+        {
+            var packageSpec = new PackageSpec();
+
+            List<CompatibilityProfile> compatibilityProfiles = null;
+            List<RuntimeDescription> runtimeDescriptions = null;
+            var wasPackOptionsSet = false;
+            var isMappingsNull = false;
+            string filePath = name == null ? null : Path.GetFullPath(packageSpecPath);
+
+            if (jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                {
+                    if (jsonReader.ValueTextEquals(EmptyStringPropertyName))
+                    {
+                        jsonReader.Skip();
+                    }
+#pragma warning disable CS0612 // Type or member is obsolete
+                    else if (jsonReader.ValueTextEquals(AuthorsPropertyName))
+                    {
+                        jsonReader.Read();
+                        if (jsonReader.TokenType == JsonTokenType.StartArray)
+                        {
+                            packageSpec.Authors = jsonReader.ReadStringArrayAsIList()?.ToArray();
+                        }
+                        packageSpec.Authors ??= [];
+                    }
+                    else if (jsonReader.ValueTextEquals(BuildOptionsPropertyName))
+                    {
+                        ReadBuildOptions(ref jsonReader, packageSpec);
+                    }
+                    else if (jsonReader.ValueTextEquals(ContentFilesPropertyName))
+                    {
+                        jsonReader.Read();
+                        jsonReader.ReadStringArrayAsIList(packageSpec.ContentFiles);
+                    }
+                    else if (jsonReader.ValueTextEquals(CopyrightPropertyName))
+                    {
+                        packageSpec.Copyright = jsonReader.ReadNextTokenAsString();
+                    }
+                    else if (jsonReader.ValueTextEquals(DescriptionPropertyName))
+                    {
+                        packageSpec.Description = jsonReader.ReadNextTokenAsString();
+                    }
+                    else if (jsonReader.ValueTextEquals(LanguagePropertyName))
+                    {
+                        packageSpec.Language = jsonReader.ReadNextTokenAsString();
+                    }
+                    else if (jsonReader.ValueTextEquals(PackIncludePropertyName))
+                    {
+                        ReadPackInclude(ref jsonReader, packageSpec);
+                    }
+                    else if (jsonReader.ValueTextEquals(PackOptionsPropertyName))
+                    {
+                        ReadPackOptions(ref jsonReader, packageSpec, ref isMappingsNull);
+                        wasPackOptionsSet = true;
+                    }
+                    else if (jsonReader.ValueTextEquals(ScriptsPropertyName))
+                    {
+                        ReadScripts(ref jsonReader, packageSpec);
+                    }
+#pragma warning restore CS0612 // Type or member is 
+                    else if (jsonReader.ValueTextEquals(DependenciesPropertyName))
+                    {
+                        ReadDependencies(
+                            ref jsonReader,
+                            packageSpec.Dependencies,
+                            filePath,
+                            isGacOrFrameworkReference: false);
+                    }
+                    else if (jsonReader.ValueTextEquals(FrameworksPropertyName))
+                    {
+                        ReadFrameworks(ref jsonReader, packageSpec);
+                    }
+                    else if (jsonReader.ValueTextEquals(RestorePropertyName))
+                    {
+                        ReadMSBuildMetadata(ref jsonReader, packageSpec);
+                    }
+                    else if (jsonReader.ValueTextEquals(RuntimesPropertyName))
+                    {
+                        runtimeDescriptions = ReadRuntimes(ref jsonReader);
+                    }
+                    else if (jsonReader.ValueTextEquals(SupportsPropertyName))
+                    {
+                        compatibilityProfiles = ReadSupports(ref jsonReader);
+                    }
+                    else if (jsonReader.ValueTextEquals(TitlePropertyName))
+                    {
+                        packageSpec.Title = jsonReader.ReadNextTokenAsString();
+                    }
+                    else if (jsonReader.ValueTextEquals(VersionPropertyName))
+                    {
+                        string version = jsonReader.ReadNextTokenAsString();
+                        if (version != null)
+                        {
+                            try
+                            {
+#pragma warning disable CS0612 // Type or member is obsolete
+                                packageSpec.HasVersionSnapshot = PackageSpecUtility.IsSnapshotVersion(version);
+#pragma warning restore CS0612 // Type or member is obsolete
+                                packageSpec.Version = PackageSpecUtility.SpecifySnapshot(version, snapshotValue);
+                            }
+                            catch (Exception ex)
+                            {
+                                throw FileFormatException.Create(ex, version, packageSpec.FilePath);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        jsonReader.Skip();
+                    }
+                }
+            }
+            packageSpec.Name = name;
+            packageSpec.FilePath = name == null ? null : Path.GetFullPath(packageSpecPath);
+
+#pragma warning disable CS0612 // Type or member is obsolete
+            if (!wasPackOptionsSet)
+            {
+                packageSpec.Owners = [];
+                packageSpec.PackOptions = new PackOptions()
+                {
+                    PackageType = Array.Empty<PackageType>()
+                };
+                packageSpec.Tags = [];
+            }
+
+            if (isMappingsNull)
+            {
+                packageSpec.PackOptions.Mappings = null;
+            }
+#pragma warning restore CS0612 // Type or member is obsolete
+
+            packageSpec.RuntimeGraph = new RuntimeGraph(
+                runtimeDescriptions ?? Enumerable.Empty<RuntimeDescription>(),
+                compatibilityProfiles ?? Enumerable.Empty<CompatibilityProfile>());
+
+            packageSpec.Name ??= packageSpec.RestoreMetadata?.ProjectName;
+
+            // Use the project.json path if one is set, otherwise use the project path
+            packageSpec.FilePath ??= packageSpec.RestoreMetadata?.ProjectJsonPath
+                    ?? packageSpec.RestoreMetadata?.ProjectPath;
+
+            return packageSpec;
+        }
+
+        internal static void ReadCentralTransitiveDependencyGroup(
+            ref Utf8JsonStreamReader jsonReader,
+            IList<LibraryDependency> results,
+            string packageSpecPath)
+        {
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                {
+                    var libraryName = jsonReader.GetString();
+                    if (string.IsNullOrEmpty(libraryName))
+                    {
+                        throw FileFormatException.Create(
+                            "Unable to resolve dependency ''.",
+                            packageSpecPath);
+                    }
+
+                    if (jsonReader.Read())
+                    {
+                        var libraryDependency = ReadLibraryDependency(ref jsonReader, packageSpecPath, libraryName);
+                        results.Add(libraryDependency);
+                    }
+                }
+            }
+        }
+
+        private static LibraryDependency ReadLibraryDependency(ref Utf8JsonStreamReader jsonReader, string packageSpecPath, string libraryName)
+        {
+            var dependencyIncludeFlagsValue = LibraryIncludeFlags.All;
+            var dependencyExcludeFlagsValue = LibraryIncludeFlags.None;
+            var suppressParentFlagsValue = LibraryIncludeFlagUtils.DefaultSuppressParent;
+            string dependencyVersionValue = null;
+
+            if (jsonReader.TokenType == JsonTokenType.String)
+            {
+                dependencyVersionValue = jsonReader.GetString();
+            }
+            else if (jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                ReadCentralTransitiveDependencyGroupProperties(
+                    ref jsonReader,
+                    ref dependencyIncludeFlagsValue,
+                    ref dependencyExcludeFlagsValue,
+                    ref suppressParentFlagsValue,
+                    ref dependencyVersionValue);
+            }
+
+            VersionRange dependencyVersionRange = null;
+
+            if (!string.IsNullOrEmpty(dependencyVersionValue))
+            {
+                try
+                {
+                    dependencyVersionRange = VersionRange.Parse(dependencyVersionValue);
+                }
+                catch (Exception ex)
+                {
+                    throw FileFormatException.Create(
+                        ex,
+                        packageSpecPath);
+                }
+            }
+
+            if (dependencyVersionRange == null)
+            {
+                throw FileFormatException.Create(
+                    new ArgumentException(Strings.MissingVersionOnDependency),
+                    packageSpecPath);
+            }
+
+            // the dependency flags are: Include flags - Exclude flags
+            var includeFlags = dependencyIncludeFlagsValue & ~dependencyExcludeFlagsValue;
+            var libraryDependency = new LibraryDependency()
+            {
+                LibraryRange = new LibraryRange()
+                {
+                    Name = libraryName,
+                    TypeConstraint = LibraryDependencyTarget.Package,
+                    VersionRange = dependencyVersionRange
+                },
+
+                IncludeType = includeFlags,
+                SuppressParent = suppressParentFlagsValue,
+                VersionCentrallyManaged = true,
+                ReferenceType = LibraryDependencyReferenceType.Transitive
+            };
+
+            return libraryDependency;
+        }
+
+        private static void ReadCentralTransitiveDependencyGroupProperties(
+            ref Utf8JsonStreamReader jsonReader,
+            ref LibraryIncludeFlags dependencyIncludeFlagsValue,
+            ref LibraryIncludeFlags dependencyExcludeFlagsValue,
+            ref LibraryIncludeFlags suppressParentFlagsValue,
+            ref string dependencyVersionValue)
+        {
+            while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+            {
+                if (jsonReader.ValueTextEquals(ExcludePropertyName))
+                {
+                    var values = jsonReader.ReadDelimitedString();
+                    dependencyExcludeFlagsValue = LibraryIncludeFlagUtils.GetFlags(values);
+                }
+                else if (jsonReader.ValueTextEquals(IncludePropertyName))
+                {
+                    var values = jsonReader.ReadDelimitedString();
+                    dependencyIncludeFlagsValue = LibraryIncludeFlagUtils.GetFlags(values);
+                }
+                else if (jsonReader.ValueTextEquals(SuppressParentPropertyName))
+                {
+                    var values = jsonReader.ReadDelimitedString();
+                    suppressParentFlagsValue = LibraryIncludeFlagUtils.GetFlags(values);
+                }
+                else if (jsonReader.ValueTextEquals(VersionPropertyName))
+                {
+                    if (jsonReader.Read())
+                    {
+                        dependencyVersionValue = jsonReader.GetString();
+                    }
+                }
+                else
+                {
+                    jsonReader.Skip();
+                }
+            }
+        }
+
+        private static void ReadDependencies(
+            ref Utf8JsonStreamReader jsonReader,
+            IList<LibraryDependency> results,
+            string packageSpecPath,
+            bool isGacOrFrameworkReference)
+        {
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                {
+                    var propertyName = jsonReader.GetString();
+                    if (string.IsNullOrEmpty(propertyName))
+                    {
+                        throw FileFormatException.Create("Unable to resolve dependency ''.", packageSpecPath);
+                    }
+
+                    // Support
+                    // "dependencies" : {
+                    //    "Name" : "1.0"
+                    // }
+
+                    if (jsonReader.Read())
+                    {
+                        var dependencyIncludeFlagsValue = LibraryIncludeFlags.All;
+                        var dependencyExcludeFlagsValue = LibraryIncludeFlags.None;
+                        var suppressParentFlagsValue = LibraryIncludeFlagUtils.DefaultSuppressParent;
+                        List<NuGetLogCode> noWarn = null;
+
+                        // This method handles both the dependencies and framework assembly sections.
+                        // Framework references should be limited to references.
+                        // Dependencies should allow everything but framework references.
+                        LibraryDependencyTarget targetFlagsValue = isGacOrFrameworkReference
+                            ? LibraryDependencyTarget.Reference
+                            : LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference;
+
+                        var autoReferenced = false;
+                        var generatePathProperty = false;
+                        var versionCentrallyManaged = false;
+                        string aliases = null;
+                        string dependencyVersionValue = null;
+                        VersionRange versionOverride = null;
+
+                        if (jsonReader.TokenType == JsonTokenType.String)
+                        {
+                            dependencyVersionValue = jsonReader.GetString();
+                        }
+                        else if (jsonReader.TokenType == JsonTokenType.StartObject)
+                        {
+                            while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                            {
+                                if (jsonReader.ValueTextEquals(AutoReferencedPropertyName))
+                                {
+                                    autoReferenced = jsonReader.ReadNextTokenAsBoolOrFalse();
+                                }
+                                else if (jsonReader.ValueTextEquals(ExcludePropertyName))
+                                {
+                                    var values = jsonReader.ReadDelimitedString();
+                                    dependencyExcludeFlagsValue = LibraryIncludeFlagUtils.GetFlags(values);
+                                }
+                                else if (jsonReader.ValueTextEquals(GeneratePathPropertyPropertyName))
+                                {
+                                    generatePathProperty = jsonReader.ReadNextTokenAsBoolOrFalse();
+                                }
+                                else if (jsonReader.ValueTextEquals(IncludePropertyName))
+                                {
+                                    var values = jsonReader.ReadDelimitedString();
+                                    dependencyIncludeFlagsValue = LibraryIncludeFlagUtils.GetFlags(values);
+                                }
+                                else if (jsonReader.ValueTextEquals(NoWarnPropertyName))
+                                {
+                                    noWarn = ReadNuGetLogCodesList(ref jsonReader);
+                                }
+                                else if (jsonReader.ValueTextEquals(SuppressParentPropertyName))
+                                {
+                                    var values = jsonReader.ReadDelimitedString();
+                                    suppressParentFlagsValue = LibraryIncludeFlagUtils.GetFlags(values);
+                                }
+                                else if (jsonReader.ValueTextEquals(TargetPropertyName))
+                                {
+                                    targetFlagsValue = ReadTarget(ref jsonReader, packageSpecPath, targetFlagsValue);
+                                }
+                                else if (jsonReader.ValueTextEquals(VersionPropertyName))
+                                {
+                                    if (jsonReader.Read())
+                                    {
+                                        dependencyVersionValue = jsonReader.GetString();
+                                    }
+                                }
+                                else if (jsonReader.ValueTextEquals(VersionOverridePropertyName))
+                                {
+                                    if (jsonReader.Read())
+                                    {
+                                        var versionPropValue = jsonReader.GetString();
+                                        try
+                                        {
+                                            versionOverride = VersionRange.Parse(versionPropValue);
+                                        }
+                                        catch (Exception ex)
+                                        {
+                                            throw FileFormatException.Create(ex, packageSpecPath);
+                                        }
+                                    }
+                                }
+                                else if (jsonReader.ValueTextEquals(VersionCentrallyManagedPropertyName))
+                                {
+                                    versionCentrallyManaged = jsonReader.ReadNextTokenAsBoolOrFalse();
+                                }
+                                else if (jsonReader.ValueTextEquals(AliasesPropertyName))
+                                {
+                                    aliases = jsonReader.ReadNextTokenAsString();
+                                }
+                                else
+                                {
+                                    jsonReader.Skip();
+                                }
+                            }
+                        }
+
+                        VersionRange dependencyVersionRange = null;
+
+                        if (!string.IsNullOrEmpty(dependencyVersionValue))
+                        {
+                            try
+                            {
+                                dependencyVersionRange = VersionRange.Parse(dependencyVersionValue);
+                            }
+                            catch (Exception ex)
+                            {
+                                throw FileFormatException.Create(
+                                    ex,
+                                    packageSpecPath);
+                            }
+                        }
+
+                        // Projects and References may have empty version ranges, Packages may not
+                        if (dependencyVersionRange == null)
+                        {
+                            if ((targetFlagsValue & LibraryDependencyTarget.Package) == LibraryDependencyTarget.Package)
+                            {
+                                throw FileFormatException.Create(
+                                new ArgumentException(Strings.MissingVersionOnDependency),
+                                packageSpecPath);
+                            }
+                            else
+                            {
+                                // Projects and references with no version property allow all versions
+                                dependencyVersionRange = VersionRange.All;
+                            }
+                        }
+
+                        // the dependency flags are: Include flags - Exclude flags
+                        var includeFlags = dependencyIncludeFlagsValue & ~dependencyExcludeFlagsValue;
+                        var libraryDependency = new LibraryDependency()
+                        {
+                            LibraryRange = new LibraryRange()
+                            {
+                                Name = propertyName,
+                                TypeConstraint = targetFlagsValue,
+                                VersionRange = dependencyVersionRange
+                            },
+                            IncludeType = includeFlags,
+                            SuppressParent = suppressParentFlagsValue,
+                            AutoReferenced = autoReferenced,
+                            GeneratePathProperty = generatePathProperty,
+                            VersionCentrallyManaged = versionCentrallyManaged,
+                            Aliases = aliases,
+                            // The ReferenceType is not persisted to the assets file
+                            // Default to LibraryDependencyReferenceType.Direct on Read
+                            ReferenceType = LibraryDependencyReferenceType.Direct,
+                            VersionOverride = versionOverride
+                        };
+
+                        if (noWarn != null)
+                        {
+                            libraryDependency.NoWarn = noWarn;
+                        }
+
+                        results.Add(libraryDependency);
+                    }
+                }
+            }
+        }
+
+        private static PackageType CreatePackageType(ref Utf8JsonStreamReader jsonReader)
+        {
+            var name = jsonReader.GetString();
+
+            return new PackageType(name, Packaging.Core.PackageType.EmptyVersion);
+        }
+
+        [Obsolete]
+        private static void ReadBuildOptions(ref Utf8JsonStreamReader jsonReader, PackageSpec packageSpec)
+        {
+            packageSpec.BuildOptions = new BuildOptions();
+
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                {
+                    if (jsonReader.ValueTextEquals(OutputNamePropertyName))
+                    {
+                        packageSpec.BuildOptions.OutputName = jsonReader.ReadNextTokenAsString();
+                    }
+                    else
+                    {
+                        jsonReader.Skip();
+                    }
+                }
+            }
+        }
+
+        private static void ReadCentralPackageVersions(
+            ref Utf8JsonStreamReader jsonReader,
+            IDictionary<string, CentralPackageVersion> centralPackageVersions,
+            string filePath)
+        {
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                {
+                    var propertyName = jsonReader.GetString();
+
+                    if (string.IsNullOrEmpty(propertyName))
+                    {
+                        throw FileFormatException.Create("Unable to resolve central version ''.", filePath);
+                    }
+
+                    string version = jsonReader.ReadNextTokenAsString();
+
+                    if (string.IsNullOrEmpty(version))
+                    {
+                        throw FileFormatException.Create("The version cannot be null or empty.", filePath);
+                    }
+
+                    centralPackageVersions[propertyName] = new CentralPackageVersion(propertyName, VersionRange.Parse(version));
+                }
+            }
+        }
+
+        private static CompatibilityProfile ReadCompatibilityProfile(ref Utf8JsonStreamReader jsonReader, string profileName)
+        {
+            List<FrameworkRuntimePair> sets = null;
+
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                {
+                    var propertyName = jsonReader.GetString();
+                    sets ??= [];
+
+                    IReadOnlyList<string> values = jsonReader.ReadNextStringOrArrayOfStringsAsReadOnlyList() ?? Array.Empty<string>();
+
+                    IEnumerable<FrameworkRuntimePair> profiles = ReadCompatibilitySets(values, propertyName);
+
+                    sets.AddRange(profiles);
+                }
+            }
+            return new CompatibilityProfile(profileName, sets ?? Enumerable.Empty<FrameworkRuntimePair>());
+        }
+
+        private static IEnumerable<FrameworkRuntimePair> ReadCompatibilitySets(IReadOnlyList<string> values, string compatibilitySetName)
+        {
+            NuGetFramework framework = NuGetFramework.Parse(compatibilitySetName);
+
+            foreach (string value in values)
+            {
+                yield return new FrameworkRuntimePair(framework, value);
+            }
+        }
+
+        private static void ReadDownloadDependencies(
+            ref Utf8JsonStreamReader jsonReader,
+            IList<DownloadDependency> downloadDependencies,
+            string packageSpecPath)
+        {
+            var seenIds = new HashSet<string>();
+
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartArray)
+            {
+                do
+                {
+                    string name = null;
+                    string versionValue = null;
+                    var isNameDefined = false;
+
+                    if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+                    {
+                        while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                        {
+                            if (jsonReader.ValueTextEquals(NamePropertyName))
+                            {
+                                isNameDefined = true;
+                                name = jsonReader.ReadNextTokenAsString();
+                            }
+                            else if (jsonReader.ValueTextEquals(VersionPropertyName))
+                            {
+                                versionValue = jsonReader.ReadNextTokenAsString();
+                            }
+                            else
+                            {
+                                jsonReader.Skip();
+                            }
+                        }
+                    }
+
+                    if (jsonReader.TokenType == JsonTokenType.EndArray)
+                    {
+                        break;
+                    }
+
+                    if (!isNameDefined)
+                    {
+                        throw FileFormatException.Create(
+                            "Unable to resolve downloadDependency ''.",
+                            packageSpecPath);
+                    }
+
+                    if (!seenIds.Add(name))
+                    {
+                        // package ID already seen, only use first definition.
+                        continue;
+                    }
+
+                    if (string.IsNullOrEmpty(versionValue))
+                    {
+                        throw FileFormatException.Create(
+                            "The version cannot be null or empty",
+                            packageSpecPath);
+                    }
+
+                    string[] versions = versionValue.Split(VersionSeparators, StringSplitOptions.RemoveEmptyEntries);
+
+                    foreach (string singleVersionValue in versions)
+                    {
+                        try
+                        {
+                            VersionRange version = VersionRange.Parse(singleVersionValue);
+
+                            downloadDependencies.Add(new DownloadDependency(name, version));
+                        }
+                        catch (Exception ex)
+                        {
+                            throw FileFormatException.Create(
+                               ex,
+                               packageSpecPath);
+                        }
+                    }
+                } while (jsonReader.TokenType == JsonTokenType.EndObject);
+            }
+        }
+
+        private static void ReadFrameworkReferences(
+            ref Utf8JsonStreamReader jsonReader,
+            ISet<FrameworkDependency> frameworkReferences,
+            string packageSpecPath)
+        {
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                {
+                    var frameworkName = jsonReader.GetString();
+                    if (string.IsNullOrEmpty(frameworkName))
+                    {
+                        throw FileFormatException.Create(
+                            "Unable to resolve frameworkReference.",
+                            packageSpecPath);
+                    }
+
+                    var privateAssets = FrameworkDependencyFlagsUtils.Default;
+
+                    if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+                    {
+                        while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                        {
+                            if (jsonReader.ValueTextEquals(PrivateAssetsPropertyName))
+                            {
+                                IEnumerable<string> strings = jsonReader.ReadDelimitedString();
+
+                                privateAssets = FrameworkDependencyFlagsUtils.GetFlags(strings);
+                            }
+                            else
+                            {
+                                jsonReader.Skip();
+                            }
+                        }
+                    }
+
+                    frameworkReferences.Add(new FrameworkDependency(frameworkName, privateAssets));
+                }
+            }
+        }
+
+        private static void ReadFrameworks(ref Utf8JsonStreamReader reader, PackageSpec packageSpec)
+        {
+            if (reader.Read() && reader.TokenType == JsonTokenType.StartObject)
+            {
+                while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    try
+                    {
+                        ReadTargetFrameworks(packageSpec, ref reader);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw FileFormatException.Create(ex, packageSpec.FilePath);
+                    }
+                }
+            }
+        }
+
+        private static void ReadImports(PackageSpec packageSpec, ref Utf8JsonStreamReader jsonReader, TargetFrameworkInformation targetFrameworkInformation)
+        {
+            IReadOnlyList<string> imports = jsonReader.ReadNextStringOrArrayOfStringsAsReadOnlyList();
+
+            if (imports != null && imports.Count > 0)
+            {
+                foreach (string import in imports.Where(element => !string.IsNullOrEmpty(element)))
+                {
+                    NuGetFramework framework = NuGetFramework.Parse(import);
+
+                    if (!framework.IsSpecificFramework)
+                    {
+                        throw FileFormatException.Create(
+                            string.Format(
+                                CultureInfo.CurrentCulture,
+                                Strings.Log_InvalidImportFramework,
+                                import,
+                                PackageSpec.PackageSpecFileName),
+                            packageSpec.FilePath);
+                    }
+
+                    targetFrameworkInformation.Imports.Add(framework);
+                }
+            }
+        }
+
+        private static void ReadMappings(ref Utf8JsonStreamReader jsonReader, string mappingKey, IDictionary<string, IncludeExcludeFiles> mappings)
+        {
+            if (jsonReader.Read())
+            {
+                switch (jsonReader.TokenType)
+                {
+                    case JsonTokenType.String:
+                        {
+                            var files = new IncludeExcludeFiles()
+                            {
+                                Include = new[] { (string)jsonReader.GetString() }
+                            };
+
+                            mappings.Add(mappingKey, files);
+                        }
+                        break;
+                    case JsonTokenType.StartArray:
+                        {
+                            IReadOnlyList<string> include = jsonReader.ReadStringArrayAsReadOnlyListFromArrayStart();
+
+                            var files = new IncludeExcludeFiles()
+                            {
+                                Include = include
+                            };
+
+                            mappings.Add(mappingKey, files);
+                        }
+                        break;
+                    case JsonTokenType.StartObject:
+                        {
+                            IReadOnlyList<string> excludeFiles = null;
+                            IReadOnlyList<string> exclude = null;
+                            IReadOnlyList<string> includeFiles = null;
+                            IReadOnlyList<string> include = null;
+
+                            while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                            {
+                                if (jsonReader.ValueTextEquals(ExcludeFilesPropertyName))
+                                {
+                                    excludeFiles = jsonReader.ReadNextStringOrArrayOfStringsAsReadOnlyList();
+                                }
+                                else if (jsonReader.ValueTextEquals(ExcludePropertyName))
+                                {
+                                    exclude = jsonReader.ReadNextStringOrArrayOfStringsAsReadOnlyList();
+                                }
+                                else if (jsonReader.ValueTextEquals(IncludeFilesPropertyName))
+                                {
+                                    includeFiles = jsonReader.ReadNextStringOrArrayOfStringsAsReadOnlyList();
+                                }
+                                else if (jsonReader.ValueTextEquals(IncludePropertyName))
+                                {
+                                    include = jsonReader.ReadNextStringOrArrayOfStringsAsReadOnlyList();
+                                }
+                                else
+                                {
+                                    jsonReader.Skip();
+                                }
+                            }
+
+                            if (include != null || includeFiles != null || exclude != null || excludeFiles != null)
+                            {
+                                var files = new IncludeExcludeFiles()
+                                {
+                                    ExcludeFiles = excludeFiles,
+                                    Exclude = exclude,
+                                    IncludeFiles = includeFiles,
+                                    Include = include
+                                };
+
+                                mappings.Add(mappingKey, files);
+                            }
+                        }
+                        break;
+                }
+            }
+        }
+
+        private static void ReadMSBuildMetadata(ref Utf8JsonStreamReader jsonReader, PackageSpec packageSpec)
+        {
+            var centralPackageVersionsManagementEnabled = false;
+            var centralPackageVersionOverrideDisabled = false;
+            var CentralPackageTransitivePinningEnabled = false;
+            List<string> configFilePaths = null;
+            var crossTargeting = false;
+            List<string> fallbackFolders = null;
+            List<ProjectRestoreMetadataFile> files = null;
+            var legacyPackagesDirectory = false;
+            List<string> originalTargetFrameworks = null;
+            string outputPath = null;
+            string packagesConfigPath = null;
+            string packagesPath = null;
+            string projectJsonPath = null;
+            string projectName = null;
+            string projectPath = null;
+            ProjectStyle? projectStyle = null;
+            string projectUniqueName = null;
+            RestoreLockProperties restoreLockProperties = null;
+            var skipContentFileWrite = false;
+            List<PackageSource> sources = null;
+            List<ProjectRestoreMetadataFrameworkInfo> targetFrameworks = null;
+            var validateRuntimeAssets = false;
+            WarningProperties warningProperties = null;
+            RestoreAuditProperties auditProperties = null;
+
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                {
+                    if (jsonReader.ValueTextEquals(CentralPackageVersionsManagementEnabledPropertyName))
+                    {
+                        centralPackageVersionsManagementEnabled = jsonReader.ReadNextTokenAsBoolOrFalse();
+                    }
+                    else if (jsonReader.ValueTextEquals(CentralPackageVersionOverrideDisabledPropertyName))
+                    {
+                        centralPackageVersionOverrideDisabled = jsonReader.ReadNextTokenAsBoolOrFalse();
+                    }
+                    else if (jsonReader.ValueTextEquals(CentralPackageTransitivePinningEnabledPropertyName))
+                    {
+                        CentralPackageTransitivePinningEnabled = jsonReader.ReadNextTokenAsBoolOrFalse();
+                    }
+                    else if (jsonReader.ValueTextEquals(ConfigFilePathsPropertyName))
+                    {
+                        jsonReader.Read();
+                        configFilePaths = jsonReader.ReadStringArrayAsIList() as List<string>;
+                    }
+                    else if (jsonReader.ValueTextEquals(CrossTargetingPropertyName))
+                    {
+                        crossTargeting = jsonReader.ReadNextTokenAsBoolOrFalse();
+                    }
+                    else if (jsonReader.ValueTextEquals(FallbackFoldersPropertyName))
+                    {
+                        jsonReader.Read();
+                        fallbackFolders = jsonReader.ReadStringArrayAsIList() as List<string>;
+                    }
+                    else if (jsonReader.ValueTextEquals(FilesPropertyName))
+                    {
+                        if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+                        {
+                            while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                            {
+                                var filePropertyName = jsonReader.GetString();
+                                files ??= [];
+
+                                files.Add(new ProjectRestoreMetadataFile(filePropertyName, jsonReader.ReadNextTokenAsString()));
+                            }
+                        }
+                    }
+                    else if (jsonReader.ValueTextEquals(FrameworksPropertyName))
+                    {
+                        targetFrameworks = ReadTargetFrameworks(ref jsonReader);
+                    }
+                    else if (jsonReader.ValueTextEquals(LegacyPackagesDirectoryPropertyName))
+                    {
+                        legacyPackagesDirectory = jsonReader.ReadNextTokenAsBoolOrFalse();
+                    }
+                    else if (jsonReader.ValueTextEquals(OriginalTargetFrameworksPropertyName))
+                    {
+                        jsonReader.Read();
+                        originalTargetFrameworks = jsonReader.ReadStringArrayAsIList() as List<string>;
+                    }
+                    else if (jsonReader.ValueTextEquals(OutputPathPropertyName))
+                    {
+                        outputPath = jsonReader.ReadNextTokenAsString();
+                    }
+                    else if (jsonReader.ValueTextEquals(PackagesConfigPathPropertyName))
+                    {
+                        packagesConfigPath = jsonReader.ReadNextTokenAsString();
+                    }
+                    else if (jsonReader.ValueTextEquals(PackagesPathPropertyName))
+                    {
+                        packagesPath = jsonReader.ReadNextTokenAsString();
+                    }
+                    else if (jsonReader.ValueTextEquals(ProjectJsonPathPropertyName))
+                    {
+                        projectJsonPath = jsonReader.ReadNextTokenAsString();
+                    }
+                    else if (jsonReader.ValueTextEquals(ProjectNamePropertyName))
+                    {
+                        projectName = jsonReader.ReadNextTokenAsString();
+                    }
+                    else if (jsonReader.ValueTextEquals(ProjectPathPropertyName))
+                    {
+                        projectPath = jsonReader.ReadNextTokenAsString();
+                    }
+                    else if (jsonReader.ValueTextEquals(ProjectStylePropertyName))
+                    {
+                        string projectStyleString = jsonReader.ReadNextTokenAsString();
+
+                        if (!string.IsNullOrEmpty(projectStyleString)
+                            && Enum.TryParse(projectStyleString, ignoreCase: true, result: out ProjectStyle projectStyleValue))
+                        {
+                            projectStyle = projectStyleValue;
+                        }
+                    }
+                    else if (jsonReader.ValueTextEquals(ProjectUniqueNamePropertyName))
+                    {
+                        projectUniqueName = jsonReader.ReadNextTokenAsString();
+                    }
+                    else if (jsonReader.ValueTextEquals(RestoreLockPropertiesPropertyName))
+                    {
+                        string nuGetLockFilePath = null;
+                        var restoreLockedMode = false;
+                        string restorePackagesWithLockFile = null;
+
+                        if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+                        {
+                            while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                            {
+                                if (jsonReader.ValueTextEquals(NuGetLockFilePathPropertyName))
+                                {
+                                    nuGetLockFilePath = jsonReader.ReadNextTokenAsString();
+                                }
+                                else if (jsonReader.ValueTextEquals(RestoreLockedModePropertyName))
+                                {
+                                    restoreLockedMode = jsonReader.ReadNextTokenAsBoolOrFalse();
+                                }
+                                else if (jsonReader.ValueTextEquals(RestorePackagesWithLockFilePropertyName))
+                                {
+                                    restorePackagesWithLockFile = jsonReader.ReadNextTokenAsString();
+                                }
+                                else
+                                {
+                                    jsonReader.Skip();
+                                }
+                            }
+                        }
+                        restoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile, nuGetLockFilePath, restoreLockedMode);
+                    }
+                    else if (jsonReader.ValueTextEquals(RestoreAuditPropertiesPropertyName))
+                    {
+                        string enableAudit = null, auditLevel = null, auditMode = null;
+                        if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+                        {
+                            while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                            {
+                                if (jsonReader.ValueTextEquals(EnableAuditPropertyName))
+                                {
+                                    enableAudit = jsonReader.ReadNextTokenAsString();
+                                }
+                                else if (jsonReader.ValueTextEquals(AuditLevelPropertyName))
+                                {
+                                    auditLevel = jsonReader.ReadNextTokenAsString();
+                                }
+                                else if (jsonReader.ValueTextEquals(AuditModePropertyName))
+                                {
+                                    auditMode = jsonReader.ReadNextTokenAsString();
+                                }
+                                else
+                                {
+                                    jsonReader.Skip();
+                                }
+                            }
+                        }
+                        auditProperties = new RestoreAuditProperties()
+                        {
+                            EnableAudit = enableAudit,
+                            AuditLevel = auditLevel,
+                            AuditMode = auditMode,
+                        };
+                    }
+                    else if (jsonReader.ValueTextEquals(SkipContentFileWritePropertyName))
+                    {
+                        skipContentFileWrite = jsonReader.ReadNextTokenAsBoolOrFalse();
+                    }
+                    else if (jsonReader.ValueTextEquals(SourcesPropertyName))
+                    {
+                        if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+                        {
+                            while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                            {
+                                var sourcePropertyName = jsonReader.GetString();
+                                sources ??= [];
+
+                                sources.Add(new PackageSource(sourcePropertyName));
+                                jsonReader.Skip();
+                            }
+                        }
+                    }
+                    else if (jsonReader.ValueTextEquals(ValidateRuntimeAssetsPropertyName))
+                    {
+                        validateRuntimeAssets = jsonReader.ReadNextTokenAsBoolOrFalse();
+                    }
+                    else if (jsonReader.ValueTextEquals(WarningPropertiesPropertyName))
+                    {
+                        var allWarningsAsErrors = false;
+                        var noWarn = new HashSet<NuGetLogCode>();
+                        var warnAsError = new HashSet<NuGetLogCode>();
+                        var warningsNotAsErrors = new HashSet<NuGetLogCode>();
+
+                        if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+                        {
+                            while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                            {
+                                if (jsonReader.ValueTextEquals(AllWarningsAsErrorsPropertyName))
+                                {
+                                    allWarningsAsErrors = jsonReader.ReadNextTokenAsBoolOrFalse();
+                                }
+                                else if (jsonReader.ValueTextEquals(NoWarnPropertyName))
+                                {
+                                    ReadNuGetLogCodes(ref jsonReader, noWarn);
+                                }
+                                else if (jsonReader.ValueTextEquals(WarnAsErrorPropertyName))
+                                {
+                                    ReadNuGetLogCodes(ref jsonReader, warnAsError);
+                                }
+                                else if (jsonReader.ValueTextEquals(WarnNotAsErrorPropertyName))
+                                {
+                                    ReadNuGetLogCodes(ref jsonReader, warningsNotAsErrors);
+                                }
+                                else
+                                {
+                                    jsonReader.Skip();
+                                }
+                            }
+                        }
+
+                        warningProperties = new WarningProperties(warnAsError, noWarn, allWarningsAsErrors, warningsNotAsErrors);
+                    }
+                    else
+                    {
+                        jsonReader.Skip();
+                    }
+                }
+            }
+
+            ProjectRestoreMetadata msbuildMetadata;
+            if (projectStyle == ProjectStyle.PackagesConfig)
+            {
+                msbuildMetadata = new PackagesConfigProjectRestoreMetadata()
+                {
+                    PackagesConfigPath = packagesConfigPath
+                };
+            }
+            else
+            {
+                msbuildMetadata = new ProjectRestoreMetadata();
+            }
+
+            msbuildMetadata.CentralPackageVersionsEnabled = centralPackageVersionsManagementEnabled;
+            msbuildMetadata.CentralPackageVersionOverrideDisabled = centralPackageVersionOverrideDisabled;
+            msbuildMetadata.CentralPackageTransitivePinningEnabled = CentralPackageTransitivePinningEnabled;
+            msbuildMetadata.RestoreAuditProperties = auditProperties;
+
+            if (configFilePaths != null)
+            {
+                msbuildMetadata.ConfigFilePaths = configFilePaths;
+            }
+
+            msbuildMetadata.CrossTargeting = crossTargeting;
+
+            if (fallbackFolders != null)
+            {
+                msbuildMetadata.FallbackFolders = fallbackFolders;
+            }
+
+            if (files != null)
+            {
+                msbuildMetadata.Files = files;
+            }
+
+            msbuildMetadata.LegacyPackagesDirectory = legacyPackagesDirectory;
+
+            if (originalTargetFrameworks != null)
+            {
+                msbuildMetadata.OriginalTargetFrameworks = originalTargetFrameworks;
+            }
+
+            msbuildMetadata.OutputPath = outputPath;
+            msbuildMetadata.PackagesPath = packagesPath;
+            msbuildMetadata.ProjectJsonPath = projectJsonPath;
+            msbuildMetadata.ProjectName = projectName;
+            msbuildMetadata.ProjectPath = projectPath;
+
+            if (projectStyle.HasValue)
+            {
+                msbuildMetadata.ProjectStyle = projectStyle.Value;
+            }
+
+            msbuildMetadata.ProjectUniqueName = projectUniqueName;
+
+            if (restoreLockProperties != null)
+            {
+                msbuildMetadata.RestoreLockProperties = restoreLockProperties;
+            }
+
+            msbuildMetadata.SkipContentFileWrite = skipContentFileWrite;
+
+            if (sources != null)
+            {
+                msbuildMetadata.Sources = sources;
+            }
+
+            if (targetFrameworks != null)
+            {
+                msbuildMetadata.TargetFrameworks = targetFrameworks;
+            }
+
+            msbuildMetadata.ValidateRuntimeAssets = validateRuntimeAssets;
+
+            if (warningProperties != null)
+            {
+                msbuildMetadata.ProjectWideWarningProperties = warningProperties;
+            }
+
+            packageSpec.RestoreMetadata = msbuildMetadata;
+        }
+
+        private static void ReadNuGetLogCodes(ref Utf8JsonStreamReader jsonReader, HashSet<NuGetLogCode> hashCodes)
+        {
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartArray)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType != JsonTokenType.EndArray)
+                {
+                    if (jsonReader.TokenType == JsonTokenType.String && Enum.TryParse(jsonReader.GetString(), out NuGetLogCode code))
+                    {
+                        hashCodes.Add(code);
+                    }
+                }
+            }
+        }
+
+        private static List<NuGetLogCode> ReadNuGetLogCodesList(ref Utf8JsonStreamReader jsonReader)
+        {
+            List<NuGetLogCode> items = null;
+
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartArray)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType != JsonTokenType.EndArray)
+                {
+                    if (jsonReader.TokenType == JsonTokenType.String && Enum.TryParse(jsonReader.GetString(), out NuGetLogCode code))
+                    {
+                        items ??= [];
+
+                        items.Add(code);
+                    }
+                }
+            }
+            return items;
+        }
+
+        private static void ReadPackageTypes(PackageSpec packageSpec, ref Utf8JsonStreamReader jsonReader)
+        {
+            IReadOnlyList<PackageType> packageTypes = null;
+            try
+            {
+                if (jsonReader.Read())
+                {
+                    PackageType packageType;
+                    switch (jsonReader.TokenType)
+                    {
+                        case JsonTokenType.String:
+                            packageType = CreatePackageType(ref jsonReader);
+                            packageTypes = new[] { packageType };
+                            break;
+                        case JsonTokenType.StartArray:
+                            var types = new List<PackageType>();
+
+                            while (jsonReader.Read() && jsonReader.TokenType != JsonTokenType.EndArray)
+                            {
+                                if (jsonReader.TokenType != JsonTokenType.String)
+                                {
+                                    throw FileFormatException.Create(
+                                        string.Format(
+                                            CultureInfo.CurrentCulture,
+                                            Strings.InvalidPackageType,
+                                            PackageSpec.PackageSpecFileName),
+                                        packageSpec.FilePath);
+                                }
+
+                                packageType = CreatePackageType(ref jsonReader);
+                                types.Add(packageType);
+                            }
+                            packageTypes = types;
+                            break;
+                        case JsonTokenType.Null:
+                            break;
+                        default:
+                            throw new InvalidCastException();
+                    }
+
+#pragma warning disable CS0612 // Type or member is obsolete
+                    if (packageTypes != null)
+                    {
+                        packageSpec.PackOptions.PackageType = packageTypes;
+                    }
+#pragma warning restore CS0612 // Type or member is obsolete
+                }
+            }
+            catch (Exception)
+            {
+                throw FileFormatException.Create(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.InvalidPackageType,
+                        PackageSpec.PackageSpecFileName),
+                    packageSpec.FilePath);
+            }
+        }
+
+        [Obsolete]
+        private static void ReadPackInclude(ref Utf8JsonStreamReader jsonReader, PackageSpec packageSpec)
+        {
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                {
+                    string propertyName = jsonReader.GetString();
+                    string propertyValue = jsonReader.ReadNextTokenAsString();
+
+                    packageSpec.PackInclude.Add(new KeyValuePair<string, string>(propertyName, propertyValue));
+                }
+            }
+        }
+
+        [Obsolete]
+        private static void ReadPackOptions(ref Utf8JsonStreamReader jsonReader, PackageSpec packageSpec, ref bool isMappingsNull)
+        {
+            var wasMappingsRead = false;
+            bool isPackOptionsValueAnObject = false;
+
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                isPackOptionsValueAnObject = true;
+                while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                {
+                    if (jsonReader.ValueTextEquals(FilesPropertyName))
+                    {
+                        wasMappingsRead = ReadPackOptionsFiles(packageSpec, ref jsonReader, wasMappingsRead);
+                    }
+                    else if (jsonReader.ValueTextEquals(IconUrlPropertyName))
+                    {
+                        packageSpec.IconUrl = jsonReader.ReadNextTokenAsString();
+                    }
+                    else if (jsonReader.ValueTextEquals(LicenseUrlPropertyName))
+                    {
+                        packageSpec.LicenseUrl = jsonReader.ReadNextTokenAsString();
+                    }
+                    else if (jsonReader.ValueTextEquals(OwnersPropertyName))
+                    {
+                        jsonReader.Read();
+                        string[] owners = jsonReader.ReadStringArrayAsIList()?.ToArray();
+                        if (owners != null)
+                        {
+                            packageSpec.Owners = owners;
+                        }
+                    }
+                    else if (jsonReader.ValueTextEquals(PackageTypePropertyName))
+                    {
+                        ReadPackageTypes(packageSpec, ref jsonReader);
+                    }
+                    else if (jsonReader.ValueTextEquals(ProjectUrlPropertyName))
+                    {
+                        packageSpec.ProjectUrl = jsonReader.ReadNextTokenAsString();
+                    }
+                    else if (jsonReader.ValueTextEquals(ReleaseNotesPropertyName))
+                    {
+                        packageSpec.ReleaseNotes = jsonReader.ReadNextTokenAsString();
+                    }
+                    else if (jsonReader.ValueTextEquals(RequireLicenseAcceptancePropertyName))
+                    {
+                        packageSpec.RequireLicenseAcceptance = jsonReader.ReadNextTokenAsBoolOrFalse();
+                    }
+                    else if (jsonReader.ValueTextEquals(SummaryPropertyName))
+                    {
+                        packageSpec.Summary = jsonReader.ReadNextTokenAsString();
+                    }
+                    else if (jsonReader.ValueTextEquals(TagsPropertyName))
+                    {
+                        jsonReader.Read();
+                        string[] tags = jsonReader.ReadStringArrayAsIList()?.ToArray();
+
+                        if (tags != null)
+                        {
+                            packageSpec.Tags = tags;
+                        }
+                    }
+                    else
+                    {
+                        jsonReader.Skip();
+                    }
+                }
+            }
+            isMappingsNull = isPackOptionsValueAnObject && !wasMappingsRead;
+        }
+
+        [Obsolete]
+        private static bool ReadPackOptionsFiles(PackageSpec packageSpec, ref Utf8JsonStreamReader jsonReader, bool wasMappingsRead)
+        {
+            IReadOnlyList<string> excludeFiles = null;
+            IReadOnlyList<string> exclude = null;
+            IReadOnlyList<string> includeFiles = null;
+            IReadOnlyList<string> include = null;
+
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                {
+                    if (jsonReader.ValueTextEquals(ExcludeFilesPropertyName))
+                    {
+                        excludeFiles = jsonReader.ReadNextStringOrArrayOfStringsAsReadOnlyList();
+                    }
+                    else if (jsonReader.ValueTextEquals(ExcludePropertyName))
+                    {
+                        exclude = jsonReader.ReadNextStringOrArrayOfStringsAsReadOnlyList();
+                    }
+                    else if (jsonReader.ValueTextEquals(IncludeFilesPropertyName))
+                    {
+                        includeFiles = jsonReader.ReadNextStringOrArrayOfStringsAsReadOnlyList();
+                    }
+                    else if (jsonReader.ValueTextEquals(IncludePropertyName))
+                    {
+                        include = jsonReader.ReadNextStringOrArrayOfStringsAsReadOnlyList();
+                    }
+                    else if (jsonReader.ValueTextEquals(MappingsPropertyName))
+                    {
+                        if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+                        {
+                            while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                            {
+                                wasMappingsRead = true;
+                                var mappingsPropertyName = jsonReader.GetString();
+                                ReadMappings(ref jsonReader, mappingsPropertyName, packageSpec.PackOptions.Mappings);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        jsonReader.Skip();
+                    }
+                }
+            }
+
+            if (include != null || includeFiles != null || exclude != null || excludeFiles != null)
+            {
+                packageSpec.PackOptions.IncludeExcludeFiles = new IncludeExcludeFiles()
+                {
+                    ExcludeFiles = excludeFiles,
+                    Exclude = exclude,
+                    IncludeFiles = includeFiles,
+                    Include = include
+                };
+            }
+
+            return wasMappingsRead;
+        }
+
+        private static RuntimeDependencySet ReadRuntimeDependencySet(ref Utf8JsonStreamReader jsonReader, string dependencySetName)
+        {
+            List<RuntimePackageDependency> dependencies = null;
+
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                {
+                    var propertyName = jsonReader.GetString();
+                    dependencies ??= [];
+
+                    var dependency = new RuntimePackageDependency(propertyName, VersionRange.Parse(jsonReader.ReadNextTokenAsString()));
+
+                    dependencies.Add(dependency);
+                }
+            }
+
+            return new RuntimeDependencySet(
+                dependencySetName,
+                dependencies);
+        }
+
+        private static RuntimeDescription ReadRuntimeDescription(ref Utf8JsonStreamReader jsonReader, string runtimeName)
+        {
+            List<string> inheritedRuntimes = null;
+            List<RuntimeDependencySet> additionalDependencies = null;
+
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                {
+                    if (jsonReader.ValueTextEquals(HashTagImportPropertyName))
+                    {
+                        jsonReader.Read();
+                        inheritedRuntimes = jsonReader.ReadStringArrayAsIList() as List<string>;
+                    }
+                    else
+                    {
+                        var propertyName = jsonReader.GetString();
+                        additionalDependencies ??= [];
+
+                        RuntimeDependencySet dependency = ReadRuntimeDependencySet(ref jsonReader, propertyName);
+
+                        additionalDependencies.Add(dependency);
+                    }
+                }
+            }
+
+            return new RuntimeDescription(
+                runtimeName,
+                inheritedRuntimes,
+                additionalDependencies);
+        }
+
+        private static List<RuntimeDescription> ReadRuntimes(ref Utf8JsonStreamReader jsonReader)
+        {
+            var runtimeDescriptions = new List<RuntimeDescription>();
+
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                {
+                    RuntimeDescription runtimeDescription = ReadRuntimeDescription(ref jsonReader, jsonReader.GetString());
+
+                    runtimeDescriptions.Add(runtimeDescription);
+                }
+            }
+
+            return runtimeDescriptions;
+        }
+
+        [Obsolete]
+        private static void ReadScripts(ref Utf8JsonStreamReader jsonReader, PackageSpec packageSpec)
+        {
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                {
+                    var propertyName = jsonReader.GetString();
+                    if (jsonReader.Read())
+                    {
+                        if (jsonReader.TokenType == JsonTokenType.String)
+                        {
+                            packageSpec.Scripts[propertyName] = new string[] { (string)jsonReader.GetString() };
+                        }
+                        else if (jsonReader.TokenType == JsonTokenType.StartArray)
+                        {
+                            var list = new List<string>();
+
+                            while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.String)
+                            {
+                                list.Add(jsonReader.GetString());
+                            }
+
+                            packageSpec.Scripts[propertyName] = list;
+                        }
+                        else
+                        {
+                            throw FileFormatException.Create(
+                            string.Format(CultureInfo.CurrentCulture, "The value of a script in '{0}' can only be a string or an array of strings", PackageSpec.PackageSpecFileName),
+                            packageSpec.FilePath);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static List<CompatibilityProfile> ReadSupports(ref Utf8JsonStreamReader jsonReader)
+        {
+            var compatibilityProfiles = new List<CompatibilityProfile>();
+
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                {
+                    var propertyName = jsonReader.GetString();
+                    CompatibilityProfile compatibilityProfile = ReadCompatibilityProfile(ref jsonReader, propertyName);
+
+                    compatibilityProfiles.Add(compatibilityProfile);
+                }
+            }
+            return compatibilityProfiles;
+        }
+
+        private static LibraryDependencyTarget ReadTarget(
+           ref Utf8JsonStreamReader jsonReader,
+           string packageSpecPath,
+           LibraryDependencyTarget targetFlagsValue)
+        {
+            if (jsonReader.Read())
+            {
+                var targetString = jsonReader.GetString();
+
+                targetFlagsValue = LibraryDependencyTargetUtils.Parse(targetString);
+
+                // Verify that the value specified is package, project, or external project
+#pragma warning disable CS0612 // Type or member is obsolete
+                if (!ValidateDependencyTarget(targetFlagsValue))
+                {
+                    string message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.InvalidDependencyTarget,
+                        targetString);
+                    throw FileFormatException.Create(
+                      message,
+                      packageSpecPath);
+                }
+#pragma warning restore CS0612 // Type or member is obsolete
+            }
+
+            return targetFlagsValue;
+        }
+
+        private static List<ProjectRestoreMetadataFrameworkInfo> ReadTargetFrameworks(ref Utf8JsonStreamReader jsonReader)
+        {
+            var targetFrameworks = new List<ProjectRestoreMetadataFrameworkInfo>();
+
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                {
+                    var frameworkPropertyName = jsonReader.GetString();
+                    NuGetFramework framework = NuGetFramework.Parse(frameworkPropertyName);
+                    var frameworkGroup = new ProjectRestoreMetadataFrameworkInfo(framework);
+
+                    if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+                    {
+                        while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                        {
+                            if (jsonReader.ValueTextEquals(ProjectReferencesPropertyName))
+                            {
+                                if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+                                {
+                                    while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                                    {
+                                        var projectReferencePropertyName = jsonReader.GetString();
+                                        string excludeAssets = null;
+                                        string includeAssets = null;
+                                        string privateAssets = null;
+                                        string projectReferenceProjectPath = null;
+
+                                        if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+                                        {
+                                            while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                                            {
+                                                if (jsonReader.ValueTextEquals(ExcludeAssetsPropertyName))
+                                                {
+                                                    excludeAssets = jsonReader.ReadNextTokenAsString();
+                                                }
+                                                else if (jsonReader.ValueTextEquals(IncludeAssetsPropertyName))
+                                                {
+                                                    includeAssets = jsonReader.ReadNextTokenAsString();
+                                                }
+                                                else if (jsonReader.ValueTextEquals(PrivateAssetsPropertyName))
+                                                {
+                                                    privateAssets = jsonReader.ReadNextTokenAsString();
+                                                }
+                                                else if (jsonReader.ValueTextEquals(ProjectPathPropertyName))
+                                                {
+                                                    projectReferenceProjectPath = jsonReader.ReadNextTokenAsString();
+                                                }
+                                                else
+                                                {
+                                                    jsonReader.Skip();
+                                                }
+
+                                            }
+                                        }
+
+                                        frameworkGroup.ProjectReferences.Add(new ProjectRestoreReference()
+                                        {
+                                            ProjectUniqueName = projectReferencePropertyName,
+                                            ProjectPath = projectReferenceProjectPath,
+
+                                            IncludeAssets = LibraryIncludeFlagUtils.GetFlags(
+                                                flags: includeAssets,
+                                                defaultFlags: LibraryIncludeFlags.All),
+
+                                            ExcludeAssets = LibraryIncludeFlagUtils.GetFlags(
+                                                flags: excludeAssets,
+                                                defaultFlags: LibraryIncludeFlags.None),
+
+                                            PrivateAssets = LibraryIncludeFlagUtils.GetFlags(
+                                                flags: privateAssets,
+                                                defaultFlags: LibraryIncludeFlagUtils.DefaultSuppressParent),
+                                        });
+                                    }
+                                }
+                            }
+                            else if (jsonReader.ValueTextEquals(TargetAliasPropertyName))
+                            {
+                                frameworkGroup.TargetAlias = jsonReader.ReadNextTokenAsString();
+                            }
+                            else
+                            {
+                                jsonReader.Skip();
+                            }
+                        }
+
+                        targetFrameworks.Add(frameworkGroup);
+                    }
+                }
+            }
+            return targetFrameworks;
+        }
+
+        private static void ReadTargetFrameworks(PackageSpec packageSpec, ref Utf8JsonStreamReader jsonReader)
+        {
+            var frameworkName = NuGetFramework.Parse(jsonReader.GetString());
+
+            var targetFrameworkInformation = new TargetFrameworkInformation();
+            NuGetFramework secondaryFramework = default;
+
+            if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
+            {
+                while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
+                {
+                    if (jsonReader.ValueTextEquals(AssetTargetFallbackPropertyName))
+                    {
+                        targetFrameworkInformation.AssetTargetFallback = jsonReader.ReadNextTokenAsBoolOrFalse();
+                    }
+                    else if (jsonReader.ValueTextEquals(SecondaryFrameworkPropertyName))
+                    {
+                        var secondaryFrameworkString = jsonReader.ReadNextTokenAsString();
+                        if (!string.IsNullOrEmpty(secondaryFrameworkString))
+                        {
+                            secondaryFramework = NuGetFramework.Parse(secondaryFrameworkString);
+                        }
+                    }
+                    else if (jsonReader.ValueTextEquals(CentralPackageVersionsPropertyName))
+                    {
+                        ReadCentralPackageVersions(
+                            ref jsonReader,
+                            targetFrameworkInformation.CentralPackageVersions,
+                            packageSpec.FilePath);
+                    }
+                    else if (jsonReader.ValueTextEquals(DependenciesPropertyName))
+                    {
+                        ReadDependencies(
+                            ref jsonReader,
+                            targetFrameworkInformation.Dependencies,
+                            packageSpec.FilePath,
+                            isGacOrFrameworkReference: false);
+                    }
+                    else if (jsonReader.ValueTextEquals(DownloadDependenciesPropertyName))
+                    {
+                        ReadDownloadDependencies(
+                            ref jsonReader,
+                            targetFrameworkInformation.DownloadDependencies,
+                            packageSpec.FilePath);
+                    }
+                    else if (jsonReader.ValueTextEquals(FrameworkAssembliesPropertyName))
+                    {
+                        ReadDependencies(
+                            ref jsonReader,
+                            targetFrameworkInformation.Dependencies,
+                            packageSpec.FilePath,
+                            isGacOrFrameworkReference: true);
+                    }
+                    else if (jsonReader.ValueTextEquals(FrameworkReferencesPropertyName))
+                    {
+                        ReadFrameworkReferences(
+                            ref jsonReader,
+                            targetFrameworkInformation.FrameworkReferences,
+                            packageSpec.FilePath);
+                    }
+                    else if (jsonReader.ValueTextEquals(ImportsPropertyName))
+                    {
+                        ReadImports(packageSpec, ref jsonReader, targetFrameworkInformation);
+                    }
+                    else if (jsonReader.ValueTextEquals(RuntimeIdentifierGraphPathPropertyName))
+                    {
+                        targetFrameworkInformation.RuntimeIdentifierGraphPath = jsonReader.ReadNextTokenAsString();
+                    }
+                    else if (jsonReader.ValueTextEquals(TargetAliasPropertyName))
+                    {
+                        targetFrameworkInformation.TargetAlias = jsonReader.ReadNextTokenAsString();
+                    }
+                    else if (jsonReader.ValueTextEquals(WarnPropertyName))
+                    {
+                        targetFrameworkInformation.Warn = jsonReader.ReadNextTokenAsBoolOrFalse();
+                    }
+                    else
+                    {
+                        jsonReader.Skip();
+                    }
+                }
+            }
+
+#pragma warning disable CS0612 // Type or member is obsolete
+            AddTargetFramework(packageSpec, frameworkName, secondaryFramework, targetFrameworkInformation);
+#pragma warning restore CS0612 // Type or member is obsolete
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -19,11 +19,10 @@ using NuGet.Versioning;
 
 namespace NuGet.ProjectModel
 {
-    public static class JsonPackageSpecReader
+    public static partial class JsonPackageSpecReader
     {
         private static readonly char[] DelimitedStringSeparators = { ' ', ',' };
         private static readonly char[] VersionSeparators = new[] { ';' };
-
         public static readonly string RestoreOptions = "restore";
         public static readonly string RestoreSettings = "restoreSettings";
         public static readonly string HideWarningsAndErrors = "hideWarningsAndErrors";
@@ -49,19 +48,15 @@ namespace NuGet.ProjectModel
             }
         }
 
+        public static PackageSpec GetPackageSpec(Stream stream, string name, string packageSpecPath, string snapshotValue)
+        {
+            return GetPackageSpec(stream, name, packageSpecPath, snapshotValue, EnvironmentVariableWrapper.Instance);
+        }
+
         [Obsolete("This method is obsolete and will be removed in a future release.")]
         public static PackageSpec GetPackageSpec(JObject json)
         {
             return GetPackageSpec(json, name: null, packageSpecPath: null, snapshotValue: null);
-        }
-
-        public static PackageSpec GetPackageSpec(Stream stream, string name, string packageSpecPath, string snapshotValue)
-        {
-            using (var streamReader = new StreamReader(stream))
-            using (var jsonReader = new JsonTextReader(streamReader))
-            {
-                return GetPackageSpec(jsonReader, name, packageSpecPath, EnvironmentVariableWrapper.Instance, snapshotValue);
-            }
         }
 
         [Obsolete("This method is obsolete and will be removed in a future release.")]
@@ -70,11 +65,37 @@ namespace NuGet.ProjectModel
             using (var stringReader = new StringReader(rawPackageSpec.ToString()))
             using (var jsonReader = new JsonTextReader(stringReader))
             {
-                return GetPackageSpec(jsonReader, name, packageSpecPath, EnvironmentVariableWrapper.Instance, snapshotValue);
+                return GetPackageSpec(jsonReader, name, packageSpecPath, snapshotValue, EnvironmentVariableWrapper.Instance);
             }
         }
 
-        internal static PackageSpec GetPackageSpec(JsonTextReader jsonReader, string name, string packageSpecPath, IEnvironmentVariableReader environmentVariableReader, string snapshotValue = null)
+        [Obsolete]
+        internal static PackageSpec GetPackageSpec(JsonTextReader jsonReader, string packageSpecPath)
+        {
+            return GetPackageSpec(jsonReader, name: null, packageSpecPath, snapshotValue: null, EnvironmentVariableWrapper.Instance);
+        }
+
+        internal static PackageSpec GetPackageSpec(Stream stream, string name, string packageSpecPath, string snapshotValue, IEnvironmentVariableReader environmentVariableReader)
+        {
+            var useNj = environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING");
+            if (string.IsNullOrEmpty(useNj) || useNj.Equals("false", StringComparison.OrdinalIgnoreCase))
+            {
+                return GetPackageSpecUtf8JsonStreamReader(stream, name, packageSpecPath, snapshotValue);
+            }
+            else
+            {
+                using (var textReader = new StreamReader(stream))
+                using (var jsonReader = new JsonTextReader(textReader))
+                {
+#pragma warning disable CS0612 // Type or member is obsolete
+                    return GetPackageSpec(jsonReader, name, packageSpecPath, snapshotValue, environmentVariableReader);
+#pragma warning restore CS0612 // Type or member is obsolete
+                }
+            }
+        }
+
+        [Obsolete]
+        internal static PackageSpec GetPackageSpec(JsonTextReader jsonReader, string name, string packageSpecPath, string snapshotValue, IEnvironmentVariableReader environmentVariableReader)
         {
             var packageSpec = new PackageSpec();
 
@@ -232,6 +253,7 @@ namespace NuGet.ProjectModel
             return packageSpec;
         }
 
+        [Obsolete]
         private static PackageType CreatePackageType(JsonTextReader jsonReader)
         {
             var name = (string)jsonReader.Value;
@@ -253,6 +275,7 @@ namespace NuGet.ProjectModel
             });
         }
 
+        [Obsolete]
         private static void ReadCentralPackageVersions(
             JsonTextReader jsonReader,
             IDictionary<string, CentralPackageVersion> centralPackageVersions,
@@ -287,6 +310,7 @@ namespace NuGet.ProjectModel
             });
         }
 
+        [Obsolete]
         private static CompatibilityProfile ReadCompatibilityProfile(JsonTextReader jsonReader, string profileName)
         {
             List<FrameworkRuntimePair> sets = null;
@@ -303,6 +327,7 @@ namespace NuGet.ProjectModel
             return new CompatibilityProfile(profileName, sets ?? Enumerable.Empty<FrameworkRuntimePair>());
         }
 
+        [Obsolete]
         private static IEnumerable<FrameworkRuntimePair> ReadCompatibilitySets(JsonTextReader jsonReader, string compatibilitySetName)
         {
             NuGetFramework framework = NuGetFramework.Parse(compatibilitySetName);
@@ -315,7 +340,8 @@ namespace NuGet.ProjectModel
             }
         }
 
-        internal static void ReadDependencies(
+        [Obsolete]
+        private static void ReadDependencies(
             JsonTextReader jsonReader,
             IList<LibraryDependency> results,
             string packageSpecPath,
@@ -514,6 +540,7 @@ namespace NuGet.ProjectModel
             });
         }
 
+        [Obsolete]
         internal static void ReadCentralTransitiveDependencyGroup(
             JsonTextReader jsonReader,
             IList<LibraryDependency> results,
@@ -636,6 +663,7 @@ namespace NuGet.ProjectModel
             });
         }
 
+        [Obsolete]
         private static void ReadDownloadDependencies(
             JsonTextReader jsonReader,
             IList<DownloadDependency> downloadDependencies,
@@ -726,6 +754,7 @@ namespace NuGet.ProjectModel
             }
         }
 
+        [Obsolete]
         private static IReadOnlyList<string> ReadEnumerableOfString(JsonTextReader jsonReader)
         {
             string value = jsonReader.ReadNextTokenAsString();
@@ -733,6 +762,7 @@ namespace NuGet.ProjectModel
             return value.Split(DelimitedStringSeparators, StringSplitOptions.RemoveEmptyEntries);
         }
 
+        [Obsolete]
         private static void ReadFrameworkReferences(
             JsonTextReader jsonReader,
             ISet<FrameworkDependency> frameworkReferences,
@@ -768,6 +798,7 @@ namespace NuGet.ProjectModel
             });
         }
 
+        [Obsolete]
         private static void ReadFrameworks(JsonTextReader jsonReader, PackageSpec packageSpec)
         {
             jsonReader.ReadObject(_ =>
@@ -786,6 +817,7 @@ namespace NuGet.ProjectModel
             });
         }
 
+        [Obsolete]
         private static void ReadImports(PackageSpec packageSpec, JsonTextReader jsonReader, TargetFrameworkInformation targetFrameworkInformation)
         {
             int lineNumber = jsonReader.LineNumber;
@@ -817,6 +849,7 @@ namespace NuGet.ProjectModel
             }
         }
 
+        [Obsolete]
         private static void ReadMappings(JsonTextReader jsonReader, string mappingKey, IDictionary<string, IncludeExcludeFiles> mappings)
         {
             if (jsonReader.ReadNextToken())
@@ -894,6 +927,7 @@ namespace NuGet.ProjectModel
             }
         }
 
+        [Obsolete]
         private static void ReadMSBuildMetadata(JsonTextReader jsonReader, PackageSpec packageSpec, IEnvironmentVariableReader environmentVariableReader)
         {
             var centralPackageVersionsManagementEnabled = false;
@@ -1238,6 +1272,7 @@ namespace NuGet.ProjectModel
             return false;
         }
 
+        [Obsolete]
         private static void ReadNuGetLogCodes(JsonTextReader jsonReader, HashSet<NuGetLogCode> hashCodes)
         {
             if (jsonReader.ReadNextToken() && jsonReader.TokenType == JsonToken.StartArray)
@@ -1252,6 +1287,7 @@ namespace NuGet.ProjectModel
             }
         }
 
+        [Obsolete]
         private static List<NuGetLogCode> ReadNuGetLogCodesList(JsonTextReader jsonReader)
         {
             List<NuGetLogCode> items = null;
@@ -1272,6 +1308,7 @@ namespace NuGet.ProjectModel
             return items;
         }
 
+        [Obsolete]
         private static void ReadPackageTypes(PackageSpec packageSpec, JsonTextReader jsonReader)
         {
             var errorLine = 0;
@@ -1476,7 +1513,8 @@ namespace NuGet.ProjectModel
             return wasMappingsRead;
         }
 
-        private static RuntimeDependencySet ReadRuntimeDependencySet(JsonTextReader jsonReader, string dependencySetName)
+        [Obsolete]
+        static RuntimeDependencySet ReadRuntimeDependencySet(JsonTextReader jsonReader, string dependencySetName)
         {
             List<RuntimePackageDependency> dependencies = null;
 
@@ -1494,6 +1532,7 @@ namespace NuGet.ProjectModel
                 dependencies);
         }
 
+        [Obsolete]
         private static RuntimeDescription ReadRuntimeDescription(JsonTextReader jsonReader, string runtimeName)
         {
             List<string> inheritedRuntimes = null;
@@ -1521,6 +1560,7 @@ namespace NuGet.ProjectModel
                 additionalDependencies);
         }
 
+        [Obsolete]
         private static List<RuntimeDescription> ReadRuntimes(JsonTextReader jsonReader)
         {
             var runtimeDescriptions = new List<RuntimeDescription>();
@@ -1569,6 +1609,7 @@ namespace NuGet.ProjectModel
             });
         }
 
+        [Obsolete]
         private static string[] ReadStringArray(JsonTextReader jsonReader)
         {
             List<string> list = jsonReader.ReadStringArrayAsList();
@@ -1576,6 +1617,7 @@ namespace NuGet.ProjectModel
             return list?.ToArray();
         }
 
+        [Obsolete]
         private static List<CompatibilityProfile> ReadSupports(JsonTextReader jsonReader)
         {
             var compatibilityProfiles = new List<CompatibilityProfile>();
@@ -1590,6 +1632,7 @@ namespace NuGet.ProjectModel
             return compatibilityProfiles;
         }
 
+        [Obsolete]
         private static LibraryDependencyTarget ReadTarget(
             JsonTextReader jsonReader,
             string packageSpecPath,
@@ -1620,6 +1663,7 @@ namespace NuGet.ProjectModel
             return targetFlagsValue;
         }
 
+        [Obsolete]
         private static List<ProjectRestoreMetadataFrameworkInfo> ReadTargetFrameworks(JsonTextReader jsonReader)
         {
             var targetFrameworks = new List<ProjectRestoreMetadataFrameworkInfo>();
@@ -1693,6 +1737,7 @@ namespace NuGet.ProjectModel
             return targetFrameworks;
         }
 
+        [Obsolete]
         private static void ReadTargetFrameworks(PackageSpec packageSpec, JsonTextReader jsonReader, out int frameworkLine, out int frameworkColumn)
         {
             frameworkLine = 0;
@@ -1773,6 +1818,12 @@ namespace NuGet.ProjectModel
                 }
             }, out frameworkLine, out frameworkColumn);
 
+            AddTargetFramework(packageSpec, frameworkName, secondaryFramework, targetFrameworkInformation);
+        }
+
+        [Obsolete]
+        private static void AddTargetFramework(PackageSpec packageSpec, NuGetFramework frameworkName, NuGetFramework secondaryFramework, TargetFrameworkInformation targetFrameworkInformation)
+        {
             NuGetFramework updatedFramework = frameworkName;
 
             if (targetFrameworkInformation.Imports.Count > 0)
@@ -1798,6 +1849,8 @@ namespace NuGet.ProjectModel
             packageSpec.TargetFrameworks.Add(targetFrameworkInformation);
         }
 
+
+        [Obsolete]
         private static NuGetFramework GetDualCompatibilityFrameworkIfNeeded(NuGetFramework frameworkName, NuGetFramework secondaryFramework)
         {
             if (secondaryFramework != default)
@@ -1808,6 +1861,7 @@ namespace NuGet.ProjectModel
             return frameworkName;
         }
 
+        [Obsolete]
         private static bool ValidateDependencyTarget(LibraryDependencyTarget targetValue)
         {
             var isValid = false;

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -23,6 +23,7 @@ namespace NuGet.ProjectModel
     {
         private static readonly char[] DelimitedStringSeparators = { ' ', ',' };
         private static readonly char[] VersionSeparators = new[] { ';' };
+        private const char VersionSeparator = ';';
         public static readonly string RestoreOptions = "restore";
         public static readonly string RestoreSettings = "restoreSettings";
         public static readonly string HideWarningsAndErrors = "hideWarningsAndErrors";
@@ -75,10 +76,9 @@ namespace NuGet.ProjectModel
             return GetPackageSpec(jsonReader, name: null, packageSpecPath, snapshotValue: null, EnvironmentVariableWrapper.Instance);
         }
 
-        internal static PackageSpec GetPackageSpec(Stream stream, string name, string packageSpecPath, string snapshotValue, IEnvironmentVariableReader environmentVariableReader)
+        internal static PackageSpec GetPackageSpec(Stream stream, string name, string packageSpecPath, string snapshotValue, IEnvironmentVariableReader environmentVariableReader, bool bypassCache = false)
         {
-            var useNj = environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING");
-            if (string.IsNullOrEmpty(useNj) || useNj.Equals("false", StringComparison.OrdinalIgnoreCase))
+            if (!JsonUtility.UseNewtonsoftJsonForParsing(environmentVariableReader, bypassCache))
             {
                 return GetPackageSpecUtf8JsonStreamReader(stream, name, packageSpecPath, snapshotValue);
             }

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -80,7 +80,7 @@ namespace NuGet.ProjectModel
         {
             if (!JsonUtility.UseNewtonsoftJsonForParsing(environmentVariableReader, bypassCache))
             {
-                return GetPackageSpecUtf8JsonStreamReader(stream, name, packageSpecPath, snapshotValue);
+                return GetPackageSpecUtf8JsonStreamReader(stream, name, packageSpecPath, environmentVariableReader, snapshotValue);
             }
             else
             {

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -66,14 +66,14 @@ namespace NuGet.ProjectModel
             using (var stringReader = new StringReader(rawPackageSpec.ToString()))
             using (var jsonReader = new JsonTextReader(stringReader))
             {
-                return GetPackageSpec(jsonReader, name, packageSpecPath, snapshotValue, EnvironmentVariableWrapper.Instance);
+                return GetPackageSpec(jsonReader, name, packageSpecPath, EnvironmentVariableWrapper.Instance, snapshotValue);
             }
         }
 
         [Obsolete]
         internal static PackageSpec GetPackageSpec(JsonTextReader jsonReader, string packageSpecPath)
         {
-            return GetPackageSpec(jsonReader, name: null, packageSpecPath, snapshotValue: null, EnvironmentVariableWrapper.Instance);
+            return GetPackageSpec(jsonReader, name: null, packageSpecPath, EnvironmentVariableWrapper.Instance);
         }
 
         internal static PackageSpec GetPackageSpec(Stream stream, string name, string packageSpecPath, string snapshotValue, IEnvironmentVariableReader environmentVariableReader, bool bypassCache = false)
@@ -88,14 +88,14 @@ namespace NuGet.ProjectModel
                 using (var jsonReader = new JsonTextReader(textReader))
                 {
 #pragma warning disable CS0612 // Type or member is obsolete
-                    return GetPackageSpec(jsonReader, name, packageSpecPath, snapshotValue, environmentVariableReader);
+                    return GetPackageSpec(jsonReader, name, packageSpecPath, environmentVariableReader, snapshotValue);
 #pragma warning restore CS0612 // Type or member is obsolete
                 }
             }
         }
 
         [Obsolete]
-        internal static PackageSpec GetPackageSpec(JsonTextReader jsonReader, string name, string packageSpecPath, string snapshotValue, IEnvironmentVariableReader environmentVariableReader)
+        internal static PackageSpec GetPackageSpec(JsonTextReader jsonReader, string name, string packageSpecPath, IEnvironmentVariableReader environmentVariableReader, string snapshotValue = null)
         {
             var packageSpec = new PackageSpec();
 

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -19,11 +19,10 @@ using NuGet.Versioning;
 
 namespace NuGet.ProjectModel
 {
-    public static class JsonPackageSpecReader
+    public static partial class JsonPackageSpecReader
     {
         private static readonly char[] DelimitedStringSeparators = { ' ', ',' };
         private static readonly char[] VersionSeparators = new[] { ';' };
-
         public static readonly string RestoreOptions = "restore";
         public static readonly string RestoreSettings = "restoreSettings";
         public static readonly string HideWarningsAndErrors = "hideWarningsAndErrors";
@@ -49,19 +48,15 @@ namespace NuGet.ProjectModel
             }
         }
 
+        public static PackageSpec GetPackageSpec(Stream stream, string name, string packageSpecPath, string snapshotValue)
+        {
+            return GetPackageSpec(stream, name, packageSpecPath, snapshotValue, EnvironmentVariableWrapper.Instance);
+        }
+
         [Obsolete("This method is obsolete and will be removed in a future release.")]
         public static PackageSpec GetPackageSpec(JObject json)
         {
             return GetPackageSpec(json, name: null, packageSpecPath: null, snapshotValue: null);
-        }
-
-        public static PackageSpec GetPackageSpec(Stream stream, string name, string packageSpecPath, string snapshotValue)
-        {
-            using (var streamReader = new StreamReader(stream))
-            using (var jsonReader = new JsonTextReader(streamReader))
-            {
-                return GetPackageSpec(jsonReader, name, packageSpecPath, EnvironmentVariableWrapper.Instance, snapshotValue);
-            }
         }
 
         [Obsolete("This method is obsolete and will be removed in a future release.")]
@@ -70,11 +65,37 @@ namespace NuGet.ProjectModel
             using (var stringReader = new StringReader(rawPackageSpec.ToString()))
             using (var jsonReader = new JsonTextReader(stringReader))
             {
-                return GetPackageSpec(jsonReader, name, packageSpecPath, EnvironmentVariableWrapper.Instance, snapshotValue);
+                return GetPackageSpec(jsonReader, name, packageSpecPath, snapshotValue, EnvironmentVariableWrapper.Instance);
             }
         }
 
-        internal static PackageSpec GetPackageSpec(JsonTextReader jsonReader, string name, string packageSpecPath, IEnvironmentVariableReader environmentVariableReader, string snapshotValue = null)
+        [Obsolete]
+        internal static PackageSpec GetPackageSpec(JsonTextReader jsonReader, string packageSpecPath)
+        {
+            return GetPackageSpec(jsonReader, name: null, packageSpecPath, snapshotValue: null, EnvironmentVariableWrapper.Instance);
+        }
+
+        internal static PackageSpec GetPackageSpec(Stream stream, string name, string packageSpecPath, string snapshotValue, IEnvironmentVariableReader environmentVariableReader)
+        {
+            var useNj = environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING");
+            if (string.IsNullOrEmpty(useNj) || useNj.Equals("false", StringComparison.OrdinalIgnoreCase))
+            {
+                return GetPackageSpecUtf8JsonStreamReader(stream, name, packageSpecPath, snapshotValue);
+            }
+            else
+            {
+                using (var textReader = new StreamReader(stream))
+                using (var jsonReader = new JsonTextReader(textReader))
+                {
+#pragma warning disable CS0612 // Type or member is obsolete
+                    return GetPackageSpec(jsonReader, name, packageSpecPath, snapshotValue, environmentVariableReader);
+#pragma warning restore CS0612 // Type or member is obsolete
+                }
+            }
+        }
+
+        [Obsolete]
+        internal static PackageSpec GetPackageSpec(JsonTextReader jsonReader, string name, string packageSpecPath, string snapshotValue, IEnvironmentVariableReader environmentVariableReader)
         {
             var packageSpec = new PackageSpec();
 
@@ -232,6 +253,7 @@ namespace NuGet.ProjectModel
             return packageSpec;
         }
 
+        [Obsolete]
         private static PackageType CreatePackageType(JsonTextReader jsonReader)
         {
             var name = (string)jsonReader.Value;
@@ -253,6 +275,7 @@ namespace NuGet.ProjectModel
             });
         }
 
+        [Obsolete]
         private static void ReadCentralPackageVersions(
             JsonTextReader jsonReader,
             IDictionary<string, CentralPackageVersion> centralPackageVersions,
@@ -287,6 +310,7 @@ namespace NuGet.ProjectModel
             });
         }
 
+        [Obsolete]
         private static CompatibilityProfile ReadCompatibilityProfile(JsonTextReader jsonReader, string profileName)
         {
             List<FrameworkRuntimePair> sets = null;
@@ -303,6 +327,7 @@ namespace NuGet.ProjectModel
             return new CompatibilityProfile(profileName, sets ?? Enumerable.Empty<FrameworkRuntimePair>());
         }
 
+        [Obsolete]
         private static IEnumerable<FrameworkRuntimePair> ReadCompatibilitySets(JsonTextReader jsonReader, string compatibilitySetName)
         {
             NuGetFramework framework = NuGetFramework.Parse(compatibilitySetName);
@@ -315,7 +340,8 @@ namespace NuGet.ProjectModel
             }
         }
 
-        internal static void ReadDependencies(
+        [Obsolete]
+        private static void ReadDependencies(
             JsonTextReader jsonReader,
             IList<LibraryDependency> results,
             string packageSpecPath,
@@ -509,6 +535,7 @@ namespace NuGet.ProjectModel
             });
         }
 
+        [Obsolete]
         internal static void ReadCentralTransitiveDependencyGroup(
             JsonTextReader jsonReader,
             IList<LibraryDependency> results,
@@ -631,6 +658,7 @@ namespace NuGet.ProjectModel
             });
         }
 
+        [Obsolete]
         private static void ReadDownloadDependencies(
             JsonTextReader jsonReader,
             IList<DownloadDependency> downloadDependencies,
@@ -721,6 +749,7 @@ namespace NuGet.ProjectModel
             }
         }
 
+        [Obsolete]
         private static IReadOnlyList<string> ReadEnumerableOfString(JsonTextReader jsonReader)
         {
             string value = jsonReader.ReadNextTokenAsString();
@@ -728,6 +757,7 @@ namespace NuGet.ProjectModel
             return value.Split(DelimitedStringSeparators, StringSplitOptions.RemoveEmptyEntries);
         }
 
+        [Obsolete]
         private static void ReadFrameworkReferences(
             JsonTextReader jsonReader,
             ISet<FrameworkDependency> frameworkReferences,
@@ -763,6 +793,7 @@ namespace NuGet.ProjectModel
             });
         }
 
+        [Obsolete]
         private static void ReadFrameworks(JsonTextReader jsonReader, PackageSpec packageSpec)
         {
             jsonReader.ReadObject(_ =>
@@ -781,6 +812,7 @@ namespace NuGet.ProjectModel
             });
         }
 
+        [Obsolete]
         private static void ReadImports(PackageSpec packageSpec, JsonTextReader jsonReader, TargetFrameworkInformation targetFrameworkInformation)
         {
             int lineNumber = jsonReader.LineNumber;
@@ -812,6 +844,7 @@ namespace NuGet.ProjectModel
             }
         }
 
+        [Obsolete]
         private static void ReadMappings(JsonTextReader jsonReader, string mappingKey, IDictionary<string, IncludeExcludeFiles> mappings)
         {
             if (jsonReader.ReadNextToken())
@@ -889,6 +922,7 @@ namespace NuGet.ProjectModel
             }
         }
 
+        [Obsolete]
         private static void ReadMSBuildMetadata(JsonTextReader jsonReader, PackageSpec packageSpec, IEnvironmentVariableReader environmentVariableReader)
         {
             var centralPackageVersionsManagementEnabled = false;
@@ -1233,6 +1267,7 @@ namespace NuGet.ProjectModel
             return false;
         }
 
+        [Obsolete]
         private static void ReadNuGetLogCodes(JsonTextReader jsonReader, HashSet<NuGetLogCode> hashCodes)
         {
             if (jsonReader.ReadNextToken() && jsonReader.TokenType == JsonToken.StartArray)
@@ -1267,6 +1302,7 @@ namespace NuGet.ProjectModel
             return items ?? Array.Empty<NuGetLogCode>();
         }
 
+        [Obsolete]
         private static void ReadPackageTypes(PackageSpec packageSpec, JsonTextReader jsonReader)
         {
             var errorLine = 0;
@@ -1471,7 +1507,8 @@ namespace NuGet.ProjectModel
             return wasMappingsRead;
         }
 
-        private static RuntimeDependencySet ReadRuntimeDependencySet(JsonTextReader jsonReader, string dependencySetName)
+        [Obsolete]
+        static RuntimeDependencySet ReadRuntimeDependencySet(JsonTextReader jsonReader, string dependencySetName)
         {
             List<RuntimePackageDependency> dependencies = null;
 
@@ -1489,6 +1526,7 @@ namespace NuGet.ProjectModel
                 dependencies);
         }
 
+        [Obsolete]
         private static RuntimeDescription ReadRuntimeDescription(JsonTextReader jsonReader, string runtimeName)
         {
             List<string> inheritedRuntimes = null;
@@ -1516,6 +1554,7 @@ namespace NuGet.ProjectModel
                 additionalDependencies);
         }
 
+        [Obsolete]
         private static List<RuntimeDescription> ReadRuntimes(JsonTextReader jsonReader)
         {
             var runtimeDescriptions = new List<RuntimeDescription>();
@@ -1564,6 +1603,7 @@ namespace NuGet.ProjectModel
             });
         }
 
+        [Obsolete]
         private static string[] ReadStringArray(JsonTextReader jsonReader)
         {
             List<string> list = jsonReader.ReadStringArrayAsList();
@@ -1571,6 +1611,7 @@ namespace NuGet.ProjectModel
             return list?.ToArray();
         }
 
+        [Obsolete]
         private static List<CompatibilityProfile> ReadSupports(JsonTextReader jsonReader)
         {
             var compatibilityProfiles = new List<CompatibilityProfile>();
@@ -1585,6 +1626,7 @@ namespace NuGet.ProjectModel
             return compatibilityProfiles;
         }
 
+        [Obsolete]
         private static LibraryDependencyTarget ReadTarget(
             JsonTextReader jsonReader,
             string packageSpecPath,
@@ -1615,6 +1657,7 @@ namespace NuGet.ProjectModel
             return targetFlagsValue;
         }
 
+        [Obsolete]
         private static List<ProjectRestoreMetadataFrameworkInfo> ReadTargetFrameworks(JsonTextReader jsonReader)
         {
             var targetFrameworks = new List<ProjectRestoreMetadataFrameworkInfo>();
@@ -1688,6 +1731,7 @@ namespace NuGet.ProjectModel
             return targetFrameworks;
         }
 
+        [Obsolete]
         private static void ReadTargetFrameworks(PackageSpec packageSpec, JsonTextReader jsonReader, out int frameworkLine, out int frameworkColumn)
         {
             frameworkLine = 0;
@@ -1768,6 +1812,12 @@ namespace NuGet.ProjectModel
                 }
             }, out frameworkLine, out frameworkColumn);
 
+            AddTargetFramework(packageSpec, frameworkName, secondaryFramework, targetFrameworkInformation);
+        }
+
+        [Obsolete]
+        private static void AddTargetFramework(PackageSpec packageSpec, NuGetFramework frameworkName, NuGetFramework secondaryFramework, TargetFrameworkInformation targetFrameworkInformation)
+        {
             NuGetFramework updatedFramework = frameworkName;
 
             if (targetFrameworkInformation.Imports.Count > 0)
@@ -1793,6 +1843,8 @@ namespace NuGet.ProjectModel
             packageSpec.TargetFrameworks.Add(targetFrameworkInformation);
         }
 
+
+        [Obsolete]
         private static NuGetFramework GetDualCompatibilityFrameworkIfNeeded(NuGetFramework frameworkName, NuGetFramework secondaryFramework)
         {
             if (secondaryFramework != default)
@@ -1803,6 +1855,7 @@ namespace NuGet.ProjectModel
             return frameworkName;
         }
 
+        [Obsolete]
         private static bool ValidateDependencyTarget(LibraryDependencyTarget targetValue)
         {
             var isValid = false;

--- a/src/NuGet.Core/NuGet.ProjectModel/LazyStringSplit.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LazyStringSplit.cs
@@ -1,0 +1,138 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuGet.ProjectModel
+{
+    /// <summary>
+    ///     Splits a string by a delimiter, producing substrings lazily during enumeration.
+    ///     Skips empty items, behaving equivalently to <see cref="string.Split(char[])"/> with
+    ///     <see cref="StringSplitOptions.RemoveEmptyEntries"/>.
+    /// </summary>
+    /// <remarks>
+    ///     Unlike <see cref="string.Split(char[])"/> and overloads, <see cref="LazyStringSplit"/>
+    ///     does not allocate an array for the return, and allocates strings on demand during
+    ///     enumeration. A custom enumerator type is used so that the only allocations made are
+    ///     the substrings themselves. We also avoid the large internal arrays assigned by the
+    ///     methods on <see cref="string"/>.
+    /// </remarks>
+    internal readonly struct LazyStringSplit : IEnumerable<string>
+    {
+        private readonly string _input;
+        private readonly char _delimiter;
+
+        public LazyStringSplit(string input, char delimiter)
+        {
+            if (input is null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            _input = input;
+            _delimiter = delimiter;
+        }
+
+        public Enumerator GetEnumerator() => new(this);
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        IEnumerator<string> IEnumerable<string>.GetEnumerator() => GetEnumerator();
+
+        public IEnumerable<T> Select<T>(Func<string, T> func)
+        {
+            foreach (string value in this)
+            {
+                yield return func(value);
+            }
+        }
+
+        public string First()
+        {
+            return FirstOrDefault() ?? throw new InvalidOperationException("Sequence is empty.");
+        }
+
+        public string? FirstOrDefault()
+        {
+            var enumerator = new Enumerator(this);
+            return enumerator.MoveNext() ? enumerator.Current : null;
+        }
+
+        public struct Enumerator : IEnumerator<string>
+        {
+            private readonly string _input;
+            private readonly char _delimiter;
+            private int _index;
+
+            internal Enumerator(in LazyStringSplit split)
+            {
+                _index = 0;
+                _input = split._input;
+                _delimiter = split._delimiter;
+                Current = null!;
+            }
+
+            public string Current { get; private set; }
+
+            public bool MoveNext()
+            {
+                while (_index != _input.Length)
+                {
+                    int delimiterIndex = _input.IndexOf(_delimiter, _index);
+
+                    if (delimiterIndex == -1)
+                    {
+                        Current = _input.Substring(_index);
+                        _index = _input.Length;
+                        return true;
+                    }
+
+                    int length = delimiterIndex - _index;
+
+                    if (length == 0)
+                    {
+                        _index++;
+                        continue;
+                    }
+
+                    Current = _input.Substring(_index, length);
+                    _index = delimiterIndex + 1;
+                    return true;
+                }
+
+                return false;
+            }
+
+            object IEnumerator.Current => Current;
+
+            void IEnumerator.Reset()
+            {
+                _index = 0;
+                Current = null!;
+            }
+
+            void IDisposable.Dispose() { }
+        }
+    }
+
+    internal static class LazyStringSplitExtensions
+    {
+        /// <remarks>
+        ///     This extension method has special knowledge of the <see cref="LazyStringSplit"/> type and
+        ///     can compute its result without allocation.
+        /// </remarks>
+        /// <inheritdoc cref="Enumerable.FirstOrDefault{TSource}(IEnumerable{TSource})"/>
+        public static string? FirstOrDefault(this LazyStringSplit lazyStringSplit)
+        {
+            LazyStringSplit.Enumerator enumerator = lazyStringSplit.GetEnumerator();
+
+            return enumerator.MoveNext()
+                ? enumerator.Current
+                : null;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
@@ -60,11 +61,10 @@ namespace NuGet.ProjectModel
 
         public LockFile Parse(string lockFileContent, ILogger log, string path)
         {
-            using (var reader = new StringReader(lockFileContent))
+            byte[] byteArray = Encoding.UTF8.GetBytes(lockFileContent);
+            using (var stream = new MemoryStream(byteArray))
             {
-#pragma warning disable CS0612 // Type or member is obsolete
-                return Read(reader, log, path);
-#pragma warning restore CS0612 // Type or member is obsolete
+                return Read(stream, log, path);
             }
         }
 
@@ -88,21 +88,33 @@ namespace NuGet.ProjectModel
 
         public LockFile Read(Stream stream, ILogger log, string path)
         {
-            using (var textReader = new StreamReader(stream))
+            return Read(stream, log, path, EnvironmentVariableWrapper.Instance);
+        }
+
+        internal LockFile Read(Stream stream, ILogger log, string path, IEnvironmentVariableReader environmentVariableReader, bool bypassCache = false)
+        {
+            if (!JsonUtility.UseNewtonsoftJsonForParsing(environmentVariableReader, bypassCache))
             {
-#pragma warning disable CS0612 // Type or member is obsolete
-                return Read(textReader, log, path);
-#pragma warning restore CS0612 // Type or member is obsolete
+                return Utf8JsonRead(stream, log, path);
+            }
+            else
+            {
+                using (var reader = new StreamReader(stream))
+                {
+#pragma warning disable CS0618 // Type or member is obsolete
+                    return Read(reader, log, path);
+#pragma warning restore CS0618 // Type or member is obsolete
+                }
             }
         }
 
-        [Obsolete]
+        [Obsolete("This method is deprecated. Use Read(Stream, string) instead.")]
         public LockFile Read(TextReader reader, string path)
         {
             return Read(reader, NullLogger.Instance, path);
         }
 
-        [Obsolete]
+        [Obsolete("This method is deprecated. Use Read(Stream, ILogger, string) instead.")]
         public LockFile Read(TextReader reader, ILogger log, string path)
         {
             try
@@ -164,6 +176,29 @@ namespace NuGet.ProjectModel
             {
                 Write(writer, lockFile);
                 return writer.ToString();
+            }
+        }
+
+        private LockFile Utf8JsonRead(Stream stream, ILogger log, string path)
+        {
+            try
+            {
+                var lockFile = JsonUtility.LoadJson<LockFile>(stream, Utf8JsonReaderExtensions.LockFileConverter);
+                lockFile.Path = path;
+                return lockFile;
+            }
+            catch (Exception ex)
+            {
+                log.LogInformation(string.Format(CultureInfo.CurrentCulture,
+                    Strings.Log_ErrorReadingLockFile,
+                    path, ex.Message));
+
+                // Ran into parsing errors, mark it as unlocked and out-of-date
+                return new LockFile
+                {
+                    Version = int.MinValue,
+                    Path = path
+                };
             }
         }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -62,7 +62,9 @@ namespace NuGet.ProjectModel
         {
             using (var reader = new StringReader(lockFileContent))
             {
+#pragma warning disable CS0612 // Type or member is obsolete
                 return Read(reader, log, path);
+#pragma warning restore CS0612 // Type or member is obsolete
             }
         }
 
@@ -88,15 +90,19 @@ namespace NuGet.ProjectModel
         {
             using (var textReader = new StreamReader(stream))
             {
+#pragma warning disable CS0612 // Type or member is obsolete
                 return Read(textReader, log, path);
+#pragma warning restore CS0612 // Type or member is obsolete
             }
         }
 
+        [Obsolete]
         public LockFile Read(TextReader reader, string path)
         {
             return Read(reader, NullLogger.Instance, path);
         }
 
+        [Obsolete]
         public LockFile Read(TextReader reader, ILogger log, string path)
         {
             try
@@ -161,6 +167,7 @@ namespace NuGet.ProjectModel
             }
         }
 
+        [Obsolete]
         private static LockFile ReadLockFile(JObject cursor, string path)
         {
             var lockFile = new LockFile()
@@ -915,6 +922,7 @@ namespace NuGet.ProjectModel
             writer.WriteObjectEnd();
         }
 
+        [Obsolete]
         private static List<CentralTransitiveDependencyGroup> ReadProjectFileTransitiveDependencyGroup(JObject json, string path)
         {
             var results = new List<CentralTransitiveDependencyGroup>();

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamIAssetsLogMessageConverter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamIAssetsLogMessageConverter.cs
@@ -1,0 +1,148 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using NuGet.Common;
+
+namespace NuGet.ProjectModel
+{
+    /// <summary>
+    /// A <see cref="IUtf8JsonStreamReaderConverter{T}"/> to allow read JSON into <see cref="IAssetsLogMessage"/>
+    /// </summary>
+    /// <example>
+    /// {
+    ///     "code": "<see cref="NuGetLogCode"/>",
+    ///     "level": "<see cref="LogLevel"/>",
+    ///     "message": "test log message",
+    ///     "warningLevel": <see cref="WarningLevel"/>,
+    ///     "filePath": "C:\a\file\path.txt",
+    ///     "startLineNumber": 1,
+    ///     "startColumnNumber": 2,
+    ///     "endLineNumber": 10,
+    ///     "endcolumnNumber": 20,
+    ///     "libraryId": "libraryId",
+    ///     "targetGraphs": [
+    ///         "targetGraph1"
+    ///     ]
+    /// }
+    /// </example>
+    internal class Utf8JsonStreamIAssetsLogMessageConverter : IUtf8JsonStreamReaderConverter<IAssetsLogMessage>
+    {
+        private static readonly byte[] LevelPropertyName = Encoding.UTF8.GetBytes(LogMessageProperties.LEVEL);
+        private static readonly byte[] CodePropertyName = Encoding.UTF8.GetBytes(LogMessageProperties.CODE);
+        private static readonly byte[] WarningLevelPropertyName = Encoding.UTF8.GetBytes(LogMessageProperties.WARNING_LEVEL);
+        private static readonly byte[] FilePathPropertyName = Encoding.UTF8.GetBytes(LogMessageProperties.FILE_PATH);
+        private static readonly byte[] StartLineNumberPropertyName = Encoding.UTF8.GetBytes(LogMessageProperties.START_LINE_NUMBER);
+        private static readonly byte[] StartColumnNumberPropertyName = Encoding.UTF8.GetBytes(LogMessageProperties.START_COLUMN_NUMBER);
+        private static readonly byte[] EndLineNumberPropertyName = Encoding.UTF8.GetBytes(LogMessageProperties.END_LINE_NUMBER);
+        private static readonly byte[] EndColumnNumberPropertyName = Encoding.UTF8.GetBytes(LogMessageProperties.END_COLUMN_NUMBER);
+        private static readonly byte[] MessagePropertyName = Encoding.UTF8.GetBytes(LogMessageProperties.MESSAGE);
+        private static readonly byte[] LibraryIdPropertyName = Encoding.UTF8.GetBytes(LogMessageProperties.LIBRARY_ID);
+        private static readonly byte[] TargetGraphsPropertyName = Encoding.UTF8.GetBytes(LogMessageProperties.TARGET_GRAPHS);
+
+        public IAssetsLogMessage Read(ref Utf8JsonStreamReader reader)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("Expected StartObject, found " + reader.TokenType);
+            }
+
+            var isValid = true;
+            LogLevel level = default;
+            NuGetLogCode code = default;
+            //matching default warning level when AssetLogMessage object is created
+            WarningLevel warningLevel = WarningLevel.Severe;
+            string message = default;
+            string filePath = default;
+            int startLineNumber = default;
+            int startColNumber = default;
+            int endLineNumber = default;
+            int endColNumber = default;
+            string libraryId = default;
+            IReadOnlyList<string> targetGraphs = null;
+
+            while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+            {
+                if (!isValid)
+                {
+                    reader.Skip();
+                }
+                if (reader.ValueTextEquals(LevelPropertyName))
+                {
+                    var levelString = reader.ReadNextTokenAsString();
+                    isValid &= Enum.TryParse(levelString, out level);
+                }
+                else if (reader.ValueTextEquals(CodePropertyName))
+                {
+                    var codeString = reader.ReadNextTokenAsString();
+                    isValid &= Enum.TryParse(codeString, out code);
+                }
+                else if (reader.ValueTextEquals(WarningLevelPropertyName))
+                {
+                    reader.Read();
+                    warningLevel = (WarningLevel)Enum.ToObject(typeof(WarningLevel), reader.GetInt32());
+                }
+                else if (reader.ValueTextEquals(FilePathPropertyName))
+                {
+                    filePath = reader.ReadNextTokenAsString();
+                }
+                else if (reader.ValueTextEquals(StartLineNumberPropertyName))
+                {
+                    reader.Read();
+                    startLineNumber = reader.GetInt32();
+                }
+                else if (reader.ValueTextEquals(StartColumnNumberPropertyName))
+                {
+                    reader.Read();
+                    startColNumber = reader.GetInt32();
+                }
+                else if (reader.ValueTextEquals(EndLineNumberPropertyName))
+                {
+                    reader.Read();
+                    endLineNumber = reader.GetInt32();
+                }
+                else if (reader.ValueTextEquals(EndColumnNumberPropertyName))
+                {
+                    reader.Read();
+                    endColNumber = reader.GetInt32();
+                }
+                else if (reader.ValueTextEquals(MessagePropertyName))
+                {
+                    message = reader.ReadNextTokenAsString();
+                }
+                else if (reader.ValueTextEquals(LibraryIdPropertyName))
+                {
+                    libraryId = reader.ReadNextTokenAsString();
+                }
+                else if (reader.ValueTextEquals(TargetGraphsPropertyName))
+                {
+                    reader.Read();
+                    targetGraphs = (List<string>)reader.ReadStringArrayAsIList();
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+            if (isValid)
+            {
+                var assetLogMessage = new AssetsLogMessage(level, code, message)
+                {
+                    TargetGraphs = targetGraphs ?? Array.Empty<string>(),
+                    FilePath = filePath,
+                    EndColumnNumber = endColNumber,
+                    EndLineNumber = endLineNumber,
+                    LibraryId = libraryId,
+                    StartColumnNumber = startColNumber,
+                    StartLineNumber = startLineNumber,
+                    WarningLevel = warningLevel
+                };
+                return assetLogMessage;
+            }
+            return null;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamLockFileConverter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamLockFileConverter.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using NuGet.Common;
 using NuGet.Frameworks;
 
 namespace NuGet.ProjectModel
@@ -85,6 +86,7 @@ namespace NuGet.ProjectModel
                         ref reader,
                         name: null,
                         packageSpecPath: null,
+                        EnvironmentVariableWrapper.Instance,
                         snapshotValue: null);
                 }
                 else if (reader.ValueTextEquals(CentralTransitiveDependencyGroupsPropertyName))

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamLockFileConverter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamLockFileConverter.cs
@@ -1,0 +1,132 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using NuGet.Frameworks;
+
+namespace NuGet.ProjectModel
+{
+    /// <summary>
+    /// A <see cref="IUtf8JsonStreamReaderConverter{T}"/> to allow read JSON into <see cref="LockFile"/>
+    /// </summary>
+    /// <example>
+    /// {
+    ///     "version": 3,
+    ///     "targets": { <see cref="Utf8JsonStreamLockFileTargetConverter"/> },
+    ///     "libraries": { <see cref="Utf8JsonStreamLockFileLibraryConverter"/> },
+    ///     "projectFileDependencyGroups": { <see cref="Utf8JsonStreamProjectFileDependencyGroupConverter"/> },
+    ///     "packageFolders": { <see cref="Utf8JsonStreamLockFileItemConverter{T}"/> },
+    ///     "project": { <see cref="JsonPackageSpecReader.GetPackageSpec(ref Utf8JsonStreamReader, string, string, string)"/> },
+    ///     "logs": [ <see cref="Utf8JsonStreamIAssetsLogMessageConverter"/> ]
+    /// }
+    /// </example>
+    internal class Utf8JsonStreamLockFileConverter : IUtf8JsonStreamReaderConverter<LockFile>
+    {
+        private static readonly byte[] VersionPropertyName = Encoding.UTF8.GetBytes("version");
+        private static readonly byte[] LibrariesPropertyName = Encoding.UTF8.GetBytes("libraries");
+        private static readonly byte[] TargetsPropertyName = Encoding.UTF8.GetBytes("targets");
+        private static readonly byte[] ProjectFileDependencyGroupsPropertyName = Encoding.UTF8.GetBytes("projectFileDependencyGroups");
+        private static readonly byte[] PackageFoldersPropertyName = Encoding.UTF8.GetBytes("packageFolders");
+        private static readonly byte[] ProjectPropertyName = Encoding.UTF8.GetBytes("project");
+        private static readonly byte[] CentralTransitiveDependencyGroupsPropertyName = Encoding.UTF8.GetBytes("centralTransitiveDependencyGroups");
+        private static readonly byte[] LogsPropertyName = Encoding.UTF8.GetBytes("logs");
+
+        public LockFile Read(ref Utf8JsonStreamReader reader)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("Expected StartObject, found " + reader.TokenType);
+            }
+
+            var lockFile = new LockFile();
+
+            while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+            {
+                if (reader.ValueTextEquals(VersionPropertyName))
+                {
+                    reader.Read();
+                    if (reader.TryGetInt32(out int version))
+                    {
+                        lockFile.Version = version;
+                    }
+                    else
+                    {
+                        lockFile.Version = int.MinValue;
+                    }
+                }
+                else if (reader.ValueTextEquals(LibrariesPropertyName))
+                {
+                    reader.Read();
+                    lockFile.Libraries = reader.ReadObjectAsList<LockFileLibrary>(Utf8JsonReaderExtensions.LockFileLibraryConverter);
+                }
+                else if (reader.ValueTextEquals(TargetsPropertyName))
+                {
+                    reader.Read();
+                    lockFile.Targets = reader.ReadObjectAsList<LockFileTarget>(Utf8JsonReaderExtensions.LockFileTargetConverter);
+                }
+                else if (reader.ValueTextEquals(ProjectFileDependencyGroupsPropertyName))
+                {
+                    reader.Read();
+                    lockFile.ProjectFileDependencyGroups = reader.ReadObjectAsList<ProjectFileDependencyGroup>(Utf8JsonReaderExtensions.ProjectFileDepencencyGroupConverter);
+                }
+                else if (reader.ValueTextEquals(PackageFoldersPropertyName))
+                {
+                    reader.Read();
+                    lockFile.PackageFolders = reader.ReadObjectAsList<LockFileItem>(Utf8JsonReaderExtensions.LockFileItemConverter);
+                }
+                else if (reader.ValueTextEquals(ProjectPropertyName))
+                {
+                    reader.Read();
+                    lockFile.PackageSpec = JsonPackageSpecReader.GetPackageSpec(
+                        ref reader,
+                        name: null,
+                        packageSpecPath: null,
+                        snapshotValue: null);
+                }
+                else if (reader.ValueTextEquals(CentralTransitiveDependencyGroupsPropertyName))
+                {
+                    IList<CentralTransitiveDependencyGroup> results = null;
+                    if (reader.Read() && reader.TokenType == JsonTokenType.StartObject)
+                    {
+                        while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+                        {
+                            results ??= new List<CentralTransitiveDependencyGroup>();
+                            var frameworkPropertyName = reader.GetString();
+                            NuGetFramework framework = NuGetFramework.Parse(frameworkPropertyName);
+
+                            JsonPackageSpecReader.ReadCentralTransitiveDependencyGroup(
+                                jsonReader: ref reader,
+                                results: out var dependencies,
+                                packageSpecPath: string.Empty);
+                            results.Add(new CentralTransitiveDependencyGroup(framework, dependencies));
+                        }
+                    }
+                    lockFile.CentralTransitiveDependencyGroups = results ?? Array.Empty<CentralTransitiveDependencyGroup>();
+                }
+                else if (reader.ValueTextEquals(LogsPropertyName))
+                {
+                    reader.Read();
+                    lockFile.LogMessages = reader.ReadListOfObjects<IAssetsLogMessage>(Utf8JsonReaderExtensions.IAssetsLogMessageConverter);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            if (!string.IsNullOrEmpty(lockFile.PackageSpec?.RestoreMetadata?.ProjectPath) && lockFile.LogMessages.Count > 0)
+            {
+                foreach (AssetsLogMessage message in lockFile.LogMessages.Where(x => string.IsNullOrEmpty(x.ProjectPath)))
+                {
+                    message.FilePath = lockFile.PackageSpec.RestoreMetadata.ProjectPath;
+                }
+            }
+
+            return lockFile;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamLockFileConverter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamLockFileConverter.cs
@@ -120,11 +120,13 @@ namespace NuGet.ProjectModel
                 }
             }
 
-            if (!string.IsNullOrEmpty(lockFile.PackageSpec?.RestoreMetadata?.ProjectPath) && lockFile.LogMessages.Count > 0)
+            var projectPath = lockFile.PackageSpec?.RestoreMetadata?.ProjectPath;
+            if (!string.IsNullOrEmpty(projectPath) && lockFile.LogMessages.Count > 0)
             {
                 foreach (AssetsLogMessage message in lockFile.LogMessages.Where(x => string.IsNullOrEmpty(x.ProjectPath)))
                 {
-                    message.FilePath = lockFile.PackageSpec.RestoreMetadata.ProjectPath;
+                    message.ProjectPath = projectPath;
+                    message.FilePath = projectPath;
                 }
             }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamLockFileItemConverter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamLockFileItemConverter.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text.Json;
+
+namespace NuGet.ProjectModel
+{
+    /// <summary>
+    /// A <see cref="IUtf8JsonStreamReaderConverter{T}"/> to allow read JSON into <see cref="LockFileItem"/>
+    /// </summary>
+    /// <example>
+    /// "path/to/the.dll": {
+    ///     "property1": "val1",
+    ///     "property2": 2
+    ///     "property3": true
+    ///     "property4": false
+    /// }
+    /// </example>
+    internal class Utf8JsonStreamLockFileItemConverter<T> : IUtf8JsonStreamReaderConverter<T> where T : LockFileItem
+    {
+        private Func<string, T> _lockFileItemCreator;
+
+        public Utf8JsonStreamLockFileItemConverter(Func<string, T> lockFileItemCreator)
+        {
+            _lockFileItemCreator = lockFileItemCreator;
+        }
+
+        public T Read(ref Utf8JsonStreamReader reader)
+        {
+            var genericType = typeof(T);
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException("Expected PropertyName, found " + reader.TokenType);
+            }
+
+            //We want to read the property name right away
+            var lockItemPath = reader.GetString();
+            LockFileItem lockFileItem = _lockFileItemCreator(lockItemPath);
+
+            reader.Read();
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    var propertyName = reader.GetString();
+                    lockFileItem.Properties[propertyName] = reader.ReadNextTokenAsString();
+                }
+            }
+
+            return lockFileItem as T;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamLockFileLibraryConverter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamLockFileLibraryConverter.cs
@@ -1,0 +1,102 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text;
+using System.Text.Json;
+using NuGet.Versioning;
+
+namespace NuGet.ProjectModel
+{
+    /// <summary>
+    /// A <see cref="IUtf8JsonStreamReaderConverter{T}"/> to allow read JSON into <see cref="LockFileLibrary"/>
+    /// </summary>
+    /// <example>
+    /// "PackageA/1.0.0": {
+    ///     "sha512": "ASha512",
+    ///     "type": "package",
+    ///     "path": "C:\a\test\path",
+    ///     "files": [
+    ///         "PackageA.nuspec",
+    ///         "lib/netstandard2.0/PackageA.dll"
+    ///     ],
+    ///     "msbuildProject": "bar",
+    ///     "servicable": true,
+    ///     "hasTools": true,
+    /// }
+    /// </example>
+    internal class Utf8JsonStreamLockFileLibraryConverter : IUtf8JsonStreamReaderConverter<LockFileLibrary>
+    {
+        private static readonly byte[] Sha512PropertyName = Encoding.UTF8.GetBytes("sha512");
+        private static readonly byte[] TypePropertyName = Encoding.UTF8.GetBytes("type");
+        private static readonly byte[] PathPropertyName = Encoding.UTF8.GetBytes("path");
+        private static readonly byte[] MsbuildProjectPropertyName = Encoding.UTF8.GetBytes("msbuildProject");
+        private static readonly byte[] ServicablePropertyName = Encoding.UTF8.GetBytes("servicable");
+        private static readonly byte[] HasToolsPropertyName = Encoding.UTF8.GetBytes("hasTools");
+        private static readonly byte[] FilesPropertyName = Encoding.UTF8.GetBytes("files");
+
+        public LockFileLibrary Read(ref Utf8JsonStreamReader reader)
+        {
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException("Expected PropertyName, found " + reader.TokenType);
+            }
+
+            var lockFileLibrary = new LockFileLibrary();
+            //We want to read the property name right away
+            var propertyName = reader.GetString();
+            var (name, version) = propertyName.SplitInTwo(LockFile.DirectorySeparatorChar);
+            lockFileLibrary.Name = name;
+            if (!string.IsNullOrWhiteSpace(version))
+            {
+                lockFileLibrary.Version = NuGetVersion.Parse(version);
+            }
+
+            reader.Read();
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("Expected StartObject, found " + reader.TokenType);
+            }
+
+            while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+            {
+                if (reader.ValueTextEquals(TypePropertyName))
+                {
+                    lockFileLibrary.Type = reader.ReadNextTokenAsString();
+                }
+                else if (reader.ValueTextEquals(PathPropertyName))
+                {
+                    lockFileLibrary.Path = reader.ReadNextTokenAsString();
+                }
+                else if (reader.ValueTextEquals(MsbuildProjectPropertyName))
+                {
+                    lockFileLibrary.MSBuildProject = reader.ReadNextTokenAsString();
+                }
+                else if (reader.ValueTextEquals(Sha512PropertyName))
+                {
+                    lockFileLibrary.Sha512 = reader.ReadNextTokenAsString();
+                }
+                else if (reader.ValueTextEquals(ServicablePropertyName))
+                {
+                    reader.Read();
+                    lockFileLibrary.IsServiceable = reader.GetBoolean();
+                }
+                else if (reader.ValueTextEquals(HasToolsPropertyName))
+                {
+                    reader.Read();
+                    lockFileLibrary.HasTools = reader.GetBoolean();
+                }
+                else if (reader.ValueTextEquals(FilesPropertyName))
+                {
+                    reader.Read();
+                    reader.ReadStringArrayAsIList(lockFileLibrary.Files);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+            return lockFileLibrary;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamLockFileTargetConverter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamLockFileTargetConverter.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text.Json;
+using NuGet.Frameworks;
+
+namespace NuGet.ProjectModel
+{
+    /// <summary>
+    /// A <see cref="IUtf8JsonStreamReaderConverter{T}"/> to allow read JSON into <see cref="LockFileTarget"/>
+    /// </summary>
+    /// <example>
+    /// "net45/win8": {
+    ///     <see cref="Utf8JsonStreamLockFileTargetLibraryConverter"/>,
+    /// }
+    /// </example>
+    internal class Utf8JsonStreamLockFileTargetConverter : IUtf8JsonStreamReaderConverter<LockFileTarget>
+    {
+        public LockFileTarget Read(ref Utf8JsonStreamReader reader)
+        {
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException("Expected PropertyName, found " + reader.TokenType);
+            }
+
+            var lockFileTarget = new LockFileTarget();
+            //We want to read the property name right away
+            var propertyName = reader.GetString();
+            var (targetFramework, runTimeFramework) = propertyName.SplitInTwo(LockFile.DirectorySeparatorChar);
+
+            lockFileTarget.TargetFramework = NuGetFramework.Parse(targetFramework);
+            lockFileTarget.RuntimeIdentifier = runTimeFramework;
+
+            reader.Read();
+            lockFileTarget.Libraries = reader.ReadObjectAsList(Utf8JsonReaderExtensions.LockFileTargetLibraryConverter);
+
+            return lockFileTarget;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamLockFileTargetLibraryConverter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamLockFileTargetLibraryConverter.cs
@@ -1,0 +1,195 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace NuGet.ProjectModel
+{
+    /// <summary>
+    /// A <see cref="IUtf8JsonStreamReaderConverter{T}"/> to allow read JSON into <see cref="LockFileTargetLibrary"/>
+    /// </summary>
+    /// <example>
+    /// "Lirbary/1.0.0": {
+    ///     "type": "package",
+    ///     "framework": ".NETCoreApp,Version=v6.0",
+    ///     "dependencies": {
+    ///         "Library.Name": "1.0.1",
+    ///         "Parser.Json": "10.0.0",
+    ///     },
+    ///     "frameworkAssemblies": [
+    ///         "System"
+    ///     ],
+    ///     "compile": {
+    ///         <see cref="Utf8JsonStreamLockFileItemConverter{T}"/>,
+    ///     },
+    ///     "runtime": {
+    ///         <see cref="Utf8JsonStreamLockFileItemConverter{T}"/>,
+    ///     },
+    ///     "resource": {
+    ///         <see cref="Utf8JsonStreamLockFileItemConverter{T}"/>,
+    ///     },
+    ///     "contentFiles": {
+    ///         <see cref="Utf8JsonStreamLockFileItemConverter{T}"/>,
+    ///     },
+    ///     "runtimeTargets": {
+    ///         <see cref="Utf8JsonStreamLockFileItemConverter{T}"/>,
+    ///     },
+    ///     "tools": {
+    ///         <see cref="Utf8JsonStreamLockFileItemConverter{T}"/>,
+    ///     },
+    ///     "embed": {
+    ///         <see cref="Utf8JsonStreamLockFileItemConverter{T}"/>,
+    ///     },
+    ///     "frameworkReferences": [
+    ///         "Framework1",
+    ///     ]
+    /// }
+    /// </example>
+    internal class Utf8JsonStreamLockFileTargetLibraryConverter : IUtf8JsonStreamReaderConverter<LockFileTargetLibrary>
+    {
+        private static readonly byte[] TypePropertyName = Encoding.UTF8.GetBytes("type");
+        private static readonly byte[] FrameworkPropertyName = Encoding.UTF8.GetBytes("framework");
+        private static readonly byte[] DependenciesPropertyName = Encoding.UTF8.GetBytes("dependencies");
+        private static readonly byte[] FrameworkAssembliesPropertyName = Encoding.UTF8.GetBytes("frameworkAssemblies");
+        private static readonly byte[] RuntimePropertyName = Encoding.UTF8.GetBytes("runtime");
+        private static readonly byte[] CompilePropertyName = Encoding.UTF8.GetBytes("compile");
+        private static readonly byte[] ResourcePropertyName = Encoding.UTF8.GetBytes("resource");
+        private static readonly byte[] NativePropertyName = Encoding.UTF8.GetBytes("native");
+        private static readonly byte[] BuildPropertyName = Encoding.UTF8.GetBytes("build");
+        private static readonly byte[] BuildMultiTargetingPropertyName = Encoding.UTF8.GetBytes("buildMultiTargeting");
+        private static readonly byte[] ContentFilesPropertyName = Encoding.UTF8.GetBytes("contentFiles");
+        private static readonly byte[] RuntimeTargetsPropertyName = Encoding.UTF8.GetBytes("runtimeTargets");
+        private static readonly byte[] ToolsPropertyName = Encoding.UTF8.GetBytes("tools");
+        private static readonly byte[] EmbedPropertyName = Encoding.UTF8.GetBytes("embed");
+        private static readonly byte[] FrameworkReferencesPropertyName = Encoding.UTF8.GetBytes("frameworkReferences");
+
+        public LockFileTargetLibrary Read(ref Utf8JsonStreamReader reader)
+        {
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException("Expected PropertyName, found " + reader.TokenType);
+            }
+
+            var lockFileTargetLibrary = new LockFileTargetLibrary();
+
+            //We want to read the property name right away
+            var propertyName = reader.GetString();
+            var (targetLibraryName, version) = propertyName.SplitInTwo('/');
+            lockFileTargetLibrary.Name = targetLibraryName;
+            lockFileTargetLibrary.Version = version is null ? null : NuGetVersion.Parse(version);
+
+            reader.Read();
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("Expected StartObject, found " + reader.TokenType);
+            }
+
+            while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+            {
+                if (reader.ValueTextEquals(TypePropertyName))
+                {
+                    lockFileTargetLibrary.Type = reader.ReadNextTokenAsString();
+                }
+                else if (reader.ValueTextEquals(FrameworkPropertyName))
+                {
+                    lockFileTargetLibrary.Framework = reader.ReadNextTokenAsString();
+                }
+                else if (reader.ValueTextEquals(DependenciesPropertyName))
+                {
+                    reader.Read();
+                    lockFileTargetLibrary.Dependencies = ReadPackageDependencyList(ref reader);
+                }
+                else if (reader.ValueTextEquals(FrameworkAssembliesPropertyName))
+                {
+                    reader.Read();
+                    lockFileTargetLibrary.FrameworkAssemblies = reader.ReadStringArrayAsIList() ?? Array.Empty<string>();
+                }
+                else if (reader.ValueTextEquals(RuntimePropertyName))
+                {
+                    reader.Read();
+                    lockFileTargetLibrary.RuntimeAssemblies = reader.ReadObjectAsList<LockFileItem>(Utf8JsonReaderExtensions.LockFileItemConverter);
+                }
+                else if (reader.ValueTextEquals(CompilePropertyName))
+                {
+                    reader.Read();
+                    lockFileTargetLibrary.CompileTimeAssemblies = reader.ReadObjectAsList<LockFileItem>(Utf8JsonReaderExtensions.LockFileItemConverter);
+                }
+                else if (reader.ValueTextEquals(ResourcePropertyName))
+                {
+                    reader.Read();
+                    lockFileTargetLibrary.ResourceAssemblies = reader.ReadObjectAsList<LockFileItem>(Utf8JsonReaderExtensions.LockFileItemConverter);
+                }
+                else if (reader.ValueTextEquals(NativePropertyName))
+                {
+                    reader.Read();
+                    lockFileTargetLibrary.NativeLibraries = reader.ReadObjectAsList<LockFileItem>(Utf8JsonReaderExtensions.LockFileItemConverter);
+                }
+                else if (reader.ValueTextEquals(BuildPropertyName))
+                {
+                    reader.Read();
+                    lockFileTargetLibrary.Build = reader.ReadObjectAsList<LockFileItem>(Utf8JsonReaderExtensions.LockFileItemConverter);
+                }
+                else if (reader.ValueTextEquals(BuildMultiTargetingPropertyName))
+                {
+                    reader.Read();
+                    lockFileTargetLibrary.BuildMultiTargeting = reader.ReadObjectAsList<LockFileItem>(Utf8JsonReaderExtensions.LockFileItemConverter);
+                }
+                else if (reader.ValueTextEquals(ContentFilesPropertyName))
+                {
+                    reader.Read();
+                    lockFileTargetLibrary.ContentFiles = reader.ReadObjectAsList<LockFileContentFile>(Utf8JsonReaderExtensions.LockFileContentFileConverter);
+                }
+                else if (reader.ValueTextEquals(RuntimeTargetsPropertyName))
+                {
+                    reader.Read();
+                    lockFileTargetLibrary.RuntimeTargets = reader.ReadObjectAsList<LockFileRuntimeTarget>(Utf8JsonReaderExtensions.LockFileRuntimeTargetConverter);
+                }
+                else if (reader.ValueTextEquals(ToolsPropertyName))
+                {
+                    reader.Read();
+                    lockFileTargetLibrary.ToolsAssemblies = reader.ReadObjectAsList<LockFileItem>(Utf8JsonReaderExtensions.LockFileItemConverter);
+                }
+                else if (reader.ValueTextEquals(EmbedPropertyName))
+                {
+                    reader.Read();
+                    lockFileTargetLibrary.EmbedAssemblies = reader.ReadObjectAsList<LockFileItem>(Utf8JsonReaderExtensions.LockFileItemConverter);
+                }
+                else if (reader.ValueTextEquals(FrameworkReferencesPropertyName))
+                {
+                    reader.Read();
+                    lockFileTargetLibrary.FrameworkReferences = reader.ReadStringArrayAsIList();
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+            lockFileTargetLibrary.Freeze();
+            return lockFileTargetLibrary;
+        }
+
+        private IList<PackageDependency> ReadPackageDependencyList(ref Utf8JsonStreamReader reader)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                return Array.Empty<PackageDependency>();
+            }
+
+            var packageDependencies = new List<PackageDependency>(10);
+            while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+            {
+                string propertyName = reader.GetString();
+                string versionString = reader.ReadNextTokenAsString();
+                packageDependencies.Add(new PackageDependency(
+                    propertyName,
+                    versionString == null ? null : VersionRange.Parse(versionString)));
+            }
+            return packageDependencies;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/StringExtensions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/StringExtensions.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+#nullable enable
+
+using System.Globalization;
+
+namespace NuGet.ProjectModel
+{
+    internal static class StringExtensions
+    {
+        internal static (string firstPart, string? secondPart) SplitInTwo(this string s, char separator)
+        {
+            if (string.IsNullOrEmpty(s))
+            {
+                return (s, null);
+            }
+            var index = CultureInfo.CurrentCulture.CompareInfo.IndexOf(s, separator, CompareOptions.Ordinal);
+
+            if (index == -1)
+            {
+                return (s, null);
+            }
+
+            return (s.Substring(0, index),
+                index >= s.Length - 1 ?
+                    null :
+                    s.Substring(index + 1));
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/Utf8JsonReaderExtensions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/Utf8JsonReaderExtensions.cs
@@ -8,6 +8,17 @@ namespace NuGet.ProjectModel
 {
     internal static class Utf8JsonReaderExtensions
     {
+        internal static readonly Utf8JsonStreamLockFileConverter LockFileConverter = new Utf8JsonStreamLockFileConverter();
+        internal static readonly Utf8JsonStreamLockFileItemConverter<LockFileItem> LockFileItemConverter = new Utf8JsonStreamLockFileItemConverter<LockFileItem>((string filePath) => new LockFileItem(filePath));
+        internal static readonly Utf8JsonStreamLockFileItemConverter<LockFileContentFile> LockFileContentFileConverter = new Utf8JsonStreamLockFileItemConverter<LockFileContentFile>((string filePath) => new LockFileContentFile(filePath));
+        internal static readonly Utf8JsonStreamLockFileItemConverter<LockFileRuntimeTarget> LockFileRuntimeTargetConverter = new Utf8JsonStreamLockFileItemConverter<LockFileRuntimeTarget>((string filePath) => new LockFileRuntimeTarget(filePath));
+        internal static readonly Utf8JsonStreamLockFileTargetLibraryConverter LockFileTargetLibraryConverter = new Utf8JsonStreamLockFileTargetLibraryConverter();
+        internal static readonly Utf8JsonStreamLockFileLibraryConverter LockFileLibraryConverter = new Utf8JsonStreamLockFileLibraryConverter();
+        internal static readonly Utf8JsonStreamLockFileTargetConverter LockFileTargetConverter = new Utf8JsonStreamLockFileTargetConverter();
+        internal static readonly Utf8JsonStreamProjectFileDependencyGroupConverter ProjectFileDepencencyGroupConverter = new Utf8JsonStreamProjectFileDependencyGroupConverter();
+        internal static readonly Utf8JsonStreamIAssetsLogMessageConverter IAssetsLogMessageConverter = new Utf8JsonStreamIAssetsLogMessageConverter();
+
+
         internal static string ReadTokenAsString(this ref Utf8JsonReader reader)
         {
             switch (reader.TokenType)

--- a/src/NuGet.Core/NuGet.ProjectModel/Utf8JsonReaderExtensions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/Utf8JsonReaderExtensions.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text.Json;
+
+namespace NuGet.ProjectModel
+{
+    internal static class Utf8JsonReaderExtensions
+    {
+        internal static string ReadTokenAsString(this ref Utf8JsonReader reader)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.True:
+                    return bool.TrueString;
+                case JsonTokenType.False:
+                    return bool.FalseString;
+                case JsonTokenType.Number:
+                    return reader.ReadNumberAsString();
+                case JsonTokenType.String:
+                    return reader.GetString();
+                case JsonTokenType.None:
+                case JsonTokenType.Null:
+                    return null;
+                default:
+                    throw new InvalidCastException();
+            }
+        }
+
+        private static string ReadNumberAsString(this ref Utf8JsonReader reader)
+        {
+            if (reader.TryGetInt64(out long value))
+            {
+                return value.ToString();
+            }
+            return reader.GetDouble().ToString();
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/Utf8JsonStreamProjectFileDependencyGroupConverter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/Utf8JsonStreamProjectFileDependencyGroupConverter.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text.Json;
+
+namespace NuGet.ProjectModel
+{
+    /// <summary>
+    /// A <see cref="IUtf8JsonStreamReaderConverter{T}"/> to allow reading JSON into <see cref="ProjectFileDependencyGroup"/>
+    /// </summary>
+    /// <example>
+    /// "net45": [
+    ///     "Json.Parser (>= 1.0.1)",
+    /// ]
+    /// </example>
+    internal class Utf8JsonStreamProjectFileDependencyGroupConverter : IUtf8JsonStreamReaderConverter<ProjectFileDependencyGroup>
+    {
+        public ProjectFileDependencyGroup Read(ref Utf8JsonStreamReader reader)
+        {
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException("Expected PropertyName, found " + reader.TokenType);
+            }
+
+            var frameworkName = reader.GetString();
+            reader.Read();
+            var dependencies = reader.ReadStringArrayAsIList() ?? Array.Empty<string>();
+
+            return new ProjectFileDependencyGroup(frameworkName, dependencies);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/Utf8JsonStreamReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/Utf8JsonStreamReader.cs
@@ -146,8 +146,7 @@ namespace NuGet.ProjectModel
                         return value.Split(DelimitedStringDelimiters, StringSplitOptions.RemoveEmptyEntries);
 
                     default:
-                        var invalidCastException = new InvalidCastException();
-                        throw new JsonException(invalidCastException.Message, invalidCastException);
+                        throw new InvalidCastException();
                 }
             }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/Utf8JsonStreamReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/Utf8JsonStreamReader.cs
@@ -1,0 +1,273 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace NuGet.ProjectModel
+{
+    /// <summary>
+    /// This struct is used to read over a memeory stream in parts, in order to avoid reading the entire stream into memory.
+    /// It functions as a wrapper around <see cref="Utf8JsonStreamReader"/>, while maintaining a stream and a buffer to read from.
+    /// </summary>
+    internal ref struct Utf8JsonStreamReader
+    {
+        private static readonly char[] DelimitedStringDelimiters = [' ', ','];
+        private static readonly byte[] Utf8Bom = [0xEF, 0xBB, 0xBF];
+
+        private const int BufferSizeDefault = 16 * 1024;
+        private const int MinBufferSize = 1024;
+        private Utf8JsonReader _reader;
+#pragma warning disable CA2213 // Disposable fields should be disposed
+        private Stream _stream;
+#pragma warning restore CA2213 // Disposable fields should be disposed
+        // The buffer is used to read from the stream in chunks.
+        private byte[] _buffer;
+        private bool _disposed;
+        private ArrayPool<byte> _bufferPool;
+        private int _bufferUsed = 0;
+
+        internal Utf8JsonStreamReader(Stream stream, int bufferSize = BufferSizeDefault, ArrayPool<byte> arrayPool = null)
+        {
+            if (stream is null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            if (bufferSize < MinBufferSize)
+            {
+                throw new ArgumentException($"Buffer size must be at least {MinBufferSize} bytes", nameof(bufferSize));
+            }
+
+            _bufferPool = arrayPool ?? ArrayPool<byte>.Shared;
+            _buffer = _bufferPool.Rent(bufferSize);
+            _disposed = false;
+            _stream = stream;
+            _stream.Read(_buffer, 0, 3);
+            if (!Utf8Bom.AsSpan().SequenceEqual(_buffer.AsSpan(0, 3)))
+            {
+                _bufferUsed = 3;
+            }
+
+            var iniialJsonReaderState = new JsonReaderState(new JsonReaderOptions
+            {
+                AllowTrailingCommas = true,
+                CommentHandling = JsonCommentHandling.Skip,
+            });
+
+            ReadStreamIntoBuffer(iniialJsonReaderState);
+            _reader.Read();
+        }
+
+        internal bool IsFinalBlock => _reader.IsFinalBlock;
+
+        internal JsonTokenType TokenType => _reader.TokenType;
+
+        internal bool ValueTextEquals(ReadOnlySpan<byte> utf8Text) => _reader.ValueTextEquals(utf8Text);
+
+        internal bool TryGetInt32(out int value) => _reader.TryGetInt32(out value);
+
+        internal string GetString() => _reader.GetString();
+
+        internal bool GetBoolean() => _reader.GetBoolean();
+
+        internal int GetInt32() => _reader.GetInt32();
+
+        internal bool Read()
+        {
+            ThrowExceptionIfDisposed();
+
+            bool wasRead;
+            while (!(wasRead = _reader.Read()) && !_reader.IsFinalBlock)
+            {
+                GetMoreBytesFromStream();
+            }
+            return wasRead;
+        }
+
+        internal void Skip()
+        {
+            ThrowExceptionIfDisposed();
+
+            bool wasSkipped;
+            while (!(wasSkipped = _reader.TrySkip()) && !_reader.IsFinalBlock)
+            {
+                GetMoreBytesFromStream();
+            }
+            if (!wasSkipped)
+            {
+                _reader.Skip();
+            }
+        }
+
+        internal string ReadNextTokenAsString()
+        {
+            ThrowExceptionIfDisposed();
+
+            if (Read())
+            {
+                return _reader.ReadTokenAsString();
+            }
+
+            return null;
+        }
+
+        internal IList<string> ReadStringArrayAsIList(IList<string> strings = null)
+        {
+            if (TokenType == JsonTokenType.StartArray)
+            {
+                while (Read() && TokenType != JsonTokenType.EndArray)
+                {
+                    string value = _reader.ReadTokenAsString();
+
+                    strings = strings ?? new List<string>();
+
+                    strings.Add(value);
+                }
+            }
+            return strings;
+        }
+
+        internal IReadOnlyList<string> ReadDelimitedString()
+        {
+            ThrowExceptionIfDisposed();
+
+            if (Read())
+            {
+                switch (TokenType)
+                {
+                    case JsonTokenType.String:
+                        var value = GetString();
+
+                        return value.Split(DelimitedStringDelimiters, StringSplitOptions.RemoveEmptyEntries);
+
+                    default:
+                        var invalidCastException = new InvalidCastException();
+                        throw new JsonException(invalidCastException.Message, invalidCastException);
+                }
+            }
+
+            return null;
+        }
+
+        internal bool ReadNextTokenAsBoolOrFalse()
+        {
+            ThrowExceptionIfDisposed();
+
+            if (Read() && (TokenType == JsonTokenType.False || TokenType == JsonTokenType.True))
+            {
+                return GetBoolean();
+            }
+            return false;
+        }
+
+        internal IReadOnlyList<string> ReadNextStringOrArrayOfStringsAsReadOnlyList()
+        {
+            ThrowExceptionIfDisposed();
+
+            if (Read())
+            {
+                switch (_reader.TokenType)
+                {
+                    case JsonTokenType.String:
+                        return new[] { (string)_reader.GetString() };
+
+                    case JsonTokenType.StartArray:
+                        return ReadStringArrayAsReadOnlyListFromArrayStart();
+
+                    case JsonTokenType.StartObject:
+                        return null;
+                }
+            }
+
+            return null;
+        }
+
+        internal IReadOnlyList<string> ReadStringArrayAsReadOnlyListFromArrayStart()
+        {
+            ThrowExceptionIfDisposed();
+
+            List<string> strings = null;
+
+            while (Read() && _reader.TokenType != JsonTokenType.EndArray)
+            {
+                string value = _reader.ReadTokenAsString();
+
+                strings = strings ?? new List<string>();
+
+                strings.Add(value);
+            }
+
+            return (IReadOnlyList<string>)strings ?? Array.Empty<string>();
+        }
+
+        // This function is called when Read() returns false and we're not already in the final block
+        private void GetMoreBytesFromStream()
+        {
+            if (_reader.BytesConsumed < _bufferUsed)
+            {
+                // If the number of bytes consumed by the reader is less than the amount set in the buffer then we have leftover bytes
+                var oldBuffer = _buffer;
+                ReadOnlySpan<byte> leftover = oldBuffer.AsSpan((int)_reader.BytesConsumed);
+                _bufferUsed = leftover.Length;
+
+                // If the leftover bytes are the same as the buffer size then we are at capacity and need to double the buffer size
+                if (leftover.Length == _buffer.Length)
+                {
+                    _buffer = _bufferPool.Rent(_buffer.Length * 2);
+                    leftover.CopyTo(_buffer);
+                    _bufferPool.Return(oldBuffer, true);
+                }
+                else
+                {
+                    leftover.CopyTo(_buffer);
+                }
+            }
+            else
+            {
+                _bufferUsed = 0;
+            }
+
+            ReadStreamIntoBuffer(_reader.CurrentState);
+        }
+
+        /// <summary>
+        /// Loops through the stream and reads it into the buffer until the buffer is full or the stream is empty, creates the Utf8JsonReader. 
+        /// </summary>
+        private void ReadStreamIntoBuffer(JsonReaderState jsonReaderState)
+        {
+            int bytesRead;
+            do
+            {
+                var spaceLeftInBuffer = _buffer.Length - _bufferUsed;
+                bytesRead = _stream.Read(_buffer, _bufferUsed, spaceLeftInBuffer);
+                _bufferUsed += bytesRead;
+            }
+            while (bytesRead != 0 && _bufferUsed != _buffer.Length);
+            _reader = new Utf8JsonReader(_buffer.AsSpan(0, _bufferUsed), isFinalBlock: bytesRead == 0, jsonReaderState);
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+                byte[] toReturn = _buffer;
+                _buffer = null!;
+                _bufferPool.Return(toReturn, true);
+            }
+        }
+
+        private void ThrowExceptionIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(Utf8JsonStreamReader));
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/Utf8JsonStreamReaderConverter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/Utf8JsonStreamReaderConverter.cs
@@ -6,8 +6,8 @@ namespace NuGet.ProjectModel
     /// An abstract class that defines a function for reading a <see cref="Utf8JsonStreamReader"/> into a <typeparamref name="T"/>
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    internal abstract class Utf8JsonStreamReaderConverter<T>
+    internal interface IUtf8JsonStreamReaderConverter<T>
     {
-        public abstract T Read(ref Utf8JsonStreamReader reader);
+        T Read(ref Utf8JsonStreamReader reader);
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/Utf8JsonStreamReaderConverter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/Utf8JsonStreamReaderConverter.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+namespace NuGet.ProjectModel
+{
+    /// <summary>
+    /// An abstract class that defines a function for reading a <see cref="Utf8JsonStreamReader"/> into a <typeparamref name="T"/>
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal abstract class Utf8JsonStreamReaderConverter<T>
+    {
+        public abstract T Read(ref Utf8JsonStreamReader reader);
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
@@ -1553,23 +1553,23 @@ namespace NuGet.CommandLine.Test
 
             Util.CreateFile(proj3Dir, "project.json",
                                             @"{
-                                            'dependencies': {
-                                                'packageD': '1.0.0',
-                                                'packageE': '1.0.*'
+                                            ""dependencies"": {
+                                                ""packageD"": ""1.0.0"",
+                                                ""packageE"": ""1.0.*""
                                             },
-                                            'frameworks': {
-                                                        'uap10.0': { }
+                                            ""frameworks"": {
+                                                        ""uap10.0"": { }
                                                     }
                                             }");
 
             Util.CreateFile(proj4Dir, "project.json",
                                             @"{
-                                            'dependencies': {
-                                                'packageE': '1.0.0',
-                                                'packageF': '*'
+                                            ""dependencies"": {
+                                                ""packageE"": ""1.0.0"",
+                                                ""packageF"": ""*""
                                             },
-                                            'frameworks': {
-                                                        'uap10.0': { }
+                                            ""frameworks"": {
+                                                        ""uap10.0"": { }
                                                     }
                                             }");
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -1288,12 +1288,12 @@ EndProject");
 
 
                 var projectJson = @"{
-                    'dependencies': {
-                    'packageA': '1.1.0',
-                    'packageB': '2.2.0'
+                    ""dependencies"": {
+                    ""packageA"": ""1.1.0"",
+                    ""packageB"": ""2.2.0""
                     },
-                    'frameworks': {
-                                'netcore50': { }
+                    ""frameworks"": {
+                                ""netcore50"": { }
                             }
                 }";
 
@@ -1992,12 +1992,12 @@ EndProject";
 
                 Util.CreateFile(Path.Combine(basePath, "A", "A.Util"), "project.json",
 @"{
-  'dependencies': {
-    'packageA': '1.1.0',
-    'packageB': '2.2.0'
+  ""dependencies"": {
+    ""packageA"": ""1.1.0"",
+    ""packageB"": ""2.2.0""
   },
-  'frameworks': {
-                'netcore50': { }
+  ""frameworks"": {
+                ""netcore50"": { }
             }
 }");
                 Util.CreateFile(Path.Combine(basePath, "B"), "B.csproj",
@@ -2022,10 +2022,10 @@ EndProject";
 
                 Util.CreateFile(Path.Combine(basePath, "B"), "project.json",
 @"{
-  'dependencies': {
+  ""dependencies"": {
   },
-  'frameworks': {
-                'netcore50': { }
+  ""frameworks"": {
+                ""netcore50"": { }
             }
 }");
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
@@ -41,11 +41,11 @@ namespace NuGet.CommandLine.Test
                 await SimpleTestPackageUtility.CreatePackagesAsync(repositoryPath, packageContext);
 
                 var projectJson = @"{
-                                                    'dependencies': {
-                                                    'packageA': '1.0.0'
+                                                    ""dependencies"": {
+                                                    ""packageA"": ""1.0.0""
                                                     },
-                                                    'frameworks': {
-                                                            'uap10.0': { }
+                                                    ""frameworks"": {
+                                                            ""uap10.0"": { }
                                                         }
                                                  }";
 
@@ -90,20 +90,20 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(projectDir1, "project.json",
                                                 @"{
-                                                    'dependencies': {
+                                                    ""dependencies"": {
                                                     },
-                                                    'frameworks': {
-                                                                'uap10.0': { }
+                                                    ""frameworks"": {
+                                                                ""uap10.0"": { }
                                                             }
                                                     }");
 
                 Util.CreateFile(projectDir2, "project.json",
                                     @"{
-                                        'version': '1.0.0-*',
-                                        'dependencies': {
+                                        ""version"": ""1.0.0-*"",
+                                        ""dependencies"": {
                                         },
-                                        'frameworks': {
-                                                    'uap10.0': { }
+                                        ""frameworks"": {
+                                                    ""uap10.0"": { }
                                                 }
                                         }");
 
@@ -151,10 +151,10 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(projectDir1, "project.json",
                                                 @"{
-                                                    'dependencies': {
+                                                    ""dependencies"": {
                                                     },
-                                                    'frameworks': {
-                                                                'uap10.0': { }
+                                                    ""frameworks"": {
+                                                                ""uap10.0"": { }
                                                             }
                                                     }");
 
@@ -163,11 +163,11 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(projectDir2, "project.json",
                                     @"{
-                                        'version': '1.0.0-*',
-                                        'dependencies': {
+                                        ""version"": ""1.0.0-*"",
+                                        ""dependencies"": {
                                         },
-                                        'frameworks': {
-                                                    'uap10.0': { }
+                                        ""frameworks"": {
+                                                    ""uap10.0"": { }
                                                 }
                                         }");
 
@@ -267,10 +267,10 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(projectDir1, "project.json",
                                                 @"{
-                                                    'dependencies': {
+                                                    ""dependencies"": {
                                                     },
-                                                    'frameworks': {
-                                                                'uap10.0': { }
+                                                    ""frameworks"": {
+                                                                ""uap10.0"": { }
                                                             }
                                                     }");
 
@@ -279,13 +279,13 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(projectDir2, "project.json",
                                     @"{
-                                        'version': '1.0.0-*',
-                                        'dependencies': {
-                                            'packageA': '1.0.0',
-                                            'packageB': '1.0.0'
+                                        ""version"": ""1.0.0-*"",
+                                        ""dependencies"": {
+                                            ""packageA"": ""1.0.0"",
+                                            ""packageB"": ""1.0.0""
                                         },
-                                        'frameworks': {
-                                                    'uap10.0': { }
+                                        ""frameworks"": {
+                                                    ""uap10.0"": { }
                                                 }
                                         }");
 
@@ -332,10 +332,10 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(projectDir1, "project.json",
                                                 @"{
-                                                    'dependencies': {
+                                                    ""dependencies"": {
                                                     },
-                                                    'frameworks': {
-                                                                'uap10.0': { }
+                                                    ""frameworks"": {
+                                                                ""uap10.0"": { }
                                                             }
                                                     }");
 
@@ -412,26 +412,26 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(projectDir1, "project.json",
                                                 @"{
-                                                    'dependencies': {
+                                                    ""dependencies"": {
                                                     },
-                                                    'frameworks': {
-                                                                'net45': { }
+                                                    ""frameworks"": {
+                                                                ""net45"": { }
                                                             }
                                                     }");
                 Util.CreateFile(projectDir2, "project.json",
                                                 @"{
-                                                    'dependencies': {
+                                                    ""dependencies"": {
                                                     },
-                                                    'frameworks': {
-                                                                'net45': { }
+                                                    ""frameworks"": {
+                                                                ""net45"": { }
                                                             }
                                                     }");
                 Util.CreateFile(projectDir3, "project.json",
                                                 @"{
-                                                    'dependencies': {
+                                                    ""dependencies"": {
                                                     },
-                                                    'frameworks': {
-                                                                'net45': { }
+                                                    ""frameworks"": {
+                                                                ""net45"": { }
                                                             }
                                                     }");
 
@@ -570,10 +570,10 @@ namespace NuGet.CommandLine.Test
 
                     Util.CreateFile(projectDir, "project.json",
                                                     @"{
-                                                    'dependencies': {
+                                                    ""dependencies"": {
                                                     },
-                                                    'frameworks': {
-                                                                'uap10.0': { }
+                                                    ""frameworks"": {
+                                                                ""uap10.0"": { }
                                                             }
                                                     }");
 
@@ -687,10 +687,10 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(projectDir1, "project.json",
                                                 @"{
-                                                    'dependencies': {
+                                                    ""dependencies"": {
                                                     },
-                                                    'frameworks': {
-                                                                'uap10.0': { }
+                                                    ""frameworks"": {
+                                                                ""uap10.0"": { }
                                                             }
                                                     }");
 
@@ -713,12 +713,12 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(projectDir2, "project.json",
                                     @"{
-                                        'version': '1.0.0-*',
-                                        'dependencies': {
+                                        ""version"": ""1.0.0-*"",
+                                        ""dependencies"": {
                                             ""packageA"": ""1.0.0""
                                         },
-                                        'frameworks': {
-                                                    'uap10.0': { }
+                                        ""frameworks"": {
+                                                    ""uap10.0"": { }
                                                 }
                                         }");
 
@@ -897,10 +897,10 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(projectDir1, "project.json",
                                                 @"{
-                                            'dependencies': {
+                                            ""dependencies"": {
                                             },
-                                            'frameworks': {
-                                                        'uap10.0': { }
+                                            ""frameworks"": {
+                                                        ""uap10.0"": { }
                                                     }
                                             }");
 
@@ -947,10 +947,10 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(projectDir1, "project.json",
                                                 @"{
-                                            'dependencies': {
+                                            ""dependencies"": {
                                             },
-                                            'frameworks': {
-                                                        'uap10.0': { }
+                                            ""frameworks"": {
+                                                        ""uap10.0"": { }
                                                     }
                                             }");
 
@@ -1002,11 +1002,11 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(projectDir1, "project.json",
                                                 @"{
-                                            'dependencies': {
-                                            'packageA': '1.1.0-beta-*'
+                                            ""dependencies"": {
+                                            ""packageA"": ""1.1.0-beta-*""
                                             },
-                                            'frameworks': {
-                                                        'uap10.0': { }
+                                            ""frameworks"": {
+                                                        ""uap10.0"": { }
                                                     }
                                             }");
 
@@ -1014,12 +1014,12 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(projectDir2, "project.json",
                                     @"{
-                                        'version': '1.0.0-*',
-                                        'dependencies': {
-                                        'packageA': '1.1.0-beta-*'
+                                        ""version"": ""1.0.0-*"",
+                                        ""dependencies"": {
+                                        ""packageA"": ""1.1.0-beta-*""
                                         },
-                                        'frameworks': {
-                                                    'uap10.0': { }
+                                        ""frameworks"": {
+                                                    ""uap10.0"": { }
                                                 }
                                         }");
 
@@ -1112,11 +1112,11 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(projectDir1, "project.json",
                                                 @"{
-                                                    'dependencies': {
-                                                        'packageA': '1.0.0'
+                                                    ""dependencies"": {
+                                                        ""packageA"": ""1.0.0""
                                                     },
-                                                    'frameworks': {
-                                                                'uap10.0': { }
+                                                    ""frameworks"": {
+                                                                ""uap10.0"": { }
                                                             }
                                                     }");
 
@@ -1124,12 +1124,12 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(projectDir2, "project.json",
                                     @"{
-                                        'version': '1.0.0-*',
-                                        'dependencies': {
-                                            'packageB': '1.0.0'
+                                        ""version"": ""1.0.0-*"",
+                                        ""dependencies"": {
+                                            ""packageB"": ""1.0.0""
                                         },
-                                        'frameworks': {
-                                                    'uap10.0': { }
+                                        ""frameworks"": {
+                                                    ""uap10.0"": { }
                                                 }
                                         }");
 
@@ -1215,11 +1215,11 @@ namespace NuGet.CommandLine.Test
                 Util.CreateTestPackage("packageA", "1.0.0-beta-01", repositoryPath);
                 Util.CreateTestPackage("packageA", "1.0.0-beta-02", repositoryPath);
                 var projectJson = @"{
-                                        'dependencies': {
-                                        'packageA': '1.0.0-*'
+                                        ""dependencies"": {
+                                        ""packageA"": ""1.0.0-*""
                                         },
-                                        'frameworks': {
-                                                'uap10.0': { }
+                                        ""frameworks"": {
+                                                ""uap10.0"": { }
                                             }
                                         }";
 
@@ -1271,11 +1271,11 @@ namespace NuGet.CommandLine.Test
                 Util.CreateTestPackage("packageA", "1.0.0-beta-01", repositoryPath);
                 Util.CreateTestPackage("packageA", "1.0.0-beta-02", repositoryPath);
                 var projectJson = @"{
-                                                    'dependencies': {
-                                                    'packageA': '1.0.0-*'
+                                                    ""dependencies"": {
+                                                    ""packageA"": ""1.0.0-*""
                                                     },
-                                                    'frameworks': {
-                                                            'uap10.0': { }
+                                                    ""frameworks"": {
+                                                            ""uap10.0"": { }
                                                         }
                                                   }";
 
@@ -1383,11 +1383,11 @@ namespace NuGet.CommandLine.Test
                 Util.CreateTestPackage("packageB", "2.0.0-beta", repositoryPath);
                 Util.CreateTestPackage("packageB", "3.0.0", repositoryPath);
                 var projectJson = @"{
-                                                    'dependencies': {
-                                                    'packageA': '1.0.0'
+                                                    ""dependencies"": {
+                                                    ""packageA"": ""1.0.0""
                                                     },
-                                                    'frameworks': {
-                                                            'uap10.0': { }
+                                                    ""frameworks"": {
+                                                            ""uap10.0"": { }
                                                         }
                                                  }";
 
@@ -1439,12 +1439,12 @@ namespace NuGet.CommandLine.Test
                 Util.CreateTestPackage("packageC", "1.0.0", repositoryPath);
                 Util.CreateTestPackage("packageC", "2.0.0-beta", repositoryPath);
                 var projectJson = @"{
-                                        'dependencies': {
-                                        'packageA': '1.0.0',
-                                        'packageB': '1.0.0-*'
+                                        ""dependencies"": {
+                                        ""packageA"": ""1.0.0"",
+                                        ""packageB"": ""1.0.0-*""
                                         },
-                                        'frameworks': {
-                                                'uap10.0': { }
+                                        ""frameworks"": {
+                                                ""uap10.0"": { }
                                             }
                                         }";
 
@@ -1495,12 +1495,12 @@ namespace NuGet.CommandLine.Test
                 Util.CreateTestPackage("packageC", "3.0.0", repositoryPath);
                 Util.CreateTestPackage("packageC", "2.1.0", repositoryPath);
                 var projectJson = @"{
-                                                    'dependencies': {
-                                                    'packageA': '1.0.0',
-                                                    'packageB': '1.0.0'
+                                                    ""dependencies"": {
+                                                    ""packageA"": ""1.0.0"",
+                                                    ""packageB"": ""1.0.0""
                                                     },
-                                                    'frameworks': {
-                                                            'uap10.0': { }
+                                                    ""frameworks"": {
+                                                            ""uap10.0"": { }
                                                         }
                                                 }";
 
@@ -1551,12 +1551,12 @@ namespace NuGet.CommandLine.Test
                 Util.CreateTestPackage("packageC", "2.0.0-beta", repositoryPath);
                 Util.CreateConfigForGlobalPackagesFolder(workingPath);
                 var projectJson = @"{
-                                                    'dependencies': {
-                                                    'packageA': '1.0.0',
-                                                    'packageB': '1.0.0-*'
+                                                    ""dependencies"": {
+                                                    ""packageA"": ""1.0.0"",
+                                                    ""packageB"": ""1.0.0-*""
                                                     },
-                                                    'frameworks': {
-                                                            'uap10.0': { }
+                                                    ""frameworks"": {
+                                                            ""uap10.0"": { }
                                                         }
                                                   }";
 
@@ -1613,21 +1613,21 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(projectDir, "testA.project.json",
                                                 @"{
-                                            'dependencies': {
-                                            'packageA': '1.1.0-beta-*'
+                                            ""dependencies"": {
+                                            ""packageA"": ""1.1.0-beta-*""
                                             },
-                                            'frameworks': {
-                                                        'uap10.0': { }
+                                            ""frameworks"": {
+                                                        ""uap10.0"": { }
                                                     }
                                             }");
 
                 Util.CreateFile(projectDir, "testB.project.json",
                                                 @"{
-                                                    'dependencies': {
-                                                    'packageA': '1.1.0-beta-*'
+                                                    ""dependencies"": {
+                                                    ""packageA"": ""1.1.0-beta-*""
                                                     },
-                                                    'frameworks': {
-                                                                'uap10.0': { }
+                                                    ""frameworks"": {
+                                                                ""uap10.0"": { }
                                                             }
                                                  }");
 
@@ -1724,11 +1724,11 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(workingPath, "test.project.json",
                                                 @"{
-                                                        'dependencies': {
-                                                        'packageA': '1.1.0-beta-*'
+                                                        ""dependencies"": {
+                                                        ""packageA"": ""1.1.0-beta-*""
                                                         },
-                                                        'frameworks': {
-                                                                    'uap10.0': { }
+                                                        ""frameworks"": {
+                                                                    ""uap10.0"": { }
                                                         }
                                                    }");
 
@@ -1785,11 +1785,11 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(projectDir, "project.json",
                                                 @"{
-                                            'dependencies': {
-                                            'packageA': '1.1.0-beta-*'
+                                            ""dependencies"": {
+                                            ""packageA"": ""1.1.0-beta-*""
                                             },
-                                            'frameworks': {
-                                                        'uap10.0': { }
+                                            ""frameworks"": {
+                                                        ""uap10.0"": { }
                                                     }
                                             }");
 
@@ -1876,12 +1876,12 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(workingPath, "project.json",
                                                 @"{
-                                                    'dependencies': {
-                                                    'packageA': '1.1.0-beta-*',
-                                                    'packageB': '2.2.0-beta-*'
+                                                    ""dependencies"": {
+                                                    ""packageA"": ""1.1.0-beta-*"",
+                                                    ""packageB"": ""2.2.0-beta-*""
                                                     },
-                                                    'frameworks': {
-                                                                'uap10.0': { }
+                                                    ""frameworks"": {
+                                                                ""uap10.0"": { }
                                                             }
                                                 }");
 
@@ -1972,12 +1972,12 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(projectDir, "project.json",
                                                 @"{
-                                                    'dependencies': {
-                                                    'packageA': '1.1.0-beta-*',
-                                                    'packageB': '2.2.0-beta-*'
+                                                    ""dependencies"": {
+                                                    ""packageA"": ""1.1.0-beta-*"",
+                                                    ""packageB"": ""2.2.0-beta-*""
                                                     },
-                                                    'frameworks': {
-                                                                'uap10.0': { }
+                                                    ""frameworks"": {
+                                                                ""uap10.0"": { }
                                                             }
                                                 }");
 
@@ -2038,12 +2038,12 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(workingPath, "project.json",
                                                 @"{
-                                                    'dependencies': {
-                                                    'packageA': '1.1.0-beta-*',
-                                                    'packageB': '2.2.0-beta-*'
+                                                    ""dependencies"": {
+                                                    ""packageA"": ""1.1.0-beta-*"",
+                                                    ""packageB"": ""2.2.0-beta-*""
                                                     },
-                                                    'frameworks': {
-                                                                'uap10.0': { }
+                                                    ""frameworks"": {
+                                                                ""uap10.0"": { }
                                                             }
                                                 }");
 
@@ -2103,12 +2103,12 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(workingPath, "project.json",
                                                 @"{
-                                                    'dependencies': {
-                                                    'packageA': '1.1.0-beta-*',
-                                                    'packageB': '2.2.0-beta-*'
+                                                    ""dependencies"": {
+                                                    ""packageA"": ""1.1.0-beta-*"",
+                                                    ""packageB"": ""2.2.0-beta-*""
                                                     },
-                                                    'frameworks': {
-                                                                'uap10.0': { }
+                                                    ""frameworks"": {
+                                                                ""uap10.0"": { }
                                                             }
                                                   }");
 
@@ -2165,11 +2165,11 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(workingPath, "project.json",
                                                 @"{
-                                                    'dependencies': {
-                                                    'packageA': '3.1.0',
+                                                    ""dependencies"": {
+                                                    ""packageA"": ""3.1.0"",
                                                     },
-                                                    'frameworks': {
-                                                                'uap10.0': { }
+                                                    ""frameworks"": {
+                                                                ""uap10.0"": { }
                                                   }
                                                }");
 
@@ -2232,12 +2232,12 @@ namespace NuGet.CommandLine.Test
 
                 Util.CreateFile(workingPath, "project.json",
                                                 @"{
-                                                    'dependencies': {
-                                                    'packageA': '1.1.0-beta-*',
-                                                    'packageB': '2.2.0-beta-*'
+                                                    ""dependencies"": {
+                                                    ""packageA"": ""1.1.0-beta-*"",
+                                                    ""packageB"": ""2.2.0-beta-*""
                                                     },
-                                                    'frameworks': {
-                                                                'uap10.0': { }
+                                                    ""frameworks"": {
+                                                                ""uap10.0"": { }
                                                             }
                                                 }");
 
@@ -2322,12 +2322,12 @@ namespace NuGet.CommandLine.Test
                 Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
                 Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
                 var projectJson = @"{
-                                        'dependencies': {
-                                        'packageA': '1.1.0',
-                                        'packageB': '2.2.0'
+                                        ""dependencies"": {
+                                        ""packageA"": ""1.1.0"",
+                                        ""packageB"": ""2.2.0""
                                         },
-                                        'frameworks': {
-                                                    'uap10.0': { }
+                                        ""frameworks"": {
+                                                    ""uap10.0"": { }
                                                 }
                                         }";
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -994,14 +994,14 @@ EndProject");
 
         public static string GetProjectJsonFileContents(string targetFramework, IEnumerable<PackageIdentity> packages)
         {
-            var dependencies = string.Join(", ", packages.Select(package => $"'{package.Id}': '{package.Version}'"));
+            var dependencies = string.Join(", ", packages.Select(package => $"\"{package.Id}\": \"{package.Version}\""));
             return $@"
 {{
-  'dependencies': {{
+  ""dependencies"": {{
     {dependencies}
   }},
-  'frameworks': {{
-    '{targetFramework}': {{ }}
+  ""frameworks"": {{
+    ""{targetFramework}"": {{ }}
   }}
 }}";
         }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegrationTestUtility.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegrationTestUtility.cs
@@ -37,12 +37,12 @@ namespace NuGet.PackageManagement.Test
         }
 
         public const string ProjectJsonWithPackage = @"{
-  'dependencies': {
-    'EntityFramework': '5.0.0'
+  ""dependencies"": {
+    ""EntityFramework"": ""5.0.0""
   },
-  'frameworks': {
-                'net46': { }
-            }
+  ""frameworks"": {
+    ""net46"": { }
+  }
 }";
 
         public static ExternalProjectReference CreateReference(string name)

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyTargetTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyTargetTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -11,11 +10,10 @@ using Xunit;
 
 namespace NuGet.ProjectModel.Test
 {
-    [Obsolete]
     public class DependencyTargetTests
     {
         [Theory]
-        [MemberData(nameof(JsonPackageSpecReaderTests.TestEnvironmentVariableReader), MemberType = typeof(JsonPackageSpecReaderTests))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void DependencyTarget_ExternalProjectValue(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -40,7 +38,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(JsonPackageSpecReaderTests.TestEnvironmentVariableReader), MemberType = typeof(JsonPackageSpecReaderTests))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void DependencyTarget_ProjectValue(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -65,7 +63,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(JsonPackageSpecReaderTests.TestEnvironmentVariableReader), MemberType = typeof(JsonPackageSpecReaderTests))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void DependencyTarget_PackageValue(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -90,7 +88,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(JsonPackageSpecReaderTests.TestEnvironmentVariableReader), MemberType = typeof(JsonPackageSpecReaderTests))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void DependencyTarget_CaseInsensitive(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -115,7 +113,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(JsonPackageSpecReaderTests.TestEnvironmentVariableReader), MemberType = typeof(JsonPackageSpecReaderTests))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void DependencyTarget_DefaultValueDefault(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -138,7 +136,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(JsonPackageSpecReaderTests.TestEnvironmentVariableReader), MemberType = typeof(JsonPackageSpecReaderTests))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void DependencyTarget_UnknownValueFails(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -173,14 +171,14 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal("Invalid dependency target value 'blah'.", exception.Message);
             Assert.EndsWith("project.json", exception.Path);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal(5, exception.Line);
             }
         }
 
         [Theory]
-        [MemberData(nameof(JsonPackageSpecReaderTests.TestEnvironmentVariableReader), MemberType = typeof(JsonPackageSpecReaderTests))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void DependencyTarget_NonWhiteListValueFails(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -215,14 +213,14 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal("Invalid dependency target value 'winmd'.", exception.Message);
             Assert.EndsWith("project.json", exception.Path);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal(5, exception.Line);
             }
         }
 
         [Theory]
-        [MemberData(nameof(JsonPackageSpecReaderTests.TestEnvironmentVariableReader), MemberType = typeof(JsonPackageSpecReaderTests))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void DependencyTarget_MultipleValuesFail(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -257,14 +255,14 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal("Invalid dependency target value 'package,project'.", exception.Message);
             Assert.EndsWith("project.json", exception.Path);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal(5, exception.Line);
             }
         }
 
         [Theory]
-        [MemberData(nameof(JsonPackageSpecReaderTests.TestEnvironmentVariableReader), MemberType = typeof(JsonPackageSpecReaderTests))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void DependencyTarget_AcceptsWhitespace(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -292,7 +290,7 @@ namespace NuGet.ProjectModel.Test
         private static PackageSpec GetPackageSpec(string json, string name, string packageSpecPath, IEnvironmentVariableReader environmentVariableReader)
         {
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
-            return JsonPackageSpecReader.GetPackageSpec(stream, name, packageSpecPath, null, environmentVariableReader);
+            return JsonPackageSpecReader.GetPackageSpec(stream, name, packageSpecPath, null, environmentVariableReader, true);
         }
 
     }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyTargetTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyTargetTests.cs
@@ -1,16 +1,22 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.IO;
 using System.Linq;
+using System.Text;
+using NuGet.Common;
 using NuGet.LibraryModel;
 using Xunit;
 
 namespace NuGet.ProjectModel.Test
 {
+    [Obsolete]
     public class DependencyTargetTests
     {
-        [Fact]
-        public void DependencyTarget_ExternalProjectValue()
+        [Theory]
+        [MemberData(nameof(JsonPackageSpecReaderTests.TestEnvironmentVariableReader), MemberType = typeof(JsonPackageSpecReaderTests))]
+        public void DependencyTarget_ExternalProjectValue(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
@@ -26,15 +32,16 @@ namespace NuGet.ProjectModel.Test
                         }";
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = GetPackageSpec(json, "TestProject", "project.json", environmentVariableReader);
             var dependency = spec.Dependencies.Single();
 
             // Assert
             Assert.Equal(LibraryDependencyTarget.ExternalProject, dependency.LibraryRange.TypeConstraint);
         }
 
-        [Fact]
-        public void DependencyTarget_ProjectValue()
+        [Theory]
+        [MemberData(nameof(JsonPackageSpecReaderTests.TestEnvironmentVariableReader), MemberType = typeof(JsonPackageSpecReaderTests))]
+        public void DependencyTarget_ProjectValue(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
@@ -50,15 +57,16 @@ namespace NuGet.ProjectModel.Test
                         }";
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = GetPackageSpec(json, "TestProject", "project.json", environmentVariableReader);
             var dependency = spec.Dependencies.Single();
 
             // Assert
             Assert.Equal(LibraryDependencyTarget.Project, dependency.LibraryRange.TypeConstraint);
         }
 
-        [Fact]
-        public void DependencyTarget_PackageValue()
+        [Theory]
+        [MemberData(nameof(JsonPackageSpecReaderTests.TestEnvironmentVariableReader), MemberType = typeof(JsonPackageSpecReaderTests))]
+        public void DependencyTarget_PackageValue(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
@@ -74,15 +82,16 @@ namespace NuGet.ProjectModel.Test
                         }";
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = GetPackageSpec(json, "TestProject", "project.json", environmentVariableReader);
             var dependency = spec.Dependencies.Single();
 
             // Assert
             Assert.Equal(LibraryDependencyTarget.Package, dependency.LibraryRange.TypeConstraint);
         }
 
-        [Fact]
-        public void DependencyTarget_CaseInsensitive()
+        [Theory]
+        [MemberData(nameof(JsonPackageSpecReaderTests.TestEnvironmentVariableReader), MemberType = typeof(JsonPackageSpecReaderTests))]
+        public void DependencyTarget_CaseInsensitive(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
@@ -98,15 +107,16 @@ namespace NuGet.ProjectModel.Test
                         }";
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = GetPackageSpec(json, "TestProject", "project.json", environmentVariableReader);
             var dependency = spec.Dependencies.Single();
 
             // Assert
             Assert.Equal(LibraryDependencyTarget.Package, dependency.LibraryRange.TypeConstraint);
         }
 
-        [Fact]
-        public void DependencyTarget_DefaultValueDefault()
+        [Theory]
+        [MemberData(nameof(JsonPackageSpecReaderTests.TestEnvironmentVariableReader), MemberType = typeof(JsonPackageSpecReaderTests))]
+        public void DependencyTarget_DefaultValueDefault(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
@@ -119,7 +129,7 @@ namespace NuGet.ProjectModel.Test
                         }";
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = GetPackageSpec(json, "TestProject", "project.json", environmentVariableReader);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -127,8 +137,9 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(expected, dependency.LibraryRange.TypeConstraint);
         }
 
-        [Fact]
-        public void DependencyTarget_UnknownValueFails()
+        [Theory]
+        [MemberData(nameof(JsonPackageSpecReaderTests.TestEnvironmentVariableReader), MemberType = typeof(JsonPackageSpecReaderTests))]
+        public void DependencyTarget_UnknownValueFails(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
@@ -149,7 +160,7 @@ namespace NuGet.ProjectModel.Test
 
             try
             {
-                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+                var spec = GetPackageSpec(json, "TestProject", "project.json", environmentVariableReader);
                 var dependency = spec.Dependencies.Single();
             }
             catch (FileFormatException ex)
@@ -161,11 +172,16 @@ namespace NuGet.ProjectModel.Test
             Assert.NotNull(exception);
             Assert.Equal("Invalid dependency target value 'blah'.", exception.Message);
             Assert.EndsWith("project.json", exception.Path);
-            Assert.Equal(5, exception.Line);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal(5, exception.Line);
+            }
         }
 
-        [Fact]
-        public void DependencyTarget_NonWhiteListValueFails()
+        [Theory]
+        [MemberData(nameof(JsonPackageSpecReaderTests.TestEnvironmentVariableReader), MemberType = typeof(JsonPackageSpecReaderTests))]
+        public void DependencyTarget_NonWhiteListValueFails(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
@@ -186,7 +202,7 @@ namespace NuGet.ProjectModel.Test
 
             try
             {
-                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+                var spec = GetPackageSpec(json, "TestProject", "project.json", environmentVariableReader);
                 var dependency = spec.Dependencies.Single();
             }
             catch (FileFormatException ex)
@@ -198,11 +214,16 @@ namespace NuGet.ProjectModel.Test
             Assert.NotNull(exception);
             Assert.Equal("Invalid dependency target value 'winmd'.", exception.Message);
             Assert.EndsWith("project.json", exception.Path);
-            Assert.Equal(5, exception.Line);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal(5, exception.Line);
+            }
         }
 
-        [Fact]
-        public void DependencyTarget_MultipleValuesFail()
+        [Theory]
+        [MemberData(nameof(JsonPackageSpecReaderTests.TestEnvironmentVariableReader), MemberType = typeof(JsonPackageSpecReaderTests))]
+        public void DependencyTarget_MultipleValuesFail(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
@@ -223,7 +244,7 @@ namespace NuGet.ProjectModel.Test
 
             try
             {
-                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+                var spec = GetPackageSpec(json, "TestProject", "project.json", environmentVariableReader);
                 var dependency = spec.Dependencies.Single();
             }
             catch (FileFormatException ex)
@@ -235,11 +256,16 @@ namespace NuGet.ProjectModel.Test
             Assert.NotNull(exception);
             Assert.Equal("Invalid dependency target value 'package,project'.", exception.Message);
             Assert.EndsWith("project.json", exception.Path);
-            Assert.Equal(5, exception.Line);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal(5, exception.Line);
+            }
         }
 
-        [Fact]
-        public void DependencyTarget_AcceptsWhitespace()
+        [Theory]
+        [MemberData(nameof(JsonPackageSpecReaderTests.TestEnvironmentVariableReader), MemberType = typeof(JsonPackageSpecReaderTests))]
+        public void DependencyTarget_AcceptsWhitespace(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
@@ -256,11 +282,18 @@ namespace NuGet.ProjectModel.Test
 
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = GetPackageSpec(json, "TestProject", "project.json", environmentVariableReader);
 
             // Assert
             var dependency = spec.Dependencies.Single();
             Assert.Equal(LibraryDependencyTarget.Package, dependency.LibraryRange.TypeConstraint);
         }
+
+        private static PackageSpec GetPackageSpec(string json, string name, string packageSpecPath, IEnvironmentVariableReader environmentVariableReader)
+        {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            return JsonPackageSpecReader.GetPackageSpec(stream, name, packageSpecPath, null, environmentVariableReader);
+        }
+
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -26,7 +26,7 @@ namespace NuGet.ProjectModel.Test
     public class JsonPackageSpecReaderTests
     {
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_PackageMissingVersion(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -58,7 +58,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_ProjectMissingVersion(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -83,7 +83,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_PackageEmptyVersion(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -115,7 +115,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_PackageWhitespaceVersion(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -147,7 +147,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_FrameworkAssemblyEmptyVersion(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -170,7 +170,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_ExplicitIncludesOverrideTypePlatform(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -196,26 +196,25 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "{}")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "{}")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{}", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""packOptions"": {}
-                              }")]
+                              }", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""packOptions"": {
                                   ""foo"": [1, 2]
                                 }
-                              }")]
+                              }", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""packOptions"": {
                                   ""packageType"": null
                                 }
-                              }")]
+                              }", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""packOptions"": {
                                   ""packageType"": []
                                 }
-                              }")]
+                              }", MemberType = typeof(LockFileParsingEnvironmentVariable))]
 #pragma warning disable CS0612 // Type or member is obsolete
         public void PackageSpecReader_PackOptions_Default(IEnvironmentVariableReader environmentVariableReader, string json)
         {
@@ -234,7 +233,7 @@ namespace NuGet.ProjectModel.Test
                                 ""packOptions"": {
                                   ""packageType"": ""foo""
                                 }
-                              }")]
+                              }", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_Malformed_Default(IEnvironmentVariableReader environmentVariableReader, string json)
         {
             // Arrange & Act
@@ -251,27 +250,27 @@ namespace NuGet.ProjectModel.Test
                                 ""packOptions"": {
                                   ""packageType"": ""foo""
                                 }
-                              }", new[] { "foo" })]
+                              }", new[] { "foo" }, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""packOptions"": {
                                   ""packageType"": ""foo, bar""
                                 }
-                              }", new[] { "foo, bar" })]
+                              }", new[] { "foo, bar" }, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""packOptions"": {
                                   ""packageType"": [ ""foo"" ]
                                 }
-                              }", new[] { "foo" })]
+                              }", new[] { "foo" }, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""packOptions"": {
                                   ""packageType"": [ ""foo, bar"" ]
                                 }
-                              }", new[] { "foo, bar" })]
+                              }", new[] { "foo, bar" }, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""packOptions"": {
                                   ""packageType"": [ ""foo"", ""bar"" ]
                                 }
-                              }", new[] { "foo", "bar" })]
+                              }", new[] { "foo", "bar" }, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_PackOptions_ValidPackageType(IEnvironmentVariableReader environmentVariableReader, string json, string[] expectedNames)
         {
             // Arrange
@@ -294,29 +293,29 @@ namespace NuGet.ProjectModel.Test
                                 ""packOptions"": {
                                   ""packageType"": 1
                                 }
-                              }")]
+                              }", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""packOptions"": {
                                   ""packageType"": false
                                 }
-                              }")]
+                              }", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""packOptions"": {
                                   ""packageType"": 1.0
                                 }
-                              }")]
+                              }", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""packOptions"": {
                                   ""packageType"": {}
                                 }
-                              }")]
+                              }", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""packOptions"": {
                                   ""packageType"": {
                                     ""name"": ""foo""
                                   }
                                 }
-                              }")]
+                              }", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""packOptions"": {
                                   ""packageType"": [
@@ -324,7 +323,7 @@ namespace NuGet.ProjectModel.Test
                                     { ""name"": ""bar"" }
                                   ]
                                 }
-                              }")]
+                              }", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""packOptions"": {
                                   ""packageType"": [
@@ -332,7 +331,7 @@ namespace NuGet.ProjectModel.Test
                                     null
                                   ]
                                 }
-                              }")]
+                              }", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""packOptions"": {
                                   ""packageType"": [
@@ -340,7 +339,7 @@ namespace NuGet.ProjectModel.Test
                                     true
                                   ]
                                 }
-                              }")]
+                              }", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_PackOptions_InvalidPackageType(IEnvironmentVariableReader environmentVariableReader, string json)
         {
             // Arrange & Act & Assert
@@ -351,7 +350,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_PackOptions_Files1(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange & Act
@@ -391,7 +390,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_PackOptions_Files2(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange & Act
@@ -445,26 +444,26 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "{}", null, true)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{}", null, true, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""buildOptions"": {}
-                              }", null, false)]
+                              }", null, false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""buildOptions"": {
                                   ""outputName"": ""dllName""
                                 }
-                              }", "dllName", false)]
+                              }", "dllName", false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""buildOptions"": {
                                   ""outputName"": ""dllName2"",
                                   ""emitEntryPoint"": true
                                 }
-                              }", "dllName2", false)]
+                              }", "dllName2", false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         [MemberData(nameof(TestEnvironmentVariableReader), @"{
                                 ""buildOptions"": {
                                   ""outputName"": null
                                 }
-                              }", null, false)]
+                              }", null, false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_BuildOptions(IEnvironmentVariableReader environmentVariableReader, string json, string expectedValue, bool nullBuildOptions)
         {
             // Arrange & Act
@@ -484,7 +483,7 @@ namespace NuGet.ProjectModel.Test
 #pragma warning restore CS0612 // Type or member is obsolete
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_ReadsWithoutRestoreSettings(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -509,7 +508,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_ReadsDependencyWithMultipleNoWarn(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -541,7 +540,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_ReadsDependencyWithSingleNoWarn(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -571,7 +570,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_ReadsDependencyWithSingleEmptyNoWarn(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -599,7 +598,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_ReadsRestoreMetadataWithWarningProperties(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -673,7 +672,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_ReadsRestoreMetadataWithWarningPropertiesAndNo_NoWarn(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -736,7 +735,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_ReadsRestoreMetadataWithWarningPropertiesAndNo_WarnAsError(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -797,7 +796,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_ReadsRestoreMetadataWithWarningPropertiesAndNo_AllWarningsAsErrors(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -863,7 +862,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_ReadsRestoreMetadataWithEmptyWarningPropertiesAnd(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -919,7 +918,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_ReadsRestoreMetadataWithNoWarningProperties(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -970,7 +969,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_RuntimeIdentifierPathNullIfEmpty(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -999,7 +998,7 @@ namespace NuGet.ProjectModel.Test
 
 #pragma warning disable CS0612 // Type or member is obsolete
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenAuthorsPropertyIsAbsent_ReturnsEmptyAuthors(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSpec packageSpec = GetPackageSpec("{}", environmentVariableReader);
@@ -1008,7 +1007,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenAuthorsValueIsNull_ReturnsEmptyAuthors(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSpec packageSpec = GetPackageSpec("{\"authors\":null}", environmentVariableReader);
@@ -1017,7 +1016,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenAuthorsValueIsString_ReturnsEmptyAuthors(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSpec packageSpec = GetPackageSpec("{\"authors\":\"b\"}", environmentVariableReader);
@@ -1026,8 +1025,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "/**/")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "/**/", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenAuthorsValueIsEmptyArray_ReturnsEmptyAuthors(IEnvironmentVariableReader environmentVariableReader, string value)
         {
             PackageSpec packageSpec = GetPackageSpec($"{{\"authors\":[{value}]}}", environmentVariableReader);
@@ -1036,8 +1035,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "{}")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[]")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{}", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[]", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenAuthorsValueElementIsNotConvertibleToString_Throws(IEnvironmentVariableReader environmentVariableReader, string value)
         {
             var json = $"{{\"authors\":[{value}]}}";
@@ -1046,10 +1045,10 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "true", "True")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "-2", "-2")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "3.14", "3.14")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "true", "True", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "-2", "-2", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "3.14", "3.14", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenAuthorsValueElementIsConvertibleToString_ReturnsAuthor(IEnvironmentVariableReader environmentVariableReader, string value, string expectedValue)
         {
             PackageSpec packageSpec = GetPackageSpec($"{{\"authors\":[{value}]}}", environmentVariableReader);
@@ -1058,7 +1057,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenBuildOptionsPropertyIsAbsent_ReturnsNullBuildOptions(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSpec packageSpec = GetPackageSpec("{}", environmentVariableReader);
@@ -1067,7 +1066,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenBuildOptionsValueIsEmptyObject_ReturnsBuildOptions(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSpec packageSpec = GetPackageSpec("{\"buildOptions\":{}}", environmentVariableReader);
@@ -1077,7 +1076,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenBuildOptionsValueOutputNameIsNull_ReturnsNullOutputName(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSpec packageSpec = GetPackageSpec("{\"buildOptions\":{\"outputName\":null}}", environmentVariableReader);
@@ -1086,7 +1085,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenBuildOptionsValueOutputNameIsValid_ReturnsOutputName(IEnvironmentVariableReader environmentVariableReader)
         {
             const string expectedResult = "a";
@@ -1099,9 +1098,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "-2", "-2")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "3.14", "3.14")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "true", "True")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "-2", "-2", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "3.14", "3.14", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "true", "True", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenBuildOptionsValueOutputNameIsConvertibleToString_ReturnsOutputName(IEnvironmentVariableReader environmentVariableReader, string outputName, string expectedValue)
         {
             PackageSpec packageSpec = GetPackageSpec($"{{\"buildOptions\":{{\"outputName\":{outputName}}}}}", environmentVariableReader);
@@ -1110,7 +1109,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenContentFilesPropertyIsAbsent_ReturnsEmptyContentFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSpec packageSpec = GetPackageSpec("{}", environmentVariableReader);
@@ -1119,7 +1118,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenContentFilesValueIsNull_ReturnsEmptyContentFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSpec packageSpec = GetPackageSpec("{\"contentFiles\":null}", environmentVariableReader);
@@ -1128,7 +1127,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenContentFilesValueIsString_ReturnsEmptyContentFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSpec packageSpec = GetPackageSpec("{\"contentFiles\":\"a\"}", environmentVariableReader);
@@ -1137,8 +1136,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "/**/")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "/**/", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenContentFilesValueIsEmptyArray_ReturnsEmptyContentFiles(IEnvironmentVariableReader environmentVariableReader, string value)
         {
             PackageSpec packageSpec = GetPackageSpec($"{{\"contentFiles\":[{value}]}}", environmentVariableReader);
@@ -1147,8 +1146,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "{}")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[]")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{}", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[]", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenContentFilesValueElementIsNotConvertibleToString_Throws(IEnvironmentVariableReader environmentVariableReader, string value)
         {
             var json = $"{{\"contentFiles\":[{value}]}}";
@@ -1157,10 +1156,10 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "true", "True")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "-2", "-2")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "3.14", "3.14")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "true", "True", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "-2", "-2", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "3.14", "3.14", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenContentFilesValueElementIsConvertibleToString_ReturnsContentFile(IEnvironmentVariableReader environmentVariableReader, string value, string expectedValue)
         {
             PackageSpec packageSpec = GetPackageSpec($"{{\"contentFiles\":[{value}]}}", environmentVariableReader);
@@ -1169,7 +1168,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenCopyrightPropertyIsAbsent_ReturnsNullCopyright(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSpec packageSpec = GetPackageSpec("{}", environmentVariableReader);
@@ -1178,7 +1177,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenCopyrightValueIsNull_ReturnsNullCopyright(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSpec packageSpec = GetPackageSpec("{\"copyright\":null}", environmentVariableReader);
@@ -1187,7 +1186,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenCopyrightValueIsString_ReturnsCopyright(IEnvironmentVariableReader environmentVariableReader)
         {
             const string expectedResult = "a";
@@ -1198,10 +1197,10 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "true", "True")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "-2", "-2")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "3.14", "3.14")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "true", "True", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "-2", "-2", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "3.14", "3.14", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenCopyrightValueIsConvertibleToString_ReturnsCopyright(IEnvironmentVariableReader environmentVariableReader, string value, string expectedValue)
         {
             PackageSpec packageSpec = GetPackageSpec($"{{\"copyright\":{value}}}", environmentVariableReader);
@@ -1211,7 +1210,7 @@ namespace NuGet.ProjectModel.Test
 #pragma warning restore CS0612 // Type or member is obsolete
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesPropertyIsAbsent_ReturnsEmptyDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSpec packageSpec = GetPackageSpec("{}", environmentVariableReader);
@@ -1220,7 +1219,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesValueIsNull_ReturnsEmptyDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSpec packageSpec = GetPackageSpec("{\"dependencies\":null}", environmentVariableReader);
@@ -1229,7 +1228,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyNameIsEmptyString_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"\":{}}}";
@@ -1238,7 +1237,7 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal("Unable to resolve dependency ''.", exception.Message);
             Assert.Null(exception.InnerException);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal(1, exception.Line);
                 Assert.Equal(21, exception.Column);
@@ -1246,7 +1245,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyValueIsVersionString_ReturnsDependencyVersionRange(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new LibraryRange(
@@ -1261,7 +1260,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyValueIsVersionRangeString_ReturnsDependencyVersionRange(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new LibraryRange(
@@ -1276,12 +1275,12 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.None)]
-        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.Assembly)]
-        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.Reference)]
-        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.WinMD)]
-        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.All)]
-        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.PackageProjectExternal)]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.None, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.Assembly, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.Reference, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.WinMD, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.All, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.PackageProjectExternal, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyTargetIsUnsupported_Throws(IEnvironmentVariableReader environmentVariableReader, LibraryDependencyTarget target)
         {
             var json = $"{{\"dependencies\":{{\"a\":{{\"version\":\"1.2.3\",\"target\":\"{target}\"}}}}}}";
@@ -1291,7 +1290,7 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal($"Invalid dependency target value '{target}'.", exception.Message);
             Assert.Null(exception.InnerException);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal(1, exception.Line);
                 // The position is after the target name, which is of variable length.
@@ -1300,7 +1299,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyAutoreferencedPropertyIsAbsent_ReturnsFalseAutoreferenced(IEnvironmentVariableReader environmentVariableReader)
         {
             LibraryDependency dependency = GetDependency($"{{\"dependencies\":{{\"a\":{{\"target\":\"Project\"}}}}}}", environmentVariableReader);
@@ -1309,8 +1308,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), true)]
-        [MemberData(nameof(TestEnvironmentVariableReader), false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), true, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyAutoreferencedValueIsBool_ReturnsBoolAutoreferenced(IEnvironmentVariableReader environmentVariableReader, bool expectedValue)
         {
             var json = $"{{\"dependencies\":{{\"a\":{{\"autoReferenced\":{expectedValue.ToString().ToLower()},\"target\":\"Project\"}}}}}}";
@@ -1321,9 +1320,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "exclude")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "include")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "suppressParent")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "exclude", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "include", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "suppressParent", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyValueIsArray_Throws(IEnvironmentVariableReader environmentVariableReader, string propertyName)
         {
             var json = $"{{\"dependencies\":{{\"a\":{{\"{propertyName}\":[\"b\"]}}}}}}";
@@ -1332,7 +1331,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyIncludeAndExcludePropertiesAreAbsent_ReturnsAllIncludeType(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
@@ -1343,8 +1342,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"Native\"", LibraryIncludeFlags.Native)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"Analyzers, Native\"", LibraryIncludeFlags.Analyzers | LibraryIncludeFlags.Native)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"Native\"", LibraryIncludeFlags.Native, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"Analyzers, Native\"", LibraryIncludeFlags.Analyzers | LibraryIncludeFlags.Native, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyExcludeValueIsValid_ReturnsIncludeType(
             IEnvironmentVariableReader environmentVariableReader,
             string value,
@@ -1358,8 +1357,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"Native\"", LibraryIncludeFlags.Native)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"Analyzers, Native\"", LibraryIncludeFlags.Analyzers | LibraryIncludeFlags.Native)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"Native\"", LibraryIncludeFlags.Native, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"Analyzers, Native\"", LibraryIncludeFlags.Analyzers | LibraryIncludeFlags.Native, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyIncludeValueIsValid_ReturnsIncludeType(
             IEnvironmentVariableReader environmentVariableReader,
             string value,
@@ -1373,7 +1372,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyIncludeValueOverridesTypeValue_ReturnsIncludeType(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"include\":\"ContentFiles\",\"type\":\"BecomesNupkgDependency, SharedFramework\",\"version\":\"1.0.0\"}}}";
@@ -1384,7 +1383,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencySuppressParentValueOverridesTypeValue_ReturnsSuppressParent(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"suppressParent\":\"ContentFiles\",\"type\":\"SharedFramework\",\"version\":\"1.0.0\"}}}";
@@ -1395,7 +1394,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencySuppressParentPropertyIsAbsent_ReturnsSuppressParent(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
@@ -1406,8 +1405,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"Compile\"", LibraryIncludeFlags.Compile)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"Analyzers, Compile\"", LibraryIncludeFlags.Analyzers | LibraryIncludeFlags.Compile)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"Compile\"", LibraryIncludeFlags.Compile, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"Analyzers, Compile\"", LibraryIncludeFlags.Analyzers | LibraryIncludeFlags.Compile, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencySuppressParentValueIsValid_ReturnsSuppressParent(
             IEnvironmentVariableReader environmentVariableReader,
             string value,
@@ -1422,14 +1421,14 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyVersionValueIsInvalid_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"version\":\"b\"}}}";
 
             FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal("Error reading '' at line 1 column 35 : 'b' is not a valid version string.", exception.Message);
                 Assert.Equal(1, exception.Line);
@@ -1442,7 +1441,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyTargetPropertyIsAbsent_ReturnsTarget(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
@@ -1453,7 +1452,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyTargetValueIsPackageAndVersionPropertyIsAbsent_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"target\":\"Package\"}}}";
@@ -1462,7 +1461,7 @@ namespace NuGet.ProjectModel.Test
             Assert.IsType<ArgumentException>(exception.InnerException);
             Assert.Null(exception.InnerException.InnerException);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal("Error reading '' at line 1 column 22 : Package dependencies must specify a version range.", exception.Message);
                 Assert.Equal(1, exception.Line);
@@ -1475,7 +1474,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyTargetValueIsProjectAndVersionPropertyIsAbsent_ReturnsAllVersionRange(IEnvironmentVariableReader environmentVariableReader)
         {
             LibraryDependency dependency = GetDependency("{\"dependencies\":{\"a\":{\"target\":\"Project\"}}}", environmentVariableReader);
@@ -1484,7 +1483,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyNoWarnPropertyIsAbsent_ReturnsEmptyNoWarns(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
@@ -1495,7 +1494,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyNoWarnValueIsValid_ReturnsNoWarns(IEnvironmentVariableReader environmentVariableReader)
         {
             NuGetLogCode[] expectedResults = { NuGetLogCode.NU1000, NuGetLogCode.NU3000 };
@@ -1510,7 +1509,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyGeneratePathPropertyPropertyIsAbsent_ReturnsFalseGeneratePathProperty(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
@@ -1521,8 +1520,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), true)]
-        [MemberData(nameof(TestEnvironmentVariableReader), false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), true, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyGeneratePathPropertyValueIsValid_ReturnsGeneratePathProperty(IEnvironmentVariableReader environmentVariableReader, bool expectedResult)
         {
             var json = $"{{\"dependencies\":{{\"a\":{{\"generatePathProperty\":{expectedResult.ToString().ToLowerInvariant()},\"version\":\"1.0.0\"}}}}}}";
@@ -1533,7 +1532,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyTypePropertyIsAbsent_ReturnsDefaultTypeConstraint(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
@@ -1546,7 +1545,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyVersionCentrallyManagedPropertyIsAbsent_ReturnsFalseVersionCentrallyManaged(IEnvironmentVariableReader environmentVariableReader)
         {
             LibraryDependency dependency = GetDependency($"{{\"dependencies\":{{\"a\":{{\"target\":\"Package\",\"version\":\"1.0.0\"}}}}}}", environmentVariableReader);
@@ -1555,8 +1554,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), true)]
-        [MemberData(nameof(TestEnvironmentVariableReader), false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), true, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDependenciesDependencyVersionCentrallyManagedValueIsBool_ReturnsBoolVersionCentrallyManaged(IEnvironmentVariableReader environmentVariableReader, bool expectedValue)
         {
             var json = $"{{\"dependencies\":{{\"a\":{{\"versionCentrallyManaged\":{expectedValue.ToString().ToLower()},\"target\":\"Package\",\"version\":\"1.0.0\"}}}}}}";
@@ -1568,7 +1567,7 @@ namespace NuGet.ProjectModel.Test
 
 #pragma warning disable CS0612 // Type or member is obsolete
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDescriptionPropertyIsAbsent_ReturnsNullDescription(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSpec packageSpec = GetPackageSpec("{}", environmentVariableReader);
@@ -1577,9 +1576,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), null)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "b")]
+        [MemberData(nameof(TestEnvironmentVariableReader), null, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "b", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenDescriptionValueIsValid_ReturnsDescription(IEnvironmentVariableReader environmentVariableReader, string expectedResult)
         {
             string description = expectedResult == null ? "null" : $"\"{expectedResult}\"";
@@ -1589,7 +1588,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenLanguagePropertyIsAbsent_ReturnsNullLanguage(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSpec packageSpec = GetPackageSpec("{}", environmentVariableReader);
@@ -1598,9 +1597,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), null)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "b")]
+        [MemberData(nameof(TestEnvironmentVariableReader), null, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "b", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenLanguageValueIsValid_ReturnsLanguage(IEnvironmentVariableReader environmentVariableReader, string expectedResult)
         {
             string language = expectedResult == null ? "null" : $"\"{expectedResult}\"";
@@ -1611,7 +1610,7 @@ namespace NuGet.ProjectModel.Test
 #pragma warning restore CS0612 // Type or member is obsolete
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksPropertyIsAbsent_ReturnsEmptyFrameworks(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSpec packageSpec = GetPackageSpec("{}", environmentVariableReader);
@@ -1620,7 +1619,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksValueIsEmptyObject_ReturnsEmptyFrameworks(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSpec packageSpec = GetPackageSpec("{\"frameworks\":{}}", environmentVariableReader);
@@ -1629,7 +1628,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksAssetTargetFallbackPropertyIsAbsent_ReturnsFalseAssetTargetFallback(IEnvironmentVariableReader environmentVariableReader)
         {
             TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{}}}", environmentVariableReader);
@@ -1638,8 +1637,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), true)]
-        [MemberData(nameof(TestEnvironmentVariableReader), false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), true, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksAssetTargetFallbackValueIsValid_ReturnsAssetTargetFallback(IEnvironmentVariableReader environmentVariableReader, bool expectedValue)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"assetTargetFallback\":{expectedValue.ToString().ToLowerInvariant()}}}}}}}";
@@ -1650,7 +1649,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WithAssetTargetFallbackAndImportsValues_ReturnsValidAssetTargetFallbackFramework(IEnvironmentVariableReader environmentVariableReader)
         {
             var json = $"{{\"frameworks\":{{\"net5.0\":{{\"assetTargetFallback\": true, \"imports\": [\"net472\", \"net471\"]}}}}}}";
@@ -1666,7 +1665,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksCentralPackageVersionsPropertyIsAbsent_ReturnsEmptyCentralPackageVersions(IEnvironmentVariableReader environmentVariableReader)
         {
             TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{}}}", environmentVariableReader);
@@ -1675,7 +1674,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksCentralPackageVersionsValueIsEmptyObject_ReturnsEmptyCentralPackageVersions(IEnvironmentVariableReader environmentVariableReader)
         {
             TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{\"centralPackageVersions\":{}}}}", environmentVariableReader);
@@ -1684,7 +1683,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksCentralPackageVersionsVersionPropertyNameIsEmptyString_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             var json = "{\"frameworks\":{\"a\":{\"centralPackageVersions\":{\"\":\"1.0.0\"}}}}";
@@ -1694,7 +1693,7 @@ namespace NuGet.ProjectModel.Test
             Assert.IsType<FileFormatException>(exception.InnerException);
             Assert.Null(exception.InnerException.InnerException);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal("Error reading '' at line 1 column 20 : Unable to resolve central version ''.", exception.Message);
                 Assert.Equal(1, exception.Line);
@@ -1707,8 +1706,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "null")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksCentralPackageVersionsVersionPropertyValueIsNullOrEmptyString_Throws(IEnvironmentVariableReader environmentVariableReader, string value)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"centralPackageVersions\":{{\"b\":{value}}}}}}}}}";
@@ -1718,7 +1717,7 @@ namespace NuGet.ProjectModel.Test
             Assert.IsType<FileFormatException>(exception.InnerException);
             Assert.Null(exception.InnerException.InnerException);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal("Error reading '' at line 1 column 20 : The version cannot be null or empty.", exception.Message);
                 Assert.Equal(1, exception.Line);
@@ -1731,7 +1730,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksCentralPackageVersionsIsValid_ReturnsCentralPackageVersions(IEnvironmentVariableReader environmentVariableReader)
         {
             const string expectedPackageId = "b";
@@ -1751,7 +1750,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksCentralPackageVersionsHasDuplicateKey_LastOneWins(IEnvironmentVariableReader environmentVariableReader)
         {
             const string expectedPackageId = "b";
@@ -1773,7 +1772,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesPropertyIsAbsent_ReturnsEmptyDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{}}}", environmentVariableReader);
@@ -1782,7 +1781,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesValueIsNull_ReturnsEmptyDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{\"dependencies\":null}}}", environmentVariableReader);
@@ -1791,14 +1790,14 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyNameIsEmptyString_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"\":{}}}}}";
 
             FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal("Error reading '' at line 1 column 20 : Unable to resolve dependency ''.", exception.Message);
                 Assert.Equal(1, exception.Line);
@@ -1813,7 +1812,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyValueIsVersionString_ReturnsDependencyVersionRange(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new LibraryRange(
@@ -1828,7 +1827,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyValueIsVersionRangeString_ReturnsDependencyVersionRange(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new LibraryRange(
@@ -1843,12 +1842,12 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.None)]
-        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.Assembly)]
-        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.Reference)]
-        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.WinMD)]
-        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.All)]
-        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.PackageProjectExternal)]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.None, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.Assembly, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.Reference, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.WinMD, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.All, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.PackageProjectExternal, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyTargetValueIsUnsupported_Throws(IEnvironmentVariableReader environmentVariableReader, LibraryDependencyTarget target)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"b\":{{\"version\":\"1.2.3\",\"target\":\"{target}\"}}}}}}}}}}";
@@ -1858,7 +1857,7 @@ namespace NuGet.ProjectModel.Test
             Assert.IsType<FileFormatException>(exception.InnerException);
             Assert.Null(exception.InnerException.InnerException);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal($"Error reading '' at line 1 column 20 : Invalid dependency target value '{target}'.", exception.Message);
                 Assert.Equal(1, exception.Line);
@@ -1871,7 +1870,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyAutoreferencedPropertyIsAbsent_ReturnsFalseAutoreferenced(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"target\":\"Project\"}}}}}";
@@ -1882,8 +1881,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), true)]
-        [MemberData(nameof(TestEnvironmentVariableReader), false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), true, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyAutoreferencedValueIsBool_ReturnsBoolAutoreferenced(IEnvironmentVariableReader environmentVariableReader, bool expectedValue)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"b\":{{\"autoReferenced\":{expectedValue.ToString().ToLower()},\"target\":\"Project\"}}}}}}}}}}";
@@ -1894,9 +1893,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "exclude")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "include")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "suppressParent")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "exclude", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "include", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "suppressParent", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyValueIsArray_Throws(IEnvironmentVariableReader environmentVariableReader, string propertyName)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"b\":{{\"{propertyName}\":[\"c\"]}}}}}}}}}}";
@@ -1908,7 +1907,7 @@ namespace NuGet.ProjectModel.Test
             Assert.IsType<InvalidCastException>(exception.InnerException);
             Assert.Null(exception.InnerException.InnerException);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal("Error reading '' at line 1 column 20 : Specified cast is not valid.", exception.Message);
                 Assert.Equal(1, exception.Line);
@@ -1921,7 +1920,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyIncludeAndExcludePropertiesAreAbsent_ReturnsAllIncludeType(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"1.0.0\"}}}}}";
@@ -1932,7 +1931,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyExcludeValueIsValid_ReturnsIncludeType(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"exclude\":\"Native\",\"version\":\"1.0.0\"}}}}}";
@@ -1943,7 +1942,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyIncludeValueIsValid_ReturnsIncludeType(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"include\":\"ContentFiles\",\"version\":\"1.0.0\"}}}}}";
@@ -1954,7 +1953,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyIncludeValueOverridesTypeValue_ReturnsIncludeType(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"include\":\"ContentFiles\",\"type\":\"BecomesNupkgDependency, SharedFramework\",\"version\":\"1.0.0\"}}}}}";
@@ -1965,7 +1964,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencySuppressParentValueOverridesTypeValue_ReturnsSuppressParent(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"suppressParent\":\"ContentFiles\",\"type\":\"SharedFramework\",\"version\":\"1.0.0\"}}}}}";
@@ -1976,7 +1975,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencySuppressParentPropertyIsAbsent_ReturnsSuppressParent(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"1.0.0\"}}}}}";
@@ -1987,7 +1986,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencySuppressParentValueIsValid_ReturnsSuppressParent(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"suppressParent\":\"Compile\",\"version\":\"1.0.0\"}}}}}";
@@ -1998,7 +1997,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyVersionValueIsInvalid_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"c\"}}}}}";
@@ -2009,7 +2008,7 @@ namespace NuGet.ProjectModel.Test
             Assert.IsType<ArgumentException>(exception.InnerException.InnerException);
             Assert.Null(exception.InnerException.InnerException.InnerException);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal("Error reading '' at line 1 column 20 : Error reading '' at line 1 column 54 : 'c' is not a valid version string.", exception.Message);
                 Assert.Equal(1, exception.Line);
@@ -2022,7 +2021,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyTargetPropertyIsAbsent_ReturnsTarget(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"1.0.0\"}}}}}";
@@ -2035,7 +2034,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyTargetValueIsPackageAndVersionPropertyIsAbsent_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"target\":\"Package\"}}}}}";
@@ -2046,7 +2045,7 @@ namespace NuGet.ProjectModel.Test
             Assert.IsType<ArgumentException>(exception.InnerException.InnerException);
             Assert.Null(exception.InnerException.InnerException.InnerException);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal("Error reading '' at line 1 column 20 : Error reading '' at line 1 column 41 : Package dependencies must specify a version range.", exception.Message);
                 Assert.Equal(1, exception.Line);
@@ -2059,7 +2058,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyTargetValueIsProjectAndVersionPropertyIsAbsent_ReturnsAllVersionRange(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"target\":\"Project\"}}}}}";
@@ -2070,7 +2069,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyNoWarnPropertyIsAbsent_ReturnsEmptyNoWarns(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"1.0.0\"}}}}}";
@@ -2081,7 +2080,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyNoWarnValueIsValid_ReturnsNoWarns(IEnvironmentVariableReader environmentVariableReader)
         {
             NuGetLogCode[] expectedResults = { NuGetLogCode.NU1000, NuGetLogCode.NU3000 };
@@ -2096,7 +2095,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyGeneratePathPropertyPropertyIsAbsent_ReturnsFalseGeneratePathProperty(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"1.0.0\"}}}}}}}";
@@ -2107,8 +2106,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), true)]
-        [MemberData(nameof(TestEnvironmentVariableReader), false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), true, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyGeneratePathPropertyValueIsValid_ReturnsGeneratePathProperty(IEnvironmentVariableReader environmentVariableReader, bool expectedResult)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"b\":{{\"generatePathProperty\":{expectedResult.ToString().ToLowerInvariant()},\"version\":\"1.0.0\"}}}}}}}}}}";
@@ -2119,7 +2118,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyTypePropertyIsAbsent_ReturnsDefaultTypeConstraint(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"1.0.0\"}}}}}";
@@ -2133,7 +2132,7 @@ namespace NuGet.ProjectModel.Test
 
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyVersionCentrallyManagedPropertyIsAbsent_ReturnsFalseVersionCentrallyManaged(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"target\":\"Package\",\"version\":\"1.0.0\"}}}}}";
@@ -2144,8 +2143,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), true)]
-        [MemberData(nameof(TestEnvironmentVariableReader), false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), true, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDependenciesDependencyVersionCentrallyManagedValueIsBool_ReturnsBoolVersionCentrallyManaged(IEnvironmentVariableReader environmentVariableReader, bool expectedValue)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"b\":{{\"versionCentrallyManaged\":{expectedValue.ToString().ToLower()},\"target\":\"Package\",\"version\":\"1.0.0\"}}}}}}}}}}";
@@ -2156,7 +2155,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDownloadDependenciesPropertyIsAbsent_ReturnsEmptyDownloadDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{}}}";
@@ -2167,7 +2166,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueIsNull_ReturnsEmptyDownloadDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"downloadDependencies\":null}}}";
@@ -2178,7 +2177,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueIsNotArray_ReturnsEmptyDownloadDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"downloadDependencies\":\"b\"}}}";
@@ -2189,7 +2188,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueIsEmptyArray_ReturnsEmptyDownloadDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"downloadDependencies\":[]}}}";
@@ -2200,7 +2199,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDownloadDependenciesDependencyNameIsAbsent_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"downloadDependencies\":[{\"version\":\"1.2.3\"}]}}}";
@@ -2209,7 +2208,7 @@ namespace NuGet.ProjectModel.Test
             Assert.IsType<FileFormatException>(exception.InnerException);
             Assert.Null(exception.InnerException.InnerException);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal("Error reading '' at line 1 column 20 : Unable to resolve downloadDependency ''.", exception.Message);
                 Assert.Equal(1, exception.Line);
@@ -2222,7 +2221,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDownloadDependenciesDependencyNameIsNull_ReturnsDownloadDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new DownloadDependency(name: null, new VersionRange(new NuGetVersion("1.2.3")));
@@ -2237,7 +2236,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDownloadDependenciesDependencyVersionIsAbsent_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"downloadDependencies\":[{\"name\":\"b\"}]}}}";
@@ -2246,7 +2245,7 @@ namespace NuGet.ProjectModel.Test
 
             Assert.IsType<FileFormatException>(exception.InnerException);
             Assert.Null(exception.InnerException.InnerException);
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal("Error reading '' at line 1 column 20 : The version cannot be null or empty", exception.Message);
                 Assert.Equal(1, exception.Line);
@@ -2259,8 +2258,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "null")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "c")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "c", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDownloadDependenciesDependencyVersionIsInvalid_Throws(IEnvironmentVariableReader environmentVariableReader, string version)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"downloadDependencies\":[{{\"name\":\"b\",\"version\":\"{version}\"}}]}}}}}}";
@@ -2273,7 +2272,7 @@ namespace NuGet.ProjectModel.Test
             Assert.IsType<ArgumentException>(exception.InnerException.InnerException);
             Assert.Null(exception.InnerException.InnerException.InnerException);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal($"Error reading '' at line 1 column 20 : Error reading '' at line 1 column {expectedColumn} : '{version}' is not a valid version string.", exception.Message);
                 Assert.Equal(1, exception.Line);
@@ -2286,7 +2285,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueIsValid_ReturnsDownloadDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new DownloadDependency(name: "b", new VersionRange(new NuGetVersion("1.2.3")));
@@ -2298,7 +2297,23 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueIsValidWithMultipleVersions_ReturnsDownloadDependencies(IEnvironmentVariableReader environmentVariableReader)
+        {
+            var json = $"{{\"frameworks\":{{\"a\":{{\"downloadDependencies\":[{{\"name\":\"b\",\"version\":\"1.2.3;;2.0.0\"}}]}}}}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
+
+            Assert.Equal(2, framework.DownloadDependencies.Count());
+            Assert.Equal("b", framework.DownloadDependencies[0].Name);
+            Assert.Equal(new VersionRange(new NuGetVersion("1.2.3")), framework.DownloadDependencies[0].VersionRange);
+            Assert.Equal("b", framework.DownloadDependencies[1].Name);
+            Assert.Equal(new VersionRange(new NuGetVersion("2.0.0")), framework.DownloadDependencies[1].VersionRange);
+
+        }
+
+        [Theory]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueHasDuplicates_PrefersFirstByName(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new DownloadDependency(name: "b", new VersionRange(new NuGetVersion("1.2.3")));
@@ -2314,7 +2329,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksFrameworkAssembliesPropertyIsAbsent_ReturnsEmptyDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{}}}";
@@ -2325,7 +2340,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksFrameworkAssembliesValueIsNull_ReturnsEmptyDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"frameworkAssemblies\":null}}}";
@@ -2336,7 +2351,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksFrameworkAssembliesValueIsEmptyObject_ReturnsEmptyDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"frameworkAssemblies\":{}}}}";
@@ -2347,7 +2362,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksFrameworkAssembliesDependencyTargetPropertyIsAbsent_ReturnsTarget(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"frameworkAssemblies\":{\"b\":{\"version\":\"1.0.0\"}}}}}";
@@ -2358,7 +2373,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksFrameworkAssembliesDependencyTargetValueIsPackageAndVersionPropertyIsAbsent_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"frameworkAssemblies\":{\"b\":{\"target\":\"Package\"}}}}}";
@@ -2369,7 +2384,7 @@ namespace NuGet.ProjectModel.Test
             Assert.IsType<ArgumentException>(exception.InnerException.InnerException);
             Assert.Null(exception.InnerException.InnerException.InnerException);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal("Error reading '' at line 1 column 20 : Error reading '' at line 1 column 48 : Package dependencies must specify a version range.", exception.Message);
                 Assert.Equal(1, exception.Line);
@@ -2382,7 +2397,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksFrameworkAssembliesDependencyTargetValueIsProjectAndVersionPropertyIsAbsent_ReturnsAllVersionRange(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"frameworkAssemblies\":{\"b\":{\"target\":\"Project\"}}}}}";
@@ -2393,7 +2408,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksFrameworkReferencesPropertyIsAbsent_ReturnsEmptyFrameworkReferences(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{}}}";
@@ -2404,7 +2419,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksFrameworkReferencesValueIsNull_ReturnsEmptyFrameworkReferences(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"frameworkReferences\":null}}}";
@@ -2415,7 +2430,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksFrameworkReferencesValueIsEmptyObject_ReturnsEmptyFrameworkReferences(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"frameworkReferences\":{}}}}";
@@ -2426,7 +2441,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksFrameworkReferencesFrameworkNameIsEmptyString_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"frameworkReferences\":{\"\":{}}}}}";
@@ -2436,7 +2451,7 @@ namespace NuGet.ProjectModel.Test
             Assert.IsType<FileFormatException>(exception.InnerException);
             Assert.Null(exception.InnerException.InnerException);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal("Error reading '' at line 1 column 20 : Unable to resolve frameworkReference.", exception.Message);
                 Assert.Equal(1, exception.Line);
@@ -2449,7 +2464,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksFrameworkReferencesPrivateAssetsPropertyIsAbsent_ReturnsNonePrivateAssets(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new FrameworkDependency(name: "b", FrameworkDependencyFlags.None);
@@ -2461,9 +2476,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"null\"")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"c\"")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"null\"", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"c\"", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksFrameworkReferencesPrivateAssetsValueIsInvalidValue_ReturnsNonePrivateAssets(IEnvironmentVariableReader environmentVariableReader, string privateAssets)
         {
             var expectedResult = new FrameworkDependency(name: "b", FrameworkDependencyFlags.None);
@@ -2475,7 +2490,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksFrameworkReferencesPrivateAssetsValueIsValidString_ReturnsPrivateAssets(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new FrameworkDependency(name: "b", FrameworkDependencyFlags.All);
@@ -2487,7 +2502,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksFrameworkReferencesPrivateAssetsValueIsValidDelimitedString_ReturnsPrivateAssets(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new FrameworkDependency(name: "b", FrameworkDependencyFlags.All);
@@ -2499,7 +2514,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksImportsPropertyIsAbsent_ReturnsEmptyImports(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{}}}";
@@ -2510,8 +2525,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "null")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksImportsValueIsArrayOfNullOrEmptyString_ImportIsSkipped(IEnvironmentVariableReader environmentVariableReader, string import)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"imports\":[{import}]}}}}}}";
@@ -2522,7 +2537,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksImportsValueIsNull_ReturnsEmptyList(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"imports\":null}}}";
@@ -2533,10 +2548,10 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "true")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "-2")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "3.14")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "{}")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "true", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "-2", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "3.14", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{}", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksImportsValueIsInvalidValue_ReturnsEmptyList(IEnvironmentVariableReader environmentVariableReader, string value)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"imports\":{value}}}}}}}";
@@ -2547,7 +2562,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksImportsValueContainsInvalidValue_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string expectedImport = "b";
@@ -2559,7 +2574,7 @@ namespace NuGet.ProjectModel.Test
             Assert.IsType<FileFormatException>(exception.InnerException);
             Assert.Null(exception.InnerException.InnerException);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal(
                     $"Error reading '' at line 1 column 20 : Imports contains an invalid framework: '{expectedImport}' in 'project.json'.",
@@ -2576,7 +2591,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksImportsValueIsString_ReturnsImport(IEnvironmentVariableReader environmentVariableReader)
         {
             NuGetFramework expectedResult = NuGetFramework.Parse("net48");
@@ -2590,7 +2605,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksImportsValueIsArrayOfStrings_ReturnsImports(IEnvironmentVariableReader environmentVariableReader)
         {
             NuGetFramework[] expectedResults = { NuGetFramework.Parse("net472"), NuGetFramework.Parse("net48") };
@@ -2605,7 +2620,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksRuntimeIdentifierGraphPathPropertyIsAbsent_ReturnsRuntimeIdentifierGraphPath(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{}}}}";
@@ -2616,9 +2631,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), null)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "b")]
+        [MemberData(nameof(TestEnvironmentVariableReader), null, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "b", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksRuntimeIdentifierGraphPathValueIsString_ReturnsRuntimeIdentifierGraphPath(IEnvironmentVariableReader environmentVariableReader, string expectedResult)
         {
             string runtimeIdentifierGraphPath = expectedResult == null ? "null" : $"\"{expectedResult}\"";
@@ -2630,7 +2645,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksWarnPropertyIsAbsent_ReturnsWarn(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{}}}}";
@@ -2641,8 +2656,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), true)]
-        [MemberData(nameof(TestEnvironmentVariableReader), false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), true, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFrameworksWarnValueIsValid_ReturnsWarn(IEnvironmentVariableReader environmentVariableReader, bool expectedResult)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"warn\":{expectedResult.ToString().ToLowerInvariant()}}}}}}}";
@@ -2654,7 +2669,7 @@ namespace NuGet.ProjectModel.Test
 
 #pragma warning disable CS0612 // Type or member is obsolete
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackIncludePropertyIsAbsent_ReturnsEmptyPackInclude(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSpec packageSpec = GetPackageSpec("{}", environmentVariableReader);
@@ -2663,7 +2678,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackIncludePropertyIsValid_ReturnsPackInclude(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResults = new List<KeyValuePair<string, string>>() { new KeyValuePair<string, string>("a", "b"), new KeyValuePair<string, string>("c", "d") };
@@ -2678,8 +2693,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "{}")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "{\"packOptions\":null}")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{}", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{\"packOptions\":null}", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsPropertyIsAbsentOrValueIsNull_ReturnsPackOptions(IEnvironmentVariableReader environmentVariableReader, string json)
         {
             PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
@@ -2700,7 +2715,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsPropertyIsAbsent_OwnersAndTagsAreEmpty(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"owners\":[\"a\"],\"tags\":[\"b\"]}";
@@ -2712,7 +2727,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsPropertyIsEmptyObject_ReturnsPackOptions(IEnvironmentVariableReader environmentVariableReader)
         {
             string json = "{\"packOptions\":{}}";
@@ -2735,7 +2750,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsValueIsValid_ReturnsPackOptions(IEnvironmentVariableReader environmentVariableReader)
         {
             const string iconUrl = "a";
@@ -2768,7 +2783,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsPackageTypeValueIsNull_ReturnsEmptyPackageTypes(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"packageType\":null}}";
@@ -2779,16 +2794,16 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "true", 34)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "-2", 32)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "3.14", 34)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "{}", 31)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[true]", 31)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[-2]", 31)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[3.14]", 31)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[null]", 31)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[{}]", 31)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[[]]", 31)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "true", 34, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "-2", 32, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "3.14", 34, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{}", 31, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[true]", 31, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[-2]", 31, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[3.14]", 31, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[null]", 31, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[{}]", 31, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[[]]", 31, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsPackageTypeIsInvalid_Throws(IEnvironmentVariableReader environmentVariableReader, string value, int expectedColumn)
         {
             var json = $"{{\"packOptions\":{{\"packageType\":{value}}}}}";
@@ -2798,7 +2813,7 @@ namespace NuGet.ProjectModel.Test
             Assert.Null(exception.InnerException);
             Assert.Equal("The pack options package type must be a string or array of strings in 'project.json'.", exception.Message);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal(1, exception.Line);
                 Assert.Equal(expectedColumn, exception.Column);
@@ -2806,10 +2821,10 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a,b\"", "a,b")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\"]", "a")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a b\"]", "a b")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a,b\"", "a,b", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\"]", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a b\"]", "a b", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsPackageTypeValueIsValid_ReturnsPackageTypes(IEnvironmentVariableReader environmentVariableReader, string value, string expectedName)
         {
             var expectedResult = new PackageType(expectedName, PackageType.EmptyVersion);
@@ -2823,7 +2838,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesValueIsNull_ReturnsNullInclude(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":null}}";
@@ -2834,7 +2849,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesValueIsEmptyObject_ReturnsNullInclude(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{}}}";
@@ -2845,7 +2860,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesIncludeValueIsNull_ReturnsNullIncludeExcludeFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{\"include\":null}}}";
@@ -2856,7 +2871,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesIncludeValueIsEmptyArray_ReturnsEmptyInclude(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{\"include\":[]}}}";
@@ -2867,13 +2882,13 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a, b\"", "a, b")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[null]", null)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"\"]", "")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\"]", "a")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a, b\"]", "a, b")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\", \"b\"]", "a", "b")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a, b\"", "a, b", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[null]", null, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"\"]", "", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\"]", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a, b\"]", "a, b", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\", \"b\"]", "a", "b", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesIncludeValueIsValid_ReturnsInclude(IEnvironmentVariableReader environmentVariableReader, string value, params string[] expectedResults)
         {
             expectedResults = expectedResults ?? new string[] { null };
@@ -2886,7 +2901,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesIncludeFilesValueIsNull_ReturnsNullIncludeExcludeFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{\"includeFiles\":null}}}";
@@ -2897,7 +2912,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesIncludeFilesValueIsEmptyArray_ReturnsEmptyIncludeFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{\"includeFiles\":[]}}}";
@@ -2908,13 +2923,13 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a, b\"", "a, b")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[null]", null)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"\"]", "")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\"]", "a")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a, b\"]", "a, b")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\", \"b\"]", "a", "b")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a, b\"", "a, b", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[null]", null, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"\"]", "", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\"]", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a, b\"]", "a, b", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\", \"b\"]", "a", "b", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesIncludeFilesValueIsValid_ReturnsIncludeFiles(IEnvironmentVariableReader environmentVariableReader, string value, params string[] expectedResults)
         {
             expectedResults = expectedResults ?? new string[] { null };
@@ -2927,7 +2942,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesExcludeValueIsNull_ReturnsNullIncludeExcludeFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{\"exclude\":null}}}";
@@ -2938,7 +2953,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesExcludeValueIsEmptyArray_ReturnsEmptyExclude(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{\"exclude\":[]}}}";
@@ -2949,13 +2964,13 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a, b\"", "a, b")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[null]", null)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"\"]", "")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\"]", "a")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a, b\"]", "a, b")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\", \"b\"]", "a", "b")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a, b\"", "a, b", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[null]", null, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"\"]", "", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\"]", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a, b\"]", "a, b", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\", \"b\"]", "a", "b", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesExcludeValueIsValid_ReturnsExclude(IEnvironmentVariableReader environmentVariableReader, string value, params string[] expectedResults)
         {
             expectedResults = expectedResults ?? new string[] { null };
@@ -2968,7 +2983,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesExcludeFilesValueIsNull_ReturnsNullIncludeExcludeFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{\"excludeFiles\":null}}}";
@@ -2979,7 +2994,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesExcludeFilesValueIsEmptyArray_ReturnsEmptyExcludeFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{\"excludeFiles\":[]}}}";
@@ -2990,13 +3005,13 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a, b\"", "a, b")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[null]", null)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"\"]", "")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\"]", "a")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a, b\"]", "a, b")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\", \"b\"]", "a", "b")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a, b\"", "a, b", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[null]", null, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"\"]", "", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\"]", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a, b\"]", "a, b", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\", \"b\"]", "a", "b", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesExcludeFilesValueIsValid_ReturnsExcludeFiles(IEnvironmentVariableReader environmentVariableReader, string value, params string[] expectedResults)
         {
             expectedResults = expectedResults ?? new string[] { null };
@@ -3009,7 +3024,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesMappingsPropertyIsAbsent_ReturnsNullMappings(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{}}}";
@@ -3020,7 +3035,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesMappingsValueIsNull_ReturnsNullMappings(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{\"mappings\":null}}}";
@@ -3031,9 +3046,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"b\"", "b")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"b,c\"", "b,c")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "[\"b\", \"c\"]", "b", "c")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"b\"", "b", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"b,c\"", "b,c", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"b\", \"c\"]", "b", "c", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesMappingsValueIsValid_ReturnsMappings(IEnvironmentVariableReader environmentVariableReader, string value, params string[] expectedIncludes)
         {
             var expectedResults = new Dictionary<string, IncludeExcludeFiles>()
@@ -3048,7 +3063,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesMappingsValueHasMultipleMappings_ReturnsMappings(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResults = new Dictionary<string, IncludeExcludeFiles>()
@@ -3064,7 +3079,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenPackOptionsFilesMappingsValueHasFiles_ReturnsMappings(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResults = new Dictionary<string, IncludeExcludeFiles>()
@@ -3089,7 +3104,7 @@ namespace NuGet.ProjectModel.Test
 #pragma warning restore CS0612 // Type or member is obsolete
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestorePropertyIsAbsent_ReturnsNullRestoreMetadata(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{}";
@@ -3099,7 +3114,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreValueIsEmptyObject_ReturnsRestoreMetadata(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"restore\":{}}";
@@ -3109,9 +3124,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "null")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreProjectStyleValueIsInvalid_ReturnsProjectStyle(IEnvironmentVariableReader environmentVariableReader, string value)
         {
             var json = $"{{\"restore\":{{\"projectStyle\":{value}}}}}";
@@ -3121,7 +3136,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreProjectStyleValueIsValid_ReturnsProjectStyle(IEnvironmentVariableReader environmentVariableReader)
         {
             const ProjectStyle expectedResult = ProjectStyle.PackageReference;
@@ -3133,9 +3148,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "null", null)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", null, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreProjectUniqueNameValueIsValid_ReturnsProjectUniqueName(
             IEnvironmentVariableReader environmentVariableReader,
             string value,
@@ -3148,9 +3163,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "null", null)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", null, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreOutputPathValueIsValid_ReturnsOutputPath(
             IEnvironmentVariableReader environmentVariableReader,
             string value,
@@ -3163,9 +3178,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "null", null)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", null, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestorePackagesPathValueIsValid_ReturnsPackagesPath(
             IEnvironmentVariableReader environmentVariableReader,
             string value,
@@ -3178,9 +3193,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "null", null)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", null, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreProjectJsonPathValueIsValid_ReturnsProjectJsonPath(
             IEnvironmentVariableReader environmentVariableReader,
             string value,
@@ -3193,9 +3208,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "null", null)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", null, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreProjectNameValueIsValid_ReturnsProjectName(
             IEnvironmentVariableReader environmentVariableReader,
             string value,
@@ -3208,9 +3223,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "null", null)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", null, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreProjectPathValueIsValid_ReturnsProjectPath(
             IEnvironmentVariableReader environmentVariableReader,
             string value,
@@ -3223,9 +3238,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), null, false)]
-        [MemberData(nameof(TestEnvironmentVariableReader), true, true)]
-        [MemberData(nameof(TestEnvironmentVariableReader), false, false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), null, false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), true, true, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), false, false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenCrossTargetingValueIsValid_ReturnsCrossTargeting(
             IEnvironmentVariableReader environmentVariableReader,
             bool? value,
@@ -3238,9 +3253,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), null, false)]
-        [MemberData(nameof(TestEnvironmentVariableReader), true, true)]
-        [MemberData(nameof(TestEnvironmentVariableReader), false, false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), null, false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), true, true, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), false, false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenLegacyPackagesDirectoryValueIsValid_ReturnsLegacyPackagesDirectory(
             IEnvironmentVariableReader environmentVariableReader,
             bool? value,
@@ -3253,9 +3268,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), null, false)]
-        [MemberData(nameof(TestEnvironmentVariableReader), true, true)]
-        [MemberData(nameof(TestEnvironmentVariableReader), false, false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), null, false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), true, true, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), false, false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenValidateRuntimeAssetsValueIsValid_ReturnsValidateRuntimeAssets(
             IEnvironmentVariableReader environmentVariableReader,
             bool? value,
@@ -3268,9 +3283,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), null, false)]
-        [MemberData(nameof(TestEnvironmentVariableReader), true, true)]
-        [MemberData(nameof(TestEnvironmentVariableReader), false, false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), null, false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), true, true, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), false, false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenSkipContentFileWriteValueIsValid_ReturnsSkipContentFileWrite(
             IEnvironmentVariableReader environmentVariableReader,
             bool? value,
@@ -3283,9 +3298,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), null, false)]
-        [MemberData(nameof(TestEnvironmentVariableReader), true, true)]
-        [MemberData(nameof(TestEnvironmentVariableReader), false, false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), null, false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), true, true, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), false, false, MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenCentralPackageVersionsManagementEnabledValueIsValid_ReturnsCentralPackageVersionsManagementEnabled(
             IEnvironmentVariableReader environmentVariableReader,
             bool? value,
@@ -3298,7 +3313,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenSourcesValueIsEmptyObject_ReturnsEmptySources(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"restore\":{\"sources\":{}}}";
@@ -3308,7 +3323,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenSourcesValueIsValid_ReturnsSources(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSource[] expectedResults = { new PackageSource(source: "a"), new PackageSource(source: "b") };
@@ -3320,7 +3335,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFilesValueIsEmptyObject_ReturnsEmptyFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"restore\":{\"files\":{}}}";
@@ -3330,7 +3345,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFilesValueIsValid_ReturnsFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             ProjectRestoreMetadataFile[] expectedResults =
@@ -3346,7 +3361,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreFrameworksValueIsEmptyObject_ReturnsEmptyFrameworks(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"restore\":{\"frameworks\":{}}}";
@@ -3356,7 +3371,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreFrameworksFrameworkNameValueIsValid_ReturnsFrameworks(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new ProjectRestoreMetadataFrameworkInfo(NuGetFramework.ParseFolder("net472"));
@@ -3369,7 +3384,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreFrameworksFrameworkValueHasProjectReferenceWithoutAssets_ReturnsFrameworks(IEnvironmentVariableReader environmentVariableReader)
         {
             var projectReference = new ProjectRestoreReference()
@@ -3391,7 +3406,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreFrameworksFrameworkValueHasProjectReferenceWithAssets_ReturnsFrameworks(IEnvironmentVariableReader environmentVariableReader)
         {
             var projectReference = new ProjectRestoreReference()
@@ -3418,7 +3433,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreConfigFilePathsValueIsEmptyArray_ReturnsEmptyConfigFilePaths(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"restore\":{\"configFilePaths\":[]}}";
@@ -3428,7 +3443,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreConfigFilePathsValueIsValid_ReturnsConfigFilePaths(IEnvironmentVariableReader environmentVariableReader)
         {
             string[] expectedResults = { "a", "b" };
@@ -3440,7 +3455,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreFallbackFoldersValueIsEmptyArray_ReturnsEmptyFallbackFolders(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"restore\":{\"fallbackFolders\":[]}}";
@@ -3450,7 +3465,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreFallbackFoldersValueIsValid_ReturnsConfigFilePaths(IEnvironmentVariableReader environmentVariableReader)
         {
             string[] expectedResults = { "a", "b" };
@@ -3462,7 +3477,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreOriginalTargetFrameworksValueIsEmptyArray_ReturnsEmptyOriginalTargetFrameworks(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"restore\":{\"originalTargetFrameworks\":[]}}";
@@ -3472,7 +3487,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreOriginalTargetFrameworksValueIsValid_ReturnsOriginalTargetFrameworks(IEnvironmentVariableReader environmentVariableReader)
         {
             string[] expectedResults = { "a", "b" };
@@ -3484,7 +3499,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreWarningPropertiesValueIsEmptyObject_ReturnsWarningProperties(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new WarningProperties();
@@ -3495,7 +3510,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreWarningPropertiesValueIsValid_ReturnsWarningProperties(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new WarningProperties(
@@ -3511,7 +3526,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreRestoreLockPropertiesValueIsEmptyObject_ReturnsRestoreLockProperties(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new RestoreLockProperties();
@@ -3522,7 +3537,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreRestoreLockPropertiesValueIsValid_ReturnsRestoreLockProperties(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new RestoreLockProperties(
@@ -3538,9 +3553,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "null")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestorePackagesConfigPathValueIsValidAndProjectStyleValueIsNotPackagesConfig_DoesNotReturnPackagesConfigPath(IEnvironmentVariableReader environmentVariableReader, string value)
         {
             var json = $"{{\"restore\":{{\"projectStyle\":\"PackageReference\",\"packagesConfigPath\":{value}}}}}";
@@ -3550,9 +3565,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "null", null)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", null, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestorePackagesConfigPathValueIsValidAndProjectStyleValueIsPackagesConfig_ReturnsPackagesConfigPath(
             IEnvironmentVariableReader environmentVariableReader,
             string value,
@@ -3566,7 +3581,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRestoreSettingsValueIsEmptyObject_ReturnsRestoreSettings(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new ProjectRestoreSettings();
@@ -3577,7 +3592,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRuntimesValueIsEmptyObject_ReturnsRuntimes(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = RuntimeGraph.Empty;
@@ -3588,7 +3603,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRuntimesValueIsValidWithImports_ReturnsRuntimes(IEnvironmentVariableReader environmentVariableReader)
         {
             var runtimeDescription = new RuntimeDescription(
@@ -3604,7 +3619,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRuntimesValueIsValidWithDependencySet_ReturnsRuntimes(IEnvironmentVariableReader environmentVariableReader)
         {
             var dependencySet = new RuntimeDependencySet(id: "b");
@@ -3620,7 +3635,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenRuntimesValueIsValidWithDependencySetWithDependency_ReturnsRuntimes(IEnvironmentVariableReader environmentVariableReader)
         {
             var dependency = new RuntimePackageDependency("c", VersionRange.Parse("[1.2.3,4.5.6)"));
@@ -3638,7 +3653,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenSupportsValueIsEmptyObject_ReturnsSupports(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = RuntimeGraph.Empty;
@@ -3649,7 +3664,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenSupportsValueIsValidWithCompatibilityProfiles_ReturnsSupports(IEnvironmentVariableReader environmentVariableReader)
         {
             var profile = new CompatibilityProfile(name: "a");
@@ -3661,7 +3676,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenSupportsValueIsValidWithCompatibilityProfilesAndFrameworkRuntimePairs_ReturnsSupports(IEnvironmentVariableReader environmentVariableReader)
         {
             FrameworkRuntimePair[] restoreContexts = new[]
@@ -3681,7 +3696,7 @@ namespace NuGet.ProjectModel.Test
 
 #pragma warning disable CS0612 // Type or member is obsolete
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenScriptsValueIsEmptyObject_ReturnsScripts(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"scripts\":{}}";
@@ -3691,7 +3706,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenScriptsValueIsInvalid_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             var json = "{\"scripts\":{\"a\":0}}";
@@ -3701,7 +3716,7 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal("The value of a script in 'project.json' can only be a string or an array of strings", exception.Message);
             Assert.Null(exception.InnerException);
 
-            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING)))
             {
                 Assert.Equal(1, exception.Line);
                 Assert.Equal(17, exception.Column);
@@ -3709,7 +3724,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenScriptsValueIsValid_ReturnsScripts(IEnvironmentVariableReader environmentVariableReader)
         {
             const string name0 = "a";
@@ -3742,9 +3757,9 @@ namespace NuGet.ProjectModel.Test
 #pragma warning restore CS0612 // Type or member is obsolete
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "null", null)]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", null, MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenTitleValueIsValid_ReturnsTitle(IEnvironmentVariableReader environmentVariableReader, string value, string expectedResult)
         {
             var json = $"{{\"title\":{value}}}";
@@ -3755,7 +3770,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenNameIsNull_RestoreMetadataProvidesFallbackName(IEnvironmentVariableReader environmentVariableReader)
         {
             const string expectedResult = "a";
@@ -3767,9 +3782,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader), "{\"restore\":{\"projectJsonPath\":\"a\"}}")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "{\"restore\":{\"projectPath\":\"a\"}}")]
-        [MemberData(nameof(TestEnvironmentVariableReader), "{\"restore\":{\"projectJsonPath\":\"a\",\"projectPath\":\"b\"}}")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{\"restore\":{\"projectJsonPath\":\"a\"}}", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{\"restore\":{\"projectPath\":\"a\"}}", MemberType = typeof(LockFileParsingEnvironmentVariable))]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{\"restore\":{\"projectJsonPath\":\"a\",\"projectPath\":\"b\"}}", MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WhenFilePathIsNull_RestoreMetadataProvidesFallbackFilePath(IEnvironmentVariableReader environmentVariableReader, string json)
         {
             const string expectedResult = "a";
@@ -3780,7 +3795,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetTargetFrameworkInformation_WithAnAlias(IEnvironmentVariableReader environmentVariableReader)
         {
             TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"net46\":{ \"targetAlias\" : \"alias\"}}}", environmentVariableReader);
@@ -3789,7 +3804,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_ReadsRestoreMetadataWithAliases(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -3825,7 +3840,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_Read(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -3852,7 +3867,7 @@ namespace NuGet.ProjectModel.Test
 
             // Act
             var results = new List<CentralTransitiveDependencyGroup>();
-            if (environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING").Equals(bool.FalseString, StringComparison.OrdinalIgnoreCase))
+            if (environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING).Equals(bool.FalseString, StringComparison.OrdinalIgnoreCase))
             {
                 using Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
                 var reader = new Utf8JsonStreamReader(stream);
@@ -3867,11 +3882,10 @@ namespace NuGet.ProjectModel.Test
                             {
                                 var frameworkPropertyName = reader.GetString();
                                 NuGetFramework framework = NuGetFramework.Parse(frameworkPropertyName);
-                                var dependencies = new List<LibraryDependency>();
 
                                 JsonPackageSpecReader.ReadCentralTransitiveDependencyGroup(
                                     jsonReader: ref reader,
-                                    results: dependencies,
+                                    results: out var dependencies,
                                     packageSpecPath: "SomePath");
                                 results.Add(new CentralTransitiveDependencyGroup(framework, dependencies));
                             }
@@ -3920,7 +3934,7 @@ namespace NuGet.ProjectModel.Test
 
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void PackageSpecReader_Malformed_Exception(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -3931,7 +3945,7 @@ namespace NuGet.ProjectModel.Test
 
             // Act
             var results = new List<CentralTransitiveDependencyGroup>();
-            if (environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING").Equals(bool.FalseString, StringComparison.OrdinalIgnoreCase))
+            if (environmentVariableReader.GetEnvironmentVariable(JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING).Equals(bool.FalseString, StringComparison.OrdinalIgnoreCase))
             {
                 Assert.ThrowsAny<System.Text.Json.JsonException>(() =>
                 {
@@ -3942,11 +3956,10 @@ namespace NuGet.ProjectModel.Test
                     {
                         reader.Read();
                         NuGetFramework framework = NuGetFramework.Parse(reader.GetString());
-                        var dependencies = new List<LibraryDependency>();
 
                         JsonPackageSpecReader.ReadCentralTransitiveDependencyGroup(
                             jsonReader: ref reader,
-                            results: dependencies,
+                            results: out var dependencies,
                             packageSpecPath: "SomePath");
                         results.Add(new CentralTransitiveDependencyGroup(framework, dependencies));
                     }
@@ -3974,7 +3987,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WithSecondaryFrameworks_ReturnsTargetFrameworkInformationWithDualCompatibilityFramework(IEnvironmentVariableReader environmentVariableReader)
         {
             var json = $"{{\"frameworks\":{{\"net5.0\":{{\"secondaryFramework\": \"native\"}}}}}}";
@@ -3987,7 +4000,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WithAssetTargetFallbackAndWithSecondaryFrameworks_ReturnsTargetFrameworkInformationWithDualCompatibilityFramework(IEnvironmentVariableReader environmentVariableReader)
         {
             var json = $"{{\"frameworks\":{{\"net5.0\":{{\"assetTargetFallback\": true, \"imports\": [\"net472\", \"net471\"], \"secondaryFramework\": \"native\" }}}}}}";
@@ -4006,7 +4019,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [MemberData(nameof(TestEnvironmentVariableReader))]
+        [MemberData(nameof(LockFileParsingEnvironmentVariable.TestEnvironmentVariableReader), MemberType = typeof(LockFileParsingEnvironmentVariable))]
         public void GetPackageSpec_WithRestoreAuditProperties_ReturnsRestoreAuditProperties(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
@@ -4142,7 +4155,7 @@ namespace NuGet.ProjectModel.Test
         private static PackageSpec GetPackageSpec(string json, string name, string packageSpecPath, string snapshotValue, IEnvironmentVariableReader environmentVariableReader)
         {
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
-            return JsonPackageSpecReader.GetPackageSpec(stream, name, packageSpecPath, snapshotValue, environmentVariableReader);
+            return JsonPackageSpecReader.GetPackageSpec(stream, name, packageSpecPath, snapshotValue, environmentVariableReader, true);
         }
 
         private static LibraryDependency GetDependency(string json, IEnvironmentVariableReader environmentVariableReader)
@@ -4171,56 +4184,6 @@ namespace NuGet.ProjectModel.Test
             TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             return framework.FrameworkReferences.Single();
-        }
-
-        public static IEnumerable<object[]> TestEnvironmentVariableReader()
-        {
-            return GetTestEnvironmentVariableReader();
-        }
-
-        public static IEnumerable<object[]> TestEnvironmentVariableReader(object value1)
-        {
-            return GetTestEnvironmentVariableReader(value1);
-        }
-
-        public static IEnumerable<object[]> TestEnvironmentVariableReader(object value1, object value2)
-        {
-            return GetTestEnvironmentVariableReader(value1, value2);
-        }
-
-        public static IEnumerable<object[]> TestEnvironmentVariableReader(object value1, object value2, object value3)
-        {
-            return GetTestEnvironmentVariableReader(value1, value2, value3);
-        }
-
-        private static IEnumerable<object[]> GetTestEnvironmentVariableReader(params object[] objects)
-        {
-            var UseNjForFileTrue = new List<object> {
-                new TestEnvironmentVariableReader(
-                    new Dictionary<string, string>()
-                    {
-                        ["NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING"] = bool.TrueString
-                    }, "NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING: true")
-                };
-            var UseNjForFileFalse = new List<object> {
-                new TestEnvironmentVariableReader(
-                    new Dictionary<string, string>()
-                    {
-                        ["NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING"] = bool.FalseString
-                    }, "NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING: false")
-                };
-
-            if (objects != null)
-            {
-                UseNjForFileFalse.AddRange(objects);
-                UseNjForFileTrue.AddRange(objects);
-            }
-
-            return new List<object[]>
-            {
-                UseNjForFileTrue.ToArray(),
-                UseNjForFileFalse.ToArray()
-            };
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -17,14 +17,17 @@ using NuGet.RuntimeModel;
 using NuGet.Versioning;
 using Test.Utility;
 using Xunit;
+using System.Text.Json;
 
 namespace NuGet.ProjectModel.Test
 {
     [UseCulture("")] // Fix tests failing on systems with non-English locales
+    [Obsolete]
     public class JsonPackageSpecReaderTests
     {
-        [Fact]
-        public void PackageSpecReader_PackageMissingVersion()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_PackageMissingVersion(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
@@ -43,7 +46,7 @@ namespace NuGet.ProjectModel.Test
 
             try
             {
-                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+                var spec = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
             }
             catch (Exception ex)
             {
@@ -54,50 +57,53 @@ namespace NuGet.ProjectModel.Test
             Assert.Contains("specify a version range", exception.Message);
         }
 
-        [Fact]
-        public void PackageSpecReader_ProjectMissingVersion()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_ProjectMissingVersion(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
-                          ""dependencies"": {
-                                ""packageA"": {
-                                    ""target"": ""project""
-                                }
-                            },
-                            ""frameworks"": {
-                                ""net46"": {}
-                            }
-                        }";
+                                  ""dependencies"": {
+                                        ""packageA"": {
+                                            ""target"": ""project""
+                                        }
+                                    },
+                                    ""frameworks"": {
+                                        ""net46"": {}
+                                    }
+                                }";
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            var spec = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
             var range = spec.Dependencies.Single().LibraryRange.VersionRange;
 
             // Assert
             Assert.Equal(VersionRange.All, range);
         }
 
-        [Fact]
-        public void PackageSpecReader_PackageEmptyVersion()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_PackageEmptyVersion(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
-                          ""dependencies"": {
-                                ""packageA"": {
-                                    ""target"": ""package"",
-                                    ""version"": """"
-                                }
-                            },
-                            ""frameworks"": {
-                                ""net46"": {}
-                            }
-                        }";
+                                  ""dependencies"": {
+                                        ""packageA"": {
+                                            ""target"": ""package"",
+                                            ""version"": """"
+                                        }
+                                    },
+                                    ""frameworks"": {
+                                        ""net46"": {}
+                                    }
+                                }";
 
             Exception exception = null;
 
             try
             {
-                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+                var spec = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
             }
             catch (Exception ex)
             {
@@ -108,27 +114,28 @@ namespace NuGet.ProjectModel.Test
             Assert.Contains("specify a version range", exception.Message);
         }
 
-        [Fact]
-        public void PackageSpecReader_PackageWhitespaceVersion()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_PackageWhitespaceVersion(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
-                          ""dependencies"": {
-                                ""packageA"": {
-                                    ""target"": ""package"",
-                                    ""version"": ""   ""
-                                }
-                            },
-                            ""frameworks"": {
-                                ""net46"": {}
-                            }
-                        }";
+                                  ""dependencies"": {
+                                        ""packageA"": {
+                                            ""target"": ""package"",
+                                            ""version"": ""   ""
+                                        }
+                                    },
+                                    ""frameworks"": {
+                                        ""net46"": {}
+                                    }
+                                }";
 
             Exception exception = null;
 
             try
             {
-                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+                var spec = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
             }
             catch (Exception ex)
             {
@@ -139,44 +146,46 @@ namespace NuGet.ProjectModel.Test
             Assert.Contains("not a valid version string", exception.Message);
         }
 
-        [Fact]
-        public void PackageSpecReader_FrameworkAssemblyEmptyVersion()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_FrameworkAssemblyEmptyVersion(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
-                            ""frameworks"": {
-                                ""net46"": {
-                                    ""frameworkAssemblies"": {
-                                       ""packageA"": """"
+                                    ""frameworks"": {
+                                        ""net46"": {
+                                            ""frameworkAssemblies"": {
+                                               ""packageA"": """"
+                                            }
+                                        }
                                     }
-                                }
-                            }
-                        }";
+                                }";
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
             var range = spec.TargetFrameworks.Single().Dependencies.Single().LibraryRange.VersionRange;
 
             // Assert
             Assert.Equal(VersionRange.All, range);
         }
 
-        [Fact]
-        public void PackageSpecReader_ExplicitIncludesOverrideTypePlatform()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_ExplicitIncludesOverrideTypePlatform(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
-                           ""dependencies"": {
-                             ""redist"": {
-                               ""version"": ""1.0.0"",
-                               ""type"": ""platform"",
-                               ""include"": ""analyzers""
-                             }
-                           }
-                         }";
+                                   ""dependencies"": {
+                                     ""redist"": {
+                                       ""version"": ""1.0.0"",
+                                       ""type"": ""platform"",
+                                       ""include"": ""analyzers""
+                                     }
+                                   }
+                                 }";
 
             // Act
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
 
             // Assert
             var dep = actual.Dependencies.FirstOrDefault(d => d.Name.Equals("redist"));
@@ -187,30 +196,49 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [InlineData("{}")]
-        [InlineData(@"{
-                        ""packOptions"": {}
-                      }")]
-        [InlineData(@"{
-                        ""packOptions"": {
-                          ""foo"": [1, 2]
-                        }
-                      }")]
-        [InlineData(@"{
-                        ""packOptions"": {
-                          ""packageType"": null
-                        }
-                      }")]
-        [InlineData(@"{
-                        ""packOptions"": {
-                          ""packageType"": []
-                        }
-                      }")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{}")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{}")]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""packOptions"": {}
+                              }")]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""packOptions"": {
+                                  ""foo"": [1, 2]
+                                }
+                              }")]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""packOptions"": {
+                                  ""packageType"": null
+                                }
+                              }")]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""packOptions"": {
+                                  ""packageType"": []
+                                }
+                              }")]
 #pragma warning disable CS0612 // Type or member is obsolete
-        public void PackageSpecReader_PackOptions_Default(string json)
+        public void PackageSpecReader_PackOptions_Default(IEnvironmentVariableReader environmentVariableReader, string json)
         {
             // Arrange & Act
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
+
+            // Assert
+            Assert.NotNull(actual.PackOptions);
+            Assert.NotNull(actual.PackOptions.PackageType);
+            Assert.Empty(actual.PackOptions.PackageType);
+        }
+
+
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"
+                                ""packOptions"": {
+                                  ""packageType"": ""foo""
+                                }
+                              }")]
+        public void PackageSpecReader_Malformed_Default(IEnvironmentVariableReader environmentVariableReader, string json)
+        {
+            // Arrange & Act
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
 
             // Assert
             Assert.NotNull(actual.PackOptions);
@@ -219,32 +247,32 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [InlineData(@"{
-                        ""packOptions"": {
-                          ""packageType"": ""foo""
-                        }
-                      }", new[] { "foo" })]
-        [InlineData(@"{
-                        ""packOptions"": {
-                          ""packageType"": ""foo, bar""
-                        }
-                      }", new[] { "foo, bar" })]
-        [InlineData(@"{
-                        ""packOptions"": {
-                          ""packageType"": [ ""foo"" ]
-                        }
-                      }", new[] { "foo" })]
-        [InlineData(@"{
-                        ""packOptions"": {
-                          ""packageType"": [ ""foo, bar"" ]
-                        }
-                      }", new[] { "foo, bar" })]
-        [InlineData(@"{
-                        ""packOptions"": {
-                          ""packageType"": [ ""foo"", ""bar"" ]
-                        }
-                      }", new[] { "foo", "bar" })]
-        public void PackageSpecReader_PackOptions_ValidPackageType(string json, string[] expectedNames)
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""packOptions"": {
+                                  ""packageType"": ""foo""
+                                }
+                              }", new[] { "foo" })]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""packOptions"": {
+                                  ""packageType"": ""foo, bar""
+                                }
+                              }", new[] { "foo, bar" })]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""packOptions"": {
+                                  ""packageType"": [ ""foo"" ]
+                                }
+                              }", new[] { "foo" })]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""packOptions"": {
+                                  ""packageType"": [ ""foo, bar"" ]
+                                }
+                              }", new[] { "foo, bar" })]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""packOptions"": {
+                                  ""packageType"": [ ""foo"", ""bar"" ]
+                                }
+                              }", new[] { "foo", "bar" })]
+        public void PackageSpecReader_PackOptions_ValidPackageType(IEnvironmentVariableReader environmentVariableReader, string json, string[] expectedNames)
         {
             // Arrange
             var expected = expectedNames
@@ -252,7 +280,7 @@ namespace NuGet.ProjectModel.Test
                 .ToArray();
 
             // Act
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
 
             // Assert
             Assert.NotNull(actual.PackOptions);
@@ -260,85 +288,87 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(expected, actual.PackOptions.PackageType.ToArray());
         }
 
+
         [Theory]
-        [InlineData(@"{
-                        ""packOptions"": {
-                          ""packageType"": 1
-                        }
-                      }")]
-        [InlineData(@"{
-                        ""packOptions"": {
-                          ""packageType"": false
-                        }
-                      }")]
-        [InlineData(@"{
-                        ""packOptions"": {
-                          ""packageType"": 1.0
-                        }
-                      }")]
-        [InlineData(@"{
-                        ""packOptions"": {
-                          ""packageType"": {}
-                        }
-                      }")]
-        [InlineData(@"{
-                        ""packOptions"": {
-                          ""packageType"": {
-                            ""name"": ""foo""
-                          }
-                        }
-                      }")]
-        [InlineData(@"{
-                        ""packOptions"": {
-                          ""packageType"": [
-                            { ""name"": ""foo"" },
-                            { ""name"": ""bar"" }
-                          ]
-                        }
-                      }")]
-        [InlineData(@"{
-                        ""packOptions"": {
-                          ""packageType"": [
-                            ""foo"",
-                            null
-                          ]
-                        }
-                      }")]
-        [InlineData(@"{
-                        ""packOptions"": {
-                          ""packageType"": [
-                            ""foo"",
-                            true
-                          ]
-                        }
-                      }")]
-        public void PackageSpecReader_PackOptions_InvalidPackageType(string json)
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""packOptions"": {
+                                  ""packageType"": 1
+                                }
+                              }")]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""packOptions"": {
+                                  ""packageType"": false
+                                }
+                              }")]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""packOptions"": {
+                                  ""packageType"": 1.0
+                                }
+                              }")]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""packOptions"": {
+                                  ""packageType"": {}
+                                }
+                              }")]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""packOptions"": {
+                                  ""packageType"": {
+                                    ""name"": ""foo""
+                                  }
+                                }
+                              }")]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""packOptions"": {
+                                  ""packageType"": [
+                                    { ""name"": ""foo"" },
+                                    { ""name"": ""bar"" }
+                                  ]
+                                }
+                              }")]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""packOptions"": {
+                                  ""packageType"": [
+                                    ""foo"",
+                                    null
+                                  ]
+                                }
+                              }")]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""packOptions"": {
+                                  ""packageType"": [
+                                    ""foo"",
+                                    true
+                                  ]
+                                }
+                              }")]
+        public void PackageSpecReader_PackOptions_InvalidPackageType(IEnvironmentVariableReader environmentVariableReader, string json)
         {
             // Arrange & Act & Assert
             var actual = Assert.Throws<FileFormatException>(
-                () => JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json"));
+                () => GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader));
 
             Assert.Contains("The pack options package type must be a string or array of strings in 'project.json'.", actual.Message);
         }
 
-        [Fact]
-        public void PackageSpecReader_PackOptions_Files1()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_PackOptions_Files1(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange & Act
             var json = @"{
-                        ""packOptions"": {
-                          ""files"": {
-                            ""include"": ""file1"",
-                            ""exclude"": ""file2"",
-                            ""includeFiles"": ""file3"",
-                            ""excludeFiles"": ""file4"",
-                            ""mappings"": {
-                              ""dest/path"": ""./src/path""
-                            }
-                          }
-                        }
-                      }";
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+                                ""packOptions"": {
+                                  ""files"": {
+                                    ""include"": ""file1"",
+                                    ""exclude"": ""file2"",
+                                    ""includeFiles"": ""file3"",
+                                    ""excludeFiles"": ""file4"",
+                                    ""mappings"": {
+                                      ""dest/path"": ""./src/path""
+                                    }
+                                  }
+                                }
+                              }";
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
 
             // Assert
             Assert.NotNull(actual.PackOptions);
@@ -360,27 +390,28 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal("./src/path", actual.PackOptions.Mappings.First().Value.Include.First());
         }
 
-        [Fact]
-        public void PackageSpecReader_PackOptions_Files2()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_PackOptions_Files2(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange & Act
             var json = @"{
-                        ""packOptions"": {
-                          ""files"": {
-                            ""include"": [""file1a"", ""file1b""],
-                            ""exclude"": [""file2a"", ""file2b""],
-                            ""includeFiles"": [""file3a"", ""file3b""],
-                            ""excludeFiles"": [""file4a"", ""file4b""],
-                            ""mappings"": {
-                              ""dest/path1"": [""./src/path1"", ""./src/path2""],
-                              ""dest/path2"": {
-                                ""includeFiles"": [""map1a"", ""map1b""],
-                              },
-                            }
-                          }
-                        }
-                      }";
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+                                ""packOptions"": {
+                                  ""files"": {
+                                    ""include"": [""file1a"", ""file1b""],
+                                    ""exclude"": [""file2a"", ""file2b""],
+                                    ""includeFiles"": [""file3a"", ""file3b""],
+                                    ""excludeFiles"": [""file4a"", ""file4b""],
+                                    ""mappings"": {
+                                      ""dest/path1"": [""./src/path1"", ""./src/path2""],
+                                      ""dest/path2"": {
+                                        ""includeFiles"": [""map1a"", ""map1b""],
+                                      },
+                                    }
+                                  }
+                                }
+                              }";
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
 
             // Assert
             Assert.NotNull(actual.PackOptions);
@@ -414,30 +445,30 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [InlineData("{}", null, true)]
-        [InlineData(@"{
-                        ""buildOptions"": {}
-                      }", null, false)]
-        [InlineData(@"{
-                        ""buildOptions"": {
-                          ""outputName"": ""dllName""
-                        }
-                      }", "dllName", false)]
-        [InlineData(@"{
-                        ""buildOptions"": {
-                          ""outputName"": ""dllName2"",
-                          ""emitEntryPoint"": true
-                        }
-                      }", "dllName2", false)]
-        [InlineData(@"{
-                        ""buildOptions"": {
-                          ""outputName"": null
-                        }
-                      }", null, false)]
-        public void PackageSpecReader_BuildOptions(string json, string expectedValue, bool nullBuildOptions)
+        [MemberData(nameof(TestEnvironmentVariableReader), "{}", null, true)]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""buildOptions"": {}
+                              }", null, false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""buildOptions"": {
+                                  ""outputName"": ""dllName""
+                                }
+                              }", "dllName", false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""buildOptions"": {
+                                  ""outputName"": ""dllName2"",
+                                  ""emitEntryPoint"": true
+                                }
+                              }", "dllName2", false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), @"{
+                                ""buildOptions"": {
+                                  ""outputName"": null
+                                }
+                              }", null, false)]
+        public void PackageSpecReader_BuildOptions(IEnvironmentVariableReader environmentVariableReader, string json, string expectedValue, bool nullBuildOptions)
         {
             // Arrange & Act
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
 
             // Assert
             if (nullBuildOptions)
@@ -452,23 +483,24 @@ namespace NuGet.ProjectModel.Test
         }
 #pragma warning restore CS0612 // Type or member is obsolete
 
-        [Fact]
-        public void PackageSpecReader_ReadsWithoutRestoreSettings()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_ReadsWithoutRestoreSettings(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
-                          ""dependencies"": {
-                                ""packageA"": {
-                                    ""target"": ""package"",
-                                    ""version"": ""1.0.0""
-                                }
-                            },
-                            ""frameworks"": {
-                                ""net46"": {}
-                            },
-                        }";
+                                  ""dependencies"": {
+                                        ""packageA"": {
+                                            ""target"": ""package"",
+                                            ""version"": ""1.0.0""
+                                        }
+                                    },
+                                    ""frameworks"": {
+                                        ""net46"": {}
+                                    },
+                                }";
 
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
 
             // Assert
             Assert.NotNull(actual);
@@ -476,27 +508,28 @@ namespace NuGet.ProjectModel.Test
             Assert.False(actual.RestoreSettings.HideWarningsAndErrors);
         }
 
-        [Fact]
-        public void PackageSpecReader_ReadsDependencyWithMultipleNoWarn()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_ReadsDependencyWithMultipleNoWarn(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
-                          ""dependencies"": {
-                                ""packageA"": {
-                                    ""target"": ""package"",
-                                    ""version"": ""1.0.0"",
-                                    ""noWarn"": [
-                                        ""NU1500"",
-                                        ""NU1107""
-                                      ]
-                                }
-                            },
-                            ""frameworks"": {
-                                ""net46"": {}
-                            },
-                        }";
+                                  ""dependencies"": {
+                                        ""packageA"": {
+                                            ""target"": ""package"",
+                                            ""version"": ""1.0.0"",
+                                            ""noWarn"": [
+                                                ""NU1500"",
+                                                ""NU1107""
+                                              ]
+                                        }
+                                    },
+                                    ""frameworks"": {
+                                        ""net46"": {}
+                                    },
+                                }";
 
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
 
             // Assert
             var dep = actual.Dependencies.FirstOrDefault(d => d.Name.Equals("packageA"));
@@ -507,26 +540,27 @@ namespace NuGet.ProjectModel.Test
             Assert.True(dep.NoWarn.Contains(NuGetLogCode.NU1107));
         }
 
-        [Fact]
-        public void PackageSpecReader_ReadsDependencyWithSingleNoWarn()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_ReadsDependencyWithSingleNoWarn(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
-                          ""dependencies"": {
-                                ""packageA"": {
-                                    ""target"": ""package"",
-                                    ""version"": ""1.0.0"",
-                                    ""noWarn"": [
-                                        ""NU1500""
-                                      ]
-                                }
-                            },
-                            ""frameworks"": {
-                                ""net46"": {}
-                            },
-                        }";
+                                  ""dependencies"": {
+                                        ""packageA"": {
+                                            ""target"": ""package"",
+                                            ""version"": ""1.0.0"",
+                                            ""noWarn"": [
+                                                ""NU1500""
+                                              ]
+                                        }
+                                    },
+                                    ""frameworks"": {
+                                        ""net46"": {}
+                                    },
+                                }";
 
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
 
             // Assert
             var dep = actual.Dependencies.FirstOrDefault(d => d.Name.Equals("packageA"));
@@ -536,25 +570,26 @@ namespace NuGet.ProjectModel.Test
             Assert.True(dep.NoWarn.Contains(NuGetLogCode.NU1500));
         }
 
-        [Fact]
-        public void PackageSpecReader_ReadsDependencyWithSingleEmptyNoWarn()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_ReadsDependencyWithSingleEmptyNoWarn(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
-                          ""dependencies"": {
-                                ""packageA"": {
-                                    ""target"": ""package"",
-                                    ""version"": ""1.0.0"",
-                                    ""noWarn"": [
-                                      ]
-                                }
-                            },
-                            ""frameworks"": {
-                                ""net46"": {}
-                            },
-                        }";
+                                  ""dependencies"": {
+                                        ""packageA"": {
+                                            ""target"": ""package"",
+                                            ""version"": ""1.0.0"",
+                                            ""noWarn"": [
+                                              ]
+                                        }
+                                    },
+                                    ""frameworks"": {
+                                        ""net46"": {}
+                                    },
+                                }";
 
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
 
             // Assert
             var dep = actual.Dependencies.FirstOrDefault(d => d.Name.Equals("packageA"));
@@ -563,61 +598,62 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(dep.NoWarn.Count, 0);
         }
 
-        [Fact]
-        public void PackageSpecReader_ReadsRestoreMetadataWithWarningProperties()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_ReadsRestoreMetadataWithWarningProperties(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{  
-                            ""restore"": {
-    ""projectUniqueName"": ""projectUniqueName"",
-    ""projectName"": ""projectName"",
-    ""projectPath"": ""projectPath"",
-    ""projectJsonPath"": ""projectJsonPath"",
-    ""packagesPath"": ""packagesPath"",
-    ""outputPath"": ""outputPath"",
-    ""projectStyle"": ""PackageReference"",
-    ""crossTargeting"": true,
-    ""configFilePaths"": [
-      ""b"",
-      ""a"",
-      ""c""
-    ],
-    ""fallbackFolders"": [
-      ""b"",
-      ""a"",
-      ""c""
-    ],
-    ""originalTargetFrameworks"": [
-      ""b"",
-      ""a"",
-      ""c""
-    ],
-    ""sources"": {
-      ""source"": {}
-    },
-    ""frameworks"": {
-      ""frameworkidentifier123-frameworkprofile"": {
-        ""projectReferences"": {}
-      }
-    },
-    ""warningProperties"": {
-      ""allWarningsAsErrors"": true,
-      ""noWarn"": [
-        ""NU1601"",
-      ],
-      ""warnAsError"": [
-        ""NU1500"",
-        ""NU1501""
-      ],
-      ""warnNotAsError"": [
-        ""NU1801"",
-        ""NU1802""
-      ]
-    }
-  }
-}";
+                                    ""restore"": {
+            ""projectUniqueName"": ""projectUniqueName"",
+            ""projectName"": ""projectName"",
+            ""projectPath"": ""projectPath"",
+            ""projectJsonPath"": ""projectJsonPath"",
+            ""packagesPath"": ""packagesPath"",
+            ""outputPath"": ""outputPath"",
+            ""projectStyle"": ""PackageReference"",
+            ""crossTargeting"": true,
+            ""configFilePaths"": [
+              ""b"",
+              ""a"",
+              ""c""
+            ],
+            ""fallbackFolders"": [
+              ""b"",
+              ""a"",
+              ""c""
+            ],
+            ""originalTargetFrameworks"": [
+              ""b"",
+              ""a"",
+              ""c""
+            ],
+            ""sources"": {
+              ""source"": {}
+            },
+            ""frameworks"": {
+              ""frameworkidentifier123-frameworkprofile"": {
+                ""projectReferences"": {}
+              }
+            },
+            ""warningProperties"": {
+              ""allWarningsAsErrors"": true,
+              ""noWarn"": [
+                ""NU1601"",
+              ],
+              ""warnAsError"": [
+                ""NU1500"",
+                ""NU1501""
+              ],
+              ""warnNotAsError"": [
+                ""NU1801"",
+                ""NU1802""
+              ]
+            }
+          }
+        }";
 
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
 
             // Assert
             var metadata = actual.RestoreMetadata;
@@ -636,54 +672,55 @@ namespace NuGet.ProjectModel.Test
             Assert.True(warningProperties.WarningsNotAsErrors.Contains(NuGetLogCode.NU1802));
         }
 
-        [Fact]
-        public void PackageSpecReader_ReadsRestoreMetadataWithWarningPropertiesAndNo_NoWarn()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_ReadsRestoreMetadataWithWarningPropertiesAndNo_NoWarn(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{  
-                            ""restore"": {
-    ""projectUniqueName"": ""projectUniqueName"",
-    ""projectName"": ""projectName"",
-    ""projectPath"": ""projectPath"",
-    ""projectJsonPath"": ""projectJsonPath"",
-    ""packagesPath"": ""packagesPath"",
-    ""outputPath"": ""outputPath"",
-    ""projectStyle"": ""PackageReference"",
-    ""crossTargeting"": true,
-    ""configFilePaths"": [
-      ""b"",
-      ""a"",
-      ""c""
-    ],
-    ""fallbackFolders"": [
-      ""b"",
-      ""a"",
-      ""c""
-    ],
-    ""originalTargetFrameworks"": [
-      ""b"",
-      ""a"",
-      ""c""
-    ],
-    ""sources"": {
-      ""source"": {}
-    },
-    ""frameworks"": {
-      ""frameworkidentifier123-frameworkprofile"": {
-        ""projectReferences"": {}
-      }
-    },
-    ""warningProperties"": {
-      ""allWarningsAsErrors"": true,
-      ""warnAsError"": [
-        ""NU1500"",
-        ""NU1501""
-      ]
-    }
-  }
-}";
+                                    ""restore"": {
+            ""projectUniqueName"": ""projectUniqueName"",
+            ""projectName"": ""projectName"",
+            ""projectPath"": ""projectPath"",
+            ""projectJsonPath"": ""projectJsonPath"",
+            ""packagesPath"": ""packagesPath"",
+            ""outputPath"": ""outputPath"",
+            ""projectStyle"": ""PackageReference"",
+            ""crossTargeting"": true,
+            ""configFilePaths"": [
+              ""b"",
+              ""a"",
+              ""c""
+            ],
+            ""fallbackFolders"": [
+              ""b"",
+              ""a"",
+              ""c""
+            ],
+            ""originalTargetFrameworks"": [
+              ""b"",
+              ""a"",
+              ""c""
+            ],
+            ""sources"": {
+              ""source"": {}
+            },
+            ""frameworks"": {
+              ""frameworkidentifier123-frameworkprofile"": {
+                ""projectReferences"": {}
+              }
+            },
+            ""warningProperties"": {
+              ""allWarningsAsErrors"": true,
+              ""warnAsError"": [
+                ""NU1500"",
+                ""NU1501""
+              ]
+            }
+          }
+        }";
 
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
 
             // Assert
             var metadata = actual.RestoreMetadata;
@@ -698,53 +735,54 @@ namespace NuGet.ProjectModel.Test
             Assert.True(warningProperties.WarningsAsErrors.Contains(NuGetLogCode.NU1501));
         }
 
-        [Fact]
-        public void PackageSpecReader_ReadsRestoreMetadataWithWarningPropertiesAndNo_WarnAsError()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_ReadsRestoreMetadataWithWarningPropertiesAndNo_WarnAsError(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{  
-                            ""restore"": {
-    ""projectUniqueName"": ""projectUniqueName"",
-    ""projectName"": ""projectName"",
-    ""projectPath"": ""projectPath"",
-    ""projectJsonPath"": ""projectJsonPath"",
-    ""packagesPath"": ""packagesPath"",
-    ""outputPath"": ""outputPath"",
-    ""projectStyle"": ""PackageReference"",
-    ""crossTargeting"": true,
-    ""configFilePaths"": [
-      ""b"",
-      ""a"",
-      ""c""
-    ],
-    ""fallbackFolders"": [
-      ""b"",
-      ""a"",
-      ""c""
-    ],
-    ""originalTargetFrameworks"": [
-      ""b"",
-      ""a"",
-      ""c""
-    ],
-    ""sources"": {
-      ""source"": {}
-    },
-    ""frameworks"": {
-      ""frameworkidentifier123-frameworkprofile"": {
-        ""projectReferences"": {}
-      }
-    },
-    ""warningProperties"": {
-      ""allWarningsAsErrors"": true,
-      ""noWarn"": [
-        ""NU1601"",
-      ]
-    }
-  }
-}";
+                                    ""restore"": {
+            ""projectUniqueName"": ""projectUniqueName"",
+            ""projectName"": ""projectName"",
+            ""projectPath"": ""projectPath"",
+            ""projectJsonPath"": ""projectJsonPath"",
+            ""packagesPath"": ""packagesPath"",
+            ""outputPath"": ""outputPath"",
+            ""projectStyle"": ""PackageReference"",
+            ""crossTargeting"": true,
+            ""configFilePaths"": [
+              ""b"",
+              ""a"",
+              ""c""
+            ],
+            ""fallbackFolders"": [
+              ""b"",
+              ""a"",
+              ""c""
+            ],
+            ""originalTargetFrameworks"": [
+              ""b"",
+              ""a"",
+              ""c""
+            ],
+            ""sources"": {
+              ""source"": {}
+            },
+            ""frameworks"": {
+              ""frameworkidentifier123-frameworkprofile"": {
+                ""projectReferences"": {}
+              }
+            },
+            ""warningProperties"": {
+              ""allWarningsAsErrors"": true,
+              ""noWarn"": [
+                ""NU1601"",
+              ]
+            }
+          }
+        }";
 
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
 
             // Assert
             var metadata = actual.RestoreMetadata;
@@ -758,56 +796,57 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(0, warningProperties.WarningsAsErrors.Count);
         }
 
-        [Fact]
-        public void PackageSpecReader_ReadsRestoreMetadataWithWarningPropertiesAndNo_AllWarningsAsErrors()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_ReadsRestoreMetadataWithWarningPropertiesAndNo_AllWarningsAsErrors(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{  
-                            ""restore"": {
-    ""projectUniqueName"": ""projectUniqueName"",
-    ""projectName"": ""projectName"",
-    ""projectPath"": ""projectPath"",
-    ""projectJsonPath"": ""projectJsonPath"",
-    ""packagesPath"": ""packagesPath"",
-    ""outputPath"": ""outputPath"",
-    ""projectStyle"": ""PackageReference"",
-    ""crossTargeting"": true,
-    ""configFilePaths"": [
-      ""b"",
-      ""a"",
-      ""c""
-    ],
-    ""fallbackFolders"": [
-      ""b"",
-      ""a"",
-      ""c""
-    ],
-    ""originalTargetFrameworks"": [
-      ""b"",
-      ""a"",
-      ""c""
-    ],
-    ""sources"": {
-      ""source"": {}
-    },
-    ""frameworks"": {
-      ""frameworkidentifier123-frameworkprofile"": {
-        ""projectReferences"": {}
-      }
-    },
-    ""warningProperties"": {
-      ""noWarn"": [
-        ""NU1601"",
-      ],
-      ""warnAsError"": [
-        ""NU1500"",
-        ""NU1501""
-      ]
-    }
-  }
-}";
+                                    ""restore"": {
+            ""projectUniqueName"": ""projectUniqueName"",
+            ""projectName"": ""projectName"",
+            ""projectPath"": ""projectPath"",
+            ""projectJsonPath"": ""projectJsonPath"",
+            ""packagesPath"": ""packagesPath"",
+            ""outputPath"": ""outputPath"",
+            ""projectStyle"": ""PackageReference"",
+            ""crossTargeting"": true,
+            ""configFilePaths"": [
+              ""b"",
+              ""a"",
+              ""c""
+            ],
+            ""fallbackFolders"": [
+              ""b"",
+              ""a"",
+              ""c""
+            ],
+            ""originalTargetFrameworks"": [
+              ""b"",
+              ""a"",
+              ""c""
+            ],
+            ""sources"": {
+              ""source"": {}
+            },
+            ""frameworks"": {
+              ""frameworkidentifier123-frameworkprofile"": {
+                ""projectReferences"": {}
+              }
+            },
+            ""warningProperties"": {
+              ""noWarn"": [
+                ""NU1601"",
+              ],
+              ""warnAsError"": [
+                ""NU1500"",
+                ""NU1501""
+              ]
+            }
+          }
+        }";
 
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
 
             // Assert
             var metadata = actual.RestoreMetadata;
@@ -823,49 +862,50 @@ namespace NuGet.ProjectModel.Test
             Assert.True(warningProperties.WarningsAsErrors.Contains(NuGetLogCode.NU1501));
         }
 
-        [Fact]
-        public void PackageSpecReader_ReadsRestoreMetadataWithEmptyWarningPropertiesAnd()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_ReadsRestoreMetadataWithEmptyWarningPropertiesAnd(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{  
-                            ""restore"": {
-    ""projectUniqueName"": ""projectUniqueName"",
-    ""projectName"": ""projectName"",
-    ""projectPath"": ""projectPath"",
-    ""projectJsonPath"": ""projectJsonPath"",
-    ""packagesPath"": ""packagesPath"",
-    ""outputPath"": ""outputPath"",
-    ""projectStyle"": ""PackageReference"",
-    ""crossTargeting"": true,
-    ""configFilePaths"": [
-      ""b"",
-      ""a"",
-      ""c""
-    ],
-    ""fallbackFolders"": [
-      ""b"",
-      ""a"",
-      ""c""
-    ],
-    ""originalTargetFrameworks"": [
-      ""b"",
-      ""a"",
-      ""c""
-    ],
-    ""sources"": {
-      ""source"": {}
-    },
-    ""frameworks"": {
-      ""frameworkidentifier123-frameworkprofile"": {
-        ""projectReferences"": {}
-      }
-    },
-    ""warningProperties"": {
-    }
-  }
-}";
+                                    ""restore"": {
+            ""projectUniqueName"": ""projectUniqueName"",
+            ""projectName"": ""projectName"",
+            ""projectPath"": ""projectPath"",
+            ""projectJsonPath"": ""projectJsonPath"",
+            ""packagesPath"": ""packagesPath"",
+            ""outputPath"": ""outputPath"",
+            ""projectStyle"": ""PackageReference"",
+            ""crossTargeting"": true,
+            ""configFilePaths"": [
+              ""b"",
+              ""a"",
+              ""c""
+            ],
+            ""fallbackFolders"": [
+              ""b"",
+              ""a"",
+              ""c""
+            ],
+            ""originalTargetFrameworks"": [
+              ""b"",
+              ""a"",
+              ""c""
+            ],
+            ""sources"": {
+              ""source"": {}
+            },
+            ""frameworks"": {
+              ""frameworkidentifier123-frameworkprofile"": {
+                ""projectReferences"": {}
+              }
+            },
+            ""warningProperties"": {
+            }
+          }
+        }";
 
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
 
             // Assert
             var metadata = actual.RestoreMetadata;
@@ -878,47 +918,48 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(0, warningProperties.WarningsAsErrors.Count);
         }
 
-        [Fact]
-        public void PackageSpecReader_ReadsRestoreMetadataWithNoWarningProperties()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_ReadsRestoreMetadataWithNoWarningProperties(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{  
-                            ""restore"": {
-    ""projectUniqueName"": ""projectUniqueName"",
-    ""projectName"": ""projectName"",
-    ""projectPath"": ""projectPath"",
-    ""projectJsonPath"": ""projectJsonPath"",
-    ""packagesPath"": ""packagesPath"",
-    ""outputPath"": ""outputPath"",
-    ""projectStyle"": ""PackageReference"",
-    ""crossTargeting"": true,
-    ""configFilePaths"": [
-      ""b"",
-      ""a"",
-      ""c""
-    ],
-    ""fallbackFolders"": [
-      ""b"",
-      ""a"",
-      ""c""
-    ],
-    ""originalTargetFrameworks"": [
-      ""b"",
-      ""a"",
-      ""c""
-    ],
-    ""sources"": {
-      ""source"": {}
-    },
-    ""frameworks"": {
-      ""frameworkidentifier123-frameworkprofile"": {
-        ""projectReferences"": {}
-      }
-    }
-  }
-}";
+                                    ""restore"": {
+            ""projectUniqueName"": ""projectUniqueName"",
+            ""projectName"": ""projectName"",
+            ""projectPath"": ""projectPath"",
+            ""projectJsonPath"": ""projectJsonPath"",
+            ""packagesPath"": ""packagesPath"",
+            ""outputPath"": ""outputPath"",
+            ""projectStyle"": ""PackageReference"",
+            ""crossTargeting"": true,
+            ""configFilePaths"": [
+              ""b"",
+              ""a"",
+              ""c""
+            ],
+            ""fallbackFolders"": [
+              ""b"",
+              ""a"",
+              ""c""
+            ],
+            ""originalTargetFrameworks"": [
+              ""b"",
+              ""a"",
+              ""c""
+            ],
+            ""sources"": {
+              ""source"": {}
+            },
+            ""frameworks"": {
+              ""frameworkidentifier123-frameworkprofile"": {
+                ""projectReferences"": {}
+              }
+            }
+          }
+        }";
 
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
 
             // Assert
             var metadata = actual.RestoreMetadata;
@@ -928,264 +969,285 @@ namespace NuGet.ProjectModel.Test
             Assert.NotNull(warningProperties);
         }
 
-        [Fact]
-        public void PackageSpecReader_RuntimeIdentifierPathNullIfEmpty()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_RuntimeIdentifierPathNullIfEmpty(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
-                            ""frameworks"": {
-                                ""net46"": {
-                                    ""dependencies"": {
-                                        ""packageA"": {
-                                        ""target"": ""package"",
-                                        ""version"": ""1.0.0"",
-                                        ""noWarn"": [
-                                            ""NU1500""
-                                        ]
-                                     }
-                                  }
-                                }
-                            }
-                        }";
+                                    ""frameworks"": {
+                                        ""net46"": {
+                                            ""dependencies"": {
+                                                ""packageA"": {
+                                                ""target"": ""package"",
+                                                ""version"": ""1.0.0"",
+                                                ""noWarn"": [
+                                                    ""NU1500""
+                                                ]
+                                             }
+                                          }
+                                        }
+                                    }
+                                }";
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
 
             // Assert
             Assert.Null(spec.TargetFrameworks.First().RuntimeIdentifierGraphPath);
         }
 
 #pragma warning disable CS0612 // Type or member is obsolete
-        [Fact]
-        public void GetPackageSpec_WhenAuthorsPropertyIsAbsent_ReturnsEmptyAuthors()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenAuthorsPropertyIsAbsent_ReturnsEmptyAuthors(IEnvironmentVariableReader environmentVariableReader)
         {
-            PackageSpec packageSpec = GetPackageSpec("{}");
-
-            Assert.Empty(packageSpec.Authors);
-        }
-
-        [Fact]
-        public void GetPackageSpec_WhenAuthorsValueIsNull_ReturnsEmptyAuthors()
-        {
-            PackageSpec packageSpec = GetPackageSpec("{\"authors\":null}");
-
-            Assert.Empty(packageSpec.Authors);
-        }
-
-        [Fact]
-        public void GetPackageSpec_WhenAuthorsValueIsString_ReturnsEmptyAuthors()
-        {
-            PackageSpec packageSpec = GetPackageSpec("{\"authors\":\"b\"}");
+            PackageSpec packageSpec = GetPackageSpec("{}", environmentVariableReader);
 
             Assert.Empty(packageSpec.Authors);
         }
 
         [Theory]
-        [InlineData("")]
-        [InlineData("/**/")]
-        public void GetPackageSpec_WhenAuthorsValueIsEmptyArray_ReturnsEmptyAuthors(string value)
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenAuthorsValueIsNull_ReturnsEmptyAuthors(IEnvironmentVariableReader environmentVariableReader)
         {
-            PackageSpec packageSpec = GetPackageSpec($"{{\"authors\":[{value}]}}");
+            PackageSpec packageSpec = GetPackageSpec("{\"authors\":null}", environmentVariableReader);
 
             Assert.Empty(packageSpec.Authors);
         }
 
         [Theory]
-        [InlineData("{}")]
-        [InlineData("[]")]
-        public void GetPackageSpec_WhenAuthorsValueElementIsNotConvertibleToString_Throws(string value)
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenAuthorsValueIsString_ReturnsEmptyAuthors(IEnvironmentVariableReader environmentVariableReader)
+        {
+            PackageSpec packageSpec = GetPackageSpec("{\"authors\":\"b\"}", environmentVariableReader);
+
+            Assert.Empty(packageSpec.Authors);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader), "")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "/**/")]
+        public void GetPackageSpec_WhenAuthorsValueIsEmptyArray_ReturnsEmptyAuthors(IEnvironmentVariableReader environmentVariableReader, string value)
+        {
+            PackageSpec packageSpec = GetPackageSpec($"{{\"authors\":[{value}]}}", environmentVariableReader);
+
+            Assert.Empty(packageSpec.Authors);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{}")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[]")]
+        public void GetPackageSpec_WhenAuthorsValueElementIsNotConvertibleToString_Throws(IEnvironmentVariableReader environmentVariableReader, string value)
         {
             var json = $"{{\"authors\":[{value}]}}";
 
-            Assert.Throws<InvalidCastException>(() => GetPackageSpec(json));
+            Assert.Throws<InvalidCastException>(() => GetPackageSpec(json, environmentVariableReader));
         }
 
         [Theory]
-        [InlineData("\"a\"", "a")]
-        [InlineData("true", "True")]
-        [InlineData("-2", "-2")]
-        [InlineData("3.14", "3.14")]
-        public void GetPackageSpec_WhenAuthorsValueElementIsConvertibleToString_ReturnsAuthor(string value, string expectedValue)
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "true", "True")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "-2", "-2")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "3.14", "3.14")]
+        public void GetPackageSpec_WhenAuthorsValueElementIsConvertibleToString_ReturnsAuthor(IEnvironmentVariableReader environmentVariableReader, string value, string expectedValue)
         {
-            PackageSpec packageSpec = GetPackageSpec($"{{\"authors\":[{value}]}}");
+            PackageSpec packageSpec = GetPackageSpec($"{{\"authors\":[{value}]}}", environmentVariableReader);
 
             Assert.Collection(packageSpec.Authors, author => Assert.Equal(expectedValue, author));
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenBuildOptionsPropertyIsAbsent_ReturnsNullBuildOptions()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenBuildOptionsPropertyIsAbsent_ReturnsNullBuildOptions(IEnvironmentVariableReader environmentVariableReader)
         {
-            PackageSpec packageSpec = GetPackageSpec("{}");
+            PackageSpec packageSpec = GetPackageSpec("{}", environmentVariableReader);
 
             Assert.Null(packageSpec.BuildOptions);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenBuildOptionsValueIsEmptyObject_ReturnsBuildOptions()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenBuildOptionsValueIsEmptyObject_ReturnsBuildOptions(IEnvironmentVariableReader environmentVariableReader)
         {
-            PackageSpec packageSpec = GetPackageSpec("{\"buildOptions\":{}}");
+            PackageSpec packageSpec = GetPackageSpec("{\"buildOptions\":{}}", environmentVariableReader);
 
             Assert.NotNull(packageSpec.BuildOptions);
             Assert.Null(packageSpec.BuildOptions.OutputName);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenBuildOptionsValueOutputNameIsNull_ReturnsNullOutputName()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenBuildOptionsValueOutputNameIsNull_ReturnsNullOutputName(IEnvironmentVariableReader environmentVariableReader)
         {
-            PackageSpec packageSpec = GetPackageSpec("{\"buildOptions\":{\"outputName\":null}}");
+            PackageSpec packageSpec = GetPackageSpec("{\"buildOptions\":{\"outputName\":null}}", environmentVariableReader);
 
             Assert.Null(packageSpec.BuildOptions.OutputName);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenBuildOptionsValueOutputNameIsValid_ReturnsOutputName()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenBuildOptionsValueOutputNameIsValid_ReturnsOutputName(IEnvironmentVariableReader environmentVariableReader)
         {
             const string expectedResult = "a";
 
             var json = $"{{\"buildOptions\":{{\"outputName\":\"{expectedResult}\"}}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.BuildOptions.OutputName);
         }
 
         [Theory]
-        [InlineData("-2", "-2")]
-        [InlineData("3.14", "3.14")]
-        [InlineData("true", "True")]
-        public void GetPackageSpec_WhenBuildOptionsValueOutputNameIsConvertibleToString_ReturnsOutputName(string outputName, string expectedValue)
+        [MemberData(nameof(TestEnvironmentVariableReader), "-2", "-2")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "3.14", "3.14")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "true", "True")]
+        public void GetPackageSpec_WhenBuildOptionsValueOutputNameIsConvertibleToString_ReturnsOutputName(IEnvironmentVariableReader environmentVariableReader, string outputName, string expectedValue)
         {
-            PackageSpec packageSpec = GetPackageSpec($"{{\"buildOptions\":{{\"outputName\":{outputName}}}}}");
+            PackageSpec packageSpec = GetPackageSpec($"{{\"buildOptions\":{{\"outputName\":{outputName}}}}}", environmentVariableReader);
 
             Assert.Equal(expectedValue, packageSpec.BuildOptions.OutputName);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenContentFilesPropertyIsAbsent_ReturnsEmptyContentFiles()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenContentFilesPropertyIsAbsent_ReturnsEmptyContentFiles(IEnvironmentVariableReader environmentVariableReader)
         {
-            PackageSpec packageSpec = GetPackageSpec("{}");
-
-            Assert.Empty(packageSpec.ContentFiles);
-        }
-
-        [Fact]
-        public void GetPackageSpec_WhenContentFilesValueIsNull_ReturnsEmptyContentFiles()
-        {
-            PackageSpec packageSpec = GetPackageSpec("{\"contentFiles\":null}");
-
-            Assert.Empty(packageSpec.ContentFiles);
-        }
-
-        [Fact]
-        public void GetPackageSpec_WhenContentFilesValueIsString_ReturnsEmptyContentFiles()
-        {
-            PackageSpec packageSpec = GetPackageSpec("{\"contentFiles\":\"a\"}");
+            PackageSpec packageSpec = GetPackageSpec("{}", environmentVariableReader);
 
             Assert.Empty(packageSpec.ContentFiles);
         }
 
         [Theory]
-        [InlineData("")]
-        [InlineData("/**/")]
-        public void GetPackageSpec_WhenContentFilesValueIsEmptyArray_ReturnsEmptyContentFiles(string value)
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenContentFilesValueIsNull_ReturnsEmptyContentFiles(IEnvironmentVariableReader environmentVariableReader)
         {
-            PackageSpec packageSpec = GetPackageSpec($"{{\"contentFiles\":[{value}]}}");
+            PackageSpec packageSpec = GetPackageSpec("{\"contentFiles\":null}", environmentVariableReader);
 
             Assert.Empty(packageSpec.ContentFiles);
         }
 
         [Theory]
-        [InlineData("{}")]
-        [InlineData("[]")]
-        public void GetPackageSpec_WhenContentFilesValueElementIsNotConvertibleToString_Throws(string value)
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenContentFilesValueIsString_ReturnsEmptyContentFiles(IEnvironmentVariableReader environmentVariableReader)
+        {
+            PackageSpec packageSpec = GetPackageSpec("{\"contentFiles\":\"a\"}", environmentVariableReader);
+
+            Assert.Empty(packageSpec.ContentFiles);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader), "")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "/**/")]
+        public void GetPackageSpec_WhenContentFilesValueIsEmptyArray_ReturnsEmptyContentFiles(IEnvironmentVariableReader environmentVariableReader, string value)
+        {
+            PackageSpec packageSpec = GetPackageSpec($"{{\"contentFiles\":[{value}]}}", environmentVariableReader);
+
+            Assert.Empty(packageSpec.ContentFiles);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{}")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[]")]
+        public void GetPackageSpec_WhenContentFilesValueElementIsNotConvertibleToString_Throws(IEnvironmentVariableReader environmentVariableReader, string value)
         {
             var json = $"{{\"contentFiles\":[{value}]}}";
 
-            Assert.Throws<InvalidCastException>(() => GetPackageSpec(json));
+            Assert.Throws<InvalidCastException>(() => GetPackageSpec(json, environmentVariableReader));
         }
 
         [Theory]
-        [InlineData("\"a\"", "a")]
-        [InlineData("true", "True")]
-        [InlineData("-2", "-2")]
-        [InlineData("3.14", "3.14")]
-        public void GetPackageSpec_WhenContentFilesValueElementIsConvertibleToString_ReturnsContentFile(string value, string expectedValue)
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "true", "True")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "-2", "-2")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "3.14", "3.14")]
+        public void GetPackageSpec_WhenContentFilesValueElementIsConvertibleToString_ReturnsContentFile(IEnvironmentVariableReader environmentVariableReader, string value, string expectedValue)
         {
-            PackageSpec packageSpec = GetPackageSpec($"{{\"contentFiles\":[{value}]}}");
+            PackageSpec packageSpec = GetPackageSpec($"{{\"contentFiles\":[{value}]}}", environmentVariableReader);
 
             Assert.Collection(packageSpec.ContentFiles, contentFile => Assert.Equal(expectedValue, contentFile));
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenCopyrightPropertyIsAbsent_ReturnsNullCopyright()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenCopyrightPropertyIsAbsent_ReturnsNullCopyright(IEnvironmentVariableReader environmentVariableReader)
         {
-            PackageSpec packageSpec = GetPackageSpec("{}");
+            PackageSpec packageSpec = GetPackageSpec("{}", environmentVariableReader);
 
             Assert.Null(packageSpec.Copyright);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenCopyrightValueIsNull_ReturnsNullCopyright()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenCopyrightValueIsNull_ReturnsNullCopyright(IEnvironmentVariableReader environmentVariableReader)
         {
-            PackageSpec packageSpec = GetPackageSpec("{\"copyright\":null}");
+            PackageSpec packageSpec = GetPackageSpec("{\"copyright\":null}", environmentVariableReader);
 
             Assert.Null(packageSpec.Copyright);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenCopyrightValueIsString_ReturnsCopyright()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenCopyrightValueIsString_ReturnsCopyright(IEnvironmentVariableReader environmentVariableReader)
         {
             const string expectedResult = "a";
 
-            PackageSpec packageSpec = GetPackageSpec($"{{\"copyright\":\"{expectedResult}\"}}");
+            PackageSpec packageSpec = GetPackageSpec($"{{\"copyright\":\"{expectedResult}\"}}", environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.Copyright);
         }
 
         [Theory]
-        [InlineData("\"a\"", "a")]
-        [InlineData("true", "True")]
-        [InlineData("-2", "-2")]
-        [InlineData("3.14", "3.14")]
-        public void GetPackageSpec_WhenCopyrightValueIsConvertibleToString_ReturnsCopyright(string value, string expectedValue)
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "true", "True")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "-2", "-2")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "3.14", "3.14")]
+        public void GetPackageSpec_WhenCopyrightValueIsConvertibleToString_ReturnsCopyright(IEnvironmentVariableReader environmentVariableReader, string value, string expectedValue)
         {
-            PackageSpec packageSpec = GetPackageSpec($"{{\"copyright\":{value}}}");
+            PackageSpec packageSpec = GetPackageSpec($"{{\"copyright\":{value}}}", environmentVariableReader);
 
             Assert.Equal(expectedValue, packageSpec.Copyright);
         }
 #pragma warning restore CS0612 // Type or member is obsolete
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesPropertyIsAbsent_ReturnsEmptyDependencies()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesPropertyIsAbsent_ReturnsEmptyDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
-            PackageSpec packageSpec = GetPackageSpec("{}");
+            PackageSpec packageSpec = GetPackageSpec("{}", environmentVariableReader);
 
             Assert.Empty(packageSpec.Dependencies);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesValueIsNull_ReturnsEmptyDependencies()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesValueIsNull_ReturnsEmptyDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
-            PackageSpec packageSpec = GetPackageSpec("{\"dependencies\":null}");
+            PackageSpec packageSpec = GetPackageSpec("{\"dependencies\":null}", environmentVariableReader);
 
             Assert.Empty(packageSpec.Dependencies);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesDependencyNameIsEmptyString_Throws()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesDependencyNameIsEmptyString_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"\":{}}}";
 
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
-
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
             Assert.Equal("Unable to resolve dependency ''.", exception.Message);
-            Assert.Equal(1, exception.Line);
-            Assert.Equal(21, exception.Column);
             Assert.Null(exception.InnerException);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal(1, exception.Line);
+                Assert.Equal(21, exception.Column);
+            }
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesDependencyValueIsVersionString_ReturnsDependencyVersionRange()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesDependencyValueIsVersionString_ReturnsDependencyVersionRange(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new LibraryRange(
                 name: "a",
@@ -1193,13 +1255,14 @@ namespace NuGet.ProjectModel.Test
                 LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference);
             var json = $"{{\"dependencies\":{{\"{expectedResult.Name}\":\"{expectedResult.VersionRange.ToShortString()}\"}}}}";
 
-            LibraryDependency dependency = GetDependency(json);
+            LibraryDependency dependency = GetDependency(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, dependency.LibraryRange);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesDependencyValueIsVersionRangeString_ReturnsDependencyVersionRange()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesDependencyValueIsVersionRangeString_ReturnsDependencyVersionRange(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new LibraryRange(
                 name: "a",
@@ -1207,207 +1270,238 @@ namespace NuGet.ProjectModel.Test
                 LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference);
             var json = $"{{\"dependencies\":{{\"{expectedResult.Name}\":\"{expectedResult.VersionRange}\"}}}}";
 
-            LibraryDependency dependency = GetDependency(json);
+            LibraryDependency dependency = GetDependency(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, dependency.LibraryRange);
         }
 
         [Theory]
-        [InlineData(LibraryDependencyTarget.None)]
-        [InlineData(LibraryDependencyTarget.Assembly)]
-        [InlineData(LibraryDependencyTarget.Reference)]
-        [InlineData(LibraryDependencyTarget.WinMD)]
-        [InlineData(LibraryDependencyTarget.All)]
-        [InlineData(LibraryDependencyTarget.PackageProjectExternal)]
-        public void GetPackageSpec_WhenDependenciesDependencyTargetIsUnsupported_Throws(LibraryDependencyTarget target)
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.None)]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.Assembly)]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.Reference)]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.WinMD)]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.All)]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.PackageProjectExternal)]
+        public void GetPackageSpec_WhenDependenciesDependencyTargetIsUnsupported_Throws(IEnvironmentVariableReader environmentVariableReader, LibraryDependencyTarget target)
         {
             var json = $"{{\"dependencies\":{{\"a\":{{\"version\":\"1.2.3\",\"target\":\"{target}\"}}}}}}";
 
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
 
             Assert.Equal($"Invalid dependency target value '{target}'.", exception.Message);
-            Assert.Equal(1, exception.Line);
-            // The position is after the target name, which is of variable length.
-            Assert.Equal(json.IndexOf(target.ToString()) + target.ToString().Length + 1, exception.Column);
             Assert.Null(exception.InnerException);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal(1, exception.Line);
+                // The position is after the target name, which is of variable length.
+                Assert.Equal(json.IndexOf(target.ToString()) + target.ToString().Length + 1, exception.Column);
+            }
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesDependencyAutoreferencedPropertyIsAbsent_ReturnsFalseAutoreferenced()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesDependencyAutoreferencedPropertyIsAbsent_ReturnsFalseAutoreferenced(IEnvironmentVariableReader environmentVariableReader)
         {
-            LibraryDependency dependency = GetDependency($"{{\"dependencies\":{{\"a\":{{\"target\":\"Project\"}}}}}}");
+            LibraryDependency dependency = GetDependency($"{{\"dependencies\":{{\"a\":{{\"target\":\"Project\"}}}}}}", environmentVariableReader);
 
             Assert.False(dependency.AutoReferenced);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void GetPackageSpec_WhenDependenciesDependencyAutoreferencedValueIsBool_ReturnsBoolAutoreferenced(bool expectedValue)
+        [MemberData(nameof(TestEnvironmentVariableReader), true)]
+        [MemberData(nameof(TestEnvironmentVariableReader), false)]
+        public void GetPackageSpec_WhenDependenciesDependencyAutoreferencedValueIsBool_ReturnsBoolAutoreferenced(IEnvironmentVariableReader environmentVariableReader, bool expectedValue)
         {
             var json = $"{{\"dependencies\":{{\"a\":{{\"autoReferenced\":{expectedValue.ToString().ToLower()},\"target\":\"Project\"}}}}}}";
 
-            LibraryDependency dependency = GetDependency(json);
+            LibraryDependency dependency = GetDependency(json, environmentVariableReader);
 
             Assert.Equal(expectedValue, dependency.AutoReferenced);
         }
 
         [Theory]
-        [InlineData("exclude")]
-        [InlineData("include")]
-        [InlineData("suppressParent")]
-        public void GetPackageSpec_WhenDependenciesDependencyValueIsArray_Throws(string propertyName)
+        [MemberData(nameof(TestEnvironmentVariableReader), "exclude")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "include")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "suppressParent")]
+        public void GetPackageSpec_WhenDependenciesDependencyValueIsArray_Throws(IEnvironmentVariableReader environmentVariableReader, string propertyName)
         {
             var json = $"{{\"dependencies\":{{\"a\":{{\"{propertyName}\":[\"b\"]}}}}}}";
 
-            Assert.Throws<InvalidCastException>(() => GetPackageSpec(json));
+            Assert.Throws<InvalidCastException>(() => GetPackageSpec(json, environmentVariableReader));
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesDependencyIncludeAndExcludePropertiesAreAbsent_ReturnsAllIncludeType()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesDependencyIncludeAndExcludePropertiesAreAbsent_ReturnsAllIncludeType(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
 
-            LibraryDependency dependency = GetDependency(json);
+            LibraryDependency dependency = GetDependency(json, environmentVariableReader);
 
             Assert.Equal(LibraryIncludeFlags.All, dependency.IncludeType);
         }
 
         [Theory]
-        [InlineData("\"Native\"", LibraryIncludeFlags.Native)]
-        [InlineData("\"Analyzers, Native\"", LibraryIncludeFlags.Analyzers | LibraryIncludeFlags.Native)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"Native\"", LibraryIncludeFlags.Native)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"Analyzers, Native\"", LibraryIncludeFlags.Analyzers | LibraryIncludeFlags.Native)]
         public void GetPackageSpec_WhenDependenciesDependencyExcludeValueIsValid_ReturnsIncludeType(
+            IEnvironmentVariableReader environmentVariableReader,
             string value,
             LibraryIncludeFlags result)
         {
             var json = $"{{\"dependencies\":{{\"a\":{{\"exclude\":{value},\"version\":\"1.0.0\"}}}}}}";
 
-            LibraryDependency dependency = GetDependency(json);
+            LibraryDependency dependency = GetDependency(json, environmentVariableReader);
 
             Assert.Equal(LibraryIncludeFlags.All & ~result, dependency.IncludeType);
         }
 
         [Theory]
-        [InlineData("\"Native\"", LibraryIncludeFlags.Native)]
-        [InlineData("\"Analyzers, Native\"", LibraryIncludeFlags.Analyzers | LibraryIncludeFlags.Native)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"Native\"", LibraryIncludeFlags.Native)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"Analyzers, Native\"", LibraryIncludeFlags.Analyzers | LibraryIncludeFlags.Native)]
         public void GetPackageSpec_WhenDependenciesDependencyIncludeValueIsValid_ReturnsIncludeType(
+            IEnvironmentVariableReader environmentVariableReader,
             string value,
             LibraryIncludeFlags expectedResult)
         {
             var json = $"{{\"dependencies\":{{\"a\":{{\"include\":{value},\"version\":\"1.0.0\"}}}}}}";
 
-            LibraryDependency dependency = GetDependency(json);
+            LibraryDependency dependency = GetDependency(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, dependency.IncludeType);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesDependencyIncludeValueOverridesTypeValue_ReturnsIncludeType()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesDependencyIncludeValueOverridesTypeValue_ReturnsIncludeType(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"include\":\"ContentFiles\",\"type\":\"BecomesNupkgDependency, SharedFramework\",\"version\":\"1.0.0\"}}}";
 
-            LibraryDependency dependency = GetDependency(json);
+            LibraryDependency dependency = GetDependency(json, environmentVariableReader);
 
             Assert.Equal(LibraryIncludeFlags.ContentFiles, dependency.IncludeType);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesDependencySuppressParentValueOverridesTypeValue_ReturnsSuppressParent()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesDependencySuppressParentValueOverridesTypeValue_ReturnsSuppressParent(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"suppressParent\":\"ContentFiles\",\"type\":\"SharedFramework\",\"version\":\"1.0.0\"}}}";
 
-            LibraryDependency dependency = GetDependency(json);
+            LibraryDependency dependency = GetDependency(json, environmentVariableReader);
 
             Assert.Equal(LibraryIncludeFlags.ContentFiles, dependency.SuppressParent);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesDependencySuppressParentPropertyIsAbsent_ReturnsSuppressParent()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesDependencySuppressParentPropertyIsAbsent_ReturnsSuppressParent(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
 
-            LibraryDependency dependency = GetDependency(json);
+            LibraryDependency dependency = GetDependency(json, environmentVariableReader);
 
             Assert.Equal(LibraryIncludeFlagUtils.DefaultSuppressParent, dependency.SuppressParent);
         }
 
         [Theory]
-        [InlineData("\"Compile\"", LibraryIncludeFlags.Compile)]
-        [InlineData("\"Analyzers, Compile\"", LibraryIncludeFlags.Analyzers | LibraryIncludeFlags.Compile)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"Compile\"", LibraryIncludeFlags.Compile)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"Analyzers, Compile\"", LibraryIncludeFlags.Analyzers | LibraryIncludeFlags.Compile)]
         public void GetPackageSpec_WhenDependenciesDependencySuppressParentValueIsValid_ReturnsSuppressParent(
+            IEnvironmentVariableReader environmentVariableReader,
             string value,
-            LibraryIncludeFlags expectedResult)
+            LibraryIncludeFlags expectedResult
+            )
         {
             var json = $"{{\"dependencies\":{{\"a\":{{\"suppressParent\":{value},\"version\":\"1.0.0\"}}}}}}";
 
-            LibraryDependency dependency = GetDependency(json);
+            LibraryDependency dependency = GetDependency(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, dependency.SuppressParent);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesDependencyVersionValueIsInvalid_Throws()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesDependencyVersionValueIsInvalid_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"version\":\"b\"}}}";
 
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
 
-            Assert.Equal("Error reading '' at line 1 column 35 : 'b' is not a valid version string.", exception.Message);
-            Assert.Equal(1, exception.Line);
-            Assert.Equal(35, exception.Column);
-            Assert.IsType<ArgumentException>(exception.InnerException);
-            Assert.Null(exception.InnerException.InnerException);
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal("Error reading '' at line 1 column 35 : 'b' is not a valid version string.", exception.Message);
+                Assert.Equal(1, exception.Line);
+                Assert.Equal(35, exception.Column);
+            }
+            else
+            {
+                Assert.Equal("Error reading '' : 'b' is not a valid version string.", exception.Message);
+            }
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesDependencyTargetPropertyIsAbsent_ReturnsTarget()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesDependencyTargetPropertyIsAbsent_ReturnsTarget(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
 
-            LibraryDependency dependency = GetDependency(json);
+            LibraryDependency dependency = GetDependency(json, environmentVariableReader);
 
             Assert.Equal(LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference, dependency.LibraryRange.TypeConstraint);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesDependencyTargetValueIsPackageAndVersionPropertyIsAbsent_Throws()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesDependencyTargetValueIsPackageAndVersionPropertyIsAbsent_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"target\":\"Package\"}}}";
 
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
-
-            Assert.Equal("Error reading '' at line 1 column 22 : Package dependencies must specify a version range.", exception.Message);
-            Assert.Equal(1, exception.Line);
-            Assert.Equal(22, exception.Column);
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
             Assert.IsType<ArgumentException>(exception.InnerException);
             Assert.Null(exception.InnerException.InnerException);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal("Error reading '' at line 1 column 22 : Package dependencies must specify a version range.", exception.Message);
+                Assert.Equal(1, exception.Line);
+                Assert.Equal(22, exception.Column);
+            }
+            else
+            {
+                Assert.Equal("Error reading '' : Package dependencies must specify a version range.", exception.Message);
+            }
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesDependencyTargetValueIsProjectAndVersionPropertyIsAbsent_ReturnsAllVersionRange()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesDependencyTargetValueIsProjectAndVersionPropertyIsAbsent_ReturnsAllVersionRange(IEnvironmentVariableReader environmentVariableReader)
         {
-            LibraryDependency dependency = GetDependency("{\"dependencies\":{\"a\":{\"target\":\"Project\"}}}");
+            LibraryDependency dependency = GetDependency("{\"dependencies\":{\"a\":{\"target\":\"Project\"}}}", environmentVariableReader);
 
             Assert.Equal(VersionRange.All, dependency.LibraryRange.VersionRange);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesDependencyNoWarnPropertyIsAbsent_ReturnsEmptyNoWarns()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesDependencyNoWarnPropertyIsAbsent_ReturnsEmptyNoWarns(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
 
-            LibraryDependency dependency = GetDependency(json);
+            LibraryDependency dependency = GetDependency(json, environmentVariableReader);
 
             Assert.Empty(dependency.NoWarn);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesDependencyNoWarnValueIsValid_ReturnsNoWarns()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesDependencyNoWarnValueIsValid_ReturnsNoWarns(IEnvironmentVariableReader environmentVariableReader)
         {
             NuGetLogCode[] expectedResults = { NuGetLogCode.NU1000, NuGetLogCode.NU3000 };
             var json = $"{{\"dependencies\":{{\"a\":{{\"noWarn\":[\"{expectedResults[0].ToString()}\",\"{expectedResults[1].ToString()}\"],\"version\":\"1.0.0\"}}}}}}";
 
-            LibraryDependency dependency = GetDependency(json);
+            LibraryDependency dependency = GetDependency(json, environmentVariableReader);
 
             Assert.Collection(
                 dependency.NoWarn,
@@ -1415,144 +1509,153 @@ namespace NuGet.ProjectModel.Test
                 noWarn => Assert.Equal(expectedResults[1], noWarn));
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesDependencyGeneratePathPropertyPropertyIsAbsent_ReturnsFalseGeneratePathProperty()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesDependencyGeneratePathPropertyPropertyIsAbsent_ReturnsFalseGeneratePathProperty(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
 
-            LibraryDependency dependency = GetDependency(json);
+            LibraryDependency dependency = GetDependency(json, environmentVariableReader);
 
             Assert.False(dependency.GeneratePathProperty);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void GetPackageSpec_WhenDependenciesDependencyGeneratePathPropertyValueIsValid_ReturnsGeneratePathProperty(bool expectedResult)
+        [MemberData(nameof(TestEnvironmentVariableReader), true)]
+        [MemberData(nameof(TestEnvironmentVariableReader), false)]
+        public void GetPackageSpec_WhenDependenciesDependencyGeneratePathPropertyValueIsValid_ReturnsGeneratePathProperty(IEnvironmentVariableReader environmentVariableReader, bool expectedResult)
         {
             var json = $"{{\"dependencies\":{{\"a\":{{\"generatePathProperty\":{expectedResult.ToString().ToLowerInvariant()},\"version\":\"1.0.0\"}}}}}}";
 
-            LibraryDependency dependency = GetDependency(json);
+            LibraryDependency dependency = GetDependency(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, dependency.GeneratePathProperty);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesDependencyTypePropertyIsAbsent_ReturnsDefaultTypeConstraint()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesDependencyTypePropertyIsAbsent_ReturnsDefaultTypeConstraint(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
 
-            LibraryDependency dependency = GetDependency(json);
+            LibraryDependency dependency = GetDependency(json, environmentVariableReader);
 
             Assert.Equal(
                 LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference,
                 dependency.LibraryRange.TypeConstraint);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenDependenciesDependencyVersionCentrallyManagedPropertyIsAbsent_ReturnsFalseVersionCentrallyManaged()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDependenciesDependencyVersionCentrallyManagedPropertyIsAbsent_ReturnsFalseVersionCentrallyManaged(IEnvironmentVariableReader environmentVariableReader)
         {
-            LibraryDependency dependency = GetDependency($"{{\"dependencies\":{{\"a\":{{\"target\":\"Package\",\"version\":\"1.0.0\"}}}}}}");
+            LibraryDependency dependency = GetDependency($"{{\"dependencies\":{{\"a\":{{\"target\":\"Package\",\"version\":\"1.0.0\"}}}}}}", environmentVariableReader);
 
             Assert.False(dependency.VersionCentrallyManaged);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void GetPackageSpec_WhenDependenciesDependencyVersionCentrallyManagedValueIsBool_ReturnsBoolVersionCentrallyManaged(bool expectedValue)
+        [MemberData(nameof(TestEnvironmentVariableReader), true)]
+        [MemberData(nameof(TestEnvironmentVariableReader), false)]
+        public void GetPackageSpec_WhenDependenciesDependencyVersionCentrallyManagedValueIsBool_ReturnsBoolVersionCentrallyManaged(IEnvironmentVariableReader environmentVariableReader, bool expectedValue)
         {
             var json = $"{{\"dependencies\":{{\"a\":{{\"versionCentrallyManaged\":{expectedValue.ToString().ToLower()},\"target\":\"Package\",\"version\":\"1.0.0\"}}}}}}";
 
-            LibraryDependency dependency = GetDependency(json);
+            LibraryDependency dependency = GetDependency(json, environmentVariableReader);
 
             Assert.Equal(expectedValue, dependency.VersionCentrallyManaged);
         }
 
 #pragma warning disable CS0612 // Type or member is obsolete
-        [Fact]
-        public void GetPackageSpec_WhenDescriptionPropertyIsAbsent_ReturnsNullDescription()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenDescriptionPropertyIsAbsent_ReturnsNullDescription(IEnvironmentVariableReader environmentVariableReader)
         {
-            PackageSpec packageSpec = GetPackageSpec("{}");
+            PackageSpec packageSpec = GetPackageSpec("{}", environmentVariableReader);
 
             Assert.Null(packageSpec.Description);
         }
 
         [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("b")]
-        public void GetPackageSpec_WhenDescriptionValueIsValid_ReturnsDescription(string expectedResult)
+        [MemberData(nameof(TestEnvironmentVariableReader), null)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "b")]
+        public void GetPackageSpec_WhenDescriptionValueIsValid_ReturnsDescription(IEnvironmentVariableReader environmentVariableReader, string expectedResult)
         {
             string description = expectedResult == null ? "null" : $"\"{expectedResult}\"";
-            PackageSpec packageSpec = GetPackageSpec($"{{\"description\":{description}}}");
+            PackageSpec packageSpec = GetPackageSpec($"{{\"description\":{description}}}", environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.Description);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenLanguagePropertyIsAbsent_ReturnsNullLanguage()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenLanguagePropertyIsAbsent_ReturnsNullLanguage(IEnvironmentVariableReader environmentVariableReader)
         {
-            PackageSpec packageSpec = GetPackageSpec("{}");
+            PackageSpec packageSpec = GetPackageSpec("{}", environmentVariableReader);
 
             Assert.Null(packageSpec.Language);
         }
 
         [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("b")]
-        public void GetPackageSpec_WhenLanguageValueIsValid_ReturnsLanguage(string expectedResult)
+        [MemberData(nameof(TestEnvironmentVariableReader), null)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "b")]
+        public void GetPackageSpec_WhenLanguageValueIsValid_ReturnsLanguage(IEnvironmentVariableReader environmentVariableReader, string expectedResult)
         {
             string language = expectedResult == null ? "null" : $"\"{expectedResult}\"";
-            PackageSpec packageSpec = GetPackageSpec($"{{\"language\":{language}}}");
+            PackageSpec packageSpec = GetPackageSpec($"{{\"language\":{language}}}", environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.Language);
         }
 #pragma warning restore CS0612 // Type or member is obsolete
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksPropertyIsAbsent_ReturnsEmptyFrameworks()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksPropertyIsAbsent_ReturnsEmptyFrameworks(IEnvironmentVariableReader environmentVariableReader)
         {
-            PackageSpec packageSpec = GetPackageSpec("{}");
+            PackageSpec packageSpec = GetPackageSpec("{}", environmentVariableReader);
 
             Assert.Empty(packageSpec.TargetFrameworks);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksValueIsEmptyObject_ReturnsEmptyFrameworks()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksValueIsEmptyObject_ReturnsEmptyFrameworks(IEnvironmentVariableReader environmentVariableReader)
         {
-            PackageSpec packageSpec = GetPackageSpec("{\"frameworks\":{}}");
+            PackageSpec packageSpec = GetPackageSpec("{\"frameworks\":{}}", environmentVariableReader);
 
             Assert.Empty(packageSpec.TargetFrameworks);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksAssetTargetFallbackPropertyIsAbsent_ReturnsFalseAssetTargetFallback()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksAssetTargetFallbackPropertyIsAbsent_ReturnsFalseAssetTargetFallback(IEnvironmentVariableReader environmentVariableReader)
         {
-            TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{}}}");
+            TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{}}}", environmentVariableReader);
 
             Assert.False(framework.AssetTargetFallback);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void GetPackageSpec_WhenFrameworksAssetTargetFallbackValueIsValid_ReturnsAssetTargetFallback(bool expectedValue)
+        [MemberData(nameof(TestEnvironmentVariableReader), true)]
+        [MemberData(nameof(TestEnvironmentVariableReader), false)]
+        public void GetPackageSpec_WhenFrameworksAssetTargetFallbackValueIsValid_ReturnsAssetTargetFallback(IEnvironmentVariableReader environmentVariableReader, bool expectedValue)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"assetTargetFallback\":{expectedValue.ToString().ToLowerInvariant()}}}}}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Equal(expectedValue, framework.AssetTargetFallback);
         }
 
-        [Fact]
-        public void GetPackageSpec_WithAssetTargetFallbackAndImportsValues_ReturnsValidAssetTargetFallbackFramework()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WithAssetTargetFallbackAndImportsValues_ReturnsValidAssetTargetFallbackFramework(IEnvironmentVariableReader environmentVariableReader)
         {
             var json = $"{{\"frameworks\":{{\"net5.0\":{{\"assetTargetFallback\": true, \"imports\": [\"net472\", \"net471\"]}}}}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             framework.AssetTargetFallback.Should().BeTrue();
             var assetTargetFallback = framework.FrameworkName as AssetTargetFallbackFramework;
@@ -1562,61 +1665,81 @@ namespace NuGet.ProjectModel.Test
             assetTargetFallback.Fallback.Last().Should().Be(FrameworkConstants.CommonFrameworks.Net471);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksCentralPackageVersionsPropertyIsAbsent_ReturnsEmptyCentralPackageVersions()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksCentralPackageVersionsPropertyIsAbsent_ReturnsEmptyCentralPackageVersions(IEnvironmentVariableReader environmentVariableReader)
         {
-            TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{}}}");
+            TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{}}}", environmentVariableReader);
 
             Assert.Empty(framework.CentralPackageVersions);
-        }
-
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksCentralPackageVersionsValueIsEmptyObject_ReturnsEmptyCentralPackageVersions()
-        {
-            TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{\"centralPackageVersions\":{}}}}");
-
-            Assert.Empty(framework.CentralPackageVersions);
-        }
-
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksCentralPackageVersionsVersionPropertyNameIsEmptyString_Throws()
-        {
-            var json = "{\"frameworks\":{\"a\":{\"centralPackageVersions\":{\"\":\"1.0.0\"}}}}";
-
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
-
-            Assert.Equal("Error reading '' at line 1 column 20 : Unable to resolve central version ''.", exception.Message);
-            Assert.Equal(1, exception.Line);
-            Assert.Equal(20, exception.Column);
-            Assert.IsType<FileFormatException>(exception.InnerException);
-            Assert.Null(exception.InnerException.InnerException);
         }
 
         [Theory]
-        [InlineData("null")]
-        [InlineData("\"\"")]
-        public void GetPackageSpec_WhenFrameworksCentralPackageVersionsVersionPropertyValueIsNullOrEmptyString_Throws(string value)
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksCentralPackageVersionsValueIsEmptyObject_ReturnsEmptyCentralPackageVersions(IEnvironmentVariableReader environmentVariableReader)
+        {
+            TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{\"centralPackageVersions\":{}}}}", environmentVariableReader);
+
+            Assert.Empty(framework.CentralPackageVersions);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksCentralPackageVersionsVersionPropertyNameIsEmptyString_Throws(IEnvironmentVariableReader environmentVariableReader)
+        {
+            var json = "{\"frameworks\":{\"a\":{\"centralPackageVersions\":{\"\":\"1.0.0\"}}}}";
+
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
+
+            Assert.IsType<FileFormatException>(exception.InnerException);
+            Assert.Null(exception.InnerException.InnerException);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal("Error reading '' at line 1 column 20 : Unable to resolve central version ''.", exception.Message);
+                Assert.Equal(1, exception.Line);
+                Assert.Equal(20, exception.Column);
+            }
+            else
+            {
+                Assert.Equal("Error reading '' : Unable to resolve central version ''.", exception.Message);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"")]
+        public void GetPackageSpec_WhenFrameworksCentralPackageVersionsVersionPropertyValueIsNullOrEmptyString_Throws(IEnvironmentVariableReader environmentVariableReader, string value)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"centralPackageVersions\":{{\"b\":{value}}}}}}}}}";
 
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
 
-            Assert.Equal("Error reading '' at line 1 column 20 : The version cannot be null or empty.", exception.Message);
-            Assert.Equal(1, exception.Line);
-            Assert.Equal(20, exception.Column);
             Assert.IsType<FileFormatException>(exception.InnerException);
             Assert.Null(exception.InnerException.InnerException);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal("Error reading '' at line 1 column 20 : The version cannot be null or empty.", exception.Message);
+                Assert.Equal(1, exception.Line);
+                Assert.Equal(20, exception.Column);
+            }
+            else
+            {
+                Assert.Equal("Error reading '' : The version cannot be null or empty.", exception.Message);
+            }
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksCentralPackageVersionsIsValid_ReturnsCentralPackageVersions()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksCentralPackageVersionsIsValid_ReturnsCentralPackageVersions(IEnvironmentVariableReader environmentVariableReader)
         {
             const string expectedPackageId = "b";
             VersionRange expectedVersionRange = VersionRange.Parse("[1.2.3,4.5.6)");
             var expectedCentralPackageVersion = new CentralPackageVersion(expectedPackageId, expectedVersionRange);
             var json = $"{{\"frameworks\":{{\"a\":{{\"centralPackageVersions\":{{\"{expectedPackageId}\":\"{expectedVersionRange.ToShortString()}\"}}}}}}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Collection(
                 framework.CentralPackageVersions,
@@ -1627,8 +1750,9 @@ namespace NuGet.ProjectModel.Test
                 });
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksCentralPackageVersionsHasDuplicateKey_LastOneWins()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksCentralPackageVersionsHasDuplicateKey_LastOneWins(IEnvironmentVariableReader environmentVariableReader)
         {
             const string expectedPackageId = "b";
             VersionRange unexpectedVersionRange = VersionRange.Parse("1.2.3");
@@ -1637,7 +1761,7 @@ namespace NuGet.ProjectModel.Test
             var json = $"{{\"frameworks\":{{\"a\":{{\"centralPackageVersions\":{{\"{expectedPackageId}\":\"{unexpectedVersionRange.ToShortString()}\"," +
                 $"\"{expectedPackageId}\":\"{expectedVersionRange.ToShortString()}\"}}}}}}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Collection(
                 framework.CentralPackageVersions,
@@ -1648,38 +1772,49 @@ namespace NuGet.ProjectModel.Test
                 });
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesPropertyIsAbsent_ReturnsEmptyDependencies()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesPropertyIsAbsent_ReturnsEmptyDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
-            TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{}}}");
+            TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{}}}", environmentVariableReader);
 
             Assert.Empty(framework.Dependencies);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesValueIsNull_ReturnsEmptyDependencies()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesValueIsNull_ReturnsEmptyDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
-            TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{\"dependencies\":null}}}");
+            TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"a\":{\"dependencies\":null}}}", environmentVariableReader);
 
             Assert.Empty(framework.Dependencies);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyNameIsEmptyString_Throws()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyNameIsEmptyString_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"\":{}}}}}";
 
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
 
-            Assert.Equal("Error reading '' at line 1 column 20 : Unable to resolve dependency ''.", exception.Message);
-            Assert.Equal(1, exception.Line);
-            Assert.Equal(20, exception.Column);
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal("Error reading '' at line 1 column 20 : Unable to resolve dependency ''.", exception.Message);
+                Assert.Equal(1, exception.Line);
+                Assert.Equal(20, exception.Column);
+            }
+            else
+            {
+                Assert.Equal("Error reading '' : Unable to resolve dependency ''.", exception.Message);
+            }
             Assert.IsType<FileFormatException>(exception.InnerException);
             Assert.Null(exception.InnerException.InnerException);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyValueIsVersionString_ReturnsDependencyVersionRange()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyValueIsVersionString_ReturnsDependencyVersionRange(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new LibraryRange(
                 name: "b",
@@ -1687,13 +1822,14 @@ namespace NuGet.ProjectModel.Test
                 LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference);
             var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"{expectedResult.Name}\":\"{expectedResult.VersionRange.ToShortString()}\"}}}}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, dependency.LibraryRange);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyValueIsVersionRangeString_ReturnsDependencyVersionRange()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyValueIsVersionRangeString_ReturnsDependencyVersionRange(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new LibraryRange(
                 name: "b",
@@ -1701,211 +1837,257 @@ namespace NuGet.ProjectModel.Test
                 LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference);
             var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"{expectedResult.Name}\":\"{expectedResult.VersionRange}\"}}}}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, dependency.LibraryRange);
         }
 
         [Theory]
-        [InlineData(LibraryDependencyTarget.None)]
-        [InlineData(LibraryDependencyTarget.Assembly)]
-        [InlineData(LibraryDependencyTarget.Reference)]
-        [InlineData(LibraryDependencyTarget.WinMD)]
-        [InlineData(LibraryDependencyTarget.All)]
-        [InlineData(LibraryDependencyTarget.PackageProjectExternal)]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyTargetValueIsUnsupported_Throws(LibraryDependencyTarget target)
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.None)]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.Assembly)]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.Reference)]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.WinMD)]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.All)]
+        [MemberData(nameof(TestEnvironmentVariableReader), LibraryDependencyTarget.PackageProjectExternal)]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyTargetValueIsUnsupported_Throws(IEnvironmentVariableReader environmentVariableReader, LibraryDependencyTarget target)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"b\":{{\"version\":\"1.2.3\",\"target\":\"{target}\"}}}}}}}}}}";
 
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
 
-            Assert.Equal($"Error reading '' at line 1 column 20 : Invalid dependency target value '{target}'.", exception.Message);
-            Assert.Equal(1, exception.Line);
-            Assert.Equal(20, exception.Column);
             Assert.IsType<FileFormatException>(exception.InnerException);
             Assert.Null(exception.InnerException.InnerException);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal($"Error reading '' at line 1 column 20 : Invalid dependency target value '{target}'.", exception.Message);
+                Assert.Equal(1, exception.Line);
+                Assert.Equal(20, exception.Column);
+            }
+            else
+            {
+                Assert.Equal($"Error reading '' : Invalid dependency target value '{target}'.", exception.Message);
+            }
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyAutoreferencedPropertyIsAbsent_ReturnsFalseAutoreferenced()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyAutoreferencedPropertyIsAbsent_ReturnsFalseAutoreferenced(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"target\":\"Project\"}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.False(dependency.AutoReferenced);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyAutoreferencedValueIsBool_ReturnsBoolAutoreferenced(bool expectedValue)
+        [MemberData(nameof(TestEnvironmentVariableReader), true)]
+        [MemberData(nameof(TestEnvironmentVariableReader), false)]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyAutoreferencedValueIsBool_ReturnsBoolAutoreferenced(IEnvironmentVariableReader environmentVariableReader, bool expectedValue)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"b\":{{\"autoReferenced\":{expectedValue.ToString().ToLower()},\"target\":\"Project\"}}}}}}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Equal(expectedValue, dependency.AutoReferenced);
         }
 
         [Theory]
-        [InlineData("exclude")]
-        [InlineData("include")]
-        [InlineData("suppressParent")]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyValueIsArray_Throws(string propertyName)
+        [MemberData(nameof(TestEnvironmentVariableReader), "exclude")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "include")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "suppressParent")]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyValueIsArray_Throws(IEnvironmentVariableReader environmentVariableReader, string propertyName)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"b\":{{\"{propertyName}\":[\"c\"]}}}}}}}}}}";
 
             // The exception messages will not be the same because the innermost exception in the baseline
             // is a Newtonsoft.Json exception, while it's a .NET exception in the improved.
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
 
-            Assert.Equal("Error reading '' at line 1 column 20 : Specified cast is not valid.", exception.Message);
-            Assert.Equal(1, exception.Line);
-            Assert.Equal(20, exception.Column);
             Assert.IsType<InvalidCastException>(exception.InnerException);
             Assert.Null(exception.InnerException.InnerException);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal("Error reading '' at line 1 column 20 : Specified cast is not valid.", exception.Message);
+                Assert.Equal(1, exception.Line);
+                Assert.Equal(20, exception.Column);
+            }
+            else
+            {
+                Assert.Equal("Error reading '' : Specified cast is not valid.", exception.Message);
+            }
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyIncludeAndExcludePropertiesAreAbsent_ReturnsAllIncludeType()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyIncludeAndExcludePropertiesAreAbsent_ReturnsAllIncludeType(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"1.0.0\"}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Equal(LibraryIncludeFlags.All, dependency.IncludeType);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyExcludeValueIsValid_ReturnsIncludeType()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyExcludeValueIsValid_ReturnsIncludeType(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"exclude\":\"Native\",\"version\":\"1.0.0\"}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Equal(LibraryIncludeFlags.All & ~LibraryIncludeFlags.Native, dependency.IncludeType);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyIncludeValueIsValid_ReturnsIncludeType()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyIncludeValueIsValid_ReturnsIncludeType(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"include\":\"ContentFiles\",\"version\":\"1.0.0\"}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Equal(LibraryIncludeFlags.ContentFiles, dependency.IncludeType);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyIncludeValueOverridesTypeValue_ReturnsIncludeType()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyIncludeValueOverridesTypeValue_ReturnsIncludeType(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"include\":\"ContentFiles\",\"type\":\"BecomesNupkgDependency, SharedFramework\",\"version\":\"1.0.0\"}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Equal(LibraryIncludeFlags.ContentFiles, dependency.IncludeType);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencySuppressParentValueOverridesTypeValue_ReturnsSuppressParent()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencySuppressParentValueOverridesTypeValue_ReturnsSuppressParent(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"suppressParent\":\"ContentFiles\",\"type\":\"SharedFramework\",\"version\":\"1.0.0\"}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Equal(LibraryIncludeFlags.ContentFiles, dependency.SuppressParent);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencySuppressParentPropertyIsAbsent_ReturnsSuppressParent()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencySuppressParentPropertyIsAbsent_ReturnsSuppressParent(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"1.0.0\"}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Equal(LibraryIncludeFlagUtils.DefaultSuppressParent, dependency.SuppressParent);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencySuppressParentValueIsValid_ReturnsSuppressParent()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencySuppressParentValueIsValid_ReturnsSuppressParent(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"suppressParent\":\"Compile\",\"version\":\"1.0.0\"}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Equal(LibraryIncludeFlags.Compile, dependency.SuppressParent);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyVersionValueIsInvalid_Throws()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyVersionValueIsInvalid_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"c\"}}}}}";
 
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
 
-            Assert.Equal("Error reading '' at line 1 column 20 : Error reading '' at line 1 column 54 : 'c' is not a valid version string.", exception.Message);
-            Assert.Equal(1, exception.Line);
-            Assert.Equal(20, exception.Column);
             Assert.IsType<FileFormatException>(exception.InnerException);
             Assert.IsType<ArgumentException>(exception.InnerException.InnerException);
             Assert.Null(exception.InnerException.InnerException.InnerException);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal("Error reading '' at line 1 column 20 : Error reading '' at line 1 column 54 : 'c' is not a valid version string.", exception.Message);
+                Assert.Equal(1, exception.Line);
+                Assert.Equal(20, exception.Column);
+            }
+            else
+            {
+                Assert.Equal("Error reading '' : Error reading '' : 'c' is not a valid version string.", exception.Message);
+            }
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyTargetPropertyIsAbsent_ReturnsTarget()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyTargetPropertyIsAbsent_ReturnsTarget(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"1.0.0\"}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Equal(
                 LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference,
                 dependency.LibraryRange.TypeConstraint);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyTargetValueIsPackageAndVersionPropertyIsAbsent_Throws()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyTargetValueIsPackageAndVersionPropertyIsAbsent_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"target\":\"Package\"}}}}}";
 
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
 
-            Assert.Equal("Error reading '' at line 1 column 20 : Error reading '' at line 1 column 41 : Package dependencies must specify a version range.", exception.Message);
-            Assert.Equal(1, exception.Line);
-            Assert.Equal(20, exception.Column);
             Assert.IsType<FileFormatException>(exception.InnerException);
             Assert.IsType<ArgumentException>(exception.InnerException.InnerException);
             Assert.Null(exception.InnerException.InnerException.InnerException);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal("Error reading '' at line 1 column 20 : Error reading '' at line 1 column 41 : Package dependencies must specify a version range.", exception.Message);
+                Assert.Equal(1, exception.Line);
+                Assert.Equal(20, exception.Column);
+            }
+            else
+            {
+                Assert.Equal("Error reading '' : Error reading '' : Package dependencies must specify a version range.", exception.Message);
+            }
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyTargetValueIsProjectAndVersionPropertyIsAbsent_ReturnsAllVersionRange()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyTargetValueIsProjectAndVersionPropertyIsAbsent_ReturnsAllVersionRange(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"target\":\"Project\"}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Equal(VersionRange.All, dependency.LibraryRange.VersionRange);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyNoWarnPropertyIsAbsent_ReturnsEmptyNoWarns()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyNoWarnPropertyIsAbsent_ReturnsEmptyNoWarns(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"1.0.0\"}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Empty(dependency.NoWarn);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyNoWarnValueIsValid_ReturnsNoWarns()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyNoWarnValueIsValid_ReturnsNoWarns(IEnvironmentVariableReader environmentVariableReader)
         {
             NuGetLogCode[] expectedResults = { NuGetLogCode.NU1000, NuGetLogCode.NU3000 };
             var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"b\":{{\"noWarn\":[\"{expectedResults[0].ToString()}\",\"{expectedResults[1].ToString()}\"],\"version\":\"1.0.0\"}}}}}}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Collection(
                 dependency.NoWarn,
@@ -1913,34 +2095,36 @@ namespace NuGet.ProjectModel.Test
                 noWarn => Assert.Equal(expectedResults[1], noWarn));
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyGeneratePathPropertyPropertyIsAbsent_ReturnsFalseGeneratePathProperty()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyGeneratePathPropertyPropertyIsAbsent_ReturnsFalseGeneratePathProperty(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"1.0.0\"}}}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.False(dependency.GeneratePathProperty);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyGeneratePathPropertyValueIsValid_ReturnsGeneratePathProperty(bool expectedResult)
+        [MemberData(nameof(TestEnvironmentVariableReader), true)]
+        [MemberData(nameof(TestEnvironmentVariableReader), false)]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyGeneratePathPropertyValueIsValid_ReturnsGeneratePathProperty(IEnvironmentVariableReader environmentVariableReader, bool expectedResult)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"b\":{{\"generatePathProperty\":{expectedResult.ToString().ToLowerInvariant()},\"version\":\"1.0.0\"}}}}}}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, dependency.GeneratePathProperty);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyTypePropertyIsAbsent_ReturnsDefaultTypeConstraint()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyTypePropertyIsAbsent_ReturnsDefaultTypeConstraint(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"version\":\"1.0.0\"}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Equal(
                 LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference,
@@ -1948,89 +2132,103 @@ namespace NuGet.ProjectModel.Test
         }
 
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyVersionCentrallyManagedPropertyIsAbsent_ReturnsFalseVersionCentrallyManaged()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyVersionCentrallyManagedPropertyIsAbsent_ReturnsFalseVersionCentrallyManaged(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"dependencies\":{\"b\":{\"target\":\"Package\",\"version\":\"1.0.0\"}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.False(dependency.VersionCentrallyManaged);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void GetPackageSpec_WhenFrameworksDependenciesDependencyVersionCentrallyManagedValueIsBool_ReturnsBoolVersionCentrallyManaged(bool expectedValue)
+        [MemberData(nameof(TestEnvironmentVariableReader), true)]
+        [MemberData(nameof(TestEnvironmentVariableReader), false)]
+        public void GetPackageSpec_WhenFrameworksDependenciesDependencyVersionCentrallyManagedValueIsBool_ReturnsBoolVersionCentrallyManaged(IEnvironmentVariableReader environmentVariableReader, bool expectedValue)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"dependencies\":{{\"b\":{{\"versionCentrallyManaged\":{expectedValue.ToString().ToLower()},\"target\":\"Package\",\"version\":\"1.0.0\"}}}}}}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Equal(expectedValue, dependency.VersionCentrallyManaged);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDownloadDependenciesPropertyIsAbsent_ReturnsEmptyDownloadDependencies()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesPropertyIsAbsent_ReturnsEmptyDownloadDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Empty(framework.DownloadDependencies);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueIsNull_ReturnsEmptyDownloadDependencies()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueIsNull_ReturnsEmptyDownloadDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"downloadDependencies\":null}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Empty(framework.DownloadDependencies);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueIsNotArray_ReturnsEmptyDownloadDependencies()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueIsNotArray_ReturnsEmptyDownloadDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"downloadDependencies\":\"b\"}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Empty(framework.DownloadDependencies);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueIsEmptyArray_ReturnsEmptyDownloadDependencies()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueIsEmptyArray_ReturnsEmptyDownloadDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"downloadDependencies\":[]}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Empty(framework.DownloadDependencies);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDownloadDependenciesDependencyNameIsAbsent_Throws()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesDependencyNameIsAbsent_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"downloadDependencies\":[{\"version\":\"1.2.3\"}]}}}";
 
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
-
-            Assert.Equal("Error reading '' at line 1 column 20 : Unable to resolve downloadDependency ''.", exception.Message);
-            Assert.Equal(1, exception.Line);
-            Assert.Equal(20, exception.Column);
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
             Assert.IsType<FileFormatException>(exception.InnerException);
             Assert.Null(exception.InnerException.InnerException);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal("Error reading '' at line 1 column 20 : Unable to resolve downloadDependency ''.", exception.Message);
+                Assert.Equal(1, exception.Line);
+                Assert.Equal(20, exception.Column);
+            }
+            else
+            {
+                Assert.Equal("Error reading '' : Unable to resolve downloadDependency ''.", exception.Message);
+            }
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDownloadDependenciesDependencyNameIsNull_ReturnsDownloadDependencies()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesDependencyNameIsNull_ReturnsDownloadDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new DownloadDependency(name: null, new VersionRange(new NuGetVersion("1.2.3")));
             var json = $"{{\"frameworks\":{{\"a\":{{\"downloadDependencies\":[{{\"name\":null,\"version\":\"{expectedResult.VersionRange.ToShortString()}\"}}]}}}}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             DownloadDependency actualResult = framework.DownloadDependencies.Single();
 
@@ -2038,52 +2236,70 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(expectedResult.VersionRange, actualResult.VersionRange);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDownloadDependenciesDependencyVersionIsAbsent_Throws()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesDependencyVersionIsAbsent_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"downloadDependencies\":[{\"name\":\"b\"}]}}}";
 
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
 
-            Assert.Equal("Error reading '' at line 1 column 20 : The version cannot be null or empty", exception.Message);
-            Assert.Equal(1, exception.Line);
-            Assert.Equal(20, exception.Column);
             Assert.IsType<FileFormatException>(exception.InnerException);
             Assert.Null(exception.InnerException.InnerException);
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal("Error reading '' at line 1 column 20 : The version cannot be null or empty", exception.Message);
+                Assert.Equal(1, exception.Line);
+                Assert.Equal(20, exception.Column);
+            }
+            else
+            {
+                Assert.Equal("Error reading '' : The version cannot be null or empty", exception.Message);
+            }
         }
 
         [Theory]
-        [InlineData("null")]
-        [InlineData("c")]
-        public void GetPackageSpec_WhenFrameworksDownloadDependenciesDependencyVersionIsInvalid_Throws(string version)
+        [MemberData(nameof(TestEnvironmentVariableReader), "null")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "c")]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesDependencyVersionIsInvalid_Throws(IEnvironmentVariableReader environmentVariableReader, string version)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"downloadDependencies\":[{{\"name\":\"b\",\"version\":\"{version}\"}}]}}}}}}";
 
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
 
             int expectedColumn = json.IndexOf($"\"{version}\"") + version.Length + 2;
 
-            Assert.Equal($"Error reading '' at line 1 column 20 : Error reading '' at line 1 column {expectedColumn} : '{version}' is not a valid version string.", exception.Message);
-            Assert.Equal(1, exception.Line);
-            Assert.Equal(20, exception.Column);
             Assert.IsType<FileFormatException>(exception.InnerException);
             Assert.IsType<ArgumentException>(exception.InnerException.InnerException);
             Assert.Null(exception.InnerException.InnerException.InnerException);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal($"Error reading '' at line 1 column 20 : Error reading '' at line 1 column {expectedColumn} : '{version}' is not a valid version string.", exception.Message);
+                Assert.Equal(1, exception.Line);
+                Assert.Equal(20, exception.Column);
+            }
+            else
+            {
+                Assert.Equal($"Error reading '' : Error reading '' : '{version}' is not a valid version string.", exception.Message);
+            }
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueIsValid_ReturnsDownloadDependencies()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueIsValid_ReturnsDownloadDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new DownloadDependency(name: "b", new VersionRange(new NuGetVersion("1.2.3")));
             var json = $"{{\"frameworks\":{{\"a\":{{\"downloadDependencies\":[{{\"name\":\"{expectedResult.Name}\",\"version\":\"{expectedResult.VersionRange.ToShortString()}\"}}]}}}}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, framework.DownloadDependencies.Single());
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueHasDuplicates_PrefersFirstByName()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksDownloadDependenciesValueHasDuplicates_PrefersFirstByName(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new DownloadDependency(name: "b", new VersionRange(new NuGetVersion("1.2.3")));
             var unexpectedResult = new DownloadDependency(name: "b", new VersionRange(new NuGetVersion("4.5.6")));
@@ -2092,251 +2308,295 @@ namespace NuGet.ProjectModel.Test
                 $"{{\"name\":\"{unexpectedResult.Name}\",\"version\":\"{unexpectedResult.VersionRange.ToShortString()}\"}}" +
                 "]}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, framework.DownloadDependencies.Single());
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksFrameworkAssembliesPropertyIsAbsent_ReturnsEmptyDependencies()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksFrameworkAssembliesPropertyIsAbsent_ReturnsEmptyDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Empty(framework.Dependencies);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksFrameworkAssembliesValueIsNull_ReturnsEmptyDependencies()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksFrameworkAssembliesValueIsNull_ReturnsEmptyDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"frameworkAssemblies\":null}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Empty(framework.Dependencies);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksFrameworkAssembliesValueIsEmptyObject_ReturnsEmptyDependencies()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksFrameworkAssembliesValueIsEmptyObject_ReturnsEmptyDependencies(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"frameworkAssemblies\":{}}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Empty(framework.Dependencies);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksFrameworkAssembliesDependencyTargetPropertyIsAbsent_ReturnsTarget()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksFrameworkAssembliesDependencyTargetPropertyIsAbsent_ReturnsTarget(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"frameworkAssemblies\":{\"b\":{\"version\":\"1.0.0\"}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Equal(LibraryDependencyTarget.Reference, dependency.LibraryRange.TypeConstraint);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksFrameworkAssembliesDependencyTargetValueIsPackageAndVersionPropertyIsAbsent_Throws()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksFrameworkAssembliesDependencyTargetValueIsPackageAndVersionPropertyIsAbsent_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"frameworkAssemblies\":{\"b\":{\"target\":\"Package\"}}}}}";
 
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
 
-            Assert.Equal("Error reading '' at line 1 column 20 : Error reading '' at line 1 column 48 : Package dependencies must specify a version range.", exception.Message);
-            Assert.Equal(1, exception.Line);
-            Assert.Equal(20, exception.Column);
             Assert.IsType<FileFormatException>(exception.InnerException);
             Assert.IsType<ArgumentException>(exception.InnerException.InnerException);
             Assert.Null(exception.InnerException.InnerException.InnerException);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal("Error reading '' at line 1 column 20 : Error reading '' at line 1 column 48 : Package dependencies must specify a version range.", exception.Message);
+                Assert.Equal(1, exception.Line);
+                Assert.Equal(20, exception.Column);
+            }
+            else
+            {
+                Assert.Equal("Error reading '' : Error reading '' : Package dependencies must specify a version range.", exception.Message);
+            }
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksFrameworkAssembliesDependencyTargetValueIsProjectAndVersionPropertyIsAbsent_ReturnsAllVersionRange()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksFrameworkAssembliesDependencyTargetValueIsProjectAndVersionPropertyIsAbsent_ReturnsAllVersionRange(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"frameworkAssemblies\":{\"b\":{\"target\":\"Project\"}}}}}";
 
-            LibraryDependency dependency = GetFrameworksDependency(json);
+            LibraryDependency dependency = GetFrameworksDependency(json, environmentVariableReader);
 
             Assert.Equal(VersionRange.All, dependency.LibraryRange.VersionRange);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksFrameworkReferencesPropertyIsAbsent_ReturnsEmptyFrameworkReferences()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksFrameworkReferencesPropertyIsAbsent_ReturnsEmptyFrameworkReferences(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Empty(framework.FrameworkReferences);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksFrameworkReferencesValueIsNull_ReturnsEmptyFrameworkReferences()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksFrameworkReferencesValueIsNull_ReturnsEmptyFrameworkReferences(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"frameworkReferences\":null}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Empty(framework.FrameworkReferences);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksFrameworkReferencesValueIsEmptyObject_ReturnsEmptyFrameworkReferences()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksFrameworkReferencesValueIsEmptyObject_ReturnsEmptyFrameworkReferences(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"frameworkReferences\":{}}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Empty(framework.FrameworkReferences);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksFrameworkReferencesFrameworkNameIsEmptyString_Throws()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksFrameworkReferencesFrameworkNameIsEmptyString_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{\"frameworkReferences\":{\"\":{}}}}}";
 
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
 
-            Assert.Equal("Error reading '' at line 1 column 20 : Unable to resolve frameworkReference.", exception.Message);
-            Assert.Equal(1, exception.Line);
-            Assert.Equal(20, exception.Column);
             Assert.IsType<FileFormatException>(exception.InnerException);
             Assert.Null(exception.InnerException.InnerException);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal("Error reading '' at line 1 column 20 : Unable to resolve frameworkReference.", exception.Message);
+                Assert.Equal(1, exception.Line);
+                Assert.Equal(20, exception.Column);
+            }
+            else
+            {
+                Assert.Equal("Error reading '' : Unable to resolve frameworkReference.", exception.Message);
+            }
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksFrameworkReferencesPrivateAssetsPropertyIsAbsent_ReturnsNonePrivateAssets()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksFrameworkReferencesPrivateAssetsPropertyIsAbsent_ReturnsNonePrivateAssets(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new FrameworkDependency(name: "b", FrameworkDependencyFlags.None);
             var json = $"{{\"frameworks\":{{\"a\":{{\"frameworkReferences\":{{\"{expectedResult.Name}\":{{}}}}}}}}}}";
 
-            FrameworkDependency dependency = GetFrameworksFrameworkReference(json);
+            FrameworkDependency dependency = GetFrameworksFrameworkReference(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, dependency);
         }
 
         [Theory]
-        [InlineData("\"null\"")]
-        [InlineData("\"\"")]
-        [InlineData("\"c\"")]
-        public void GetPackageSpec_WhenFrameworksFrameworkReferencesPrivateAssetsValueIsInvalidValue_ReturnsNonePrivateAssets(string privateAssets)
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"null\"")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"c\"")]
+        public void GetPackageSpec_WhenFrameworksFrameworkReferencesPrivateAssetsValueIsInvalidValue_ReturnsNonePrivateAssets(IEnvironmentVariableReader environmentVariableReader, string privateAssets)
         {
             var expectedResult = new FrameworkDependency(name: "b", FrameworkDependencyFlags.None);
             var json = $"{{\"frameworks\":{{\"a\":{{\"frameworkReferences\":{{\"{expectedResult.Name}\":{{\"privateAssets\":{privateAssets}}}}}}}}}}}";
 
-            FrameworkDependency dependency = GetFrameworksFrameworkReference(json);
+            FrameworkDependency dependency = GetFrameworksFrameworkReference(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, dependency);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksFrameworkReferencesPrivateAssetsValueIsValidString_ReturnsPrivateAssets()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksFrameworkReferencesPrivateAssetsValueIsValidString_ReturnsPrivateAssets(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new FrameworkDependency(name: "b", FrameworkDependencyFlags.All);
             var json = $"{{\"frameworks\":{{\"a\":{{\"frameworkReferences\":{{\"{expectedResult.Name}\":{{\"privateAssets\":\"{expectedResult.PrivateAssets.ToString().ToLowerInvariant()}\"}}}}}}}}}}";
 
-            FrameworkDependency dependency = GetFrameworksFrameworkReference(json);
+            FrameworkDependency dependency = GetFrameworksFrameworkReference(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, dependency);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksFrameworkReferencesPrivateAssetsValueIsValidDelimitedString_ReturnsPrivateAssets()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksFrameworkReferencesPrivateAssetsValueIsValidDelimitedString_ReturnsPrivateAssets(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new FrameworkDependency(name: "b", FrameworkDependencyFlags.All);
             var json = $"{{\"frameworks\":{{\"a\":{{\"frameworkReferences\":{{\"{expectedResult.Name}\":{{\"privateAssets\":\"none,all\"}}}}}}}}}}";
 
-            FrameworkDependency dependency = GetFrameworksFrameworkReference(json);
+            FrameworkDependency dependency = GetFrameworksFrameworkReference(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, dependency);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksImportsPropertyIsAbsent_ReturnsEmptyImports()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksImportsPropertyIsAbsent_ReturnsEmptyImports(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Empty(framework.Imports);
         }
 
         [Theory]
-        [InlineData("null")]
-        [InlineData("\"\"")]
-        public void GetPackageSpec_WhenFrameworksImportsValueIsArrayOfNullOrEmptyString_ImportIsSkipped(string import)
+        [MemberData(nameof(TestEnvironmentVariableReader), "null")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"")]
+        public void GetPackageSpec_WhenFrameworksImportsValueIsArrayOfNullOrEmptyString_ImportIsSkipped(IEnvironmentVariableReader environmentVariableReader, string import)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"imports\":[{import}]}}}}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
-
-            Assert.Empty(framework.Imports);
-        }
-
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksImportsValueIsNull_ReturnsEmptyList()
-        {
-            const string json = "{\"frameworks\":{\"a\":{\"imports\":null}}}";
-
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Empty(framework.Imports);
         }
 
         [Theory]
-        [InlineData("true")]
-        [InlineData("-2")]
-        [InlineData("3.14")]
-        [InlineData("{}")]
-        public void GetPackageSpec_WhenFrameworksImportsValueIsInvalidValue_ReturnsEmptyList(string value)
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksImportsValueIsNull_ReturnsEmptyList(IEnvironmentVariableReader environmentVariableReader)
         {
-            var json = $"{{\"frameworks\":{{\"a\":{{\"imports\":{value}}}}}}}";
+            const string json = "{\"frameworks\":{\"a\":{\"imports\":null}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Empty(framework.Imports);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksImportsValueContainsInvalidValue_Throws()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader), "true")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "-2")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "3.14")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{}")]
+        public void GetPackageSpec_WhenFrameworksImportsValueIsInvalidValue_ReturnsEmptyList(IEnvironmentVariableReader environmentVariableReader, string value)
+        {
+            var json = $"{{\"frameworks\":{{\"a\":{{\"imports\":{value}}}}}}}";
+
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
+
+            Assert.Empty(framework.Imports);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksImportsValueContainsInvalidValue_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             const string expectedImport = "b";
 
             var json = $"{{\"frameworks\":{{\"a\":{{\"imports\":[\"{expectedImport}\"]}}}}}}";
 
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
 
-            Assert.Equal(
-                $"Error reading '' at line 1 column 20 : Imports contains an invalid framework: '{expectedImport}' in 'project.json'.",
-                exception.Message);
-            Assert.Equal(1, exception.Line);
-            Assert.Equal(20, exception.Column);
             Assert.IsType<FileFormatException>(exception.InnerException);
             Assert.Null(exception.InnerException.InnerException);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal(
+                    $"Error reading '' at line 1 column 20 : Imports contains an invalid framework: '{expectedImport}' in 'project.json'.",
+                    exception.Message);
+                Assert.Equal(1, exception.Line);
+                Assert.Equal(20, exception.Column);
+            }
+            else
+            {
+                Assert.Equal(
+                    $"Error reading '' : Imports contains an invalid framework: '{expectedImport}' in 'project.json'.",
+                    exception.Message);
+            }
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksImportsValueIsString_ReturnsImport()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksImportsValueIsString_ReturnsImport(IEnvironmentVariableReader environmentVariableReader)
         {
             NuGetFramework expectedResult = NuGetFramework.Parse("net48");
             var json = $"{{\"frameworks\":{{\"a\":{{\"imports\":\"{expectedResult.GetShortFolderName()}\"}}}}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Collection(
                 framework.Imports,
                 actualResult => Assert.Equal(expectedResult, actualResult));
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksImportsValueIsArrayOfStrings_ReturnsImports()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksImportsValueIsArrayOfStrings_ReturnsImports(IEnvironmentVariableReader environmentVariableReader)
         {
             NuGetFramework[] expectedResults = { NuGetFramework.Parse("net472"), NuGetFramework.Parse("net48") };
             var json = $"{{\"frameworks\":{{\"a\":{{\"imports\":[\"{expectedResults[0].GetShortFolderName()}\",\"{expectedResults[1].GetShortFolderName()}\"]}}}}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Collection(
                 framework.Imports,
@@ -2344,68 +2604,72 @@ namespace NuGet.ProjectModel.Test
                 actualResult => Assert.Equal(expectedResults[1], actualResult));
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksRuntimeIdentifierGraphPathPropertyIsAbsent_ReturnsRuntimeIdentifierGraphPath()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksRuntimeIdentifierGraphPathPropertyIsAbsent_ReturnsRuntimeIdentifierGraphPath(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{}}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Null(framework.RuntimeIdentifierGraphPath);
         }
 
         [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("b")]
-        public void GetPackageSpec_WhenFrameworksRuntimeIdentifierGraphPathValueIsString_ReturnsRuntimeIdentifierGraphPath(string expectedResult)
+        [MemberData(nameof(TestEnvironmentVariableReader), null)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "b")]
+        public void GetPackageSpec_WhenFrameworksRuntimeIdentifierGraphPathValueIsString_ReturnsRuntimeIdentifierGraphPath(IEnvironmentVariableReader environmentVariableReader, string expectedResult)
         {
             string runtimeIdentifierGraphPath = expectedResult == null ? "null" : $"\"{expectedResult}\"";
             var json = $"{{\"frameworks\":{{\"a\":{{\"runtimeIdentifierGraphPath\":{runtimeIdentifierGraphPath}}}}}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, framework.RuntimeIdentifierGraphPath);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFrameworksWarnPropertyIsAbsent_ReturnsWarn()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFrameworksWarnPropertyIsAbsent_ReturnsWarn(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"frameworks\":{\"a\":{}}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.False(framework.Warn);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void GetPackageSpec_WhenFrameworksWarnValueIsValid_ReturnsWarn(bool expectedResult)
+        [MemberData(nameof(TestEnvironmentVariableReader), true)]
+        [MemberData(nameof(TestEnvironmentVariableReader), false)]
+        public void GetPackageSpec_WhenFrameworksWarnValueIsValid_ReturnsWarn(IEnvironmentVariableReader environmentVariableReader, bool expectedResult)
         {
             var json = $"{{\"frameworks\":{{\"a\":{{\"warn\":{expectedResult.ToString().ToLowerInvariant()}}}}}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, framework.Warn);
         }
 
 #pragma warning disable CS0612 // Type or member is obsolete
-        [Fact]
-        public void GetPackageSpec_WhenPackIncludePropertyIsAbsent_ReturnsEmptyPackInclude()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackIncludePropertyIsAbsent_ReturnsEmptyPackInclude(IEnvironmentVariableReader environmentVariableReader)
         {
-            PackageSpec packageSpec = GetPackageSpec("{}");
+            PackageSpec packageSpec = GetPackageSpec("{}", environmentVariableReader);
 
             Assert.Empty(packageSpec.PackInclude);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenPackIncludePropertyIsValid_ReturnsPackInclude()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackIncludePropertyIsValid_ReturnsPackInclude(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResults = new List<KeyValuePair<string, string>>() { new KeyValuePair<string, string>("a", "b"), new KeyValuePair<string, string>("c", "d") };
             var json = $"{{\"packInclude\":{{\"{expectedResults[0].Key}\":\"{expectedResults[0].Value}\",\"{expectedResults[1].Key}\":\"{expectedResults[1].Value}\"}}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Collection(
                 packageSpec.PackInclude,
@@ -2414,11 +2678,11 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [InlineData("{}")]
-        [InlineData("{\"packOptions\":null}")]
-        public void GetPackageSpec_WhenPackOptionsPropertyIsAbsentOrValueIsNull_ReturnsPackOptions(string json)
+        [MemberData(nameof(TestEnvironmentVariableReader), "{}")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{\"packOptions\":null}")]
+        public void GetPackageSpec_WhenPackOptionsPropertyIsAbsentOrValueIsNull_ReturnsPackOptions(IEnvironmentVariableReader environmentVariableReader, string json)
         {
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.NotNull(packageSpec.PackOptions);
             Assert.Null(packageSpec.PackOptions.IncludeExcludeFiles);
@@ -2435,23 +2699,25 @@ namespace NuGet.ProjectModel.Test
             Assert.Empty(packageSpec.Tags);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenPackOptionsPropertyIsAbsent_OwnersAndTagsAreEmpty()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackOptionsPropertyIsAbsent_OwnersAndTagsAreEmpty(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"owners\":[\"a\"],\"tags\":[\"b\"]}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Empty(packageSpec.Owners);
             Assert.Empty(packageSpec.Tags);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenPackOptionsPropertyIsEmptyObject_ReturnsPackOptions()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackOptionsPropertyIsEmptyObject_ReturnsPackOptions(IEnvironmentVariableReader environmentVariableReader)
         {
             string json = "{\"packOptions\":{}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.NotNull(packageSpec.PackOptions);
             Assert.Null(packageSpec.PackOptions.IncludeExcludeFiles);
@@ -2468,8 +2734,9 @@ namespace NuGet.ProjectModel.Test
             Assert.Empty(packageSpec.Tags);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenPackOptionsValueIsValid_ReturnsPackOptions()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackOptionsValueIsValid_ReturnsPackOptions(IEnvironmentVariableReader environmentVariableReader)
         {
             const string iconUrl = "a";
             const string licenseUrl = "b";
@@ -2484,7 +2751,7 @@ namespace NuGet.ProjectModel.Test
                 $"\"projectUrl\":\"{projectUrl}\",\"releaseNotes\":\"{releaseNotes}\",\"requireLicenseAcceptance\":{requireLicenseAcceptance.ToString().ToLowerInvariant()}," +
                 $"\"summary\":\"{summary}\",\"tags\":[{string.Join(",", tags.Select(tag => $"\"{tag}\""))}]}}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.NotNull(packageSpec.PackOptions);
             Assert.Null(packageSpec.PackOptions.IncludeExcludeFiles);
@@ -2500,612 +2767,610 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(tags, packageSpec.Tags);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenPackOptionsPackageTypeValueIsNull_ReturnsEmptyPackageTypes()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackOptionsPackageTypeValueIsNull_ReturnsEmptyPackageTypes(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"packageType\":null}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Empty(packageSpec.PackOptions.PackageType);
         }
 
         [Theory]
-        [InlineData("true", 34)]
-        [InlineData("-2", 32)]
-        [InlineData("3.14", 34)]
-        [InlineData("{}", 31)]
-        [InlineData("[true]", 31)]
-        [InlineData("[-2]", 31)]
-        [InlineData("[3.14]", 31)]
-        [InlineData("[null]", 31)]
-        [InlineData("[{}]", 31)]
-        [InlineData("[[]]", 31)]
-        public void GetPackageSpec_WhenPackOptionsPackageTypeIsInvalid_Throws(string value, int expectedColumn)
+        [MemberData(nameof(TestEnvironmentVariableReader), "true", 34)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "-2", 32)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "3.14", 34)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{}", 31)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[true]", 31)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[-2]", 31)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[3.14]", 31)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[null]", 31)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[{}]", 31)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[[]]", 31)]
+        public void GetPackageSpec_WhenPackOptionsPackageTypeIsInvalid_Throws(IEnvironmentVariableReader environmentVariableReader, string value, int expectedColumn)
         {
             var json = $"{{\"packOptions\":{{\"packageType\":{value}}}}}";
 
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
 
-            Assert.Equal("The pack options package type must be a string or array of strings in 'project.json'.", exception.Message);
-            Assert.Equal(1, exception.Line);
-            Assert.Equal(expectedColumn, exception.Column);
             Assert.Null(exception.InnerException);
+            Assert.Equal("The pack options package type must be a string or array of strings in 'project.json'.", exception.Message);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal(1, exception.Line);
+                Assert.Equal(expectedColumn, exception.Column);
+            }
         }
 
         [Theory]
-        [InlineData("\"a\"", "a")]
-        [InlineData("\"a,b\"", "a,b")]
-        [InlineData("[\"a\"]", "a")]
-        [InlineData("[\"a b\"]", "a b")]
-        public void GetPackageSpec_WhenPackOptionsPackageTypeValueIsValid_ReturnsPackageTypes(string value, string expectedName)
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a,b\"", "a,b")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\"]", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a b\"]", "a b")]
+        public void GetPackageSpec_WhenPackOptionsPackageTypeValueIsValid_ReturnsPackageTypes(IEnvironmentVariableReader environmentVariableReader, string value, string expectedName)
         {
             var expectedResult = new PackageType(expectedName, PackageType.EmptyVersion);
             var json = $"{{\"packOptions\":{{\"packageType\":{value}}}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Collection(
                 packageSpec.PackOptions.PackageType,
                 actualResult => Assert.Equal(expectedResult, actualResult));
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenPackOptionsFilesValueIsNull_ReturnsNullInclude()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackOptionsFilesValueIsNull_ReturnsNullInclude(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":null}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Null(packageSpec.PackOptions.IncludeExcludeFiles);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenPackOptionsFilesValueIsEmptyObject_ReturnsNullInclude()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackOptionsFilesValueIsEmptyObject_ReturnsNullInclude(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Null(packageSpec.PackOptions.IncludeExcludeFiles);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenPackOptionsFilesIncludeValueIsNull_ReturnsNullIncludeExcludeFiles()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackOptionsFilesIncludeValueIsNull_ReturnsNullIncludeExcludeFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{\"include\":null}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Null(packageSpec.PackOptions.IncludeExcludeFiles);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenPackOptionsFilesIncludeValueIsEmptyArray_ReturnsEmptyInclude()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackOptionsFilesIncludeValueIsEmptyArray_ReturnsEmptyInclude(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{\"include\":[]}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Empty(packageSpec.PackOptions.IncludeExcludeFiles.Include);
         }
 
         [Theory]
-        [InlineData("\"a\"", "a")]
-        [InlineData("\"a, b\"", "a, b")]
-        [InlineData("[null]", null)]
-        [InlineData("[\"\"]", "")]
-        [InlineData("[\"a\"]", "a")]
-        [InlineData("[\"a, b\"]", "a, b")]
-        [InlineData("[\"a\", \"b\"]", "a", "b")]
-        public void GetPackageSpec_WhenPackOptionsFilesIncludeValueIsValid_ReturnsInclude(string value, params string[] expectedResults)
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a, b\"", "a, b")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[null]", null)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"\"]", "")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\"]", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a, b\"]", "a, b")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\", \"b\"]", "a", "b")]
+        public void GetPackageSpec_WhenPackOptionsFilesIncludeValueIsValid_ReturnsInclude(IEnvironmentVariableReader environmentVariableReader, string value, params string[] expectedResults)
         {
             expectedResults = expectedResults ?? new string[] { null };
 
             var json = $"{{\"packOptions\":{{\"files\":{{\"include\":{value}}}}}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResults, packageSpec.PackOptions.IncludeExcludeFiles.Include);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenPackOptionsFilesIncludeFilesValueIsNull_ReturnsNullIncludeExcludeFiles()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackOptionsFilesIncludeFilesValueIsNull_ReturnsNullIncludeExcludeFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{\"includeFiles\":null}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Null(packageSpec.PackOptions.IncludeExcludeFiles);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenPackOptionsFilesIncludeFilesValueIsEmptyArray_ReturnsEmptyIncludeFiles()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackOptionsFilesIncludeFilesValueIsEmptyArray_ReturnsEmptyIncludeFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{\"includeFiles\":[]}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Empty(packageSpec.PackOptions.IncludeExcludeFiles.IncludeFiles);
         }
 
         [Theory]
-        [InlineData("\"a\"", "a")]
-        [InlineData("\"a, b\"", "a, b")]
-        [InlineData("[null]", null)]
-        [InlineData("[\"\"]", "")]
-        [InlineData("[\"a\"]", "a")]
-        [InlineData("[\"a, b\"]", "a, b")]
-        [InlineData("[\"a\", \"b\"]", "a", "b")]
-        public void GetPackageSpec_WhenPackOptionsFilesIncludeFilesValueIsValid_ReturnsIncludeFiles(string value, params string[] expectedResults)
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a, b\"", "a, b")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[null]", null)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"\"]", "")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\"]", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a, b\"]", "a, b")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\", \"b\"]", "a", "b")]
+        public void GetPackageSpec_WhenPackOptionsFilesIncludeFilesValueIsValid_ReturnsIncludeFiles(IEnvironmentVariableReader environmentVariableReader, string value, params string[] expectedResults)
         {
             expectedResults = expectedResults ?? new string[] { null };
 
             var json = $"{{\"packOptions\":{{\"files\":{{\"includeFiles\":{value}}}}}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResults, packageSpec.PackOptions.IncludeExcludeFiles.IncludeFiles);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenPackOptionsFilesExcludeValueIsNull_ReturnsNullIncludeExcludeFiles()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackOptionsFilesExcludeValueIsNull_ReturnsNullIncludeExcludeFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{\"exclude\":null}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Null(packageSpec.PackOptions.IncludeExcludeFiles);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenPackOptionsFilesExcludeValueIsEmptyArray_ReturnsEmptyExclude()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackOptionsFilesExcludeValueIsEmptyArray_ReturnsEmptyExclude(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{\"exclude\":[]}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Empty(packageSpec.PackOptions.IncludeExcludeFiles.Exclude);
         }
 
         [Theory]
-        [InlineData("\"a\"", "a")]
-        [InlineData("\"a, b\"", "a, b")]
-        [InlineData("[null]", null)]
-        [InlineData("[\"\"]", "")]
-        [InlineData("[\"a\"]", "a")]
-        [InlineData("[\"a, b\"]", "a, b")]
-        [InlineData("[\"a\", \"b\"]", "a", "b")]
-        public void GetPackageSpec_WhenPackOptionsFilesExcludeValueIsValid_ReturnsExclude(string value, params string[] expectedResults)
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a, b\"", "a, b")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[null]", null)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"\"]", "")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\"]", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a, b\"]", "a, b")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\", \"b\"]", "a", "b")]
+        public void GetPackageSpec_WhenPackOptionsFilesExcludeValueIsValid_ReturnsExclude(IEnvironmentVariableReader environmentVariableReader, string value, params string[] expectedResults)
         {
             expectedResults = expectedResults ?? new string[] { null };
 
             var json = $"{{\"packOptions\":{{\"files\":{{\"exclude\":{value}}}}}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResults, packageSpec.PackOptions.IncludeExcludeFiles.Exclude);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenPackOptionsFilesExcludeFilesValueIsNull_ReturnsNullIncludeExcludeFiles()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackOptionsFilesExcludeFilesValueIsNull_ReturnsNullIncludeExcludeFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{\"excludeFiles\":null}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Null(packageSpec.PackOptions.IncludeExcludeFiles);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenPackOptionsFilesExcludeFilesValueIsEmptyArray_ReturnsEmptyExcludeFiles()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackOptionsFilesExcludeFilesValueIsEmptyArray_ReturnsEmptyExcludeFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{\"excludeFiles\":[]}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Empty(packageSpec.PackOptions.IncludeExcludeFiles.ExcludeFiles);
         }
 
         [Theory]
-        [InlineData("\"a\"", "a")]
-        [InlineData("\"a, b\"", "a, b")]
-        [InlineData("[null]", null)]
-        [InlineData("[\"\"]", "")]
-        [InlineData("[\"a\"]", "a")]
-        [InlineData("[\"a, b\"]", "a, b")]
-        [InlineData("[\"a\", \"b\"]", "a", "b")]
-        public void GetPackageSpec_WhenPackOptionsFilesExcludeFilesValueIsValid_ReturnsExcludeFiles(string value, params string[] expectedResults)
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a, b\"", "a, b")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[null]", null)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"\"]", "")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\"]", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a, b\"]", "a, b")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"a\", \"b\"]", "a", "b")]
+        public void GetPackageSpec_WhenPackOptionsFilesExcludeFilesValueIsValid_ReturnsExcludeFiles(IEnvironmentVariableReader environmentVariableReader, string value, params string[] expectedResults)
         {
             expectedResults = expectedResults ?? new string[] { null };
 
             var json = $"{{\"packOptions\":{{\"files\":{{\"excludeFiles\":{value}}}}}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResults, packageSpec.PackOptions.IncludeExcludeFiles.ExcludeFiles);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenPackOptionsFilesMappingsPropertyIsAbsent_ReturnsNullMappings()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackOptionsFilesMappingsPropertyIsAbsent_ReturnsNullMappings(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"packOptions\":{\"files\":{}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
-
-            Assert.Null(packageSpec.PackOptions.Mappings);
-        }
-
-        [Fact]
-        public void GetPackageSpec_WhenPackOptionsFilesMappingsValueIsNull_ReturnsNullMappings()
-        {
-            const string json = "{\"packOptions\":{\"files\":{\"mappings\":null}}}";
-
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Null(packageSpec.PackOptions.Mappings);
         }
 
         [Theory]
-        [InlineData("\"b\"", "b")]
-        [InlineData("\"b,c\"", "b,c")]
-        [InlineData("[\"b\", \"c\"]", "b", "c")]
-        public void GetPackageSpec_WhenPackOptionsFilesMappingsValueIsValid_ReturnsMappings(string value, params string[] expectedIncludes)
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackOptionsFilesMappingsValueIsNull_ReturnsNullMappings(IEnvironmentVariableReader environmentVariableReader)
+        {
+            const string json = "{\"packOptions\":{\"files\":{\"mappings\":null}}}";
+
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
+
+            Assert.Null(packageSpec.PackOptions.Mappings);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"b\"", "b")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"b,c\"", "b,c")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "[\"b\", \"c\"]", "b", "c")]
+        public void GetPackageSpec_WhenPackOptionsFilesMappingsValueIsValid_ReturnsMappings(IEnvironmentVariableReader environmentVariableReader, string value, params string[] expectedIncludes)
         {
             var expectedResults = new Dictionary<string, IncludeExcludeFiles>()
-            {
-                { "a", new IncludeExcludeFiles() { Include = expectedIncludes } }
-            };
+                    {
+                        { "a", new IncludeExcludeFiles() { Include = expectedIncludes } }
+                    };
             var json = $"{{\"packOptions\":{{\"files\":{{\"mappings\":{{\"a\":{value}}}}}}}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResults, packageSpec.PackOptions.Mappings);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenPackOptionsFilesMappingsValueHasMultipleMappings_ReturnsMappings()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackOptionsFilesMappingsValueHasMultipleMappings_ReturnsMappings(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResults = new Dictionary<string, IncludeExcludeFiles>()
-            {
-                { "a", new IncludeExcludeFiles() { Include = new[] { "b" } } },
-                { "c", new IncludeExcludeFiles() { Include = new[] { "d", "e" } } }
-            };
+                    {
+                        { "a", new IncludeExcludeFiles() { Include = new[] { "b" } } },
+                        { "c", new IncludeExcludeFiles() { Include = new[] { "d", "e" } } }
+                    };
             const string json = "{\"packOptions\":{\"files\":{\"mappings\":{\"a\":\"b\",\"c\":[\"d\", \"e\"]}}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResults, packageSpec.PackOptions.Mappings);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenPackOptionsFilesMappingsValueHasFiles_ReturnsMappings()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenPackOptionsFilesMappingsValueHasFiles_ReturnsMappings(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResults = new Dictionary<string, IncludeExcludeFiles>()
-            {
-                {
-                    "a",
-                    new IncludeExcludeFiles()
                     {
-                        Include = new [] { "b" },
-                        IncludeFiles = new [] { "c" },
-                        Exclude = new [] { "d" },
-                        ExcludeFiles = new [] { "e" }
-                    }
-                }
-            };
+                        {
+                            "a",
+                            new IncludeExcludeFiles()
+                            {
+                                Include = new [] { "b" },
+                                IncludeFiles = new [] { "c" },
+                                Exclude = new [] { "d" },
+                                ExcludeFiles = new [] { "e" }
+                            }
+                        }
+                    };
             const string json = "{\"packOptions\":{\"files\":{\"mappings\":{\"a\":{\"include\":\"b\",\"includeFiles\":\"c\",\"exclude\":\"d\",\"excludeFiles\":\"e\"}}}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResults, packageSpec.PackOptions.Mappings);
         }
 #pragma warning restore CS0612 // Type or member is obsolete
 
-        [Fact]
-        public void GetPackageSpec_WhenRestorePropertyIsAbsent_ReturnsNullRestoreMetadata()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRestorePropertyIsAbsent_ReturnsNullRestoreMetadata(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Null(packageSpec.RestoreMetadata);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRestoreValueIsEmptyObject_ReturnsRestoreMetadata()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRestoreValueIsEmptyObject_ReturnsRestoreMetadata(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"restore\":{}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.NotNull(packageSpec.RestoreMetadata);
         }
 
         [Theory]
-        [InlineData("null")]
-        [InlineData("\"\"")]
-        [InlineData("\"a\"")]
-        public void GetPackageSpec_WhenRestoreProjectStyleValueIsInvalid_ReturnsProjectStyle(string value)
+        [MemberData(nameof(TestEnvironmentVariableReader), "null")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"")]
+        public void GetPackageSpec_WhenRestoreProjectStyleValueIsInvalid_ReturnsProjectStyle(IEnvironmentVariableReader environmentVariableReader, string value)
         {
             var json = $"{{\"restore\":{{\"projectStyle\":{value}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(ProjectStyle.Unknown, packageSpec.RestoreMetadata.ProjectStyle);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRestoreProjectStyleValueIsValid_ReturnsProjectStyle()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRestoreProjectStyleValueIsValid_ReturnsProjectStyle(IEnvironmentVariableReader environmentVariableReader)
         {
             const ProjectStyle expectedResult = ProjectStyle.PackageReference;
 
             var json = $"{{\"restore\":{{\"projectStyle\":\"{expectedResult.ToString().ToLowerInvariant()}\"}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.RestoreMetadata.ProjectStyle);
         }
 
         [Theory]
-        [InlineData("null", null)]
-        [InlineData("\"\"", "")]
-        [InlineData("\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", null)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
         public void GetPackageSpec_WhenRestoreProjectUniqueNameValueIsValid_ReturnsProjectUniqueName(
+            IEnvironmentVariableReader environmentVariableReader,
             string value,
             string expectedValue)
         {
             var json = $"{{\"restore\":{{\"projectUniqueName\":{value}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedValue, packageSpec.RestoreMetadata.ProjectUniqueName);
         }
 
         [Theory]
-        [InlineData("null", null)]
-        [InlineData("\"\"", "")]
-        [InlineData("\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", null)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
         public void GetPackageSpec_WhenRestoreOutputPathValueIsValid_ReturnsOutputPath(
+            IEnvironmentVariableReader environmentVariableReader,
             string value,
             string expectedValue)
         {
             var json = $"{{\"restore\":{{\"outputPath\":{value}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedValue, packageSpec.RestoreMetadata.OutputPath);
         }
 
         [Theory]
-        [InlineData("null", null)]
-        [InlineData("\"\"", "")]
-        [InlineData("\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", null)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
         public void GetPackageSpec_WhenRestorePackagesPathValueIsValid_ReturnsPackagesPath(
+            IEnvironmentVariableReader environmentVariableReader,
             string value,
             string expectedValue)
         {
             var json = $"{{\"restore\":{{\"packagesPath\":{value}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedValue, packageSpec.RestoreMetadata.PackagesPath);
         }
 
         [Theory]
-        [InlineData("null", null)]
-        [InlineData("\"\"", "")]
-        [InlineData("\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", null)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
         public void GetPackageSpec_WhenRestoreProjectJsonPathValueIsValid_ReturnsProjectJsonPath(
+            IEnvironmentVariableReader environmentVariableReader,
             string value,
             string expectedValue)
         {
             var json = $"{{\"restore\":{{\"projectJsonPath\":{value}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedValue, packageSpec.RestoreMetadata.ProjectJsonPath);
         }
 
         [Theory]
-        [InlineData("null", null)]
-        [InlineData("\"\"", "")]
-        [InlineData("\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", null)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
         public void GetPackageSpec_WhenRestoreProjectNameValueIsValid_ReturnsProjectName(
+            IEnvironmentVariableReader environmentVariableReader,
             string value,
             string expectedValue)
         {
             var json = $"{{\"restore\":{{\"projectName\":{value}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedValue, packageSpec.RestoreMetadata.ProjectName);
         }
 
         [Theory]
-        [InlineData("null", null)]
-        [InlineData("\"\"", "")]
-        [InlineData("\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", null)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
         public void GetPackageSpec_WhenRestoreProjectPathValueIsValid_ReturnsProjectPath(
+            IEnvironmentVariableReader environmentVariableReader,
             string value,
             string expectedValue)
         {
             var json = $"{{\"restore\":{{\"projectPath\":{value}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedValue, packageSpec.RestoreMetadata.ProjectPath);
         }
 
         [Theory]
-        [InlineData(null, false)]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), null, false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), true, true)]
+        [MemberData(nameof(TestEnvironmentVariableReader), false, false)]
         public void GetPackageSpec_WhenCrossTargetingValueIsValid_ReturnsCrossTargeting(
+            IEnvironmentVariableReader environmentVariableReader,
             bool? value,
             bool expectedValue)
         {
             var json = $"{{\"restore\":{{\"crossTargeting\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CrossTargeting);
         }
 
         [Theory]
-        [InlineData(null, false)]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), null, false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), true, true)]
+        [MemberData(nameof(TestEnvironmentVariableReader), false, false)]
         public void GetPackageSpec_WhenLegacyPackagesDirectoryValueIsValid_ReturnsLegacyPackagesDirectory(
+            IEnvironmentVariableReader environmentVariableReader,
             bool? value,
             bool expectedValue)
         {
             var json = $"{{\"restore\":{{\"legacyPackagesDirectory\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedValue, packageSpec.RestoreMetadata.LegacyPackagesDirectory);
         }
 
         [Theory]
-        [InlineData(null, false)]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), null, false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), true, true)]
+        [MemberData(nameof(TestEnvironmentVariableReader), false, false)]
         public void GetPackageSpec_WhenValidateRuntimeAssetsValueIsValid_ReturnsValidateRuntimeAssets(
+            IEnvironmentVariableReader environmentVariableReader,
             bool? value,
             bool expectedValue)
         {
             var json = $"{{\"restore\":{{\"validateRuntimeAssets\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedValue, packageSpec.RestoreMetadata.ValidateRuntimeAssets);
         }
 
         [Theory]
-        [InlineData(null, false)]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), null, false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), true, true)]
+        [MemberData(nameof(TestEnvironmentVariableReader), false, false)]
         public void GetPackageSpec_WhenSkipContentFileWriteValueIsValid_ReturnsSkipContentFileWrite(
+            IEnvironmentVariableReader environmentVariableReader,
             bool? value,
             bool expectedValue)
         {
             var json = $"{{\"restore\":{{\"skipContentFileWrite\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedValue, packageSpec.RestoreMetadata.SkipContentFileWrite);
         }
 
         [Theory]
-        [InlineData(null, false)]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), null, false)]
+        [MemberData(nameof(TestEnvironmentVariableReader), true, true)]
+        [MemberData(nameof(TestEnvironmentVariableReader), false, false)]
         public void GetPackageSpec_WhenCentralPackageVersionsManagementEnabledValueIsValid_ReturnsCentralPackageVersionsManagementEnabled(
+            IEnvironmentVariableReader environmentVariableReader,
             bool? value,
             bool expectedValue)
         {
             var json = $"{{\"restore\":{{\"centralPackageVersionsManagementEnabled\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CentralPackageVersionsEnabled);
         }
 
         [Theory]
-        [InlineData(null, false)]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void GetPackageSpec_WhenCentralPackageFloatingVersionsEnabledValueIsValid_ReturnsCentralPackageFloatingVersionsEnabled(
-            bool? value,
-            bool expectedValue)
-        {
-            var json = $"{{\"restore\":{{\"centralPackageFloatingVersionsEnabled\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
-
-            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CentralPackageFloatingVersionsEnabled);
-        }
-
-        [Theory]
-        [InlineData(null, false)]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void GetPackageSpec_WhenCentralPackageVersionOverrideDisabledValueIsValid_ReturnsCentralPackageVersionOverrideDisabled(
-            bool? value,
-            bool expectedValue)
-        {
-            var json = $"{{\"restore\":{{\"centralPackageVersionOverrideDisabled\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
-
-            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CentralPackageVersionOverrideDisabled);
-        }
-
-        [Theory]
-        [InlineData(null, false)]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void GetPackageSpec_WhenCentralPackageTransitivePinningEnabledValueIsValid_ReturnsCentralPackageTransitivePinningEnabled(
-            bool? value,
-            bool expectedValue)
-        {
-            var json = $"{{\"restore\":{{\"CentralPackageTransitivePinningEnabled\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
-
-            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CentralPackageTransitivePinningEnabled);
-        }
-
-        [Fact]
-        public void GetPackageSpec_WhenSourcesValueIsEmptyObject_ReturnsEmptySources()
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenSourcesValueIsEmptyObject_ReturnsEmptySources(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"restore\":{\"sources\":{}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Empty(packageSpec.RestoreMetadata.Sources);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenSourcesValueIsValid_ReturnsSources()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenSourcesValueIsValid_ReturnsSources(IEnvironmentVariableReader environmentVariableReader)
         {
             PackageSource[] expectedResults = { new PackageSource(source: "a"), new PackageSource(source: "b") };
             string values = string.Join(",", expectedResults.Select(expectedResult => $"\"{expectedResult.Name}\":{{}}"));
             var json = $"{{\"restore\":{{\"sources\":{{{values}}}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResults, packageSpec.RestoreMetadata.Sources);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFilesValueIsEmptyObject_ReturnsEmptyFiles()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFilesValueIsEmptyObject_ReturnsEmptyFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"restore\":{\"files\":{}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Empty(packageSpec.RestoreMetadata.Files);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenFilesValueIsValid_ReturnsFiles()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenFilesValueIsValid_ReturnsFiles(IEnvironmentVariableReader environmentVariableReader)
         {
             ProjectRestoreMetadataFile[] expectedResults =
             {
-                new ProjectRestoreMetadataFile(packagePath: "a", absolutePath: "b"),
-                new ProjectRestoreMetadataFile(packagePath: "c", absolutePath:"d")
-            };
+                        new ProjectRestoreMetadataFile(packagePath: "a", absolutePath: "b"),
+                        new ProjectRestoreMetadataFile(packagePath: "c", absolutePath:"d")
+                    };
             string values = string.Join(",", expectedResults.Select(expectedResult => $"\"{expectedResult.PackagePath}\":\"{expectedResult.AbsolutePath}\""));
             var json = $"{{\"restore\":{{\"files\":{{{values}}}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResults, packageSpec.RestoreMetadata.Files);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRestoreFrameworksValueIsEmptyObject_ReturnsEmptyFrameworks()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRestoreFrameworksValueIsEmptyObject_ReturnsEmptyFrameworks(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"restore\":{\"frameworks\":{}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Empty(packageSpec.RestoreMetadata.TargetFrameworks);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRestoreFrameworksFrameworkNameValueIsValid_ReturnsFrameworks()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRestoreFrameworksFrameworkNameValueIsValid_ReturnsFrameworks(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new ProjectRestoreMetadataFrameworkInfo(NuGetFramework.ParseFolder("net472"));
             var json = $"{{\"restore\":{{\"frameworks\":{{\"{expectedResult.FrameworkName.GetShortFolderName()}\":{{}}}}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Collection(
                 packageSpec.RestoreMetadata.TargetFrameworks,
                 actualResult => Assert.Equal(expectedResult, actualResult));
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRestoreFrameworksFrameworkValueHasProjectReferenceWithoutAssets_ReturnsFrameworks()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRestoreFrameworksFrameworkValueHasProjectReferenceWithoutAssets_ReturnsFrameworks(IEnvironmentVariableReader environmentVariableReader)
         {
             var projectReference = new ProjectRestoreReference()
             {
@@ -3118,15 +3383,16 @@ namespace NuGet.ProjectModel.Test
 
             var json = $"{{\"restore\":{{\"frameworks\":{{\"{expectedResult.FrameworkName.GetShortFolderName()}\":{{\"projectReferences\":{{" +
                 $"\"{projectReference.ProjectUniqueName}\":{{\"projectPath\":\"{projectReference.ProjectPath}\"}}}}}}}}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Collection(
                 packageSpec.RestoreMetadata.TargetFrameworks,
                 actualResult => Assert.Equal(expectedResult, actualResult));
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRestoreFrameworksFrameworkValueHasProjectReferenceWithAssets_ReturnsFrameworks()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRestoreFrameworksFrameworkValueHasProjectReferenceWithAssets_ReturnsFrameworks(IEnvironmentVariableReader environmentVariableReader)
         {
             var projectReference = new ProjectRestoreReference()
             {
@@ -3144,85 +3410,93 @@ namespace NuGet.ProjectModel.Test
                 $"\"{projectReference.ProjectUniqueName}\":{{\"projectPath\":\"{projectReference.ProjectPath}\"," +
                 $"\"includeAssets\":\"{projectReference.IncludeAssets}\",\"excludeAssets\":\"{projectReference.ExcludeAssets}\"," +
                 $"\"privateAssets\":\"{projectReference.PrivateAssets}\"}}}}}}}}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Collection(
                 packageSpec.RestoreMetadata.TargetFrameworks,
                 actualResult => Assert.Equal(expectedResult, actualResult));
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRestoreConfigFilePathsValueIsEmptyArray_ReturnsEmptyConfigFilePaths()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRestoreConfigFilePathsValueIsEmptyArray_ReturnsEmptyConfigFilePaths(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"restore\":{\"configFilePaths\":[]}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Empty(packageSpec.RestoreMetadata.ConfigFilePaths);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRestoreConfigFilePathsValueIsValid_ReturnsConfigFilePaths()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRestoreConfigFilePathsValueIsValid_ReturnsConfigFilePaths(IEnvironmentVariableReader environmentVariableReader)
         {
             string[] expectedResults = { "a", "b" };
             string values = string.Join(",", expectedResults.Select(expectedResult => $"\"{expectedResult}\""));
             var json = $"{{\"restore\":{{\"configFilePaths\":[{values}]}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResults, packageSpec.RestoreMetadata.ConfigFilePaths);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRestoreFallbackFoldersValueIsEmptyArray_ReturnsEmptyFallbackFolders()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRestoreFallbackFoldersValueIsEmptyArray_ReturnsEmptyFallbackFolders(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"restore\":{\"fallbackFolders\":[]}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Empty(packageSpec.RestoreMetadata.FallbackFolders);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRestoreFallbackFoldersValueIsValid_ReturnsConfigFilePaths()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRestoreFallbackFoldersValueIsValid_ReturnsConfigFilePaths(IEnvironmentVariableReader environmentVariableReader)
         {
             string[] expectedResults = { "a", "b" };
             string values = string.Join(",", expectedResults.Select(expectedResult => $"\"{expectedResult}\""));
             var json = $"{{\"restore\":{{\"fallbackFolders\":[{values}]}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResults, packageSpec.RestoreMetadata.FallbackFolders);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRestoreOriginalTargetFrameworksValueIsEmptyArray_ReturnsEmptyOriginalTargetFrameworks()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRestoreOriginalTargetFrameworksValueIsEmptyArray_ReturnsEmptyOriginalTargetFrameworks(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"restore\":{\"originalTargetFrameworks\":[]}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Empty(packageSpec.RestoreMetadata.OriginalTargetFrameworks);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRestoreOriginalTargetFrameworksValueIsValid_ReturnsOriginalTargetFrameworks()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRestoreOriginalTargetFrameworksValueIsValid_ReturnsOriginalTargetFrameworks(IEnvironmentVariableReader environmentVariableReader)
         {
             string[] expectedResults = { "a", "b" };
             string values = string.Join(",", expectedResults.Select(expectedResult => $"\"{expectedResult}\""));
             var json = $"{{\"restore\":{{\"originalTargetFrameworks\":[{values}]}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResults, packageSpec.RestoreMetadata.OriginalTargetFrameworks);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRestoreWarningPropertiesValueIsEmptyObject_ReturnsWarningProperties()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRestoreWarningPropertiesValueIsEmptyObject_ReturnsWarningProperties(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new WarningProperties();
             const string json = "{\"restore\":{\"warningProperties\":{}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.RestoreMetadata.ProjectWideWarningProperties);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRestoreWarningPropertiesValueIsValid_ReturnsWarningProperties()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRestoreWarningPropertiesValueIsValid_ReturnsWarningProperties(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new WarningProperties(
                 new HashSet<NuGetLogCode>() { NuGetLogCode.NU3000 },
@@ -3231,23 +3505,25 @@ namespace NuGet.ProjectModel.Test
                 new HashSet<NuGetLogCode>());
             var json = $"{{\"restore\":{{\"warningProperties\":{{\"allWarningsAsErrors\":{expectedResult.AllWarningsAsErrors.ToString().ToLowerInvariant()}," +
                 $"\"warnAsError\":[\"{expectedResult.WarningsAsErrors.Single()}\"],\"noWarn\":[\"{expectedResult.NoWarn.Single()}\"]}}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.RestoreMetadata.ProjectWideWarningProperties);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRestoreRestoreLockPropertiesValueIsEmptyObject_ReturnsRestoreLockProperties()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRestoreRestoreLockPropertiesValueIsEmptyObject_ReturnsRestoreLockProperties(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new RestoreLockProperties();
             const string json = "{\"restore\":{\"restoreLockProperties\":{}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.RestoreMetadata.RestoreLockProperties);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRestoreRestoreLockPropertiesValueIsValid_ReturnsRestoreLockProperties()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRestoreRestoreLockPropertiesValueIsValid_ReturnsRestoreLockProperties(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new RestoreLockProperties(
                 restorePackagesWithLockFile: "a",
@@ -3256,61 +3532,64 @@ namespace NuGet.ProjectModel.Test
             var json = $"{{\"restore\":{{\"restoreLockProperties\":{{\"restoreLockedMode\":{expectedResult.RestoreLockedMode.ToString().ToLowerInvariant()}," +
                 $"\"restorePackagesWithLockFile\":\"{expectedResult.RestorePackagesWithLockFile}\"," +
                 $"\"nuGetLockFilePath\":\"{expectedResult.NuGetLockFilePath}\"}}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.RestoreMetadata.RestoreLockProperties);
         }
 
         [Theory]
-        [InlineData("null")]
-        [InlineData("\"\"")]
-        [InlineData("\"a\"")]
-        public void GetPackageSpec_WhenRestorePackagesConfigPathValueIsValidAndProjectStyleValueIsNotPackagesConfig_DoesNotReturnPackagesConfigPath(
-            string value)
+        [MemberData(nameof(TestEnvironmentVariableReader), "null")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"")]
+        public void GetPackageSpec_WhenRestorePackagesConfigPathValueIsValidAndProjectStyleValueIsNotPackagesConfig_DoesNotReturnPackagesConfigPath(IEnvironmentVariableReader environmentVariableReader, string value)
         {
             var json = $"{{\"restore\":{{\"projectStyle\":\"PackageReference\",\"packagesConfigPath\":{value}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.IsNotType<PackagesConfigProjectRestoreMetadata>(packageSpec.RestoreMetadata);
         }
 
         [Theory]
-        [InlineData("null", null)]
-        [InlineData("\"\"", "")]
-        [InlineData("\"a\"", "a")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", null)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
         public void GetPackageSpec_WhenRestorePackagesConfigPathValueIsValidAndProjectStyleValueIsPackagesConfig_ReturnsPackagesConfigPath(
+            IEnvironmentVariableReader environmentVariableReader,
             string value,
             string expectedValue)
         {
             var json = $"{{\"restore\":{{\"projectStyle\":\"PackagesConfig\",\"packagesConfigPath\":{value}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.IsType<PackagesConfigProjectRestoreMetadata>(packageSpec.RestoreMetadata);
             Assert.Equal(expectedValue, ((PackagesConfigProjectRestoreMetadata)packageSpec.RestoreMetadata).PackagesConfigPath);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRestoreSettingsValueIsEmptyObject_ReturnsRestoreSettings()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRestoreSettingsValueIsEmptyObject_ReturnsRestoreSettings(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = new ProjectRestoreSettings();
             const string json = "{\"restoreSettings\":{}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.RestoreSettings);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRuntimesValueIsEmptyObject_ReturnsRuntimes()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRuntimesValueIsEmptyObject_ReturnsRuntimes(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = RuntimeGraph.Empty;
             const string json = "{\"runtimes\":{}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.RuntimeGraph);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRuntimesValueIsValidWithImports_ReturnsRuntimes()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRuntimesValueIsValidWithImports_ReturnsRuntimes(IEnvironmentVariableReader environmentVariableReader)
         {
             var runtimeDescription = new RuntimeDescription(
                 runtimeIdentifier: "a",
@@ -3319,13 +3598,14 @@ namespace NuGet.ProjectModel.Test
             var expectedResult = new RuntimeGraph(new[] { runtimeDescription });
             var json = $"{{\"runtimes\":{{\"{runtimeDescription.RuntimeIdentifier}\":{{\"#import\":[" +
                 $"{string.Join(",", runtimeDescription.InheritedRuntimes.Select(runtime => $"\"{runtime}\""))}]}}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.RuntimeGraph);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRuntimesValueIsValidWithDependencySet_ReturnsRuntimes()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRuntimesValueIsValidWithDependencySet_ReturnsRuntimes(IEnvironmentVariableReader environmentVariableReader)
         {
             var dependencySet = new RuntimeDependencySet(id: "b");
             var runtimeDescription = new RuntimeDescription(
@@ -3334,13 +3614,14 @@ namespace NuGet.ProjectModel.Test
                 runtimeDependencySets: new[] { dependencySet });
             var expectedResult = new RuntimeGraph(new[] { runtimeDescription });
             var json = $"{{\"runtimes\":{{\"{runtimeDescription.RuntimeIdentifier}\":{{\"{dependencySet.Id}\":{{}}}}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.RuntimeGraph);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenRuntimesValueIsValidWithDependencySetWithDependency_ReturnsRuntimes()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenRuntimesValueIsValidWithDependencySetWithDependency_ReturnsRuntimes(IEnvironmentVariableReader environmentVariableReader)
         {
             var dependency = new RuntimePackageDependency("c", VersionRange.Parse("[1.2.3,4.5.6)"));
             var dependencySet = new RuntimeDependencySet(id: "b", new[] { dependency });
@@ -3351,75 +3632,85 @@ namespace NuGet.ProjectModel.Test
             var expectedResult = new RuntimeGraph(new[] { runtimeDescription });
             var json = $"{{\"runtimes\":{{\"{runtimeDescription.RuntimeIdentifier}\":{{\"{dependencySet.Id}\":{{" +
                 $"\"{dependency.Id}\":\"{dependency.VersionRange.ToLegacyString()}\"}}}}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.RuntimeGraph);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenSupportsValueIsEmptyObject_ReturnsSupports()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenSupportsValueIsEmptyObject_ReturnsSupports(IEnvironmentVariableReader environmentVariableReader)
         {
             var expectedResult = RuntimeGraph.Empty;
             const string json = "{\"supports\":{}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.RuntimeGraph);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenSupportsValueIsValidWithCompatibilityProfiles_ReturnsSupports()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenSupportsValueIsValidWithCompatibilityProfiles_ReturnsSupports(IEnvironmentVariableReader environmentVariableReader)
         {
             var profile = new CompatibilityProfile(name: "a");
             var expectedResult = new RuntimeGraph(new[] { profile });
             var json = $"{{\"supports\":{{\"{profile.Name}\":{{}}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.RuntimeGraph);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenSupportsValueIsValidWithCompatibilityProfilesAndFrameworkRuntimePairs_ReturnsSupports()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenSupportsValueIsValidWithCompatibilityProfilesAndFrameworkRuntimePairs_ReturnsSupports(IEnvironmentVariableReader environmentVariableReader)
         {
             FrameworkRuntimePair[] restoreContexts = new[]
             {
-                new FrameworkRuntimePair(NuGetFramework.Parse("net472"), "b"),
-                new FrameworkRuntimePair(NuGetFramework.Parse("net48"), "c")
-            };
+                        new FrameworkRuntimePair(NuGetFramework.Parse("net472"), "b"),
+                        new FrameworkRuntimePair(NuGetFramework.Parse("net48"), "c")
+                    };
             var profile = new CompatibilityProfile(name: "a", restoreContexts);
             var expectedResult = new RuntimeGraph(new[] { profile });
             var json = $"{{\"supports\":{{\"{profile.Name}\":{{" +
                 $"\"{restoreContexts[0].Framework.GetShortFolderName()}\":\"{restoreContexts[0].RuntimeIdentifier}\"," +
                 $"\"{restoreContexts[1].Framework.GetShortFolderName()}\":[\"{restoreContexts[1].RuntimeIdentifier}\"]}}}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.RuntimeGraph);
         }
 
 #pragma warning disable CS0612 // Type or member is obsolete
-        [Fact]
-        public void GetPackageSpec_WhenScriptsValueIsEmptyObject_ReturnsScripts()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenScriptsValueIsEmptyObject_ReturnsScripts(IEnvironmentVariableReader environmentVariableReader)
         {
             const string json = "{\"scripts\":{}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Empty(packageSpec.Scripts);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenScriptsValueIsInvalid_Throws()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenScriptsValueIsInvalid_Throws(IEnvironmentVariableReader environmentVariableReader)
         {
             var json = "{\"scripts\":{\"a\":0}}";
 
-            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+            FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json, environmentVariableReader));
 
             Assert.Equal("The value of a script in 'project.json' can only be a string or an array of strings", exception.Message);
-            Assert.Equal(1, exception.Line);
-            Assert.Equal(17, exception.Column);
             Assert.Null(exception.InnerException);
+
+            if (string.Equals(bool.TrueString, environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING")))
+            {
+                Assert.Equal(1, exception.Line);
+                Assert.Equal(17, exception.Column);
+            }
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenScriptsValueIsValid_ReturnsScripts()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenScriptsValueIsValid_ReturnsScripts(IEnvironmentVariableReader environmentVariableReader)
         {
             const string name0 = "a";
             const string name1 = "b";
@@ -3428,7 +3719,7 @@ namespace NuGet.ProjectModel.Test
             const string script2 = "e";
 
             var json = $"{{\"scripts\":{{\"{name0}\":\"{script0}\",\"{name1}\":[\"{script1}\",\"{script2}\"]}}}}";
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Collection(
                 packageSpec.Scripts,
@@ -3451,76 +3742,79 @@ namespace NuGet.ProjectModel.Test
 #pragma warning restore CS0612 // Type or member is obsolete
 
         [Theory]
-        [InlineData("null", null)]
-        [InlineData("\"\"", "")]
-        [InlineData("\"a\"", "a")]
-        public void GetPackageSpec_WhenTitleValueIsValid_ReturnsTitle(string value, string expectedResult)
+        [MemberData(nameof(TestEnvironmentVariableReader), "null", null)]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"\"", "")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "\"a\"", "a")]
+        public void GetPackageSpec_WhenTitleValueIsValid_ReturnsTitle(IEnvironmentVariableReader environmentVariableReader, string value, string expectedResult)
         {
             var json = $"{{\"title\":{value}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.Title);
         }
 
-        [Fact]
-        public void GetPackageSpec_WhenNameIsNull_RestoreMetadataProvidesFallbackName()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WhenNameIsNull_RestoreMetadataProvidesFallbackName(IEnvironmentVariableReader environmentVariableReader)
         {
             const string expectedResult = "a";
             var json = $"{{\"restore\":{{\"projectName\":\"{expectedResult}\"}}}}";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.Name);
         }
 
         [Theory]
-        [InlineData("{\"restore\":{\"projectJsonPath\":\"a\"}}")]
-        [InlineData("{\"restore\":{\"projectPath\":\"a\"}}")]
-        [InlineData("{\"restore\":{\"projectJsonPath\":\"a\",\"projectPath\":\"b\"}}")]
-        public void GetPackageSpec_WhenFilePathIsNull_RestoreMetadataProvidesFallbackFilePath(string json)
+        [MemberData(nameof(TestEnvironmentVariableReader), "{\"restore\":{\"projectJsonPath\":\"a\"}}")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{\"restore\":{\"projectPath\":\"a\"}}")]
+        [MemberData(nameof(TestEnvironmentVariableReader), "{\"restore\":{\"projectJsonPath\":\"a\",\"projectPath\":\"b\"}}")]
+        public void GetPackageSpec_WhenFilePathIsNull_RestoreMetadataProvidesFallbackFilePath(IEnvironmentVariableReader environmentVariableReader, string json)
         {
             const string expectedResult = "a";
 
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             Assert.Equal(expectedResult, packageSpec.FilePath);
         }
 
-        [Fact]
-        public void GetTargetFrameworkInformation_WithAnAlias()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetTargetFrameworkInformation_WithAnAlias(IEnvironmentVariableReader environmentVariableReader)
         {
-            TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"net46\":{ \"targetAlias\" : \"alias\"}}}");
+            TargetFrameworkInformation framework = GetFramework("{\"frameworks\":{\"net46\":{ \"targetAlias\" : \"alias\"}}}", environmentVariableReader);
 
             Assert.Equal("alias", framework.TargetAlias);
         }
 
-        [Fact]
-        public void PackageSpecReader_ReadsRestoreMetadataWithAliases()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_ReadsRestoreMetadataWithAliases(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{  
-                            ""restore"": {
-    ""projectUniqueName"": ""projectUniqueName"",
-    ""projectName"": ""projectName"",
-    ""projectPath"": ""projectPath"",
-    ""projectJsonPath"": ""projectJsonPath"",
-    ""packagesPath"": ""packagesPath"",
-    ""outputPath"": ""outputPath"",
-    ""projectStyle"": ""PackageReference"",
-    ""crossTargeting"": true,
-    ""frameworks"": {
-      ""frameworkidentifier123-frameworkprofile"": {
-        ""targetAlias"" : ""alias"",
-        ""projectReferences"": {}
-      }
-    },
-    ""warningProperties"": {
-    }
-  }
-}";
+                                    ""restore"": {
+            ""projectUniqueName"": ""projectUniqueName"",
+            ""projectName"": ""projectName"",
+            ""projectPath"": ""projectPath"",
+            ""projectJsonPath"": ""projectJsonPath"",
+            ""packagesPath"": ""packagesPath"",
+            ""outputPath"": ""outputPath"",
+            ""projectStyle"": ""PackageReference"",
+            ""crossTargeting"": true,
+            ""frameworks"": {
+              ""frameworkidentifier123-frameworkprofile"": {
+                ""targetAlias"" : ""alias"",
+                ""projectReferences"": {}
+              }
+            },
+            ""warningProperties"": {
+            }
+          }
+        }";
 
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null, environmentVariableReader);
 
             // Assert
             var metadata = actual.RestoreMetadata;
@@ -3530,50 +3824,80 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal("alias", metadata.TargetFrameworks.Single().TargetAlias);
         }
 
-
-        [Fact]
-        public void PackageSpecReader_Read()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_Read(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = @"{
-                            ""centralTransitiveDependencyGroups"": {
-                                    "".NETCoreApp,Version=v3.1"": {
-                                        ""Foo"": {
-                                            ""exclude"": ""Native"",
-                                            ""include"": ""Build"",
-                                            ""suppressParent"": ""All"",
-                                            ""version"": ""1.0.0""
+                                    ""centralTransitiveDependencyGroups"": {
+                                            "".NETCoreApp,Version=v3.1"": {
+                                                ""Foo"": {
+                                                    ""exclude"": ""Native"",
+                                                    ""include"": ""Build"",
+                                                    ""suppressParent"": ""All"",
+                                                    ""version"": ""1.0.0""
+                                            }
+                                        },
+                                            "".NETCoreApp,Version=v3.0"": {
+                                                ""Bar"": {
+                                                    ""exclude"": ""Native"",
+                                                    ""include"": ""Build"",
+                                                    ""suppressParent"": ""All"",
+                                                    ""version"": ""2.0.0""
+                                            }
+                                        }
                                     }
-                                },
-                                    "".NETCoreApp,Version=v3.0"": {
-                                        ""Bar"": {
-                                            ""exclude"": ""Native"",
-                                            ""include"": ""Build"",
-                                            ""suppressParent"": ""All"",
-                                            ""version"": ""2.0.0""
-                                    }
-                                }
-                            }
-                        }";
+                                }";
 
             // Act
             var results = new List<CentralTransitiveDependencyGroup>();
-            using (var stringReader = new StringReader(json.ToString()))
-            using (var jsonReader = new JsonTextReader(stringReader))
+            if (environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING").Equals(bool.FalseString, StringComparison.OrdinalIgnoreCase))
             {
-                jsonReader.ReadObject(ctdPropertyName =>
+                using Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+                var reader = new Utf8JsonStreamReader(stream);
+
+                if (reader.TokenType == JsonTokenType.StartObject)
                 {
-                    jsonReader.ReadObject(frameworkPropertyName =>
+                    while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
                     {
-                        var dependencies = new List<LibraryDependency>();
-                        NuGetFramework framework = NuGetFramework.Parse(frameworkPropertyName);
-                        JsonPackageSpecReader.ReadCentralTransitiveDependencyGroup(
-                            jsonReader: jsonReader,
-                            results: dependencies,
-                            packageSpecPath: "SomePath");
-                        results.Add(new CentralTransitiveDependencyGroup(framework, dependencies));
+                        if (reader.Read() && reader.TokenType == JsonTokenType.StartObject)
+                        {
+                            while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+                            {
+                                var frameworkPropertyName = reader.GetString();
+                                NuGetFramework framework = NuGetFramework.Parse(frameworkPropertyName);
+                                var dependencies = new List<LibraryDependency>();
+
+                                JsonPackageSpecReader.ReadCentralTransitiveDependencyGroup(
+                                    jsonReader: ref reader,
+                                    results: dependencies,
+                                    packageSpecPath: "SomePath");
+                                results.Add(new CentralTransitiveDependencyGroup(framework, dependencies));
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                using (var stringReader = new StringReader(json.ToString()))
+                using (var jsonReader = new JsonTextReader(stringReader))
+                {
+                    jsonReader.ReadObject(ctdPropertyName =>
+                    {
+                        jsonReader.ReadObject(frameworkPropertyName =>
+                        {
+                            var dependencies = new List<LibraryDependency>();
+                            NuGetFramework framework = NuGetFramework.Parse(frameworkPropertyName);
+                            JsonPackageSpecReader.ReadCentralTransitiveDependencyGroup(
+                                jsonReader: jsonReader,
+                                results: dependencies,
+                                packageSpecPath: "SomePath");
+                            results.Add(new CentralTransitiveDependencyGroup(framework, dependencies));
+                        });
                     });
-                });
+                }
             }
 
             // Assert
@@ -3594,24 +3918,81 @@ namespace NuGet.ProjectModel.Test
             Assert.True(secondGroup.TransitiveDependencies.First().VersionCentrallyManaged);
         }
 
-        [Fact]
-        public void GetPackageSpec_WithSecondaryFrameworks_ReturnsTargetFrameworkInformationWithDualCompatibilityFramework()
+
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void PackageSpecReader_Malformed_Exception(IEnvironmentVariableReader environmentVariableReader)
+        {
+            // Arrange
+            var json = @"
+{
+    "".NETCoreApp,Version=v3.1"": {
+        ""Foo"":";
+
+            // Act
+            var results = new List<CentralTransitiveDependencyGroup>();
+            if (environmentVariableReader.GetEnvironmentVariable("NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING").Equals(bool.FalseString, StringComparison.OrdinalIgnoreCase))
+            {
+                Assert.ThrowsAny<System.Text.Json.JsonException>(() =>
+                {
+                    using Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+                    var reader = new Utf8JsonStreamReader(stream);
+
+                    if (reader.TokenType == JsonTokenType.StartObject)
+                    {
+                        reader.Read();
+                        NuGetFramework framework = NuGetFramework.Parse(reader.GetString());
+                        var dependencies = new List<LibraryDependency>();
+
+                        JsonPackageSpecReader.ReadCentralTransitiveDependencyGroup(
+                            jsonReader: ref reader,
+                            results: dependencies,
+                            packageSpecPath: "SomePath");
+                        results.Add(new CentralTransitiveDependencyGroup(framework, dependencies));
+                    }
+                });
+            }
+            else
+            {
+                using (var stringReader = new StringReader(json.ToString()))
+                using (var jsonReader = new JsonTextReader(stringReader))
+                {
+                    jsonReader.Read();
+                    jsonReader.Read();
+                    var dependencies = new List<LibraryDependency>();
+                    NuGetFramework framework = NuGetFramework.Parse((string)jsonReader.Value);
+                    JsonPackageSpecReader.ReadCentralTransitiveDependencyGroup(
+                        jsonReader: jsonReader,
+                        results: dependencies,
+                        packageSpecPath: "SomePath");
+                    results.Add(new CentralTransitiveDependencyGroup(framework, dependencies));
+                }
+                // Assert
+                Assert.Equal(1, results.Count);
+                var firstGroup = results.ElementAt(0);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WithSecondaryFrameworks_ReturnsTargetFrameworkInformationWithDualCompatibilityFramework(IEnvironmentVariableReader environmentVariableReader)
         {
             var json = $"{{\"frameworks\":{{\"net5.0\":{{\"secondaryFramework\": \"native\"}}}}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
             framework.FrameworkName.Should().BeOfType<DualCompatibilityFramework>();
             var dualCompatibilityFramework = framework.FrameworkName as DualCompatibilityFramework;
             dualCompatibilityFramework.RootFramework.Should().Be(FrameworkConstants.CommonFrameworks.Net50);
             dualCompatibilityFramework.SecondaryFramework.Should().Be(FrameworkConstants.CommonFrameworks.Native);
         }
 
-        [Fact]
-        public void GetPackageSpec_WithAssetTargetFallbackAndWithSecondaryFrameworks_ReturnsTargetFrameworkInformationWithDualCompatibilityFramework()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WithAssetTargetFallbackAndWithSecondaryFrameworks_ReturnsTargetFrameworkInformationWithDualCompatibilityFramework(IEnvironmentVariableReader environmentVariableReader)
         {
             var json = $"{{\"frameworks\":{{\"net5.0\":{{\"assetTargetFallback\": true, \"imports\": [\"net472\", \"net471\"], \"secondaryFramework\": \"native\" }}}}}}";
 
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
             framework.FrameworkName.Should().BeOfType<AssetTargetFallbackFramework>();
             framework.AssetTargetFallback.Should().BeTrue();
             var assetTargetFallbackFramework = framework.FrameworkName as AssetTargetFallbackFramework;
@@ -3624,14 +4005,15 @@ namespace NuGet.ProjectModel.Test
             assetTargetFallbackFramework.Fallback.Last().Should().Be(FrameworkConstants.CommonFrameworks.Net471);
         }
 
-        [Fact]
-        public void GetPackageSpec_WithRestoreAuditProperties_ReturnsRestoreAuditProperties()
+        [Theory]
+        [MemberData(nameof(TestEnvironmentVariableReader))]
+        public void GetPackageSpec_WithRestoreAuditProperties_ReturnsRestoreAuditProperties(IEnvironmentVariableReader environmentVariableReader)
         {
             // Arrange
             var json = $"{{\"restore\":{{\"restoreAuditProperties\":{{\"enableAudit\": \"a\", \"auditLevel\": \"b\", \"auditMode\": \"c\"}}}}}}";
 
             // Act
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             // Assert
             packageSpec.RestoreMetadata.RestoreAuditProperties.EnableAudit.Should().Be("a");
@@ -3752,32 +4134,93 @@ namespace NuGet.ProjectModel.Test
             }
         }
 
-        private static LibraryDependency GetDependency(string json)
+        private static PackageSpec GetPackageSpec(string json, IEnvironmentVariableReader environmentVariableReader)
         {
-            PackageSpec packageSpec = GetPackageSpec(json);
+            return GetPackageSpec(json, name: null, packageSpecPath: null, snapshotValue: null, environmentVariableReader: environmentVariableReader);
+        }
+
+        private static PackageSpec GetPackageSpec(string json, string name, string packageSpecPath, string snapshotValue, IEnvironmentVariableReader environmentVariableReader)
+        {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            return JsonPackageSpecReader.GetPackageSpec(stream, name, packageSpecPath, snapshotValue, environmentVariableReader);
+        }
+
+        private static LibraryDependency GetDependency(string json, IEnvironmentVariableReader environmentVariableReader)
+        {
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             return packageSpec.Dependencies.Single();
         }
 
-        private static TargetFrameworkInformation GetFramework(string json)
+        private static TargetFrameworkInformation GetFramework(string json, IEnvironmentVariableReader environmentVariableReader)
         {
-            PackageSpec packageSpec = GetPackageSpec(json);
+            PackageSpec packageSpec = GetPackageSpec(json, environmentVariableReader);
 
             return packageSpec.TargetFrameworks.Single();
         }
 
-        private static LibraryDependency GetFrameworksDependency(string json)
+        private static LibraryDependency GetFrameworksDependency(string json, IEnvironmentVariableReader environmentVariableReader)
         {
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             return framework.Dependencies.Single();
         }
 
-        private static FrameworkDependency GetFrameworksFrameworkReference(string json)
+        private static FrameworkDependency GetFrameworksFrameworkReference(string json, IEnvironmentVariableReader environmentVariableReader)
         {
-            TargetFrameworkInformation framework = GetFramework(json);
+            TargetFrameworkInformation framework = GetFramework(json, environmentVariableReader);
 
             return framework.FrameworkReferences.Single();
+        }
+
+        public static IEnumerable<object[]> TestEnvironmentVariableReader()
+        {
+            return GetTestEnvironmentVariableReader();
+        }
+
+        public static IEnumerable<object[]> TestEnvironmentVariableReader(object value1)
+        {
+            return GetTestEnvironmentVariableReader(value1);
+        }
+
+        public static IEnumerable<object[]> TestEnvironmentVariableReader(object value1, object value2)
+        {
+            return GetTestEnvironmentVariableReader(value1, value2);
+        }
+
+        public static IEnumerable<object[]> TestEnvironmentVariableReader(object value1, object value2, object value3)
+        {
+            return GetTestEnvironmentVariableReader(value1, value2, value3);
+        }
+
+        private static IEnumerable<object[]> GetTestEnvironmentVariableReader(params object[] objects)
+        {
+            var UseNjForFileTrue = new List<object> {
+                new TestEnvironmentVariableReader(
+                    new Dictionary<string, string>()
+                    {
+                        ["NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING"] = bool.TrueString
+                    }, "NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING: true")
+                };
+            var UseNjForFileFalse = new List<object> {
+                new TestEnvironmentVariableReader(
+                    new Dictionary<string, string>()
+                    {
+                        ["NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING"] = bool.FalseString
+                    }, "NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING: false")
+                };
+
+            if (objects != null)
+            {
+                UseNjForFileFalse.AddRange(objects);
+                UseNjForFileTrue.AddRange(objects);
+            }
+
+            return new List<object[]>
+            {
+                UseNjForFileTrue.ToArray(),
+                UseNjForFileFalse.ToArray()
+            };
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LazyStringSplitTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LazyStringSplitTests.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Collections.Generic;
+using System;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    public sealed class LazyStringSplitTests
+    {
+        [Theory]
+        [InlineData("a;b;c", ';', new[] { "a", "b", "c" })]
+        [InlineData("a_b_c", '_', new[] { "a", "b", "c" })]
+        [InlineData("aa;bb;cc", ';', new[] { "aa", "bb", "cc" })]
+        [InlineData("aaa;bbb;ccc", ';', new[] { "aaa", "bbb", "ccc" })]
+        [InlineData(";a;b;c", ';', new[] { "a", "b", "c" })]
+        [InlineData("a;b;c;", ';', new[] { "a", "b", "c" })]
+        [InlineData(";a;b;c;", ';', new[] { "a", "b", "c" })]
+        [InlineData(";;a;;b;;c;;", ';', new[] { "a", "b", "c" })]
+        [InlineData("", ';', new string[0])]
+        [InlineData(";", ';', new string[0])]
+        [InlineData(";;", ';', new string[0])]
+        [InlineData(";;;", ';', new string[0])]
+        [InlineData(";;;a", ';', new[] { "a" })]
+        [InlineData("a;;;", ';', new[] { "a" })]
+        [InlineData(";a;;", ';', new[] { "a" })]
+        [InlineData(";;a;", ';', new[] { "a" })]
+        [InlineData("a", ';', new[] { "a" })]
+        [InlineData("aa", ';', new[] { "aa" })]
+        public void ProducesCorrectEnumeration(string input, char delimiter, string[] expected)
+        {
+            // This boxes
+            IEnumerable<string> actual = new LazyStringSplit(input, delimiter);
+
+            Assert.Equal(expected, actual);
+
+            // Non boxing foreach
+            var list = new List<string>();
+
+            foreach (var s in new LazyStringSplit(input, delimiter))
+            {
+                list.Add(s);
+            }
+
+            Assert.Equal(expected, list);
+
+            // Equivalence with string.Split
+            Assert.Equal(expected, input.Split(new[] { delimiter }, StringSplitOptions.RemoveEmptyEntries));
+        }
+
+        [Fact]
+        public void Constructor_WithNullInput_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new LazyStringSplit(null!, ' '));
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
@@ -213,7 +213,6 @@ namespace NuGet.ProjectModel.Test
 
             var target = lockFile.Targets.Single();
             Assert.Equal(NuGetFramework.Parse("dotnet"), target.TargetFramework);
-
             var runtimeTargetLibrary = target.Libraries.Single();
             Assert.Equal("System.Runtime", runtimeTargetLibrary.Name);
             Assert.Equal(NuGetVersion.Parse("4.0.20-beta-22927"), runtimeTargetLibrary.Version);

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileParsingEnvironmentVariable.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileParsingEnvironmentVariable.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Test.Utility;
+
+namespace NuGet.ProjectModel
+{
+    public static class LockFileParsingEnvironmentVariable
+    {
+        public static IEnumerable<object[]> TestEnvironmentVariableReader()
+        {
+            return GetTestEnvironmentVariableReader();
+        }
+
+        public static IEnumerable<object[]> TestEnvironmentVariableReader(object value1)
+        {
+            return GetTestEnvironmentVariableReader(value1);
+        }
+
+        public static IEnumerable<object[]> TestEnvironmentVariableReader(object value1, object value2)
+        {
+            return GetTestEnvironmentVariableReader(value1, value2);
+        }
+
+        public static IEnumerable<object[]> TestEnvironmentVariableReader(object value1, object value2, object value3)
+        {
+            return GetTestEnvironmentVariableReader(value1, value2, value3);
+        }
+
+        private static IEnumerable<object[]> GetTestEnvironmentVariableReader(params object[] objects)
+        {
+            var UseNjForFileTrue = new List<object> {
+                new TestEnvironmentVariableReader(
+                    new Dictionary<string, string>()
+                    {
+                        [JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING] = bool.TrueString
+                    }, "NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING: true")
+                };
+            var UseNjForFileFalse = new List<object> {
+                new TestEnvironmentVariableReader(
+                    new Dictionary<string, string>()
+                    {
+                        [JsonUtility.NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING] = bool.FalseString
+                    }, "NUGET_EXPERIMENTAL_USE_NJ_FOR_FILE_PARSING: false")
+                };
+
+            if (objects != null)
+            {
+                UseNjForFileFalse.AddRange(objects);
+                UseNjForFileTrue.AddRange(objects);
+            }
+
+            return new List<object[]>
+            {
+                UseNjForFileTrue.ToArray(),
+                UseNjForFileFalse.ToArray()
+            };
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTestUtility.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTestUtility.cs
@@ -21,7 +21,9 @@ namespace NuGet.ProjectModel.Test
             var ms = new MemoryStream(Encoding.UTF8.GetBytes(json));
             var streamReader = new StreamReader(ms);
             var jsonReader = new JsonTextReader(streamReader);
+#pragma warning disable CS0612 // Type or member is obsolete
             return JsonPackageSpecReader.GetPackageSpec(jsonReader, "project", "project.json", environmentReader);
+#pragma warning restore CS0612 // Type or member is obsolete
         }
 
         public static PackageSpec RoundTripJson(string json, IEnvironmentVariableReader environmentReader)

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/StringExtensionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/StringExtensionTests.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    public class StringExtensionTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void SplitInTwo_WithNullOrEmptyString_ReturnStringAndNull(string s)
+        {
+            var result = s.SplitInTwo('/');
+            Assert.Equal(s, result.firstPart);
+            Assert.Null(result.secondPart);
+        }
+
+        [Theory]
+        [InlineData("part1/part2", "part1", "part2")]
+        [InlineData("part1/part2/NotPart3", "part1", "part2/NotPart3")]
+        public void SplitInTwo_WithSeperator_ReturnStringInTwoParts(string s, string expectedFirstPart, string expectedSecondPart)
+        {
+            var results = s.SplitInTwo('/');
+            Assert.Equal(expectedFirstPart, results.firstPart);
+            Assert.Equal(expectedSecondPart, results.secondPart);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Utf8JsonReaderExtensionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Utf8JsonReaderExtensionsTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    [UseCulture("")] // Fix tests failing on systems with non-English locales
+    public class Utf8JsonReaderExtensionsTests
+    {
+        [Theory]
+        [InlineData("null", null)]
+        [InlineData("true", "True")]
+        [InlineData("false", "False")]
+        [InlineData("-2", "-2")]
+        [InlineData("9223372036854775807", "9223372036854775807")]
+        [InlineData("3.14", "3.14")]
+        [InlineData("\"b\"", "b")]
+        public void ReadTokenAsString_WhenValueIsConvertibleToString_ReturnsValueAsString(
+            string value,
+            string expectedResult)
+        {
+            var json = $"{{\"a\":{value}}}";
+            var encodedBytes = Encoding.UTF8.GetBytes(json);
+            var reader = new Utf8JsonReader(encodedBytes);
+            reader.Read();
+            reader.Read();
+            reader.Read();
+            string actualResult = reader.ReadTokenAsString();
+            Assert.Equal(expectedResult, actualResult);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Utf8JsonStreamReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Utf8JsonStreamReaderTests.cs
@@ -570,7 +570,7 @@ namespace NuGet.ProjectModel.Test
                     actualValue => Assert.Equal("-2", actualValue),
                     actualValue => Assert.Equal("3.14", actualValue),
                     actualValue => Assert.Equal("True", actualValue),
-                    actualValue => Assert.Equal(null, actualValue));
+                    actualValue => Assert.Null(actualValue));
                 Assert.Equal(JsonTokenType.EndArray, reader.TokenType);
             }
         }
@@ -855,7 +855,7 @@ namespace NuGet.ProjectModel.Test
 
                 Assert.Collection(
                     actualResults,
-                    actualResult => Assert.Equal(null, actualResult),
+                    actualResult => Assert.Null(null),
                     actualResult => Assert.Equal("True", actualResult),
                     actualResult => Assert.Equal("-2", actualResult),
                     actualResult => Assert.Equal("3.14", actualResult),

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Utf8JsonStreamReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Utf8JsonStreamReaderTests.cs
@@ -1,0 +1,833 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Moq;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    [UseCulture("")] // Fix tests failing on systems with non-English locales
+    public class Utf8JsonStreamReaderTests
+    {
+        private static readonly string JsonWithOverflowObject = "{\"object1\":{\"a\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"b\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"c\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"d\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"e\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"f\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"g\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"h\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"i\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"j\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"k\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"l\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"m\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"n\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"o\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"p\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"q\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"r\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"s\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"t\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"u\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\"},\"object2\":{\"a\":\"abcdefghijklmnopqrstuvwxyz\",\"b\":\"abcdefghijklmnopqrstuvwxyz\",\"c\":\"abcdefghijklmnopqrstuvwxyz\",\"d\":\"abcdefghijklmnopqrstuvwxyz\",\"e\":\"abcdefghijklmnopqrstuvwxyz\",\"f\":\"abcdefghijklmnopqrstuvwxyz\",\"g\":\"abcdefghijklmnopqrstuvwxyz\",\"h\":\"abcdefghijklmnopqrstuvwxyz\",\"i\":\"abcdefghijklmnopqrstuvwxyz\",\"j\":\"abcdefghijklmnopqrstuvwxyz\",\"k\":\"abcdefghijklmnopqrstuvwxyz\",\"l\":\"abcdefghijklmnopqrstuvwxyz\",\"m\":\"abcdefghijklmnopqrstuvwxyz\",\"n\":\"abcdefghijklmnopqrstuvwxyz\",\"o\":\"abcdefghijklmnopqrstuvwxyz\",\"p\":\"abcdefghijklmnopqrstuvwxyz\",\"q\":\"abcdefghijklmnopqrstuvwxyz\",\"r\":\"abcdefghijklmnopqrstuvwxyz\",\"s\":\"abcdefghijklmnopqrstuvwxyz\",\"t\":\"abcdefghijklmnopqrstuvwxyz\",\"u\":\"abcdefghijklmnopqrstuvwxyz\"}}";
+        private static readonly string JsonWithoutOverflow = "{\"object1\":{\"a\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"b\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"c\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"d\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"e\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"f\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"g\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"h\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"i\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"j\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"k\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"l\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"m\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"n\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"o\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"p\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"q\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"r\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"s\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"t\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"u\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\"}}";
+        private static readonly string JsonWithOverflow = "{\"object1\":{\"a\":\"abcdefghijklmnopqrstuvwxyz\",\"b\":\"abcdefghijklmnopqrstuvwxyz\",\"c\":\"abcdefghijklmnopqrstuvwxyz\",\"d\":\"abcdefghijklmnopqrstuvwxyz\",\"e\":\"abcdefghijklmnopqrstuvwxyz\",\"f\":\"abcdefghijklmnopqrstuvwxyz\",\"g\":\"abcdefghijklmnopqrstuvwxyz\",\"h\":\"abcdefghijklmnopqrstuvwxyz\",\"i\":\"abcdefghijklmnopqrstuvwxyz\",\"j\":\"abcdefghijklmnopqrstuvwxyz\",\"k\":\"abcdefghijklmnopqrstuvwxyz\",\"l\":\"abcdefghijklmnopqrstuvwxyz\",\"m\":\"abcdefghijklmnopqrstuvwxyz\",\"n\":\"abcdefghijklmnopqrstuvwxyz\",\"o\":\"abcdefghijklmnopqrstuvwxyz\",\"p\":\"abcdefghijklmnopqrstuvwxyz\",\"q\":\"abcdefghijklmnopqrstuvwxyz\",\"r\":\"abcdefghijklmnopqrstuvwxyz\",\"s\":\"abcdefghijklmnopqrstuvwxyz\",\"t\":\"abcdefghijklmnopqrstuvwxyz\",\"u\":\"abcdefghijklmnopqrstuvwxyz\"}, \"object2\": {\"a\":\"abcdefghijklmnopqrstuvwxyz\",\"b\":\"abcdefghijklmnopqrstuvwxyz\",\"c\":\"abcdefghijklmnopqrstuvwxyz\",\"d\":\"abcdefghijklmnopqrstuvwxyz\",\"e\":\"abcdefghijklmnopqrstuvwxyz\",\"f\":\"abcdefghijklmnopqrstuvwxyz\",\"g\":\"abcdefghijklmnopqrstuvwxyz\",\"h\":\"abcdefghijklmnopqrstuvwxyz\",\"i\":\"abcdefghijklmnopqrstuvwxyz\",\"j\":\"abcdefghijklmnopqrstuvwxyz\",\"k\":\"abcdefghijklmnopqrstuvwxyz\",\"l\":\"abcdefghijklmnopqrstuvwxyz\",\"m\":\"abcdefghijklmnopqrstuvwxyz\",\"n\":\"abcdefghijklmnopqrstuvwxyz\",\"o\":\"abcdefghijklmnopqrstuvwxyz\",\"p\":\"abcdefghijklmnopqrstuvwxyz\",\"q\":\"abcdefghijklmnopqrstuvwxyz\",\"r\":\"abcdefghijklmnopqrstuvwxyz\",\"s\":\"abcdefghijklmnopqrstuvwxyz\",\"t\":\"abcdefghijklmnopqrstuvwxyz\",\"u\":\"abcdefghijklmnopqrstuvwxyz\"}, \"object3\":{\"a\":\"abcdefghijklmnopqrstuvwxyz\",\"b\":\"abcdefghijklmnopqrstuvwxyz\",\"c\":\"abcdefghijklmnopqrstuvwxyz\",\"d\":\"abcdefghijklmnopqrstuvwxyz\",\"e\":\"abcdefghijklmnopqrstuvwxyz\",\"f\":\"abcdefghijklmnopqrstuvwxyz\",\"g\":\"abcdefghijklmnopqrstuvwxyz\",\"h\":\"abcdefghijklmnopqrstuvwxyz\",\"i\":\"abcdefghijklmnopqrstuvwxyz\",\"j\":\"abcdefghijklmnopqrstuvwxyz\",\"k\":\"abcdefghijklmnopqrstuvwxyz\",\"l\":\"abcdefghijklmnopqrstuvwxyz\",\"m\":\"abcdefghijklmnopqrstuvwxyz\",\"n\":\"abcdefghijklmnopqrstuvwxyz\",\"o\":\"abcdefghijklmnopqrstuvwxyz\",\"p\":\"abcdefghijklmnopqrstuvwxyz\",\"q\":\"abcdefghijklmnopqrstuvwxyz\",\"r\":\"abcdefghijklmnopqrstuvwxyz\",\"s\":\"abcdefghijklmnopqrstuvwxyz\",\"t\":\"abcdefghijklmnopqrstuvwxyz\",\"u\":\"abcdefghijklmnopqrstuvwxyz\"}}";
+        private static readonly string SmallJson = "{\"object1\":{\"a\":\"abcdefghijklmnopqrstuvwxyz\"}}";
+
+        [Fact]
+        public void Utf8JsonStreamReaderCtr_WhenStreamIsNull_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                using var reader = new Utf8JsonStreamReader(null);
+            });
+        }
+
+        [Fact]
+        public void Utf8JsonStreamReaderCtr_WhenBufferToSmall_Throws()
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var json = "{}";
+
+                using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(json)))
+                using (var reader = new Utf8JsonStreamReader(stream, 10))
+                {
+                }
+            });
+        }
+
+        [Fact]
+        public void Utf8JsonStreamReaderCtr_WhenStreamStartsWithUtf8Bom_SkipThem()
+        {
+            var json = Encoding.UTF8.GetString(Encoding.UTF8.GetPreamble()) + "{}";
+
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(json)))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                Assert.Equal(5, stream.Position);
+                Assert.Equal(JsonTokenType.StartObject, reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void Utf8JsonStreamReaderCtr_WhenStreamStartsWithoutUtf8Bom_ReadFromStart()
+        {
+            var json = "{}";
+
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(json)))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                Assert.Equal(2, stream.Position);
+                Assert.Equal(JsonTokenType.StartObject, reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void Utf8JsonStreamReaderCtr_WhenReadingWithOverflow_FinalBlockFalse()
+        {
+            var json = Encoding.UTF8.GetBytes(JsonWithOverflowObject);
+            using (var stream = new MemoryStream(json))
+            using (var reader = new Utf8JsonStreamReader(stream, 1024))
+            {
+                Assert.False(reader.IsFinalBlock);
+            }
+        }
+
+        [Fact]
+        public void Read_WhenReadingMalfornedJsonString_Throws()
+        {
+            var json = Encoding.UTF8.GetBytes("{\"a\":\"string}");
+
+            Assert.ThrowsAny<JsonException>(() =>
+            {
+                using (var stream = new MemoryStream(json))
+                using (var reader = new Utf8JsonStreamReader(stream))
+                {
+                    Assert.True(reader.IsFinalBlock);
+                    Assert.Equal(JsonTokenType.StartObject, reader.TokenType);
+                    reader.Read();
+                    Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+                    reader.Read();
+                }
+            });
+        }
+
+        [Fact]
+        public void Read_WhenReadingMalfornedJson_Throws()
+        {
+            var json = Encoding.UTF8.GetBytes("{\"a\":\"string\"}ohno");
+            Assert.ThrowsAny<JsonException>(() =>
+            {
+                using (var stream = new MemoryStream(json))
+                using (var reader = new Utf8JsonStreamReader(stream))
+                {
+                    Assert.True(reader.IsFinalBlock);
+                    Assert.Equal(JsonTokenType.StartObject, reader.TokenType);
+                    reader.Read();
+                    Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+                    reader.Read();
+                    reader.Read();
+                    reader.Read();
+                    reader.Read();
+                }
+            });
+        }
+
+        [Fact]
+        public void Read_WhenReadingSmallJson_Read()
+        {
+            var json = Encoding.UTF8.GetBytes(SmallJson);
+
+            using (var stream = new MemoryStream(json))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                Assert.True(reader.IsFinalBlock);
+                Assert.Equal(JsonTokenType.StartObject, reader.TokenType);
+                reader.Read();
+                Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+                reader.Read();
+                Assert.Equal(JsonTokenType.StartObject, reader.TokenType);
+                reader.Read();
+                Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+                reader.Read();
+                Assert.Equal(JsonTokenType.String, reader.TokenType);
+                reader.Read();
+                Assert.Equal(JsonTokenType.EndObject, reader.TokenType);
+                reader.Read();
+                Assert.Equal(JsonTokenType.EndObject, reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void Read_WhenReadingSmallJsonPastEnd_Read()
+        {
+            var json = Encoding.UTF8.GetBytes(SmallJson);
+            using (var stream = new MemoryStream(json))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                Assert.True(reader.IsFinalBlock);
+                Assert.Equal(JsonTokenType.StartObject, reader.TokenType);
+                reader.Read();
+                Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+                reader.Read();
+                Assert.Equal(JsonTokenType.StartObject, reader.TokenType);
+                reader.Read();
+                Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+                reader.Read();
+                Assert.Equal(JsonTokenType.String, reader.TokenType);
+                reader.Read();
+                Assert.Equal(JsonTokenType.EndObject, reader.TokenType);
+                reader.Read();
+                Assert.Equal(JsonTokenType.EndObject, reader.TokenType);
+                Assert.False(reader.Read());
+            }
+        }
+
+        [Fact]
+        public void Read_WhenReadingWithoutOverflow_Read()
+        {
+            var json = Encoding.UTF8.GetBytes(JsonWithoutOverflow);
+
+            using (var stream = new MemoryStream(json))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                Assert.Equal(JsonTokenType.StartObject, reader.TokenType);
+                reader.Read();
+                Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void Read_WhenReadingWithOverflow_ReadNextBuffer()
+        {
+            var json = Encoding.UTF8.GetBytes(JsonWithOverflowObject);
+            var mock = SetupMockArrayBuffer();
+
+            using (var stream = new MemoryStream(json))
+            using (var reader = new Utf8JsonStreamReader(stream, 1024, mock.Object))
+            {
+                while (reader.Read())
+                {
+                    if (reader.TokenType == JsonTokenType.PropertyName && reader.GetString() == "r")
+                    {
+                        break;
+                    }
+                }
+                reader.Read();
+                mock.Verify(m => m.Rent(1024), Times.Exactly(1));
+                Assert.Equal(JsonTokenType.String, reader.TokenType);
+                Assert.Equal("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", reader.GetString());
+                reader.Read();
+                Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+                Assert.Equal("s", reader.GetString());
+            }
+        }
+
+        [Fact]
+        public void Read_WhenReadingWithLargeToken_ResizeBuffer()
+        {
+            var json = Encoding.UTF8.GetBytes("{\"largeToken\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"smallToken\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\"}");
+            var mock = SetupMockArrayBuffer();
+
+            using (var stream = new MemoryStream(json))
+            using (var reader = new Utf8JsonStreamReader(stream, 1024, mock.Object))
+            {
+                reader.Read();
+                reader.Read();
+
+                mock.Verify(m => m.Rent(1024), Times.Exactly(1));
+                mock.Verify(m => m.Rent(2048), Times.Exactly(1));
+                mock.Verify(m => m.Return(It.IsAny<byte[]>(), true), Times.Exactly(1));
+                Assert.Equal(JsonTokenType.String, reader.TokenType);
+                Assert.Equal("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz",
+                    reader.GetString());
+            }
+        }
+
+        [Fact]
+        public void Read_WhenReadingWithLargeTokenReadPastFinal()
+        {
+            var json = Encoding.UTF8.GetBytes("{\"largeToken\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\",\"smallToken\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\"}");
+            var mock = SetupMockArrayBuffer();
+
+            using (var stream = new MemoryStream(json))
+            using (var reader = new Utf8JsonStreamReader(stream, 1024, mock.Object))
+            {
+                reader.Read();
+                reader.Read();
+                reader.Read();
+                reader.Read();
+                reader.Read();
+                mock.Verify(m => m.Rent(1024), Times.Exactly(1));
+                mock.Verify(m => m.Rent(2048), Times.Exactly(1));
+                mock.Verify(m => m.Return(It.IsAny<byte[]>(), true), Times.Exactly(1));
+                Assert.False(reader.Read());
+            }
+        }
+
+        [Fact]
+        public void Read_WhenReadingWithOverflowToBufferSize_LoadNextBuffer()
+        {
+            var json = Encoding.UTF8.GetBytes("{\"largeToken\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst\",\"smallToken\":\"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\"}");
+
+            using (var stream = new MemoryStream(json))
+            using (var reader = new Utf8JsonStreamReader(stream, 1024))
+            {
+                reader.Read();
+                reader.Read();
+                reader.Read();
+
+                Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+                Assert.Equal("smallToken", reader.GetString());
+                Assert.True(reader.Read());
+                Assert.Equal(JsonTokenType.String, reader.TokenType);
+                Assert.Equal("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", reader.GetString());
+            }
+        }
+
+        [Fact]
+        public void Dispose_NoErrors()
+        {
+            var json = Encoding.UTF8.GetBytes(SmallJson);
+            var mock = SetupMockArrayBuffer();
+
+            using (var stream = new MemoryStream(json))
+            using (var reader = new Utf8JsonStreamReader(stream, 1024, arrayPool: mock.Object))
+            {
+                Assert.Equal(JsonTokenType.StartObject, reader.TokenType);
+            }
+            mock.Verify(m => m.Return(It.IsAny<byte[]>(), true), Times.Exactly(1));
+        }
+
+        [Fact]
+        public void Dispose_Read_ObjectDisposedException()
+        {
+            var json = Encoding.UTF8.GetBytes(SmallJson);
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                using (var stream = new MemoryStream(json))
+                using (var reader = new Utf8JsonStreamReader(stream))
+                {
+                    Assert.Equal(JsonTokenType.StartObject, reader.TokenType);
+                    reader.Dispose();
+                    reader.Read();
+                }
+            });
+        }
+
+        [Fact]
+        public void Dispose_Skip_ObjectDisposedException()
+        {
+            var json = Encoding.UTF8.GetBytes(SmallJson);
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                using (var stream = new MemoryStream(json))
+                using (var reader = new Utf8JsonStreamReader(stream))
+                {
+                    Assert.Equal(JsonTokenType.StartObject, reader.TokenType);
+                    reader.Dispose();
+                    reader.Skip();
+                }
+            });
+        }
+
+        [Theory]
+        [InlineData("{\"object1\": { \"a\":\"asdad\" }")]
+        [InlineData("{\"object1\": { \"a\":\"asdad }}")]
+        [InlineData("{\"object1\":  \"a\":\"asdad\" }}")]
+        public void Skip_WhenReadingWithMalformedJson(string malformedJson)
+        {
+            var json = Encoding.UTF8.GetBytes(malformedJson);
+
+            Assert.ThrowsAny<JsonException>(() =>
+            {
+                using (var stream = new MemoryStream(json))
+                using (var reader = new Utf8JsonStreamReader(stream))
+                {
+                    Assert.Equal(JsonTokenType.StartObject, reader.TokenType);
+                    reader.Skip();
+                    Assert.Equal(JsonTokenType.EndObject, reader.TokenType);
+                }
+            });
+        }
+
+        [Fact]
+        public void Skip_WhenReadingWithoutOverflow_SkipObject()
+        {
+            var json = Encoding.UTF8.GetBytes(JsonWithoutOverflow);
+
+            using (var stream = new MemoryStream(json))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                Assert.Equal(JsonTokenType.StartObject, reader.TokenType);
+                reader.Skip();
+                Assert.Equal(JsonTokenType.EndObject, reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void Skip_WhenReadingWithOverflow_Skip()
+        {
+            var json = Encoding.UTF8.GetBytes(JsonWithOverflow);
+            var mock = SetupMockArrayBuffer();
+
+            using (var stream = new MemoryStream(json))
+            using (var reader = new Utf8JsonStreamReader(stream, 1024, mock.Object))
+            {
+                reader.Read();
+                reader.Skip();
+                reader.Read();
+                reader.Skip();
+                Assert.Equal(JsonTokenType.EndObject, reader.TokenType);
+                reader.Read();
+                Assert.Equal("object3", reader.GetString());
+                mock.Verify(m => m.Rent(1024), Times.Exactly(1));
+            }
+        }
+
+        [Fact]
+        public void Skip_WhenReadingWithOverflowObject_ResizeBuffer()
+        {
+            var json = Encoding.UTF8.GetBytes(JsonWithOverflowObject);
+            var mock = SetupMockArrayBuffer();
+
+            using (var stream = new MemoryStream(json))
+            using (var reader = new Utf8JsonStreamReader(stream, 1024, mock.Object))
+            {
+                reader.Read();
+                reader.Skip();
+                reader.Read();
+                Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+                Assert.Equal("object2", reader.GetString());
+                mock.Verify(m => m.Rent(1024), Times.Exactly(1));
+                mock.Verify(m => m.Rent(2048), Times.Exactly(1));
+                mock.Verify(m => m.Return(It.IsAny<byte[]>(), true), Times.Exactly(1));
+            }
+        }
+
+        [Fact]
+        public void ReadNextTokenAsString_WhenCalled_AdvanceToken()
+        {
+            var json = Encoding.UTF8.GetBytes("{\"token\":\"value\"}");
+
+            using (var stream = new MemoryStream(json))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                reader.Read();
+                Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+                var result = reader.ReadNextTokenAsString();
+                Assert.Equal(JsonTokenType.String, reader.TokenType);
+                Assert.Equal("value", result);
+            }
+        }
+
+        [Fact]
+        public void ReadNextTokenAsString_WithMalformedJson_GetException()
+        {
+            var json = Encoding.UTF8.GetBytes("{\"token\":\"value}");
+            Assert.ThrowsAny<JsonException>(() =>
+            {
+                using (var stream = new MemoryStream(json))
+                using (var reader = new Utf8JsonStreamReader(stream))
+                {
+                    reader.Read();
+                    Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+                    reader.ReadNextTokenAsString();
+                }
+            });
+        }
+
+        [Theory]
+        [InlineData("true", JsonTokenType.True)]
+        [InlineData("false", JsonTokenType.False)]
+        [InlineData("-2", JsonTokenType.Number)]
+        [InlineData("3.14", JsonTokenType.Number)]
+        [InlineData("{}", JsonTokenType.StartObject)]
+        [InlineData("[]", JsonTokenType.StartArray)]
+        [InlineData("[true]", JsonTokenType.StartArray)]
+        [InlineData("[-2]", JsonTokenType.StartArray)]
+        [InlineData("[3.14]", JsonTokenType.StartArray)]
+        [InlineData("[\"a\", \"b\"]", JsonTokenType.StartArray)]
+        public void ReadDelimitedString_WhenValueIsNotString_Throws(string value, JsonTokenType expectedTokenType)
+        {
+            var json = $"{{\"a\":{value}}}";
+            var encodedBytes = Encoding.UTF8.GetBytes(json);
+            var tokenType = JsonTokenType.None;
+            var exceptionThrown = Assert.Throws<JsonException>(() =>
+            {
+                using var stream = new MemoryStream(encodedBytes);
+                using var reader = new Utf8JsonStreamReader(stream);
+                reader.Read();
+                try
+                {
+                    reader.ReadDelimitedString();
+                }
+                finally
+                {
+                    tokenType = reader.TokenType;
+                }
+            });
+            Assert.NotNull(exceptionThrown.InnerException);
+            Assert.IsType(typeof(InvalidCastException), exceptionThrown.InnerException);
+            Assert.Equal(expectedTokenType, tokenType);
+        }
+
+        [Fact]
+        public void ReadDelimitedString_WhenValueIsString_ReturnsValue()
+        {
+            const string expectedResult = "b";
+            var json = $"{{\"a\":\"{expectedResult}\"}}";
+            var encodedBytes = Encoding.UTF8.GetBytes(json);
+            using (var stream = new MemoryStream(encodedBytes))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                reader.Read();
+                IEnumerable<string> actualResults = reader.ReadDelimitedString();
+                Assert.Collection(actualResults, actualResult => Assert.Equal(expectedResult, actualResult));
+                Assert.Equal(JsonTokenType.String, reader.TokenType);
+            }
+        }
+
+        [Theory]
+        [InlineData("b,c,d")]
+        [InlineData("b c d")]
+        public void ReadDelimitedString_WhenValueIsDelimitedString_ReturnsValues(string value)
+        {
+            string[] expectedResults = value.Split(new[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);
+            var json = $"{{\"a\":\"{value}\"}}";
+            var encodedBytes = Encoding.UTF8.GetBytes(json);
+            using (var stream = new MemoryStream(encodedBytes))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                reader.Read();
+                IEnumerable<string> actualResults = reader.ReadDelimitedString();
+                Assert.Equal(expectedResults, actualResults);
+                Assert.Equal(JsonTokenType.String, reader.TokenType);
+            }
+        }
+
+        [Theory]
+        [InlineData("null")]
+        [InlineData("\"b\"")]
+        [InlineData("{}")]
+        public void ReadStringArrayAsIList_WhenValueIsNotArray_ReturnsNull(string value)
+        {
+            var json = $"{{\"a\":{value}}}";
+            var encodedBytes = Encoding.UTF8.GetBytes(json);
+            using (var stream = new MemoryStream(encodedBytes))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                reader.Read();
+                reader.Read();
+                Assert.NotEqual(JsonTokenType.PropertyName, reader.TokenType);
+                IList<string> actualValues = reader.ReadStringArrayAsIList();
+                Assert.Null(actualValues);
+            }
+        }
+
+        [Fact]
+        public void ReadStringArrayAsIList_WhenValueIsEmptyArray_ReturnsNull()
+        {
+            var encodedBytes = Encoding.UTF8.GetBytes("{\"a\":[]}");
+            using (var stream = new MemoryStream(encodedBytes))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                reader.Read();
+                reader.Read();
+                Assert.NotEqual(JsonTokenType.PropertyName, reader.TokenType);
+                IList<string> actualValues = reader.ReadStringArrayAsIList();
+                Assert.Null(actualValues);
+            }
+        }
+
+        [Fact]
+        public void ReadStringArrayAsIList_WithSupportedTypes_ReturnsStringArray()
+        {
+            var encodedBytes = Encoding.UTF8.GetBytes("[\"a\",-2,3.14,true,null]");
+            using (var stream = new MemoryStream(encodedBytes))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                IList<string> actualValues = reader.ReadStringArrayAsIList();
+
+                Assert.Collection(
+                    actualValues,
+                    actualValue => Assert.Equal("a", actualValue),
+                    actualValue => Assert.Equal("-2", actualValue),
+                    actualValue => Assert.Equal("3.14", actualValue),
+                    actualValue => Assert.Equal("True", actualValue),
+                    actualValue => Assert.Equal(null, actualValue));
+                Assert.Equal(JsonTokenType.EndArray, reader.TokenType);
+            }
+        }
+
+        [Theory]
+        [InlineData("[]")]
+        [InlineData("{}")]
+        public void ReadStringArrayAsIList_WithUnsupportedTypes_Throws(string element)
+        {
+            var encodedBytes = Encoding.UTF8.GetBytes($"[{element}]");
+            Assert.Throws<InvalidCastException>(() =>
+            {
+                using (var stream = new MemoryStream(encodedBytes))
+                using (var reader = new Utf8JsonStreamReader(stream))
+                {
+                    reader.ReadStringArrayAsIList();
+                }
+            });
+        }
+
+
+        [Theory]
+        [InlineData("true", true)]
+        [InlineData("false", false)]
+        public void ReadNextTokenAsBoolOrFalse_WithValidValues_ReturnsBoolean(string value, bool expectedResult)
+        {
+            var json = $"{{\"a\":{value}}}";
+            var encodedBytes = Encoding.UTF8.GetBytes(json);
+            using (var stream = new MemoryStream(encodedBytes))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                reader.Read();
+                bool actualResult = reader.ReadNextTokenAsBoolOrFalse();
+                Assert.Equal(expectedResult, actualResult);
+            }
+        }
+
+        [Theory]
+        [InlineData("\"words\"")]
+        [InlineData("-3")]
+        [InlineData("3.3")]
+        [InlineData("[]")]
+        [InlineData("{}")]
+        public void ReadNextTokenAsBoolOrFalse_WithInvalidValues_ReturnsFalse(string value)
+        {
+            var json = $"{{\"a\":{value}}}";
+            var encodedBytes = Encoding.UTF8.GetBytes(json);
+            using (var stream = new MemoryStream(encodedBytes))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                reader.Read();
+                bool actualResult = reader.ReadNextTokenAsBoolOrFalse();
+                Assert.False(actualResult);
+            }
+        }
+
+        [Fact]
+        public void ReadNextStringOrArrayOfStringsAsReadOnlyList_WhenValueIsNull_ReturnsNull()
+        {
+            const string json = "{\"a\":null}";
+            var encodedBytes = Encoding.UTF8.GetBytes(json);
+            using (var stream = new MemoryStream(encodedBytes))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                reader.Read();
+                IEnumerable<string> actualResults = reader.ReadNextStringOrArrayOfStringsAsReadOnlyList();
+                Assert.Null(actualResults);
+                Assert.Equal(JsonTokenType.Null, reader.TokenType);
+            }
+        }
+
+        [Theory]
+        [InlineData("true", JsonTokenType.True)]
+        [InlineData("false", JsonTokenType.False)]
+        [InlineData("-2", JsonTokenType.Number)]
+        [InlineData("3.14", JsonTokenType.Number)]
+        [InlineData("{}", JsonTokenType.StartObject)]
+        public void ReadNextStringOrArrayOfStringsAsReadOnlyList_WhenValueIsNotString_ReturnsNull(
+            string value,
+            JsonTokenType expectedTokenType)
+        {
+            var json = $"{{\"a\":{value}}}";
+            var encodedBytes = Encoding.UTF8.GetBytes(json);
+            using (var stream = new MemoryStream(encodedBytes))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                reader.Read();
+                Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+
+                IEnumerable<string> actualResults = reader.ReadNextStringOrArrayOfStringsAsReadOnlyList();
+
+                Assert.Null(actualResults);
+                Assert.Equal(expectedTokenType, reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadNextStringOrArrayOfStringsAsReadOnlyList_WhenValueIsString_ReturnsValue()
+        {
+            const string expectedResult = "b";
+            var json = $"{{\"a\":\"{expectedResult}\"}}";
+            var encodedBytes = Encoding.UTF8.GetBytes(json);
+            using (var stream = new MemoryStream(encodedBytes))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                reader.Read();
+                Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+
+                IEnumerable<string> actualResults = reader.ReadNextStringOrArrayOfStringsAsReadOnlyList();
+
+                Assert.Collection(actualResults, actualResult => Assert.Equal(expectedResult, actualResult));
+                Assert.Equal(JsonTokenType.String, reader.TokenType);
+            }
+        }
+
+        [Theory]
+        [InlineData("b,c,d")]
+        [InlineData("b c d")]
+        public void ReadNextStringOrArrayOfStringsAsReadOnlyList_WhenValueIsDelimitedString_ReturnsValue(string expectedResult)
+        {
+            var json = $"{{\"a\":\"{expectedResult}\"}}";
+            var encodedBytes = Encoding.UTF8.GetBytes(json);
+            using (var stream = new MemoryStream(encodedBytes))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                reader.Read();
+                Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+
+                IEnumerable<string> actualResults = reader.ReadNextStringOrArrayOfStringsAsReadOnlyList();
+
+                Assert.Collection(actualResults, actualResult => Assert.Equal(expectedResult, actualResult));
+                Assert.Equal(JsonTokenType.String, reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadNextStringOrArrayOfStringsAsReadOnlyList_WhenValueIsEmptyArray_ReturnsEmptyList()
+        {
+            const string json = "{\"a\":[]}";
+            var encodedBytes = Encoding.UTF8.GetBytes(json);
+            using (var stream = new MemoryStream(encodedBytes))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                reader.Read();
+                Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+
+                IReadOnlyList<string> actualResults = reader.ReadNextStringOrArrayOfStringsAsReadOnlyList();
+
+                Assert.Empty(actualResults);
+                Assert.Equal(JsonTokenType.EndArray, reader.TokenType);
+            }
+        }
+
+        [Theory]
+        [InlineData("null", null)]
+        [InlineData("true", "True")]
+        [InlineData("-2", "-2")]
+        [InlineData("3.14", "3.14")]
+        [InlineData("\"b\"", "b")]
+        public void ReadNextStringOrArrayOfStringsAsReadOnlyList_WhenValueIsConvertibleToString_ReturnsValueAsString(
+            string value,
+            string expectedResult)
+        {
+            var json = $"{{\"a\":[{value}]}}";
+            var encodedBytes = Encoding.UTF8.GetBytes(json);
+            using (var stream = new MemoryStream(encodedBytes))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                reader.Read();
+
+                Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+
+                IEnumerable<string> actualResults = reader.ReadNextStringOrArrayOfStringsAsReadOnlyList();
+
+                Assert.Collection(actualResults, actualResult => Assert.Equal(expectedResult, actualResult));
+                Assert.Equal(JsonTokenType.EndArray, reader.TokenType);
+            }
+        }
+
+        [Theory]
+        [InlineData("[]", JsonTokenType.StartArray)]
+        [InlineData("{}", JsonTokenType.StartObject)]
+        public void ReadNextStringOrArrayOfStringsAsReadOnlyList_WhenValueIsNotConvertibleToString_ReturnsValueAsString(
+            string value,
+            JsonTokenType expectedToken)
+        {
+            var json = $"{{\"a\":[{value}]}}";
+            var encodedBytes = Encoding.UTF8.GetBytes(json);
+            var tokenType = JsonTokenType.None;
+            var exceptionThrown = Assert.Throws<InvalidCastException>(() =>
+            {
+                using var stream = new MemoryStream(encodedBytes);
+                using var reader = new Utf8JsonStreamReader(stream);
+                reader.Read();
+                Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+                try
+                {
+                    reader.ReadNextStringOrArrayOfStringsAsReadOnlyList();
+                }
+                finally
+                {
+                    tokenType = reader.TokenType;
+                }
+            });
+            Assert.Equal(expectedToken, tokenType);
+        }
+
+        [Fact]
+        public void ReadNextStringOrArrayOfStringsAsReadOnlyList_WhenValueIsArrayOfStrings_ReturnsValues()
+        {
+            string[] expectedResults = { "b", "c" };
+            var json = $"{{\"a\":[{string.Join(",", expectedResults.Select(expectedResult => $"\"{expectedResult}\""))}]}}";
+            var encodedBytes = Encoding.UTF8.GetBytes(json);
+            using (var stream = new MemoryStream(encodedBytes))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                reader.Read();
+                Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+
+                IEnumerable<string> actualResults = reader.ReadNextStringOrArrayOfStringsAsReadOnlyList();
+
+                Assert.Equal(expectedResults, actualResults);
+                Assert.Equal(JsonTokenType.EndArray, reader.TokenType);
+            }
+        }
+
+        [Fact]
+        public void ReadStringArrayAsReadOnlyListFromArrayStart_WhenValuesAreConvertibleToString_ReturnsReadOnlyList()
+        {
+            const string json = "[null, true, -2, 3.14, \"a\"]";
+            var encodedBytes = Encoding.UTF8.GetBytes(json);
+            using (var stream = new MemoryStream(encodedBytes))
+            using (var reader = new Utf8JsonStreamReader(stream))
+            {
+                Assert.Equal(JsonTokenType.StartArray, reader.TokenType);
+
+                IEnumerable<string> actualResults = reader.ReadStringArrayAsReadOnlyListFromArrayStart();
+
+                Assert.Collection(
+                    actualResults,
+                    actualResult => Assert.Equal(null, actualResult),
+                    actualResult => Assert.Equal("True", actualResult),
+                    actualResult => Assert.Equal("-2", actualResult),
+                    actualResult => Assert.Equal("3.14", actualResult),
+                    actualResult => Assert.Equal("a", actualResult));
+                Assert.Equal(JsonTokenType.EndArray, reader.TokenType);
+            }
+        }
+
+        [Theory]
+        [InlineData("[]", JsonTokenType.StartArray)]
+        [InlineData("{}", JsonTokenType.StartObject)]
+        public void ReadStringArrayAsReadOnlyListFromArrayStart_WhenValuesAreNotConvertibleToString_Throws(
+            string value,
+            JsonTokenType expectedToken)
+        {
+            var json = $"[{value}]";
+            var encodedBytes = Encoding.UTF8.GetBytes(json);
+            var tokenType = JsonTokenType.None;
+            var exceptionThrown = Assert.Throws<InvalidCastException>(() =>
+            {
+                using var stream = new MemoryStream(encodedBytes);
+                using var reader = new Utf8JsonStreamReader(stream);
+                Assert.Equal(JsonTokenType.StartArray, reader.TokenType);
+                try
+                {
+                    reader.ReadStringArrayAsReadOnlyListFromArrayStart();
+                }
+                finally
+                {
+                    tokenType = reader.TokenType;
+                }
+            });
+            Assert.Equal(expectedToken, tokenType);
+        }
+
+        private Mock<ArrayPool<byte>> SetupMockArrayBuffer()
+        {
+            Mock<ArrayPool<byte>> mock = new Mock<ArrayPool<byte>>();
+            mock.Setup(m => m.Rent(1024)).Returns(new byte[1024]);
+            mock.Setup(m => m.Rent(2048)).Returns(new byte[2048]);
+            mock.Setup(m => m.Return(It.IsAny<byte[]>(), It.IsAny<bool>()));
+
+            return mock;
+        }
+    }
+}

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
@@ -396,7 +396,6 @@ namespace NuGet.Tests.Apex
         {
             var timeout = TimeSpan.FromSeconds(20);
             var timer = Stopwatch.StartNew();
-            string content = null;
 
             do
             {
@@ -405,9 +404,8 @@ namespace NuGet.Tests.Apex
                 {
                     try
                     {
-                        content = File.ReadAllText(path);
                         var format = new LockFileFormat();
-                        return format.Parse(content, path);
+                        return format.Read(path);
                     }
                     catch
                     {

--- a/test/TestUtilities/Test.Utility/TestEnvironmentVariableReader.cs
+++ b/test/TestUtilities/Test.Utility/TestEnvironmentVariableReader.cs
@@ -11,6 +11,8 @@ namespace Test.Utility
     {
         private readonly IReadOnlyDictionary<string, string> _variables;
 
+        private readonly string _toStringSuffix;
+
         public static IEnvironmentVariableReader EmptyInstance { get; } = new TestEnvironmentVariableReader();
 
         private TestEnvironmentVariableReader()
@@ -18,9 +20,10 @@ namespace Test.Utility
             _variables = new Dictionary<string, string>();
         }
 
-        public TestEnvironmentVariableReader(IReadOnlyDictionary<string, string> variables)
+        public TestEnvironmentVariableReader(IReadOnlyDictionary<string, string> variables, string toStringSuffix = null)
         {
             _variables = variables ?? throw new ArgumentNullException(nameof(variables));
+            _toStringSuffix = toStringSuffix;
         }
 
         public string GetEnvironmentVariable(string variable)
@@ -31,6 +34,15 @@ namespace Test.Utility
             }
 
             return null;
+        }
+
+        public override string ToString()
+        {
+            if (string.IsNullOrEmpty(_toStringSuffix))
+            {
+                return base.ToString();
+            }
+            return $"{base.ToString()}({_toStringSuffix})";
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12715

Regression? Last working version:

## Description
Currently we use JObject to parse the assets file. This library reads the full file into memory causing performance issues with the GC. This PR switches it to use System.Text.Json, allowing up to read the file in pieces and parse it without having to load the full file into memory. This work was done in a feature branch and this is the PR to merge that feature branch into dev
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled - https://github.com/NuGet/Client.Engineering/issues/2686
  - **OR**
  - [ ] N/A
