### PR TITLE
Cherry-pick "fix package updates when casing does not match (#5642)" commit into 6.9 branch.

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -14,7 +14,6 @@ using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
-using NuGet.LibraryModel;
 using NuGet.PackageManagement.Utility;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -3201,13 +3200,13 @@ namespace NuGet.PackageManagement
         {
             var frameworksWithResultingPackage = packageSpec
                 .TargetFrameworks
-                .Where(e => e.Dependencies.Any(a => a.Name == packageIdentityId))
+                .Where(e => e.Dependencies.Any(a => string.Equals(a.Name, packageIdentityId, StringComparison.OrdinalIgnoreCase)))
                 .Select(e => e.FrameworkName)
                 .Distinct();
 
             var frameworksWithoutResultingPackage = packageSpec
                 .TargetFrameworks
-                .Where(e => !e.Dependencies.Any(a => a.Name == packageIdentityId))
+                .Where(e => !e.Dependencies.Any(a => string.Equals(a.Name, packageIdentityId, StringComparison.OrdinalIgnoreCase)))
                 .Select(e => e.FrameworkName)
                 .Distinct();
 
@@ -3232,7 +3231,7 @@ namespace NuGet.PackageManagement
             {
                 foreach (var dependency in framework.Dependencies)
                 {
-                    if (dependency.Name == packageIdentityId)
+                    if (string.Equals(dependency.Name, packageIdentityId, StringComparison.OrdinalIgnoreCase))
                     {
                         versions ??= new();
                         versions.Add(dependency.LibraryRange.VersionRange);
@@ -3341,7 +3340,7 @@ namespace NuGet.PackageManagement
                                 pathResolver,
                                 originalAction.PackageIdentity);
 
-                            var framework = installationContext.SuccessfulFrameworks.FirstOrDefault();
+                            var framework = installationContext.SuccessfulFrameworks.First();
                             var resolvedAction = projectAction.RestoreResult.LockFile.PackageSpec.TargetFrameworks.FirstOrDefault(fm => fm.FrameworkName.Equals(framework))
                                 .Dependencies.First(dependency => dependency.Name.Equals(originalAction.PackageIdentity.Id, StringComparison.OrdinalIgnoreCase));
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerUtilityTests.cs
@@ -268,5 +268,50 @@ namespace NuGet.PackageManagement.Test
             buildIntegrationInstallationContext.SuccessfulFrameworks.Should().Contain(FrameworkConstants.CommonFrameworks.Net472);
             buildIntegrationInstallationContext.AreAllPackagesConditional.Should().BeTrue();
         }
+
+        [Fact]
+        public void CreateInstallationContextForPackageId_WithDifferencePackageIdCase_ReturnsCorrectValue()
+        {
+            // Arrange
+
+            var originalPackageSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project", @"C:\",
+                @"
+                {
+                    ""frameworks"": {
+                        ""net472"": {
+                            ""dependencies"": {
+                                ""a"" : ""1.0.0""
+                            }
+                        }
+                    }
+                }");
+
+            string referenceSpec = @"
+                {
+                    ""frameworks"": {
+                        ""net472"": {
+                            ""dependencies"": {
+                                ""a"" : ""2.0.0""
+                            }
+                        }
+                    }
+                }";
+            Dictionary<NuGetFramework, string> originalFrameworks = new()
+            {
+                { FrameworkConstants.CommonFrameworks.Net472, "net472" }
+            };
+
+            var resultingPackageSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("project", @"C:\", referenceSpec);
+
+            // Act
+            var buildIntegrationInstallationContext = NuGetPackageManager.CreateInstallationContextForPackageId(packageIdentityId: "A", resultingPackageSpec, originalPackageSpec, unsuccessfulFrameworks: new(), originalFrameworks);
+
+            // Assert
+            buildIntegrationInstallationContext.OriginalFrameworks.Should().Equal(originalFrameworks);
+            buildIntegrationInstallationContext.SuccessfulFrameworks.Should().HaveCount(1);
+            buildIntegrationInstallationContext.UnsuccessfulFrameworks.Should().HaveCount(0);
+            buildIntegrationInstallationContext.SuccessfulFrameworks.Should().Contain(FrameworkConstants.CommonFrameworks.Net472);
+            buildIntegrationInstallationContext.AreAllPackagesConditional.Should().BeFalse();
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Tracking: https://github.com/NuGet/Home/issues/13259 & https://github.com/NuGet/Client.Engineering/issues/2704

Regression? Last working version: Yes, worked in NuGet 6.8 version.

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Cherry-pick https://github.com/NuGet/NuGet.Client/commit/b49d8914861cf18287302ab311fc9d2566e06fe1 commit into release-6.9.x branch.

cc @zivkan 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A