### PR TITLE
Add nullable annotations to NuGet.Configuration

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
@@ -190,7 +190,7 @@ namespace NuGet.PackageManagement.VisualStudio
             SettingsChanged?.Invoke(this, EventArgs.Empty);
         }
 
-        public SettingSection GetSection(string sectionName)
+        public SettingSection? GetSection(string sectionName)
         {
             return SolutionSettings.GetSection(sectionName);
         }

--- a/src/NuGet.Core/NuGet.Configuration/ClientCertificate/ClientCertificateProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/ClientCertificate/ClientCertificateProvider.cs
@@ -55,7 +55,7 @@ namespace NuGet.Configuration
 
         public IReadOnlyList<ClientCertItem> GetClientCertificates()
         {
-            SettingSection clientCertificatesSection = _settings.GetSection(ConfigurationConstants.ClientCertificates);
+            SettingSection? clientCertificatesSection = _settings.GetSection(ConfigurationConstants.ClientCertificates);
             if (clientCertificatesSection == null)
             {
                 return Enumerable.Empty<ClientCertItem>().ToList();
@@ -76,7 +76,7 @@ namespace NuGet.Configuration
             return result;
         }
 
-        public ClientCertItem GetClientCertificate(string packageSourceName)
+        public ClientCertItem? GetClientCertificate(string packageSourceName)
         {
             return GetClientCertificates().FirstOrDefault(i => string.Equals(i.PackageSource, packageSourceName, StringComparison.Ordinal));
         }

--- a/src/NuGet.Core/NuGet.Configuration/Credential/ICredentialService.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Credential/ICredentialService.cs
@@ -26,9 +26,9 @@ namespace NuGet.Configuration
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="uri" /> is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
-        Task<ICredentials> GetCredentialsAsync(
+        Task<ICredentials?> GetCredentialsAsync(
             Uri uri,
-            IWebProxy proxy,
+            IWebProxy? proxy,
             CredentialRequestType type,
             string message,
             CancellationToken cancellationToken);
@@ -49,7 +49,7 @@ namespace NuGet.Configuration
         bool TryGetLastKnownGoodCredentialsFromCache(
             Uri uri,
             bool isProxy,
-            out ICredentials credentials);
+            out ICredentials? credentials);
 
         /// <summary>
         /// Gets a value indicating whether this credential service wants to handle "default credentials" specially,

--- a/src/NuGet.Core/NuGet.Configuration/Exceptions/NuGetConfigurationException.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Exceptions/NuGetConfigurationException.cs
@@ -17,7 +17,7 @@ namespace NuGet.Configuration
         {
         }
 
-        public NuGetConfigurationException(string message, Exception innerException)
+        public NuGetConfigurationException(string message, Exception? innerException)
             : base(message, innerException)
         {
         }

--- a/src/NuGet.Core/NuGet.Configuration/NuGet.Configuration.csproj
+++ b/src/NuGet.Core/NuGet.Configuration/NuGet.Configuration.csproj
@@ -9,6 +9,7 @@
     <Shipping>true</Shipping>
     <IncludeInVSIX>true</IncludeInVSIX>
     <XPLATProject>true</XPLATProject>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceCredential.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceCredential.cs
@@ -44,7 +44,7 @@ namespace NuGet.Configuration
         /// Comma-delimited list of authentication types the credential is valid for as stored in the config file.
         /// If null or empty, all authentication types are valid. Example: 'basic,negotiate'
         /// </summary>
-        public string ValidAuthenticationTypesText { get; }
+        public string? ValidAuthenticationTypesText { get; }
 
         /// <summary>
         /// Retrieves password in clear text. Decrypts on-demand.
@@ -67,7 +67,7 @@ namespace NuGet.Configuration
                 }
                 else
                 {
-                    return PasswordText;
+                    return PasswordText!;
                 }
             }
         }
@@ -94,7 +94,7 @@ namespace NuGet.Configuration
         /// Comma-delimited list of authentication types the credential is valid for as stored in the config file.
         /// If null or empty, all authentication types are valid. Example: 'basic,negotiate'
         /// </param>
-        public PackageSourceCredential(string source, string username, string passwordText, bool isPasswordClearText, string validAuthenticationTypesText)
+        public PackageSourceCredential(string source, string username, string passwordText, bool isPasswordClearText, string? validAuthenticationTypesText)
         {
             Source = source ?? throw new ArgumentNullException(nameof(source));
             Username = username ?? throw new ArgumentNullException(nameof(username));
@@ -134,7 +134,7 @@ namespace NuGet.Configuration
             string username,
             string password,
             bool storePasswordInClearText,
-            string validAuthenticationTypesText)
+            string? validAuthenticationTypesText)
         {
             if (source == null)
             {
@@ -194,11 +194,11 @@ namespace NuGet.Configuration
         /// <returns>
         /// Enumeration of valid authentication types. If empty, all authentication types are valid.
         /// </returns>
-        private static IEnumerable<string> ParseAuthTypeFilterString(string str)
+        private static IEnumerable<string> ParseAuthTypeFilterString(string? str)
         {
             return string.IsNullOrWhiteSpace(str)
                 ? Enumerable.Empty<string>()
-                : str.Split(',').Select(x => x.Trim()).Where(x => x != string.Empty);
+                : str!.Split(',').Select(x => x.Trim()).Where(x => x != string.Empty);
         }
 
 
@@ -207,7 +207,7 @@ namespace NuGet.Configuration
             return new CredentialsItem(Source, Username, PasswordText, IsPasswordClearText, ValidAuthenticationTypesText);
         }
 
-        public bool Equals(PackageSourceCredential other)
+        public bool Equals(PackageSourceCredential? other)
         {
             if (other == null)
             {
@@ -225,7 +225,7 @@ namespace NuGet.Configuration
                 IsPasswordClearText == other.IsPasswordClearText;
         }
 
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
             return Equals(other as PackageSourceCredential);
         }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -721,7 +721,9 @@ namespace NuGet.Configuration
                     .Where(g => g.Count() > 1)
                     .Select(g => g.First())
                     .First();
-                throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.ShowError_ConfigDuplicateDisabledSources, duplicatedKey.Key, duplicatedKey.Origin.ConfigFilePath), e);
+                string filePath = duplicatedKey.Origin?.ConfigFilePath ?? Resources.ShowError_UnknownOrigin;
+                string message = string.Format(CultureInfo.CurrentCulture, Resources.ShowError_ConfigDuplicateDisabledSources, duplicatedKey.Key, filePath);
+                throw new NuGetConfigurationException(message, e);
             }
 
             var credentialsSection = Settings.GetSection(ConfigurationConstants.CredentialsSectionName);

--- a/src/NuGet.Core/NuGet.Configuration/PackageSourceMapping/PackageSourceMappingProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSourceMapping/PackageSourceMappingProvider.cs
@@ -34,7 +34,7 @@ namespace NuGet.Configuration
 
         public IReadOnlyList<PackageSourceMappingSourceItem> GetPackageSourceMappingItems()
         {
-            SettingSection packageSourceMappingSection = _settings.GetSection(ConfigurationConstants.PackageSourceMapping);
+            SettingSection? packageSourceMappingSection = _settings.GetSection(ConfigurationConstants.PackageSourceMapping);
             if (packageSourceMappingSection == null)
             {
                 return Enumerable.Empty<PackageSourceMappingSourceItem>().ToList();

--- a/src/NuGet.Core/NuGet.Configuration/Proxy/IProxyCache.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Proxy/IProxyCache.cs
@@ -9,6 +9,6 @@ namespace NuGet.Configuration
     public interface IProxyCache
     {
         void Add(IWebProxy proxy);
-        IWebProxy GetProxy(Uri uri);
+        IWebProxy? GetProxy(Uri uri);
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
@@ -46,7 +46,7 @@ namespace NuGet.Configuration
             _environment = environment;
         }
 
-        public IWebProxy GetProxy(Uri sourceUri)
+        public IWebProxy? GetProxy(Uri sourceUri)
         {
             // Check if the user has configured proxy details in settings or in the environment.
             var configuredProxy = GetUserConfiguredProxy();
@@ -77,14 +77,14 @@ namespace NuGet.Configuration
             return _cachedCredentials.TryAdd(configuredProxy.ProxyAddress, proxyCredentials);
         }
 
-        public WebProxy GetUserConfiguredProxy()
+        public WebProxy? GetUserConfiguredProxy()
         {
             // Try reading from the settings. The values are stored as 3 config values http_proxy, http_proxy.user, http_proxy.password
             var host = SettingsUtility.GetConfigValue(_settings, ConfigurationConstants.HostKey);
             if (!string.IsNullOrEmpty(host))
             {
                 // The host is the minimal value we need to assume a user configured proxy.
-                var webProxy = new WebProxy(host);
+                var webProxy = new WebProxy(host!);
 
                 if (RuntimeEnvironmentHelper.IsWindows)
                 {
@@ -101,7 +101,7 @@ namespace NuGet.Configuration
                 if (!string.IsNullOrEmpty(noProxy))
                 {
                     // split comma-separated list of domains
-                    webProxy.BypassList = noProxy.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                    webProxy.BypassList = noProxy!.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                 }
 
                 return webProxy;
@@ -109,7 +109,7 @@ namespace NuGet.Configuration
 
             // Next try reading from the environment variable http_proxy. This would be specified as http://<username>:<password>@proxy.com
             host = _environment.GetEnvironmentVariable(ConfigurationConstants.HostKey);
-            Uri uri;
+            Uri? uri;
             if (!string.IsNullOrEmpty(host)
                 && Uri.TryCreate(host, UriKind.Absolute, out uri))
             {
@@ -129,7 +129,7 @@ namespace NuGet.Configuration
                 if (!string.IsNullOrEmpty(noProxy))
                 {
                     // split comma-separated list of domains
-                    webProxy.BypassList = noProxy.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                    webProxy.BypassList = noProxy!.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                 }
 
                 return webProxy;
@@ -150,9 +150,9 @@ namespace NuGet.Configuration
                 updateValueFactory: (_, __) => { Version = Guid.NewGuid(); return credentials; });
         }
 
-        public NetworkCredential GetCredential(Uri proxyAddress, string authType)
+        public NetworkCredential? GetCredential(Uri proxyAddress, string authType)
         {
-            ICredentials cachedCredentials;
+            ICredentials? cachedCredentials;
             if (_cachedCredentials.TryGetValue(proxyAddress, out cachedCredentials))
             {
                 return cachedCredentials.GetCredential(proxyAddress, authType);
@@ -162,10 +162,10 @@ namespace NuGet.Configuration
         }
 
         [Obsolete("Retained for backcompat only. Use UpdateCredential instead")]
-        public void Add(IWebProxy proxy)
+        public void Add(IWebProxy? proxy)
         {
             var webProxy = proxy as WebProxy;
-            if (webProxy != null)
+            if (webProxy != null && webProxy.Credentials is not null)
             {
                 _cachedCredentials.TryAdd(webProxy.ProxyAddress, webProxy.Credentials);
             }

--- a/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
@@ -165,7 +165,7 @@ namespace NuGet.Configuration
         public void Add(IWebProxy? proxy)
         {
             var webProxy = proxy as WebProxy;
-            if (webProxy != null && webProxy.Credentials is not null)
+            if (webProxy?.Credentials is not null)
             {
                 _cachedCredentials.TryAdd(webProxy.ProxyAddress, webProxy.Credentials);
             }

--- a/src/NuGet.Core/NuGet.Configuration/Proxy/WebProxy.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Proxy/WebProxy.cs
@@ -17,7 +17,7 @@ namespace NuGet.Configuration
     {
         private IReadOnlyList<string> _bypassList = Array.Empty<string>();
 
-        private Regex[] _regExBypassList; // can be null
+        private Regex[]? _regExBypassList;
 
         public WebProxy(string proxyAddress)
         {
@@ -27,6 +27,7 @@ namespace NuGet.Configuration
             }
 
             ProxyAddress = CreateProxyUri(proxyAddress);
+            BypassList = Array.Empty<string>();
         }
 
         public WebProxy(Uri proxyAddress)
@@ -37,11 +38,12 @@ namespace NuGet.Configuration
             }
 
             ProxyAddress = proxyAddress;
+            BypassList = Array.Empty<string>();
         }
 
         public Uri ProxyAddress { get; private set; }
 
-        public ICredentials Credentials { get; set; }
+        public ICredentials? Credentials { get; set; }
 
         public IReadOnlyList<string> BypassList
         {
@@ -92,11 +94,6 @@ namespace NuGet.Configuration
 
         private static Uri CreateProxyUri(string address)
         {
-            if (address == null)
-            {
-                return null;
-            }
-
             if (address.IndexOf("://", StringComparison.Ordinal) == -1)
             {
                 address = "http://" + address;

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
@@ -1,32 +1,32 @@
 #nullable enable
 NuGet.Configuration.AddItem
-~NuGet.Configuration.AddItem.AddItem(string key, string value) -> void
-~NuGet.Configuration.AddItem.AddItem(string key, string value, System.Collections.Generic.IReadOnlyDictionary<string, string> additionalAttributes) -> void
-~NuGet.Configuration.AddItem.AddOrUpdateAdditionalAttribute(string attributeName, string value) -> void
-~NuGet.Configuration.AddItem.AdditionalAttributes.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>
-~NuGet.Configuration.AddItem.Key.get -> string
+NuGet.Configuration.AddItem.AddItem(string! key, string? value) -> void
+NuGet.Configuration.AddItem.AddItem(string! key, string? value, System.Collections.Generic.IReadOnlyDictionary<string!, string!>? additionalAttributes) -> void
+NuGet.Configuration.AddItem.AddOrUpdateAdditionalAttribute(string! attributeName, string! value) -> void
+NuGet.Configuration.AddItem.AdditionalAttributes.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+NuGet.Configuration.AddItem.Key.get -> string!
 NuGet.Configuration.AuthorItem
-~NuGet.Configuration.AuthorItem.AuthorItem(string name, params NuGet.Configuration.CertificateItem[] certificates) -> void
+NuGet.Configuration.AuthorItem.AuthorItem(string! name, params NuGet.Configuration.CertificateItem![]! certificates) -> void
 NuGet.Configuration.CertificateItem
 NuGet.Configuration.CertificateItem.AllowUntrustedRoot.get -> bool
 NuGet.Configuration.CertificateItem.AllowUntrustedRoot.set -> void
-~NuGet.Configuration.CertificateItem.CertificateItem(string fingerprint, NuGet.Common.HashAlgorithmName hashAlgorithm, bool allowUntrustedRoot = false) -> void
-~NuGet.Configuration.CertificateItem.Fingerprint.get -> string
-~NuGet.Configuration.CertificateItem.Fingerprint.set -> void
+NuGet.Configuration.CertificateItem.CertificateItem(string! fingerprint, NuGet.Common.HashAlgorithmName hashAlgorithm, bool allowUntrustedRoot = false) -> void
+NuGet.Configuration.CertificateItem.Fingerprint.get -> string!
+NuGet.Configuration.CertificateItem.Fingerprint.set -> void
 NuGet.Configuration.CertificateItem.HashAlgorithm.get -> NuGet.Common.HashAlgorithmName
 NuGet.Configuration.CertificateItem.HashAlgorithm.set -> void
 NuGet.Configuration.ClearItem
 NuGet.Configuration.ClearItem.ClearItem() -> void
 NuGet.Configuration.ClientCertItem
-~NuGet.Configuration.ClientCertItem.ClientCertItem(string packageSource) -> void
-~NuGet.Configuration.ClientCertItem.PackageSource.get -> string
-~NuGet.Configuration.ClientCertItem.SetPackageSource(string value) -> void
+NuGet.Configuration.ClientCertItem.ClientCertItem(string! packageSource) -> void
+NuGet.Configuration.ClientCertItem.PackageSource.get -> string!
+NuGet.Configuration.ClientCertItem.SetPackageSource(string! value) -> void
 NuGet.Configuration.ClientCertificateProvider
-~NuGet.Configuration.ClientCertificateProvider.AddOrUpdate(NuGet.Configuration.ClientCertItem item) -> void
-~NuGet.Configuration.ClientCertificateProvider.ClientCertificateProvider(NuGet.Configuration.ISettings settings) -> void
-~NuGet.Configuration.ClientCertificateProvider.GetClientCertificate(string packageSourceName) -> NuGet.Configuration.ClientCertItem
-~NuGet.Configuration.ClientCertificateProvider.GetClientCertificates() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.ClientCertItem>
-~NuGet.Configuration.ClientCertificateProvider.Remove(System.Collections.Generic.IReadOnlyList<NuGet.Configuration.ClientCertItem> items) -> void
+NuGet.Configuration.ClientCertificateProvider.AddOrUpdate(NuGet.Configuration.ClientCertItem! item) -> void
+NuGet.Configuration.ClientCertificateProvider.ClientCertificateProvider(NuGet.Configuration.ISettings! settings) -> void
+NuGet.Configuration.ClientCertificateProvider.GetClientCertificate(string! packageSourceName) -> NuGet.Configuration.ClientCertItem?
+NuGet.Configuration.ClientCertificateProvider.GetClientCertificates() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.ClientCertItem!>!
+NuGet.Configuration.ClientCertificateProvider.Remove(System.Collections.Generic.IReadOnlyList<NuGet.Configuration.ClientCertItem!>! items) -> void
 NuGet.Configuration.ConfigurationConstants
 NuGet.Configuration.ConfigurationDefaults
 NuGet.Configuration.ConfigurationDefaults.DefaultPackageRestoreConsent.get -> string?
@@ -37,37 +37,37 @@ NuGet.Configuration.CredentialRequestType.Forbidden = 2 -> NuGet.Configuration.C
 NuGet.Configuration.CredentialRequestType.Proxy = 0 -> NuGet.Configuration.CredentialRequestType
 NuGet.Configuration.CredentialRequestType.Unauthorized = 1 -> NuGet.Configuration.CredentialRequestType
 NuGet.Configuration.CredentialsItem
-~NuGet.Configuration.CredentialsItem.CredentialsItem(string name, string username, string password, bool isPasswordClearText, string validAuthenticationTypes) -> void
+NuGet.Configuration.CredentialsItem.CredentialsItem(string! name, string! username, string! password, bool isPasswordClearText, string? validAuthenticationTypes) -> void
 NuGet.Configuration.CredentialsItem.IsPasswordClearText.get -> bool
-~NuGet.Configuration.CredentialsItem.Password.get -> string
-~NuGet.Configuration.CredentialsItem.UpdatePassword(string password, bool isPasswordClearText = true) -> void
-~NuGet.Configuration.CredentialsItem.Username.get -> string
-~NuGet.Configuration.CredentialsItem.Username.set -> void
-~NuGet.Configuration.CredentialsItem.ValidAuthenticationTypes.get -> string
-~NuGet.Configuration.CredentialsItem.ValidAuthenticationTypes.set -> void
+NuGet.Configuration.CredentialsItem.Password.get -> string!
+NuGet.Configuration.CredentialsItem.UpdatePassword(string! password, bool isPasswordClearText = true) -> void
+NuGet.Configuration.CredentialsItem.Username.get -> string!
+NuGet.Configuration.CredentialsItem.Username.set -> void
+NuGet.Configuration.CredentialsItem.ValidAuthenticationTypes.get -> string?
+NuGet.Configuration.CredentialsItem.ValidAuthenticationTypes.set -> void
 NuGet.Configuration.EncryptionUtility
 NuGet.Configuration.FileClientCertItem
-~NuGet.Configuration.FileClientCertItem.FileClientCertItem(string packageSource, string filePath, string password, bool storePasswordInClearText, string settingsFilePath) -> void
-~NuGet.Configuration.FileClientCertItem.FilePath.get -> string
+NuGet.Configuration.FileClientCertItem.FileClientCertItem(string! packageSource, string! filePath, string? password, bool storePasswordInClearText, string! settingsFilePath) -> void
+NuGet.Configuration.FileClientCertItem.FilePath.get -> string!
 NuGet.Configuration.FileClientCertItem.IsPasswordIsClearText.get -> bool
-~NuGet.Configuration.FileClientCertItem.Password.get -> string
-~NuGet.Configuration.FileClientCertItem.Update(string filePath, string password, bool storePasswordInClearText) -> void
+NuGet.Configuration.FileClientCertItem.Password.get -> string?
+NuGet.Configuration.FileClientCertItem.Update(string! filePath, string? password, bool storePasswordInClearText) -> void
 NuGet.Configuration.IClientCertificateProvider
-~NuGet.Configuration.IClientCertificateProvider.AddOrUpdate(NuGet.Configuration.ClientCertItem item) -> void
-~NuGet.Configuration.IClientCertificateProvider.GetClientCertificates() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.ClientCertItem>
-~NuGet.Configuration.IClientCertificateProvider.Remove(System.Collections.Generic.IReadOnlyList<NuGet.Configuration.ClientCertItem> items) -> void
+NuGet.Configuration.IClientCertificateProvider.AddOrUpdate(NuGet.Configuration.ClientCertItem! item) -> void
+NuGet.Configuration.IClientCertificateProvider.GetClientCertificates() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.ClientCertItem!>!
+NuGet.Configuration.IClientCertificateProvider.Remove(System.Collections.Generic.IReadOnlyList<NuGet.Configuration.ClientCertItem!>! items) -> void
 NuGet.Configuration.ICredentialCache
-~NuGet.Configuration.ICredentialCache.Add(System.Uri uri, System.Net.ICredentials credentials) -> void
-~NuGet.Configuration.ICredentialCache.GetCredentials(System.Uri uri) -> System.Net.ICredentials
+NuGet.Configuration.ICredentialCache.Add(System.Uri! uri, System.Net.ICredentials! credentials) -> void
+NuGet.Configuration.ICredentialCache.GetCredentials(System.Uri! uri) -> System.Net.ICredentials!
 NuGet.Configuration.ICredentialService
-~NuGet.Configuration.ICredentialService.GetCredentialsAsync(System.Uri uri, System.Net.IWebProxy proxy, NuGet.Configuration.CredentialRequestType type, string message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.ICredentials>
+NuGet.Configuration.ICredentialService.GetCredentialsAsync(System.Uri! uri, System.Net.IWebProxy? proxy, NuGet.Configuration.CredentialRequestType type, string! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.ICredentials?>!
 NuGet.Configuration.ICredentialService.HandlesDefaultCredentials.get -> bool
-~NuGet.Configuration.ICredentialService.TryGetLastKnownGoodCredentialsFromCache(System.Uri uri, bool isProxy, out System.Net.ICredentials credentials) -> bool
+NuGet.Configuration.ICredentialService.TryGetLastKnownGoodCredentialsFromCache(System.Uri! uri, bool isProxy, out System.Net.ICredentials? credentials) -> bool
 NuGet.Configuration.IExtensionLocator
-~NuGet.Configuration.IExtensionLocator.FindCredentialProviders() -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Configuration.IExtensionLocator.FindExtensions() -> System.Collections.Generic.IEnumerable<string>
+NuGet.Configuration.IExtensionLocator.FindCredentialProviders() -> System.Collections.Generic.IEnumerable<string!>!
+NuGet.Configuration.IExtensionLocator.FindExtensions() -> System.Collections.Generic.IEnumerable<string!>!
 NuGet.Configuration.IMachineWideSettings
-~NuGet.Configuration.IMachineWideSettings.Settings.get -> NuGet.Configuration.ISettings
+NuGet.Configuration.IMachineWideSettings.Settings.get -> NuGet.Configuration.ISettings!
 NuGet.Configuration.IPackageSourceProvider
 NuGet.Configuration.IPackageSourceProvider.ActivePackageSourceName.get -> string?
 NuGet.Configuration.IPackageSourceProvider.AddPackageSource(NuGet.Configuration.PackageSource! source) -> void
@@ -84,44 +84,44 @@ NuGet.Configuration.IPackageSourceProvider.SaveActivePackageSource(NuGet.Configu
 NuGet.Configuration.IPackageSourceProvider.SavePackageSources(System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource!>! sources) -> void
 NuGet.Configuration.IPackageSourceProvider.UpdatePackageSource(NuGet.Configuration.PackageSource! source, bool updateCredentials, bool updateEnabled) -> void
 NuGet.Configuration.IProxyCache
-~NuGet.Configuration.IProxyCache.Add(System.Net.IWebProxy proxy) -> void
-~NuGet.Configuration.IProxyCache.GetProxy(System.Uri uri) -> System.Net.IWebProxy
+NuGet.Configuration.IProxyCache.Add(System.Net.IWebProxy! proxy) -> void
+NuGet.Configuration.IProxyCache.GetProxy(System.Uri! uri) -> System.Net.IWebProxy?
 NuGet.Configuration.IProxyCredentialCache
-~NuGet.Configuration.IProxyCredentialCache.UpdateCredential(System.Uri proxyAddress, System.Net.NetworkCredential credentials) -> void
+NuGet.Configuration.IProxyCredentialCache.UpdateCredential(System.Uri! proxyAddress, System.Net.NetworkCredential! credentials) -> void
 NuGet.Configuration.IProxyCredentialCache.Version.get -> System.Guid
 NuGet.Configuration.ISettings
-~NuGet.Configuration.ISettings.AddOrUpdate(string sectionName, NuGet.Configuration.SettingItem item) -> void
-~NuGet.Configuration.ISettings.GetConfigFilePaths() -> System.Collections.Generic.IList<string>
-~NuGet.Configuration.ISettings.GetConfigRoots() -> System.Collections.Generic.IList<string>
-~NuGet.Configuration.ISettings.GetSection(string sectionName) -> NuGet.Configuration.SettingSection
-~NuGet.Configuration.ISettings.Remove(string sectionName, NuGet.Configuration.SettingItem item) -> void
+NuGet.Configuration.ISettings.AddOrUpdate(string! sectionName, NuGet.Configuration.SettingItem! item) -> void
+NuGet.Configuration.ISettings.GetConfigFilePaths() -> System.Collections.Generic.IList<string!>!
+NuGet.Configuration.ISettings.GetConfigRoots() -> System.Collections.Generic.IList<string!>!
+NuGet.Configuration.ISettings.GetSection(string! sectionName) -> NuGet.Configuration.SettingSection?
+NuGet.Configuration.ISettings.Remove(string! sectionName, NuGet.Configuration.SettingItem! item) -> void
 NuGet.Configuration.ISettings.SaveToDisk() -> void
-NuGet.Configuration.ISettings.SettingsChanged -> System.EventHandler
+NuGet.Configuration.ISettings.SettingsChanged -> System.EventHandler?
 NuGet.Configuration.NuGetConfigurationException
-~NuGet.Configuration.NuGetConfigurationException.NuGetConfigurationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~NuGet.Configuration.NuGetConfigurationException.NuGetConfigurationException(string message) -> void
-~NuGet.Configuration.NuGetConfigurationException.NuGetConfigurationException(string message, System.Exception innerException) -> void
+NuGet.Configuration.NuGetConfigurationException.NuGetConfigurationException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+NuGet.Configuration.NuGetConfigurationException.NuGetConfigurationException(string! message) -> void
+NuGet.Configuration.NuGetConfigurationException.NuGetConfigurationException(string! message, System.Exception? innerException) -> void
 NuGet.Configuration.NuGetConstants
 NuGet.Configuration.NuGetPathContext
-~NuGet.Configuration.NuGetPathContext.FallbackPackageFolders.get -> System.Collections.Generic.IReadOnlyList<string>
-~NuGet.Configuration.NuGetPathContext.HttpCacheFolder.get -> string
+NuGet.Configuration.NuGetPathContext.FallbackPackageFolders.get -> System.Collections.Generic.IReadOnlyList<string!>!
+NuGet.Configuration.NuGetPathContext.HttpCacheFolder.get -> string!
 NuGet.Configuration.NuGetPathContext.NuGetPathContext() -> void
-~NuGet.Configuration.NuGetPathContext.UserPackageFolder.get -> string
+NuGet.Configuration.NuGetPathContext.UserPackageFolder.get -> string!
 NuGet.Configuration.NullSettings
-~NuGet.Configuration.NullSettings.AddOrUpdate(string sectionName, NuGet.Configuration.SettingItem item) -> void
-~NuGet.Configuration.NullSettings.GetConfigFilePaths() -> System.Collections.Generic.IList<string>
-~NuGet.Configuration.NullSettings.GetConfigRoots() -> System.Collections.Generic.IList<string>
-~NuGet.Configuration.NullSettings.GetSection(string sectionName) -> NuGet.Configuration.SettingSection
+NuGet.Configuration.NullSettings.AddOrUpdate(string! sectionName, NuGet.Configuration.SettingItem! item) -> void
+NuGet.Configuration.NullSettings.GetConfigFilePaths() -> System.Collections.Generic.IList<string!>!
+NuGet.Configuration.NullSettings.GetConfigRoots() -> System.Collections.Generic.IList<string!>!
+NuGet.Configuration.NullSettings.GetSection(string! sectionName) -> NuGet.Configuration.SettingSection?
 NuGet.Configuration.NullSettings.NullSettings() -> void
-~NuGet.Configuration.NullSettings.Remove(string sectionName, NuGet.Configuration.SettingItem item) -> void
+NuGet.Configuration.NullSettings.Remove(string! sectionName, NuGet.Configuration.SettingItem! item) -> void
 NuGet.Configuration.NullSettings.SaveToDisk() -> void
-NuGet.Configuration.NullSettings.SettingsChanged -> System.EventHandler
+NuGet.Configuration.NullSettings.SettingsChanged -> System.EventHandler?
 NuGet.Configuration.OwnersItem
-~NuGet.Configuration.OwnersItem.Content.get -> System.Collections.Generic.IList<string>
-~NuGet.Configuration.OwnersItem.OwnersItem(string owners) -> void
+NuGet.Configuration.OwnersItem.Content.get -> System.Collections.Generic.IList<string!>!
+NuGet.Configuration.OwnersItem.OwnersItem(string! owners) -> void
 NuGet.Configuration.PackagePatternItem
-~NuGet.Configuration.PackagePatternItem.PackagePatternItem(string pattern) -> void
-~NuGet.Configuration.PackagePatternItem.Pattern.get -> string
+NuGet.Configuration.PackagePatternItem.PackagePatternItem(string! pattern) -> void
+NuGet.Configuration.PackagePatternItem.Pattern.get -> string!
 NuGet.Configuration.PackageSource
 NuGet.Configuration.PackageSource.AllowInsecureConnections.get -> bool
 NuGet.Configuration.PackageSource.AllowInsecureConnections.set -> void
@@ -158,33 +158,33 @@ NuGet.Configuration.PackageSource.Source.set -> void
 NuGet.Configuration.PackageSource.SourceUri.get -> System.Uri!
 NuGet.Configuration.PackageSource.TrySourceAsUri.get -> System.Uri?
 NuGet.Configuration.PackageSourceCredential
-~NuGet.Configuration.PackageSourceCredential.AsCredentialsItem() -> NuGet.Configuration.CredentialsItem
-~NuGet.Configuration.PackageSourceCredential.Equals(NuGet.Configuration.PackageSourceCredential other) -> bool
+NuGet.Configuration.PackageSourceCredential.AsCredentialsItem() -> NuGet.Configuration.CredentialsItem!
+NuGet.Configuration.PackageSourceCredential.Equals(NuGet.Configuration.PackageSourceCredential? other) -> bool
 NuGet.Configuration.PackageSourceCredential.IsPasswordClearText.get -> bool
 NuGet.Configuration.PackageSourceCredential.IsValid() -> bool
-~NuGet.Configuration.PackageSourceCredential.PackageSourceCredential(string source, string username, string passwordText, bool isPasswordClearText, string validAuthenticationTypesText) -> void
-~NuGet.Configuration.PackageSourceCredential.Password.get -> string
-~NuGet.Configuration.PackageSourceCredential.PasswordText.get -> string
-~NuGet.Configuration.PackageSourceCredential.Source.get -> string
-~NuGet.Configuration.PackageSourceCredential.ToICredentials() -> System.Net.ICredentials
-~NuGet.Configuration.PackageSourceCredential.Username.get -> string
-~NuGet.Configuration.PackageSourceCredential.ValidAuthenticationTypes.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Configuration.PackageSourceCredential.ValidAuthenticationTypesText.get -> string
+NuGet.Configuration.PackageSourceCredential.PackageSourceCredential(string! source, string! username, string! passwordText, bool isPasswordClearText, string? validAuthenticationTypesText) -> void
+NuGet.Configuration.PackageSourceCredential.Password.get -> string!
+NuGet.Configuration.PackageSourceCredential.PasswordText.get -> string!
+NuGet.Configuration.PackageSourceCredential.Source.get -> string!
+NuGet.Configuration.PackageSourceCredential.ToICredentials() -> System.Net.ICredentials!
+NuGet.Configuration.PackageSourceCredential.Username.get -> string!
+NuGet.Configuration.PackageSourceCredential.ValidAuthenticationTypes.get -> System.Collections.Generic.IEnumerable<string!>!
+NuGet.Configuration.PackageSourceCredential.ValidAuthenticationTypesText.get -> string?
 NuGet.Configuration.PackageSourceMapping
 NuGet.Configuration.PackageSourceMapping.GetConfiguredPackageSources(string! packageId) -> System.Collections.Generic.IReadOnlyList<string!>!
 NuGet.Configuration.PackageSourceMapping.IsEnabled.get -> bool
 NuGet.Configuration.PackageSourceMapping.PackageSourceMapping(System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<string!>!>! patterns) -> void
 NuGet.Configuration.PackageSourceMapping.SearchForPattern(string! packageId) -> string?
 NuGet.Configuration.PackageSourceMappingProvider
-~NuGet.Configuration.PackageSourceMappingProvider.GetPackageSourceMappingItems() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSourceMappingSourceItem>
-~NuGet.Configuration.PackageSourceMappingProvider.PackageSourceMappingProvider(NuGet.Configuration.ISettings settings) -> void
-~NuGet.Configuration.PackageSourceMappingProvider.PackageSourceMappingProvider(NuGet.Configuration.ISettings settings, bool shouldSkipSave) -> void
-~NuGet.Configuration.PackageSourceMappingProvider.SavePackageSourceMappings(System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSourceMappingSourceItem> packageSourceMappingsSourceItems) -> void
+NuGet.Configuration.PackageSourceMappingProvider.GetPackageSourceMappingItems() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSourceMappingSourceItem!>!
+NuGet.Configuration.PackageSourceMappingProvider.PackageSourceMappingProvider(NuGet.Configuration.ISettings! settings) -> void
+NuGet.Configuration.PackageSourceMappingProvider.PackageSourceMappingProvider(NuGet.Configuration.ISettings! settings, bool shouldSkipSave) -> void
+NuGet.Configuration.PackageSourceMappingProvider.SavePackageSourceMappings(System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSourceMappingSourceItem!>! packageSourceMappingsSourceItems) -> void
 NuGet.Configuration.PackageSourceMappingProvider.ShouldSkipSave.get -> bool
 NuGet.Configuration.PackageSourceMappingSourceItem
-~NuGet.Configuration.PackageSourceMappingSourceItem.PackageSourceMappingSourceItem(string name, System.Collections.Generic.IEnumerable<NuGet.Configuration.PackagePatternItem> packagePatternItems) -> void
-~NuGet.Configuration.PackageSourceMappingSourceItem.Patterns.get -> System.Collections.Generic.IList<NuGet.Configuration.PackagePatternItem>
-~NuGet.Configuration.PackageSourceMappingSourceItem.SetKey(string value) -> void
+NuGet.Configuration.PackageSourceMappingSourceItem.PackageSourceMappingSourceItem(string! name, System.Collections.Generic.IEnumerable<NuGet.Configuration.PackagePatternItem!>! packagePatternItems) -> void
+NuGet.Configuration.PackageSourceMappingSourceItem.Patterns.get -> System.Collections.Generic.IList<NuGet.Configuration.PackagePatternItem!>!
+NuGet.Configuration.PackageSourceMappingSourceItem.SetKey(string! value) -> void
 NuGet.Configuration.PackageSourceProvider
 NuGet.Configuration.PackageSourceProvider.ActivePackageSourceName.get -> string?
 NuGet.Configuration.PackageSourceProvider.AddPackageSource(NuGet.Configuration.PackageSource! source) -> void
@@ -209,28 +209,28 @@ NuGet.Configuration.PackageSourceProvider.SavePackageSources(System.Collections.
 NuGet.Configuration.PackageSourceProvider.Settings.get -> NuGet.Configuration.ISettings!
 NuGet.Configuration.PackageSourceProvider.UpdatePackageSource(NuGet.Configuration.PackageSource! source, bool updateCredentials, bool updateEnabled) -> void
 NuGet.Configuration.ProxyCache
-~NuGet.Configuration.ProxyCache.Add(System.Net.IWebProxy proxy) -> void
-~NuGet.Configuration.ProxyCache.GetCredential(System.Uri proxyAddress, string authType) -> System.Net.NetworkCredential
-~NuGet.Configuration.ProxyCache.GetProxy(System.Uri sourceUri) -> System.Net.IWebProxy
-~NuGet.Configuration.ProxyCache.GetUserConfiguredProxy() -> NuGet.Configuration.WebProxy
-~NuGet.Configuration.ProxyCache.ProxyCache(NuGet.Configuration.ISettings settings, NuGet.Common.IEnvironmentVariableReader environment) -> void
-~NuGet.Configuration.ProxyCache.UpdateCredential(System.Uri proxyAddress, System.Net.NetworkCredential credentials) -> void
+NuGet.Configuration.ProxyCache.Add(System.Net.IWebProxy? proxy) -> void
+NuGet.Configuration.ProxyCache.GetCredential(System.Uri! proxyAddress, string! authType) -> System.Net.NetworkCredential?
+NuGet.Configuration.ProxyCache.GetProxy(System.Uri! sourceUri) -> System.Net.IWebProxy?
+NuGet.Configuration.ProxyCache.GetUserConfiguredProxy() -> NuGet.Configuration.WebProxy?
+NuGet.Configuration.ProxyCache.ProxyCache(NuGet.Configuration.ISettings! settings, NuGet.Common.IEnvironmentVariableReader! environment) -> void
+NuGet.Configuration.ProxyCache.UpdateCredential(System.Uri! proxyAddress, System.Net.NetworkCredential! credentials) -> void
 NuGet.Configuration.ProxyCache.Version.get -> System.Guid
 NuGet.Configuration.RepositoryItem
-~NuGet.Configuration.RepositoryItem.Name.get -> string
-~NuGet.Configuration.RepositoryItem.Name.set -> void
-~NuGet.Configuration.RepositoryItem.Owners.get -> System.Collections.Generic.IList<string>
-~NuGet.Configuration.RepositoryItem.RepositoryItem(string name, string serviceIndex, params NuGet.Configuration.CertificateItem[] certificates) -> void
-~NuGet.Configuration.RepositoryItem.RepositoryItem(string name, string serviceIndex, string owners, params NuGet.Configuration.CertificateItem[] certificates) -> void
-~NuGet.Configuration.RepositoryItem.ServiceIndex.get -> string
+NuGet.Configuration.RepositoryItem.Name.get -> string!
+NuGet.Configuration.RepositoryItem.Name.set -> void
+NuGet.Configuration.RepositoryItem.Owners.get -> System.Collections.Generic.IList<string!>!
+NuGet.Configuration.RepositoryItem.RepositoryItem(string! name, string! serviceIndex, params NuGet.Configuration.CertificateItem![]! certificates) -> void
+NuGet.Configuration.RepositoryItem.RepositoryItem(string! name, string! serviceIndex, string? owners, params NuGet.Configuration.CertificateItem![]! certificates) -> void
+NuGet.Configuration.RepositoryItem.ServiceIndex.get -> string!
 NuGet.Configuration.SettingBase
 NuGet.Configuration.SettingBase.SettingBase() -> void
 NuGet.Configuration.SettingElement
-~NuGet.Configuration.SettingElement.AddAttribute(string attributeName, string value) -> void
-~NuGet.Configuration.SettingElement.AddOrUpdateAttribute(string attributeName, string value) -> void
-~NuGet.Configuration.SettingElement.MutableAttributes.get -> System.Collections.Generic.Dictionary<string, string>
+NuGet.Configuration.SettingElement.AddAttribute(string! attributeName, string! value) -> void
+NuGet.Configuration.SettingElement.AddOrUpdateAttribute(string! attributeName, string? value) -> void
+NuGet.Configuration.SettingElement.MutableAttributes.get -> System.Collections.Generic.Dictionary<string!, string!>!
 NuGet.Configuration.SettingElement.SettingElement() -> void
-~NuGet.Configuration.SettingElement.SettingElement(System.Collections.Generic.IReadOnlyDictionary<string, string> attributes) -> void
+NuGet.Configuration.SettingElement.SettingElement(System.Collections.Generic.IReadOnlyDictionary<string!, string!>? attributes) -> void
 NuGet.Configuration.SettingElementType
 NuGet.Configuration.SettingElementType.ActivePackageSource = 2 -> NuGet.Configuration.SettingElementType
 NuGet.Configuration.SettingElementType.Add = 9 -> NuGet.Configuration.SettingElementType
@@ -254,291 +254,285 @@ NuGet.Configuration.SettingElementType.StoreCert = 16 -> NuGet.Configuration.Set
 NuGet.Configuration.SettingElementType.Unknown = 0 -> NuGet.Configuration.SettingElementType
 NuGet.Configuration.SettingItem
 NuGet.Configuration.SettingItem.SettingItem() -> void
-~NuGet.Configuration.SettingItem.SettingItem(System.Collections.Generic.IReadOnlyDictionary<string, string> attributes) -> void
+NuGet.Configuration.SettingItem.SettingItem(System.Collections.Generic.IReadOnlyDictionary<string!, string!>? attributes) -> void
 NuGet.Configuration.SettingSection
-~NuGet.Configuration.SettingSection.GetFirstItemWithAttribute<T>(string attributeName, string expectedAttributeValue) -> T
-~NuGet.Configuration.SettingSection.Items.get -> System.Collections.Generic.IReadOnlyCollection<NuGet.Configuration.SettingItem>
-~NuGet.Configuration.SettingSection.SettingSection(string name, System.Collections.Generic.IReadOnlyDictionary<string, string> attributes, System.Collections.Generic.IEnumerable<NuGet.Configuration.SettingItem> children) -> void
+NuGet.Configuration.SettingSection.GetFirstItemWithAttribute<T>(string! attributeName, string! expectedAttributeValue) -> T?
+NuGet.Configuration.SettingSection.Items.get -> System.Collections.Generic.IReadOnlyCollection<NuGet.Configuration.SettingItem!>!
+NuGet.Configuration.SettingSection.SettingSection(string! name, System.Collections.Generic.IReadOnlyDictionary<string!, string!>? attributes, System.Collections.Generic.IEnumerable<NuGet.Configuration.SettingItem!>? children) -> void
 NuGet.Configuration.SettingText
-~NuGet.Configuration.SettingText.SettingText(string value) -> void
-~NuGet.Configuration.SettingText.Value.get -> string
-~NuGet.Configuration.SettingText.Value.set -> void
+NuGet.Configuration.SettingText.SettingText(string! value) -> void
+NuGet.Configuration.SettingText.Value.get -> string!
+NuGet.Configuration.SettingText.Value.set -> void
 NuGet.Configuration.Settings
-~NuGet.Configuration.Settings.AddOrUpdate(string sectionName, NuGet.Configuration.SettingItem item) -> void
-~NuGet.Configuration.Settings.GetConfigFilePaths() -> System.Collections.Generic.IList<string>
-~NuGet.Configuration.Settings.GetConfigRoots() -> System.Collections.Generic.IList<string>
-~NuGet.Configuration.Settings.GetSection(string sectionName) -> NuGet.Configuration.SettingSection
-~NuGet.Configuration.Settings.Remove(string sectionName, NuGet.Configuration.SettingItem item) -> void
+NuGet.Configuration.Settings.AddOrUpdate(string! sectionName, NuGet.Configuration.SettingItem! item) -> void
+NuGet.Configuration.Settings.GetConfigFilePaths() -> System.Collections.Generic.IList<string!>!
+NuGet.Configuration.Settings.GetConfigRoots() -> System.Collections.Generic.IList<string!>!
+NuGet.Configuration.Settings.GetSection(string! sectionName) -> NuGet.Configuration.SettingSection?
+NuGet.Configuration.Settings.Remove(string! sectionName, NuGet.Configuration.SettingItem! item) -> void
 NuGet.Configuration.Settings.SaveToDisk() -> void
-~NuGet.Configuration.Settings.Settings(string root) -> void
-~NuGet.Configuration.Settings.Settings(string root, string fileName) -> void
-~NuGet.Configuration.Settings.Settings(string root, string fileName, bool isMachineWide) -> void
-NuGet.Configuration.Settings.SettingsChanged -> System.EventHandler
-~NuGet.Configuration.SettingsGroup<T>
-~NuGet.Configuration.SettingsGroup<T>.Children.get -> System.Collections.Generic.IList<T>
-NuGet.Configuration.SettingsGroup<T>.SettingsGroup() -> void
-~NuGet.Configuration.SettingsGroup<T>.SettingsGroup(System.Collections.Generic.IReadOnlyDictionary<string, string> attributes, System.Collections.Generic.IEnumerable<T> children) -> void
-~NuGet.Configuration.SettingsGroup<T>.TryGetChild(T expectedChild, out T currentChild) -> bool
+NuGet.Configuration.Settings.Settings(string! root) -> void
+NuGet.Configuration.Settings.Settings(string! root, string! fileName) -> void
+NuGet.Configuration.Settings.Settings(string! root, string! fileName, bool isMachineWide) -> void
+NuGet.Configuration.Settings.SettingsChanged -> System.EventHandler?
+NuGet.Configuration.SettingsGroup<T>
+NuGet.Configuration.SettingsGroup<T>.Children.get -> System.Collections.Generic.IList<T!>!
+NuGet.Configuration.SettingsGroup<T>.TryGetChild(T! expectedChild, out T? currentChild) -> bool
 NuGet.Configuration.SettingsLoadingContext
 NuGet.Configuration.SettingsLoadingContext.Dispose() -> void
 NuGet.Configuration.SettingsLoadingContext.SettingsLoadingContext() -> void
 NuGet.Configuration.SettingsUtility
 NuGet.Configuration.SourceItem
-~NuGet.Configuration.SourceItem.AllowInsecureConnections.get -> string
-~NuGet.Configuration.SourceItem.AllowInsecureConnections.set -> void
-~NuGet.Configuration.SourceItem.ProtocolVersion.get -> string
-~NuGet.Configuration.SourceItem.ProtocolVersion.set -> void
-~NuGet.Configuration.SourceItem.SourceItem(string key, string value) -> void
-~NuGet.Configuration.SourceItem.SourceItem(string key, string value, string protocolVersion) -> void
-~NuGet.Configuration.SourceItem.SourceItem(string key, string value, string protocolVersion, string allowInsecureConnections) -> void
+NuGet.Configuration.SourceItem.AllowInsecureConnections.get -> string?
+NuGet.Configuration.SourceItem.AllowInsecureConnections.set -> void
+NuGet.Configuration.SourceItem.ProtocolVersion.get -> string?
+NuGet.Configuration.SourceItem.ProtocolVersion.set -> void
+NuGet.Configuration.SourceItem.SourceItem(string! key, string! value) -> void
+NuGet.Configuration.SourceItem.SourceItem(string! key, string! value, string? protocolVersion) -> void
+NuGet.Configuration.SourceItem.SourceItem(string! key, string! value, string? protocolVersion, string? allowInsecureConnections) -> void
 NuGet.Configuration.StoreClientCertItem
 NuGet.Configuration.StoreClientCertItem.FindType.get -> System.Security.Cryptography.X509Certificates.X509FindType
-~NuGet.Configuration.StoreClientCertItem.FindValue.get -> string
-~NuGet.Configuration.StoreClientCertItem.StoreClientCertItem(string packageSource, string findValue, System.Security.Cryptography.X509Certificates.StoreLocation? storeLocation = null, System.Security.Cryptography.X509Certificates.StoreName? storeName = null, System.Security.Cryptography.X509Certificates.X509FindType? findBy = null) -> void
+NuGet.Configuration.StoreClientCertItem.FindValue.get -> string!
+NuGet.Configuration.StoreClientCertItem.StoreClientCertItem(string! packageSource, string! findValue, System.Security.Cryptography.X509Certificates.StoreLocation? storeLocation = null, System.Security.Cryptography.X509Certificates.StoreName? storeName = null, System.Security.Cryptography.X509Certificates.X509FindType? findBy = null) -> void
 NuGet.Configuration.StoreClientCertItem.StoreLocation.get -> System.Security.Cryptography.X509Certificates.StoreLocation
 NuGet.Configuration.StoreClientCertItem.StoreName.get -> System.Security.Cryptography.X509Certificates.StoreName
-~NuGet.Configuration.StoreClientCertItem.Update(string findValue, System.Security.Cryptography.X509Certificates.StoreLocation? storeLocation = null, System.Security.Cryptography.X509Certificates.StoreName? storeName = null, System.Security.Cryptography.X509Certificates.X509FindType? findBy = null) -> void
+NuGet.Configuration.StoreClientCertItem.Update(string? findValue, System.Security.Cryptography.X509Certificates.StoreLocation? storeLocation = null, System.Security.Cryptography.X509Certificates.StoreName? storeName = null, System.Security.Cryptography.X509Certificates.X509FindType? findBy = null) -> void
 NuGet.Configuration.TrustedSignerItem
-~NuGet.Configuration.TrustedSignerItem.Certificates.get -> System.Collections.Generic.IList<NuGet.Configuration.CertificateItem>
-~NuGet.Configuration.TrustedSignerItem.SetName(string value) -> void
-~NuGet.Configuration.TrustedSignerItem.TrustedSignerItem(string name, System.Collections.Generic.IEnumerable<NuGet.Configuration.CertificateItem> certificates) -> void
+NuGet.Configuration.TrustedSignerItem.Certificates.get -> System.Collections.Generic.IList<NuGet.Configuration.CertificateItem!>!
+NuGet.Configuration.TrustedSignerItem.SetName(string! value) -> void
+NuGet.Configuration.TrustedSignerItem.TrustedSignerItem(string! name, System.Collections.Generic.IEnumerable<NuGet.Configuration.CertificateItem!>! certificates) -> void
 NuGet.Configuration.UnknownItem
-~NuGet.Configuration.UnknownItem.Attributes.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>
-~NuGet.Configuration.UnknownItem.Children.get -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.SettingBase>
-~NuGet.Configuration.UnknownItem.UnknownItem(string name, System.Collections.Generic.IReadOnlyDictionary<string, string> attributes, System.Collections.Generic.IEnumerable<NuGet.Configuration.SettingBase> children) -> void
+NuGet.Configuration.UnknownItem.Children.get -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.SettingBase!>!
+NuGet.Configuration.UnknownItem.UnknownItem(string! name, System.Collections.Generic.IReadOnlyDictionary<string!, string!>? attributes, System.Collections.Generic.IEnumerable<NuGet.Configuration.SettingBase!>? children) -> void
 NuGet.Configuration.VirtualSettingSection
 NuGet.Configuration.WebProxy
-~NuGet.Configuration.WebProxy.BypassList.get -> System.Collections.Generic.IReadOnlyList<string>
-~NuGet.Configuration.WebProxy.BypassList.set -> void
-~NuGet.Configuration.WebProxy.Credentials.get -> System.Net.ICredentials
-~NuGet.Configuration.WebProxy.Credentials.set -> void
-~NuGet.Configuration.WebProxy.GetProxy(System.Uri destination) -> System.Uri
-~NuGet.Configuration.WebProxy.IsBypassed(System.Uri uri) -> bool
-~NuGet.Configuration.WebProxy.ProxyAddress.get -> System.Uri
-~NuGet.Configuration.WebProxy.WebProxy(System.Uri proxyAddress) -> void
-~NuGet.Configuration.WebProxy.WebProxy(string proxyAddress) -> void
+NuGet.Configuration.WebProxy.BypassList.get -> System.Collections.Generic.IReadOnlyList<string!>!
+NuGet.Configuration.WebProxy.BypassList.set -> void
+NuGet.Configuration.WebProxy.Credentials.get -> System.Net.ICredentials?
+NuGet.Configuration.WebProxy.Credentials.set -> void
+NuGet.Configuration.WebProxy.GetProxy(System.Uri! destination) -> System.Uri!
+NuGet.Configuration.WebProxy.IsBypassed(System.Uri! uri) -> bool
+NuGet.Configuration.WebProxy.ProxyAddress.get -> System.Uri!
+NuGet.Configuration.WebProxy.WebProxy(System.Uri! proxyAddress) -> void
+NuGet.Configuration.WebProxy.WebProxy(string! proxyAddress) -> void
 NuGet.Configuration.XPlatMachineWideSetting
-~NuGet.Configuration.XPlatMachineWideSetting.Settings.get -> NuGet.Configuration.ISettings
+NuGet.Configuration.XPlatMachineWideSetting.Settings.get -> NuGet.Configuration.ISettings!
 NuGet.Configuration.XPlatMachineWideSetting.XPlatMachineWideSetting() -> void
-~abstract NuGet.Configuration.ClientCertItem.Search() -> System.Collections.Generic.IEnumerable<System.Security.Cryptography.X509Certificates.X509Certificate>
-~abstract NuGet.Configuration.SettingBase.Clone() -> NuGet.Configuration.SettingBase
+abstract NuGet.Configuration.ClientCertItem.Search() -> System.Collections.Generic.IEnumerable<System.Security.Cryptography.X509Certificates.X509Certificate!>!
+abstract NuGet.Configuration.SettingBase.Clone() -> NuGet.Configuration.SettingBase!
 abstract NuGet.Configuration.SettingBase.IsEmpty() -> bool
-~const NuGet.Configuration.NuGetConstants.V2FeedUrl = "https://www.nuget.org/api/v2/" -> string
-~const NuGet.Configuration.NuGetConstants.V3FeedUrl = "https://api.nuget.org/v3/index.json" -> string
+abstract NuGet.Configuration.SettingElement.ElementName.get -> string!
+const NuGet.Configuration.NuGetConstants.V2FeedUrl = "https://www.nuget.org/api/v2/" -> string!
+const NuGet.Configuration.NuGetConstants.V3FeedUrl = "https://api.nuget.org/v3/index.json" -> string!
 const NuGet.Configuration.PackageSource.DefaultProtocolVersion = 2 -> int
 const NuGet.Configuration.PackageSource.MaxProtocolVersion = 3 -> int
-~override NuGet.Configuration.AddItem.Clone() -> NuGet.Configuration.SettingBase
-~override NuGet.Configuration.AddItem.DisallowedValues.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyCollection<string>>
-~override NuGet.Configuration.AddItem.ElementName.get -> string
-~override NuGet.Configuration.AddItem.RequiredAttributes.get -> System.Collections.Generic.IReadOnlyCollection<string>
-~override NuGet.Configuration.AuthorItem.Clone() -> NuGet.Configuration.SettingBase
-~override NuGet.Configuration.AuthorItem.ElementName.get -> string
-~override NuGet.Configuration.AuthorItem.Equals(object other) -> bool
+override NuGet.Configuration.AddItem.Clone() -> NuGet.Configuration.SettingBase!
+override NuGet.Configuration.AddItem.DisallowedValues.get -> System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyCollection<string!>!>!
+override NuGet.Configuration.AddItem.ElementName.get -> string!
+override NuGet.Configuration.AddItem.RequiredAttributes.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+override NuGet.Configuration.AuthorItem.Clone() -> NuGet.Configuration.SettingBase!
+override NuGet.Configuration.AuthorItem.ElementName.get -> string!
+override NuGet.Configuration.AuthorItem.Equals(object? other) -> bool
 override NuGet.Configuration.AuthorItem.GetHashCode() -> int
-~override NuGet.Configuration.CertificateItem.Clone() -> NuGet.Configuration.SettingBase
-~override NuGet.Configuration.CertificateItem.ElementName.get -> string
-~override NuGet.Configuration.CertificateItem.Equals(object other) -> bool
+override NuGet.Configuration.CertificateItem.Clone() -> NuGet.Configuration.SettingBase!
+override NuGet.Configuration.CertificateItem.ElementName.get -> string!
+override NuGet.Configuration.CertificateItem.Equals(object? other) -> bool
 override NuGet.Configuration.CertificateItem.GetHashCode() -> int
-~override NuGet.Configuration.ClearItem.Clone() -> NuGet.Configuration.SettingBase
-~override NuGet.Configuration.ClearItem.ElementName.get -> string
-~override NuGet.Configuration.ClearItem.Equals(object other) -> bool
+override NuGet.Configuration.ClearItem.Clone() -> NuGet.Configuration.SettingBase!
+override NuGet.Configuration.ClearItem.ElementName.get -> string!
+override NuGet.Configuration.ClearItem.Equals(object? other) -> bool
 override NuGet.Configuration.ClearItem.GetHashCode() -> int
 override NuGet.Configuration.ClearItem.IsEmpty() -> bool
 override NuGet.Configuration.ClientCertItem.CanHaveChildren.get -> bool
-~override NuGet.Configuration.ClientCertItem.Equals(object other) -> bool
+override NuGet.Configuration.ClientCertItem.Equals(object? other) -> bool
 override NuGet.Configuration.ClientCertItem.GetHashCode() -> int
-~override NuGet.Configuration.CredentialsItem.Clone() -> NuGet.Configuration.SettingBase
-~override NuGet.Configuration.CredentialsItem.ElementName.get -> string
-~override NuGet.Configuration.CredentialsItem.Equals(object other) -> bool
+override NuGet.Configuration.CredentialsItem.Clone() -> NuGet.Configuration.SettingBase!
+override NuGet.Configuration.CredentialsItem.ElementName.get -> string!
+override NuGet.Configuration.CredentialsItem.Equals(object? other) -> bool
 override NuGet.Configuration.CredentialsItem.GetHashCode() -> int
 override NuGet.Configuration.CredentialsItem.IsEmpty() -> bool
-~override NuGet.Configuration.FileClientCertItem.Clone() -> NuGet.Configuration.SettingBase
-~override NuGet.Configuration.FileClientCertItem.ElementName.get -> string
-~override NuGet.Configuration.FileClientCertItem.Search() -> System.Collections.Generic.IEnumerable<System.Security.Cryptography.X509Certificates.X509Certificate>
-~override NuGet.Configuration.OwnersItem.Clone() -> NuGet.Configuration.SettingBase
-~override NuGet.Configuration.OwnersItem.ElementName.get -> string
-~override NuGet.Configuration.OwnersItem.Equals(object other) -> bool
+override NuGet.Configuration.FileClientCertItem.Clone() -> NuGet.Configuration.SettingBase!
+override NuGet.Configuration.FileClientCertItem.ElementName.get -> string!
+override NuGet.Configuration.FileClientCertItem.Search() -> System.Collections.Generic.IEnumerable<System.Security.Cryptography.X509Certificates.X509Certificate!>!
+override NuGet.Configuration.OwnersItem.Clone() -> NuGet.Configuration.SettingBase!
+override NuGet.Configuration.OwnersItem.ElementName.get -> string!
+override NuGet.Configuration.OwnersItem.Equals(object? other) -> bool
 override NuGet.Configuration.OwnersItem.GetHashCode() -> int
-~override NuGet.Configuration.PackagePatternItem.Clone() -> NuGet.Configuration.SettingBase
-~override NuGet.Configuration.PackagePatternItem.ElementName.get -> string
-~override NuGet.Configuration.PackagePatternItem.Equals(object other) -> bool
+override NuGet.Configuration.PackagePatternItem.Clone() -> NuGet.Configuration.SettingBase!
+override NuGet.Configuration.PackagePatternItem.ElementName.get -> string!
+override NuGet.Configuration.PackagePatternItem.Equals(object? other) -> bool
 override NuGet.Configuration.PackagePatternItem.GetHashCode() -> int
 override NuGet.Configuration.PackageSource.Equals(object? obj) -> bool
 override NuGet.Configuration.PackageSource.GetHashCode() -> int
 override NuGet.Configuration.PackageSource.ToString() -> string!
-~override NuGet.Configuration.PackageSourceCredential.Equals(object other) -> bool
+override NuGet.Configuration.PackageSourceCredential.Equals(object? other) -> bool
 override NuGet.Configuration.PackageSourceCredential.GetHashCode() -> int
 override NuGet.Configuration.PackageSourceMappingSourceItem.CanHaveChildren.get -> bool
-~override NuGet.Configuration.PackageSourceMappingSourceItem.Clone() -> NuGet.Configuration.SettingBase
-~override NuGet.Configuration.PackageSourceMappingSourceItem.ElementName.get -> string
-~override NuGet.Configuration.PackageSourceMappingSourceItem.Equals(object other) -> bool
+override NuGet.Configuration.PackageSourceMappingSourceItem.Clone() -> NuGet.Configuration.SettingBase!
+override NuGet.Configuration.PackageSourceMappingSourceItem.ElementName.get -> string!
+override NuGet.Configuration.PackageSourceMappingSourceItem.Equals(object? other) -> bool
 override NuGet.Configuration.PackageSourceMappingSourceItem.GetHashCode() -> int
-~override NuGet.Configuration.PackageSourceMappingSourceItem.RequiredAttributes.get -> System.Collections.Generic.IReadOnlyCollection<string>
-~override NuGet.Configuration.RepositoryItem.Clone() -> NuGet.Configuration.SettingBase
-~override NuGet.Configuration.RepositoryItem.ElementName.get -> string
-~override NuGet.Configuration.RepositoryItem.Equals(object other) -> bool
+override NuGet.Configuration.PackageSourceMappingSourceItem.RequiredAttributes.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+override NuGet.Configuration.RepositoryItem.Clone() -> NuGet.Configuration.SettingBase!
+override NuGet.Configuration.RepositoryItem.ElementName.get -> string!
+override NuGet.Configuration.RepositoryItem.Equals(object? other) -> bool
 override NuGet.Configuration.RepositoryItem.GetHashCode() -> int
 override NuGet.Configuration.SettingElement.IsEmpty() -> bool
-~override NuGet.Configuration.SettingSection.ElementName.get -> string
-~override NuGet.Configuration.SettingSection.ElementName.set -> void
-~override NuGet.Configuration.SettingSection.Equals(object other) -> bool
+override NuGet.Configuration.SettingSection.Equals(object? other) -> bool
 override NuGet.Configuration.SettingSection.GetHashCode() -> int
-~override NuGet.Configuration.SettingText.Clone() -> NuGet.Configuration.SettingBase
-~override NuGet.Configuration.SettingText.Equals(object other) -> bool
+override NuGet.Configuration.SettingText.Clone() -> NuGet.Configuration.SettingBase!
+override NuGet.Configuration.SettingText.Equals(object? other) -> bool
 override NuGet.Configuration.SettingText.GetHashCode() -> int
 override NuGet.Configuration.SettingText.IsEmpty() -> bool
 override NuGet.Configuration.SettingsGroup<T>.IsEmpty() -> bool
-~override NuGet.Configuration.SourceItem.Clone() -> NuGet.Configuration.SettingBase
-~override NuGet.Configuration.StoreClientCertItem.Clone() -> NuGet.Configuration.SettingBase
-~override NuGet.Configuration.StoreClientCertItem.ElementName.get -> string
-~override NuGet.Configuration.StoreClientCertItem.Search() -> System.Collections.Generic.IEnumerable<System.Security.Cryptography.X509Certificates.X509Certificate>
+override NuGet.Configuration.SourceItem.Clone() -> NuGet.Configuration.SettingBase!
+override NuGet.Configuration.StoreClientCertItem.Clone() -> NuGet.Configuration.SettingBase!
+override NuGet.Configuration.StoreClientCertItem.ElementName.get -> string!
+override NuGet.Configuration.StoreClientCertItem.Search() -> System.Collections.Generic.IEnumerable<System.Security.Cryptography.X509Certificates.X509Certificate!>!
 override NuGet.Configuration.TrustedSignerItem.CanHaveChildren.get -> bool
-~override NuGet.Configuration.UnknownItem.Clone() -> NuGet.Configuration.SettingBase
-~override NuGet.Configuration.UnknownItem.ElementName.get -> string
-~override NuGet.Configuration.UnknownItem.Equals(object other) -> bool
+override NuGet.Configuration.UnknownItem.Clone() -> NuGet.Configuration.SettingBase!
+override NuGet.Configuration.UnknownItem.ElementName.get -> string!
+override NuGet.Configuration.UnknownItem.Equals(object? other) -> bool
 override NuGet.Configuration.UnknownItem.GetHashCode() -> int
 override NuGet.Configuration.UnknownItem.IsEmpty() -> bool
-~override NuGet.Configuration.VirtualSettingSection.Clone() -> NuGet.Configuration.SettingBase
-~override sealed NuGet.Configuration.AddItem.Equals(object other) -> bool
+override NuGet.Configuration.VirtualSettingSection.Clone() -> NuGet.Configuration.SettingBase!
+override sealed NuGet.Configuration.AddItem.Equals(object? other) -> bool
 override sealed NuGet.Configuration.AddItem.GetHashCode() -> int
 static NuGet.Configuration.ConfigurationDefaults.Instance.get -> NuGet.Configuration.ConfigurationDefaults!
-~static NuGet.Configuration.EncryptionUtility.DecryptString(string encryptedString) -> string
-~static NuGet.Configuration.EncryptionUtility.EncryptString(string value) -> string
-~static NuGet.Configuration.NuGetPathContext.Create(NuGet.Configuration.ISettings settings) -> NuGet.Configuration.NuGetPathContext
-~static NuGet.Configuration.NuGetPathContext.Create(string settingsRoot) -> NuGet.Configuration.NuGetPathContext
-~static NuGet.Configuration.NullSettings.Instance.get -> NuGet.Configuration.NullSettings
-~static NuGet.Configuration.PackageSourceCredential.FromUserInput(string source, string username, string password, bool storePasswordInClearText, string validAuthenticationTypesText) -> NuGet.Configuration.PackageSourceCredential
+static NuGet.Configuration.EncryptionUtility.DecryptString(string! encryptedString) -> string!
+static NuGet.Configuration.EncryptionUtility.EncryptString(string! value) -> string!
+static NuGet.Configuration.NuGetPathContext.Create(NuGet.Configuration.ISettings! settings) -> NuGet.Configuration.NuGetPathContext!
+static NuGet.Configuration.NuGetPathContext.Create(string! settingsRoot) -> NuGet.Configuration.NuGetPathContext!
+static NuGet.Configuration.NullSettings.Instance.get -> NuGet.Configuration.NullSettings!
+static NuGet.Configuration.PackageSourceCredential.FromUserInput(string! source, string! username, string! password, bool storePasswordInClearText, string? validAuthenticationTypesText) -> NuGet.Configuration.PackageSourceCredential!
 static NuGet.Configuration.PackageSourceMapping.GetPackageSourceMapping(NuGet.Configuration.ISettings! settings) -> NuGet.Configuration.PackageSourceMapping!
 static NuGet.Configuration.PackageSourceProvider.LoadPackageSources(NuGet.Configuration.ISettings! settings) -> System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource!>!
-~static NuGet.Configuration.ProxyCache.Instance.get -> NuGet.Configuration.ProxyCache
-~static NuGet.Configuration.Settings.ApplyEnvironmentTransform(string value) -> string
-~static NuGet.Configuration.Settings.GetFileNameAndItsRoot(string root, string settingsPath) -> System.Tuple<string, string>
-~static NuGet.Configuration.Settings.LoadDefaultSettings(string root) -> NuGet.Configuration.ISettings
-~static NuGet.Configuration.Settings.LoadDefaultSettings(string root, string configFileName, NuGet.Configuration.IMachineWideSettings machineWideSettings) -> NuGet.Configuration.ISettings
-~static NuGet.Configuration.Settings.LoadDefaultSettings(string root, string configFileName, NuGet.Configuration.IMachineWideSettings machineWideSettings, NuGet.Configuration.SettingsLoadingContext settingsLoadingContext) -> NuGet.Configuration.ISettings
-~static NuGet.Configuration.Settings.LoadImmutableSettingsGivenConfigPaths(System.Collections.Generic.IList<string> configFilePaths, NuGet.Configuration.SettingsLoadingContext settingsLoadingContext) -> NuGet.Configuration.ISettings
-~static NuGet.Configuration.Settings.LoadMachineWideSettings(string root, params string[] paths) -> NuGet.Configuration.ISettings
-~static NuGet.Configuration.Settings.LoadSettingsGivenConfigPaths(System.Collections.Generic.IList<string> configFilePaths) -> NuGet.Configuration.ISettings
-~static NuGet.Configuration.Settings.LoadSpecificSettings(string root, string configFileName) -> NuGet.Configuration.ISettings
-~static NuGet.Configuration.SettingsUtility.DeleteConfigValue(NuGet.Configuration.ISettings settings, string key) -> bool
-~static NuGet.Configuration.SettingsUtility.DeleteValue(NuGet.Configuration.ISettings settings, string section, string attributeKey, string attributeValue) -> bool
-~static NuGet.Configuration.SettingsUtility.GetConfigValue(NuGet.Configuration.ISettings settings, string key, bool decrypt = false, bool isPath = false) -> string
-~static NuGet.Configuration.SettingsUtility.GetDecryptedValueForAddItem(NuGet.Configuration.ISettings settings, string section, string key, bool isPath = false) -> string
-~static NuGet.Configuration.SettingsUtility.GetDefaultPushSource(NuGet.Configuration.ISettings settings) -> string
-~static NuGet.Configuration.SettingsUtility.GetEnabledSources(NuGet.Configuration.ISettings settings) -> System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource>
-~static NuGet.Configuration.SettingsUtility.GetFallbackPackageFolders(NuGet.Configuration.ISettings settings) -> System.Collections.Generic.IReadOnlyList<string>
-~static NuGet.Configuration.SettingsUtility.GetGlobalPackagesFolder(NuGet.Configuration.ISettings settings) -> string
-~static NuGet.Configuration.SettingsUtility.GetHttpCacheFolder() -> string
-~static NuGet.Configuration.SettingsUtility.GetMaxHttpRequest(NuGet.Configuration.ISettings settings) -> int
-~static NuGet.Configuration.SettingsUtility.GetPluginsCacheFolder() -> string
-~static NuGet.Configuration.SettingsUtility.GetRepositoryPath(NuGet.Configuration.ISettings settings) -> string
-~static NuGet.Configuration.SettingsUtility.GetRevocationMode(NuGet.Common.IEnvironmentVariableReader environmentVariableReader = null) -> NuGet.Common.RevocationMode
-~static NuGet.Configuration.SettingsUtility.GetSignatureValidationMode(NuGet.Configuration.ISettings settings) -> NuGet.Common.SignatureValidationMode
-~static NuGet.Configuration.SettingsUtility.GetUpdatePackageLastAccessTimeEnabledStatus(NuGet.Configuration.ISettings settings) -> bool
-~static NuGet.Configuration.SettingsUtility.GetValueForAddItem(NuGet.Configuration.ISettings settings, string section, string key, bool isPath = false) -> string
-~static NuGet.Configuration.SettingsUtility.SetConfigValue(NuGet.Configuration.ISettings settings, string key, string value, bool encrypt = false) -> void
-~static NuGet.Configuration.SettingsUtility.SetEncryptedValueForAddItem(NuGet.Configuration.ISettings settings, string section, string key, string value) -> void
-~static NuGet.Configuration.StoreClientCertItem.GetString(System.Security.Cryptography.X509Certificates.StoreLocation storeLocation) -> string
-~static NuGet.Configuration.StoreClientCertItem.GetString(System.Security.Cryptography.X509Certificates.StoreName storeName) -> string
-~static NuGet.Configuration.StoreClientCertItem.GetString(System.Security.Cryptography.X509Certificates.X509FindType type) -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.ActivePackageSourceSectionName -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.Add -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.AllowInsecureConnections -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.AllowUntrustedRoot -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.ApiKeys -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.Author -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.BeginIgnoreMarker -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.BindingRedirectsSection -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.Certificate -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.Clear -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.ClearTextPasswordAttribute -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.ClearTextPasswordToken -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.ClientCertificates -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.Config -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.Configuration -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.ConfigurationDefaultsFile -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.CredentialsSectionName -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.DefaultPackageManagementFormatKey -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.DefaultPushSource -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.DependencyVersion -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.DisabledPackageSources -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.DoNotShowPackageManagementSelectionKey -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.Enabled -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.EndIgnoreMarker -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.FailOnBindingRedirects -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.FallbackPackageFolders -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.FileCertificate -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.FindByAttribute -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.FindValueAttribute -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.Fingerprint -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.FingerprintAlgorithm -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.GlobalPackagesFolder -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.HashAlgorithm -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.HostKey -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.KeyAttribute -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.MaxHttpRequestsPerSource -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.NameAttribute -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.NoProxy -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.Owners -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.Package -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.PackageManagementSection -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.PackageRestore -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.PackageSourceAttribute -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.PackageSourceMapping -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.PackageSources -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.PasswordAttribute -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.PasswordKey -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.PasswordToken -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.PathAttribute -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.PatternAttribute -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.ProtocolVersionAttribute -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.Repository -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.RepositoryPath -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.ServiceIndex -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.SignatureValidationMode -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.SkipBindingRedirectsKey -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.StoreCertificate -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.StoreLocationAttribute -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.StoreNameAttribute -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.TrustedSigners -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.UpdatePackageLastAccessTime -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.UserKey -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.UsernameToken -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.ValidAuthenticationTypesToken -> string
-~static readonly NuGet.Configuration.ConfigurationConstants.ValueAttribute -> string
-~static readonly NuGet.Configuration.NuGetConstants.DefaultConfigContent -> string
-~static readonly NuGet.Configuration.NuGetConstants.DefaultGalleryServerUrl -> string
-~static readonly NuGet.Configuration.NuGetConstants.FeedName -> string
-~static readonly NuGet.Configuration.NuGetConstants.ManifestExtension -> string
-~static readonly NuGet.Configuration.NuGetConstants.ManifestSymbolsExtension -> string
-~static readonly NuGet.Configuration.NuGetConstants.NuGetHostName -> string
-~static readonly NuGet.Configuration.NuGetConstants.NuGetSolutionSettingsFolder -> string
-~static readonly NuGet.Configuration.NuGetConstants.NuGetSymbolHostName -> string
-~static readonly NuGet.Configuration.NuGetConstants.PackageExtension -> string
-~static readonly NuGet.Configuration.NuGetConstants.PackageReferenceFile -> string
-~static readonly NuGet.Configuration.NuGetConstants.PackageSpecFileName -> string
-~static readonly NuGet.Configuration.NuGetConstants.ReadmeExtension -> string
-~static readonly NuGet.Configuration.NuGetConstants.ReadmeFileName -> string
-~static readonly NuGet.Configuration.NuGetConstants.SnupkgExtension -> string
-~static readonly NuGet.Configuration.NuGetConstants.SymbolsExtension -> string
-~static readonly NuGet.Configuration.NuGetConstants.V1FeedUrl -> string
-~static readonly NuGet.Configuration.NuGetConstants.V2LegacyFeedUrl -> string
-~static readonly NuGet.Configuration.NuGetConstants.V2LegacyOfficialPackageSourceUrl -> string
+static NuGet.Configuration.ProxyCache.Instance.get -> NuGet.Configuration.ProxyCache!
+static NuGet.Configuration.Settings.ApplyEnvironmentTransform(string! value) -> string!
+static NuGet.Configuration.Settings.GetFileNameAndItsRoot(string! root, string! settingsPath) -> System.Tuple<string!, string!>!
+static NuGet.Configuration.Settings.LoadDefaultSettings(string? root) -> NuGet.Configuration.ISettings!
+static NuGet.Configuration.Settings.LoadDefaultSettings(string? root, string? configFileName, NuGet.Configuration.IMachineWideSettings? machineWideSettings) -> NuGet.Configuration.ISettings!
+static NuGet.Configuration.Settings.LoadDefaultSettings(string? root, string? configFileName, NuGet.Configuration.IMachineWideSettings? machineWideSettings, NuGet.Configuration.SettingsLoadingContext? settingsLoadingContext) -> NuGet.Configuration.ISettings!
+static NuGet.Configuration.Settings.LoadImmutableSettingsGivenConfigPaths(System.Collections.Generic.IList<string!>? configFilePaths, NuGet.Configuration.SettingsLoadingContext! settingsLoadingContext) -> NuGet.Configuration.ISettings!
+static NuGet.Configuration.Settings.LoadMachineWideSettings(string! root, params string![]! paths) -> NuGet.Configuration.ISettings!
+static NuGet.Configuration.Settings.LoadSettingsGivenConfigPaths(System.Collections.Generic.IList<string!>! configFilePaths) -> NuGet.Configuration.ISettings!
+static NuGet.Configuration.Settings.LoadSpecificSettings(string! root, string! configFileName) -> NuGet.Configuration.ISettings!
+static NuGet.Configuration.SettingsUtility.DeleteConfigValue(NuGet.Configuration.ISettings! settings, string! key) -> bool
+static NuGet.Configuration.SettingsUtility.DeleteValue(NuGet.Configuration.ISettings! settings, string! section, string! attributeKey, string! attributeValue) -> bool
+static NuGet.Configuration.SettingsUtility.GetConfigValue(NuGet.Configuration.ISettings! settings, string! key, bool decrypt = false, bool isPath = false) -> string?
+static NuGet.Configuration.SettingsUtility.GetDecryptedValueForAddItem(NuGet.Configuration.ISettings! settings, string! section, string! key, bool isPath = false) -> string?
+static NuGet.Configuration.SettingsUtility.GetDefaultPushSource(NuGet.Configuration.ISettings! settings) -> string?
+static NuGet.Configuration.SettingsUtility.GetEnabledSources(NuGet.Configuration.ISettings! settings) -> System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource!>!
+static NuGet.Configuration.SettingsUtility.GetFallbackPackageFolders(NuGet.Configuration.ISettings! settings) -> System.Collections.Generic.IReadOnlyList<string!>!
+static NuGet.Configuration.SettingsUtility.GetGlobalPackagesFolder(NuGet.Configuration.ISettings! settings) -> string!
+static NuGet.Configuration.SettingsUtility.GetHttpCacheFolder() -> string!
+static NuGet.Configuration.SettingsUtility.GetMaxHttpRequest(NuGet.Configuration.ISettings! settings) -> int
+static NuGet.Configuration.SettingsUtility.GetPluginsCacheFolder() -> string!
+static NuGet.Configuration.SettingsUtility.GetRepositoryPath(NuGet.Configuration.ISettings! settings) -> string?
+static NuGet.Configuration.SettingsUtility.GetRevocationMode(NuGet.Common.IEnvironmentVariableReader? environmentVariableReader = null) -> NuGet.Common.RevocationMode
+static NuGet.Configuration.SettingsUtility.GetSignatureValidationMode(NuGet.Configuration.ISettings! settings) -> NuGet.Common.SignatureValidationMode
+static NuGet.Configuration.SettingsUtility.GetUpdatePackageLastAccessTimeEnabledStatus(NuGet.Configuration.ISettings! settings) -> bool
+static NuGet.Configuration.SettingsUtility.GetValueForAddItem(NuGet.Configuration.ISettings! settings, string! section, string! key, bool isPath = false) -> string?
+static NuGet.Configuration.SettingsUtility.SetConfigValue(NuGet.Configuration.ISettings! settings, string! key, string? value, bool encrypt = false) -> void
+static NuGet.Configuration.SettingsUtility.SetEncryptedValueForAddItem(NuGet.Configuration.ISettings! settings, string! section, string! key, string? value) -> void
+static NuGet.Configuration.StoreClientCertItem.GetString(System.Security.Cryptography.X509Certificates.StoreLocation storeLocation) -> string!
+static NuGet.Configuration.StoreClientCertItem.GetString(System.Security.Cryptography.X509Certificates.StoreName storeName) -> string!
+static NuGet.Configuration.StoreClientCertItem.GetString(System.Security.Cryptography.X509Certificates.X509FindType type) -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.ActivePackageSourceSectionName -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.Add -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.AllowInsecureConnections -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.AllowUntrustedRoot -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.ApiKeys -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.Author -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.BeginIgnoreMarker -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.BindingRedirectsSection -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.Certificate -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.Clear -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.ClearTextPasswordAttribute -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.ClearTextPasswordToken -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.ClientCertificates -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.Config -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.Configuration -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.ConfigurationDefaultsFile -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.CredentialsSectionName -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.DefaultPackageManagementFormatKey -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.DefaultPushSource -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.DependencyVersion -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.DisabledPackageSources -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.DoNotShowPackageManagementSelectionKey -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.Enabled -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.EndIgnoreMarker -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.FailOnBindingRedirects -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.FallbackPackageFolders -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.FileCertificate -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.FindByAttribute -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.FindValueAttribute -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.Fingerprint -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.FingerprintAlgorithm -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.GlobalPackagesFolder -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.HashAlgorithm -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.HostKey -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.KeyAttribute -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.MaxHttpRequestsPerSource -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.NameAttribute -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.NoProxy -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.Owners -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.Package -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.PackageManagementSection -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.PackageRestore -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.PackageSourceAttribute -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.PackageSourceMapping -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.PackageSources -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.PasswordAttribute -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.PasswordKey -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.PasswordToken -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.PathAttribute -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.PatternAttribute -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.ProtocolVersionAttribute -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.Repository -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.RepositoryPath -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.ServiceIndex -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.SignatureValidationMode -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.SkipBindingRedirectsKey -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.StoreCertificate -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.StoreLocationAttribute -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.StoreNameAttribute -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.TrustedSigners -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.UpdatePackageLastAccessTime -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.UserKey -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.UsernameToken -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.ValidAuthenticationTypesToken -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.ValueAttribute -> string!
+static readonly NuGet.Configuration.NuGetConstants.DefaultConfigContent -> string!
+static readonly NuGet.Configuration.NuGetConstants.DefaultGalleryServerUrl -> string!
+static readonly NuGet.Configuration.NuGetConstants.FeedName -> string!
+static readonly NuGet.Configuration.NuGetConstants.ManifestExtension -> string!
+static readonly NuGet.Configuration.NuGetConstants.ManifestSymbolsExtension -> string!
+static readonly NuGet.Configuration.NuGetConstants.NuGetHostName -> string!
+static readonly NuGet.Configuration.NuGetConstants.NuGetSolutionSettingsFolder -> string!
+static readonly NuGet.Configuration.NuGetConstants.NuGetSymbolHostName -> string!
+static readonly NuGet.Configuration.NuGetConstants.PackageExtension -> string!
+static readonly NuGet.Configuration.NuGetConstants.PackageReferenceFile -> string!
+static readonly NuGet.Configuration.NuGetConstants.PackageSpecFileName -> string!
+static readonly NuGet.Configuration.NuGetConstants.ReadmeExtension -> string!
+static readonly NuGet.Configuration.NuGetConstants.ReadmeFileName -> string!
+static readonly NuGet.Configuration.NuGetConstants.SnupkgExtension -> string!
+static readonly NuGet.Configuration.NuGetConstants.SymbolsExtension -> string!
+static readonly NuGet.Configuration.NuGetConstants.V1FeedUrl -> string!
+static readonly NuGet.Configuration.NuGetConstants.V2LegacyFeedUrl -> string!
+static readonly NuGet.Configuration.NuGetConstants.V2LegacyOfficialPackageSourceUrl -> string!
 static readonly NuGet.Configuration.OwnersItem.OwnersListSeparator -> char
-~static readonly NuGet.Configuration.Settings.DefaultSettingsFileName -> string
-~static readonly NuGet.Configuration.Settings.OrderedSettingsFileNames -> string[]
-~static readonly NuGet.Configuration.Settings.SupportedMachineWideConfigExtension -> string[]
-~static readonly NuGet.Configuration.SettingsUtility.DefaultGlobalPackagesFolderPath -> string
-~virtual NuGet.Configuration.AddItem.GetValueAsPath() -> string
-~virtual NuGet.Configuration.AddItem.Value.get -> string
-~virtual NuGet.Configuration.AddItem.Value.set -> void
-~virtual NuGet.Configuration.PackageSourceMappingSourceItem.Key.get -> string
-~virtual NuGet.Configuration.SettingElement.AllowedAttributes.get -> System.Collections.Generic.IReadOnlyCollection<string>
-~virtual NuGet.Configuration.SettingElement.AllowedValues.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyCollection<string>>
-~virtual NuGet.Configuration.SettingElement.DisallowedValues.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyCollection<string>>
-~virtual NuGet.Configuration.SettingElement.ElementName.get -> string
-~virtual NuGet.Configuration.SettingElement.ElementName.set -> void
-~virtual NuGet.Configuration.SettingElement.RequiredAttributes.get -> System.Collections.Generic.IReadOnlyCollection<string>
+static readonly NuGet.Configuration.Settings.DefaultSettingsFileName -> string!
+static readonly NuGet.Configuration.Settings.OrderedSettingsFileNames -> string![]!
+static readonly NuGet.Configuration.Settings.SupportedMachineWideConfigExtension -> string![]!
+static readonly NuGet.Configuration.SettingsUtility.DefaultGlobalPackagesFolderPath -> string!
+virtual NuGet.Configuration.AddItem.GetValueAsPath() -> string!
+virtual NuGet.Configuration.AddItem.Value.get -> string!
+virtual NuGet.Configuration.AddItem.Value.set -> void
+virtual NuGet.Configuration.PackageSourceMappingSourceItem.Key.get -> string!
+virtual NuGet.Configuration.SettingElement.AllowedAttributes.get -> System.Collections.Generic.IReadOnlyCollection<string!>?
+virtual NuGet.Configuration.SettingElement.AllowedValues.get -> System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyCollection<string!>!>?
+virtual NuGet.Configuration.SettingElement.DisallowedValues.get -> System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyCollection<string!>!>?
+virtual NuGet.Configuration.SettingElement.RequiredAttributes.get -> System.Collections.Generic.IReadOnlyCollection<string!>?
 virtual NuGet.Configuration.SettingItem.CanHaveChildren.get -> bool
 virtual NuGet.Configuration.SettingsGroup<T>.CanBeCleared.get -> bool
-~virtual NuGet.Configuration.TrustedSignerItem.Name.get -> string
+virtual NuGet.Configuration.TrustedSignerItem.Name.get -> string!

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -1,12 +1,18 @@
 #nullable enable
 NuGet.Configuration.ConfigurationDefaults.DefaultAuditSources.get -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSource!>!
 NuGet.Configuration.IPackageSourceProvider.LoadAuditSources() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSource!>!
+NuGet.Configuration.NuGetPathContext.FallbackPackageFolders.init -> void
+NuGet.Configuration.NuGetPathContext.HttpCacheFolder.init -> void
+NuGet.Configuration.NuGetPathContext.UserPackageFolder.init -> void
 NuGet.Configuration.PackageSourceProvider.LoadAuditSources() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSource!>!
 NuGet.Configuration.PackageSourceProvider.PackageSourceProvider(NuGet.Configuration.ISettings! settings, NuGet.Configuration.ConfigurationDefaults! configurationDefaults) -> void
 NuGet.Configuration.PackageSourceProvider.PackageSourceProvider(NuGet.Configuration.ISettings! settings, NuGet.Configuration.ConfigurationDefaults! configurationDefaults, bool enablePackageSourcesChangedEvent) -> void
 NuGet.Configuration.SettingElementType.AuditSources = 20 -> NuGet.Configuration.SettingElementType
-~NuGet.Configuration.SettingElement.ConfigPath.get -> string
-~NuGet.Configuration.SettingItem.GetAttributes() -> System.Collections.Generic.IReadOnlyDictionary<string, string>
-~NuGet.Configuration.Settings.GetAllSettingSections() -> System.Collections.Generic.IEnumerable<string>
-~static NuGet.Configuration.ConfigurationConstants.GetConfigKeys() -> System.Collections.Generic.IReadOnlyList<string>
-~static readonly NuGet.Configuration.ConfigurationConstants.AuditSources -> string
+NuGet.Configuration.SettingElement.ConfigPath.get -> string?
+NuGet.Configuration.SettingItem.GetAttributes() -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+NuGet.Configuration.Settings.GetAllSettingSections() -> System.Collections.Generic.IEnumerable<string!>!
+NuGet.Configuration.SettingsGroup<T>.SettingsGroup(string! name) -> void
+NuGet.Configuration.SettingsGroup<T>.SettingsGroup(string! name, System.Collections.Generic.IReadOnlyDictionary<string!, string!>? attributes, System.Collections.Generic.IEnumerable<T!>? children) -> void
+override NuGet.Configuration.SettingsGroup<T>.ElementName.get -> string!
+static NuGet.Configuration.ConfigurationConstants.GetConfigKeys() -> System.Collections.Generic.IReadOnlyList<string!>!
+static readonly NuGet.Configuration.ConfigurationConstants.AuditSources -> string!

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -457,6 +457,15 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to File location not known.
+        /// </summary>
+        internal static string ShowError_UnknownOrigin {
+            get {
+                return ResourceManager.GetString("ShowError_UnknownOrigin", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Text elements should not be empty..
         /// </summary>
         internal static string TextShouldNotBeEmpty {

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -309,4 +309,7 @@
 1 - config file path
 </comment>
   </data>
+  <data name="ShowError_UnknownOrigin" xml:space="preserve">
+    <value>File location not known</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
@@ -16,7 +16,7 @@ namespace NuGet.Configuration
         /// </summary>
         /// <param name="sectionName">name to match sections</param>
         /// <returns>null if no section with the given name was found</returns>
-        SettingSection GetSection(string sectionName);
+        SettingSection? GetSection(string sectionName);
 
         /// <summary>
         /// Adds or updates the given <paramref name="item"/> to the settings.
@@ -47,7 +47,7 @@ namespace NuGet.Configuration
         /// <summary>
         /// Event raised when the setting have been changed.
         /// </summary>
-        event EventHandler SettingsChanged;
+        event EventHandler? SettingsChanged;
 
         /// <summary>
         /// Get a list of all the paths of the settings files used as part of this settings object. The paths are ordered with the closest one to user first.

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ImmutableSettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ImmutableSettings.cs
@@ -17,7 +17,7 @@ namespace NuGet.Configuration
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
         }
 
-        public event EventHandler SettingsChanged
+        public event EventHandler? SettingsChanged
         {
             add
             {
@@ -43,7 +43,7 @@ namespace NuGet.Configuration
             return _settings.GetConfigRoots();
         }
 
-        public SettingSection GetSection(string sectionName)
+        public SettingSection? GetSection(string sectionName)
         {
             return _settings.GetSection(sectionName);
         }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/AddItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/AddItem.cs
@@ -36,7 +36,7 @@ namespace NuGet.Configuration
                 { ConfigurationConstants.KeyAttribute, new HashSet<string>(new [] {string.Empty }) }
             });
 
-        public AddItem(string key, string value)
+        public AddItem(string key, string? value)
             : this(key, value, additionalAttributes: null)
         {
         }
@@ -46,7 +46,7 @@ namespace NuGet.Configuration
         {
         }
 
-        public AddItem(string key, string value, IReadOnlyDictionary<string, string> additionalAttributes)
+        public AddItem(string key, string? value, IReadOnlyDictionary<string, string>? additionalAttributes)
             : base()
         {
             if (string.IsNullOrEmpty(key))
@@ -102,7 +102,7 @@ namespace NuGet.Configuration
         // Due to how settings AddOrUpdate is implemented, anything extending AddItem must only use the Key in GetHashCode and Equals
         // otherwise existing items won't be updated and new duplicates will always be added.
         // In other words, all sub-class properties must be ignored by these methods.
-        public sealed override bool Equals(object other)
+        public sealed override bool Equals(object? other)
         {
             var item = other as AddItem;
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/AuthorItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/AuthorItem.cs
@@ -27,7 +27,7 @@ namespace NuGet.Configuration
 
         public override SettingBase Clone()
         {
-            var newItem = new AuthorItem(Name, Certificates.Select(c => c.Clone() as CertificateItem).ToArray());
+            var newItem = new AuthorItem(Name, Certificates.Select(c => (CertificateItem)c.Clone()).ToArray());
 
             if (Origin != null)
             {
@@ -59,7 +59,7 @@ namespace NuGet.Configuration
             return element;
         }
 
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
             if (other is AuthorItem author)
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/CertificateItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/CertificateItem.cs
@@ -103,7 +103,7 @@ namespace NuGet.Configuration
             return newItem;
         }
 
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
             if (other is CertificateItem cert)
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/ClearItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/ClearItem.cs
@@ -33,7 +33,7 @@ namespace NuGet.Configuration
             return newItem;
         }
 
-        public override bool Equals(object other) => other is ClearItem;
+        public override bool Equals(object? other) => other is ClearItem;
         public override int GetHashCode() => ElementName.GetHashCode();
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/ClientCertItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/ClientCertItem.cs
@@ -31,7 +31,7 @@ namespace NuGet.Configuration
 
         protected override bool CanHaveChildren => false;
 
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
             var item = other as ClientCertItem;
             if (item == null)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/CredentialsItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/CredentialsItem.cs
@@ -146,7 +146,7 @@ namespace NuGet.Configuration
             var elementDescendants = element.Elements();
             var countOfDescendants = elementDescendants.Count();
 
-            var parsedItems = elementDescendants.Select(e => (AddItem)SettingFactory.Parse(e, origin));
+            var parsedItems = elementDescendants.Select(e => SettingFactory.Parse(e, origin)).OfType<AddItem>();
 
             foreach (var item in parsedItems)
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/CredentialsItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/CredentialsItem.cs
@@ -146,7 +146,7 @@ namespace NuGet.Configuration
             var elementDescendants = element.Elements();
             var countOfDescendants = elementDescendants.Count();
 
-            var parsedItems = elementDescendants.Select(e => SettingFactory.Parse(e, origin) as AddItem).Where(i => i != null).Cast<AddItem>();
+            var parsedItems = elementDescendants.Select(e => (AddItem)SettingFactory.Parse(e, origin));
 
             foreach (var item in parsedItems)
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/CredentialsItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/CredentialsItem.cs
@@ -18,6 +18,9 @@ namespace NuGet.Configuration
     /// </summary>
     public sealed class CredentialsItem : SettingItem
     {
+        // The element name for credential items is the source name it's related to. But source names can have characters that are not allowed in XML element names.
+        // For example, a source name "Package Source" will be encoded as "Package_x0020_Source" in the XML element name.
+        // This property contains the decoded element name, and therefore needs to be encoded when it's written to the XML.
         public override string ElementName { get; }
 
         public string Username
@@ -118,6 +121,7 @@ namespace NuGet.Configuration
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(password));
             }
 
+            // ElementName is not being read from XML, so it's not decoded.
             ElementName = name;
 
             _username = new AddItem(ConfigurationConstants.UsernameToken, username);
@@ -136,6 +140,7 @@ namespace NuGet.Configuration
         internal CredentialsItem(XElement element, SettingsFile origin)
             : base(element, origin)
         {
+            // ElementName is read from XML file, so it must be decoded.
             ElementName = XmlConvert.DecodeName(element.Name.LocalName);
 
             var elementDescendants = element.Elements();
@@ -215,6 +220,7 @@ namespace NuGet.Configuration
                 return Node;
             }
 
+            // Always encode the element name, since it might contain characters that are not allowed in XML element names.
             var element = new XElement(XmlUtility.GetEncodedXMLName(ElementName),
                 _username.AsXNode(),
                 _password.AsXNode());

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/OwnersItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/OwnersItem.cs
@@ -83,7 +83,7 @@ namespace NuGet.Configuration
             return element;
         }
 
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
             if (other is OwnersItem owners)
             {
@@ -102,7 +102,7 @@ namespace NuGet.Configuration
 
         internal override void Update(SettingItem other)
         {
-            var owners = other as OwnersItem;
+            var owners = (OwnersItem)other;
 
             if (!owners.Content.Any())
             {
@@ -125,7 +125,7 @@ namespace NuGet.Configuration
                     if (Node != null)
                     {
                         _content.SetNode(_content.AsXNode());
-                        (Node as XElement).Add(_content.Node);
+                        ((XElement)Node).Add(_content.Node);
                         Origin.IsDirty = true;
                     }
                 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/PackagePatternItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/PackagePatternItem.cs
@@ -48,7 +48,7 @@ namespace NuGet.Configuration
             return newItem;
         }
 
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
             if (other is PackagePatternItem item)
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
@@ -7,7 +7,7 @@ namespace NuGet.Configuration
 {
     public sealed class SourceItem : AddItem
     {
-        public string ProtocolVersion
+        public string? ProtocolVersion
         {
             get
             {
@@ -21,7 +21,7 @@ namespace NuGet.Configuration
             set => AddOrUpdateAttribute(ConfigurationConstants.ProtocolVersionAttribute, value);
         }
 
-        public string AllowInsecureConnections
+        public string? AllowInsecureConnections
         {
             get
             {
@@ -40,12 +40,12 @@ namespace NuGet.Configuration
         {
         }
 
-        public SourceItem(string key, string value, string protocolVersion)
+        public SourceItem(string key, string value, string? protocolVersion)
             : this(key, value, protocolVersion, allowInsecureConnections: "")
         {
         }
 
-        public SourceItem(string key, string value, string protocolVersion, string allowInsecureConnections)
+        public SourceItem(string key, string value, string? protocolVersion, string? allowInsecureConnections)
             : base(key, value)
         {
             if (!string.IsNullOrEmpty(protocolVersion))

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/StoreClientCertItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/StoreClientCertItem.cs
@@ -78,7 +78,7 @@ namespace NuGet.Configuration
                 storeLocation = DefaultStoreLocation.ToString();
             }
 
-            AddAttribute(ConfigurationConstants.StoreLocationAttribute, storeLocation);
+            AddAttribute(ConfigurationConstants.StoreLocationAttribute, storeLocation!);
 
             var storeName = element.Attribute(XName.Get(ConfigurationConstants.StoreNameAttribute))?.Value;
             if (string.IsNullOrWhiteSpace(storeName))
@@ -86,7 +86,7 @@ namespace NuGet.Configuration
                 storeName = DefaultStoreName.ToString();
             }
 
-            AddAttribute(ConfigurationConstants.StoreNameAttribute, storeName);
+            AddAttribute(ConfigurationConstants.StoreNameAttribute, storeName!);
 
             var findBy = element.Attribute(XName.Get(ConfigurationConstants.FindByAttribute))?.Value;
             if (string.IsNullOrWhiteSpace(findBy))
@@ -94,7 +94,7 @@ namespace NuGet.Configuration
                 findBy = GetString(DefaultFindBy);
             }
 
-            AddAttribute(ConfigurationConstants.FindByAttribute, findBy);
+            AddAttribute(ConfigurationConstants.FindByAttribute, findBy!);
 
             var findValue = element.Attribute(XName.Get(ConfigurationConstants.FindValueAttribute))?.Value;
             if (string.IsNullOrWhiteSpace(findValue))
@@ -102,7 +102,7 @@ namespace NuGet.Configuration
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty);
             }
 
-            AddAttribute(ConfigurationConstants.FindValueAttribute, findValue);
+            AddAttribute(ConfigurationConstants.FindValueAttribute, findValue!);
         }
 
         public override string ElementName => ConfigurationConstants.StoreCertificate;
@@ -260,7 +260,7 @@ namespace NuGet.Configuration
             }
         }
 
-        public void Update(string findValue,
+        public void Update(string? findValue,
                            StoreLocation? storeLocation = null,
                            StoreName? storeName = null,
                            X509FindType? findBy = null)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/UnknownItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/UnknownItem.cs
@@ -10,11 +10,9 @@ namespace NuGet.Configuration
 {
     public sealed class UnknownItem : SettingItem, ISettingsGroup
     {
-        public override string ElementName { get; protected set; }
+        public override string ElementName { get; }
 
         public IReadOnlyList<SettingBase> Children => _mutableChildren.Select(c => c.Value).ToList();
-
-        public new IReadOnlyDictionary<string, string> Attributes => base.Attributes;
 
         public override bool IsEmpty() => false;
 
@@ -39,7 +37,7 @@ namespace NuGet.Configuration
             }
         }
 
-        public UnknownItem(string name, IReadOnlyDictionary<string, string> attributes, IEnumerable<SettingBase> children)
+        public UnknownItem(string name, IReadOnlyDictionary<string, string>? attributes, IEnumerable<SettingBase>? children)
             : base(attributes)
         {
             if (string.IsNullOrEmpty(name))
@@ -99,7 +97,7 @@ namespace NuGet.Configuration
 
                     if (Node != null)
                     {
-                        setting.SetNode(setting.AsXNode());
+                        setting.SetNode(setting.AsXNode()!);
 
                         XElementUtility.AddIndented(Node as XElement, setting.Node);
                         Origin.IsDirty = true;
@@ -163,7 +161,7 @@ namespace NuGet.Configuration
             return element;
         }
 
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
             var unknown = other as UnknownItem;
 
@@ -186,7 +184,7 @@ namespace NuGet.Configuration
         {
             base.Update(setting);
 
-            var unknown = setting as UnknownItem;
+            var unknown = (UnknownItem)setting;
 
             var otherChildren = new Dictionary<SettingBase, SettingBase>(unknown._mutableChildren);
             foreach (var child in Children)
@@ -202,7 +200,7 @@ namespace NuGet.Configuration
                 }
                 else if (child is SettingItem item)
                 {
-                    item.Update(otherChild as SettingItem);
+                    item.Update((SettingItem)otherChild);
                 }
             }
 
@@ -230,7 +228,7 @@ namespace NuGet.Configuration
                 {
                     if (existingChild is SettingItem childItem)
                     {
-                        childItem.Update(child as SettingItem);
+                        childItem.Update((SettingItem)child);
                     }
                 }
                 else

--- a/src/NuGet.Core/NuGet.Configuration/Settings/NuGetConfiguration.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/NuGetConfiguration.cs
@@ -12,8 +12,6 @@ namespace NuGet.Configuration
 {
     internal sealed class NuGetConfiguration : SettingsGroup<SettingSection>, ISettingsGroup
     {
-        public override string ElementName => ConfigurationConstants.Configuration;
-
         internal IReadOnlyDictionary<string, SettingSection> Sections => Children.ToDictionary(c => c.ElementName);
 
         protected override bool CanBeCleared => false;
@@ -23,7 +21,7 @@ namespace NuGet.Configuration
         /// This constructor should only be used for tests.
         /// </remarks>
         private NuGetConfiguration(IReadOnlyDictionary<string, string> attributes, IEnumerable<SettingSection> children)
-            : base(attributes, children)
+            : base(name: ConfigurationConstants.Configuration, attributes, children)
         {
         }
 
@@ -32,7 +30,7 @@ namespace NuGet.Configuration
         /// This constructor should only be used for tests.
         /// </remarks>
         internal NuGetConfiguration(params SettingSection[] sections)
-            : base()
+            : base(ConfigurationConstants.Configuration)
         {
             foreach (var section in sections)
             {
@@ -42,7 +40,7 @@ namespace NuGet.Configuration
         }
 
         internal NuGetConfiguration(SettingsFile origin)
-            : base()
+            : base(ConfigurationConstants.Configuration)
         {
             var defaultSource = new SourceItem(NuGetConstants.FeedName, NuGetConstants.V3FeedUrl, protocolVersion: PackageSourceProvider.MaxSupportedProtocolVersion.ToString(CultureInfo.CurrentCulture));
 
@@ -62,7 +60,7 @@ namespace NuGet.Configuration
         }
 
         internal NuGetConfiguration(XElement element, SettingsFile origin)
-            : base(element, origin)
+            : base(ConfigurationConstants.Configuration, element, origin)
         {
             if (!string.Equals(element.Name.LocalName, ElementName, StringComparison.OrdinalIgnoreCase))
             {
@@ -114,7 +112,7 @@ namespace NuGet.Configuration
             }
         }
 
-        public SettingSection GetSection(string sectionName)
+        public SettingSection? GetSection(string sectionName)
         {
             if (Sections.TryGetValue(sectionName, out var section))
             {
@@ -142,10 +140,10 @@ namespace NuGet.Configuration
 
         public override SettingBase Clone()
         {
-            return new NuGetConfiguration(Attributes, Sections.Select(s => s.Value.Clone() as SettingSection));
+            return new NuGetConfiguration(Attributes, Sections.Select(s => (SettingSection)s.Value.Clone()));
         }
 
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
             var nugetConfiguration = other as NuGetConfiguration;
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/NuGetPathContext.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/NuGetPathContext.cs
@@ -12,17 +12,17 @@ namespace NuGet.Configuration
         /// <summary>
         /// Fallback package folders. There many be zero or more of these.
         /// </summary>
-        public IReadOnlyList<string> FallbackPackageFolders { get; internal set; }
+        public required IReadOnlyList<string> FallbackPackageFolders { get; init; }
 
         /// <summary>
         /// User global packages folder.
         /// </summary>
-        public string UserPackageFolder { get; internal set; }
+        public required string UserPackageFolder { get; init; }
 
         /// <summary>
         /// User level http cache.
         /// </summary>
-        public string HttpCacheFolder { get; internal set; }
+        public required string HttpCacheFolder { get; init; }
 
         /// <summary>
         /// Load paths from already loaded settings.

--- a/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
@@ -10,11 +10,11 @@ namespace NuGet.Configuration
 {
     public class NullSettings : ISettings
     {
-        public event EventHandler SettingsChanged = delegate { };
+        public event EventHandler? SettingsChanged = delegate { };
 
         public static NullSettings Instance { get; } = new NullSettings();
 
-        public SettingSection GetSection(string sectionName) => null;
+        public SettingSection? GetSection(string sectionName) => null;
 
         public void AddOrUpdate(string sectionName, SettingItem item) => throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.InvalidNullSettingsOperation, nameof(AddOrUpdate)));
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ParsedSettingSection.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ParsedSettingSection.cs
@@ -9,8 +9,8 @@ namespace NuGet.Configuration
 {
     internal sealed class ParsedSettingSection : SettingSection
     {
-        internal ParsedSettingSection(XElement element, SettingsFile origin)
-            : base(element, origin)
+        internal ParsedSettingSection(string name, XElement element, SettingsFile origin)
+            : base(name, element, origin)
         {
         }
 
@@ -25,7 +25,7 @@ namespace NuGet.Configuration
 
         public override SettingBase Clone()
         {
-            return new VirtualSettingSection(ElementName, Attributes, Items.Select(s => s.Clone() as SettingItem));
+            return new VirtualSettingSection(ElementName, Attributes, Items.Select(s => (SettingItem)s.Clone()));
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingBase.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingBase.cs
@@ -8,11 +8,11 @@ namespace NuGet.Configuration
 {
     public abstract class SettingBase
     {
-        internal XNode Node { get; private set; }
+        internal XNode? Node { get; private set; }
 
-        internal ISettingsGroup Parent { get; set; }
+        internal ISettingsGroup? Parent { get; set; }
 
-        internal SettingsFile Origin { get; private set; }
+        internal SettingsFile? Origin { get; private set; }
 
         internal SettingBase(XNode node, SettingsFile origin)
         {
@@ -43,7 +43,7 @@ namespace NuGet.Configuration
         /// <summary>
         /// Gives the representation of this setting as an XNode object
         /// </summary>
-        internal virtual XNode AsXNode() => Node;
+        internal virtual XNode? AsXNode() => Node;
 
         /// <summary>
         /// Creates a shallow copy of the setting.
@@ -84,7 +84,10 @@ namespace NuGet.Configuration
             if (!IsCopy() && !IsAbstract())
             {
                 XElementUtility.RemoveIndented(Node);
-                Origin.IsDirty = true;
+                if (Origin != null)
+                {
+                    Origin.IsDirty = true;
+                }
 
                 Node = null;
             }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingElement.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingElement.cs
@@ -118,7 +118,7 @@ namespace NuGet.Configuration
                 return Node;
             }
 
-            var element = new XElement(XmlUtility.GetEncodedXMLName(ElementName));
+            var element = new XElement(ElementName);
 
             foreach (var attr in Attributes)
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -37,7 +37,7 @@ namespace NuGet.Configuration
                 switch (parentType)
                 {
                     case SettingElementType.Configuration:
-                        return new ParsedSettingSection(element, origin);
+                        return new ParsedSettingSection(element.Name.LocalName, element, origin);
 
                     case SettingElementType.PackageSourceCredentials:
                         return new CredentialsItem(element, origin);
@@ -95,12 +95,12 @@ namespace NuGet.Configuration
                 return new UnknownItem(element, origin);
             }
 
-            return null;
+            throw new InvalidOperationException("An invalid code path was taken. This should only happen when a new settings type is not implemented correctly.");
         }
 
         private class SettingElementKeyComparer : IComparer<SettingElement>, IEqualityComparer<SettingElement>
         {
-            public int Compare(SettingElement x, SettingElement y)
+            public int Compare(SettingElement? x, SettingElement? y)
             {
                 if (ReferenceEquals(x, y))
                 {
@@ -122,7 +122,7 @@ namespace NuGet.Configuration
                     y.ElementName + string.Join("", y.Attributes.Select(a => a.Value)));
             }
 
-            public bool Equals(SettingElement x, SettingElement y)
+            public bool Equals(SettingElement? x, SettingElement? y)
             {
                 if (ReferenceEquals(x, y))
                 {
@@ -158,7 +158,7 @@ namespace NuGet.Configuration
 
             HashSet<T> distinctDescendants = new HashSet<T>(comparer);
 
-            List<T> duplicatedDescendants = null;
+            List<T>? duplicatedDescendants = null;
 
             foreach (var item in descendants)
             {
@@ -176,7 +176,7 @@ namespace NuGet.Configuration
             if (xElement.Name.LocalName.Equals(ConfigurationConstants.PackageSourceMapping, StringComparison.OrdinalIgnoreCase) && duplicatedDescendants != null)
             {
                 var duplicatedKey = string.Join(", ", duplicatedDescendants.Select(d => d.Attributes["key"]));
-                var source = duplicatedDescendants.Select(d => d.Origin.ConfigFilePath).First();
+                var source = duplicatedDescendants.Select(d => d.Origin?.ConfigFilePath).Where(d => d is not null).First();
                 throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.Error_DuplicatePackageSource, duplicatedKey, source));
             }
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -176,7 +176,7 @@ namespace NuGet.Configuration
             if (xElement.Name.LocalName.Equals(ConfigurationConstants.PackageSourceMapping, StringComparison.OrdinalIgnoreCase) && duplicatedDescendants != null)
             {
                 var duplicatedKey = string.Join(", ", duplicatedDescendants.Select(d => d.Attributes["key"]));
-                var source = duplicatedDescendants.Select(d => d.Origin?.ConfigFilePath).Where(d => d is not null).First();
+                var source = duplicatedDescendants.Select(d => d.Origin?.ConfigFilePath).First(d => d is not null);
                 throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.Error_DuplicatePackageSource, duplicatedKey, source));
             }
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingItem.cs
@@ -13,14 +13,14 @@ namespace NuGet.Configuration
     {
         protected virtual bool CanHaveChildren => false;
 
-        internal SettingItem MergedWith { get; set; }
+        internal SettingItem? MergedWith { get; set; }
 
         protected SettingItem()
             : base()
         {
         }
 
-        protected SettingItem(IReadOnlyDictionary<string, string> attributes)
+        protected SettingItem(IReadOnlyDictionary<string, string>? attributes)
             : base(attributes)
         {
         }
@@ -71,7 +71,7 @@ namespace NuGet.Configuration
                     otherAttributes.Remove(attribute.Key);
                 }
 
-                string value = null;
+                string? value = null;
                 if (otherValue != null)
                 {
                     value = otherValue;

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingSection.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingSection.cs
@@ -3,53 +3,29 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using System.Xml;
 using System.Xml.Linq;
-using NuGet.Shared;
 
 namespace NuGet.Configuration
 {
     public abstract class SettingSection : SettingsGroup<SettingItem>
     {
-        private string _elementName;
-        public override string ElementName
-        {
-            get => XmlConvert.DecodeName(_elementName);
-            protected set
-            {
-                if (string.IsNullOrEmpty(value))
-                {
-                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.PropertyCannotBeNullOrEmpty, nameof(ElementName)));
-                }
-
-                _elementName = XmlUtility.GetEncodedXMLName(value);
-            }
-        }
-
         public IReadOnlyCollection<SettingItem> Items => Children.ToList();
 
-        public T GetFirstItemWithAttribute<T>(string attributeName, string expectedAttributeValue) where T : SettingItem
+        public T? GetFirstItemWithAttribute<T>(string attributeName, string expectedAttributeValue) where T : SettingItem
         {
             return Items.OfType<T>().FirstOrDefault(c =>
                 c.Attributes.TryGetValue(attributeName, out var attributeValue) &&
                 string.Equals(attributeValue, expectedAttributeValue, StringComparison.OrdinalIgnoreCase));
         }
 
-        protected SettingSection(string name, IReadOnlyDictionary<string, string> attributes, IEnumerable<SettingItem> children)
-            : base(attributes, children)
+        protected SettingSection(string name, IReadOnlyDictionary<string, string>? attributes, IEnumerable<SettingItem>? children)
+            : base(name, attributes, children)
         {
-            if (string.IsNullOrEmpty(name))
-            {
-                throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(name));
-            }
-
-            ElementName = name;
         }
 
-        internal SettingSection(XElement element, SettingsFile origin)
-            : base(element, origin)
+        internal SettingSection(string name, XElement element, SettingsFile origin)
+            : base(name, element, origin)
         {
         }
 
@@ -75,7 +51,7 @@ namespace NuGet.Configuration
             return false;
         }
 
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
             var section = other as SettingSection;
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingText.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingText.cs
@@ -35,7 +35,7 @@ namespace NuGet.Configuration
             _value = value;
         }
 
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
             var text = other as SettingText;
 
@@ -78,7 +78,7 @@ namespace NuGet.Configuration
                 throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.UserSettings_UnableToParseConfigFile, Resources.TextShouldNotBeEmpty, origin.ConfigFilePath));
             }
 
-            Value = value;
+            _value = value;
         }
 
         internal override XNode AsXNode()

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -475,8 +475,7 @@ namespace NuGet.Configuration
             validSettingFiles.AddRange(
                 settingsFiles
                     .Select(file => ReadSettings(file.DirectoryName!, file.FullName, settingsLoadingContext: settingsLoadingContext))
-                    .Where(file => file != null)
-                    .Cast<SettingsFile>());
+                    .OfType<SettingsFile>());
 
             return LoadSettingsForSpecificConfigs(
                 root.FullName,

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -460,7 +460,7 @@ namespace NuGet.Configuration
         /// </summary>
         internal static ISettings LoadSettings(
             DirectoryInfo root,
-            IMachineWideSettings machineWideSettings,
+            IMachineWideSettings? machineWideSettings,
             bool loadUserWideSettings,
             bool useTestingGlobalPath,
             SettingsLoadingContext? settingsLoadingContext = null)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -439,8 +439,7 @@ namespace NuGet.Configuration
                             }
                             return settingsLoadingContext.GetOrCreateSettingsFile(f);
                         })
-                        .Where(f => f != null)
-                        .Cast<SettingsFile>());
+                        .OfType<SettingsFile>());
             }
 
             return LoadSettingsForSpecificConfigs(

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -43,7 +43,7 @@ namespace NuGet.Configuration
 
         private readonly Dictionary<string, VirtualSettingSection> _computedSections;
 
-        public SettingSection GetSection(string sectionName)
+        public SettingSection? GetSection(string sectionName)
         {
             if (_computedSections.TryGetValue(sectionName, out var section))
             {
@@ -121,16 +121,19 @@ namespace NuGet.Configuration
             settingsFile.AddOrUpdate(sectionName, item);
 
             // AddOrUpdate should have created this section, therefore this should always exist.
-            settingsFile.TryGetSection(sectionName, out var settingFileSection);
+            settingsFile.TryGetSection(sectionName, out SettingSection? retrievedSettingFileSection);
+            SettingSection settingFileSection = retrievedSettingFileSection!;
 
             // If it is an add we have to manually add it to the _computedSections.
-            var computedSectionExists = _computedSections.TryGetValue(sectionName, out var section);
-            if (computedSectionExists && !section.Items.Contains(item))
+            if (_computedSections.TryGetValue(sectionName, out var section))
             {
-                var existingItem = settingFileSection.Items.First(i => i.Equals(item));
-                section.Add(existingItem);
+                if (!section.Items.Contains(item))
+                {
+                    var existingItem = settingFileSection.Items.First(i => i.Equals(item));
+                    section.Add(existingItem);
+                }
             }
-            else if (!computedSectionExists)
+            else
             {
                 _computedSections.Add(sectionName,
                     new VirtualSettingSection(settingFileSection));
@@ -167,7 +170,7 @@ namespace NuGet.Configuration
             }
         }
 
-        public event EventHandler SettingsChanged = delegate { };
+        public event EventHandler? SettingsChanged = delegate { };
 
         public Settings(string root)
             : this(new List<SettingsFile> { new SettingsFile(root) }) { }
@@ -207,7 +210,7 @@ namespace NuGet.Configuration
             _computedSections = computedSections;
         }
 
-        private SettingsFile GetOutputSettingFileForSection(string sectionName)
+        private SettingsFile? GetOutputSettingFileForSection(string sectionName)
         {
             // Search for the furthest from the user that can be written
             // to that is not clearing the ones before it on the hierarchy
@@ -224,7 +227,7 @@ namespace NuGet.Configuration
 
             if (clearedSections.Any())
             {
-                return clearedSections.First().Origin;
+                return clearedSections.First()!.Origin;
             }
 
             // if none have a clear tag, default to furthest from the user
@@ -251,7 +254,7 @@ namespace NuGet.Configuration
         /// Load default settings based on a directory.
         /// This includes machine wide settings.
         /// </summary>
-        public static ISettings LoadDefaultSettings(string root)
+        public static ISettings LoadDefaultSettings(string? root)
         {
             return LoadSettings(
                 root,
@@ -292,9 +295,9 @@ namespace NuGet.Configuration
         /// </param>
         /// <returns>The settings object loaded.</returns>
         public static ISettings LoadDefaultSettings(
-            string root,
-            string configFileName,
-            IMachineWideSettings machineWideSettings)
+            string? root,
+            string? configFileName,
+            IMachineWideSettings? machineWideSettings)
         {
             return LoadDefaultSettings(root, configFileName, machineWideSettings, settingsLoadingContext: null);
         }
@@ -331,10 +334,10 @@ namespace NuGet.Configuration
         /// <param name="settingsLoadingContext">A <see cref="SettingsLoadingContext" /> object to use when loading the settings.</param>
         /// <returns>The settings object loaded.</returns>
         public static ISettings LoadDefaultSettings(
-            string root,
-            string configFileName,
-            IMachineWideSettings machineWideSettings,
-            SettingsLoadingContext settingsLoadingContext)
+            string? root,
+            string? configFileName,
+            IMachineWideSettings? machineWideSettings,
+            SettingsLoadingContext? settingsLoadingContext)
         {
             return LoadSettings(
                 root,
@@ -364,7 +367,7 @@ namespace NuGet.Configuration
                 useTestingGlobalPath: false);
         }
 
-        public static ISettings LoadImmutableSettingsGivenConfigPaths(IList<string> configFilePaths, SettingsLoadingContext settingsLoadingContext)
+        public static ISettings LoadImmutableSettingsGivenConfigPaths(IList<string>? configFilePaths, SettingsLoadingContext settingsLoadingContext)
         {
             if (configFilePaths == null || configFilePaths.Count == 0)
             {
@@ -391,7 +394,7 @@ namespace NuGet.Configuration
             foreach (var configFile in configFilePaths)
             {
                 var file = new FileInfo(configFile);
-                settings.Add(new SettingsFile(file.DirectoryName, file.Name));
+                settings.Add(new SettingsFile(file.DirectoryName!, file.Name));
             }
 
             return LoadSettingsGivenSettingsFiles(settings);
@@ -414,12 +417,12 @@ namespace NuGet.Configuration
         /// For internal use only
         /// </summary>
         internal static ISettings LoadSettings(
-            string root,
-            string configFileName,
-            IMachineWideSettings machineWideSettings,
+            string? root,
+            string? configFileName,
+            IMachineWideSettings? machineWideSettings,
             bool loadUserWideSettings,
             bool useTestingGlobalPath,
-            SettingsLoadingContext settingsLoadingContext = null)
+            SettingsLoadingContext? settingsLoadingContext = null)
         {
             // Walk up the tree to find a config file; also look in .nuget subdirectories
             // If a configFile is passed, don't walk up the tree. Only use that single config file.
@@ -436,7 +439,8 @@ namespace NuGet.Configuration
                             }
                             return settingsLoadingContext.GetOrCreateSettingsFile(f);
                         })
-                        .Where(f => f != null));
+                        .Where(f => f != null)
+                        .Cast<SettingsFile>());
             }
 
             return LoadSettingsForSpecificConfigs(
@@ -459,7 +463,7 @@ namespace NuGet.Configuration
             IMachineWideSettings machineWideSettings,
             bool loadUserWideSettings,
             bool useTestingGlobalPath,
-            SettingsLoadingContext settingsLoadingContext = null)
+            SettingsLoadingContext? settingsLoadingContext = null)
         {
             var validSettingFiles = new List<SettingsFile>();
             var comparer = PathUtility.GetStringComparisonBasedOnOS();
@@ -470,8 +474,9 @@ namespace NuGet.Configuration
 
             validSettingFiles.AddRange(
                 settingsFiles
-                    .Select(file => ReadSettings(file.DirectoryName, file.FullName, settingsLoadingContext: settingsLoadingContext))
-                    .Where(file => file != null));
+                    .Select(file => ReadSettings(file.DirectoryName!, file.FullName, settingsLoadingContext: settingsLoadingContext))
+                    .Where(file => file != null)
+                    .Cast<SettingsFile>());
 
             return LoadSettingsForSpecificConfigs(
                 root.FullName,
@@ -484,13 +489,13 @@ namespace NuGet.Configuration
         }
 
         private static ISettings LoadSettingsForSpecificConfigs(
-            string root,
-            string configFileName,
+            string? root,
+            string? configFileName,
             List<SettingsFile> validSettingFiles,
-            IMachineWideSettings machineWideSettings,
+            IMachineWideSettings? machineWideSettings,
             bool loadUserWideSettings,
             bool useTestingGlobalPath,
-            SettingsLoadingContext settingsLoadingContext = null)
+            SettingsLoadingContext? settingsLoadingContext = null)
         {
             if (loadUserWideSettings)
             {
@@ -501,7 +506,9 @@ namespace NuGet.Configuration
             {
                 // Priority gives you the settings file in the order you want to start reading them
                 var files = mwSettings.Priority.Select(
-                    s => ReadSettings(s.DirectoryPath, s.FileName, s.IsMachineWide, settingsLoadingContext: settingsLoadingContext));
+                    s => ReadSettings(s.DirectoryPath, s.FileName, s.IsMachineWide, settingsLoadingContext: settingsLoadingContext))
+                    .Where(s => s != null)
+                    .Cast<SettingsFile>();
 
                 validSettingFiles.AddRange(files);
             }
@@ -531,10 +538,10 @@ namespace NuGet.Configuration
         /// <param name="settingsLoadingContext"></param>
         /// <returns></returns>
         internal static IEnumerable<SettingsFile> LoadUserSpecificSettings(
-            string root,
-            string configFileName,
+            string? root,
+            string? configFileName,
             bool useTestingGlobalPath,
-            SettingsLoadingContext settingsLoadingContext = null)
+            SettingsLoadingContext? settingsLoadingContext = null)
         {
             // Path.Combine is performed with root so it should not be null
             // However, it is legal for it be empty in this method
@@ -551,9 +558,12 @@ namespace NuGet.Configuration
                 var defaultSettingsFilePath = Path.Combine(userSettingsDir, DefaultSettingsFileName);
 
                 // ReadSettings will try to create the default config file if it doesn't exist
-                SettingsFile userSpecificSettings = ReadSettings(rootDirectory, defaultSettingsFilePath, settingsLoadingContext: settingsLoadingContext);
+                SettingsFile? userSpecificSettings = ReadSettings(rootDirectory, defaultSettingsFilePath, settingsLoadingContext: settingsLoadingContext);
 
-                yield return userSpecificSettings;
+                if (userSpecificSettings != null)
+                {
+                    yield return userSpecificSettings;
+                }
 
                 // For backwards compatibility, we first return default user specific the non-default configs and then the additional files from the nested `config` directory
                 var additionalConfigurationPath = GetAdditionalUserWideConfigurationDirectory(userSettingsDir);
@@ -580,8 +590,11 @@ namespace NuGet.Configuration
                         Path.Combine(rootDirectory, configFileName));
                     throw new InvalidOperationException(message);
                 }
-
-                yield return ReadSettings(rootDirectory, configFileName, settingsLoadingContext: settingsLoadingContext);
+                var settings = ReadSettings(rootDirectory, configFileName, settingsLoadingContext: settingsLoadingContext);
+                if (settings != null)
+                {
+                    yield return settings;
+                }
             }
         }
 
@@ -668,19 +681,19 @@ namespace NuGet.Configuration
 
         public static Tuple<string, string> GetFileNameAndItsRoot(string root, string settingsPath)
         {
-            string fileName = null;
-            string directory = null;
+            string fileName;
+            string directory;
 
             if (Path.IsPathRooted(settingsPath))
             {
                 fileName = Path.GetFileName(settingsPath);
-                directory = Path.GetDirectoryName(settingsPath);
+                directory = Path.GetDirectoryName(settingsPath)!;
             }
             else if (!FileSystemUtility.IsPathAFile(settingsPath))
             {
                 var fullPath = Path.Combine(root ?? string.Empty, settingsPath);
                 fileName = Path.GetFileName(fullPath);
-                directory = Path.GetDirectoryName(fullPath);
+                directory = Path.GetDirectoryName(fullPath)!;
             }
             else
             {
@@ -723,7 +736,10 @@ namespace NuGet.Configuration
         {
             if (string.IsNullOrEmpty(originDirectoryPath) || string.IsNullOrEmpty(originFilePath))
             {
+#pragma warning disable CS8603 // Possible null reference return.
+                // This code path doesn't seem possible, but if I'm wrong, then deleting this block will change the behavior of the code.
                 return null;
+#pragma warning restore CS8603 // Possible null reference return.
             }
 
             if (string.IsNullOrEmpty(path))
@@ -731,7 +747,7 @@ namespace NuGet.Configuration
                 return path;
             }
 
-            var rawPath = Path.Combine(originDirectoryPath, ResolvePath(Path.GetDirectoryName(originFilePath), path));
+            var rawPath = Path.Combine(originDirectoryPath, ResolvePath(Path.GetDirectoryName(originFilePath)!, path));
             var normalizedPath = new DirectoryInfo(rawPath).FullName;
             return normalizedPath;
         }
@@ -749,7 +765,7 @@ namespace NuGet.Configuration
 
             try
             {
-                root = Path.GetPathRoot(value);
+                root = Path.GetPathRoot(value)!;
             }
             catch (ArgumentException ex)
             {
@@ -765,12 +781,12 @@ namespace NuGet.Configuration
                 && root.Length == 1
                 && (root[0] == Path.DirectorySeparatorChar || value[0] == Path.AltDirectorySeparatorChar))
             {
-                return Path.Combine(Path.GetPathRoot(configDirectory), value.Substring(1));
+                return Path.Combine(Path.GetPathRoot(configDirectory)!, value.Substring(1));
             }
             return Path.Combine(configDirectory, value);
         }
 
-        private static SettingsFile ReadSettings(string settingsRoot, string settingsPath, bool isMachineWideSettings = false, bool isAdditionalUserWideConfig = false, SettingsLoadingContext settingsLoadingContext = null)
+        private static SettingsFile? ReadSettings(string settingsRoot, string settingsPath, bool isMachineWideSettings = false, bool isAdditionalUserWideConfig = false, SettingsLoadingContext? settingsLoadingContext = null)
         {
             try
             {
@@ -823,7 +839,7 @@ namespace NuGet.Configuration
         /// </summary>
         /// <remarks>For windows <see cref="OrderedSettingsFileNames"/> contains a single casing since
         /// the file system is case insensitive.</remarks>
-        private static string GetSettingsFileNameFromDir(string directory)
+        private static string? GetSettingsFileNameFromDir(string directory)
         {
             foreach (var nugetConfigCasing in OrderedSettingsFileNames)
             {
@@ -839,10 +855,11 @@ namespace NuGet.Configuration
 
         private static IEnumerable<string> GetSettingsFilePaths(string root)
         {
-            while (root != null)
+            string? current = root;
+            while (current != null)
             {
-                yield return root;
-                root = Path.GetDirectoryName(root);
+                yield return current;
+                current = Path.GetDirectoryName(current);
             }
 
             yield break;

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsGroup.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsGroup.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Xml.Linq;
 using NuGet.Shared;
@@ -15,15 +16,17 @@ namespace NuGet.Configuration
 
         protected virtual bool CanBeCleared => true;
 
-        protected SettingsGroup()
-            : base()
+        public override string ElementName { get; }
+
+        protected SettingsGroup(string name)
+            : this(name, attributes: null, children: null)
         {
-            Children = new List<T>();
         }
 
-        protected SettingsGroup(IReadOnlyDictionary<string, string> attributes, IEnumerable<T> children)
+        protected SettingsGroup(string name, IReadOnlyDictionary<string, string>? attributes, IEnumerable<T>? children)
             : base(attributes)
         {
+            ElementName = name ?? throw new ArgumentNullException(message: Resources.Argument_Cannot_Be_Null_Or_Empty, paramName: nameof(name));
             if (children == null)
             {
                 Children = new List<T>();
@@ -36,10 +39,10 @@ namespace NuGet.Configuration
 
         public override bool IsEmpty() => !Children.Any() || Children.All(c => c.IsEmpty());
 
-        internal SettingsGroup(XElement element, SettingsFile origin)
+        internal SettingsGroup(string name, XElement element, SettingsFile origin)
             : base(element, origin)
         {
-            ElementName = element.Name.LocalName;
+            ElementName = name;
 
             Children = SettingFactory.ParseChildren<T>(element, origin, CanBeCleared).ToList();
 
@@ -91,6 +94,11 @@ namespace NuGet.Configuration
             if (setting == null)
             {
                 throw new ArgumentNullException(nameof(setting));
+            }
+
+            if (Origin is null)
+            {
+                throw new InvalidOperationException("Cannot call this method on a setting where Origin is null.");
             }
 
             if (Origin.IsMachineWide)
@@ -149,7 +157,7 @@ namespace NuGet.Configuration
             }
         }
 
-        protected bool TryGetChild(T expectedChild, out T currentChild)
+        protected bool TryGetChild(T expectedChild, [NotNullWhen(true)] out T? currentChild)
         {
             currentChild = null;
 
@@ -168,7 +176,7 @@ namespace NuGet.Configuration
 
         void ISettingsGroup.Remove(SettingElement setting)
         {
-            Remove(setting as T);
+            Remove((T)setting);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsLoadingContext.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsLoadingContext.cs
@@ -22,7 +22,7 @@ namespace NuGet.Configuration
         /// <summary>
         /// Occurs when a file is read.
         /// </summary>
-        internal event EventHandler<string> FileRead;
+        internal event EventHandler<string>? FileRead;
 
         /// <inheritdoc cref="IDisposable.Dispose" />
         public void Dispose()
@@ -70,7 +70,7 @@ namespace NuGet.Configuration
                     var fileInfo = new FileInfo(key);
 
                     // Load the settings file, this will throw an exception if something is wrong with the file
-                    var settingsFile = new SettingsFile(fileInfo.DirectoryName, fileInfo.Name, isMachineWide, isReadOnly);
+                    var settingsFile = new SettingsFile(fileInfo.DirectoryName!, fileInfo.Name, isMachineWide, isReadOnly);
 
                     // Fire the FileRead event so unit tests can detect when a file was actually read versus cached
                     FileRead?.Invoke(this, fileInfo.FullName);

--- a/src/NuGet.Core/NuGet.Configuration/Settings/VirtualSettingSection.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/VirtualSettingSection.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace NuGet.Configuration
@@ -20,7 +21,7 @@ namespace NuGet.Configuration
         {
         }
 
-        internal VirtualSettingSection(string name, IReadOnlyDictionary<string, string> attributes, IEnumerable<SettingItem> children)
+        internal VirtualSettingSection(string name, IReadOnlyDictionary<string, string>? attributes, IEnumerable<SettingItem>? children)
             : base(name, attributes, children)
         {
         }
@@ -50,7 +51,7 @@ namespace NuGet.Configuration
                 {
                     if (item is UnknownItem unknown)
                     {
-                        unknown.Merge(currentItem as UnknownItem);
+                        unknown.Merge((UnknownItem)currentItem);
                     }
 
                     item.MergedWith = currentItem;
@@ -124,7 +125,7 @@ namespace NuGet.Configuration
             }
         }
 
-        private bool TryRemoveAllMergedWith(SettingItem currentSetting, out SettingItem undeletedItem)
+        private bool TryRemoveAllMergedWith(SettingItem currentSetting, [NotNullWhen(false)] out SettingItem? undeletedItem)
         {
             undeletedItem = null;
             var mergedSettings = new List<SettingItem>();
@@ -139,7 +140,7 @@ namespace NuGet.Configuration
             {
                 try
                 {
-                    elementToDelete.Parent.Remove(elementToDelete);
+                    elementToDelete.Parent!.Remove(elementToDelete);
                 }
                 // This means setting was merged with a machine wide settings.
                 catch
@@ -154,7 +155,7 @@ namespace NuGet.Configuration
 
         public override SettingBase Clone()
         {
-            return new VirtualSettingSection(ElementName, Attributes, Items.Select(s => s.Clone() as SettingItem));
+            return new VirtualSettingSection(ElementName, Attributes, Items.Select(s => (SettingItem)s.Clone()));
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Utility/FileSystemUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/FileSystemUtility.cs
@@ -30,7 +30,7 @@ namespace NuGet.Configuration
 
         internal static void AddFile(string fullPath, Action<Stream> writeToStream)
         {
-            Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
+            Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
             using (Stream outputStream = File.Create(fullPath))
             {
                 writeToStream(outputStream);
@@ -62,7 +62,7 @@ namespace NuGet.Configuration
             return File.Exists(Path.Combine(root, file));
         }
 
-        internal static IEnumerable<string> GetFilesRelativeToRoot(string root, string path = "", string[] filters = null, SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        internal static IEnumerable<string> GetFilesRelativeToRoot(string root, string path = "", string[]? filters = null, SearchOption searchOption = SearchOption.TopDirectoryOnly)
         {
             path = EnsureTrailingSlash(Path.Combine(root, path));
             if (filters == null || !filters.Any())

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -19,7 +19,7 @@ namespace NuGet.Configuration
         public static readonly string DefaultGlobalPackagesFolderPath = "packages" + Path.DirectorySeparatorChar;
         private const string RevocationModeEnvironmentKey = "NUGET_CERT_REVOCATION_MODE";
 
-        public static string GetValueForAddItem(ISettings settings, string section, string key, bool isPath = false)
+        public static string? GetValueForAddItem(ISettings settings, string section, string key, bool isPath = false)
         {
             if (settings == null)
             {
@@ -64,13 +64,13 @@ namespace NuGet.Configuration
         }
 
 
-        public static string GetRepositoryPath(ISettings settings)
+        public static string? GetRepositoryPath(ISettings settings)
         {
             var path = GetValueForAddItem(settings, ConfigurationConstants.Config, ConfigurationConstants.RepositoryPath, isPath: true);
 
             if (!string.IsNullOrEmpty(path))
             {
-                path = path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+                path = path!.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
             }
 
             return path;
@@ -121,7 +121,7 @@ namespace NuGet.Configuration
             return false;
         }
 
-        public static string GetDecryptedValueForAddItem(ISettings settings, string section, string key, bool isPath = false)
+        public static string? GetDecryptedValueForAddItem(ISettings settings, string section, string key, bool isPath = false)
         {
             if (settings == null)
             {
@@ -151,13 +151,13 @@ namespace NuGet.Configuration
 
             if (isPath)
             {
-                return Settings.ResolvePathFromOrigin(encryptedItem.Origin.DirectoryPath, encryptedItem.Origin.ConfigFilePath, decryptedString);
+                return Settings.ResolvePathFromOrigin(encryptedItem!.Origin!.DirectoryPath, encryptedItem.Origin.ConfigFilePath, decryptedString);
             }
 
             return decryptedString;
         }
 
-        public static void SetEncryptedValueForAddItem(ISettings settings, string section, string key, string value)
+        public static void SetEncryptedValueForAddItem(ISettings settings, string section, string key, string? value)
         {
             if (settings == null)
             {
@@ -178,7 +178,7 @@ namespace NuGet.Configuration
             var elementValue = string.Empty;
             if (!string.IsNullOrEmpty(value))
             {
-                elementValue = EncryptionUtility.EncryptString(value);
+                elementValue = EncryptionUtility.EncryptString(value!);
             }
 
             settings.AddOrUpdate(section, new AddItem(key, elementValue));
@@ -193,7 +193,7 @@ namespace NuGet.Configuration
         /// <param name="decrypt">Determines if the retrieved value needs to be decrypted.</param>
         /// <param name="isPath">Determines if the retrieved value is returned as a path.</param>
         /// <returns>Null if the key was not found, value from config otherwise.</returns>
-        public static string GetConfigValue(ISettings settings, string key, bool decrypt = false, bool isPath = false)
+        public static string? GetConfigValue(ISettings settings, string key, bool decrypt = false, bool isPath = false)
         {
             if (decrypt)
             {
@@ -210,7 +210,7 @@ namespace NuGet.Configuration
         /// <param name="key">The key to store.</param>
         /// <param name="value">The value to store.</param>
         /// <param name="encrypt">Determines if the value needs to be encrypted prior to storing.</param>
-        public static void SetConfigValue(ISettings settings, string key, string value, bool encrypt = false)
+        public static void SetConfigValue(ISettings settings, string key, string? value, bool encrypt = false)
         {
             if (settings == null)
             {
@@ -260,7 +260,7 @@ namespace NuGet.Configuration
 
             if (!string.IsNullOrEmpty(path))
             {
-                path = path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+                path = path!.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
                 path = Path.GetFullPath(path);
                 return path;
             }
@@ -321,7 +321,7 @@ namespace NuGet.Configuration
             // we care more about the bottom ones, so those ones should go first.
             IList<string> configFilePaths = settings.GetConfigFilePaths();
             return fallbackValues
-                .OrderBy(i => configFilePaths.IndexOf(i.Origin?.ConfigFilePath)) //lower index => higher priority => closer to user.
+                .OrderBy(i => configFilePaths.IndexOf(i.Origin?.ConfigFilePath!)) //lower index => higher priority => closer to user.
                 .OfType<AddItem>()
                 .Select(folder => folder.GetValueAsPath())
                 .ToList();
@@ -384,7 +384,7 @@ namespace NuGet.Configuration
         /// - A relative file path
         /// - The name of a registered source from a config file
         /// </summary>
-        public static string GetDefaultPushSource(ISettings settings)
+        public static string? GetDefaultPushSource(ISettings settings)
         {
             if (settings == null)
             {
@@ -396,7 +396,7 @@ namespace NuGet.Configuration
 
             var source = configSetting?.Value;
 
-            var sourceUri = UriUtility.TryCreateSourceUri(source, UriKind.RelativeOrAbsolute);
+            var sourceUri = UriUtility.TryCreateSourceUri(source!, UriKind.RelativeOrAbsolute);
             if (sourceUri != null && !sourceUri.IsAbsoluteUri)
             {
                 // For non-absolute sources, it could be the name of a config source, or a relative file path.
@@ -405,14 +405,14 @@ namespace NuGet.Configuration
                 if (!allSources.Any(s => s.IsEnabled && s.Name.Equals(source, StringComparison.OrdinalIgnoreCase)))
                 {
                     // It wasn't the name of a source, so treat it like a relative file 
-                    source = Settings.ResolvePathFromOrigin(configSetting.Origin.DirectoryPath, configSetting.Origin.ConfigFilePath, source);
+                    source = Settings.ResolvePathFromOrigin(configSetting!.Origin!.DirectoryPath, configSetting.Origin.ConfigFilePath, source!);
                 }
             }
 
             return source;
         }
 
-        public static RevocationMode GetRevocationMode(IEnvironmentVariableReader environmentVariableReader = null)
+        public static RevocationMode GetRevocationMode(IEnvironmentVariableReader? environmentVariableReader = null)
         {
             var reader = environmentVariableReader ?? EnvironmentVariableWrapper.Instance;
             var revocationModeSetting = reader.GetEnvironmentVariable(RevocationModeEnvironmentKey);

--- a/src/NuGet.Core/NuGet.Configuration/Utility/XElementUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/XElementUtility.cs
@@ -11,19 +11,19 @@ namespace NuGet.Configuration
 {
     internal static class XElementUtility
     {
-        internal static string GetOptionalAttributeValue(XElement element, string localName)
+        internal static string? GetOptionalAttributeValue(XElement element, string localName)
         {
             var attr = element.Attribute(localName);
             return attr?.Value;
         }
 
-        internal static string GetOptionalAttributeValue(XElement element, string localName, string namespaceName)
+        internal static string? GetOptionalAttributeValue(XElement element, string localName, string namespaceName)
         {
             var attr = element.Attribute(XName.Get(localName, namespaceName));
             return attr?.Value;
         }
 
-        internal static void AddIndented(XContainer container, XNode content)
+        internal static void AddIndented(XContainer? container, XNode? content)
         {
             if (container != null && content != null)
             {
@@ -40,7 +40,7 @@ namespace NuGet.Configuration
             }
         }
 
-        internal static void RemoveIndented(XNode element)
+        internal static void RemoveIndented(XNode? element)
         {
             if (element != null)
             {
@@ -60,7 +60,7 @@ namespace NuGet.Configuration
 
                 if (isLastChild
                     && textBeforeOrNull != null
-                    && IsWhiteSpace(textAfterOrNull))
+                    && (textAfterOrNull is null || IsWhiteSpace(textAfterOrNull)))
                 {
                     textBeforeOrNull.Value = textBeforeOrNull.Value.Substring(0, textBeforeOrNull.Value.Length - oneIndentLevel.Length);
                 }
@@ -90,7 +90,7 @@ namespace NuGet.Configuration
             return string.IsNullOrWhiteSpace(textNode.Value);
         }
 
-        private static void IndentChildrenElements(XContainer container, string containerIndent, string oneIndentLevel)
+        private static void IndentChildrenElements(XContainer? container, string containerIndent, string oneIndentLevel)
         {
             if (container != null)
             {

--- a/src/NuGet.Core/NuGet.Credentials/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Credentials/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -5,10 +5,10 @@ NuGet.Credentials.CredentialResponse.CredentialResponse(NuGet.Credentials.Creden
 ~NuGet.Credentials.CredentialResponse.Credentials.get -> System.Net.ICredentials
 NuGet.Credentials.CredentialResponse.Status.get -> NuGet.Credentials.CredentialStatus
 NuGet.Credentials.CredentialService
-~NuGet.Credentials.CredentialService.CredentialService(NuGet.Common.AsyncLazy<System.Collections.Generic.IEnumerable<NuGet.Credentials.ICredentialProvider>> providers, bool nonInteractive, bool handlesDefaultCredentials) -> void
-~NuGet.Credentials.CredentialService.GetCredentialsAsync(System.Uri uri, System.Net.IWebProxy proxy, NuGet.Configuration.CredentialRequestType type, string message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.ICredentials>
+NuGet.Credentials.CredentialService.CredentialService(NuGet.Common.AsyncLazy<System.Collections.Generic.IEnumerable<NuGet.Credentials.ICredentialProvider!>!>! providers, bool nonInteractive, bool handlesDefaultCredentials) -> void
+NuGet.Credentials.CredentialService.GetCredentialsAsync(System.Uri! uri, System.Net.IWebProxy? proxy, NuGet.Configuration.CredentialRequestType type, string! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.ICredentials?>!
 NuGet.Credentials.CredentialService.HandlesDefaultCredentials.get -> bool
-~NuGet.Credentials.CredentialService.TryGetLastKnownGoodCredentialsFromCache(System.Uri uri, bool isProxy, out System.Net.ICredentials credentials) -> bool
+NuGet.Credentials.CredentialService.TryGetLastKnownGoodCredentialsFromCache(System.Uri! uri, bool isProxy, out System.Net.ICredentials? credentials) -> bool
 NuGet.Credentials.CredentialStatus
 NuGet.Credentials.CredentialStatus.ProviderNotApplicable = 1 -> NuGet.Credentials.CredentialStatus
 NuGet.Credentials.CredentialStatus.Success = 0 -> NuGet.Credentials.CredentialStatus

--- a/src/NuGet.Core/NuGet.Credentials/PublicAPI/netcoreapp5.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Credentials/PublicAPI/netcoreapp5.0/PublicAPI.Shipped.txt
@@ -5,10 +5,10 @@ NuGet.Credentials.CredentialResponse.CredentialResponse(NuGet.Credentials.Creden
 ~NuGet.Credentials.CredentialResponse.Credentials.get -> System.Net.ICredentials
 NuGet.Credentials.CredentialResponse.Status.get -> NuGet.Credentials.CredentialStatus
 NuGet.Credentials.CredentialService
-~NuGet.Credentials.CredentialService.CredentialService(NuGet.Common.AsyncLazy<System.Collections.Generic.IEnumerable<NuGet.Credentials.ICredentialProvider>> providers, bool nonInteractive, bool handlesDefaultCredentials) -> void
-~NuGet.Credentials.CredentialService.GetCredentialsAsync(System.Uri uri, System.Net.IWebProxy proxy, NuGet.Configuration.CredentialRequestType type, string message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.ICredentials>
+NuGet.Credentials.CredentialService.CredentialService(NuGet.Common.AsyncLazy<System.Collections.Generic.IEnumerable<NuGet.Credentials.ICredentialProvider!>!>! providers, bool nonInteractive, bool handlesDefaultCredentials) -> void
+NuGet.Credentials.CredentialService.GetCredentialsAsync(System.Uri! uri, System.Net.IWebProxy? proxy, NuGet.Configuration.CredentialRequestType type, string! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.ICredentials?>!
 NuGet.Credentials.CredentialService.HandlesDefaultCredentials.get -> bool
-~NuGet.Credentials.CredentialService.TryGetLastKnownGoodCredentialsFromCache(System.Uri uri, bool isProxy, out System.Net.ICredentials credentials) -> bool
+NuGet.Credentials.CredentialService.TryGetLastKnownGoodCredentialsFromCache(System.Uri! uri, bool isProxy, out System.Net.ICredentials? credentials) -> bool
 NuGet.Credentials.CredentialStatus
 NuGet.Credentials.CredentialStatus.ProviderNotApplicable = 1 -> NuGet.Credentials.CredentialStatus
 NuGet.Credentials.CredentialStatus.Success = 0 -> NuGet.Credentials.CredentialStatus

--- a/src/NuGet.Core/NuGet.Credentials/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Credentials/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -5,10 +5,10 @@ NuGet.Credentials.CredentialResponse.CredentialResponse(NuGet.Credentials.Creden
 ~NuGet.Credentials.CredentialResponse.Credentials.get -> System.Net.ICredentials
 NuGet.Credentials.CredentialResponse.Status.get -> NuGet.Credentials.CredentialStatus
 NuGet.Credentials.CredentialService
-~NuGet.Credentials.CredentialService.CredentialService(NuGet.Common.AsyncLazy<System.Collections.Generic.IEnumerable<NuGet.Credentials.ICredentialProvider>> providers, bool nonInteractive, bool handlesDefaultCredentials) -> void
-~NuGet.Credentials.CredentialService.GetCredentialsAsync(System.Uri uri, System.Net.IWebProxy proxy, NuGet.Configuration.CredentialRequestType type, string message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.ICredentials>
+NuGet.Credentials.CredentialService.CredentialService(NuGet.Common.AsyncLazy<System.Collections.Generic.IEnumerable<NuGet.Credentials.ICredentialProvider!>!>! providers, bool nonInteractive, bool handlesDefaultCredentials) -> void
+NuGet.Credentials.CredentialService.GetCredentialsAsync(System.Uri! uri, System.Net.IWebProxy? proxy, NuGet.Configuration.CredentialRequestType type, string! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.ICredentials?>!
 NuGet.Credentials.CredentialService.HandlesDefaultCredentials.get -> bool
-~NuGet.Credentials.CredentialService.TryGetLastKnownGoodCredentialsFromCache(System.Uri uri, bool isProxy, out System.Net.ICredentials credentials) -> bool
+NuGet.Credentials.CredentialService.TryGetLastKnownGoodCredentialsFromCache(System.Uri! uri, bool isProxy, out System.Net.ICredentials? credentials) -> bool
 NuGet.Credentials.CredentialStatus
 NuGet.Credentials.CredentialStatus.ProviderNotApplicable = 1 -> NuGet.Credentials.CredentialStatus
 NuGet.Credentials.CredentialStatus.Success = 0 -> NuGet.Credentials.CredentialStatus

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
@@ -199,7 +199,7 @@ namespace NuGet.Protocol.FuncTest
                 // This occurs because when HttpClientHandler.Credentials is set (i.e., not null) while accessing the index.json.
                 // These credentials are automatically sent with requests to the private feed upon receiving 401 challenge.
                 // As a result, NuGet does not need to invoke the credential service again while retrieving the package information.
-                mockedCredentialService.Verify(x => x.TryGetLastKnownGoodCredentialsFromCache(It.IsAny<Uri>(), It.IsAny<bool>(), out It.Ref<ICredentials>.IsAny), Times.Once);
+                mockedCredentialService.Verify(x => x.TryGetLastKnownGoodCredentialsFromCache(It.IsAny<Uri>(), It.IsAny<bool>(), out It.Ref<ICredentials?>.IsAny), Times.Once);
 
                 // ExecuteAsync returns Task<T>, so need to return something to give it a <T>.
                 return (object?)null;
@@ -220,7 +220,7 @@ namespace NuGet.Protocol.FuncTest
                     });
                 // Setup TryGetLastKnownGoodCredentialsFromCache mock
                 mockedCredentialService
-                    .Setup(x => x.TryGetLastKnownGoodCredentialsFromCache(packageSource.SourceUri, It.IsAny<bool>(), out It.Ref<ICredentials>.IsAny))
+                    .Setup(x => x.TryGetLastKnownGoodCredentialsFromCache(packageSource.SourceUri, It.IsAny<bool>(), out It.Ref<ICredentials?>.IsAny))
                     .Returns((Uri sourceUri, bool isProxyRequest, out ICredentials? outCredentials) =>
                     {
                         outCredentials = cachedCredentials;

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/ClientCertificateProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/ClientCertificateProviderTests.cs
@@ -34,8 +34,8 @@ namespace NuGet.Configuration.Test
                 var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
                 Assert.Equal(1, packageSourceList.Count);
-                Assert.Equal(1, packageSourceList[0].ClientCertificates.Count);
-                Assert.Equal(testInfo.Certificate, packageSourceList[0].ClientCertificates[0]);
+                Assert.Equal(1, packageSourceList[0].ClientCertificates!.Count);
+                Assert.Equal(testInfo.Certificate, packageSourceList[0].ClientCertificates![0]);
             }
         }
 
@@ -51,7 +51,7 @@ namespace NuGet.Configuration.Test
                 var settings = testInfo.LoadSettingsFromConfigFile();
                 var clientCertificateProvider = new ClientCertificateProvider(settings);
                 clientCertificateProvider.AddOrUpdate(new StoreClientCertItem(testInfo.PackageSourceName,
-                                                                              testInfo.CertificateFindValue.ToString(),
+                                                                              testInfo.CertificateFindValue.ToString()!,
                                                                               testInfo.CertificateStoreLocation,
                                                                               testInfo.CertificateStoreName,
                                                                               testInfo.CertificateFindBy));
@@ -60,8 +60,8 @@ namespace NuGet.Configuration.Test
                 var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
                 Assert.Equal(1, packageSourceList.Count);
-                Assert.Equal(1, packageSourceList[0].ClientCertificates.Count);
-                Assert.Equal(testInfo.Certificate, packageSourceList[0].ClientCertificates[0]);
+                Assert.Equal(1, packageSourceList[0].ClientCertificates!.Count);
+                Assert.Equal(testInfo.Certificate, packageSourceList[0].ClientCertificates![0]);
             }
         }
 
@@ -115,7 +115,7 @@ namespace NuGet.Configuration.Test
 
             public ISettings LoadSettingsFromConfigFile()
             {
-                var directory = Path.GetDirectoryName(ConfigFile);
+                var directory = Path.GetDirectoryName(ConfigFile)!;
                 var filename = Path.GetFileName(ConfigFile);
                 return Settings.LoadSpecificSettings(directory, filename);
             }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/ConfigurationDefaultsThreadSafetyTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/ConfigurationDefaultsThreadSafetyTests.cs
@@ -41,7 +41,7 @@ namespace NuGet.Configuration.Test
 
             for (int attempt = 0; attempt < 10; attempt++)
             {
-                ConfigurationDefaults configurationDefaults = new(Path.GetDirectoryName(testContext.NuGetConfig), Path.GetFileName(testContext.NuGetConfig));
+                ConfigurationDefaults configurationDefaults = new(Path.GetDirectoryName(testContext.NuGetConfig)!, Path.GetFileName(testContext.NuGetConfig));
 
                 // Act
                 RunInParallel(EnumerateDefaultSources, attempt);
@@ -70,7 +70,7 @@ namespace NuGet.Configuration.Test
                 using SimpleTestPathContext testContext = new();
                 testContext.Settings.SetDefaultPushSource(testContext.PackageSource);
 
-                ConfigurationDefaults configurationDefaults = new(Path.GetDirectoryName(testContext.NuGetConfig), Path.GetFileName(testContext.NuGetConfig));
+                ConfigurationDefaults configurationDefaults = new(Path.GetDirectoryName(testContext.NuGetConfig)!, Path.GetFileName(testContext.NuGetConfig));
 
                 // Act
                 RunInParallel(CheckDefaultPushSource, attempt);
@@ -80,7 +80,7 @@ namespace NuGet.Configuration.Test
 
                 void CheckDefaultPushSource()
                 {
-                    string source = configurationDefaults.DefaultPushSource;
+                    string? source = configurationDefaults.DefaultPushSource;
                     if (source == null)
                     {
                         throw new Exception("Default package source is null");
@@ -107,7 +107,7 @@ namespace NuGet.Configuration.Test
                 threads[i].Join();
             }
 
-            if (exceptions.TryDequeue(out Exception ex))
+            if (exceptions.TryDequeue(out Exception? ex))
             {
                 throw new Exception("At least one thread did not complete successfully on attempt " + (attempt + 1), ex);
             }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/EnvironmentSupportTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/EnvironmentSupportTests.cs
@@ -61,7 +61,7 @@ namespace NuGet.Configuration.Test
                 var settings = new Settings(nugetConfigFileFolder, nugetConfigFile);
 
                 //Assert
-                var settingsForConfig = settings.GetSection("config")?.Items.OfType<AddItem>();
+                var settingsForConfig = settings.GetSection("config")?.Items.OfType<AddItem>()!;
                 Assert.Single(settingsForConfig);
                 Assert.Equal(settingsForConfig.Single().GetValueAsPath(), Path.Combine(nugetConfigFileFolder, expectedRepositoryPath));
             }
@@ -117,7 +117,7 @@ namespace NuGet.Configuration.Test
                 var settings = new Settings(nugetConfigFileFolder, nugetConfigFile);
 
                 //Assert
-                var settingsForConfig = settings.GetSection("config")?.Items.OfType<AddItem>();
+                var settingsForConfig = settings.GetSection("config")?.Items.OfType<AddItem>()!;
                 Assert.Single(settingsForConfig);
                 Assert.Equal(expectedRepositoryPath, settingsForConfig.Single().GetValueAsPath());
             }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/FallbackFolderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/FallbackFolderTests.cs
@@ -246,7 +246,7 @@ namespace NuGet.Configuration.Test
             }
         }
 
-        private static string GetFileName(string path)
+        private static string? GetFileName(string path)
         {
             return path.Split(new char[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries).LastOrDefault();
         }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/NuGet.Configuration.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/NuGet.Configuration.Test.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>$(TargetFrameworksExe)</TargetFrameworks>
     <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Configuration.</Description>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceMappingProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceMappingProviderTests.cs
@@ -17,7 +17,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void Constructor_WithNullSettingsThrows()
         {
-            Assert.Throws<ArgumentNullException>(() => new PackageSourceMappingProvider(null));
+            Assert.Throws<ArgumentNullException>(() => new PackageSourceMappingProvider(null!));
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -290,7 +290,7 @@ namespace NuGet.Configuration.Test
                 File.WriteAllText(settingsFile.FullName, configContents);
 
                 var settings = Settings.LoadSettings(
-                    settingsFile.Directory,
+                    settingsFile.Directory!,
                     machineWideSettings: null,
                     loadUserWideSettings: false,
                     useTestingGlobalPath: false);
@@ -568,7 +568,7 @@ namespace NuGet.Configuration.Test
                 var disabledPackagesSection = settings.GetSection("disabledPackageSources");
                 disabledPackagesSection.Should().NotBeNull();
 
-                var expectedDisabledSources = disabledPackagesSection?.Items.ToList();
+                var expectedDisabledSources = disabledPackagesSection!.Items.ToList();
 
                 var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
@@ -585,7 +585,7 @@ namespace NuGet.Configuration.Test
                 var actualDisabledSourcesSection = newSettings.GetSection("disabledPackageSources");
                 actualDisabledSourcesSection.Should().NotBeNull();
 
-                var actualDisabledSources = actualDisabledSourcesSection?.Items.ToList();
+                var actualDisabledSources = actualDisabledSourcesSection!.Items.ToList();
 
                 Assert.Equal(expectedDisabledSources.Count, actualDisabledSources.Count);
                 foreach (var item in expectedDisabledSources)
@@ -627,7 +627,7 @@ namespace NuGet.Configuration.Test
                 var disabledPackagesSection = settings.GetSection("disabledPackageSources");
                 disabledPackagesSection.Should().NotBeNull();
 
-                var disabledSources = disabledPackagesSection?.Items.Select(c => c as AddItem).ToList();
+                var disabledSources = disabledPackagesSection!.Items.Select(c => (AddItem)c).ToList();
 
                 // Pre-Assert
                 Assert.Equal(2, disabledSources.Count);
@@ -657,7 +657,7 @@ namespace NuGet.Configuration.Test
                 disabledPackagesSection = newSettings.GetSection("disabledPackageSources");
                 disabledPackagesSection.Should().NotBeNull();
 
-                disabledSources = disabledPackagesSection?.Items.Select(c => c as AddItem).ToList();
+                disabledSources = disabledPackagesSection!.Items.Select(c => (AddItem)c).ToList();
 
                 Assert.Equal(1, disabledSources.Count);
                 Assert.Equal("Microsoft and .NET", disabledSources[0].Key);
@@ -1067,10 +1067,10 @@ namespace NuGet.Configuration.Test
                 // Assert
                 var packageSourcesSection = settings.GetSection("packageSources");
                 packageSourcesSection.Should().NotBeNull();
-                packageSourcesSection.Items.Count.Should().Be(3);
+                packageSourcesSection!.Items.Count.Should().Be(3);
                 packageSourcesSection.Items.Should().AllBeOfType<SourceItem>();
 
-                var children = packageSourcesSection.Items.Select(c => c as SourceItem).ToList();
+                var children = packageSourcesSection.Items.Select(c => (SourceItem)c).ToList();
                 children[0].Key.Should().Be("one");
                 children[0].ProtocolVersion.Should().BeNullOrEmpty();
                 children[1].Key.Should().Be("two");
@@ -1110,10 +1110,10 @@ namespace NuGet.Configuration.Test
                 // Assert
                 var packageSourcesSection = settings.GetSection("packageSources");
                 packageSourcesSection.Should().NotBeNull();
-                packageSourcesSection.Items.Count.Should().Be(2);
+                packageSourcesSection!.Items.Count.Should().Be(2);
                 packageSourcesSection.Items.Should().AllBeOfType<SourceItem>();
 
-                var children = packageSourcesSection.Items.Select(c => c as SourceItem).ToList();
+                var children = packageSourcesSection.Items.Select(c => (SourceItem)c).ToList();
                 children[0].Key.Should().Be("Source2-Name");
                 children[0].ProtocolVersion.Should().BeNullOrEmpty();
                 children[1].Key.Should().Be("Source1-Name");
@@ -1146,10 +1146,10 @@ namespace NuGet.Configuration.Test
                 // Assert
                 var packageSourcesSection = settings.GetSection("packageSources");
                 packageSourcesSection.Should().NotBeNull();
-                packageSourcesSection.Items.Count.Should().Be(3);
+                packageSourcesSection!.Items.Count.Should().Be(3);
                 packageSourcesSection.Items.Should().AllBeOfType<SourceItem>();
 
-                var children = packageSourcesSection.Items.Select(c => c as SourceItem).ToList();
+                var children = packageSourcesSection.Items.Select(c => (SourceItem)c).ToList();
                 children[0].Key.Should().Be("one");
                 children[0].ProtocolVersion.Should().BeNullOrEmpty();
                 children[1].Key.Should().Be("two");
@@ -1159,11 +1159,11 @@ namespace NuGet.Configuration.Test
 
                 var disabledPackageSourcesSection = settings.GetSection("disabledPackageSources");
                 disabledPackageSourcesSection.Should().NotBeNull();
-                disabledPackageSourcesSection.Items.Count.Should().Be(1);
+                disabledPackageSourcesSection!.Items.Count.Should().Be(1);
 
                 var two = disabledPackageSourcesSection.Items.FirstOrDefault() as AddItem;
                 two.Should().NotBeNull();
-                two.Key.Should().Be("two");
+                two!.Key.Should().Be("two");
                 two.Value.Should().Be("true");
             }
         }
@@ -1197,10 +1197,10 @@ namespace NuGet.Configuration.Test
                 // Assert
                 var packageSourcesSection = settings.GetSection("packageSources");
                 packageSourcesSection.Should().NotBeNull();
-                packageSourcesSection.Items.Count.Should().Be(3);
+                packageSourcesSection!.Items.Count.Should().Be(3);
                 packageSourcesSection.Items.Should().AllBeOfType<SourceItem>();
 
-                var children = packageSourcesSection.Items.Select(c => c as SourceItem).ToList();
+                var children = packageSourcesSection.Items.Select(c => (SourceItem)c).ToList();
                 children[0].Key.Should().Be("one");
                 children[0].ProtocolVersion.Should().BeNullOrEmpty();
                 children[1].Key.Should().Be("twoname");
@@ -1214,10 +1214,10 @@ namespace NuGet.Configuration.Test
 
                 var sourcesCredentialsSection = settings.GetSection("packageSourceCredentials");
                 sourcesCredentialsSection.Should().NotBeNull();
-                sourcesCredentialsSection.Items.Count.Should().Be(1);
+                sourcesCredentialsSection!.Items.Count.Should().Be(1);
                 var two = sourcesCredentialsSection.Items.FirstOrDefault() as CredentialsItem;
                 two.Should().NotBeNull();
-                two.ElementName.Should().Be("twoname");
+                two!.ElementName.Should().Be("twoname");
                 two.Username.Should().Be("User");
                 two.IsPasswordClearText.Should().BeFalse();
                 two.Password.Should().Be(encryptedPassword);
@@ -1252,10 +1252,10 @@ namespace NuGet.Configuration.Test
                 // Assert
                 var packageSourcesSection = settings.GetSection("packageSources");
                 packageSourcesSection.Should().NotBeNull();
-                packageSourcesSection.Items.Count.Should().Be(3);
+                packageSourcesSection!.Items.Count.Should().Be(3);
                 packageSourcesSection.Items.Should().AllBeOfType<SourceItem>();
 
-                var children = packageSourcesSection.Items.Select(c => c as SourceItem).ToList();
+                var children = packageSourcesSection.Items.Select(c => (SourceItem)c).ToList();
                 children[0].Key.Should().Be("one");
                 children[0].ProtocolVersion.Should().BeNullOrEmpty();
                 children[1].Key.Should().Be("twoname");
@@ -1269,10 +1269,10 @@ namespace NuGet.Configuration.Test
 
                 var sourcesCredentialsSection = settings.GetSection("packageSourceCredentials");
                 sourcesCredentialsSection.Should().NotBeNull();
-                sourcesCredentialsSection.Items.Count.Should().Be(1);
+                sourcesCredentialsSection!.Items.Count.Should().Be(1);
                 var two = sourcesCredentialsSection.Items.FirstOrDefault() as CredentialsItem;
                 two.Should().NotBeNull();
-                two.ElementName.Should().Be("twoname");
+                two!.ElementName.Should().Be("twoname");
                 two.Username.Should().Be("User");
                 two.IsPasswordClearText.Should().BeTrue();
                 two.Password.Should().Be("password");
@@ -1810,7 +1810,7 @@ namespace NuGet.Configuration.Test
 
                 File.WriteAllText(Path.Combine(directory.Path, "machinewide.config"), machineWideContents);
                 var additionalConfigPath = Path.Combine(directory.Path, "TestingGlobalPath", "config", "contoso.nuget.config");
-                Directory.CreateDirectory(Path.GetDirectoryName(additionalConfigPath));
+                Directory.CreateDirectory(Path.GetDirectoryName(additionalConfigPath)!);
                 File.WriteAllText(additionalConfigPath, additionalConfigContents);
 
                 var machineWideSetting = new Settings(directory.Path, "machinewide.config", isMachineWide: true);
@@ -2227,7 +2227,7 @@ namespace NuGet.Configuration.Test
             target.PackageSourcesChanged += (s, e) => { eventRun = true; };
 
             // Act
-            setting.Raise(s => s.SettingsChanged += null, (EventArgs)null);
+            setting.Raise(s => s.SettingsChanged += null, (EventArgs?)null);
 
             // Assert
             Assert.Equal(subscribeToEvent, eventRun);
@@ -2254,10 +2254,10 @@ namespace NuGet.Configuration.Test
 
             // Act
             PackageSourceProvider psp = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
-            PackageSource source = psp.GetPackageSourceBySource(sourceUrl);
+            PackageSource? source = psp.GetPackageSourceBySource(sourceUrl);
 
             // Assert
-            source.Name.Should().Be("s1");
+            source!.Name.Should().Be("s1");
         }
 
         [Fact]
@@ -2447,7 +2447,7 @@ namespace NuGet.Configuration.Test
             Assert.True(ps.IsOfficial == isOfficial);
         }
 
-        private void AssertCredentials(PackageSourceCredential actual, string source, string userName, string passwordText, bool isPasswordClearText = true)
+        private void AssertCredentials(PackageSourceCredential? actual, string source, string userName, string passwordText, bool isPasswordClearText = true)
         {
             Assert.NotNull(actual);
             Assert.Equal(source, actual.Source);
@@ -2460,7 +2460,7 @@ namespace NuGet.Configuration.Test
         {
             var settingsFile = new FileInfo(Path.Combine(directory.Path, "TestingGlobalPath", "NuGet.Config"));
 
-            settingsFile.Directory.Create();
+            settingsFile.Directory!.Create();
 
             File.WriteAllText(settingsFile.FullName, @"<?xml version=""1.0"" encoding=""utf-8""?><configuration />");
         }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
@@ -35,7 +35,7 @@ namespace NuGet.Configuration.Test
 
             // source credential
             result.Credentials.Should().NotBeNull();
-            result.Credentials.Source.Should().BeEquivalentTo(source.Credentials.Source);
+            result.Credentials!.Source.Should().BeEquivalentTo(source.Credentials.Source);
             result.Credentials.Username.Should().BeEquivalentTo(source.Credentials.Username);
             result.Credentials.IsPasswordClearText.Should().Be(source.Credentials.IsPasswordClearText);
         }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/ProxyCacheTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/ProxyCacheTests.cs
@@ -141,14 +141,14 @@ namespace NuGet.Configuration.Test
             var proxyCache = new ProxyCache(settings, environment.Object);
 
             // Act
-            var proxy = proxyCache.GetUserConfiguredProxy() as WebProxy;
+            var proxy = proxyCache.GetUserConfiguredProxy();
 
             // Assert
             AssertProxy(host, username, password, proxy);
-            Assert.Equal(bypassedAddresses, proxy.BypassList);
+            Assert.Equal(bypassedAddresses, proxy!.BypassList);
         }
 
-        private static void AssertProxy(string proxyAddress, string username, string password, WebProxy actual)
+        private static void AssertProxy(string proxyAddress, string? username, string? password, WebProxy? actual)
         {
             Assert.NotNull(actual);
             Assert.Equal(proxyAddress, actual.ProxyAddress.OriginalString);

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/AddItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/AddItemTests.cs
@@ -74,7 +74,7 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("section");
                 section.Should().NotBeNull();
 
-                var children = section.Items.ToList();
+                var children = section!.Items.ToList();
 
                 children.Should().NotBeEmpty();
                 children.Count.Should().Be(1);
@@ -106,11 +106,11 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as AddItem;
+                var element = (AddItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
                 // Assert
-                SettingsTestUtils.DeepEquals(element, expectedSetting).Should().BeTrue();
+                SettingsTestUtils.DeepEquals(element!, expectedSetting).Should().BeTrue();
             }
         }
 
@@ -137,11 +137,11 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as AddItem;
+                var element = (AddItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
                 // Assert
-                SettingsTestUtils.DeepEquals(element, expectedSetting).Should().BeTrue();
+                SettingsTestUtils.DeepEquals(element!, expectedSetting).Should().BeTrue();
             }
         }
 
@@ -172,11 +172,11 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var value = section.Items.FirstOrDefault() as AddItem;
+                var value = (AddItem?)section!.Items.FirstOrDefault();
                 value.Should().NotBeNull();
 
                 // Assert
-                SettingsTestUtils.DeepEquals(value, expectedSetting).Should().BeTrue();
+                SettingsTestUtils.DeepEquals(value!, expectedSetting).Should().BeTrue();
             }
         }
 
@@ -231,18 +231,18 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as AddItem;
+                var element = (AddItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
-                element.Value = "newValue";
+                element!.Value = "newValue";
                 element.Value.Should().Be("newValue");
 
                 var section2 = settingsFile.GetSection("Section");
                 section2.Should().NotBeNull();
 
-                var element2 = section2.Items.FirstOrDefault() as AddItem;
+                var element2 = (AddItem?)section2!.Items.FirstOrDefault();
                 element2.Should().NotBeNull();
-                element2.Value.Should().Be("value1");
+                element2!.Value.Should().Be("value1");
 
                 settingsFile.AddOrUpdate("Section", element);
                 settingsFile.SaveToDisk();
@@ -250,9 +250,9 @@ namespace NuGet.Configuration.Test
                 var section3 = settingsFile.GetSection("Section");
                 section3.Should().NotBeNull();
 
-                var element3 = section.Items.FirstOrDefault() as AddItem;
+                var element3 = (AddItem?)section!.Items.FirstOrDefault();
                 element3.Should().NotBeNull();
-                element3.Value.Should().Be("newValue");
+                element3!.Value.Should().Be("newValue");
 
                 var updatedFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
                 updatedFileHash.Should().NotBeEquivalentTo(configFileHash);
@@ -307,7 +307,7 @@ namespace NuGet.Configuration.Test
 
                 // Assert
                 section.Should().NotBeNull();
-                section.Items.Should().NotBeEmpty();
+                section!.Items.Should().NotBeEmpty();
                 section.Items.Should().AllBeOfType<AddItem>();
 
                 if (RuntimeEnvironmentHelper.IsWindows)
@@ -316,25 +316,25 @@ namespace NuGet.Configuration.Test
 
                     var item = section.GetFirstItemWithAttribute<AddItem>("key", "key1");
                     item.Should().NotBeNull();
-                    item.GetValueAsPath().Should().Be(new DirectoryInfo(Path.Combine(mockBaseDirectory, @"..\value1")).FullName);
+                    item!.GetValueAsPath().Should().Be(new DirectoryInfo(Path.Combine(mockBaseDirectory, @"..\value1")).FullName);
                     item = section.GetFirstItemWithAttribute<AddItem>("key", "key2");
                     item.Should().NotBeNull();
-                    item.GetValueAsPath().Should().Be(Path.Combine(mockBaseDirectory, @"a\b\c"));
+                    item!.GetValueAsPath().Should().Be(Path.Combine(mockBaseDirectory, @"a\b\c"));
                     item = section.GetFirstItemWithAttribute<AddItem>("key", "key3");
                     item.Should().NotBeNull();
-                    item.GetValueAsPath().Should().Be(new DirectoryInfo(Path.Combine(mockBaseDirectory, @".\a\b\c")).FullName);
+                    item!.GetValueAsPath().Should().Be(new DirectoryInfo(Path.Combine(mockBaseDirectory, @".\a\b\c")).FullName);
                     item = section.GetFirstItemWithAttribute<AddItem>("key", "key4");
                     item.Should().NotBeNull();
-                    item.GetValueAsPath().Should().Be(@"c:\value2");
+                    item!.GetValueAsPath().Should().Be(@"c:\value2");
                     item = section.GetFirstItemWithAttribute<AddItem>("key", "key5");
                     item.Should().NotBeNull();
-                    item.GetValueAsPath().Should().Be(@"http://value3");
+                    item!.GetValueAsPath().Should().Be(@"http://value3");
                     item = section.GetFirstItemWithAttribute<AddItem>("key", "key6");
                     item.Should().NotBeNull();
-                    item.GetValueAsPath().Should().Be(@"\\a\b\c");
+                    item!.GetValueAsPath().Should().Be(@"\\a\b\c");
                     item = section.GetFirstItemWithAttribute<AddItem>("key", "key7");
                     item.Should().NotBeNull();
-                    item.GetValueAsPath().Should().Be(Path.Combine(Path.GetPathRoot(mockBaseDirectory), @"a\b\c"));
+                    item!.GetValueAsPath().Should().Be(Path.Combine(Path.GetPathRoot(mockBaseDirectory)!, @"a\b\c"));
                 }
                 else
                 {
@@ -342,19 +342,19 @@ namespace NuGet.Configuration.Test
 
                     var item = section.GetFirstItemWithAttribute<AddItem>("key", "key1");
                     item.Should().NotBeNull();
-                    item.GetValueAsPath().Should().Be(new DirectoryInfo(Path.Combine(mockBaseDirectory, @"../value1")).FullName);
+                    item!.GetValueAsPath().Should().Be(new DirectoryInfo(Path.Combine(mockBaseDirectory, @"../value1")).FullName);
                     item = section.GetFirstItemWithAttribute<AddItem>("key", "key2");
                     item.Should().NotBeNull();
-                    item.GetValueAsPath().Should().Be(Path.Combine(mockBaseDirectory, @"a/b/c"));
+                    item!.GetValueAsPath().Should().Be(Path.Combine(mockBaseDirectory, @"a/b/c"));
                     item = section.GetFirstItemWithAttribute<AddItem>("key", "key3");
                     item.Should().NotBeNull();
-                    item.GetValueAsPath().Should().Be(new DirectoryInfo(Path.Combine(mockBaseDirectory, @"./a/b/c")).FullName);
+                    item!.GetValueAsPath().Should().Be(new DirectoryInfo(Path.Combine(mockBaseDirectory, @"./a/b/c")).FullName);
                     item = section.GetFirstItemWithAttribute<AddItem>("key", "key5");
                     item.Should().NotBeNull();
-                    item.GetValueAsPath().Should().Be(@"http://value3");
+                    item!.GetValueAsPath().Should().Be(@"http://value3");
                     item = section.GetFirstItemWithAttribute<AddItem>("key", "key7");
                     item.Should().NotBeNull();
-                    item.GetValueAsPath().Should().Be(@"/a/b/c");
+                    item!.GetValueAsPath().Should().Be(@"/a/b/c");
                 }
             }
         }
@@ -405,12 +405,12 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
+                section!.Items.Count.Should().Be(1);
                 var item = section.Items.First();
                 item.IsCopy().Should().BeFalse();
                 item.Origin.Should().NotBeNull();
 
-                var clone = item.Clone() as AddItem;
+                var clone = (AddItem)item.Clone();
                 clone.IsCopy().Should().BeTrue();
                 clone.Origin.Should().NotBeNull();
                 SettingsTestUtils.DeepEquals(clone, item).Should().BeTrue();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/AuthorItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/AuthorItemTests.cs
@@ -84,8 +84,8 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as AuthorItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (AuthorItem)section.Items.First();
 
                 var expectedItem = new AuthorItem("authorName",
                     new CertificateItem("abcdefg", Common.HashAlgorithmName.SHA256, allowUntrustedRoot: true));
@@ -115,10 +115,10 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as AuthorItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (AuthorItem)section.Items.First();
 
-                var updatedItem = item.Clone() as AuthorItem;
+                var updatedItem = (AuthorItem)item.Clone();
                 updatedItem.Certificates.Add(new CertificateItem("xyz", Common.HashAlgorithmName.SHA256));
 
                 item.Update(updatedItem);
@@ -164,10 +164,10 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as AuthorItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (AuthorItem)section.Items.First();
 
-                var updatedItem = item.Clone() as AuthorItem;
+                var updatedItem = (AuthorItem)item.Clone();
                 updatedItem.Certificates.RemoveAt(1);
 
                 item.Update(updatedItem);
@@ -211,10 +211,10 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as AuthorItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (AuthorItem)section.Items.First();
 
-                var updatedItem = item.Clone() as AuthorItem;
+                var updatedItem = (AuthorItem)item.Clone();
                 updatedItem.Certificates.Clear();
 
                 // Act and Assert
@@ -248,10 +248,10 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as AuthorItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (AuthorItem)section.Items.First();
 
-                var updatedItem = item.Clone() as AuthorItem;
+                var updatedItem = (AuthorItem)item.Clone();
                 var cert = updatedItem.Certificates.First();
                 cert.HashAlgorithm = Common.HashAlgorithmName.SHA384;
 
@@ -327,12 +327,12 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
+                section!.Items.Count.Should().Be(1);
                 var item = section.Items.First();
                 item.IsCopy().Should().BeFalse();
                 item.Origin.Should().NotBeNull();
 
-                var clone = item.Clone() as AuthorItem;
+                var clone = (AuthorItem)item.Clone();
                 clone.IsCopy().Should().BeTrue();
                 clone.Origin.Should().NotBeNull();
                 SettingsTestUtils.DeepEquals(clone, item).Should().BeTrue();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CertificateItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CertificateItemTests.cs
@@ -153,8 +153,8 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as CertificateItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (CertificateItem)section.Items.First();
 
                 var expectedItem = new CertificateItem("abcdefg", Common.HashAlgorithmName.SHA256, allowUntrustedRoot: true);
                 SettingsTestUtils.DeepEquals(item, expectedItem).Should().BeTrue();
@@ -181,10 +181,10 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as CertificateItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (CertificateItem)section.Items.First();
 
-                var updatedItem = item.Clone() as CertificateItem;
+                var updatedItem = (CertificateItem)item.Clone();
                 updatedItem.HashAlgorithm = Common.HashAlgorithmName.SHA512;
 
                 item.Update(updatedItem);
@@ -224,10 +224,10 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as CertificateItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (CertificateItem)section.Items.First();
 
-                var updatedItem = item.Clone() as CertificateItem;
+                var updatedItem = (CertificateItem)item.Clone();
                 updatedItem.AllowUntrustedRoot = false;
 
                 item.Update(updatedItem);
@@ -293,7 +293,7 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
+                section!.Items.Count.Should().Be(1);
                 var item = section.Items.First();
                 item.IsCopy().Should().BeFalse();
                 item.Origin.Should().NotBeNull();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/ClearItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/ClearItemTests.cs
@@ -34,7 +34,7 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("section");
                 section.Should().NotBeNull();
 
-                var children = section.Items.ToList();
+                var children = section!.Items.ToList();
 
                 children.Should().NotBeEmpty();
                 children.Count.Should().Be(1);
@@ -65,7 +65,7 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
+                section!.Items.Count.Should().Be(1);
                 section.Items.FirstOrDefault().Should().BeOfType<ClearItem>();
             }
         }
@@ -92,7 +92,7 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
+                section!.Items.Count.Should().Be(1);
                 section.Items.FirstOrDefault().Should().BeOfType<ClearItem>();
             }
         }
@@ -170,12 +170,12 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
+                section!.Items.Count.Should().Be(1);
                 var item = section.Items.First();
                 item.IsCopy().Should().BeFalse();
                 item.Origin.Should().NotBeNull();
 
-                var clone = item.Clone() as ClearItem;
+                var clone = (ClearItem)item.Clone();
                 clone.IsCopy().Should().BeTrue();
                 clone.Origin.Should().NotBeNull();
                 SettingsTestUtils.DeepEquals(clone, item).Should().BeTrue();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
@@ -327,7 +327,7 @@ namespace NuGet.Configuration.Test
                 // Assert
                 credentials.Username.Should().Be("newuser");
 
-                var credentialElement = credentials.AsXNode() as XElement;
+                var credentialElement = (XElement)credentials.AsXNode();
                 var childElements = credentialElement.Elements().ToList();
 
                 childElements.Count.Should().Be(2);
@@ -359,7 +359,7 @@ namespace NuGet.Configuration.Test
                 // Assert
                 credentials.Password.Should().Be("newpass");
 
-                var credentialElement = credentials.AsXNode() as XElement;
+                var credentialElement = (XElement)credentials.AsXNode();
                 var childElements = credentialElement.Elements().ToList();
 
                 childElements.Count.Should().Be(2);
@@ -391,7 +391,7 @@ namespace NuGet.Configuration.Test
                 // Assert
                 credentials.Password.Should().Be("newpass");
 
-                var credentialElement = credentials.AsXNode() as XElement;
+                var credentialElement = (XElement)credentials.AsXNode();
                 var childElements = credentialElement.Elements().ToList();
 
                 childElements.Count.Should().Be(2);
@@ -423,7 +423,7 @@ namespace NuGet.Configuration.Test
                 // Assert
                 credentials.Password.Should().Be("newpass");
 
-                var credentialElement = credentials.AsXNode() as XElement;
+                var credentialElement = (XElement)credentials.AsXNode();
                 var childElements = credentialElement.Elements().ToList();
 
                 childElements.Count.Should().Be(2);
@@ -455,7 +455,7 @@ namespace NuGet.Configuration.Test
                 // Assert
                 credentials.Password.Should().Be("newpass");
 
-                var credentialElement = credentials.AsXNode() as XElement;
+                var credentialElement = (XElement)credentials.AsXNode();
                 var childElements = credentialElement.Elements().ToList();
 
                 childElements.Count.Should().Be(2);
@@ -491,7 +491,7 @@ namespace NuGet.Configuration.Test
                 origin.IsDirty.Should().BeTrue();
                 origin.SaveToDisk();
 
-                var credentialElement = credentials.AsXNode() as XElement;
+                var credentialElement = (XElement)credentials.AsXNode();
                 var childElements = credentialElement.Elements().ToList();
 
                 childElements.Count.Should().Be(2);
@@ -519,7 +519,7 @@ namespace NuGet.Configuration.Test
 
             // Assert
             xnode.Should().BeOfType<XElement>();
-            var xelement = xnode as XElement;
+            var xelement = (XElement)xnode;
 
             xelement.Name.LocalName.Should().Be("credentials_x0020_name");
             var elements = xelement.Elements().ToList();
@@ -548,7 +548,7 @@ namespace NuGet.Configuration.Test
 
             // Assert
             xnode.Should().BeOfType<XElement>();
-            var xelement = xnode as XElement;
+            var xelement = (XElement)xnode;
 
             xelement.Name.LocalName.Should().Be("https_x003A__x002F__x002F_nuget.contoso.com_x002F_v3_x002F_index.json");
         }
@@ -564,7 +564,7 @@ namespace NuGet.Configuration.Test
 
             // Assert
             xnode.Should().BeOfType<XElement>();
-            var xelement = xnode as XElement;
+            var xelement = (XElement)xnode;
 
             xelement.Name.LocalName.Should().Be("name");
             var elements = xelement.Elements().ToList();
@@ -593,7 +593,7 @@ namespace NuGet.Configuration.Test
 
             // Assert
             xnode.Should().BeOfType<XElement>();
-            var xelement = xnode as XElement;
+            var xelement = (XElement)xnode;
 
             xelement.Name.LocalName.Should().Be("name");
             var elements = xelement.Elements().ToList();
@@ -661,12 +661,12 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("packageSourceCredentials", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
+                section!.Items.Count.Should().Be(1);
                 var item = section.Items.First();
                 item.IsCopy().Should().BeFalse();
                 item.Origin.Should().NotBeNull();
 
-                var clone = item.Clone() as CredentialsItem;
+                var clone = (CredentialsItem)item.Clone();
                 clone.IsCopy().Should().BeTrue();
                 clone.Origin.Should().NotBeNull();
                 SettingsTestUtils.DeepEquals(clone, item).Should().BeTrue();
@@ -696,12 +696,12 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("packageSourceCredentials", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
+                section!.Items.Count.Should().Be(1);
                 var item = section.Items.First();
                 item.IsCopy().Should().BeFalse();
                 item.Origin.Should().NotBeNull();
 
-                var clone = item.Clone() as CredentialsItem;
+                var clone = (CredentialsItem)item.Clone();
                 clone.IsCopy().Should().BeTrue();
                 clone.Origin.Should().NotBeNull();
                 SettingsTestUtils.DeepEquals(clone, item).Should().BeTrue();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/FileClientCertItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/FileClientCertItemTests.cs
@@ -45,7 +45,7 @@ namespace NuGet.Configuration.Test
                                                                         @".\certificate.pfx",
                                                                         null,
                                                                         false,
-                                                                        string.Empty);
+                                                                        "\\fake\\path");
 
                 SettingsTestUtils.DeepEquals(fileClientCertItem, expectedFileClientCertItem).Should().BeTrue();
             }
@@ -86,7 +86,7 @@ namespace NuGet.Configuration.Test
                                                                         @".\certificate.pfx",
                                                                         "...",
                                                                         true,
-                                                                        string.Empty);
+                                                                        "\\fake\\path");
 
                 SettingsTestUtils.DeepEquals(fileClientCertItem, expectedFileClientCertItem).Should().BeTrue();
             }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/FileClientCertItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/FileClientCertItemTests.cs
@@ -30,7 +30,7 @@ namespace NuGet.Configuration.Test
                 var settingsFile = new SettingsFile(mockBaseDirectory);
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
-                var items = section.Items.ToList();
+                var items = section!.Items.ToList();
 
                 items.Count.Should().Be(1);
 
@@ -71,7 +71,7 @@ namespace NuGet.Configuration.Test
                 var settingsFile = new SettingsFile(mockBaseDirectory);
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
-                var items = section.Items.ToList();
+                var items = section!.Items.ToList();
 
                 items.Count.Should().Be(1);
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/FileClientCertItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/FileClientCertItemTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.IO;
 using System.Linq;
 using FluentAssertions;
 using NuGet.Test.Utility;
@@ -45,7 +46,7 @@ namespace NuGet.Configuration.Test
                                                                         @".\certificate.pfx",
                                                                         null,
                                                                         false,
-                                                                        "\\fake\\path");
+                                                                        Path.Combine(mockBaseDirectory, nugetConfigPath));
 
                 SettingsTestUtils.DeepEquals(fileClientCertItem, expectedFileClientCertItem).Should().BeTrue();
             }
@@ -86,7 +87,7 @@ namespace NuGet.Configuration.Test
                                                                         @".\certificate.pfx",
                                                                         "...",
                                                                         true,
-                                                                        "\\fake\\path");
+                                                                        Path.Combine(mockBaseDirectory, nugetConfigPath));
 
                 SettingsTestUtils.DeepEquals(fileClientCertItem, expectedFileClientCertItem).Should().BeTrue();
             }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/OwnersItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/OwnersItemTests.cs
@@ -112,8 +112,8 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as OwnersItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (OwnersItem)section.Items.First();
 
                 var expectedItem = new OwnersItem("test;text;owner");
                 SettingsTestUtils.DeepEquals(item, expectedItem).Should().BeTrue();
@@ -140,10 +140,10 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as OwnersItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (OwnersItem)section.Items.First();
 
-                var updatedItem = item.Clone() as OwnersItem;
+                var updatedItem = (OwnersItem)item.Clone();
                 updatedItem.Content.Clear();
                 updatedItem.Content.Add("abc");
 
@@ -184,10 +184,10 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as OwnersItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (OwnersItem)section.Items.First();
 
-                var updatedItem = item.Clone() as OwnersItem;
+                var updatedItem = (OwnersItem)item.Clone();
                 updatedItem.Content.Clear();
 
                 var ex = Record.Exception(() => item.Update(updatedItem));
@@ -252,7 +252,7 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
+                section!.Items.Count.Should().Be(1);
                 var item = section.Items.First();
                 item.IsCopy().Should().BeFalse();
                 item.Origin.Should().NotBeNull();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/PackagePatternItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/PackagePatternItemTests.cs
@@ -79,7 +79,7 @@ namespace NuGet.Configuration.Test
         public void Clone_CreatesEquivalentObjects(string patternName)
         {
             var original = new PackagePatternItem(patternName);
-            var clone = original.Clone() as PackagePatternItem;
+            var clone = (PackagePatternItem)original.Clone();
 
             original.Equals(clone).Should().BeTrue();
             original.GetHashCode().Equals(clone.GetHashCode()).Should().BeTrue();
@@ -166,8 +166,8 @@ namespace NuGet.Configuration.Test
             var section = settingsFile.GetSection("packageSourceMapping");
             section.Should().NotBeNull();
 
-            section.Items.Count.Should().Be(1);
-            var item = (section.Items.First() as PackageSourceMappingSourceItem).Patterns.First();
+            section!.Items.Count.Should().Be(1);
+            var item = ((PackageSourceMappingSourceItem)section.Items.First()).Patterns.First();
 
             var expectedItem = new PackagePatternItem("sadas");
             SettingsTestUtils.DeepEquals(item, expectedItem).Should().BeTrue();
@@ -194,8 +194,8 @@ namespace NuGet.Configuration.Test
             settingsFile.TryGetSection("packageSourceMapping", out var section).Should().BeTrue();
             section.Should().NotBeNull();
 
-            section.Items.Count.Should().Be(1);
-            var packageSourcePatternsItem = section.Items.First() as PackageSourceMappingSourceItem;
+            section!.Items.Count.Should().Be(1);
+            var packageSourcePatternsItem = (PackageSourceMappingSourceItem)section.Items.First();
             var updatedItem = new PackagePatternItem("updated");
             packageSourcePatternsItem.Patterns.First().Update(updatedItem);
             SettingsTestUtils.DeepEquals(packageSourcePatternsItem.Patterns.First(), updatedItem).Should().BeTrue();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/PackageSourceMappingSourceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/PackageSourceMappingSourceItemTests.cs
@@ -30,7 +30,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void Constructor_WithNullPackagePatterns_Throws()
         {
-            Assert.Throws<ArgumentException>(() => new PackageSourceMappingSourceItem("name", null));
+            Assert.Throws<ArgumentException>(() => new PackageSourceMappingSourceItem("name", null!));
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace NuGet.Configuration.Test
         public void Clone_CreatesEquivalentPackagePatterns()
         {
             var original = new PackageSourceMappingSourceItem("name", new List<PackagePatternItem>() { new PackagePatternItem("stuff"), new PackagePatternItem("stuff2") });
-            var clone = original.Clone() as PackageSourceMappingSourceItem;
+            var clone = (PackageSourceMappingSourceItem)original.Clone();
             original.Equals(clone).Should().BeTrue();
             original.GetHashCode().Equals(clone.GetHashCode()).Should().BeTrue();
             SettingsTestUtils.DeepEquals(original, clone).Should().BeTrue();
@@ -184,8 +184,8 @@ namespace NuGet.Configuration.Test
             var section = settingsFile.GetSection("packageSourceMapping");
             section.Should().NotBeNull();
 
-            section.Items.Count.Should().Be(1);
-            var packageSourceMappingSourceItem = section.Items.First() as PackageSourceMappingSourceItem;
+            section!.Items.Count.Should().Be(1);
+            var packageSourceMappingSourceItem = (PackageSourceMappingSourceItem)section.Items.First();
             var item = packageSourceMappingSourceItem.Patterns.First();
             var expectedItem = new PackagePatternItem("sadas");
             SettingsTestUtils.DeepEquals(item, expectedItem).Should().BeTrue();
@@ -214,8 +214,8 @@ namespace NuGet.Configuration.Test
             var section = settingsFile.GetSection("packageSourceMapping");
             section.Should().NotBeNull();
 
-            section.Items.Count.Should().Be(1);
-            var packageSourceMappingSourceItem = section.Items.First() as PackageSourceMappingSourceItem;
+            section!.Items.Count.Should().Be(1);
+            var packageSourceMappingSourceItem = (PackageSourceMappingSourceItem)section.Items.First();
             var item = packageSourceMappingSourceItem.Patterns.First();
             var expectedItem = new PackagePatternItem("sadas");
             SettingsTestUtils.DeepEquals(item, expectedItem).Should().BeTrue();
@@ -242,11 +242,11 @@ namespace NuGet.Configuration.Test
             settingsFile.TryGetSection("packageSourceMapping", out var section).Should().BeTrue();
             section.Should().NotBeNull();
 
-            section.Items.Count.Should().Be(1);
-            var packageSourceMappingSourceItem = section.Items.First() as PackageSourceMappingSourceItem;
+            section!.Items.Count.Should().Be(1);
+            var packageSourceMappingSourceItem = (PackageSourceMappingSourceItem)section.Items.First();
             packageSourceMappingSourceItem.Patterns.Should().HaveCount(1);
 
-            var clone = packageSourceMappingSourceItem.Clone() as PackageSourceMappingSourceItem;
+            var clone = (PackageSourceMappingSourceItem)packageSourceMappingSourceItem.Clone();
             clone.Patterns.Add(new PackagePatternItem("second"));
 
             packageSourceMappingSourceItem.Update(clone);
@@ -291,11 +291,11 @@ namespace NuGet.Configuration.Test
             settingsFile.TryGetSection("packageSourceMapping", out var section).Should().BeTrue();
             section.Should().NotBeNull();
 
-            section.Items.Count.Should().Be(1);
-            var packageSourceMappingSourceItem = section.Items.First() as PackageSourceMappingSourceItem;
+            section!.Items.Count.Should().Be(1);
+            var packageSourceMappingSourceItem = (PackageSourceMappingSourceItem)section.Items.First();
             packageSourceMappingSourceItem.Patterns.Should().HaveCount(3);
 
-            var clone = packageSourceMappingSourceItem.Clone() as PackageSourceMappingSourceItem;
+            var clone = (PackageSourceMappingSourceItem)packageSourceMappingSourceItem.Clone();
             clone.Patterns.Add(new PackagePatternItem("third"));
             clone.Patterns.Add(new PackagePatternItem("third")); // Add a duplicate pattern to ensure it's handled without exception.
 
@@ -341,11 +341,11 @@ namespace NuGet.Configuration.Test
             settingsFile.TryGetSection("packageSourceMapping", out var section).Should().BeTrue();
             section.Should().NotBeNull();
 
-            section.Items.Count.Should().Be(1);
-            var packageSourceMappingSourceItem = section.Items.First() as PackageSourceMappingSourceItem;
+            section!.Items.Count.Should().Be(1);
+            var packageSourceMappingSourceItem = (PackageSourceMappingSourceItem)section.Items.First();
             packageSourceMappingSourceItem.Patterns.Should().HaveCount(2);
 
-            var clone = packageSourceMappingSourceItem.Clone() as PackageSourceMappingSourceItem;
+            var clone = (PackageSourceMappingSourceItem)packageSourceMappingSourceItem.Clone();
             clone.Patterns.RemoveAt(1);
 
             packageSourceMappingSourceItem.Update(clone);
@@ -387,11 +387,11 @@ namespace NuGet.Configuration.Test
             settingsFile.TryGetSection("packageSourceMapping", out var section).Should().BeTrue();
             section.Should().NotBeNull();
 
-            section.Items.Count.Should().Be(1);
-            var packageSourceMappingSourceItem = section.Items.First() as PackageSourceMappingSourceItem;
+            section!.Items.Count.Should().Be(1);
+            var packageSourceMappingSourceItem = (PackageSourceMappingSourceItem)section.Items.First();
             packageSourceMappingSourceItem.Patterns.Should().HaveCount(1);
 
-            var clone = packageSourceMappingSourceItem.Clone() as PackageSourceMappingSourceItem;
+            var clone = (PackageSourceMappingSourceItem)packageSourceMappingSourceItem.Clone();
             clone.Patterns.Clear();
 
             var ex = Record.Exception(() => packageSourceMappingSourceItem.Update(clone));
@@ -423,11 +423,11 @@ namespace NuGet.Configuration.Test
             settingsFile.TryGetSection("packageSourceMapping", out var section).Should().BeTrue();
             section.Should().NotBeNull();
 
-            section.Items.Count.Should().Be(1);
-            var packageSourceMappingSourceItem = section.Items.First() as PackageSourceMappingSourceItem;
+            section!.Items.Count.Should().Be(1);
+            var packageSourceMappingSourceItem = (PackageSourceMappingSourceItem)section.Items.First();
             packageSourceMappingSourceItem.Patterns.Should().HaveCount(2);
 
-            var clone = packageSourceMappingSourceItem.Clone() as PackageSourceMappingSourceItem;
+            var clone = (PackageSourceMappingSourceItem)packageSourceMappingSourceItem.Clone();
             clone.Patterns.RemoveAt(1);
             clone.Patterns.Add(new PackagePatternItem("third"));
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/RepositoryItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/RepositoryItemTests.cs
@@ -167,8 +167,8 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as RepositoryItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (RepositoryItem)section.Items.First();
 
                 var expectedItem = new RepositoryItem("repositoryName", "https://api.test/index/",
                     new CertificateItem("abcdefg", Common.HashAlgorithmName.SHA256, allowUntrustedRoot: true));
@@ -199,8 +199,8 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as RepositoryItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (RepositoryItem)section.Items.First();
 
                 var expectedItem = new RepositoryItem("repositoryName", "https://api.test/index/", "test;text",
                     new CertificateItem("abcdefg", Common.HashAlgorithmName.SHA256, allowUntrustedRoot: true));
@@ -230,10 +230,10 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as RepositoryItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (RepositoryItem)section.Items.First();
 
-                var updatedItem = item.Clone() as RepositoryItem;
+                var updatedItem = (RepositoryItem)item.Clone();
                 updatedItem.Certificates.Add(new CertificateItem("xyz", Common.HashAlgorithmName.SHA256));
 
                 item.Update(updatedItem);
@@ -279,11 +279,11 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.Last() as RepositoryItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (RepositoryItem)section.Items.Last();
                 item.Certificates.Count.Should().Be(2);
 
-                var updatedItem = item.Clone() as RepositoryItem;
+                var updatedItem = (RepositoryItem)item.Clone();
                 updatedItem.Certificates.RemoveAt(1);
 
                 item.Update(updatedItem);
@@ -328,11 +328,11 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as RepositoryItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (RepositoryItem)section.Items.First();
                 item.Certificates.Count.Should().Be(1);
 
-                var updatedItem = item.Clone() as RepositoryItem;
+                var updatedItem = (RepositoryItem)item.Clone();
                 updatedItem.Certificates.Clear();
 
                 var ex = Record.Exception(() => item.Update(updatedItem));
@@ -366,10 +366,10 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as RepositoryItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (RepositoryItem)section.Items.First();
 
-                var updatedItem = item.Clone() as RepositoryItem;
+                var updatedItem = (RepositoryItem)item.Clone();
                 var cert = updatedItem.Certificates.First();
                 cert.HashAlgorithm = Common.HashAlgorithmName.SHA384;
 
@@ -414,11 +414,11 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as RepositoryItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (RepositoryItem)section.Items.First();
                 item.Owners.Count.Should().Be(0);
 
-                var updatedItem = item.Clone() as RepositoryItem;
+                var updatedItem = (RepositoryItem)item.Clone();
                 updatedItem.Owners.Add("owner1");
 
                 item.Update(updatedItem);
@@ -464,11 +464,11 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as RepositoryItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (RepositoryItem)section.Items.First();
                 item.Owners.Count.Should().Be(1);
 
-                var updatedItem = item.Clone() as RepositoryItem;
+                var updatedItem = (RepositoryItem)item.Clone();
                 updatedItem.Owners.AddRange(new[] { "owner2", "owner3" });
 
                 item.Update(updatedItem);
@@ -514,11 +514,11 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as RepositoryItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (RepositoryItem)section.Items.First();
                 item.Owners.Count.Should().Be(2);
 
-                var updatedItem = item.Clone() as RepositoryItem;
+                var updatedItem = (RepositoryItem)item.Clone();
                 updatedItem.Owners.RemoveAt(1);
 
                 item.Update(updatedItem);
@@ -565,11 +565,11 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as RepositoryItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (RepositoryItem)section.Items.First();
                 item.Owners.Count.Should().Be(2);
 
-                var updatedItem = item.Clone() as RepositoryItem;
+                var updatedItem = (RepositoryItem)item.Clone();
                 updatedItem.Owners.Clear();
 
                 item.Update(updatedItem);
@@ -614,10 +614,10 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as RepositoryItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (RepositoryItem)section.Items.First();
 
-                var updatedItem = item.Clone() as RepositoryItem;
+                var updatedItem = (RepositoryItem)item.Clone();
                 updatedItem.Name = "newName";
 
                 item.Update(updatedItem);
@@ -697,12 +697,12 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
+                section!.Items.Count.Should().Be(1);
                 var item = section.Items.First();
                 item.IsCopy().Should().BeFalse();
                 item.Origin.Should().NotBeNull();
 
-                var clone = item.Clone() as RepositoryItem;
+                var clone = (RepositoryItem)item.Clone();
                 clone.IsCopy().Should().BeTrue();
                 clone.Origin.Should().NotBeNull();
                 SettingsTestUtils.DeepEquals(clone, item).Should().BeTrue();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingSectionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingSectionTests.cs
@@ -37,7 +37,7 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var key3Element = section.GetFirstItemWithAttribute<AddItem>("key", "key3");
+                var key3Element = section!.GetFirstItemWithAttribute<AddItem>("key", "key3");
 
                 // Assert
                 key3Element.Should().BeNull();
@@ -66,7 +66,7 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var children = section.Items;
+                var children = section!.Items;
 
                 // Assert
                 children.Should().NotBeEmpty();
@@ -104,7 +104,7 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("config");
                 section.Should().NotBeNull();
 
-                var children = section.Items.ToList();
+                var children = section!.Items.ToList();
 
                 // Assert
                 children.Should().NotBeEmpty();
@@ -137,13 +137,13 @@ namespace NuGet.Configuration.Test
                 // Act
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
-                section.Items.Count.Should().Be(2);
+                section!.Items.Count.Should().Be(2);
 
                 settingsFile.AddOrUpdate("Section", new AddItem("key2", "value2"));
 
                 section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
-                section.Items.Count.Should().Be(3);
+                section!.Items.Count.Should().Be(3);
 
                 settingsFile.SaveToDisk();
 
@@ -175,15 +175,15 @@ namespace NuGet.Configuration.Test
                 // Act
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
-                section.Items.Count.Should().Be(2);
+                section!.Items.Count.Should().Be(2);
 
                 settingsFile.AddOrUpdate("Section", new AddItem("key0", "value0", new Dictionary<string, string>() { { "meta1", "data1" } }));
 
                 section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
-                section.Items.Count.Should().Be(2);
+                section!.Items.Count.Should().Be(2);
 
-                var item = section.Items.First() as AddItem;
+                var item = (AddItem)section.Items.First();
                 item.Should().NotBeNull();
                 item.AdditionalAttributes.Count.Should().Be(1);
                 item.AdditionalAttributes["meta1"].Should().Be("data1");
@@ -218,7 +218,7 @@ namespace NuGet.Configuration.Test
                 // Act
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
-                section.Items.Count.Should().Be(2);
+                section!.Items.Count.Should().Be(2);
 
                 var ex = Record.Exception(() => settingsFile.AddOrUpdate("Section", new AddItem("key2", "value2")));
                 ex.Should().NotBeNull();
@@ -227,7 +227,7 @@ namespace NuGet.Configuration.Test
 
                 section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
-                section.Items.Count.Should().Be(2);
+                section!.Items.Count.Should().Be(2);
 
                 settingsFile.SaveToDisk();
 
@@ -259,7 +259,7 @@ namespace NuGet.Configuration.Test
                 // Act
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
-                section.Items.Count.Should().Be(2);
+                section!.Items.Count.Should().Be(2);
 
                 var ex = Record.Exception(() => settingsFile.AddOrUpdate("Section", new AddItem("key2", "value2")));
                 ex.Should().NotBeNull();
@@ -268,7 +268,7 @@ namespace NuGet.Configuration.Test
 
                 section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
-                section.Items.Count.Should().Be(2);
+                section!.Items.Count.Should().Be(2);
 
                 settingsFile.SaveToDisk();
 
@@ -301,17 +301,17 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var child = section.GetFirstItemWithAttribute<AddItem>("key", "key0");
+                var child = section!.GetFirstItemWithAttribute<AddItem>("key", "key0");
                 child.Should().NotBeNull();
 
-                settingsFile.Remove("Section", child);
+                settingsFile.Remove("Section", child!);
                 settingsFile.SaveToDisk();
 
                 var updatedFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
                 updatedFileHash.Should().NotBeEquivalentTo(configFileHash);
 
                 section = settingsFile.GetSection("Section");
-                section.Items.Count.Should().Be(1);
+                section!.Items.Count.Should().Be(1);
                 var deletedChild = section.GetFirstItemWithAttribute<AddItem>("key", "key0");
                 deletedChild.Should().BeNull();
             }
@@ -341,10 +341,10 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var child = section.GetFirstItemWithAttribute<AddItem>("key", "key0");
+                var child = section!.GetFirstItemWithAttribute<AddItem>("key", "key0");
                 child.Should().NotBeNull();
 
-                var ex = Record.Exception(() => settingsFile.Remove("Section", child));
+                var ex = Record.Exception(() => settingsFile.Remove("Section", child!));
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
                 ex.Message.Should().Be("Unable to update setting since it is in a machine-wide NuGet.Config.");
@@ -380,10 +380,10 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var child = section.GetFirstItemWithAttribute<AddItem>("key", "key0");
+                var child = section!.GetFirstItemWithAttribute<AddItem>("key", "key0");
                 child.Should().NotBeNull();
 
-                var ex = Record.Exception(() => settingsFile.Remove("Section", child));
+                var ex = Record.Exception(() => settingsFile.Remove("Section", child!));
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
                 ex.Message.Should().Be(Resources.CannotUpdateReadOnlyConfig);
@@ -418,10 +418,10 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var child = section.GetFirstItemWithAttribute<AddItem>("key", "key0");
+                var child = section!.GetFirstItemWithAttribute<AddItem>("key", "key0");
                 child.Should().NotBeNull();
 
-                settingsFile.Remove("Section", child);
+                settingsFile.Remove("Section", child!);
                 settingsFile.SaveToDisk();
 
                 var updatedFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
@@ -456,7 +456,7 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                section.Remove(new AddItem("key7", "value7"));
+                section!.Remove(new AddItem("key7", "value7"));
 
                 var updatedFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
                 updatedFileHash.Should().BeEquivalentTo(configFileHash);
@@ -516,7 +516,7 @@ namespace NuGet.Configuration.Test
             var xNode = section.AsXNode();
             xNode.Should().BeOfType<XElement>();
             var xelement = xNode as XElement;
-            xelement.Name.LocalName.Should().Be("section_x0020_name");
+            xelement!.Name.LocalName.Should().Be("section_x0020_name");
         }
 
         [Fact]
@@ -564,10 +564,10 @@ namespace NuGet.Configuration.Test
                 section.Should().NotBeNull();
                 section.Should().BeOfType<ParsedSettingSection>();
 
-                section.IsCopy().Should().BeFalse();
+                section!.IsCopy().Should().BeFalse();
                 section.Origin.Should().NotBeNull();
 
-                var clone = section.Clone() as SettingSection;
+                var clone = (SettingSection)section.Clone();
                 clone.IsAbstract().Should().BeTrue();
                 clone.Origin.Should().BeNull();
                 clone.Should().BeOfType<VirtualSettingSection>();
@@ -580,7 +580,7 @@ namespace NuGet.Configuration.Test
                 virtualSection.Origin.Should().BeNull();
                 virtualSection.IsAbstract().Should().BeTrue();
 
-                var virtualClone = virtualSection.Clone() as SettingSection;
+                var virtualClone = (SettingSection)virtualSection.Clone();
                 virtualClone.IsAbstract().Should().BeTrue();
                 virtualClone.Origin.Should().BeNull();
                 virtualClone.Should().BeOfType<VirtualSettingSection>();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingTextTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingTextTests.cs
@@ -33,12 +33,12 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as UnknownItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (UnknownItem)section.Items.First();
                 item.Should().NotBeNull();
 
                 item.Children.Count.Should().Be(1);
-                var text = item.Children.First() as SettingText;
+                var text = (SettingText)item.Children.First();
                 text.Should().NotBeNull();
 
                 text.Value.Should().Be("This is a test");
@@ -67,12 +67,12 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as UnknownItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (UnknownItem)section.Items.First();
                 item.Should().NotBeNull();
 
                 item.Children.Count.Should().Be(1);
-                var text = item.Children.First() as SettingText;
+                var text = (SettingText)item.Children.First();
                 text.Should().NotBeNull();
 
                 text.Value.Should().Be("This is a test");
@@ -84,12 +84,12 @@ namespace NuGet.Configuration.Test
                 section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                item = section.Items.First() as UnknownItem;
+                section!.Items.Count.Should().Be(1);
+                item = (UnknownItem)section.Items.First();
                 item.Should().NotBeNull();
 
                 item.Children.Count.Should().Be(1);
-                text = item.Children.First() as SettingText;
+                text = (SettingText)item.Children.First();
                 text.Should().NotBeNull();
 
                 text.Value.Should().Be("This is another test");
@@ -134,8 +134,8 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
-                var item = section.Items.First() as UnknownItem;
+                section!.Items.Count.Should().Be(1);
+                var item = (UnknownItem)section.Items.First();
                 item.IsCopy().Should().BeFalse();
                 item.Origin.Should().NotBeNull();
 
@@ -144,7 +144,7 @@ namespace NuGet.Configuration.Test
                 text.IsCopy().Should().BeFalse();
                 text.Origin.Should().NotBeNull();
 
-                var clone = text.Clone() as SettingText;
+                var clone = (SettingText)text.Clone();
                 clone.IsCopy().Should().BeTrue();
                 clone.Origin.Should().NotBeNull();
                 SettingsTestUtils.DeepEquals(clone, text).Should().BeTrue();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingsFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingsFileTests.cs
@@ -17,7 +17,7 @@ namespace NuGet.Configuration.Test
         public void SettingsFile_Constructor_WithNullRoot_Throws()
         {
             // Act & Assert
-            var ex = Record.Exception(() => new SettingsFile(null));
+            var ex = Record.Exception(() => new SettingsFile(null!));
             Assert.NotNull(ex);
             Assert.IsAssignableFrom<ArgumentException>(ex);
         }
@@ -109,13 +109,13 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var key1Element = section.GetFirstItemWithAttribute<AddItem>("key", "key1");
+                var key1Element = section!.GetFirstItemWithAttribute<AddItem>("key", "key1");
                 var key2Element = section.GetFirstItemWithAttribute<AddItem>("key", "key2");
                 key1Element.Should().NotBeNull();
                 key2Element.Should().NotBeNull();
 
-                key1Element.Value.Should().Be("value1");
-                key2Element.Value.Should().Be("value2");
+                key1Element!.Value.Should().Be("value1");
+                key2Element!.Value.Should().Be("value2");
             }
         }
 
@@ -142,13 +142,13 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var key1Element = section.GetFirstItemWithAttribute<AddItem>("key", "key1");
+                var key1Element = section!.GetFirstItemWithAttribute<AddItem>("key", "key1");
                 var key2Element = section.GetFirstItemWithAttribute<AddItem>("key", "key2");
                 key1Element.Should().NotBeNull();
                 key2Element.Should().NotBeNull();
 
-                key1Element.Value.Should().Be("value1");
-                key2Element.Value.Should().Be("value2");
+                key1Element!.Value.Should().Be("value1");
+                key2Element!.Value.Should().Be("value2");
             }
         }
 
@@ -215,10 +215,10 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var addItem = section.Items.FirstOrDefault() as AddItem;
+                var addItem = section!.Items.FirstOrDefault() as AddItem;
                 addItem.Should().NotBeNull();
 
-                addItem.Key.Should().Be("key1");
+                addItem!.Key.Should().Be("key1");
                 addItem.Value.Should().Be("value1");
             }
         }
@@ -253,7 +253,7 @@ namespace NuGet.Configuration.Test
                 var settingsFile = new SettingsFile(mockBaseDirectory);
 
                 // Act & Assert
-                var ex = Record.Exception(() => settingsFile.AddOrUpdate("SomeKey", item: null));
+                var ex = Record.Exception(() => settingsFile.AddOrUpdate("SomeKey", item: null!));
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<ArgumentNullException>();
             }
@@ -287,7 +287,7 @@ namespace NuGet.Configuration.Test
                 settingsFile.SaveToDisk();
 
                 var section = settingsFile.GetSection("Section");
-                section.Items.Count.Should().Be(1);
+                section!.Items.Count.Should().Be(1);
 
                 var updatedFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
                 updatedFileHash.Should().BeEquivalentTo(configFileHash);
@@ -322,7 +322,7 @@ namespace NuGet.Configuration.Test
                 settingsFile.SaveToDisk();
 
                 var section = settingsFile.GetSection("Section");
-                section.Items.Count.Should().Be(1);
+                section!.Items.Count.Should().Be(1);
 
                 var updatedFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
                 updatedFileHash.Should().BeEquivalentTo(configFileHash);
@@ -365,7 +365,7 @@ namespace NuGet.Configuration.Test
                 SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, configFile))).Should().Be(result);
                 var section = settingsFile.GetSection("NewSectionName");
                 section.Should().NotBeNull();
-                section.Items.Count.Should().Be(1);
+                section!.Items.Count.Should().Be(1);
             }
         }
 
@@ -437,9 +437,9 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "key");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "key");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("NewValue");
+                item!.Value.Should().Be("NewValue");
             }
         }
 
@@ -489,9 +489,9 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "newKey");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "newKey");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value");
+                item!.Value.Should().Be("value");
             }
         }
 
@@ -545,9 +545,9 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "newKey");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "newKey");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value");
+                item!.Value.Should().Be("value");
             }
         }
 
@@ -574,9 +574,9 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "key0");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "key0");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value0");
+                item!.Value.Should().Be("value0");
 
                 var ex = Record.Exception(() => settingsFile.Remove("Section", item));
                 ex.Should().NotBeNull();
@@ -586,7 +586,7 @@ namespace NuGet.Configuration.Test
                 settingsFile.SaveToDisk();
 
                 var section1 = settingsFile.GetSection("Section");
-                section1.Items.Count.Should().Be(1);
+                section1!.Items.Count.Should().Be(1);
 
                 var updatedFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
                 updatedFileHash.Should().BeEquivalentTo(configFileHash);
@@ -616,9 +616,9 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "key0");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "key0");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value0");
+                item!.Value.Should().Be("value0");
 
                 var ex = Record.Exception(() => settingsFile.Remove("Section", item));
                 ex.Should().NotBeNull();
@@ -628,7 +628,7 @@ namespace NuGet.Configuration.Test
                 settingsFile.SaveToDisk();
 
                 var section1 = settingsFile.GetSection("Section");
-                section1.Items.Count.Should().Be(1);
+                section1!.Items.Count.Should().Be(1);
 
                 var updatedFileHash = SettingsTestUtils.GetFileHash(Path.Combine(mockBaseDirectory, nugetConfigPath));
                 updatedFileHash.Should().BeEquivalentTo(configFileHash);
@@ -657,9 +657,9 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value2");
+                item!.Value.Should().Be("value2");
 
                 settingsFile.Remove("SectionName", item);
                 settingsFile.SaveToDisk();
@@ -697,8 +697,8 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<SettingItem>("key", "DeleteMe");
-                settingsFile.Remove("SectionName", item);
+                var item = section!.GetFirstItemWithAttribute<SettingItem>("key", "DeleteMe");
+                settingsFile.Remove("SectionName", item!);
                 settingsFile.SaveToDisk();
 
                 var result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -716,7 +716,7 @@ namespace NuGet.Configuration.Test
                 section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                item = section.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
+                item = section!.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
                 item.Should().BeNull();
             }
         }
@@ -749,8 +749,8 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<SettingItem>("key", "DeleteMe");
-                settingsFile.Remove("SectionName", item);
+                var item = section!.GetFirstItemWithAttribute<SettingItem>("key", "DeleteMe");
+                settingsFile.Remove("SectionName", item!);
                 settingsFile.SaveToDisk();
 
                 var result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -771,7 +771,7 @@ namespace NuGet.Configuration.Test
                 section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                item = section.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
+                item = section!.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
                 item.Should().BeNull();
             }
         }
@@ -806,8 +806,8 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<SettingItem>("key", "DeleteMe");
-                settingsFile.Remove("SectionName", item);
+                var item = section!.GetFirstItemWithAttribute<SettingItem>("key", "DeleteMe");
+                settingsFile.Remove("SectionName", item!);
                 settingsFile.SaveToDisk();
 
                 var result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -830,7 +830,7 @@ namespace NuGet.Configuration.Test
                 section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                item = section.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
+                item = section!.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
                 item.Should().BeNull();
             }
         }
@@ -946,7 +946,7 @@ namespace NuGet.Configuration.Test
                 foreach (var pair in settingsDict)
                 {
                     expectedSettingsDict.TryGetValue(pair.Key, out var expectedSection).Should().BeTrue();
-                    SettingsTestUtils.DeepEquals(pair.Value, expectedSection).Should().BeTrue();
+                    SettingsTestUtils.DeepEquals(pair.Value, expectedSection!).Should().BeTrue();
                     expectedSettingsDict.Remove(pair.Key);
                 }
                 expectedSettingsDict.Should().BeEmpty();
@@ -995,7 +995,7 @@ namespace NuGet.Configuration.Test
                 foreach (var pair in settingsDict)
                 {
                     expectedSettingsDict.TryGetValue(pair.Key, out var expectedSection).Should().BeTrue();
-                    SettingsTestUtils.DeepEquals(pair.Value, expectedSection).Should().BeTrue();
+                    SettingsTestUtils.DeepEquals(pair.Value, expectedSection!).Should().BeTrue();
                     expectedSettingsDict.Remove(pair.Key);
                 }
                 expectedSettingsDict.Should().BeEmpty();
@@ -1039,7 +1039,7 @@ namespace NuGet.Configuration.Test
                 foreach (var pair in settingsDict)
                 {
                     expectedSettingsDict.TryGetValue(pair.Key, out var expectedSection).Should().BeTrue();
-                    SettingsTestUtils.DeepEquals(pair.Value, expectedSection).Should().BeTrue();
+                    SettingsTestUtils.DeepEquals(pair.Value, expectedSection!).Should().BeTrue();
                     expectedSettingsDict.Remove(pair.Key);
                 }
                 expectedSettingsDict.Should().BeEmpty();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
@@ -38,7 +38,7 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("PACkagEsourCEs");
                 section.Should().NotBeNull();
 
-                var children = section.Items.ToList();
+                var children = section!.Items.ToList();
 
                 children.Should().NotBeEmpty();
                 children.Count.Should().Be(1);
@@ -83,7 +83,7 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("packageSources");
                 section.Should().NotBeNull();
 
-                var children = section.Items.Cast<SourceItem>().ToList();
+                var children = section!.Items.Cast<SourceItem>().ToList();
 
                 children.Should().NotBeEmpty();
                 children.Count.Should().Be(5);
@@ -217,12 +217,12 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("packageSources", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
+                section!.Items.Count.Should().Be(1);
                 var item = section.Items.First();
                 item.IsCopy().Should().BeFalse();
                 item.Origin.Should().NotBeNull();
 
-                var clone = item.Clone() as SourceItem;
+                var clone = (SourceItem)item.Clone();
                 clone.IsCopy().Should().BeTrue();
                 clone.Origin.Should().NotBeNull();
                 SettingsTestUtils.DeepEquals(clone, item).Should().BeTrue();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/StoreClientCertItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/StoreClientCertItemTests.cs
@@ -35,7 +35,7 @@ namespace NuGet.Configuration.Test
                 var settingsFile = new SettingsFile(mockBaseDirectory);
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
-                var items = section.Items.ToList();
+                var items = section!.Items.ToList();
 
                 items.Count.Should().Be(1);
 
@@ -86,7 +86,7 @@ namespace NuGet.Configuration.Test
                 var settingsFile = new SettingsFile(mockBaseDirectory);
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
-                var items = section.Items.ToList();
+                var items = section!.Items.ToList();
 
                 items.Count.Should().Be(3);
 
@@ -125,7 +125,7 @@ namespace NuGet.Configuration.Test
                 var settingsFile = new SettingsFile(mockBaseDirectory);
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
-                var items = section.Items.ToList();
+                var items = section!.Items.ToList();
 
                 items.Count.Should().Be(3);
 
@@ -177,7 +177,7 @@ namespace NuGet.Configuration.Test
                 var settingsFile = new SettingsFile(mockBaseDirectory);
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
-                var items = section.Items.ToList();
+                var items = section!.Items.ToList();
 
                 items.Count.Should().Be(3);
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/TrustedSignerItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/TrustedSignerItemTests.cs
@@ -35,22 +35,22 @@ namespace NuGet.Configuration.Test
                 var settingsFile = new SettingsFile(mockBaseDirectory);
                 var section = settingsFile.GetSection("SectionName");
                 section.Should().NotBeNull();
-                var items = section.Items.ToList();
+                var items = section!.Items.ToList();
 
                 items.Count.Should().Be(2);
 
-                var trustedSignerItem = items[0] as TrustedSignerItem;
+                var trustedSignerItem = (TrustedSignerItem)items[0];
                 trustedSignerItem.Name.Should().Be("repositoryName");
 
-                var repositoryitem = items[0] as RepositoryItem;
+                var repositoryitem = (RepositoryItem)items[0];
                 var expectedRepositoryItem = new RepositoryItem("repositoryName", "https://api.test/index/", "test;text",
                     new CertificateItem("abcdefg", Common.HashAlgorithmName.SHA256, allowUntrustedRoot: true));
                 SettingsTestUtils.DeepEquals(repositoryitem, expectedRepositoryItem).Should().BeTrue();
 
-                trustedSignerItem = items[1] as TrustedSignerItem;
+                trustedSignerItem = (TrustedSignerItem)items[1];
                 trustedSignerItem.Name.Should().Be("authorName");
 
-                var authorItem = items[1] as AuthorItem;
+                var authorItem = (AuthorItem)items[1];
                 var expectedAuthorItem = new AuthorItem("authorName",
                     new CertificateItem("abcdefg", Common.HashAlgorithmName.SHA256, allowUntrustedRoot: true));
                 SettingsTestUtils.DeepEquals(authorItem, expectedAuthorItem).Should().BeTrue();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/UnknownItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/UnknownItemTests.cs
@@ -46,11 +46,11 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault();
+                var element = section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
                 // Assert
-                SettingsTestUtils.DeepEquals(element, expectedSetting).Should().BeTrue();
+                SettingsTestUtils.DeepEquals(element!, expectedSetting).Should().BeTrue();
             }
         }
 
@@ -79,11 +79,11 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault();
+                var element = section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
                 // Assert
-                SettingsTestUtils.DeepEquals(element, expectedSetting).Should().BeTrue();
+                SettingsTestUtils.DeepEquals(element!, expectedSetting).Should().BeTrue();
             }
         }
 
@@ -110,11 +110,11 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault();
+                var element = section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
                 // Assert
-                SettingsTestUtils.DeepEquals(element, expectedSetting).Should().BeTrue();
+                SettingsTestUtils.DeepEquals(element!, expectedSetting).Should().BeTrue();
             }
         }
 
@@ -144,11 +144,11 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault();
+                var element = section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
                 // Assert
-                SettingsTestUtils.DeepEquals(element, expectedSetting).Should().BeTrue();
+                SettingsTestUtils.DeepEquals(element!, expectedSetting).Should().BeTrue();
             }
         }
 
@@ -181,11 +181,11 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault();
+                var element = section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
                 // Assert
-                SettingsTestUtils.DeepEquals(element, expectedSetting).Should().BeTrue();
+                SettingsTestUtils.DeepEquals(element!, expectedSetting).Should().BeTrue();
             }
         }
 
@@ -210,11 +210,11 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as UnknownItem;
+                var element = (UnknownItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
                 // Assert
-                var ex = Record.Exception(() => element.Add(new SettingText("test")));
+                var ex = Record.Exception(() => element!.Add(new SettingText("test")));
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
             }
@@ -241,11 +241,11 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as UnknownItem;
+                var element = (UnknownItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
                 // Assert
-                var ex = Record.Exception(() => element.Add(new SettingText("test")));
+                var ex = Record.Exception(() => element!.Add(new SettingText("test")));
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
             }
@@ -275,10 +275,10 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as UnknownItem;
+                var element = (UnknownItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
-                element.Add(new AddItem("key", "val")).Should().BeTrue();
+                element!.Add(new AddItem("key", "val")).Should().BeTrue();
 
                 // Assert
                 SettingsTestUtils.DeepEquals(element, expectedSetting).Should().BeTrue();
@@ -309,10 +309,10 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as UnknownItem;
+                var element = (UnknownItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
-                element.Add(new SettingText("Text for test")).Should().BeTrue();
+                element!.Add(new SettingText("Text for test")).Should().BeTrue();
 
                 // Assert
                 SettingsTestUtils.DeepEquals(element, expectedSetting).Should().BeTrue();
@@ -343,11 +343,11 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as UnknownItem;
+                var element = (UnknownItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
                 // Assert
-                var ex = Record.Exception(() => element.Remove(element.Children.First()));
+                var ex = Record.Exception(() => element!.Remove(element.Children.First()));
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
             }
@@ -376,11 +376,11 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as UnknownItem;
+                var element = (UnknownItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
                 // Assert
-                var ex = Record.Exception(() => element.Remove(element.Children.First()));
+                var ex = Record.Exception(() => element!.Remove(element.Children.First()));
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
             }
@@ -414,10 +414,10 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as UnknownItem;
+                var element = (UnknownItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
-                element.Remove(new AddItem("key3", "val3"));
+                element!.Remove(new AddItem("key3", "val3"));
 
                 // Assert
                 SettingsTestUtils.DeepEquals(element, expectedSetting).Should().BeTrue();
@@ -453,10 +453,10 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as UnknownItem;
+                var element = (UnknownItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
-                element.Remove(element.Children.First());
+                element!.Remove(element.Children.First());
 
                 // Assert
                 SettingsTestUtils.DeepEquals(element, expectedSetting).Should().BeTrue();
@@ -495,9 +495,9 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as UnknownItem;
+                var element = (UnknownItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
-                element.Remove(element.Children.First());
+                element!.Remove(element.Children.First());
 
                 settingsFile.AddOrUpdate("Section", element);
                 settingsFile.SaveToDisk();
@@ -547,10 +547,10 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as UnknownItem;
+                var element = (UnknownItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
-                element.Update(updateSetting);
+                element!.Update(updateSetting);
 
                 // Assert
                 element.Attributes["new"].Should().Be("attr");
@@ -582,10 +582,10 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as UnknownItem;
+                var element = (UnknownItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
-                element.Update(updateSetting);
+                element!.Update(updateSetting);
 
                 // Assert
                 element.Attributes.TryGetValue("old", out var _).Should().BeFalse();
@@ -617,10 +617,10 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as UnknownItem;
+                var element = (UnknownItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
-                element.Update(updateSetting);
+                element!.Update(updateSetting);
 
                 // Assert
                 element.Attributes["old"].Should().Be("newAttr");
@@ -652,10 +652,10 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as UnknownItem;
+                var element = (UnknownItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
-                element.Update(updateSetting);
+                element!.Update(updateSetting);
 
                 // Assert
                 element.Children.Count.Should().Be(1);
@@ -688,10 +688,10 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as UnknownItem;
+                var element = (UnknownItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
-                element.Update(updateSetting);
+                element!.Update(updateSetting);
 
                 // Assert
                 element.Children.Count.Should().Be(1);
@@ -727,10 +727,10 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as UnknownItem;
+                var element = (UnknownItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
-                element.Update(updateSetting);
+                element!.Update(updateSetting);
 
                 // Assert
                 element.Children.Count.Should().Be(1);
@@ -767,10 +767,10 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as UnknownItem;
+                var element = (UnknownItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
-                element.Update(updateSetting);
+                element!.Update(updateSetting);
 
                 // Assert
                 element.Children.Count.Should().Be(1);
@@ -806,15 +806,15 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as UnknownItem;
+                var element = (UnknownItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
-                element.Update(updateSetting);
+                element!.Update(updateSetting);
 
                 // Assert
                 element.Children.Count.Should().Be(1);
                 element.Children.First().Should().BeOfType<AddItem>();
-                (element.Children.First() as AddItem).AdditionalAttributes["meta"].Should().Be("data");
+                ((AddItem)element.Children.First()).AdditionalAttributes["meta"].Should().Be("data");
             }
         }
 
@@ -845,15 +845,15 @@ namespace NuGet.Configuration.Test
                 var section = settingsFile.GetSection("Section");
                 section.Should().NotBeNull();
 
-                var element = section.Items.FirstOrDefault() as UnknownItem;
+                var element = (UnknownItem?)section!.Items.FirstOrDefault();
                 element.Should().NotBeNull();
 
-                element.Update(updateSetting);
+                element!.Update(updateSetting);
 
                 // Assert
                 element.Children.Count.Should().Be(1);
                 element.Children.First().Should().BeOfType<SettingText>();
-                (element.Children.First() as SettingText).Value.Should().Be("New test");
+                ((SettingText)element.Children.First()).Value.Should().Be("New test");
             }
         }
 
@@ -985,12 +985,12 @@ namespace NuGet.Configuration.Test
                 settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(1);
+                section!.Items.Count.Should().Be(1);
                 var item = section.Items.First();
                 item.IsCopy().Should().BeFalse();
                 item.Origin.Should().NotBeNull();
 
-                var clone = item.Clone() as UnknownItem;
+                var clone = (UnknownItem)item.Clone();
                 clone.IsCopy().Should().BeTrue();
                 clone.Origin.Should().NotBeNull();
                 SettingsTestUtils.DeepEquals(clone, item).Should().BeTrue();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsLoadingContextTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsLoadingContextTests.cs
@@ -101,7 +101,7 @@ namespace NuGet.Configuration.Test
         {
             var settingsLoadingContext = new SettingsLoadingContext();
 
-            Action action = () => settingsLoadingContext.GetOrCreateSettingsFile(filePath: null);
+            Action action = () => settingsLoadingContext.GetOrCreateSettingsFile(filePath: null!);
 
             action.Should()
                 .Throw<ArgumentNullException>()
@@ -121,7 +121,7 @@ namespace NuGet.Configuration.Test
 
             settingsLoadingContext.Dispose();
 
-            Action action = () => settingsLoadingContext.GetOrCreateSettingsFile(filePath: null);
+            Action action = () => settingsLoadingContext.GetOrCreateSettingsFile(filePath: null!);
 
             action.Should()
                 .Throw<ObjectDisposedException>()

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTestUtils.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTestUtils.cs
@@ -82,19 +82,19 @@ namespace NuGet.Configuration.Test
         {
             if (setting1 is SettingSection)
             {
-                return Section_DeepEquals(setting1 as SettingSection, setting2 as SettingSection);
+                return Section_DeepEquals((SettingSection)setting1, (SettingSection)setting2);
             }
             else if (setting1 is AddItem)
             {
-                return AddItem_DeepEquals(setting1 as AddItem, setting2 as AddItem);
+                return AddItem_DeepEquals((AddItem)setting1, (AddItem)setting2);
             }
             else if (setting1 is CredentialsItem)
             {
-                return CredentialsItem_DeepEquals(setting1 as CredentialsItem, setting2 as CredentialsItem);
+                return CredentialsItem_DeepEquals((CredentialsItem)setting1, (CredentialsItem)setting2);
             }
             else if (setting1 is UnknownItem)
             {
-                return UnkownItem_DeepEquals(setting1 as UnknownItem, setting2 as UnknownItem);
+                return UnkownItem_DeepEquals((UnknownItem)setting1, (UnknownItem)setting2);
             }
             else if (setting1 is ClearItem clear1)
             {
@@ -106,35 +106,35 @@ namespace NuGet.Configuration.Test
             }
             else if (setting1 is RepositoryItem)
             {
-                return RepositoryItem_DeepEquals(setting1 as RepositoryItem, setting2 as RepositoryItem);
+                return RepositoryItem_DeepEquals((RepositoryItem)setting1, (RepositoryItem)setting2);
             }
             else if (setting1 is AuthorItem)
             {
-                return AuthorItem_DeepEquals(setting1 as AuthorItem, setting2 as AuthorItem);
+                return AuthorItem_DeepEquals((AuthorItem)setting1, (AuthorItem)setting2);
             }
             else if (setting1 is OwnersItem)
             {
-                return OwnersItem_DeepEquals(setting1 as OwnersItem, setting2 as OwnersItem);
+                return OwnersItem_DeepEquals((OwnersItem)setting1, (OwnersItem)setting2);
             }
             else if (setting1 is CertificateItem)
             {
-                return CertificateItem_DeepEquals(setting1 as CertificateItem, setting2 as CertificateItem);
+                return CertificateItem_DeepEquals((CertificateItem)setting1, (CertificateItem)setting2);
             }
             else if (setting1 is StoreClientCertItem)
             {
-                return StoreClientCertItem_DeepEquals(setting1 as StoreClientCertItem, setting2 as StoreClientCertItem);
+                return StoreClientCertItem_DeepEquals((StoreClientCertItem)setting1, (StoreClientCertItem)setting2);
             }
             else if (setting1 is FileClientCertItem)
             {
-                return FileClientCertItem_DeepEquals(setting1 as FileClientCertItem, setting2 as FileClientCertItem);
+                return FileClientCertItem_DeepEquals((FileClientCertItem)setting1, (FileClientCertItem)setting2);
             }
             else if (setting1 is PackagePatternItem)
             {
-                return PackagePatternItem_DeepEquals(setting1 as PackagePatternItem, setting2 as PackagePatternItem);
+                return PackagePatternItem_DeepEquals((PackagePatternItem)setting1, (PackagePatternItem)setting2);
             }
             else if (setting2 is PackageSourceMappingSourceItem)
             {
-                return PackageSourceMappingSourceItem_Equals(setting1 as PackageSourceMappingSourceItem, setting2 as PackageSourceMappingSourceItem);
+                return PackageSourceMappingSourceItem_Equals((PackageSourceMappingSourceItem)setting1, (PackageSourceMappingSourceItem)setting2);
             }
 
             return false;

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -43,7 +43,7 @@ namespace NuGet.Configuration.Test
                 section.Should().NotBeNull();
 
                 // Assert
-                var children = section.Items.ToList();
+                var children = section!.Items.ToList();
                 children.Count.Should().Be(3);
                 SettingsTestUtils.DeepEquals(children[1], new AddItem("key3", "value3")).Should().BeTrue();
                 SettingsTestUtils.DeepEquals(children[2], new AddItem("key4", "value4")).Should().BeTrue();
@@ -87,7 +87,7 @@ namespace NuGet.Configuration.Test
                 section.Should().NotBeNull();
 
                 // Assert
-                var children = section.Items.ToList();
+                var children = section!.Items.ToList();
                 children.Count.Should().Be(3);
 
                 children[0].Should().BeOfType<ClearItem>();
@@ -134,14 +134,14 @@ namespace NuGet.Configuration.Test
                 var parentConfig = Path.Combine(mockBaseDirectory, "dir1", "NuGet.Config");
                 var childConfig = Path.Combine(mockBaseDirectory, "dir1", "dir2", "NuGet.Config");
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "key1");
-                item.Origin.ConfigFilePath.Should().Be(childConfig); // key1 was overidden, so it has a new origin!
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "key1");
+                item!.Origin!.ConfigFilePath.Should().Be(childConfig); // key1 was overidden, so it has a new origin!
 
                 item = section.GetFirstItemWithAttribute<AddItem>("key", "key2");
-                item.Origin.ConfigFilePath.Should().Be(parentConfig);
+                item!.Origin!.ConfigFilePath.Should().Be(parentConfig);
 
                 item = section.GetFirstItemWithAttribute<AddItem>("key", "key3");
-                item.Origin.ConfigFilePath.Should().Be(childConfig);
+                item!.Origin!.ConfigFilePath.Should().Be(childConfig);
             }
         }
 
@@ -179,7 +179,7 @@ namespace NuGet.Configuration.Test
 
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
-                section.IsAbstract().Should().BeTrue();
+                section!.IsAbstract().Should().BeTrue();
 
                 foreach (var item in section.Items)
                 {
@@ -222,19 +222,19 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                section.Items.Count.Should().Be(4);
+                section!.Items.Count.Should().Be(4);
 
                 var item = section.GetFirstItemWithAttribute<AddItem>("key", "key1") as AddItem;
-                item.Value.Should().Be("value1");
+                item!.Value.Should().Be("value1");
 
                 item = section.GetFirstItemWithAttribute<AddItem>("key", "key2") as AddItem;
-                item.Value.Should().Be("value2");
+                item!.Value.Should().Be("value2");
 
                 item = section.GetFirstItemWithAttribute<AddItem>("key", "key3") as AddItem;
-                item.Value.Should().Be("value3");
+                item!.Value.Should().Be("value3");
 
                 item = section.GetFirstItemWithAttribute<AddItem>("key", "key4") as AddItem;
-                item.Value.Should().Be("value4");
+                item!.Value.Should().Be("value4");
             }
         }
 
@@ -272,11 +272,11 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "key2");
-                item.Value.Should().Be("LastOneWins2");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "key2");
+                item!.Value.Should().Be("LastOneWins2");
 
                 item = section.GetFirstItemWithAttribute<AddItem>("key", "key1");
-                item.Value.Should().Be("LastOneWins1");
+                item!.Value.Should().Be("LastOneWins1");
             }
         }
 
@@ -313,9 +313,9 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "key2") as AddItem;
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "key2") as AddItem;
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value2");
+                item!.Value.Should().Be("value2");
 
                 section.GetFirstItemWithAttribute<AddItem>("key", "key1").Should().BeNull();
             }
@@ -344,10 +344,10 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "path-key");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "path-key");
                 item.Should().NotBeNull();
 
-                var result = item.GetValueAsPath();
+                var result = item!.GetValueAsPath();
 
                 // Assert
                 result.Should().Be(new DirectoryInfo(Path.Combine(mockBaseDirectory, value)).FullName);
@@ -379,10 +379,10 @@ namespace NuGet.Configuration.Test
                     var section = settings.GetSection("SectionName");
                     section.Should().NotBeNull();
 
-                    var addItem = section.GetFirstItemWithAttribute<AddItem>("key", "path-key");
+                    var addItem = section!.GetFirstItemWithAttribute<AddItem>("key", "path-key");
                     addItem.Should().NotBeNull();
 
-                    var result = addItem.GetValueAsPath();
+                    var result = addItem!.GetValueAsPath();
                     // Assert
                     result.Should().Be(value);
                 }
@@ -423,7 +423,7 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var children = section.Items.ToList();
+                var children = section!.Items.ToList();
 
                 // Assert
                 children.Count.Should().Be(2);
@@ -481,20 +481,20 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var addItem = section.GetFirstItemWithAttribute<AddItem>("key", "key1");
+                var addItem = section!.GetFirstItemWithAttribute<AddItem>("key", "key1");
                 addItem.Should().NotBeNull();
-                addItem.Value.Should().Be("value1");
+                addItem!.Value.Should().Be("value1");
 
                 // the value in NuGet\Config\IDE\a1.config overrides the value in
                 // NuGet\Config\a1.config
                 addItem = section.GetFirstItemWithAttribute<AddItem>("key", "key2");
                 addItem.Should().NotBeNull();
-                addItem.Value.Should().Be("value3");
+                addItem!.Value.Should().Be("value3");
 
                 // the value in user.config overrides the value in NuGet\Config\IDE\a1.config
                 addItem = section.GetFirstItemWithAttribute<AddItem>("key", "key3");
                 addItem.Should().NotBeNull();
-                addItem.Value.Should().Be("user");
+                addItem!.Value.Should().Be("user");
             }
         }
 
@@ -553,24 +553,24 @@ namespace NuGet.Configuration.Test
                 var section = settings1.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "key3");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "key3");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("user1");
+                item!.Value.Should().Be("user1");
 
-                item = section.GetFirstItemWithAttribute<AddItem>("key", "key1");
+                item = section!.GetFirstItemWithAttribute<AddItem>("key", "key1");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value1");
+                item!.Value.Should().Be("value1");
 
                 section = settings2.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                item = section.GetFirstItemWithAttribute<AddItem>("key", "key3");
+                item = section!.GetFirstItemWithAttribute<AddItem>("key", "key3");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("user2");
+                item!.Value.Should().Be("user2");
 
                 item = section.GetFirstItemWithAttribute<AddItem>("key", "key1");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value1");
+                item!.Value.Should().Be("value1");
             }
         }
 
@@ -604,7 +604,7 @@ namespace NuGet.Configuration.Test
                 var settings = new Settings(mockBaseDirectory);
 
                 // Act & Assert
-                var ex = Record.Exception(() => settings.AddOrUpdate("SomeKey", item: null));
+                var ex = Record.Exception(() => settings.AddOrUpdate("SomeKey", item: null!));
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<ArgumentNullException>();
             }
@@ -646,7 +646,7 @@ namespace NuGet.Configuration.Test
                 SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, configFile))).Should().Be(result);
                 var section = settings.GetSection("NewSectionName");
                 section.Should().NotBeNull();
-                section.Items.Count.Should().Be(1);
+                section!.Items.Count.Should().Be(1);
             }
         }
 
@@ -718,9 +718,9 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "key");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "key");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("NewValue");
+                item!.Value.Should().Be("NewValue");
             }
         }
 
@@ -790,10 +790,10 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var key1 = section.GetFirstItemWithAttribute<AddItem>("key", "key1");
+                var key1 = section!.GetFirstItemWithAttribute<AddItem>("key", "key1");
                 key1.Should().NotBeNull();
 
-                key1.Value.Should().Be("newValue");
+                key1!.Value.Should().Be("newValue");
             }
         }
 
@@ -933,30 +933,30 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("Section1");
                 section.Should().NotBeNull();
 
-                var key1 = section.GetFirstItemWithAttribute<AddItem>("key", "newKey1");
+                var key1 = section!.GetFirstItemWithAttribute<AddItem>("key", "newKey1");
                 key1.Should().NotBeNull();
-                key1.Value.Should().Be("newValue");
+                key1!.Value.Should().Be("newValue");
 
                 section = settings.GetSection("Section2");
                 section.Should().NotBeNull();
 
-                key1 = section.GetFirstItemWithAttribute<AddItem>("key", "newKey2");
+                key1 = section!.GetFirstItemWithAttribute<AddItem>("key", "newKey2");
                 key1.Should().NotBeNull();
-                key1.Value.Should().Be("newValue");
+                key1!.Value.Should().Be("newValue");
 
                 section = settings.GetSection("Section3");
                 section.Should().NotBeNull();
 
-                key1 = section.GetFirstItemWithAttribute<AddItem>("key", "newKey3");
+                key1 = section!.GetFirstItemWithAttribute<AddItem>("key", "newKey3");
                 key1.Should().NotBeNull();
-                key1.Value.Should().Be("newValue");
+                key1!.Value.Should().Be("newValue");
 
                 section = settings.GetSection("SectionN");
                 section.Should().NotBeNull();
 
-                key1 = section.GetFirstItemWithAttribute<AddItem>("key", "newKeyN");
+                key1 = section!.GetFirstItemWithAttribute<AddItem>("key", "newKeyN");
                 key1.Should().NotBeNull();
-                key1.Value.Should().Be("newValue");
+                key1!.Value.Should().Be("newValue");
             }
         }
 
@@ -1006,9 +1006,9 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "newKey");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "newKey");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value");
+                item!.Value.Should().Be("value");
             }
         }
 
@@ -1062,9 +1062,9 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "newKey");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "newKey");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value");
+                item!.Value.Should().Be("value");
             }
         }
 
@@ -1100,7 +1100,7 @@ namespace NuGet.Configuration.Test
                 var settings = new Settings(new SettingsFile[] { settingsFile });
 
                 // Act & Assert
-                var ex = Record.Exception(() => settings.AddOrUpdate(settingsFile, "SomeKey", item: null));
+                var ex = Record.Exception(() => settings.AddOrUpdate(settingsFile, "SomeKey", item: null!));
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<ArgumentNullException>();
             }
@@ -1161,7 +1161,7 @@ namespace NuGet.Configuration.Test
                 SettingsTestUtils.RemoveWhitespace(File.ReadAllText(Path.Combine(mockBaseDirectory, configFile))).Should().Be(result);
                 var section = settings.GetSection("NewSectionName");
                 section.Should().NotBeNull();
-                section.Items.Count.Should().Be(1);
+                section!.Items.Count.Should().Be(1);
             }
         }
 
@@ -1235,9 +1235,9 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "key");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "key");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("NewValue");
+                item!.Value.Should().Be("NewValue");
             }
         }
 
@@ -1288,9 +1288,9 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "newKey");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "newKey");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value");
+                item!.Value.Should().Be("value");
             }
         }
 
@@ -1345,9 +1345,9 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "newKey");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "newKey");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value");
+                item!.Value.Should().Be("value");
             }
         }
 
@@ -1380,9 +1380,9 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value1");
+                item!.Value.Should().Be("value1");
 
                 var ex = Record.Exception(() => settings.Remove("SectionName", item));
                 ex.Should().NotBeNull();
@@ -1396,9 +1396,9 @@ namespace NuGet.Configuration.Test
                 section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                item = section.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
+                item = section!.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value1");
+                item!.Value.Should().Be("value1");
             }
         }
 
@@ -1424,9 +1424,9 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value2");
+                item!.Value.Should().Be("value2");
 
                 settings.Remove("SectionName", item);
                 settings.SaveToDisk();
@@ -1479,9 +1479,9 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value3");
+                item!.Value.Should().Be("value3");
 
                 settings.Remove("SectionName", item);
                 settings.SaveToDisk();
@@ -1501,7 +1501,7 @@ namespace NuGet.Configuration.Test
                 section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                item = section.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
+                item = section!.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
                 item.Should().BeNull();
             }
         }
@@ -1555,9 +1555,9 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value3");
+                item!.Value.Should().Be("value3");
 
                 settings.Remove("SectionName", item);
                 settings.SaveToDisk();
@@ -1576,9 +1576,9 @@ namespace NuGet.Configuration.Test
                 section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                item = section.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
+                item = section!.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value1");
+                item!.Value.Should().Be("value1");
             }
         }
 
@@ -1623,9 +1623,9 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value3");
+                item!.Value.Should().Be("value3");
 
                 settings.Remove("SectionName", item);
                 settings.SaveToDisk();
@@ -1644,7 +1644,7 @@ namespace NuGet.Configuration.Test
                 section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                item = section.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
+                item = section!.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
                 item.Should().BeNull();
             }
         }
@@ -1692,9 +1692,9 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
+                var item = section!.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
                 item.Should().NotBeNull();
-                item.Value.Should().Be("value3");
+                item!.Value.Should().Be("value3");
 
                 settings.Remove("SectionName", item);
                 settings.SaveToDisk();
@@ -1721,7 +1721,7 @@ namespace NuGet.Configuration.Test
                 section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                item = section.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
+                item = section!.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
                 item.Should().BeNull();
             }
         }
@@ -1751,8 +1751,8 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<SettingItem>("key", "DeleteMe");
-                settings.Remove("SectionName", item);
+                var item = section!.GetFirstItemWithAttribute<SettingItem>("key", "DeleteMe");
+                settings.Remove("SectionName", item!);
                 settings.SaveToDisk();
 
                 var result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -1770,7 +1770,7 @@ namespace NuGet.Configuration.Test
                 section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                item = section.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
+                item = section!.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
                 item.Should().BeNull();
             }
         }
@@ -1803,8 +1803,8 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<SettingItem>("key", "DeleteMe");
-                settings.Remove("SectionName", item);
+                var item = section!.GetFirstItemWithAttribute<SettingItem>("key", "DeleteMe");
+                settings.Remove("SectionName", item!);
                 settings.SaveToDisk();
 
                 var result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -1825,7 +1825,7 @@ namespace NuGet.Configuration.Test
                 section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                item = section.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
+                item = section!.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
                 item.Should().BeNull();
             }
         }
@@ -1860,8 +1860,8 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item = section.GetFirstItemWithAttribute<SettingItem>("key", "DeleteMe");
-                settings.Remove("SectionName", item);
+                var item = section!.GetFirstItemWithAttribute<SettingItem>("key", "DeleteMe");
+                settings.Remove("SectionName", item!);
                 settings.SaveToDisk();
 
                 var result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -1884,7 +1884,7 @@ namespace NuGet.Configuration.Test
                 section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                item = section.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
+                item = section!.GetFirstItemWithAttribute<AddItem>("key", "DeleteMe");
                 item.Should().BeNull();
             }
         }
@@ -2010,7 +2010,7 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var machineValue = section.GetFirstItemWithAttribute<AddItem>("key", "machine");
+                var machineValue = section!.GetFirstItemWithAttribute<AddItem>("key", "machine");
                 machineValue.Should().BeNull();
 
                 var environmentValue = section.GetFirstItemWithAttribute<AddItem>("key", "environment");
@@ -2018,7 +2018,7 @@ namespace NuGet.Configuration.Test
 
                 var userFileValue = section.GetFirstItemWithAttribute<AddItem>("key", "user");
                 userFileValue.Should().NotBeNull();
-                userFileValue.Value.Should().Be("true");
+                userFileValue!.Value.Should().Be("true");
             }
         }
 
@@ -2084,10 +2084,10 @@ namespace NuGet.Configuration.Test
 
         [Theory]
         [InlineData(@"D:\", @"C:\Users\SomeUsers\AppData\Roaming\nuget\nuget.config", @"C:\Users\SomeUsers\AppData\Roaming\nuget", @"nuget.config", "windows")]
-        [InlineData(@"D:\", (string)null, @"D:\", (string)null, "windows")]
+        [InlineData(@"D:\", (string)null!, @"D:\", (string)null!, "windows")]
         [InlineData(@"D:\", "nuget.config", @"D:\", "nuget.config", "windows")]
         [InlineData(@"/Root", @"/Home/Users/nuget/nuget.config", @"/Home/Users/nuget", @"nuget.config", "linux")]
-        [InlineData(@"/", (string)null, @"/", (string)null, "linux")]
+        [InlineData(@"/", (string)null!, @"/", (string)null!, "linux")]
         [InlineData(@"/", "nuget.config", @"/", "nuget.config", "linux")]
         public void GetFileNameAndItsRoot_ParsesPathsCorrectly(string root, string settingsPath, string expectedRoot, string expectedFileName, string os)
         {
@@ -2107,21 +2107,21 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
 #if IS_CORECLR
-            var programFilesX86Data = Environment.GetEnvironmentVariable("PROGRAMFILES(X86)");
+            var programFilesX86Data = Environment.GetEnvironmentVariable("PROGRAMFILES(X86)")!;
 
             if (string.IsNullOrEmpty(programFilesX86Data))
             {
-                programFilesX86Data = Environment.GetEnvironmentVariable("PROGRAMFILES");
+                programFilesX86Data = Environment.GetEnvironmentVariable("PROGRAMFILES")!;
             }
-            var userSetting = Environment.GetEnvironmentVariable("APPDATA");
+            var userSetting = Environment.GetEnvironmentVariable("APPDATA")!;
 #else
-            var programFilesX86Data = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+            var programFilesX86Data = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)!;
 
             if (string.IsNullOrEmpty(programFilesX86Data))
             {
-                programFilesX86Data = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+                programFilesX86Data = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)!;
             }
-            var userSetting = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            var userSetting = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)!;
 #endif
 
             // Act
@@ -2143,7 +2143,7 @@ namespace NuGet.Configuration.Test
             // Arrange
 #if IS_CORECLR
             var commonApplicationData = @"/Library/Application Support";
-            var userSetting = Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".nuget");
+            var userSetting = Path.Combine(Environment.GetEnvironmentVariable("HOME")!, ".nuget");
 #else
             var commonApplicationData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
             var userSetting = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
@@ -2168,7 +2168,7 @@ namespace NuGet.Configuration.Test
             // Arrange
 #if IS_CORECLR
             var commonApplicationData = @"/etc/opt";
-            var userSetting = Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".nuget");
+            var userSetting = Path.Combine(Environment.GetEnvironmentVariable("HOME")!, ".nuget");
 #else
             var commonApplicationData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
             var userSetting = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
@@ -2419,6 +2419,7 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadImmutableSettingsGivenConfigPaths(new string[] { configAPath, configBPath }, settingsLoadContext);
                 // Assert
                 var section = settings.GetSection("SectionName");
+                Assert.NotNull(section);
                 Assert.Equal(1, section.Items.Count);
                 Assert.Equal("a", ((AddItem)section.Items.First()).Value);
 
@@ -2426,6 +2427,7 @@ namespace NuGet.Configuration.Test
                 settings = Settings.LoadImmutableSettingsGivenConfigPaths(new string[] { configCPath, configBPath }, settingsLoadContext);
                 // Assert
                 section = settings.GetSection("SectionName");
+                Assert.NotNull(section);
                 Assert.Equal(1, section.Items.Count);
                 Assert.Equal("c", ((AddItem)section.Items.First()).Value);
 
@@ -2433,6 +2435,7 @@ namespace NuGet.Configuration.Test
                 settings = Settings.LoadImmutableSettingsGivenConfigPaths(new string[] { configBPath, configCPath }, settingsLoadContext);
                 // Assert
                 section = settings.GetSection("SectionName");
+                Assert.NotNull(section);
                 Assert.Equal(1, section.Items.Count);
                 Assert.Equal("b", ((AddItem)section.Items.First()).Value);
             }
@@ -2470,6 +2473,7 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadImmutableSettingsGivenConfigPaths(new string[] { configAPath, configBPath }, new SettingsLoadingContext());
                 // Assert
                 var section = settings.GetSection("SectionName");
+                Assert.NotNull(section);
                 Assert.Equal(1, section.Items.Count);
                 Assert.Equal("a", ((AddItem)section.Items.First()).Value);
 
@@ -2486,6 +2490,7 @@ namespace NuGet.Configuration.Test
 
                 settings = Settings.LoadImmutableSettingsGivenConfigPaths(new string[] { configAPath, configBPath }, new SettingsLoadingContext());
                 section = settings.GetSection("SectionName");
+                Assert.NotNull(section);
                 Assert.Equal(1, section.Items.Count);
                 Assert.Equal("new", ((AddItem)section.Items.First()).Value);
             }
@@ -2582,21 +2587,21 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item1 = section.GetFirstItemWithAttribute<AddItem>("key", "key1");
+                var item1 = section!.GetFirstItemWithAttribute<AddItem>("key", "key1");
                 item1.Should().NotBeNull();
-                item1.Value.Should().Be("local");
+                item1!.Value.Should().Be("local");
 
                 var item2 = section.GetFirstItemWithAttribute<AddItem>("key", "key2");
                 item2.Should().NotBeNull();
-                item2.Value.Should().Be("local");
+                item2!.Value.Should().Be("local");
 
                 var item3 = section.GetFirstItemWithAttribute<AddItem>("key", "key3");
                 item3.Should().NotBeNull();
-                item3.Value.Should().Be("user");
+                item3!.Value.Should().Be("user");
 
                 var item4 = section.GetFirstItemWithAttribute<AddItem>("key", "key4");
                 item4.Should().NotBeNull();
-                item4.Value.Should().Be("additional");
+                item4!.Value.Should().Be("additional");
             }
         }
 
@@ -2647,21 +2652,21 @@ namespace NuGet.Configuration.Test
                 var section = settings.GetSection("SectionName");
                 section.Should().NotBeNull();
 
-                var item1 = section.GetFirstItemWithAttribute<AddItem>("key", "key1");
+                var item1 = section!.GetFirstItemWithAttribute<AddItem>("key", "key1");
                 item1.Should().NotBeNull();
-                item1.Value.Should().Be("local");
+                item1!.Value.Should().Be("local");
 
                 var item2 = section.GetFirstItemWithAttribute<AddItem>("key", "key2");
                 item2.Should().NotBeNull();
-                item2.Value.Should().Be("local");
+                item2!.Value.Should().Be("local");
 
                 var item3 = section.GetFirstItemWithAttribute<AddItem>("key", "key3");
                 item3.Should().NotBeNull();
-                item3.Value.Should().Be("additional");
+                item3!.Value.Should().Be("additional");
 
                 var item4 = section.GetFirstItemWithAttribute<AddItem>("key", "key4");
                 item4.Should().NotBeNull();
-                item4.Value.Should().Be("additional");
+                item4!.Value.Should().Be("additional");
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
@@ -19,14 +19,14 @@ namespace NuGet.Configuration.Test
 #if !IS_CORECLR
             var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 #else
-            string userProfile = null;
+            string userProfile;
             if (RuntimeEnvironmentHelper.IsWindows)
             {
-                userProfile = Environment.GetEnvironmentVariable("UserProfile");
+                userProfile = Environment.GetEnvironmentVariable("UserProfile")!;
             }
             else
             {
-                userProfile = Environment.GetEnvironmentVariable("HOME");
+                userProfile = Environment.GetEnvironmentVariable("HOME")!;
             }
 #endif
             var expectedPath = Path.Combine(userProfile, ".nuget", SettingsUtility.DefaultGlobalPackagesFolderPath);
@@ -192,7 +192,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void GetValueForAddItem_WithNullSettings_Throws()
         {
-            var ex = Record.Exception(() => SettingsUtility.GetValueForAddItem(settings: null, section: "randomSection", key: "randomKey"));
+            var ex = Record.Exception(() => SettingsUtility.GetValueForAddItem(settings: null!, section: "randomSection", key: "randomKey"));
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();
@@ -201,7 +201,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void DeleteValue_WithNullSettings_Throws()
         {
-            var ex = Record.Exception(() => SettingsUtility.DeleteValue(settings: null, section: "randomSection", attributeKey: "randomKey", attributeValue: "randomValue"));
+            var ex = Record.Exception(() => SettingsUtility.DeleteValue(settings: null!, section: "randomSection", attributeKey: "randomKey", attributeValue: "randomValue"));
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();
@@ -210,7 +210,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void GetRepositoryPath_WithNullSettings_Throws()
         {
-            var ex = Record.Exception(() => SettingsUtility.GetRepositoryPath(settings: null));
+            var ex = Record.Exception(() => SettingsUtility.GetRepositoryPath(settings: null!));
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();
@@ -219,7 +219,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void GetMaxHttpRequest_WithNullSettings_Throws()
         {
-            var ex = Record.Exception(() => SettingsUtility.GetMaxHttpRequest(settings: null));
+            var ex = Record.Exception(() => SettingsUtility.GetMaxHttpRequest(settings: null!));
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();
@@ -228,7 +228,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void GetSignatureValidationMode_WithNullSettings_Throws()
         {
-            var ex = Record.Exception(() => SettingsUtility.GetSignatureValidationMode(settings: null));
+            var ex = Record.Exception(() => SettingsUtility.GetSignatureValidationMode(settings: null!));
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();
@@ -237,7 +237,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void GetDecryptedValueForAddItem_WithNullSettings_Throws()
         {
-            var ex = Record.Exception(() => SettingsUtility.GetDecryptedValueForAddItem(settings: null, section: "randomSection", key: "randomKey"));
+            var ex = Record.Exception(() => SettingsUtility.GetDecryptedValueForAddItem(settings: null!, section: "randomSection", key: "randomKey"));
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();
@@ -246,7 +246,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void SetEncryptedValueForAddItem_WithNullSettings_Throws()
         {
-            var ex = Record.Exception(() => SettingsUtility.SetEncryptedValueForAddItem(settings: null, section: "randomSection", key: "randomKey", value: "value"));
+            var ex = Record.Exception(() => SettingsUtility.SetEncryptedValueForAddItem(settings: null!, section: "randomSection", key: "randomKey", value: "value"));
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();
@@ -255,7 +255,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void GetConfigValue_WithNullSettings_Throws()
         {
-            var ex = Record.Exception(() => SettingsUtility.GetConfigValue(settings: null, key: "randomKey"));
+            var ex = Record.Exception(() => SettingsUtility.GetConfigValue(settings: null!, key: "randomKey"));
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();
@@ -264,7 +264,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void SetConfigValue_WithNullSettings_Throws()
         {
-            var ex = Record.Exception(() => SettingsUtility.SetConfigValue(settings: null, key: "randomKey", value: "value"));
+            var ex = Record.Exception(() => SettingsUtility.SetConfigValue(settings: null!, key: "randomKey", value: "value"));
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();
@@ -273,7 +273,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void DeleteConfigValue_WithNullSettings_Throws()
         {
-            var ex = Record.Exception(() => SettingsUtility.DeleteConfigValue(settings: null, key: "randomKey"));
+            var ex = Record.Exception(() => SettingsUtility.DeleteConfigValue(settings: null!, key: "randomKey"));
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();
@@ -309,7 +309,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void GetGlobalPackagesFolder_WithNullSettings_Throws()
         {
-            var ex = Record.Exception(() => SettingsUtility.GetGlobalPackagesFolder(settings: null));
+            var ex = Record.Exception(() => SettingsUtility.GetGlobalPackagesFolder(settings: null!));
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();
@@ -318,7 +318,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void GetFallbackPackageFolders_WithNullSettings_Throws()
         {
-            var ex = Record.Exception(() => SettingsUtility.GetFallbackPackageFolders(settings: null));
+            var ex = Record.Exception(() => SettingsUtility.GetFallbackPackageFolders(settings: null!));
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();
@@ -327,7 +327,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void GetEnabledSources_WithNullSettings_Throws()
         {
-            var ex = Record.Exception(() => SettingsUtility.GetEnabledSources(settings: null));
+            var ex = Record.Exception(() => SettingsUtility.GetEnabledSources(settings: null!));
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();
@@ -336,7 +336,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void GetDefaultPushSource_WithNullSettings_Throws()
         {
-            var ex = Record.Exception(() => SettingsUtility.GetDefaultPushSource(settings: null));
+            var ex = Record.Exception(() => SettingsUtility.GetDefaultPushSource(settings: null!));
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();
@@ -345,7 +345,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void GetUpdatePackageLastAccessTimeEnabledStatus_WithNullSettings_Throws()
         {
-            var ex = Record.Exception(() => SettingsUtility.GetUpdatePackageLastAccessTimeEnabledStatus(settings: null));
+            var ex = Record.Exception(() => SettingsUtility.GetUpdatePackageLastAccessTimeEnabledStatus(settings: null!));
 
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13250

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Enabled `nullable` in NuGet.Configuration and its test project.

Dealing with `SettingBase.Origin` and `SettingElement.ElementName` was particularly difficult (without suppressing the warnings), and I introduced some breaking API changes in these abstract classes as a result. However, this only affect classes that extend the configuration, but we don't provide extensibility other assemblies to add custom configuration classes. Therefore, it's unlikely that anyone should be affected by those API changes (witnessed by the fact that none of NuGet's other projects needed changes due to those API changes).

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A: no functionality changes, only adding null annotations. <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
