### PR TITLE
deprecate nuget list

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -60,6 +60,21 @@ namespace NuGet.CommandLine
 
         protected Configuration.ICredentialService CredentialService { get; private set; }
 
+        public DeprecatedCommandAttribute DeprecatedCommandAttribute
+        {
+            get
+            {
+                var deprecatedAttrs = GetType().GetCustomAttributes(typeof(DeprecatedCommandAttribute), false);
+
+                if (deprecatedAttrs.Length > 0)
+                {
+                    return deprecatedAttrs[0] as DeprecatedCommandAttribute;
+                }
+
+                return null;
+            }
+        }
+
         public string CurrentDirectory
         {
             get
@@ -114,6 +129,12 @@ namespace NuGet.CommandLine
         {
             if (Help)
             {
+                if (DeprecatedCommandAttribute != null)
+                {
+                    var deprecationMessage = DeprecatedCommandAttribute.GetDeprecationMessage(CommandAttribute.CommandName);
+                    Console.WriteWarning(deprecationMessage);
+                }
+
                 HelpCommand.ViewHelpForCommand(CommandAttribute.CommandName);
             }
             else
@@ -150,6 +171,12 @@ namespace NuGet.CommandLine
                 RepositoryFactory = new CommandLineRepositoryFactory(Console);
 
                 UserAgent.SetUserAgentString(new UserAgentStringBuilder(CommandLineConstants.UserAgent));
+
+                if (DeprecatedCommandAttribute != null)
+                {
+                    var deprecationMessage = DeprecatedCommandAttribute.GetDeprecationMessage(CommandAttribute.CommandName);
+                    Console.WriteWarning(deprecationMessage);
+                }
 
                 OutputNuGetVersion();
                 ExecuteCommandAsync().GetAwaiter().GetResult();

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/DeprecatedCommandAttribute.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/DeprecatedCommandAttribute.cs
@@ -18,12 +18,6 @@ namespace NuGet.CommandLine
     public sealed class DeprecatedCommandAttribute : Attribute
     {
         /// <summary>
-        /// Placeholder for AlternativeCommand property
-        /// </summary>
-        /// <see cref="AlternativeCommand"/>
-        private Type _alternativeCommand;
-
-        /// <summary>
         /// The concrete Type that is an alternative to the command that has this DeprecatedCommand attribute.
         ///
         /// The Type must fully implement the ICommand interface
@@ -31,22 +25,7 @@ namespace NuGet.CommandLine
         /// If no alternative is provided in the attribute, this property will be null
         /// </summary>
         /// <see cref="ICommand">
-        public Type AlternativeCommand
-        {
-            get => _alternativeCommand;
-            private set
-            {
-                if (!typeof(ICommand).IsAssignableFrom(value))
-                {
-                    var msg = string.Format("{0} must be a {1} that implements {2} interface",
-                        nameof(AlternativeCommand),
-                        nameof(Type),
-                        typeof(ICommand).FullName);
-                    throw new ArgumentException(msg);
-                }
-                _alternativeCommand = value;
-            }
-        }
+        public Type AlternativeCommand { get; private set; }
 
         public DeprecatedCommandAttribute(Type AlternativeCommand)
         {

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/DeprecatedCommandAttribute.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/DeprecatedCommandAttribute.cs
@@ -1,0 +1,88 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+
+namespace NuGet.CommandLine
+{
+    /// <summary>
+    /// Attribute for marking nuget.exe commands as deprecated.
+    ///
+    /// By using this attribute in ICommand-based classes, it will show a warning message each
+    /// command invocation and in each help command invocation.
+    /// 
+    /// <see cref="ICommand"/>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class DeprecatedCommandAttribute : Attribute
+    {
+        /// <summary>
+        /// Placeholder for AlternativeCommand property
+        /// </summary>
+        /// <see cref="AlternativeCommand"/>
+        private Type _alternativeCommand;
+
+        /// <summary>
+        /// The concrete Type that is an alternative to the command that has this DeprecatedCommand attribute.
+        ///
+        /// The Type must fully implement the ICommand interface
+        /// 
+        /// If no alternative is provided in the attribute, this property will be null
+        /// </summary>
+        /// <see cref="ICommand">
+        public Type AlternativeCommand
+        {
+            get => _alternativeCommand;
+            private set
+            {
+                if (!typeof(ICommand).IsAssignableFrom(value))
+                {
+                    var msg = string.Format("{0} must be a {1} that implements {2} interface",
+                        nameof(AlternativeCommand),
+                        nameof(Type),
+                        typeof(ICommand).FullName);
+                    throw new ArgumentException(msg);
+                }
+                _alternativeCommand = value;
+            }
+        }
+
+        public DeprecatedCommandAttribute(Type AlternativeCommand)
+        {
+            this.AlternativeCommand = AlternativeCommand;
+        }
+
+        /// <summary>
+        /// Generates the deprecation warning message
+        /// </summary>
+        /// <param name="currentCommand">name of the current command that is deprecated</param>
+        /// <returns>The deprecation warning message</returns>
+        public string GetDeprecationMessage(string currentCommand)
+        {
+            var binaryName = Assembly.GetExecutingAssembly().GetName().Name;
+
+            if (AlternativeCommand == null)
+            {
+                var warningResource = LocalizedResourceManager.GetString("CommandDeprecationWarningSimple");
+
+                return string.Format(warningResource, binaryName, currentCommand);
+            }
+
+            var cmdAttrAlternative = AlternativeCommand.GetCustomAttributes(typeof(CommandAttribute), false);
+            if (cmdAttrAlternative.Length > 1)
+            {
+                throw new ArgumentException("Multiple CommandAttribute attributes is not allowed");
+            }
+
+            if (cmdAttrAlternative.Length == 1)
+            {
+                var cmdAlternative = cmdAttrAlternative[0] as CommandAttribute;
+
+                return string.Format(NuGetResources.Warning_CommandDeprecated, binaryName, currentCommand, cmdAlternative.CommandName);
+            }
+
+            throw new ArgumentException("No CommandAttribute attribute found");
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ICommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ICommand.cs
@@ -10,6 +10,8 @@ namespace NuGet.CommandLine
 
         CommandAttribute CommandAttribute { get; }
 
+        DeprecatedCommandAttribute DeprecatedCommandAttribute { get; }
+
         IList<string> Arguments { get; }
 
         void Execute();

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ListCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ListCommand.cs
@@ -18,6 +18,7 @@ namespace NuGet.CommandLine
          UsageSummaryResourceName = "ListCommandUsageSummary",
          UsageDescriptionResourceName = "ListCommandUsageDescription",
          UsageExampleResourceName = "ListCommandUsageExamples")]
+    [DeprecatedCommand(typeof(SearchCommand))]
     public class ListCommand : Command
     {
         private readonly List<string> _sources = new List<string>();

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -1666,6 +1666,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0} {1}&apos; is deprecated. Use &apos;{0} {2}&apos; instead..
+        /// </summary>
+        public static string Warning_CommandDeprecated {
+            get {
+                return ResourceManager.GetString("Warning_CommandDeprecated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The value &quot;{0}&quot; for {1} is a sample value and should be removed..
         /// </summary>
         public static string Warning_DefaultSpecValue {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -738,4 +738,10 @@ Do not localize `SDK`, `dotnet pack`, msbuild -t:pack` and 'true'.</comment>
   <data name="Error_CannotFindNonArchitectureSpecificMsbuild" xml:space="preserve">
     <value>The resolved MSBuild directory is `{0}` which is an architecture-specific directory. Could not find MSBuild in its parent directory (non-architecture specific).</value>
   </data>
+  <data name="Warning_CommandDeprecated" xml:space="preserve">
+    <value>'{0} {1}' is deprecated. Use '{0} {2}' instead.</value>
+    <comment>{0} - name of the assembly running the command, e.g., NuGet
+{1} - current command marked as deprecated, e.g., list
+{2} - replacement command. For example, search</comment>
+  </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/DeprecatedCommandAttributeTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/DeprecatedCommandAttributeTest.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.Test
+{
+    /// <summary>
+    /// This test class uses two sample command (greet, and hello) implementations, located in SampleCommandExtensions project
+    /// </summary>
+    public class DeprecatedCommandAttributeTest
+    {
+        private readonly string _warning_greet_aternative = string.Format(
+                NuGetResources.CommandLine_Warning,
+                string.Format(
+                    NuGetResources.Warning_CommandDeprecated,
+                    "NuGet", "greet", "hello"));
+
+        [Fact]
+        public void DeprecatedCommandAttribute_GreetCommandWithDeprecationAttribute_WarningMessage()
+        {
+            var result = CommandRunner.Run(
+                        Util.GetNuGetExePath(),
+                        Directory.GetCurrentDirectory(),
+                        "greet");
+
+            Util.VerifyResultSuccess(result, _warning_greet_aternative);
+            Util.VerifyResultSuccess(result, "Greetings");
+        }
+
+        [Fact]
+        public void DeprecatedCommandAttribute_GreetingCommandHelpFlag_WarningMessage()
+        {
+            var result = CommandRunner.Run(
+                        Util.GetNuGetExePath(),
+                        Directory.GetCurrentDirectory(),
+                        "greet -h");
+
+            Util.VerifyResultSuccess(result, _warning_greet_aternative);
+            Util.VerifyResultSuccess(result, "help");
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
@@ -97,7 +97,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.Equal(0, result.ExitCode);
-                var output = result.Output;
+                var output = RemoveDeprecationWarning(result.Output);
                 Assert.Equal($"testPackage1 1.1.0{Environment.NewLine}testPackage2 2.0.0{Environment.NewLine}", output);
             }
         }
@@ -122,7 +122,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.Equal(0, r.ExitCode);
-                var output = r.Output;
+                var output = RemoveDeprecationWarning(r.Output);
                 string[] lines = output.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
 
                 Assert.Equal(5, lines.Length);
@@ -172,7 +172,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.Equal(0, result.ExitCode);
-                var output = result.Output;
+                var output = RemoveDeprecationWarning(result.Output);
                 Assert.Equal($"testPackage1 1.1.0{Environment.NewLine}testPackage2 2.0.0{Environment.NewLine}", output);
             }
         }
@@ -224,7 +224,7 @@ namespace NuGet.CommandLine.Test
                     // verify that only package id & version is displayed
                     var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, RemoveHttpWarning(result.Output));
+                    Assert.Equal(expectedOutput, RemoveDeprecationWarning(RemoveHttpWarning(result.Output)));
 
                     Assert.Contains("$filter=IsLatestVersion", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -280,7 +280,7 @@ namespace NuGet.CommandLine.Test
                     // verify that only testPackage2 is listed since the package testPackage1
                     // is not listed.
                     var expectedOutput = "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, RemoveHttpWarning(r1.Output));
+                    Assert.Equal(expectedOutput, RemoveDeprecationWarning(RemoveHttpWarning(r1.Output)));
 
                     Assert.Contains("$filter=IsLatestVersion", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -341,7 +341,7 @@ namespace NuGet.CommandLine.Test
                     var expectedOutput =
                         "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, RemoveHttpWarning(r1.Output));
+                    Assert.Equal(expectedOutput, RemoveDeprecationWarning(RemoveHttpWarning(r1.Output)));
 
                     Assert.Contains("$filter=IsLatestVersion", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -453,7 +453,7 @@ namespace NuGet.CommandLine.Test
                     // verify that the output is detailed
                     var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, RemoveHttpWarning(r1.Output));
+                    Assert.Equal(expectedOutput, RemoveDeprecationWarning(RemoveHttpWarning(r1.Output)));
 
                     Assert.DoesNotContain("$filter", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -512,7 +512,7 @@ namespace NuGet.CommandLine.Test
                     // verify that the output is detailed
                     var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, RemoveHttpWarning(r1.Output));
+                    Assert.Equal(expectedOutput, RemoveDeprecationWarning(RemoveHttpWarning(r1.Output)));
 
                     Assert.Contains("$filter=IsAbsoluteLatestVersion", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -571,7 +571,7 @@ namespace NuGet.CommandLine.Test
                     // verify that the output is detailed
                     var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    RemoveHttpWarning(r1.Output).Should().Be(expectedOutput);
+                    RemoveDeprecationWarning(RemoveHttpWarning(r1.Output)).Should().Be(expectedOutput);
 
                     Assert.DoesNotContain("$filter", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -670,7 +670,7 @@ namespace NuGet.CommandLine.Test
                         // verify that only package id & version is displayed
                         var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                             "testPackage2 2.1.0" + Environment.NewLine;
-                        Assert.Equal(expectedOutput, RemoveHttpWarning(result.Output));
+                        Assert.Equal(expectedOutput, RemoveDeprecationWarning(RemoveHttpWarning(result.Output)));
 
                         Assert.Contains("$filter=IsLatestVersion", searchRequest);
                         Assert.Contains("searchTerm='test", searchRequest);
@@ -1253,6 +1253,16 @@ namespace NuGet.CommandLine.Test
             );
 
             return string.Join(Environment.NewLine, lines.Select(e => e).Where(e => !e.StartsWith("WARNING: You are running the")));
+        }
+
+        private static string RemoveDeprecationWarning(string input)
+        {
+            string[] lines = input.Split(
+                new string[] { "\r\n", "\r", "\n" },
+                StringSplitOptions.None
+            );
+
+            return string.Join(Environment.NewLine, lines.Select(e => e).Where(e => !e.StartsWith("WARNING: 'NuGet list' is deprecated.")));
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
@@ -9,7 +9,6 @@ using System.Net;
 using System.Text;
 using FluentAssertions;
 using NuGet.Common;
-using NuGet.Configuration.Test;
 using NuGet.Packaging;
 using NuGet.Test.Utility;
 using Test.Utility;
@@ -1243,6 +1242,32 @@ namespace NuGet.CommandLine.Test
             var expectedOutput = "testPackage1 1.1.0";
             Assert.Contains(expectedOutput, result.Output);
             Assert.Contains("WARNING: You are running the 'list' operation with 'HTTP' sources", result.AllOutput);
+        }
+
+        [Fact]
+        public void ListCommand_CheckDeprecationMessage()
+        {
+            // Arrange
+            var nugetexe = Util.GetNuGetExePath();
+            string deprecation = string.Format(NuGetResources.Warning_CommandDeprecated, "NuGet", "list", "search");
+
+            using (var repositoryPath = TestDirectory.Create())
+            {
+                Util.CreateTestPackage("testPackage1", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("testPackage2", "2.0.0", repositoryPath);
+
+                string[] args = ["list", "-Source", repositoryPath];
+
+                // Act
+                var result = CommandRunner.Run(
+                    nugetexe,
+                    Directory.GetCurrentDirectory(),
+                    string.Join(" ", args));
+
+                // Assert
+                Assert.Equal(0, result.ExitCode);
+                Assert.Equal($"WARNING: {deprecation}{Environment.NewLine}testPackage1 1.1.0{Environment.NewLine}testPackage2 2.0.0{Environment.NewLine}", result.Output);
+            }
         }
 
         private static string RemoveHttpWarning(string input)

--- a/test/TestExtensions/SampleCommandLineExtensions/GreetCommand.cs
+++ b/test/TestExtensions/SampleCommandLineExtensions/GreetCommand.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using NuGet.CommandLine;
+using NuGet;
+
+namespace SampleCommandLineExtensions
+{
+    [Export]
+    [Command("greet", "Prints greetings")]
+    [DeprecatedCommand(typeof(HelloCommand))]
+    public class GreetCommand : Command
+    {
+        public override void ExecuteCommand()
+        {
+            Console.WriteLine("Greetings");
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/7912

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This PR is inspired by https://github.com/NuGet/NuGet.Client/pull/2772
This PR
- It adds an attribute that will allow for deprecating commands
```c#
[Export]
[Command("greet", "Prints greetings")]
[DeprecatedCommand(typeof(HelloCommand))]
public class GreetCommand : Command
{
    // ... command implementation
}
```
- Uses the attribute to deprecate `nuget list`

### Running `nuget list`
```
> .\nuget.exe list
WARNING: 'nuget list' is deprecated. Use 'nuget search' instead.
...
```

### Running `nuget list -h`
```
> .\nuget.exe list -h
WARNING: 'nuget list' is deprecated. Use 'nuget search' instead.
...
```
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
