### PR TITLE
[`dotnet package search`] Ignore null properties when rendering JSON format output

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/SearchResultPackagesConverter.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/SearchResultPackagesConverter.cs
@@ -46,12 +46,11 @@ namespace NuGet.CommandLine.XPlat
                 {
                     writer.WriteNumber(JsonProperties.DownloadCount, (decimal)value.DownloadCount);
                 }
-                else
-                {
-                    writer.WriteNull(JsonProperties.DownloadCount);
-                }
 
-                writer.WriteString(JsonProperties.Owners, value.Owners);
+                if (value.Owners is not null)
+                {
+                    writer.WriteString(JsonProperties.Owners, value.Owners);
+                }
             }
 
             if (_verbosity == PackageSearchVerbosity.Detailed)
@@ -62,10 +61,6 @@ namespace NuGet.CommandLine.XPlat
                 {
                     writer.WriteBoolean("vulnerable", true);
                 }
-                else
-                {
-                    writer.WriteNull("vulnerable");
-                }
 
                 writer.WriteString(JsonProperties.ProjectUrl, value.ProjectUrl.ToString());
 
@@ -74,10 +69,6 @@ namespace NuGet.CommandLine.XPlat
                 if (packageDeprecationMetadata != null)
                 {
                     writer.WriteString(JsonProperties.Deprecation, packageDeprecationMetadata.Message);
-                }
-                else
-                {
-                    writer.WriteNull(JsonProperties.Deprecation);
                 }
             }
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultJsonRenderer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultJsonRenderer.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 
@@ -47,7 +48,8 @@ namespace NuGet.CommandLine.XPlat
             var options = new JsonSerializerOptions
             {
                 WriteIndented = true,
-                Converters = { new SearchResultPackagesConverter(_verbosity, _exactMatch) }
+                Converters = { new SearchResultPackagesConverter(_verbosity, _exactMatch) },
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
             };
             var json = JsonSerializer.Serialize(_packageSearchMainOutput, options);
             _logger.LogMinimal(json);

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchResultJsonPrinterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchResultJsonPrinterTests.cs
@@ -32,7 +32,6 @@ namespace NuGet.CommandLine.Xplat.Tests
   ""searchResult"": [
     {{
       ""sourceName"": ""MockSource"",
-      ""problems"": null,
       ""packages"": []
     }}
   ]
@@ -71,13 +70,11 @@ namespace NuGet.CommandLine.Xplat.Tests
   ""searchResult"": [
     {{
       ""sourceName"": ""MockSource"",
-      ""problems"": null,
       ""packages"": [
         {{
           ""id"": ""NuGet.Versioning"",
           ""latestVersion"": ""4.3.0"",
-          ""totalDownloads"": 123456,
-          ""owners"": null
+          ""totalDownloads"": 123456
         }}
       ]
     }}
@@ -118,19 +115,16 @@ namespace NuGet.CommandLine.Xplat.Tests
   ""searchResult"": [
     {{
       ""sourceName"": ""MockSource"",
-      ""problems"": null,
       ""packages"": [
         {{
           ""id"": ""NuGet.Versioning"",
           ""latestVersion"": ""4.3.0"",
-          ""totalDownloads"": 123456,
-          ""owners"": null
+          ""totalDownloads"": 123456
         }},
         {{
           ""id"": ""NuGet.Versioning"",
           ""latestVersion"": ""4.3.0"",
-          ""totalDownloads"": 123456,
-          ""owners"": null
+          ""totalDownloads"": 123456
         }}
       ]
     }}

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerFixture.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerFixture.cs
@@ -345,7 +345,6 @@ namespace NuGet.CommandLine.Xplat.Tests
   ""searchResult"": [
     {{
       ""sourceName"": ""{ServerWithMultipleEndpoints.Uri}v3/index.json"",
-      ""problems"": null,
       ""packages"": [
         {{
           ""id"": ""Fake.Newtonsoft.Json"",
@@ -353,7 +352,6 @@ namespace NuGet.CommandLine.Xplat.Tests
           ""totalDownloads"": 531607259,
           ""owners"": ""James Newton-King"",
           ""description"": ""My description."",
-          ""vulnerable"": null,
           ""projectUrl"": ""http://myuri/"",
           ""deprecation"": ""This package has been deprecated""
         }}
@@ -368,7 +366,6 @@ namespace NuGet.CommandLine.Xplat.Tests
   ""searchResult"": [
     {{
       ""sourceName"": ""{ServerWithMultipleEndpoints.Uri}v3/index.json"",
-      ""problems"": null,
       ""packages"": [
         {{
           ""id"": ""Fake.Newtonsoft.Json"",
@@ -387,7 +384,6 @@ namespace NuGet.CommandLine.Xplat.Tests
   ""searchResult"": [
     {{
       ""sourceName"": ""{ServerWithMultipleEndpoints.Uri}v3/index.json"",
-      ""problems"": null,
       ""packages"": [
         {{
           ""id"": ""Fake.Newtonsoft.Json"",


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13166

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Previously we had null properties being printed out in the search result in the json format
![image](https://github.com/NuGet/NuGet.Client/assets/59111203/4e7295ad-ecef-4cfb-a699-55badfed9044)

This PR makes sure that null properties are not rendered
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
