### PR TITLE
Use NJ by default for reading assets files, not STJ

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/JsonUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonUtility.cs
@@ -70,7 +70,7 @@ namespace NuGet.ProjectModel
                 }
                 else
                 {
-                    UseNewtonsoftJson = false;
+                    UseNewtonsoftJson = true;
                 }
             }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Mitigates https://github.com/NuGet/Home/issues/13248

Regression? Yes, https://github.com/NuGet/NuGet.Client/pull/5627 appears to have introduced the issue

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Cloning the SDK repo locally, I was (after many hours and many more failed attempts) able to confirm that switching the assets file parser to Newtonsoft.Json by default fixes at least one of the failed SDK tests. So this way we can avoid reverting the entire feature.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
