### PR TITLE
All calls to SourceRepository.GetResource must pass a cancellation token

### DIFF
--- a/build/BannedSymbols.txt
+++ b/build/BannedSymbols.txt
@@ -18,3 +18,6 @@ M:Microsoft.VisualStudio.Shell.IAsyncServiceProvider.GetServiceAsync(System.Type
 M:Microsoft.VisualStudio.Shell.AsyncPackage.GetServiceAsync(System.Type); Do not retrieve services from AsyncPackage, use the Async Service provider instead, which that class implements. Use the Microsoft.VisualStudio.Shell.ServiceExtensions.GetServiceAsync for services that have UI thread affinity or that you don't know about their affinity, and use NuGet.VisualStudio.ServiceProviderExtensions.GetFreeThreadedServiceAsync<TService, TInterface> for free threaded services.
 
 M:System.IO.Path.GetTempPath(); Use NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp)
+
+M:NuGet.Protocol.Core.Types.SourceRepository.GetResource`1(); Pass a cancellation token
+M:NuGet.Protocol.Core.Types.SourceRepository.GetResourceAsync`1(); Pass a cancellation token

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -1084,7 +1084,7 @@ namespace NuGet.CommandLine
             var findLocalPackagesResource = Repository
                 .Factory
                 .GetCoreV3(packagesFolderPath)
-                .GetResource<FindLocalPackagesResource>();
+                .GetResource<FindLocalPackagesResource>(CancellationToken.None);
 
             // Collect all packages
             IDictionary<PackageIdentity, PackageReference> packageReferences =

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
@@ -70,7 +70,7 @@ namespace NuGet.CommandLine
             foreach (PackageSource source in listEndpoints)
             {
                 SourceRepository repository = Repository.Factory.GetCoreV3(source);
-                PackageSearchResource resource = await repository.GetResourceAsync<PackageSearchResource>();
+                PackageSearchResource resource = await repository.GetResourceAsync<PackageSearchResource>(cancellationToken);
 
                 if (resource is null)
                 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -384,7 +384,6 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         {
             var packageSource = new PackageSource(source);
             var repository = _sourceRepositoryProvider.CreateRepository(packageSource);
-            var resource = repository.GetResource<PackageSearchResource>();
 
             return repository;
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Utils/InstalledPackageEnumerator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Utils/InstalledPackageEnumerator.cs
@@ -233,7 +233,7 @@ namespace NuGetConsole.Host.PowerShell
 
             var dependencyInfoResource = await packageManager
                 .PackagesFolderSourceRepository
-                .GetResourceAsync<DependencyInfoResource>();
+                .GetResourceAsync<DependencyInfoResource>(token);
 
             using (var sourceCacheContext = new SourceCacheContext())
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -1186,7 +1186,7 @@ namespace NuGet.PackageManagement.UI
 
             foreach (var source in sources)
             {
-                var metadataResource = source.GetResource<PackageMetadataResource>();
+                var metadataResource = source.GetResource<PackageMetadataResource>(token);
                 if (metadataResource == null)
                 {
                     continue;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -263,7 +263,7 @@ namespace NuGet.CommandLine.XPlat
         {
             IList<PackageSource> sources = AddPackageCommandUtility.EvaluateSources(originalPackageSpec.RestoreMetadata.Sources, originalPackageSpec.RestoreMetadata.ConfigFilePaths);
 
-            return await AddPackageCommandUtility.GetLatestVersionFromSourcesAsync(sources, logger, packageId, prerelease);
+            return await AddPackageCommandUtility.GetLatestVersionFromSourcesAsync(sources, logger, packageId, prerelease, CancellationToken.None);
         }
 
         private static LibraryDependency GenerateLibraryDependency(

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/AddPackageCommandUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/AddPackageCommandUtility.cs
@@ -25,7 +25,7 @@ namespace NuGet.CommandLine.XPlat.Utility
         /// <param name="prerelease">Whether to include prerelease versions</param>
         /// <returns>Return the latest version available from multiple sources and if no version is found returns null.</returns>
 
-        public static async Task<NuGetVersion> GetLatestVersionFromSourcesAsync(IList<PackageSource> sources, ILogger logger, string packageId, bool prerelease)
+        public static async Task<NuGetVersion> GetLatestVersionFromSourcesAsync(IList<PackageSource> sources, ILogger logger, string packageId, bool prerelease, CancellationToken cancellationToken)
         {
             var maxTasks = Environment.ProcessorCount;
             var tasks = new List<Task<NuGetVersion>>();
@@ -33,7 +33,7 @@ namespace NuGet.CommandLine.XPlat.Utility
 
             foreach (var source in sources)
             {
-                tasks.Add(Task.Run(() => GetLatestVersionFromSourceAsync(source, logger, packageId, prerelease)));
+                tasks.Add(Task.Run(() => GetLatestVersionFromSourceAsync(source, logger, packageId, prerelease, cancellationToken)));
                 if (maxTasks <= tasks.Count)
                 {
                     var finishedTask = await Task.WhenAny(tasks);
@@ -64,10 +64,10 @@ namespace NuGet.CommandLine.XPlat.Utility
         /// <param name="packageId">Package to look for</param>
         /// <param name="prerelease">Whether to include prerelease versions</param>
         /// <returns>Returns the latest version available from a source or a null if non is found.</returns>
-        public static async Task<NuGetVersion> GetLatestVersionFromSourceAsync(PackageSource source, ILogger logger, string packageId, bool prerelease)
+        public static async Task<NuGetVersion> GetLatestVersionFromSourceAsync(PackageSource source, ILogger logger, string packageId, bool prerelease, CancellationToken cancellationToken)
         {
             SourceRepository repository = Repository.Factory.GetCoreV3(source);
-            PackageMetadataResource resource = await repository.GetResourceAsync<PackageMetadataResource>();
+            PackageMetadataResource resource = await repository.GetResourceAsync<PackageMetadataResource>(cancellationToken);
 
             using (var cache = new SourceCacheContext())
             {

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -34,7 +35,7 @@ namespace NuGet.Commands
             {
                 logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "delete", packageSource.Source));
             }
-            var packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, packageSource);
+            var packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, packageSource, CancellationToken.None);
 
             await packageUpdateResource.Delete(
                 packageId,

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -39,7 +40,7 @@ namespace NuGet.Commands
                 timeoutSeconds = 5 * 60;
             }
             PackageSource packageSource = CommandRunnerUtility.GetOrCreatePackageSource(sourceProvider, source);
-            var packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, packageSource);
+            var packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, packageSource, CancellationToken.None);
 
             // Only warn for V3 style sources because they have a service index which is different from the final push url.
             if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections &&
@@ -58,7 +59,7 @@ namespace NuGet.Commands
                 && !sourceUri.IsFile
                 && sourceUri.IsAbsoluteUri)
             {
-                symbolPackageUpdateResource = await CommandRunnerUtility.GetSymbolPackageUpdateResource(sourceProvider, source);
+                symbolPackageUpdateResource = await CommandRunnerUtility.GetSymbolPackageUpdateResource(sourceProvider, source, CancellationToken.None);
                 if (symbolPackageUpdateResource != null)
                 {
                     symbolSource = symbolPackageUpdateResource.SourceUri.AbsoluteUri;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -257,7 +257,7 @@ namespace NuGet.Commands
             ILogger logger,
             CancellationToken cancellationToken)
         {
-            await EnsureResource();
+            await EnsureResource(cancellationToken);
 
             if (libraryRange.VersionRange?.MinVersion != null && libraryRange.VersionRange.IsMinInclusive && !libraryRange.VersionRange.IsFloating)
             {
@@ -400,7 +400,7 @@ namespace NuGet.Commands
             FindPackageByIdDependencyInfo packageInfo = null;
             try
             {
-                await EnsureResource();
+                await EnsureResource(cancellationToken);
 
                 if (_throttle != null)
                 {
@@ -494,7 +494,7 @@ namespace NuGet.Commands
 
             try
             {
-                await EnsureResource();
+                await EnsureResource(cancellationToken);
 
                 if (_throttle != null)
                 {
@@ -604,11 +604,11 @@ namespace NuGet.Commands
             return nuGetFramework;
         }
 
-        private async Task EnsureResource()
+        private async Task EnsureResource(CancellationToken cancellationToken)
         {
             if (_findPackagesByIdResource == null)
             {
-                var resource = await _sourceRepository.GetResourceAsync<FindPackageByIdResource>();
+                var resource = await _sourceRepository.GetResourceAsync<FindPackageByIdResource>(cancellationToken);
 
                 lock (_lock)
                 {

--- a/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -68,12 +69,12 @@ namespace NuGet.Commands
             return apiKey;
         }
 
-        public static async Task<PackageUpdateResource> GetPackageUpdateResource(IPackageSourceProvider sourceProvider, PackageSource packageSource)
+        public static async Task<PackageUpdateResource> GetPackageUpdateResource(IPackageSourceProvider sourceProvider, PackageSource packageSource, CancellationToken cancellationToken)
         {
             var sourceRepositoryProvider = new CachingSourceProvider(sourceProvider);
             var sourceRepository = sourceRepositoryProvider.CreateRepository(packageSource);
 
-            return await sourceRepository.GetResourceAsync<PackageUpdateResource>();
+            return await sourceRepository.GetResourceAsync<PackageUpdateResource>(cancellationToken);
         }
 
         public static PackageSource GetOrCreatePackageSource(IPackageSourceProvider sourceProvider, string source)
@@ -97,7 +98,7 @@ namespace NuGet.Commands
             return packageSource;
         }
 
-        public static async Task<SymbolPackageUpdateResourceV3> GetSymbolPackageUpdateResource(IPackageSourceProvider sourceProvider, string source)
+        public static async Task<SymbolPackageUpdateResourceV3> GetSymbolPackageUpdateResource(IPackageSourceProvider sourceProvider, string source, CancellationToken cancellationToken)
         {
             // Use a loaded PackageSource if possible since it contains credential info
             var packageSource = sourceProvider.LoadPackageSources()
@@ -112,7 +113,7 @@ namespace NuGet.Commands
             var sourceRepositoryProvider = new CachingSourceProvider(sourceProvider);
             var sourceRepository = sourceRepositoryProvider.CreateRepository(packageSource);
 
-            return await sourceRepository.GetResourceAsync<SymbolPackageUpdateResourceV3>();
+            return await sourceRepository.GetResourceAsync<SymbolPackageUpdateResourceV3>(cancellationToken);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
@@ -435,7 +435,7 @@ namespace NuGet.Protocol
                 throw new ArgumentNullException(nameof(throttle));
             }
 
-            Func<Task<HttpHandlerResource>> factory = () => source.GetResourceAsync<HttpHandlerResource>();
+            Func<Task<HttpHandlerResource>> factory = () => source.GetResourceAsync<HttpHandlerResource>(CancellationToken.None);
 
             return new HttpSource(source.PackageSource, factory, throttle);
         }

--- a/src/NuGet.Core/NuGet.Protocol/Providers/PackageMetadataResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/PackageMetadataResourceV3Provider.cs
@@ -22,9 +22,9 @@ namespace NuGet.Protocol
 
             if (await source.GetResourceAsync<ServiceIndexResourceV3>(token) != null)
             {
-                var regResource = await source.GetResourceAsync<RegistrationResourceV3>();
-                var reportAbuseResource = await source.GetResourceAsync<ReportAbuseResourceV3>();
-                var packageDetailsUriResource = await source.GetResourceAsync<PackageDetailsUriResourceV3>();
+                var regResource = await source.GetResourceAsync<RegistrationResourceV3>(token);
+                var reportAbuseResource = await source.GetResourceAsync<ReportAbuseResourceV3>(token);
+                var packageDetailsUriResource = await source.GetResourceAsync<PackageDetailsUriResourceV3>(token);
 
                 var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
 

--- a/src/NuGet.Core/NuGet.Protocol/Providers/RawSearchResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/RawSearchResourceV3Provider.cs
@@ -21,7 +21,7 @@ namespace NuGet.Protocol
         public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
         {
             RawSearchResourceV3 curResource = null;
-            var serviceIndex = await source.GetResourceAsync<ServiceIndexResourceV3>();
+            var serviceIndex = await source.GetResourceAsync<ServiceIndexResourceV3>(token);
 
             if (serviceIndex != null)
             {

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceProvider.cs
@@ -20,7 +20,7 @@ namespace NuGet.Protocol
         public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository sourceRepository, CancellationToken token)
         {
             INuGetResource resource = null;
-            var serviceIndexResource = await sourceRepository.GetResourceAsync<ServiceIndexResourceV3>();
+            var serviceIndexResource = await sourceRepository.GetResourceAsync<ServiceIndexResourceV3>(token);
             var packageBaseAddress = serviceIndexResource?.GetServiceEntryUris(ServiceTypes.PackageBaseAddress);
 
             if (packageBaseAddress != null

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
@@ -464,7 +464,7 @@ namespace NuGet.Protocol
                     await _dependencyInfoSemaphore.WaitAsync(cancellationToken);
                     if (_dependencyInfoResource == null)
                     {
-                        _dependencyInfoResource = await SourceRepository.GetResourceAsync<DependencyInfoResource>();
+                        _dependencyInfoResource = await SourceRepository.GetResourceAsync<DependencyInfoResource>(cancellationToken);
                     }
                 }
                 finally

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResourceProvider.cs
@@ -21,7 +21,7 @@ namespace NuGet.Protocol
         {
             INuGetResource resource = null;
 
-            var serviceIndexResource = await sourceRepository.GetResourceAsync<ServiceIndexResourceV3>();
+            var serviceIndexResource = await sourceRepository.GetResourceAsync<ServiceIndexResourceV3>(token);
 
             if (serviceIndexResource != null)
             {

--- a/src/NuGet.Core/NuGet.Protocol/SourceRepository.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SourceRepository.cs
@@ -112,7 +112,6 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         /// <typeparam name="T">Expected resource type</typeparam>
         /// <returns>Null if the resource does not exist</returns>
-        [Obsolete("Use the overload that takes a CancellationToken. If you don't want to support cancelation, use CancellationToken.None.")]
         public virtual T GetResource<T>() where T : class, INuGetResource
         {
             return GetResource<T>(CancellationToken.None);
@@ -136,7 +135,6 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         /// <typeparam name="T">Expected resource type</typeparam>
         /// <returns>Null if the resource does not exist</returns>
-        [Obsolete("Use the overload that takes a CancellationToken. If you don't want to support cancelation, use CancellationToken.None.")]
         public virtual async Task<T> GetResourceAsync<T>() where T : class, INuGetResource
         {
             return await GetResourceAsync<T>(CancellationToken.None);

--- a/src/NuGet.Core/NuGet.Protocol/SourceRepository.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SourceRepository.cs
@@ -112,6 +112,7 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         /// <typeparam name="T">Expected resource type</typeparam>
         /// <returns>Null if the resource does not exist</returns>
+        [Obsolete("Use the overload that takes a CancellationToken. If you don't want to support cancelation, use CancellationToken.None.")]
         public virtual T GetResource<T>() where T : class, INuGetResource
         {
             return GetResource<T>(CancellationToken.None);
@@ -135,6 +136,7 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         /// <typeparam name="T">Expected resource type</typeparam>
         /// <returns>Null if the resource does not exist</returns>
+        [Obsolete("Use the overload that takes a CancellationToken. If you don't want to support cancelation, use CancellationToken.None.")]
         public virtual async Task<T> GetResourceAsync<T>() where T : class, INuGetResource
         {
             return await GetResourceAsync<T>(CancellationToken.None);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -879,7 +879,7 @@ namespace NuGet.PackageManagement.UI.Test
             mockRemoteSourceRepository.SetupGet(m => m.PackageSource).Returns(remotePackageSource);
 
             // Required by UIActionEngine to check license metadata.
-            mockRemoteSourceRepository.Setup(m => m.GetResource<PackageMetadataResource>()).Returns(mockPackageMetadataResource.Object);
+            mockRemoteSourceRepository.Setup(m => m.GetResource<PackageMetadataResource>(It.IsAny<CancellationToken>())).Returns(mockPackageMetadataResource.Object);
             return mockRemoteSourceRepository.Object;
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
@@ -51,7 +51,7 @@ namespace NuGet.Protocol.FuncTest
                     packageSource.Credentials = new PackageSourceCredential(packageSource.Name, "user", "pass", true, "basic");
                     var repository = Repository.Factory.GetCoreV3(packageSource);
 
-                    var httpSourceResource = await repository.GetResourceAsync<HttpSourceResource>();
+                    var httpSourceResource = await repository.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
                     var source = httpSourceResource.HttpSource;
 
                     using (var sourceCacheContext = new SourceCacheContext()
@@ -121,7 +121,7 @@ namespace NuGet.Protocol.FuncTest
                     SetupCredentialServiceMock(mockedCredentialService, expectedCredentials, packageSource);
                     HttpHandlerResourceV3.CredentialService = new Lazy<ICredentialService>(() => mockedCredentialService.Object);
 
-                    var httpSourceResource = await repository.GetResourceAsync<HttpSourceResource>();
+                    var httpSourceResource = await repository.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
                     var source = httpSourceResource.HttpSource;
 
                     using var sourceCacheContext = new SourceCacheContext()

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
@@ -22,7 +22,7 @@ namespace NuGet.Protocol.FuncTest
             // Arrange
             var repo = Repository.Factory.GetCoreV3(TestSources.NuGetV2Uri);
 
-            var downloadResource = await repo.GetResourceAsync<DownloadResource>();
+            var downloadResource = await repo.GetResourceAsync<DownloadResource>(CancellationToken.None);
 
             var package = new SourcePackageDependencyInfo("WindowsAzure.Storage", new NuGetVersion("6.2.0"), null, true, repo, new Uri($@"{TestSources.NuGetV2Uri}/package/WindowsAzure.Storage/6.2.0"), "");
 
@@ -49,7 +49,7 @@ namespace NuGet.Protocol.FuncTest
             // Arrange
             var repo = Repository.Factory.GetCoreV3(TestSources.NuGetV2Uri);
 
-            var downloadResource = await repo.GetResourceAsync<DownloadResource>();
+            var downloadResource = await repo.GetResourceAsync<DownloadResource>(CancellationToken.None);
 
             var package = new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("6.2.0"));
 
@@ -76,7 +76,7 @@ namespace NuGet.Protocol.FuncTest
             // Arrange
             var repo = Repository.Factory.GetCoreV3(TestSources.NuGetV2Uri);
 
-            var downloadResource = await repo.GetResourceAsync<DownloadResource>();
+            var downloadResource = await repo.GetResourceAsync<DownloadResource>(CancellationToken.None);
 
             var package = new SourcePackageDependencyInfo("not-found", new NuGetVersion("6.2.0"), null, true, repo, new Uri($@"{TestSources.NuGetV2Uri}/package/not-found/6.2.0"), "");
 
@@ -104,7 +104,7 @@ namespace NuGet.Protocol.FuncTest
             var repo = Repository.Factory.GetCoreV3($"https://www.{randomName}.org/api/v2/");
 
             // Act & Assert
-            Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () => await repo.GetResourceAsync<DownloadResource>());
+            Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () => await repo.GetResourceAsync<DownloadResource>(CancellationToken.None));
 
             Assert.NotNull(ex);
             Assert.Equal($"Unable to load the service index for source https://www.{randomName}.org/api/v2/.", ex.Message);
@@ -116,7 +116,7 @@ namespace NuGet.Protocol.FuncTest
             // Arrange
             var repo = Repository.Factory.GetCoreV3(TestSources.NuGetV2Uri);
 
-            var packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>();
+            var packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
 
             var package = new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("6.2.0"));
 

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/FindPackageByIdResourceTests.cs
@@ -25,7 +25,7 @@ namespace NuGet.Protocol.FuncTest
         {
             // Arrange
             var repo = Repository.Factory.GetCoreV3(packageSource);
-            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>();
+            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
             var logger = new TestLogger();
 
             using (var context = new SourceCacheContext())
@@ -51,7 +51,7 @@ namespace NuGet.Protocol.FuncTest
         {
             // Arrange
             var repo = Repository.Factory.GetCoreV3(packageSource);
-            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>();
+            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
             var logger = new TestLogger();
 
             using (var context = new SourceCacheContext())
@@ -77,7 +77,7 @@ namespace NuGet.Protocol.FuncTest
         {
             // Arrange
             var repo = Repository.Factory.GetCoreV3(packageSource);
-            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>();
+            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
             var logger = new TestLogger();
 
             using (var context = new SourceCacheContext())
@@ -103,7 +103,7 @@ namespace NuGet.Protocol.FuncTest
         {
             // Arrange
             var repo = Repository.Factory.GetCoreV2(packageSource);
-            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>();
+            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
             var logger = new TestLogger();
 
             using (var context = new SourceCacheContext())
@@ -129,7 +129,7 @@ namespace NuGet.Protocol.FuncTest
         {
             // Arrange
             var repo = Repository.Factory.GetCoreV2(packageSource);
-            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>();
+            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
             var logger = new TestLogger();
 
             using (var context = new SourceCacheContext())
@@ -155,7 +155,7 @@ namespace NuGet.Protocol.FuncTest
         {
             // Arrange
             var repo = Repository.Factory.GetCoreV2(packageSource);
-            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>();
+            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
             var logger = new TestLogger();
 
             using (var context = new SourceCacheContext())
@@ -195,7 +195,7 @@ namespace NuGet.Protocol.FuncTest
             var source = MockSourceRepository.Create(timeoutHandler);
 
             // Now arrange the NuGet Client SDK experience
-            var protocolResource = await source.GetResourceAsync<FindPackageByIdResource>();
+            var protocolResource = await source.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
 
             using (var destination = new MemoryStream())
             {

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/ODataServiceDocumentResourceV2Tests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/ODataServiceDocumentResourceV2Tests.cs
@@ -26,7 +26,7 @@ namespace NuGet.Protocol.FuncTest
             var repo = Repository.Factory.GetCoreV3(TestSources.NuGetV2Uri);
 
             // Act 
-            var resource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>();
+            var resource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None);
 
             // Assert
             Assert.NotNull(resource);
@@ -40,7 +40,7 @@ namespace NuGet.Protocol.FuncTest
             var repo = Repository.Factory.GetCoreV3("https://www.nuget.org/api/v99///");
 
             // Act 
-            var resource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>();
+            var resource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None);
 
             // Assert
             Assert.NotNull(resource);
@@ -56,7 +56,7 @@ namespace NuGet.Protocol.FuncTest
 
             // Act & Assert
             Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () =>
-                await repo.GetResourceAsync<ODataServiceDocumentResourceV2>());
+                await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None));
 
             Assert.Equal(
                 $"Unable to load the service index for source https://www.{randomName}.org/api/v2.",

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/AddPackageCommandUtilityTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/AddPackageCommandUtilityTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.CommandLine.XPlat.Utility;
 using NuGet.Common;
@@ -80,7 +81,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var logger = NullLogger.Instance;
-                var result = await AddPackageCommandUtility.GetLatestVersionFromSourcesAsync(sources, logger, package, prerelease);
+                var result = await AddPackageCommandUtility.GetLatestVersionFromSourcesAsync(sources, logger, package, prerelease, CancellationToken.None);
 
                 //Asert
                 Assert.Equal(new NuGetVersion(expectedVersion), result);
@@ -100,7 +101,7 @@ namespace NuGet.XPlat.FuncTest
         {
             using (var testDirectory = TestDirectory.Create())
             {
-                // Arange
+                // Arrange
                 var sourceAPath = await GetSourceWithPackages(sourceA, testDirectory, "SourceA");
                 var sourceBPath = await GetSourceWithPackages(sourceB, testDirectory, "SourceB");
 
@@ -108,9 +109,9 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var logger = NullLogger.Instance;
-                var result = await AddPackageCommandUtility.GetLatestVersionFromSourcesAsync(sources, logger, package, prerelease);
+                var result = await AddPackageCommandUtility.GetLatestVersionFromSourcesAsync(sources, logger, package, prerelease, CancellationToken.None);
 
-                //Asert
+                // Assert
                 Assert.Null(result);
             }
         }
@@ -152,7 +153,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var logger = NullLogger.Instance;
-                var result = await AddPackageCommandUtility.GetLatestVersionFromSourcesAsync(sources, logger, packages.Last().Id, false);
+                var result = await AddPackageCommandUtility.GetLatestVersionFromSourcesAsync(sources, logger, packages.Last().Id, false, CancellationToken.None);
 
                 // Assert
                 Assert.Equal(packages.Last().Identity.Version, result);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
@@ -190,7 +190,7 @@ namespace NuGet.Commands.Test
                 .ThrowsAsync(new PackageNotFoundProtocolException(new PackageIdentity("x", NuGetVersion.Parse("1.0.0"))));
 
             var source = new Mock<SourceRepository>();
-            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>())
+            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None))
                 .ReturnsAsync(findResource.Object);
             source.SetupGet(s => s.PackageSource)
                 .Returns(new PackageSource("http://test/index.json"));
@@ -244,7 +244,7 @@ namespace NuGet.Commands.Test
                     Enumerable.Empty<FrameworkSpecificGroup>()));
 
             var source = new Mock<SourceRepository>();
-            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>())
+            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None))
                 .ReturnsAsync(findResource.Object);
             source.SetupGet(s => s.PackageSource)
                 .Returns(new PackageSource("http://test/index.json"));
@@ -296,7 +296,7 @@ namespace NuGet.Commands.Test
                 .Callback(() => dependencyHitCount++);
 
             var source = new Mock<SourceRepository>();
-            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>())
+            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None))
                 .ReturnsAsync(findResource.Object);
             source.SetupGet(s => s.PackageSource)
                 .Returns(new PackageSource("http://test/index.json"));
@@ -433,7 +433,7 @@ namespace NuGet.Commands.Test
                 .Callback(() => versionsHitCount++);
 
             var source = new Mock<SourceRepository>();
-            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>())
+            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None))
                 .ReturnsAsync(findResource.Object);
             source.SetupGet(s => s.PackageSource)
                 .Returns(new PackageSource("http://test/index.json"));
@@ -544,7 +544,7 @@ namespace NuGet.Commands.Test
                         It.IsAny<CancellationToken>()))
                     .ThrowsAsync(new FatalProtocolException("simulated"));
 
-                test.SourceRepository.Setup(s => s.GetResourceAsync<FindPackageByIdResource>())
+                test.SourceRepository.Setup(s => s.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None))
                     .ReturnsAsync(resource.Object);
 
                 await Assert.ThrowsAsync<FatalProtocolException>(
@@ -570,7 +570,7 @@ namespace NuGet.Commands.Test
                         It.IsAny<CancellationToken>()))
                     .ThrowsAsync(new FatalProtocolException("simulated"));
 
-                test.SourceRepository.Setup(s => s.GetResourceAsync<FindPackageByIdResource>())
+                test.SourceRepository.Setup(s => s.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None))
                     .ReturnsAsync(resource.Object);
 
                 var packageDownloader = await test.Provider.GetPackageDownloaderAsync(
@@ -599,7 +599,7 @@ namespace NuGet.Commands.Test
                         It.IsAny<CancellationToken>()))
                     .ThrowsAsync(new FatalProtocolException("simulated"));
 
-                test.SourceRepository.Setup(s => s.GetResourceAsync<FindPackageByIdResource>())
+                test.SourceRepository.Setup(s => s.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None))
                     .ReturnsAsync(resource.Object);
 
                 Assert.Equal(0, test.Logger.Warnings);
@@ -643,7 +643,7 @@ namespace NuGet.Commands.Test
                         It.IsAny<CancellationToken>()))
                     .ReturnsAsync(expectedPackageDownloader.Object);
 
-                test.SourceRepository.Setup(s => s.GetResourceAsync<FindPackageByIdResource>())
+                test.SourceRepository.Setup(s => s.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None))
                     .ReturnsAsync(resource.Object);
 
                 var actualPackageDownloader = await test.Provider.GetPackageDownloaderAsync(
@@ -675,7 +675,7 @@ namespace NuGet.Commands.Test
                 .Throws(expectedException);
 
             var source = new Mock<SourceRepository>();
-            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>())
+            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None))
                 .ReturnsAsync(findResource.Object);
             source.SetupGet(s => s.PackageSource)
                 .Returns(new PackageSource("http://test/index.json"));
@@ -733,7 +733,7 @@ namespace NuGet.Commands.Test
                 .Throws(expectedException);
 
             var source = new Mock<SourceRepository>();
-            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>())
+            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None))
                 .ReturnsAsync(findResource.Object);
             source.SetupGet(s => s.PackageSource)
                 .Returns(new PackageSource("http://test/index.json"));
@@ -803,7 +803,7 @@ namespace NuGet.Commands.Test
                     Enumerable.Empty<FrameworkSpecificGroup>()));
 
             var source = new Mock<SourceRepository>();
-            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>())
+            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None))
                 .ReturnsAsync(findResource.Object);
             source.SetupGet(s => s.PackageSource)
                 .Returns(new PackageSource("http://test/index.json"));
@@ -865,7 +865,7 @@ namespace NuGet.Commands.Test
                     Enumerable.Empty<FrameworkSpecificGroup>()));
 
             var source = new Mock<SourceRepository>();
-            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>())
+            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None))
                 .ReturnsAsync(findResource.Object);
             source.SetupGet(s => s.PackageSource)
                 .Returns(new PackageSource("http://test/index.json"));

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/Utility/PackageGraphAnalysisUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/Utility/PackageGraphAnalysisUtilitiesTests.cs
@@ -141,7 +141,7 @@ namespace NuGet.PackageManagement.Test
                 var packageDependencyInfos = await PackageGraphAnalysisUtilities.GetDependencyInfoForPackageIdentitiesAsync(
                     packageIdentities: installedList,
                     nuGetFramework: CommonFrameworks.Net45,
-                    dependencyInfoResource: await sourceReposistory.GetResourceAsync<DependencyInfoResource>(),
+                    dependencyInfoResource: await sourceReposistory.GetResourceAsync<DependencyInfoResource>(CancellationToken.None),
                     sourceCacheContext: new SourceCacheContext(),
                     includeUnresolved: true,
                     logger: NullLogger.Instance,

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
@@ -29,7 +29,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>();
+            var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None);
 
             // Act
             var result = await autoCompleteResource.IdStartsWith("Azure", false, NullLogger.Instance, CancellationToken.None);
@@ -51,7 +51,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>();
+            var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None);
 
             // Act
             var result = await autoCompleteResource.VersionStartsWith("xunit", "1", false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -72,7 +72,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>();
+            var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None);
 
             // Act
             var result = await autoCompleteResource.VersionStartsWith("azure", "1", false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV3Tests.cs
@@ -30,7 +30,7 @@ namespace NuGet.Protocol.Tests
                 JsonData.AutoCompleteEndpointNewtResult);
 
             var repo = StaticHttpHandler.CreateSource(sourceName, Repository.Provider.GetCoreV3(), responses);
-            var resource = await repo.GetResourceAsync<AutoCompleteResource>();
+            var resource = await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None);
 
             var logger = new TestLogger();
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DependencyInfoResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DependencyInfoResourceV2FeedTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>();
+            var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>(CancellationToken.None);
 
             // Act
             var dependencyInfoList = await dependencyInfoResource.ResolvePackages("WindowsAzure.Storage",
@@ -57,7 +57,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>();
+            var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>(CancellationToken.None);
 
             var packageIdentity = new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("4.3.2-preview"));
 
@@ -85,7 +85,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>();
+            var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>(CancellationToken.None);
 
             var package = new PackageIdentity("xunit", NuGetVersion.Parse("2.1.0-beta1-build2945"));
             var dep1 = new PackageIdentity("xunit.core", NuGetVersion.Parse("2.1.0-beta1-build2945"));
@@ -114,7 +114,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>();
+            var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>(CancellationToken.None);
 
             var package = new PackageIdentity("xunit", NuGetVersion.Parse("2.1.0-beta1-build2945"));
 
@@ -150,7 +150,7 @@ namespace NuGet.Protocol.Tests
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses,
                  ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
 
-            var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>();
+            var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>(CancellationToken.None);
 
             var package = new PackageIdentity("xunit", NuGetVersion.Parse("1.0.0-notfound"));
 
@@ -174,7 +174,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>();
+            var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>(CancellationToken.None);
 
             // Act
             var results = await dependencyInfoResource.ResolvePackages("not-found", NuGetFramework.Parse("net45"), NullSourceCacheContext.Instance, Common.NullLogger.Instance, CancellationToken.None);
@@ -196,7 +196,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>();
+            var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>(CancellationToken.None);
 
             var package = new PackageIdentity("DotNetOpenAuth.Core", NuGetVersion.Parse("4.3.2.13293"));
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceV2FeedTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Protocol.Tests
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses,
                  ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
 
-            var downloadResource = await repo.GetResourceAsync<DownloadResource>();
+            var downloadResource = await repo.GetResourceAsync<DownloadResource>(CancellationToken.None);
 
             // Act
             using (var packagesFolder = TestDirectory.Create())

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpHandlerResourceV3ProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpHandlerResourceV3ProviderTests.cs
@@ -32,10 +32,10 @@ namespace NuGet.Protocol.Tests
             // HttpSourceResourceProvider updates PackageSource.MaxHttpRequestsPerSource value for .NET Framework code paths
             // HttpSource constructor accepts a delegate that creates HttpHandlerResource and it stores the delegate in a private variable.
             // Hence used discard to ignore the return value and fetched HttpHandlerResource from the source repository to verify behavior. 
-            _ = await sourceRepository.GetResourceAsync<HttpSourceResource>();
+            _ = await sourceRepository.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
 
             // Act
-            HttpHandlerResource httpHandlerResource = await sourceRepository.GetResourceAsync<HttpHandlerResource>();
+            HttpHandlerResource httpHandlerResource = await sourceRepository.GetResourceAsync<HttpHandlerResource>(CancellationToken.None);
 
             // Assert
             Assert.NotNull(httpHandlerResource);
@@ -54,10 +54,10 @@ namespace NuGet.Protocol.Tests
             // HttpSourceResourceProvider updates PackageSource.MaxHttpRequestsPerSource value for .NET Framework code paths
             // HttpSource constructor accepts a delegate that creates HttpHandlerResource and it stores the delegate in a private variable.
             // Hence used discard to ignore the return value and fetched HttpHandlerResource from the source repository to verify behavior.
-            _ = await sourceRepository.GetResourceAsync<HttpSourceResource>();
+            _ = await sourceRepository.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
 
             // Act            
-            HttpHandlerResource httpHandlerResource = await sourceRepository.GetResourceAsync<HttpHandlerResource>();
+            HttpHandlerResource httpHandlerResource = await sourceRepository.GetResourceAsync<HttpHandlerResource>(CancellationToken.None);
 
             // Assert
             Assert.NotNull(httpHandlerResource);
@@ -78,10 +78,10 @@ namespace NuGet.Protocol.Tests
             // HttpSourceResourceProvider updates PackageSource.MaxHttpRequestsPerSource value for .NET Framework code paths
             // HttpSource constructor accepts a delegate that creates HttpHandlerResource and it stores the delegate in a private variable.
             // Hence used discard to ignore the return value and fetched HttpHandlerResource from the source repository to verify behavior.
-            _ = await sourceRepository.GetResourceAsync<HttpSourceResource>();
+            _ = await sourceRepository.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
 
             // Act            
-            HttpHandlerResource httpHandlerResource = await sourceRepository.GetResourceAsync<HttpHandlerResource>();
+            HttpHandlerResource httpHandlerResource = await sourceRepository.GetResourceAsync<HttpHandlerResource>(CancellationToken.None);
 
             // Assert
             Assert.NotNull(httpHandlerResource);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/ClientCertificatesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/ClientCertificatesTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
@@ -25,7 +26,7 @@ namespace NuGet.Protocol.Tests
             var sourceRepository = new SourceRepository(packageSource, new[] { new HttpHandlerResourceV3Provider() });
 
             // Act
-            var httpHandlerResourceV3 = sourceRepository.GetResource<HttpHandlerResource>();
+            var httpHandlerResourceV3 = sourceRepository.GetResource<HttpHandlerResource>(CancellationToken.None);
 
             // Assert
             Assert.NotNull(httpHandlerResourceV3);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSourceResourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSourceResourceProviderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
@@ -22,7 +23,7 @@ namespace NuGet.Protocol.Tests
             var sourceRepository = new SourceRepository(packageSource, new[] { new HttpSourceResourceProvider() });
 
             // Act
-            HttpSourceResource httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>();
+            HttpSourceResource httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
 
             // Assert
             Assert.NotNull(httpSourceResource);
@@ -37,7 +38,7 @@ namespace NuGet.Protocol.Tests
             var sourceRepository = new SourceRepository(packageSource, new[] { new HttpSourceResourceProvider() });
 
             // Act
-            HttpSourceResource httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>();
+            HttpSourceResource httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
 
             // Assert
             Assert.NotNull(httpSourceResource);
@@ -55,7 +56,7 @@ namespace NuGet.Protocol.Tests
             var sourceRepository = new SourceRepository(packageSource, new[] { new HttpSourceResourceProvider() });
 
             // Act
-            HttpSourceResource httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>();
+            HttpSourceResource httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
 
             // Assert
             Assert.NotNull(httpSourceResource);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/MetadataClientTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/MetadataClientTests.cs
@@ -28,7 +28,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<DependencyInfoResource>();
+            var resource = await repo.GetResourceAsync<DependencyInfoResource>(CancellationToken.None);
 
             // Act
             using (var sourceCacheContext = new SourceCacheContext())
@@ -54,7 +54,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<DependencyInfoResource>();
+            var resource = await repo.GetResourceAsync<DependencyInfoResource>(CancellationToken.None);
 
             var package = new PackageIdentity("deepequal", NuGetVersion.Parse("0.9.0"));
 
@@ -78,7 +78,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<DependencyInfoResource>();
+            var resource = await repo.GetResourceAsync<DependencyInfoResource>(CancellationToken.None);
 
             // Act
             using (var sourceCacheContext = new SourceCacheContext())
@@ -102,7 +102,7 @@ namespace NuGet.Protocol.Tests
             // Owin is not added
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<DependencyInfoResource>();
+            var resource = await repo.GetResourceAsync<DependencyInfoResource>(CancellationToken.None);
 
             // Act
             using (var sourceCacheContext = new SourceCacheContext())
@@ -126,7 +126,7 @@ namespace NuGet.Protocol.Tests
             // Owin is not added
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<DependencyInfoResource>();
+            var resource = await repo.GetResourceAsync<DependencyInfoResource>(CancellationToken.None);
 
             // Act
             using (var sourceCacheContext = new SourceCacheContext())
@@ -149,7 +149,7 @@ namespace NuGet.Protocol.Tests
             // Owin is not added
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<DependencyInfoResource>();
+            var resource = await repo.GetResourceAsync<DependencyInfoResource>(CancellationToken.None);
 
             var package = new PackageIdentity("owin", NuGetVersion.Parse("1.0.0"));
 
@@ -174,7 +174,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<DependencyInfoResource>();
+            var resource = await repo.GetResourceAsync<DependencyInfoResource>(CancellationToken.None);
 
             var package = new PackageIdentity("unlistedpackagea", NuGetVersion.Parse("1.0.0"));
 
@@ -202,7 +202,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<DependencyInfoResource>();
+            var resource = await repo.GetResourceAsync<DependencyInfoResource>(CancellationToken.None);
 
             var package = new PackageIdentity("unlistedpackagec", NuGetVersion.Parse("1.0.0"));
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/MetadataResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/MetadataResourceV2FeedTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>();
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
 
             // Act
             var latestVersion = await metadataResource.GetLatestVersion("WindowsAzure.Storage", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -53,7 +53,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>();
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
 
             // Act
             var latestVersion = await metadataResource.GetLatestVersion("WindowsAzure.Storage", false, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -75,7 +75,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>();
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
 
             // Act
             var versions = await metadataResource.GetVersions("WindowsAzure.Storage", false, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -97,7 +97,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>();
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
 
             // Act
             var versions = await metadataResource.GetVersions("WindowsAzure.Storage", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -119,7 +119,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>();
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
 
             // Act
             var exist = await metadataResource.Exists("WindowsAzure.Storage", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -142,7 +142,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>();
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
 
             var package = new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("4.3.2-preview"));
 
@@ -170,7 +170,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>();
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
 
             var packageIdList = new List<string>() { "WindowsAzure.Storage", "xunit" };
 
@@ -198,7 +198,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>();
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
 
             // Act
             var latestVersion = await metadataResource.GetLatestVersion("not-found", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -221,7 +221,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>();
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
 
             // Act
             var versions = await metadataResource.GetVersions("not-found", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -245,7 +245,7 @@ namespace NuGet.Protocol.Tests
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses,
                  ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>();
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
 
             var package = new PackageIdentity("xunit", new NuGetVersion("1.0.0-notfound"));
 
@@ -270,7 +270,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>();
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
 
             // Act
             var exist = await metadataResource.Exists("not-found", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ODataServiceDocumentV2Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ODataServiceDocumentV2Tests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Protocol.Core.Types;
 using Test.Utility;
@@ -24,7 +25,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>();
+            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None);
 
             // Act
             var baseAddress = oDataServiceDocumentResource.BaseAddress;
@@ -44,7 +45,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>();
+            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None);
 
             // Act
             var baseAddress = oDataServiceDocumentResource.BaseAddress;
@@ -66,7 +67,7 @@ namespace NuGet.Protocol.Tests
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             // Act
-            var resource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>();
+            var resource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None);
 
             // Assert
             Assert.Equal(serviceAddress.Trim('/'), resource.BaseAddress);
@@ -83,7 +84,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>();
+            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None);
 
             // Act
             var baseAddress = oDataServiceDocumentResource.BaseAddress;
@@ -103,7 +104,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>();
+            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None);
 
             // Act
             var baseAddress = oDataServiceDocumentResource.BaseAddress;
@@ -123,7 +124,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>();
+            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None);
 
             // Act
             var baseAddress = oDataServiceDocumentResource.BaseAddress;

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV2FeedTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>();
+            var packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
 
             // Act
             var metadata = await packageMetadataResource.GetMetadataAsync("WindowsAzure.Storage", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -72,7 +72,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>();
+            var packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
 
             // Act
             var metadata = await packageMetadataResource.GetMetadataAsync("afine", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -97,7 +97,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>();
+            var packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
 
             // Act
             var metadata = await packageMetadataResource.GetMetadataAsync("not-found", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -119,7 +119,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>();
+            var packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
 
             var packageIdentity = new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("4.3.2-preview"));
 
@@ -146,7 +146,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>();
+            var packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
 
             var packageIdentity = new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("0.0.0"));
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<PackageMetadataResource>();
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
 
             var package = new PackageIdentity("deepequal", NuGetVersion.Parse("0.9.0"));
 
@@ -68,7 +68,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<PackageMetadataResource>();
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
 
             var package = new PackageIdentity("unlistedpackagea", NuGetVersion.Parse("1.0.0"));
 
@@ -92,7 +92,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<PackageMetadataResource>();
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
 
             // Act
             using (var sourceCacheContext = new SourceCacheContext())
@@ -117,7 +117,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<PackageMetadataResource>();
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
 
             var package = new PackageIdentity("deepequal", NuGetVersion.Parse("0.0.0"));
 
@@ -153,7 +153,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(sourceName, Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<PackageMetadataResource>();
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
 
             var package = new PackageIdentity("PackageA", NuGetVersion.Parse("1.0.0"));
 
@@ -202,7 +202,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(sourceName, Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<PackageMetadataResource>();
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
 
             var package = new PackageIdentity("PackageA", NuGetVersion.Parse("1.0.0"));
 
@@ -256,7 +256,7 @@ namespace NuGet.Protocol.Tests
             };
 
             var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-            var resource = await repo.GetResourceAsync<PackageMetadataResource>();
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
 
             //Act
             using (var sourceCacheContext = new SourceCacheContext())
@@ -292,7 +292,7 @@ namespace NuGet.Protocol.Tests
             };
 
             var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-            var resource = await repo.GetResourceAsync<PackageMetadataResource>();
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
 
             //Act
             using (var sourceCacheContext = new SourceCacheContext())

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV2FeedTests.cs
@@ -30,7 +30,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var packageSearchResource = await repo.GetResourceAsync<PackageSearchResource>();
+            var packageSearchResource = await repo.GetResourceAsync<PackageSearchResource>(CancellationToken.None);
 
             var searchFilter = new SearchFilter(includePrerelease: false)
             {
@@ -76,7 +76,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var packageSearchResource = await repo.GetResourceAsync<PackageSearchResource>();
+            var packageSearchResource = await repo.GetResourceAsync<PackageSearchResource>(CancellationToken.None);
 
             var searchFilter = new SearchFilter(includePrerelease: false)
             {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV3Tests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<PackageSearchResource>();
+            var resource = await repo.GetResourceAsync<PackageSearchResource>(CancellationToken.None);
 
             // Act
             var packages = await resource.SearchAsync(
@@ -107,7 +107,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<PackageSearchResource>();
+            var resource = await repo.GetResourceAsync<PackageSearchResource>(CancellationToken.None);
 
             // Act
             var packages = (IEnumerable<PackageSearchMetadataBuilder.ClonedPackageSearchMetadata>)await resource.SearchAsync(
@@ -136,7 +136,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<PackageSearchResource>();
+            var resource = await repo.GetResourceAsync<PackageSearchResource>(CancellationToken.None);
 
             // Act
             var packages = await resource.SearchAsync(
@@ -163,7 +163,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<PackageSearchResource>();
+            var resource = await repo.GetResourceAsync<PackageSearchResource>(CancellationToken.None);
 
             // Act
             var packages = await resource.SearchAsync(

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PowershellAutoCompleteResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PowershellAutoCompleteResourceTests.cs
@@ -51,7 +51,7 @@ namespace NuGet.Protocol.Tests
         {
             // Arrange
             var source = StaticHttpHandler.CreateSource(sourceUrl, Repository.Provider.GetVisualStudio(), ResponsesDict);
-            var resource = await source.GetResourceAsync<AutoCompleteResource>();
+            var resource = await source.GetResourceAsync<AutoCompleteResource>(CancellationToken.None);
             Assert.NotNull(resource);
 
             var logger = new TestLogger();
@@ -83,7 +83,7 @@ namespace NuGet.Protocol.Tests
         {
             // Arrange
             var source = StaticHttpHandler.CreateSource(sourceUrl, Repository.Provider.GetVisualStudio(), ResponsesDict);
-            var resource = await source.GetResourceAsync<AutoCompleteResource>();
+            var resource = await source.GetResourceAsync<AutoCompleteResource>(CancellationToken.None);
             Assert.NotNull(resource);
 
             var logger = new TestLogger();
@@ -105,7 +105,7 @@ namespace NuGet.Protocol.Tests
         {
             // Arrange
             var source = StaticHttpHandler.CreateSource(sourceUrl, Repository.Provider.GetVisualStudio(), ResponsesDict);
-            var resource = await source.GetResourceAsync<AutoCompleteResource>();
+            var resource = await source.GetResourceAsync<AutoCompleteResource>(CancellationToken.None);
             Assert.NotNull(resource);
 
             var logger = new TestLogger();

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceTests.cs
@@ -312,7 +312,7 @@ namespace NuGet.Protocol.Tests
 
                 using (var cacheContext = new SourceCacheContext())
                 {
-                    var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
+                    var resource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
 
                     // Act
                     var info = await resource.GetDependencyInfoAsync(

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV2FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV2FindPackageByIdResourceTests.cs
@@ -210,7 +210,7 @@ namespace NuGet.Protocol.Tests
 
             using (var cacheContext = new SourceCacheContext())
             {
-                var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
+                var resource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
 
                 // Act
                 var versions = await resource.GetAllVersionsAsync(
@@ -366,7 +366,7 @@ namespace NuGet.Protocol.Tests
 
                 using (var cacheContext = new SourceCacheContext())
                 {
-                    var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
+                    var resource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
 
                     // Act
                     var info = await resource.GetDependencyInfoAsync(
@@ -424,7 +424,7 @@ namespace NuGet.Protocol.Tests
 
                 using (var cacheContext = new SourceCacheContext())
                 {
-                    var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
+                    var resource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
 
                     // Act
                     var info = await resource.GetDependencyInfoAsync(

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV3FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV3FindPackageByIdResourceTests.cs
@@ -294,7 +294,7 @@ namespace NuGet.Protocol.Tests
                 var logger = new TestLogger();
 
                 // Act
-                var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
+                var resource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
                 var info = await resource.GetDependencyInfoAsync(
                     "DEEPEQUAL",
                     new NuGetVersion("1.4.0.1-RC"),

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Protocol.Core.Types;
@@ -43,7 +44,7 @@ namespace NuGet.Protocol.Tests
                 };
 
                 var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-                var resource = await repo.GetResourceAsync<PackageUpdateResource>();
+                var resource = await repo.GetResourceAsync<PackageUpdateResource>(CancellationToken.None);
                 var apiKey = "SomeApiKey";
 
                 // Act
@@ -91,7 +92,7 @@ namespace NuGet.Protocol.Tests
                 };
 
                 var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-                var resource = await repo.GetResourceAsync<PackageUpdateResource>();
+                var resource = await repo.GetResourceAsync<PackageUpdateResource>(CancellationToken.None);
                 var apiKey = string.Empty;
 
                 // Act
@@ -138,7 +139,7 @@ namespace NuGet.Protocol.Tests
                 };
 
                 var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-                var resource = await repo.GetResourceAsync<PackageUpdateResource>();
+                var resource = await repo.GetResourceAsync<PackageUpdateResource>(CancellationToken.None);
                 var apiKey = "SomeApiKey";
 
                 var packageInfo = await SimpleTestPackageUtility.CreateFullPackageAsync(workingDir, "test", "1.0.0");
@@ -192,7 +193,7 @@ namespace NuGet.Protocol.Tests
                 };
 
                 var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-                var resource = await repo.GetResourceAsync<PackageUpdateResource>();
+                var resource = await repo.GetResourceAsync<PackageUpdateResource>(CancellationToken.None);
                 var apiKey = string.Empty;
 
                 var packageInfo = await SimpleTestPackageUtility.CreateFullPackageAsync(workingDir, "test", "1.0.0");
@@ -283,7 +284,7 @@ namespace NuGet.Protocol.Tests
                 };
 
                 var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-                var resource = await repo.GetResourceAsync<PackageUpdateResource>();
+                var resource = await repo.GetResourceAsync<PackageUpdateResource>(CancellationToken.None);
                 UserAgent.SetUserAgentString(new UserAgentStringBuilder("test client"));
 
                 // Act
@@ -349,7 +350,7 @@ namespace NuGet.Protocol.Tests
                 };
 
                 var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-                var resource = await repo.GetResourceAsync<PackageUpdateResource>();
+                var resource = await repo.GetResourceAsync<PackageUpdateResource>(CancellationToken.None);
                 UserAgent.SetUserAgentString(new UserAgentStringBuilder("test client"));
                 var logger = new TestLogger();
                 // Act
@@ -424,7 +425,7 @@ namespace NuGet.Protocol.Tests
                 };
 
                 var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-                var resource = await repo.GetResourceAsync<PackageUpdateResource>();
+                var resource = await repo.GetResourceAsync<PackageUpdateResource>(CancellationToken.None);
                 UserAgent.SetUserAgentString(new UserAgentStringBuilder("test client"));
 
                 // Act
@@ -500,7 +501,7 @@ namespace NuGet.Protocol.Tests
                 };
 
                 var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-                var resource = await repo.GetResourceAsync<PackageUpdateResource>();
+                var resource = await repo.GetResourceAsync<PackageUpdateResource>(CancellationToken.None);
                 UserAgent.SetUserAgentString(new UserAgentStringBuilder("test client"));
 
                 // Act
@@ -553,7 +554,7 @@ namespace NuGet.Protocol.Tests
                 };
 
                 var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-                var resource = await repo.GetResourceAsync<PackageUpdateResource>();
+                var resource = await repo.GetResourceAsync<PackageUpdateResource>(CancellationToken.None);
                 UserAgent.SetUserAgentString(new UserAgentStringBuilder("test client"));
 
                 // Act
@@ -603,7 +604,7 @@ namespace NuGet.Protocol.Tests
                 };
 
                 var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-                var resource = await repo.GetResourceAsync<PackageUpdateResource>();
+                var resource = await repo.GetResourceAsync<PackageUpdateResource>(CancellationToken.None);
                 UserAgent.SetUserAgentString(new UserAgentStringBuilder("test client"));
 
                 // Act
@@ -666,7 +667,7 @@ namespace NuGet.Protocol.Tests
                 };
 
                 var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-                var resource = await repo.GetResourceAsync<PackageUpdateResource>();
+                var resource = await repo.GetResourceAsync<PackageUpdateResource>(CancellationToken.None);
                 UserAgent.SetUserAgentString(new UserAgentStringBuilder("test client"));
 
                 // Act
@@ -735,7 +736,7 @@ namespace NuGet.Protocol.Tests
                 };
 
                 var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-                var resource = await repo.GetResourceAsync<PackageUpdateResource>();
+                var resource = await repo.GetResourceAsync<PackageUpdateResource>(CancellationToken.None);
                 UserAgent.SetUserAgentString(new UserAgentStringBuilder("test client"));
 
                 // Act
@@ -802,7 +803,7 @@ namespace NuGet.Protocol.Tests
                 };
 
                 var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-                var resource = await repo.GetResourceAsync<PackageUpdateResource>();
+                var resource = await repo.GetResourceAsync<PackageUpdateResource>(CancellationToken.None);
                 UserAgent.SetUserAgentString(new UserAgentStringBuilder("test client"));
 
                 // Act
@@ -854,7 +855,7 @@ namespace NuGet.Protocol.Tests
                         }
                     },
                 };
-            var resource = await StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses).GetResourceAsync<PackageUpdateResource>();
+            var resource = await StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses).GetResourceAsync<PackageUpdateResource>(CancellationToken.None);
             var logger = new TestLogger();
 
             // Act
@@ -921,7 +922,7 @@ namespace NuGet.Protocol.Tests
                     },
                 };
 
-            var resource = await StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses).GetResourceAsync<PackageUpdateResource>();
+            var resource = await StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses).GetResourceAsync<PackageUpdateResource>(CancellationToken.None);
             UserAgent.SetUserAgentString(new UserAgentStringBuilder("test client"));
             var logger = new TestLogger();
 
@@ -989,7 +990,7 @@ namespace NuGet.Protocol.Tests
                     },
                 };
 
-            var resource = await StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses).GetResourceAsync<PackageUpdateResource>();
+            var resource = await StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses).GetResourceAsync<PackageUpdateResource>(CancellationToken.None);
             UserAgent.SetUserAgentString(new UserAgentStringBuilder("test client"));
             var logger = new TestLogger();
 
@@ -1043,7 +1044,7 @@ namespace NuGet.Protocol.Tests
                 };
 
                 var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-                var resource = await repo.GetResourceAsync<PackageUpdateResource>();
+                var resource = await repo.GetResourceAsync<PackageUpdateResource>(CancellationToken.None);
                 var apiKey = string.Empty;
                 var logger = new TestLogger();
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/RepositorySignatureResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/RepositorySignatureResourceTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using Newtonsoft.Json.Linq;
@@ -39,7 +40,7 @@ namespace NuGet.Protocol.Tests
             var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
 
             // Act
-            var repositorySignatureResource = await repo.GetResourceAsync<RepositorySignatureResource>();
+            var repositorySignatureResource = await repo.GetResourceAsync<RepositorySignatureResource>(CancellationToken.None);
 
             // Assert
             Assert.False(repositorySignatureResource.AllRepositorySigned);
@@ -63,7 +64,7 @@ namespace NuGet.Protocol.Tests
             var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
 
             // Act
-            var repositorySignatureResource = await repo.GetResourceAsync<RepositorySignatureResource>();
+            var repositorySignatureResource = await repo.GetResourceAsync<RepositorySignatureResource>(CancellationToken.None);
 
             // Assert
             Assert.Null(repositorySignatureResource);
@@ -110,7 +111,7 @@ namespace NuGet.Protocol.Tests
             var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
 
             // Act & Assert
-            await Assert.ThrowsAsync<FatalProtocolException>(async () => await repo.GetResourceAsync<RepositorySignatureResource>());
+            await Assert.ThrowsAsync<FatalProtocolException>(async () => await repo.GetResourceAsync<RepositorySignatureResource>(CancellationToken.None));
         }
 
         [Fact]
@@ -127,7 +128,7 @@ namespace NuGet.Protocol.Tests
             var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
 
             // Act & Assert
-            await Assert.ThrowsAsync<FatalProtocolException>(async () => await repo.GetResourceAsync<RepositorySignatureResource>());
+            await Assert.ThrowsAsync<FatalProtocolException>(async () => await repo.GetResourceAsync<RepositorySignatureResource>(CancellationToken.None));
         }
 
 
@@ -145,7 +146,7 @@ namespace NuGet.Protocol.Tests
             var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
 
             // Act
-            var repositorySignatureResource = await repo.GetResourceAsync<RepositorySignatureResource>();
+            var repositorySignatureResource = await repo.GetResourceAsync<RepositorySignatureResource>(CancellationToken.None);
             repositorySignatureResource.UpdateRepositorySignatureInfo();
 
             // Assert
@@ -174,7 +175,7 @@ namespace NuGet.Protocol.Tests
             var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
 
             // Act
-            var repositorySignatureResource = await repo.GetResourceAsync<RepositorySignatureResource>();
+            var repositorySignatureResource = await repo.GetResourceAsync<RepositorySignatureResource>(CancellationToken.None);
             repositorySignatureResource.UpdateRepositorySignatureInfo();
 
             // Assert
@@ -211,7 +212,7 @@ namespace NuGet.Protocol.Tests
             var repos = sources.Select(p => StaticHttpHandler.CreateSource(p, Repository.Provider.GetCoreV3(), responses));
 
             // Act
-            var findPackageByIdResourceTasks = repos.Select(p => p.GetResourceAsync<FindPackageByIdResource>());
+            var findPackageByIdResourceTasks = repos.Select(p => p.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None));
 
             await Task.WhenAll(findPackageByIdResourceTasks);
 

--- a/tools-local/ensure-nupkg-dependencies-on-source/NuGetFeed.cs
+++ b/tools-local/ensure-nupkg-dependencies-on-source/NuGetFeed.cs
@@ -15,11 +15,11 @@ namespace ensure_nupkg_dependencies_on_source
             _sourceRepository = sourceRepository;
         }
 
-        public async ValueTask<FindPackageByIdResource> GetFindPackageByIdResourceAsync()
+        public async ValueTask<FindPackageByIdResource> GetFindPackageByIdResourceAsync(CancellationToken cancellationToken)
         {
             if (_findPackageByIdResource == null)
             {
-                _findPackageByIdResource = await _sourceRepository.GetResourceAsync<FindPackageByIdResource>();
+                _findPackageByIdResource = await _sourceRepository.GetResourceAsync<FindPackageByIdResource>(cancellationToken);
             }
 
             return _findPackageByIdResource;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13234
Fixes: https://github.com/NuGet/Home/issues/11813

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

`CancellationToken`s weren't being passed around everywhere needed. In the case of the two linked issues, it was 

I don't know what NuGet.Protocol looked like before the V3 protocol was added, but since it was added, there are resource providers that need the service index, so it no longer makes sense to call `GetResourceAsync` or `GetResource` without passing a cancellation token. Therefore I marked these two overloads (without the cancellation token parameter) as obsolete. **This is a breaking change** from an API point of view. What's worse is that these are commonly used APIs by anyone using the NuGet.Protocol package (part of the NuGet Client SDK), therefore I'm expecting high impact. However, the fix is trivial to implement.

All the other changes in PR are just fixing compile errors (since we treat warnings as errors). I passed in cancellation tokens where possible, but there are some methods that don't have a cancellation token already, but mostly this was in NuGet.CommandLine or NuGet.CommandLine.XPlat, where we don't handle ctrl-c directly anyway.

Honestly, it would be great to ban `CancellationToken.None` in our non-test code, but it will require a bunch of breaking API changes where existing public APIs need to start taking in a cancellation token, which is more effort than I'm willing to make for this quick fix.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A: No UX changes, just "backend" changes. <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
