### PR TITLE
[`dotnet package search`] Don't show help output for source errors.

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchCommand.cs
@@ -122,7 +122,7 @@ namespace NuGet.CommandLine.XPlat
                 catch (ArgumentException ex)
                 {
                     logger.LogError(ex.Message);
-                    return 1;
+                    return ExitCodes.EXIT_COMMANDLINE_ARGUMENT_PRSING_FAILURE;
                 }
             });
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchCommand.cs
@@ -122,7 +122,7 @@ namespace NuGet.CommandLine.XPlat
                 catch (ArgumentException ex)
                 {
                     logger.LogError(ex.Message);
-                    return ExitCodes.EXIT_COMMANDLINE_ARGUMENT_PARSING_FAILURE;
+                    return ExitCodes.InvalidArguments;
                 }
             });
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchCommand.cs
@@ -122,7 +122,7 @@ namespace NuGet.CommandLine.XPlat
                 catch (ArgumentException ex)
                 {
                     logger.LogError(ex.Message);
-                    return ExitCodes.EXIT_COMMANDLINE_ARGUMENT_PRSING_FAILURE;
+                    return ExitCodes.EXIT_COMMANDLINE_ARGUMENT_PARSING_FAILURE;
                 }
             });
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchRunner.cs
@@ -50,7 +50,7 @@ namespace NuGet.CommandLine.XPlat
                 packageSearchResultRenderer.RenderProblem(new PackageSearchProblem(PackageSearchProblemType.Error, ex.Message));
                 packageSearchResultRenderer.Finish();
 
-                return 1;
+                return 0;
             }
 
             WarnForHTTPSources(listEndpoints, packageSearchArgs.Logger);
@@ -61,7 +61,7 @@ namespace NuGet.CommandLine.XPlat
                 packageSearchResultRenderer.RenderProblem(new PackageSearchProblem(PackageSearchProblemType.Error, Strings.Error_NoSource));
                 packageSearchResultRenderer.Finish();
 
-                return 1;
+                return 0;
             }
 
             Func<PackageSource, Task<IEnumerable<IPackageSearchMetadata>>> searchPackageSourceAsync =

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchRunner.cs
@@ -50,7 +50,7 @@ namespace NuGet.CommandLine.XPlat
                 packageSearchResultRenderer.RenderProblem(new PackageSearchProblem(PackageSearchProblemType.Error, ex.Message));
                 packageSearchResultRenderer.Finish();
 
-                return 0;
+                return -1;
             }
 
             WarnForHTTPSources(listEndpoints, packageSearchArgs.Logger);
@@ -61,7 +61,7 @@ namespace NuGet.CommandLine.XPlat
                 packageSearchResultRenderer.RenderProblem(new PackageSearchProblem(PackageSearchProblemType.Error, Strings.Error_NoSource));
                 packageSearchResultRenderer.Finish();
 
-                return 0;
+                return -1;
             }
 
             Func<PackageSource, Task<IEnumerable<IPackageSearchMetadata>>> searchPackageSourceAsync =

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchRunner.cs
@@ -50,7 +50,7 @@ namespace NuGet.CommandLine.XPlat
                 packageSearchResultRenderer.RenderProblem(new PackageSearchProblem(PackageSearchProblemType.Error, ex.Message));
                 packageSearchResultRenderer.Finish();
 
-                return ExitCodes.EXIT_COMMAND_EXECUTION_FAILURE;
+                return ExitCodes.Error;
             }
 
             WarnForHTTPSources(listEndpoints, packageSearchArgs.Logger);
@@ -61,7 +61,7 @@ namespace NuGet.CommandLine.XPlat
                 packageSearchResultRenderer.RenderProblem(new PackageSearchProblem(PackageSearchProblemType.Error, Strings.Error_NoSource));
                 packageSearchResultRenderer.Finish();
 
-                return ExitCodes.EXIT_COMMAND_EXECUTION_FAILURE;
+                return ExitCodes.Error;
             }
 
             Func<PackageSource, Task<IEnumerable<IPackageSearchMetadata>>> searchPackageSourceAsync =
@@ -126,7 +126,7 @@ namespace NuGet.CommandLine.XPlat
             }
 
             packageSearchResultRenderer.Finish();
-            return ExitCodes.EXIT_SUCCESS;
+            return ExitCodes.Success;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchRunner.cs
@@ -50,7 +50,7 @@ namespace NuGet.CommandLine.XPlat
                 packageSearchResultRenderer.RenderProblem(new PackageSearchProblem(PackageSearchProblemType.Error, ex.Message));
                 packageSearchResultRenderer.Finish();
 
-                return -1;
+                return ExitCodes.EXIT_COMMAND_EXECUTION_FAILURE;
             }
 
             WarnForHTTPSources(listEndpoints, packageSearchArgs.Logger);
@@ -61,7 +61,7 @@ namespace NuGet.CommandLine.XPlat
                 packageSearchResultRenderer.RenderProblem(new PackageSearchProblem(PackageSearchProblemType.Error, Strings.Error_NoSource));
                 packageSearchResultRenderer.Finish();
 
-                return -1;
+                return ExitCodes.EXIT_COMMAND_EXECUTION_FAILURE;
             }
 
             Func<PackageSource, Task<IEnumerable<IPackageSearchMetadata>>> searchPackageSourceAsync =
@@ -126,7 +126,7 @@ namespace NuGet.CommandLine.XPlat
             }
 
             packageSearchResultRenderer.Finish();
-            return 0;
+            return ExitCodes.EXIT_SUCCESS;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/ExitCodes.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/ExitCodes.cs
@@ -9,7 +9,7 @@ namespace NuGet.CommandLine.XPlat
         internal const int EXIT_SUCCESS = 0;
 
         // Exit code used when te command line arguments are not parsed successfully.
-        internal const int EXIT_COMMANDLINE_ARGUMENT_PRSING_FAILURE = 1;
+        internal const int EXIT_COMMANDLINE_ARGUMENT_PARSING_FAILURE = 1;
 
         // Exit code used when the command line arguments are parsed successfully bu the command fails to run successfully.
         internal const int EXIT_COMMAND_EXECUTION_FAILURE = 2;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/ExitCodes.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/ExitCodes.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.CommandLine.XPlat
+{
+    internal static class ExitCodes
+    {
+        // Exit code use when the command line arguments are parsed successfully and the command is run successfully
+        internal const int EXIT_SUCCESS = 0;
+
+        // Exit code used when te command line arguments are not parsed successfully.
+        internal const int EXIT_COMMANDLINE_ARGUMENT_PRSING_FAILURE = 1;
+
+        // Exit code used when the command line arguments are parsed successfully bu the command fails to run successfully.
+        internal const int EXIT_COMMAND_EXECUTION_FAILURE = 2;
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/ExitCodes.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/ExitCodes.cs
@@ -6,12 +6,12 @@ namespace NuGet.CommandLine.XPlat
     internal static class ExitCodes
     {
         // Exit code use when the command line arguments are parsed successfully and the command is run successfully
-        internal const int EXIT_SUCCESS = 0;
+        internal const int Success = 0;
 
         // Exit code used when te command line arguments are not parsed successfully.
-        internal const int EXIT_COMMANDLINE_ARGUMENT_PARSING_FAILURE = 1;
+        internal const int InvalidArguments = 1;
 
         // Exit code used when the command line arguments are parsed successfully bu the command fails to run successfully.
-        internal const int EXIT_COMMAND_EXECUTION_FAILURE = 2;
+        internal const int Error = 2;
     }
 }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetPackageSearchTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetPackageSearchTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System;
+using NuGet.CommandLine.Xplat.Tests;
+using NuGet.Test.Utility;
+using Xunit;
+using System.IO;
+using System.Reflection;
+
+namespace Dotnet.Integration.Test
+{
+    [Collection(DotnetIntegrationCollection.Name)]
+    public class DotnetPackageSearchTests : IClassFixture<PackageSearchRunnerFixture>
+    {
+        private readonly DotnetIntegrationTestFixture _testFixture;
+        private readonly PackageSearchRunnerFixture _packageSearchRunnerFixture;
+
+        public DotnetPackageSearchTests(DotnetIntegrationTestFixture testFixture, PackageSearchRunnerFixture packageSearchRunnerFixture)
+        {
+            _testFixture = testFixture;
+            _packageSearchRunnerFixture = packageSearchRunnerFixture;
+        }
+
+        internal string NormalizeNewlines(string input)
+        {
+            return input.Replace("\r\n", "\n").Replace("\r", "\n");
+        }
+
+        [Fact]
+        public void DotnetPackageSearch_Succeed()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                var args = new string[] { "package", "search", "json", "--source", $"{_packageSearchRunnerFixture.ServerWithMultipleEndpoints.Uri}v3/index.json", "--format", "json" };
+
+                // Act
+                var result = _testFixture.RunDotnetExpectSuccess(pathContext.PackageSource, string.Join(" ", args));
+
+                // Assert
+                Assert.Equal(0, result.ExitCode);
+                Assert.Contains("\"total downloads\": 531607259,", result.AllOutput);
+                Assert.Contains("\"owners\": \"James Newton-King\",", result.AllOutput);
+                Assert.Contains("\"total downloads\": 531607259,", result.AllOutput);
+                Assert.Contains("\"latestVersion\": \"12.0.3\"", result.AllOutput);
+            }
+        }
+
+        [Fact]
+        public void DotnetPackageSearch_WithInvalidSource_FailWithNoHelpOutput()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                string source = "invalid-source";
+                var args = new string[] { "package", "search", "json", "--source", source, "--format", "json" };
+                Dictionary<string, string> finalEnvironmentVariables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["MSBuildSDKsPath"] = _testFixture.MsBuildSdksPath,
+                    ["UseSharedCompilation"] = bool.FalseString,
+                    ["DOTNET_MULTILEVEL_LOOKUP"] = "0",
+                    ["DOTNET_ROOT"] = TestDotnetCLiUtility.CopyAndPatchLatestDotnetCli(Path.GetFullPath(Assembly.GetExecutingAssembly().Location)),
+                    ["MSBUILDDISABLENODEREUSE"] = bool.TrueString,
+                    ["NUGET_SHOW_STACK"] = bool.TrueString
+                };
+
+                string error = "is invalid. Provide a valid source.";
+                string help = "dotnet package search [<SearchTerm>] [options]";
+                // Act
+                var result = CommandRunner.Run(_testFixture.TestDotnetCli, pathContext.PackageSource, string.Join(" ", args), environmentVariables: finalEnvironmentVariables);
+
+                // Assert
+                Assert.Contains(error, result.AllOutput);
+                Assert.DoesNotContain(help, result.AllOutput);
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerFixture.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerFixture.cs
@@ -10,9 +10,9 @@ namespace NuGet.CommandLine.Xplat.Tests
         public string SinglePackageQueryResponse { get; private set; }
         public string ExactMatchMetadataResponse { get; private set; }
         public MockServer ServerWithMultipleEndpoints { get; private set; }
-        internal string ExpectedSearchResultDetailed { get; set; }
-        internal string ExpectedSearchResultNormal { get; set; }
-        internal string ExpectedSearchResultMinimal { get; set; }
+        public string ExpectedSearchResultDetailed { get; set; }
+        public string ExpectedSearchResultNormal { get; set; }
+        public string ExpectedSearchResultMinimal { get; set; }
 
         public PackageSearchRunnerFixture()
         {

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
@@ -406,7 +406,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         }
 
         [Fact]
-        public async Task PackageSearchRunner_WhenSourceIsInvalid_ReturnsExitCodeOne()
+        public async Task PackageSearchRunner_WhenSourceIsInvalid_ReturnsExecutionFailureExitCode()
         {
             // Arrange
             ISettings settings = Settings.LoadDefaultSettings(
@@ -434,7 +434,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                 cancellationToken: System.Threading.CancellationToken.None);
 
             // Assert
-            Assert.Equal(-1, exitCode);
+            Assert.Equal(ExitCodes.EXIT_COMMAND_EXECUTION_FAILURE, exitCode);
             Assert.Contains(expectedError, StoredErrorMessage);
         }
 
@@ -467,7 +467,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                 cancellationToken: System.Threading.CancellationToken.None);
 
             // Assert
-            Assert.Equal(0, exitCode);
+            Assert.Equal(ExitCodes.EXIT_SUCCESS, exitCode);
             Assert.Contains(expectedError, StoredErrorMessage);
         }
 
@@ -504,7 +504,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                     cancellationToken: cts.Token);
 
             // Assert
-            Assert.Equal(0, exitCode);
+            Assert.Equal(ExitCodes.EXIT_SUCCESS, exitCode);
             Assert.Contains(expectedError, StoredErrorMessage);
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
@@ -434,7 +434,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                 cancellationToken: System.Threading.CancellationToken.None);
 
             // Assert
-            Assert.Equal(1, exitCode);
+            Assert.Equal(0, exitCode);
             Assert.Contains(expectedError, StoredErrorMessage);
         }
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
@@ -434,7 +434,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                 cancellationToken: System.Threading.CancellationToken.None);
 
             // Assert
-            Assert.Equal(0, exitCode);
+            Assert.Equal(-1, exitCode);
             Assert.Contains(expectedError, StoredErrorMessage);
         }
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
@@ -406,7 +406,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         }
 
         [Fact]
-        public async Task PackageSearchRunner_WhenSourceIsInvalid_ReturnsExecutionFailureExitCode()
+        public async Task PackageSearchRunner_WhenSourceIsInvalid_ReturnsErrorExitCode()
         {
             // Arrange
             ISettings settings = Settings.LoadDefaultSettings(
@@ -434,7 +434,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                 cancellationToken: System.Threading.CancellationToken.None);
 
             // Assert
-            Assert.Equal(ExitCodes.EXIT_COMMAND_EXECUTION_FAILURE, exitCode);
+            Assert.Equal(ExitCodes.Error, exitCode);
             Assert.Contains(expectedError, StoredErrorMessage);
         }
 
@@ -467,7 +467,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                 cancellationToken: System.Threading.CancellationToken.None);
 
             // Assert
-            Assert.Equal(ExitCodes.EXIT_SUCCESS, exitCode);
+            Assert.Equal(ExitCodes.Success, exitCode);
             Assert.Contains(expectedError, StoredErrorMessage);
         }
 
@@ -504,7 +504,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                     cancellationToken: cts.Token);
 
             // Assert
-            Assert.Equal(ExitCodes.EXIT_SUCCESS, exitCode);
+            Assert.Equal(ExitCodes.Success, exitCode);
             Assert.Contains(expectedError, StoredErrorMessage);
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13161

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Example command: `dotnet package search --source my-source`
Expected Behavior:

The SDK should handle invalid sources gracefully, providing a clear error message without interfering with the expected JSON output format.

Current Problem:

When the provided source is invalid (e.g., my-source does not exist in any config file or is not a valid source by itself), the SDK outputs both the help message and the JSON output together.

                {
                  "version": 1,
                  "problems": [
                    {
                      "text": "The specified source "my-source" is invalid. Provide a valid source.",
                      "problemType": "Error"
                    }
                  ],
                  "searchResult": []
                }
                Description:
                  Searches one or more package sources for packages that match a search term. If no sources are specified, all sources defined in the NuGet.Config are used.
                
                Usage:
                  dotnet package search [<SearchTerm>] [options]
                
                Arguments:
                  <SearchTerm>  Search term to filter package names, descriptions, and tags. Used as a literal value. Example: `dotnet package search some.package`. See also `--exact-match`.
                
                Options:
                  --source <Source>          The package source to search. You can pass multiple `--source` options to search multiple package sour....

This SDK and NuGet side of the `dotnet package search` command communicate via exit codes.
- if the exit code is 0, help output is not shown.
- if the exit code is 1, help output is shown.
This PR makes sure the exit code 1 only for errors caused by problems from parsing user command input. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
