### PR TITLE
Migrate from `PublishBuildArtifacts` to `PublishPipelineArtifact`

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -38,12 +38,11 @@ steps:
     arguments: "-BuildRTM $(BuildRTM) -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(Build.SourceBranchName) -CommitHash $(Build.SourceVersion) -BuildNumber $(Build.BuildNumber)"
   displayName: "Configure VSTS CI Environment"
 
-- task: PublishBuildArtifacts@1
+- task: PublishPipelineArtifact@1
   displayName: 'Publish buildinfo.json as an artifact'
   inputs:
-    ArtifactName: 'BuildInfo'
-    ArtifactType: 'Container'
-    PathToPublish: '$(Build.Repository.LocalPath)\artifacts\buildinfo.json'
+    targetPath: '$(Build.Repository.LocalPath)\artifacts\buildinfo.json'
+    artifactName: 'BuildInfo'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: PowerShell@1
@@ -195,12 +194,11 @@ steps:
       SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(System.AccessToken) -CommitSha $(Build.SourceVersion) -TestName "$env:AGENT_JOBNAME"
   condition: "not(eq(variables['ManualGitHubChecks'], 'false'))"
 
-- task: PublishBuildArtifacts@1
+- task: PublishPipelineArtifact@1
   displayName: "Publish NuGet.CommandLine.Test as artifact"
   inputs:
-    PathtoPublish: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472"
-    ArtifactName: "NuGet.CommandLine.Test"
-    ArtifactType: "Container"
+    targetPath: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472"
+    artifactName: "NuGet.CommandLine.Test"
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1
@@ -330,12 +328,11 @@ steps:
     outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-- task: PublishBuildArtifacts@1
+- task: PublishPipelineArtifact@1
   displayName: 'Publish BootstrapperInfo.json as a build artifact'
   inputs:
-    PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
-    ArtifactName: MicroBuildOutputs
-    ArtifactType: Container
+    targetPath: $(Build.StagingDirectory)\MicroBuild\Output
+    artifactName: MicroBuildOutputs
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: PowerShell@1
@@ -436,12 +433,11 @@ steps:
     dropMetadataContainerName: 'DropMetadata-ProfilingInputs'
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
-- task: PublishBuildArtifacts@1
+- task: PublishPipelineArtifact@1
   displayName: "Publish NuGet.exe VSIX and EndToEnd.zip as artifact"
   inputs:
-    PathtoPublish: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
-    ArtifactName: "$(VsixPublishDir)"
-    ArtifactType: "Container"
+    targetPath : "$(Build.Repository.LocalPath)\\artifacts\\VS15"
+    artifactName: "$(VsixPublishDir)"
 
 - task: PublishPipelineArtifact@1
   displayName: "Publish localizationArtifacts artifact"

--- a/eng/pipelines/templates/CrossFramework_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/CrossFramework_Tests_On_Windows.yml
@@ -65,12 +65,11 @@ steps:
     testRunTitle: 'NuGet.Client Cross Verify Tests On Windows (.NET 8.0)'
     condition: "succeededOrFailed()"
 
-- task: PublishBuildArtifacts@1
+- task: PublishPipelineArtifact@1
   displayName: "Publish Test Freeze Dump"
   inputs:
-    PathtoPublish: "$(Build.Repository.LocalPath)/build/TestResults"
-    ArtifactName: "$(Agent.JobName)"
-    ArtifactType: "Container"
+    targetPath: "$(Build.Repository.LocalPath)/build/TestResults"
+    artifactName: "$(Agent.JobName)"
   condition: "or(failed(), canceled())"
 
 - task: PowerShell@1

--- a/eng/pipelines/templates/Functional_Tests_On_Windows.yml
+++ b/eng/pipelines/templates/Functional_Tests_On_Windows.yml
@@ -68,12 +68,11 @@ steps:
     testRunTitle: "NuGet.Client Functional Tests On Windows"
   condition: "succeededOrFailed()"
 
-- task: PublishBuildArtifacts@1
+- task: PublishPipelineArtifact@1
   displayName: "Publish Test Freeze Dump"
   inputs:
-    PathtoPublish: "$(Build.Repository.LocalPath)/build/TestResults"
-    ArtifactName: "$(Agent.JobName)"
-    ArtifactType: "Container"
+    targetPath: "$(Build.Repository.LocalPath)/build/TestResults"
+    artifactName: "$(Agent.JobName)"
   condition: "or(failed(), canceled())"
 
 - task: PowerShell@1

--- a/eng/pipelines/templates/Source_Build.yml
+++ b/eng/pipelines/templates/Source_Build.yml
@@ -7,14 +7,13 @@ steps:
       ./eng/source-build/build.sh
   condition: "always()"
 
-- task: PublishBuildArtifacts@1
+- task: PublishPipelineArtifact@1
   displayName: Upload source-build log
   condition: "or(failed(), eq(variables['System.debug'], 'true'))"
   continueOnError: true
   inputs:
-    PathToPublish: "artifacts/sb/log/source-build.binlog"
-    ArtifactName: "Source-build log"
-    ArtifactType: Container
+    targetPath: "artifacts/sb/log/source-build.binlog"
+    artifactName: "Source-build log"
 
 - task: ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'

--- a/eng/pipelines/templates/Tests_On_Linux.yml
+++ b/eng/pipelines/templates/Tests_On_Linux.yml
@@ -27,12 +27,11 @@ steps:
     searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
   condition: "succeededOrFailed()"
 
-- task: PublishBuildArtifacts@1
+- task: PublishPipelineArtifact@1
   displayName: "Publish Test Freeze Dump"
   inputs:
-    PathtoPublish: "$(Build.Repository.LocalPath)/build/TestResults"
-    ArtifactName: "$(Agent.JobName)"
-    ArtifactType: "Container"
+    targetPath: "$(Build.Repository.LocalPath)/build/TestResults"
+    artifactName: "$(Agent.JobName)"
   condition: "or(failed(), canceled())"
 
 - task: PowerShell@2

--- a/eng/pipelines/templates/Tests_On_Mac.yml
+++ b/eng/pipelines/templates/Tests_On_Mac.yml
@@ -35,12 +35,11 @@ steps:
     testRunTitle: "NuGet.Client $(TestRunDisplayName) On Mac"
   condition: "always()"
 
-- task: PublishBuildArtifacts@1
+- task: PublishPipelineArtifact@1
   displayName: "Publish Test Freeze Dump"
   inputs:
-    PathtoPublish: "$(Build.Repository.LocalPath)/build/TestResults"
-    ArtifactName: "$(Agent.JobName)"
-    ArtifactType: "Container"
+    targetPath: "$(Build.Repository.LocalPath)/build/TestResults"
+    artifactName: "$(Agent.JobName)"
   condition: "or(failed(), canceled())"
 
 - task: PowerShell@2


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13249

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Guidance suggests using pipeline artifacts over build artifacts. Even though I may replace this again as I'm working on a template migration, I figured it's simple enough to PR now, and may allow migration tooling to work better.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
