### PR TITLE
Address formatter nullability warnings - remove nowarn from NuGet.VisualStudio.Internal.Contracts

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/FloatRangeFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/FloatRangeFormatter.cs
@@ -33,7 +33,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                 switch (reader.ReadString())
                 {
                     case FloatBehaviorPropertyName:
-                        floatBehavior = options.Resolver.GetFormatter<NuGetVersionFloatBehavior>().Deserialize(ref reader, options);
+                        floatBehavior = options.Resolver.GetFormatter<NuGetVersionFloatBehavior>()!.Deserialize(ref reader, options);
                         break;
 
                     case MinVersionPropertyName:
@@ -62,7 +62,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             writer.Write(MinVersionPropertyName);
             NuGetVersionFormatter.Instance.Serialize(ref writer, value.MinVersion, options);
             writer.Write(FloatBehaviorPropertyName);
-            options.Resolver.GetFormatter<NuGetVersionFloatBehavior>().Serialize(ref writer, value.FloatBehavior, options);
+            options.Resolver.GetFormatter<NuGetVersionFloatBehavior>()!.Serialize(ref writer, value.FloatBehavior, options);
             writer.Write(ReleasePrefixPropertyName);
             writer.Write(value.OriginalReleasePrefix);
         }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/ILogMessageFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/ILogMessageFormatter.cs
@@ -75,7 +75,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                     switch (reader.ReadString())
                     {
                         case CodePropertyName:
-                            code = options.Resolver.GetFormatter<NuGetLogCode>().Deserialize(ref reader, options);
+                            code = options.Resolver.GetFormatter<NuGetLogCode>()!.Deserialize(ref reader, options);
                             break;
 
                         case EndColumnNumberPropertyName:
@@ -91,7 +91,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                             break;
 
                         case LevelPropertyName:
-                            logLevel = options.Resolver.GetFormatter<LogLevel>().Deserialize(ref reader, options);
+                            logLevel = options.Resolver.GetFormatter<LogLevel>()!.Deserialize(ref reader, options);
                             break;
 
                         case LibraryIdPropertyName:
@@ -139,7 +139,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                             break;
 
                         case TimePropertyName:
-                            time = options.Resolver.GetFormatter<DateTimeOffset>().Deserialize(ref reader, options);
+                            time = options.Resolver.GetFormatter<DateTimeOffset>()!.Deserialize(ref reader, options);
                             break;
 
                         case TypeNamePropertyName:
@@ -147,7 +147,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                             break;
 
                         case WarningLevelPropertyName:
-                            warningLevel = options.Resolver.GetFormatter<WarningLevel>().Deserialize(ref reader, options);
+                            warningLevel = options.Resolver.GetFormatter<WarningLevel>()!.Deserialize(ref reader, options);
                             break;
 
                         default:
@@ -285,17 +285,17 @@ namespace NuGet.VisualStudio.Internal.Contracts
             writer.Write(TypeNamePropertyName);
             writer.Write(value.GetType().Name);
             writer.Write(CodePropertyName);
-            options.Resolver.GetFormatter<NuGetLogCode>().Serialize(ref writer, value.Code, options);
+            options.Resolver.GetFormatter<NuGetLogCode>()!.Serialize(ref writer, value.Code, options);
             writer.Write(LevelPropertyName);
-            options.Resolver.GetFormatter<LogLevel>().Serialize(ref writer, value.Level, options);
+            options.Resolver.GetFormatter<LogLevel>()!.Serialize(ref writer, value.Level, options);
             writer.Write(MessagePropertyName);
             writer.Write(value.Message);
             writer.Write(ProjectPathPropertyName);
             writer.Write(value.ProjectPath);
             writer.Write(TimePropertyName);
-            options.Resolver.GetFormatter<DateTimeOffset>().Serialize(ref writer, value.Time, options);
+            options.Resolver.GetFormatter<DateTimeOffset>()!.Serialize(ref writer, value.Time, options);
             writer.Write(WarningLevelPropertyName);
-            options.Resolver.GetFormatter<WarningLevel>().Serialize(ref writer, value.WarningLevel, options);
+            options.Resolver.GetFormatter<WarningLevel>()!.Serialize(ref writer, value.WarningLevel, options);
         }
 
         private void Serialize(ref MessagePackWriter writer, LogMessage logMessage, MessagePackSerializerOptions options)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IProjectContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/IProjectContextInfoFormatter.cs
@@ -35,10 +35,10 @@ namespace NuGet.VisualStudio.Internal.Contracts
                         projectId = reader.ReadString();
                         break;
                     case ProjectKindPropertyName:
-                        projectKind = options.Resolver.GetFormatter<NuGetProjectKind>().Deserialize(ref reader, options);
+                        projectKind = options.Resolver.GetFormatter<NuGetProjectKind>()!.Deserialize(ref reader, options);
                         break;
                     case ProjectStylePropertyName:
-                        projectStyle = options.Resolver.GetFormatter<ProjectStyle>().Deserialize(ref reader, options);
+                        projectStyle = options.Resolver.GetFormatter<ProjectStyle>()!.Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -57,9 +57,9 @@ namespace NuGet.VisualStudio.Internal.Contracts
             writer.Write(ProjectIdPropertyName);
             writer.Write(value.ProjectId);
             writer.Write(ProjectKindPropertyName);
-            options.Resolver.GetFormatter<NuGetProjectKind>().Serialize(ref writer, value.ProjectKind, options);
+            options.Resolver.GetFormatter<NuGetProjectKind>()!.Serialize(ref writer, value.ProjectKind, options);
             writer.Write(ProjectStylePropertyName);
-            options.Resolver.GetFormatter<ProjectStyle>().Serialize(ref writer, value.ProjectStyle, options);
+            options.Resolver.GetFormatter<ProjectStyle>()!.Serialize(ref writer, value.ProjectStyle, options);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/ImplicitProjectActionFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/ImplicitProjectActionFormatter.cs
@@ -42,7 +42,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                         break;
 
                     case ProjectActionTypePropertyName:
-                        projectActionType = options.Resolver.GetFormatter<NuGetProjectActionType>().Deserialize(ref reader, options);
+                        projectActionType = options.Resolver.GetFormatter<NuGetProjectActionType>()!.Deserialize(ref reader, options);
                         break;
 
                     default:
@@ -66,7 +66,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             writer.Write(PackageIdentityPropertyName);
             PackageIdentityFormatter.Instance.Serialize(ref writer, value.PackageIdentity, options);
             writer.Write(ProjectActionTypePropertyName);
-            options.Resolver.GetFormatter<NuGetProjectActionType>().Serialize(ref writer, value.ProjectActionType, options);
+            options.Resolver.GetFormatter<NuGetProjectActionType>()!.Serialize(ref writer, value.ProjectActionType, options);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/LicenseMetadataFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/LicenseMetadataFormatter.cs
@@ -42,7 +42,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                     case TypePropertyName:
                         if (!reader.TryReadNil())
                         {
-                            type = options.Resolver.GetFormatter<LicenseType>().Deserialize(ref reader, options);
+                            type = options.Resolver.GetFormatter<LicenseType>()!.Deserialize(ref reader, options);
                         }
                         break;
                     case LicensePropertyName:
@@ -58,11 +58,11 @@ namespace NuGet.VisualStudio.Internal.Contracts
                     case WarningsAndErrorsPropertyName:
                         if (!reader.TryReadNil())
                         {
-                            warningsAndErrors = options.Resolver.GetFormatter<IReadOnlyList<string>>().Deserialize(ref reader, options);
+                            warningsAndErrors = options.Resolver.GetFormatter<IReadOnlyList<string>>()!.Deserialize(ref reader, options);
                         }
                         break;
                     case VersionPropertyName:
-                        version = options.Resolver.GetFormatter<Version>().Deserialize(ref reader, options);
+                        version = options.Resolver.GetFormatter<Version>()!.Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -81,7 +81,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
             writer.WriteMapHeader(count: 5);
             writer.Write(TypePropertyName);
-            options.Resolver.GetFormatter<LicenseType>().Serialize(ref writer, value.Type, options);
+            options.Resolver.GetFormatter<LicenseType>()!.Serialize(ref writer, value.Type, options);
 
             writer.Write(LicensePropertyName);
             writer.Write(value.License);
@@ -96,11 +96,11 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
             else
             {
-                options.Resolver.GetFormatter<IReadOnlyList<string>>().Serialize(ref writer, value.WarningsAndErrors, options);
+                options.Resolver.GetFormatter<IReadOnlyList<string>>()!.Serialize(ref writer, value.WarningsAndErrors, options);
             }
 
             writer.Write(VersionPropertyName);
-            options.Resolver.GetFormatter<Version>().Serialize(ref writer, value.Version, options);
+            options.Resolver.GetFormatter<Version>()!.Serialize(ref writer, value.Version, options);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDependencyFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDependencyFormatter.cs
@@ -37,7 +37,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                 switch (reader.ReadString())
                 {
                     case ExcludePropertyName:
-                        exclude = options.Resolver.GetFormatter<IReadOnlyList<string>>().Deserialize(ref reader, options);
+                        exclude = options.Resolver.GetFormatter<IReadOnlyList<string>>()!.Deserialize(ref reader, options);
                         break;
 
                     case IdPropertyName:
@@ -45,7 +45,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                         break;
 
                     case IncludePropertyName:
-                        include = options.Resolver.GetFormatter<IReadOnlyList<string>>().Deserialize(ref reader, options);
+                        include = options.Resolver.GetFormatter<IReadOnlyList<string>>()!.Deserialize(ref reader, options);
                         break;
 
                     case VersionRangePropertyName:
@@ -71,9 +71,9 @@ namespace NuGet.VisualStudio.Internal.Contracts
             writer.Write(VersionRangePropertyName);
             VersionRangeFormatter.Instance.Serialize(ref writer, value.VersionRange, options);
             writer.Write(IncludePropertyName);
-            options.Resolver.GetFormatter<IReadOnlyList<string>>().Serialize(ref writer, value.Include, options);
+            options.Resolver.GetFormatter<IReadOnlyList<string>>()!.Serialize(ref writer, value.Include, options);
             writer.Write(ExcludePropertyName);
-            options.Resolver.GetFormatter<IReadOnlyList<string>>().Serialize(ref writer, value.Exclude, options);
+            options.Resolver.GetFormatter<IReadOnlyList<string>>()!.Serialize(ref writer, value.Exclude, options);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDependencyGroupFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDependencyGroupFormatter.cs
@@ -37,7 +37,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                         framework = NuGetFrameworkFormatter.Instance.Deserialize(ref reader, options);
                         break;
                     case PackagesPropertyName:
-                        packageDependencies = options.Resolver.GetFormatter<IEnumerable<PackageDependency>>().Deserialize(ref reader, options);
+                        packageDependencies = options.Resolver.GetFormatter<IEnumerable<PackageDependency>>()!.Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -57,7 +57,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             writer.Write(TargetFrameworkPropertyName);
             NuGetFrameworkFormatter.Instance.Serialize(ref writer, value.TargetFramework, options);
             writer.Write(PackagesPropertyName);
-            options.Resolver.GetFormatter<IEnumerable<PackageDependency>>().Serialize(ref writer, value.Packages, options);
+            options.Resolver.GetFormatter<IEnumerable<PackageDependency>>()!.Serialize(ref writer, value.Packages, options);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDeprecationMetadataContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageDeprecationMetadataContextInfoFormatter.cs
@@ -35,7 +35,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                         message = reader.ReadString();
                         break;
                     case ReasonsPropertyName:
-                        reasons = reader.TryReadNil() ? null : options.Resolver.GetFormatter<IReadOnlyCollection<string>>().Deserialize(ref reader, options);
+                        reasons = reader.TryReadNil() ? null : options.Resolver.GetFormatter<IReadOnlyCollection<string>>()!.Deserialize(ref reader, options);
                         break;
                     case AlternatePackageMetadataPropertyName:
                         alternatePackageMetadataContextInfo = reader.TryReadNil() ? null : AlternatePackageMetadataContextInfoFormatter.Instance.Deserialize(ref reader, options);
@@ -61,7 +61,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
             else
             {
-                options.Resolver.GetFormatter<IReadOnlyCollection<string>>().Serialize(ref writer, value.Reasons, options);
+                options.Resolver.GetFormatter<IReadOnlyCollection<string>>()!.Serialize(ref writer, value.Reasons, options);
             }
 
             writer.Write(AlternatePackageMetadataPropertyName);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSearchMetadataContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSearchMetadataContextInfoFormatter.cs
@@ -88,7 +88,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                     case IconUrlPropertyName:
                         if (!reader.TryReadNil())
                         {
-                            iconUrl = options.Resolver.GetFormatter<Uri>().Deserialize(ref reader, options);
+                            iconUrl = options.Resolver.GetFormatter<Uri>()!.Deserialize(ref reader, options);
                         }
                         break;
                     case TitlePropertyName:
@@ -100,19 +100,19 @@ namespace NuGet.VisualStudio.Internal.Contracts
                     case LicenseMetadataPropertyName:
                         if (!reader.TryReadNil())
                         {
-                            licenseMetadata = options.Resolver.GetFormatter<LicenseMetadata>().Deserialize(ref reader, options);
+                            licenseMetadata = options.Resolver.GetFormatter<LicenseMetadata>()!.Deserialize(ref reader, options);
                         }
                         break;
                     case LicenseUrlPropertyName:
                         if (!reader.TryReadNil())
                         {
-                            licenseUrl = options.Resolver.GetFormatter<Uri>().Deserialize(ref reader, options);
+                            licenseUrl = options.Resolver.GetFormatter<Uri>()!.Deserialize(ref reader, options);
                         }
                         break;
                     case ProjectUrlPropertyName:
                         if (!reader.TryReadNil())
                         {
-                            projectUrl = options.Resolver.GetFormatter<Uri>().Deserialize(ref reader, options);
+                            projectUrl = options.Resolver.GetFormatter<Uri>()!.Deserialize(ref reader, options);
                         }
                         break;
                     case PackagePathPropertyName:
@@ -121,7 +121,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                     case PublishedPropertyName:
                         if (!reader.TryReadNil())
                         {
-                            published = options.Resolver.GetFormatter<DateTimeOffset>().Deserialize(ref reader, options);
+                            published = options.Resolver.GetFormatter<DateTimeOffset>()!.Deserialize(ref reader, options);
                         }
                         break;
                     case OwnersPropertyName:
@@ -130,13 +130,13 @@ namespace NuGet.VisualStudio.Internal.Contracts
                     case ReportAbuseUrlPropertyName:
                         if (!reader.TryReadNil())
                         {
-                            reportAbuseUrl = options.Resolver.GetFormatter<Uri>().Deserialize(ref reader, options);
+                            reportAbuseUrl = options.Resolver.GetFormatter<Uri>()!.Deserialize(ref reader, options);
                         }
                         break;
                     case PackageDetailsUrlPropertyName:
                         if (!reader.TryReadNil())
                         {
-                            packageDetailsUrl = options.Resolver.GetFormatter<Uri>().Deserialize(ref reader, options);
+                            packageDetailsUrl = options.Resolver.GetFormatter<Uri>()!.Deserialize(ref reader, options);
                         }
                         break;
                     case RequireLicenseAcceptancePropertyName:
@@ -154,7 +154,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                     case RecommenderVersionPropertyName:
                         if (!reader.TryReadNil())
                         {
-                            recommenderVersion = options.Resolver.GetFormatter<(string, string)>().Deserialize(ref reader, options);
+                            recommenderVersion = options.Resolver.GetFormatter<(string, string)>()!.Deserialize(ref reader, options);
                         }
                         break;
                     case DownloadCountPropertyName:
@@ -166,13 +166,13 @@ namespace NuGet.VisualStudio.Internal.Contracts
                     case DependencySetsPropertyName:
                         if (!reader.TryReadNil())
                         {
-                            dependencySets = options.Resolver.GetFormatter<IReadOnlyCollection<PackageDependencyGroup>>().Deserialize(ref reader, options);
+                            dependencySets = options.Resolver.GetFormatter<IReadOnlyCollection<PackageDependencyGroup>>()!.Deserialize(ref reader, options);
                         }
                         break;
                     case VulnerabilitiesPropertyName:
                         if (!reader.TryReadNil())
                         {
-                            vulnerabilities = options.Resolver.GetFormatter<IReadOnlyCollection<PackageVulnerabilityMetadataContextInfo>>().Deserialize(ref reader, options);
+                            vulnerabilities = options.Resolver.GetFormatter<IReadOnlyCollection<PackageVulnerabilityMetadataContextInfo>>()!.Deserialize(ref reader, options);
                         }
                         break;
                     case IsListedPropertyName:
@@ -231,7 +231,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
             else
             {
-                options.Resolver.GetFormatter<Uri>().Serialize(ref writer, value.IconUrl, options);
+                options.Resolver.GetFormatter<Uri>()!.Serialize(ref writer, value.IconUrl, options);
             }
 
             writer.Write(TagsPropertyName);
@@ -254,7 +254,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
             else
             {
-                options.Resolver.GetFormatter<LicenseMetadata>().Serialize(ref writer, value.LicenseMetadata, options);
+                options.Resolver.GetFormatter<LicenseMetadata>()!.Serialize(ref writer, value.LicenseMetadata, options);
             }
 
             writer.Write(LicenseUrlPropertyName);
@@ -264,7 +264,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
             else
             {
-                options.Resolver.GetFormatter<Uri>().Serialize(ref writer, value.LicenseUrl, options);
+                options.Resolver.GetFormatter<Uri>()!.Serialize(ref writer, value.LicenseUrl, options);
             }
 
             writer.Write(OwnersPropertyName);
@@ -278,7 +278,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
             else
             {
-                options.Resolver.GetFormatter<Uri>().Serialize(ref writer, value.ProjectUrl, options);
+                options.Resolver.GetFormatter<Uri>()!.Serialize(ref writer, value.ProjectUrl, options);
             }
 
             writer.Write(PublishedPropertyName);
@@ -288,7 +288,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
             else
             {
-                options.Resolver.GetFormatter<DateTimeOffset>().Serialize(ref writer, value.Published.Value, options);
+                options.Resolver.GetFormatter<DateTimeOffset>()!.Serialize(ref writer, value.Published.Value, options);
             }
 
             writer.Write(ReportAbuseUrlPropertyName);
@@ -298,7 +298,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
             else
             {
-                options.Resolver.GetFormatter<Uri>().Serialize(ref writer, value.ReportAbuseUrl, options);
+                options.Resolver.GetFormatter<Uri>()!.Serialize(ref writer, value.ReportAbuseUrl, options);
             }
 
             writer.Write(PackageDetailsUrlPropertyName);
@@ -308,7 +308,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
             else
             {
-                options.Resolver.GetFormatter<Uri>().Serialize(ref writer, value.PackageDetailsUrl, options);
+                options.Resolver.GetFormatter<Uri>()!.Serialize(ref writer, value.PackageDetailsUrl, options);
             }
 
             writer.Write(PackagePathPropertyName);
@@ -333,7 +333,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
             else
             {
-                options.Resolver.GetFormatter<IReadOnlyCollection<PackageDependencyGroup>>().Serialize(ref writer, value.DependencySets, options);
+                options.Resolver.GetFormatter<IReadOnlyCollection<PackageDependencyGroup>>()!.Serialize(ref writer, value.DependencySets, options);
             }
 
             writer.Write(DownloadCountPropertyName);
@@ -353,7 +353,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
             else
             {
-                options.Resolver.GetFormatter<IReadOnlyCollection<PackageVulnerabilityMetadataContextInfo>>().Serialize(ref writer, value.Vulnerabilities, options);
+                options.Resolver.GetFormatter<IReadOnlyCollection<PackageVulnerabilityMetadataContextInfo>>()!.Serialize(ref writer, value.Vulnerabilities, options);
             }
 
             writer.Write(IsRecommendedPropertyName);
@@ -366,7 +366,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
             else
             {
-                options.Resolver.GetFormatter<(string, string)>().Serialize(ref writer, value.RecommenderVersion.Value, options);
+                options.Resolver.GetFormatter<(string, string)>()!.Serialize(ref writer, value.RecommenderVersion.Value, options);
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageVulnerabilityMetadataContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageVulnerabilityMetadataContextInfoFormatter.cs
@@ -30,7 +30,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                 switch (reader.ReadString())
                 {
                     case AdvisoryUrlPropertyName:
-                        advisoryUrl = options.Resolver.GetFormatter<Uri>().Deserialize(ref reader, options);
+                        advisoryUrl = options.Resolver.GetFormatter<Uri>()!.Deserialize(ref reader, options);
                         break;
                     case SeverityPropertyName:
                         severity = reader.ReadInt32();
@@ -50,7 +50,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
             writer.WriteMapHeader(count: 2);
             writer.Write(AdvisoryUrlPropertyName);
-            options.Resolver.GetFormatter<Uri>().Serialize(ref writer, value.AdvisoryUrl, options);
+            options.Resolver.GetFormatter<Uri>()!.Serialize(ref writer, value.AdvisoryUrl, options);
             writer.Write(SeverityPropertyName);
             writer.Write(value.Severity);
         }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/ProjectActionFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/ProjectActionFormatter.cs
@@ -60,7 +60,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                         break;
 
                     case ProjectActionTypePropertyName:
-                        projectActionType = options.Resolver.GetFormatter<NuGetProjectActionType>().Deserialize(ref reader, options);
+                        projectActionType = options.Resolver.GetFormatter<NuGetProjectActionType>()!.Deserialize(ref reader, options);
                         break;
 
                     case ProjectIdPropertyName:
@@ -89,7 +89,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             writer.Write(PackageIdentityPropertyName);
             PackageIdentityFormatter.Instance.Serialize(ref writer, value.PackageIdentity, options);
             writer.Write(ProjectActionTypePropertyName);
-            options.Resolver.GetFormatter<NuGetProjectActionType>().Serialize(ref writer, value.ProjectActionType, options);
+            options.Resolver.GetFormatter<NuGetProjectActionType>()!.Serialize(ref writer, value.ProjectActionType, options);
             writer.Write(ProjectIdPropertyName);
             writer.Write(value.ProjectId);
             writer.Write(ImplicitActionsPropertyName);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/SearchFilterFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/SearchFilterFormatter.cs
@@ -44,16 +44,16 @@ namespace NuGet.VisualStudio.Internal.Contracts
                         includeDelisted = reader.ReadBoolean();
                         break;
                     case PackageTypesPropertyName:
-                        packageTypes = options.Resolver.GetFormatter<IEnumerable<string>>().Deserialize(ref reader, options);
+                        packageTypes = options.Resolver.GetFormatter<IEnumerable<string>>()!.Deserialize(ref reader, options);
                         break;
                     case FilterPropertyName:
-                        filterType = options.Resolver.GetFormatter<SearchFilterType?>().Deserialize(ref reader, options);
+                        filterType = options.Resolver.GetFormatter<SearchFilterType?>()!.Deserialize(ref reader, options);
                         break;
                     case OrderByPropertyName:
-                        searchOrderBy = options.Resolver.GetFormatter<SearchOrderBy?>().Deserialize(ref reader, options);
+                        searchOrderBy = options.Resolver.GetFormatter<SearchOrderBy?>()!.Deserialize(ref reader, options);
                         break;
                     case SupportedFrameworksPropertyName:
-                        supportedFrameworks = options.Resolver.GetFormatter<IEnumerable<string>>().Deserialize(ref reader, options);
+                        supportedFrameworks = options.Resolver.GetFormatter<IEnumerable<string>>()!.Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -78,13 +78,13 @@ namespace NuGet.VisualStudio.Internal.Contracts
             writer.Write(IncludeDelistedPropertyName);
             writer.Write(value.IncludeDelisted);
             writer.Write(PackageTypesPropertyName);
-            options.Resolver.GetFormatter<IEnumerable<string>>().Serialize(ref writer, value.PackageTypes, options);
+            options.Resolver.GetFormatter<IEnumerable<string>>()!.Serialize(ref writer, value.PackageTypes, options);
             writer.Write(FilterPropertyName);
-            options.Resolver.GetFormatter<SearchFilterType?>().Serialize(ref writer, value.Filter, options);
+            options.Resolver.GetFormatter<SearchFilterType?>()!.Serialize(ref writer, value.Filter, options);
             writer.Write(OrderByPropertyName);
-            options.Resolver.GetFormatter<SearchOrderBy?>().Serialize(ref writer, value.OrderBy, options);
+            options.Resolver.GetFormatter<SearchOrderBy?>()!.Serialize(ref writer, value.OrderBy, options);
             writer.Write(SupportedFrameworksPropertyName);
-            options.Resolver.GetFormatter<IEnumerable<string>>().Serialize(ref writer, value.SupportedFrameworks, options);
+            options.Resolver.GetFormatter<IEnumerable<string>>()!.Serialize(ref writer, value.SupportedFrameworks, options);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/SearchResultContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/SearchResultContextInfoFormatter.cs
@@ -38,10 +38,10 @@ namespace NuGet.VisualStudio.Internal.Contracts
                         hasMoreItems = reader.ReadBoolean();
                         break;
                     case PackageSearchItemsPropertyName:
-                        packageSearchItems = options.Resolver.GetFormatter<IReadOnlyCollection<PackageSearchMetadataContextInfo>>().Deserialize(ref reader, options);
+                        packageSearchItems = options.Resolver.GetFormatter<IReadOnlyCollection<PackageSearchMetadataContextInfo>>()!.Deserialize(ref reader, options);
                         break;
                     case SourceLoadingStatusPropertyName:
-                        sourceLoadingStatus = options.Resolver.GetFormatter<IReadOnlyDictionary<string, LoadingStatus>>().Deserialize(ref reader, options);
+                        sourceLoadingStatus = options.Resolver.GetFormatter<IReadOnlyDictionary<string, LoadingStatus>>()!.Deserialize(ref reader, options);
                         break;
                     case OperationIdPropertyName:
                         if (!reader.TryReadNil())
@@ -71,7 +71,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             writer.Write(HasMoreItemsPropertyName);
             writer.Write(value.HasMoreItems);
             writer.Write(SourceLoadingStatusPropertyName);
-            options.Resolver.GetFormatter<IReadOnlyDictionary<string, LoadingStatus>>().Serialize(ref writer, value.SourceLoadingStatus, options);
+            options.Resolver.GetFormatter<IReadOnlyDictionary<string, LoadingStatus>>()!.Serialize(ref writer, value.SourceLoadingStatus, options);
             writer.Write(OperationIdPropertyName);
             if (value.OperationId.HasValue)
             {
@@ -83,7 +83,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
 
             writer.Write(PackageSearchItemsPropertyName);
-            options.Resolver.GetFormatter<IReadOnlyCollection<PackageSearchMetadataContextInfo>>().Serialize(ref writer, value.PackageSearchItems, options);
+            options.Resolver.GetFormatter<IReadOnlyCollection<PackageSearchMetadataContextInfo>>()!.Serialize(ref writer, value.PackageSearchItems, options);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGet.VisualStudio.Internal.Contracts.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGet.VisualStudio.Internal.Contracts.csproj
@@ -6,7 +6,6 @@
     <IncludeInVsix>true</IncludeInVsix>
     <RootNamespace>NuGet.VisualStudio.Internal.Contracts</RootNamespace>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn);CS8602</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13179

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Remove the no warn from the contracts assembly. 
Note that it's extremely unlikely the formatters are not there (we define them) and being defensive there is not gonna help.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
