### PR TITLE
Make IVsProjectAdapter.IsCapabilityMatch not async

### DIFF
--- a/build/Shared/vs-threading.MembersRequiringMainThread.txt
+++ b/build/Shared/vs-threading.MembersRequiringMainThread.txt
@@ -12,3 +12,4 @@
 [NuGet.PackageManagement.VisualStudio.EnvDTEProjectUtility]::TryGetNestedFile
 [NuGet.ProjectManagement.IProjectBuildProperties]::GetPropertyValue
 [NuGet.VisualStudio.IVsProjectBuildProperties]::GetPropertyValue
+[NuGet.VisualStudio.IVsProjectAdapter]::IsCapabilityMatch

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
@@ -67,8 +67,8 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             // Check that the project supports both CPS and PackageReferences
-            if (!(await vsProject.IsCapabilityMatchAsync(NuGet.VisualStudio.IDE.ProjectCapabilities.Cps) &&
-                await vsProject.IsCapabilityMatchAsync(NuGet.VisualStudio.IDE.ProjectCapabilities.PackageReferences)))
+            if (!(vsProject.IsCapabilityMatch(NuGet.VisualStudio.IDE.ProjectCapabilities.Cps) &&
+                vsProject.IsCapabilityMatch(NuGet.VisualStudio.IDE.ProjectCapabilities.PackageReferences)))
             {
                 return null;
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProjectProvider.cs
@@ -106,7 +106,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 || PackageReference.Equals(restoreProjectStyle, StringComparison.OrdinalIgnoreCase)
                 || (vsProject4.PackageReferences?.InstalledPackages?.Length ?? 0) > 0)
             {
-                var nominatesOnSolutionLoad = await vsProjectAdapter.IsCapabilityMatchAsync(NuGet.VisualStudio.IDE.ProjectCapabilities.PackageReferences);
+                var nominatesOnSolutionLoad = vsProjectAdapter.IsCapabilityMatch(NuGet.VisualStudio.IDE.ProjectCapabilities.PackageReferences);
                 return new VsManagedLanguagesProjectSystemServices(vsProjectAdapter, _threadingService, vsProject4, nominatesOnSolutionLoad, _scriptExecutor);
             }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -265,10 +265,9 @@ namespace NuGet.PackageManagement.VisualStudio
             return frameworkStrings.FirstOrDefault();
         }
 
-        public async Task<bool> IsCapabilityMatchAsync(string capabilityExpression)
+        public bool IsCapabilityMatch(string capabilityExpression)
         {
-            await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
-
+            ThreadHelper.ThrowIfNotOnUIThread();
             return VsHierarchy.IsCapabilityMatch(capabilityExpression);
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
@@ -76,6 +76,6 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// See <see cref="Microsoft.VisualStudio.Shell.PackageUtilities.IsCapabilityMatch(IVsHierarchy, string)"/>
         /// </summary>
-        Task<bool> IsCapabilityMatchAsync(string capabilityExpression);
+        bool IsCapabilityMatch(string capabilityExpression);
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
@@ -168,7 +168,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             return Enumerable.Empty<(string ItemId, string[] ItemMetadata)>();
         }
 
-        public Task<bool> IsCapabilityMatchAsync(string capabilityExpression)
+        public bool IsCapabilityMatch(string capabilityExpression)
         {
             throw new NotImplementedException();
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Projects/CpsPackageReferenceProjectProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Projects/CpsPackageReferenceProjectProviderTests.cs
@@ -32,10 +32,10 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Projects
             var projectAdapter = new Mock<IVsProjectAdapter>();
             projectAdapter.SetupGet(a => a.VsHierarchy)
                 .Returns(hierarchy.Object);
-            projectAdapter.Setup(a => a.IsCapabilityMatchAsync(NuGet.VisualStudio.IDE.ProjectCapabilities.Cps))
-                .Returns(Task.FromResult(true));
-            projectAdapter.Setup(a => a.IsCapabilityMatchAsync(NuGet.VisualStudio.IDE.ProjectCapabilities.PackageReferences))
-                .Returns(Task.FromResult(false));
+            projectAdapter.Setup(a => a.IsCapabilityMatch(NuGet.VisualStudio.IDE.ProjectCapabilities.Cps))
+                .Returns(true);
+            projectAdapter.Setup(a => a.IsCapabilityMatch(NuGet.VisualStudio.IDE.ProjectCapabilities.PackageReferences))
+                .Returns(false);
 
             var nugetProjectContext = new Mock<INuGetProjectContext>();
 
@@ -54,8 +54,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Projects
 
             // Assert
             Assert.Null(actual);
-            projectAdapter.Verify(a => a.IsCapabilityMatchAsync(NuGet.VisualStudio.IDE.ProjectCapabilities.Cps), Times.Once);
-            projectAdapter.Verify(a => a.IsCapabilityMatchAsync(NuGet.VisualStudio.IDE.ProjectCapabilities.PackageReferences), Times.Once);
+            projectAdapter.Verify(a => a.IsCapabilityMatch(NuGet.VisualStudio.IDE.ProjectCapabilities.Cps), Times.Once);
+            projectAdapter.Verify(a => a.IsCapabilityMatch(NuGet.VisualStudio.IDE.ProjectCapabilities.PackageReferences), Times.Once);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13268

Regression? technically yes
Last working version: VS 16.9: https://github.com/NuGet/NuGet.Client/commit/43ec68cfe8013457edc59f852069c9ebece0509d

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Make the method not async.
* Since the VS Threading analyzer only auto detects UI thread requirements through method implementations, it can't infer UI thread requirements through interfaces. Therefore, add this API to `vs-threading.MembersRequiringMainThread.txt`

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: existing tests updated, but otherwise no functionality change.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
