### PR TITLE
Add Restore Instrumentation

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -323,7 +323,7 @@ namespace NuGet.Commands
 
                 telemetry.StartIntervalMeasure();
                 // Create assets file
-                if(NuGetEventSource.IsEnabled) TraceEvents.BuildAssetsFileStart(_request.Project.FilePath);
+                if (NuGetEventSource.IsEnabled) TraceEvents.BuildAssetsFileStart(_request.Project.FilePath);
                 LockFile assetsFile = BuildAssetsFile(
                     _request.ExistingLockFile,
                     _request.Project,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -193,9 +193,9 @@ namespace NuGet.Commands
                         bool noOp;
                         TimeSpan? cacheFileAge;
 
-                        if (NuGetEventSource.IsEnabled) TraceEvents.CalcDependencySpecStart(_request.Project.FilePath);
+                        if (NuGetEventSource.IsEnabled) TraceEvents.CalcNoOpRestoreStart(_request.Project.FilePath);
                         (cacheFile, noOp, cacheFileAge) = EvaluateCacheFile();
-                        if (NuGetEventSource.IsEnabled) TraceEvents.CalcDependencySpecStop(_request.Project.FilePath);
+                        if (NuGetEventSource.IsEnabled) TraceEvents.CalcNoOpRestoreStop(_request.Project.FilePath);
 
                         telemetry.TelemetryEvent[NoOpCacheFileEvaluationResult] = noOp;
                         telemetry.EndIntervalMeasure(NoOpCacheFileEvaluateDuration);
@@ -1427,13 +1427,14 @@ namespace NuGet.Commands
         {
             private const string EventNameBuildAssetsFile = "RestoreCommand/BuildAssetsFile";
             private const string EventNameBuildRestoreGraph = "RestoreCommand/BuildRestoreGraph";
-            private const string EventNameCalcDependencySpec = "RestoreCommand/CalcDependencySpec";
+            private const string EventNameCalcNoOpRestore = "RestoreCommand/CalcNoOpRestore";
 
             public static void BuildAssetsFileStart(string filePath)
             {
                 var eventOptions = new EventSourceOptions
                 {
-                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Keywords = NuGetEventSource.Keywords.Performance |
+                                NuGetEventSource.Keywords.Restore,
                     Opcode = EventOpcode.Start
                 };
 
@@ -1444,7 +1445,8 @@ namespace NuGet.Commands
             {
                 var eventOptions = new EventSourceOptions
                 {
-                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Keywords = NuGetEventSource.Keywords.Performance |
+                                NuGetEventSource.Keywords.Restore,
                     Opcode = EventOpcode.Stop
                 };
 
@@ -1455,7 +1457,8 @@ namespace NuGet.Commands
             {
                 var eventOptions = new EventSourceOptions
                 {
-                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Keywords = NuGetEventSource.Keywords.Performance |
+                                NuGetEventSource.Keywords.Restore,
                     Opcode = EventOpcode.Start
                 };
 
@@ -1466,33 +1469,36 @@ namespace NuGet.Commands
             {
                 var eventOptions = new EventSourceOptions
                 {
-                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Keywords = NuGetEventSource.Keywords.Performance |
+                                NuGetEventSource.Keywords.Restore,
                     Opcode = EventOpcode.Stop
                 };
 
                 NuGetEventSource.Instance.Write(EventNameBuildRestoreGraph, eventOptions, new { FilePath = filePath });
             }
 
-            public static void CalcDependencySpecStart(string filePath)
+            public static void CalcNoOpRestoreStart(string filePath)
             {
                 var eventOptions = new EventSourceOptions
                 {
-                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Keywords = NuGetEventSource.Keywords.Performance |
+                                NuGetEventSource.Keywords.Restore,
                     Opcode = EventOpcode.Start
                 };
 
-                NuGetEventSource.Instance.Write(EventNameCalcDependencySpec, eventOptions, new { FilePath = filePath });
+                NuGetEventSource.Instance.Write(EventNameCalcNoOpRestore, eventOptions, new { FilePath = filePath });
             }
 
-            public static void CalcDependencySpecStop(string filePath)
+            public static void CalcNoOpRestoreStop(string filePath)
             {
                 var eventOptions = new EventSourceOptions
                 {
-                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Keywords = NuGetEventSource.Keywords.Performance |
+                                NuGetEventSource.Keywords.Restore,
                     Opcode = EventOpcode.Stop
                 };
 
-                NuGetEventSource.Instance.Write(EventNameCalcDependencySpec, eventOptions, new { FilePath = filePath });
+                NuGetEventSource.Instance.Write(EventNameCalcNoOpRestore, eventOptions, new { FilePath = filePath });
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -191,7 +192,11 @@ namespace NuGet.Commands
                         telemetry.StartIntervalMeasure();
                         bool noOp;
                         TimeSpan? cacheFileAge;
+
+                        if (NuGetEventSource.IsEnabled) TraceEvents.CalcDependencySpecStart(_request.Project.FilePath);
                         (cacheFile, noOp, cacheFileAge) = EvaluateCacheFile();
+                        if (NuGetEventSource.IsEnabled) TraceEvents.CalcDependencySpecStop(_request.Project.FilePath);
+
                         telemetry.TelemetryEvent[NoOpCacheFileEvaluationResult] = noOp;
                         telemetry.EndIntervalMeasure(NoOpCacheFileEvaluateDuration);
                         if (noOp)
@@ -278,12 +283,14 @@ namespace NuGet.Commands
                     using (telemetry.StartIndependentInterval(GenerateRestoreGraphDuration))
                     {
                         // Restore
+                        if (NuGetEventSource.IsEnabled) TraceEvents.BuildRestoreGraphStart(_request.Project.FilePath);
                         graphs = await ExecuteRestoreAsync(
                         _request.DependencyProviders.GlobalPackages,
                         _request.DependencyProviders.FallbackPackageFolders,
                         contextForProject,
                         token,
                         telemetry);
+                        if (NuGetEventSource.IsEnabled) TraceEvents.BuildRestoreGraphStop(_request.Project.FilePath);
                     }
                 }
                 else
@@ -316,12 +323,14 @@ namespace NuGet.Commands
 
                 telemetry.StartIntervalMeasure();
                 // Create assets file
+                if(NuGetEventSource.IsEnabled) TraceEvents.BuildAssetsFileStart(_request.Project.FilePath);
                 LockFile assetsFile = BuildAssetsFile(
                     _request.ExistingLockFile,
                     _request.Project,
                     graphs,
                     localRepositories,
                     contextForProject);
+                if (NuGetEventSource.IsEnabled) TraceEvents.BuildAssetsFileStop(_request.Project.FilePath);
                 telemetry.EndIntervalMeasure(GenerateAssetsFileDuration);
 
                 IList<CompatibilityCheckResult> checkResults = null;
@@ -1412,6 +1421,79 @@ namespace NuGet.Commands
                 project,
                 msbuildProjectPath: null,
                 projectReferences: Enumerable.Empty<string>());
+        }
+
+        private static class TraceEvents
+        {
+            private const string EventNameBuildAssetsFile = "RestoreCommand/BuildAssetsFile";
+            private const string EventNameBuildRestoreGraph = "RestoreCommand/BuildRestoreGraph";
+            private const string EventNameCalcDependencySpec = "RestoreCommand/CalcDependencySpec";
+
+            public static void BuildAssetsFileStart(string filePath)
+            {
+                var eventOptions = new EventSourceOptions
+                {
+                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Opcode = EventOpcode.Start
+                };
+
+                NuGetEventSource.Instance.Write(EventNameBuildAssetsFile, eventOptions, new { FilePath = filePath });
+            }
+
+            public static void BuildAssetsFileStop(string filePath)
+            {
+                var eventOptions = new EventSourceOptions
+                {
+                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Opcode = EventOpcode.Stop
+                };
+
+                NuGetEventSource.Instance.Write(EventNameBuildAssetsFile, eventOptions, new { FilePath = filePath });
+            }
+
+            public static void BuildRestoreGraphStart(string filePath)
+            {
+                var eventOptions = new EventSourceOptions
+                {
+                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Opcode = EventOpcode.Start
+                };
+
+                NuGetEventSource.Instance.Write(EventNameBuildRestoreGraph, eventOptions, new { FilePath = filePath });
+            }
+
+            public static void BuildRestoreGraphStop(string filePath)
+            {
+                var eventOptions = new EventSourceOptions
+                {
+                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Opcode = EventOpcode.Stop
+                };
+
+                NuGetEventSource.Instance.Write(EventNameBuildRestoreGraph, eventOptions, new { FilePath = filePath });
+            }
+
+            public static void CalcDependencySpecStart(string filePath)
+            {
+                var eventOptions = new EventSourceOptions
+                {
+                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Opcode = EventOpcode.Start
+                };
+
+                NuGetEventSource.Instance.Write(EventNameCalcDependencySpec, eventOptions, new { FilePath = filePath });
+            }
+
+            public static void CalcDependencySpecStop(string filePath)
+            {
+                var eventOptions = new EventSourceOptions
+                {
+                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Opcode = EventOpcode.Stop
+                };
+
+                NuGetEventSource.Instance.Write(EventNameCalcDependencySpec, eventOptions, new { FilePath = filePath });
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -162,27 +163,35 @@ namespace NuGet.Commands
             var isTool = ProjectStyle == ProjectStyle.DotnetCliTool;
 
             // Commit the assets file to disk.
+            if (NuGetEventSource.IsEnabled) TraceEvents.WriteAssetsFileStart(LockFilePath);
             await CommitAssetsFileAsync(
                 lockFileFormat,
                 result: this,
                 log: log,
                 toolCommit: isTool,
                 token: token);
+            if (NuGetEventSource.IsEnabled) TraceEvents.WriteAssetsFileStop(LockFilePath);
 
             //Commit the cache file to disk
+            if (NuGetEventSource.IsEnabled) TraceEvents.WriteCacheFileStart(CacheFilePath);
             await CommitCacheFileAsync(
                 log: log,
                 toolCommit: isTool);
+            if (NuGetEventSource.IsEnabled) TraceEvents.WriteCacheFileStop(CacheFilePath);
 
             // Commit the lock file to disk
+            if (NuGetEventSource.IsEnabled) TraceEvents.WritePackagesLockFileStart(_newPackagesLockFilePath);
             await CommitLockFileAsync(
                 log: log,
                 toolCommit: isTool);
+            if (NuGetEventSource.IsEnabled) TraceEvents.WritePackagesLockFileStop(_newPackagesLockFilePath);
 
             // Commit the dg spec file to disk
+            if (NuGetEventSource.IsEnabled) TraceEvents.WriteDgSpecFileStart(_dependencyGraphSpecFilePath);
             await CommitDgSpecFileAsync(
                 log: log,
                 toolCommit: isTool);
+            if (NuGetEventSource.IsEnabled) TraceEvents.WriteDgSpecFileStop(_dependencyGraphSpecFilePath);
         }
 
         private async Task CommitAssetsFileAsync(
@@ -299,6 +308,102 @@ namespace NuGet.Commands
                 await FileUtility.ReplaceWithLock(
                     (outputPath) => _dependencyGraphSpec.Save(outputPath),
                     _dependencyGraphSpecFilePath);
+            }
+        }
+
+        private static class TraceEvents
+        {
+            private const string EventNameWriteAssetsFile = "RestoreResult/WriteAssetsFile";
+            private const string EventNameWriteCacheFile = "RestoreResult/WriteCacheFile";
+            private const string EventNameWritePackagesLockFile = "RestoreResult/WritePackagesLockFile";
+            private const string EventNameWriteDgSpecFile = "RestoreResult/WriteDgSpecFile";
+
+            public static void WriteAssetsFileStart(string filePath)
+            {
+                var eventOptions = new EventSourceOptions
+                {
+                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Opcode = EventOpcode.Start
+                };
+
+                NuGetEventSource.Instance.Write(EventNameWriteAssetsFile, eventOptions, new { FilePath = filePath });
+            }
+
+            public static void WriteAssetsFileStop(string filePath)
+            {
+                var eventOptions = new EventSourceOptions
+                {
+                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Opcode = EventOpcode.Stop
+                };
+
+                NuGetEventSource.Instance.Write(EventNameWriteAssetsFile, eventOptions, new { FilePath = filePath });
+            }
+
+            public static void WriteCacheFileStart(string filePath)
+            {
+                var eventOptions = new EventSourceOptions
+                {
+                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Opcode = EventOpcode.Start
+                };
+
+                NuGetEventSource.Instance.Write(EventNameWriteCacheFile, eventOptions, new { FilePath = filePath });
+            }
+
+            public static void WriteCacheFileStop(string filePath)
+            {
+                var eventOptions = new EventSourceOptions
+                {
+                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Opcode = EventOpcode.Stop
+                };
+
+                NuGetEventSource.Instance.Write(EventNameWriteCacheFile, eventOptions, new { FilePath = filePath });
+            }
+
+            public static void WritePackagesLockFileStart(string filePath)
+            {
+                var eventOptions = new EventSourceOptions
+                {
+                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Opcode = EventOpcode.Start
+                };
+
+                NuGetEventSource.Instance.Write(EventNameWritePackagesLockFile, eventOptions, new { FilePath = filePath });
+            }
+
+            public static void WritePackagesLockFileStop(string filePath)
+            {
+                var eventOptions = new EventSourceOptions
+                {
+                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Opcode = EventOpcode.Stop
+                };
+
+                NuGetEventSource.Instance.Write(EventNameWritePackagesLockFile, eventOptions, new { FilePath = filePath });
+            }
+
+            public static void WriteDgSpecFileStart(string filePath)
+            {
+                var eventOptions = new EventSourceOptions
+                {
+                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Opcode = EventOpcode.Start
+                };
+
+                NuGetEventSource.Instance.Write(EventNameWriteDgSpecFile, eventOptions, new { FilePath = filePath });
+            }
+
+            public static void WriteDgSpecFileStop(string filePath)
+            {
+                var eventOptions = new EventSourceOptions
+                {
+                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Opcode = EventOpcode.Stop
+                };
+
+                NuGetEventSource.Instance.Write(EventNameWriteDgSpecFile, eventOptions, new { FilePath = filePath });
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -322,7 +322,8 @@ namespace NuGet.Commands
             {
                 var eventOptions = new EventSourceOptions
                 {
-                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Keywords = NuGetEventSource.Keywords.Performance |
+                                NuGetEventSource.Keywords.Restore,
                     Opcode = EventOpcode.Start
                 };
 
@@ -333,7 +334,8 @@ namespace NuGet.Commands
             {
                 var eventOptions = new EventSourceOptions
                 {
-                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Keywords = NuGetEventSource.Keywords.Performance |
+                                NuGetEventSource.Keywords.Restore,
                     Opcode = EventOpcode.Stop
                 };
 
@@ -344,7 +346,8 @@ namespace NuGet.Commands
             {
                 var eventOptions = new EventSourceOptions
                 {
-                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Keywords = NuGetEventSource.Keywords.Performance |
+                                NuGetEventSource.Keywords.Restore,
                     Opcode = EventOpcode.Start
                 };
 
@@ -355,7 +358,8 @@ namespace NuGet.Commands
             {
                 var eventOptions = new EventSourceOptions
                 {
-                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Keywords = NuGetEventSource.Keywords.Performance |
+                                NuGetEventSource.Keywords.Restore,
                     Opcode = EventOpcode.Stop
                 };
 
@@ -366,7 +370,8 @@ namespace NuGet.Commands
             {
                 var eventOptions = new EventSourceOptions
                 {
-                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Keywords = NuGetEventSource.Keywords.Performance |
+                                NuGetEventSource.Keywords.Restore,
                     Opcode = EventOpcode.Start
                 };
 
@@ -377,7 +382,8 @@ namespace NuGet.Commands
             {
                 var eventOptions = new EventSourceOptions
                 {
-                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Keywords = NuGetEventSource.Keywords.Performance |
+                                NuGetEventSource.Keywords.Restore,
                     Opcode = EventOpcode.Stop
                 };
 
@@ -388,7 +394,8 @@ namespace NuGet.Commands
             {
                 var eventOptions = new EventSourceOptions
                 {
-                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Keywords = NuGetEventSource.Keywords.Performance |
+                                NuGetEventSource.Keywords.Restore,
                     Opcode = EventOpcode.Start
                 };
 
@@ -399,7 +406,8 @@ namespace NuGet.Commands
             {
                 var eventOptions = new EventSourceOptions
                 {
-                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Keywords = NuGetEventSource.Keywords.Performance |
+                                NuGetEventSource.Keywords.Restore,
                     Opcode = EventOpcode.Stop
                 };
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -278,7 +279,9 @@ namespace NuGet.Commands
             var request = summaryRequest.Request;
 
             var command = new RestoreCommand(request);
+            if (NuGetEventSource.IsEnabled) TraceEvents.RestoreProjectStart(request.Project.FilePath);
             var result = await command.ExecuteAsync(token);
+            if (NuGetEventSource.IsEnabled) TraceEvents.RestoreProjectStop(request.Project.FilePath);
 
             return new RestoreResultPair(summaryRequest, result);
         }
@@ -292,7 +295,9 @@ namespace NuGet.Commands
 
             // Commit the result
             log.LogVerbose(Strings.Log_Committing);
+            if (NuGetEventSource.IsEnabled) TraceEvents.CommitAsyncStart(summaryRequest.InputPath);
             await result.CommitAsync(log, token);
+            if (NuGetEventSource.IsEnabled) TraceEvents.CommitAsyncStop(summaryRequest.InputPath);
 
             if (result.Success)
             {
@@ -401,6 +406,56 @@ namespace NuGet.Commands
             }
 
             return Strings.Error_InvalidCommandLineInput;
+        }
+
+        private static class TraceEvents
+        {
+            private const string EventNameRestoreProject = "RestoreRunner/RestoreProject";
+            private const string EventNameCommitAsync = "RestoreRunner/CommitAsync";
+
+            public static void RestoreProjectStart(string filePath)
+            {
+                var eventOptions = new EventSourceOptions
+                {
+                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Opcode = EventOpcode.Start
+                };
+
+                NuGetEventSource.Instance.Write(EventNameRestoreProject, eventOptions, new { FilePath = filePath });
+            }
+
+            public static void RestoreProjectStop(string filePath)
+            {
+                var eventOptions = new EventSourceOptions
+                {
+                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Opcode = EventOpcode.Stop
+                };
+
+                NuGetEventSource.Instance.Write(EventNameRestoreProject, eventOptions, new { FilePath = filePath });
+            }
+
+            public static void CommitAsyncStart(string filePath)
+            {
+                var eventOptions = new EventSourceOptions
+                {
+                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Opcode = EventOpcode.Start
+                };
+
+                NuGetEventSource.Instance.Write(EventNameCommitAsync, eventOptions, new { FilePath = filePath });
+            }
+
+            public static void CommitAsyncStop(string filePath)
+            {
+                var eventOptions = new EventSourceOptions
+                {
+                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Opcode = EventOpcode.Stop
+                };
+
+                NuGetEventSource.Instance.Write(EventNameCommitAsync, eventOptions, new { FilePath = filePath });
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -417,7 +417,8 @@ namespace NuGet.Commands
             {
                 var eventOptions = new EventSourceOptions
                 {
-                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Keywords = NuGetEventSource.Keywords.Performance |
+                                NuGetEventSource.Keywords.Restore,
                     Opcode = EventOpcode.Start
                 };
 
@@ -428,7 +429,8 @@ namespace NuGet.Commands
             {
                 var eventOptions = new EventSourceOptions
                 {
-                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Keywords = NuGetEventSource.Keywords.Performance |
+                                NuGetEventSource.Keywords.Restore,
                     Opcode = EventOpcode.Stop
                 };
 
@@ -439,7 +441,8 @@ namespace NuGet.Commands
             {
                 var eventOptions = new EventSourceOptions
                 {
-                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Keywords = NuGetEventSource.Keywords.Performance |
+                                NuGetEventSource.Keywords.Restore,
                     Opcode = EventOpcode.Start
                 };
 
@@ -450,7 +453,8 @@ namespace NuGet.Commands
             {
                 var eventOptions = new EventSourceOptions
                 {
-                    Keywords = NuGetEventSource.Keywords.Performance,
+                    Keywords = NuGetEventSource.Keywords.Performance |
+                                NuGetEventSource.Keywords.Restore,
                     Opcode = EventOpcode.Stop
                 };
 

--- a/src/NuGet.Core/NuGet.Common/NuGetEventSource.cs
+++ b/src/NuGet.Core/NuGet.Common/NuGetEventSource.cs
@@ -48,6 +48,11 @@ namespace NuGet.Common
             /// The event keyword for tracing events related to the NuGet-based MSBuild project SDK resolver.
             /// </summary>
             public const EventKeywords SdkResolver = (EventKeywords)16;
+
+            /// <summary>
+            /// The event keyword for tracing events related to restore.
+            /// </summary>
+            public const EventKeywords Restore = (EventKeywords)32;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
+const NuGet.Common.NuGetEventSource.Keywords.Restore = (System.Diagnostics.Tracing.EventKeywords)32 -> System.Diagnostics.Tracing.EventKeywords
 static NuGet.Common.MSBuildStringUtility.GetNuGetLogCodes(string! s) -> System.Collections.Generic.IList<NuGet.Common.NuGetLogCode>!


### PR DESCRIPTION
Adds restore instrumentation via `NuGetEventSource` to enable performance analysis and comparisons on particular areas of restore.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13274

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Adds ETW events for measuring performance during restore

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Not needed
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
