### PR TITLE
Add 64-bit non crypto hash algo for dgspec uniqueness computation

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -300,7 +300,7 @@ namespace NuGet.ProjectModel
 
         public string GetHash()
         {
-            using (var hashFunc = new Sha512HashFunction())
+            using (var hashFunc = new FnvHash64Function())
             using (var writer = new HashObjectWriter(hashFunc))
             {
                 Write(writer, hashing: true, PackageSpecWriter.Write);

--- a/src/NuGet.Core/NuGet.ProjectModel/FnvHash64Function.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/FnvHash64Function.cs
@@ -1,0 +1,92 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Packaging;
+
+namespace NuGet.ProjectModel
+{
+    /// <summary>
+    /// A Fowler-Noll-Vo (FNV) 64-bit hash function that supports non-cryptographic hashing to optimize speed and minimize collisions.
+    /// https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+    /// </summary>
+    internal sealed class FnvHash64Function : IHashFunction
+    {
+        private ulong _hash;
+
+        public void Update(byte[] data, int offset, int count)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            if (_hash == 0)
+            {
+                _hash = FnvHash64.Hash(data, count);
+            }
+            else
+            {
+                _hash = FnvHash64.Update(_hash, data, count);
+            }
+        }
+
+        public byte[] GetHashBytes()
+        {
+            return BitConverter.GetBytes(_hash);
+        }
+
+        public string GetHash()
+        {
+            return Convert.ToBase64String(GetHashBytes());
+        }
+
+        // Interface is Disposable for SHA512 - this class has nothing to dispose.
+        public void Dispose() { }
+
+        internal static class FnvHash64
+        {
+            public const ulong Offset = 14695981039346656037;
+            public const ulong Prime = 1099511628211;
+
+            public static ulong Hash(byte[] data, int count = 0)
+            {
+                ulong hash = Offset;
+
+                if (count == 0)
+                {
+                    count = data.Length;
+                }
+
+                unchecked
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        var b = data[i];
+                        hash = (hash ^ b) * Prime;
+                    }
+                }
+
+                return hash;
+            }
+
+            public static ulong Combine(ulong left, ulong right)
+            {
+                unchecked
+                {
+                    return (left ^ right) * Prime;
+                }
+            }
+
+            public static ulong Update(ulong current, byte[] data, int count = 0)
+            {
+                return Combine(current, Hash(data, count));
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/FnvHash64FunctionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/FnvHash64FunctionTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    public class FnvHash64FunctionTests
+    {
+        private const string ExpectedResult = "BSgChkz/Y68=";
+        private static readonly byte[] Input = Encoding.UTF8.GetBytes("BeachClubExtraAvocadoSpread");
+
+        [Fact]
+        public void Update_SupportsIncrementalUpdates()
+        {
+            using var hashFunc = new FnvHash64Function();
+
+            for (var i = 0; i < Input.Length; ++i)
+            {
+                hashFunc.Update(Input, i, count: 1);
+            }
+
+            var actualResult = hashFunc.GetHash();
+
+            Assert.Equal(ExpectedResult, actualResult);
+        }
+
+        [Fact]
+        public void Update_ThrowsIfDataNull()
+        {
+            using var hashFunc = new FnvHash64Function();
+
+            Assert.Throws<ArgumentNullException>(() => hashFunc.Update(null, 0, count: 0));
+        }
+
+        [Fact]
+        public void Update_ThrowsIfCountNegative()
+        {
+            using var hashFunc = new FnvHash64Function();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => hashFunc.Update(Input, 0, count: -1));
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/HashObjectWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/HashObjectWriterTests.cs
@@ -18,7 +18,7 @@ namespace NuGet.ProjectModel.Test
 
         public HashObjectWriterTests()
         {
-            _hashFunc = new Sha512HashFunction();
+            _hashFunc = new FnvHash64Function();
             _writer = new HashObjectWriter(_hashFunc);
         }
 
@@ -65,7 +65,7 @@ namespace NuGet.ProjectModel.Test
         {
             _writer.WriteObjectStart();
 
-            const string expectedHash = "wtA8bvsWw/gGSw0FnkX5UfF0hCGmIlcaUgCd3MKmcIUeGtAmn72B1FhW+iD/rNCB3SD+znYRQgvvtJ65hLwjyg==";
+            const string expectedHash = "uhgChkz2Y68=";
             string actualHash = _writer.GetHash();
 
             Assert.Equal(expectedHash, actualHash);
@@ -97,8 +97,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [InlineData("", "z6NXo38IFDLUr7F/bIoub9q2RcWGd9G0kd0sZ2LrUsjAAOxeICRcA8sN6CZR1kIMrZl/AluqG57zeTOuEBQ1Bw==")]
-        [InlineData(PropertyName, "7NPeUey7AxorbVFFvKtffuKjuI3T9fqrDmyP9jMRFaMIQZdiMqy4+dvV2ci7nhuZjOXx5qdfiIns7wluMZYjlQ==")]
+        [InlineData("", "1fyYPzTw+J4=")]
+        [InlineData(PropertyName, "aEkDaamOy8A=")]
         public void WriteObjectStart_WithName_WithValidName_WritesObjectStart(string name, string expectedHash)
         {
             _writer.WriteObjectStart();
@@ -160,8 +160,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [InlineData("", -1, "Py0m1BAc1GMLdv3VwUlClC/IwVxlRDmvpmUpLV1aQeFXw/eJsxWsbS/xi/Lu/HxvoufXcjJmlljwfe/B/aIccQ==")]
-        [InlineData(PropertyName, 1, "Z7FWuyPxOQ7v6uelHNSbq7no7P2EXqJRh0k6ONDfevPFA3yycn77N+keqUWo9rq6efTrRpjaKxKuvhdas2tzfg==")]
+        [InlineData("", -1, "5vr8D8iI2Lg=")]
+        [InlineData(PropertyName, 1, "dtICaalIy8A=")]
         public void WriteNameValue_WithIntValue_WithValidValue_WritesNameValue(string name, int value, string expectedHash)
         {
             _writer.WriteObjectStart();
@@ -198,8 +198,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [InlineData("", true, "MuWFFw3nbGG78iKZZPcYZVMFfn8pxOZA3gBgB2KKL5Lysc/SX/xo5csUe9gvavVgis2wsA3EqJ8ZJkgU6s3SCA==")]
-        [InlineData(PropertyName, false, "/prsw57A47qiwYscCHCc5UJZdEJtaxpyeagaTzwlIDbFf0CSFJeU4EIqSBvh3q9iy9SwRk3Q+RGQH7KjrhvohQ==")]
+        [InlineData("", true, "rE+NQworCkw=")]
+        [InlineData(PropertyName, false, "0rT5fJwG03I=")]
         public void WriteNameValue_WithBoolValue_WithValidValue_WritesNameValue(string name, bool value, string expectedHash)
         {
             _writer.WriteObjectStart();
@@ -236,9 +236,9 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [InlineData("", "", "y119K+M0qb7ZuOPtqhZB3oSq3qICw6ulw46gpooqe+mgd11zySkL+dONrIm8asZiUOWKa1Vo8lSp0c4Df92gHQ==")]
-        [InlineData(PropertyName, null, "KYuQ62iFQ/6Cd6svsq38bCPZq2HUZJae+e8kyvFpxkjpBMGOa/88lvo++bIb2zHL7eO5MJN9I8r1/kwe0lSctg==")]
-        [InlineData(PropertyName, "b", "kQ/OLQaqRdPBgNd/wzuUuTmSoCW13jaonYx5//arvLFtDo85lv5kfr1ATCol6HH9lDFtNS44X/HSjSI7xnxSDA==")]
+        [InlineData("", "", "OAojEMgFBbk=")]
+        [InlineData(PropertyName, null, "ViPwxht58Ok=")]
+        [InlineData(PropertyName, "b", "kwmmpEQYi7g=")]
         public void WriteNameValue_WithStringValue_WithValidValue_WritesNameValue(string name, string value, string expectedHash)
         {
             _writer.WriteObjectStart();
@@ -275,8 +275,8 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [InlineData("", null, "bAe84bYqI4pvIFTbU9k55dzFYneWYlLw6w2Hbbw9F71iXKv9CYdVl6WE20O73WP2Gs8N1jY8vNLnpRy2uSOkIw==")]
-        [InlineData(PropertyName, "b", "6lWKPWARIKyDadU74W5+bb7W7/1mFLyZaljfm4UpudCTeiny7dbPU5hB/C63Xt6LDpqbjtLvoxS0hiWIbWGvkA==")]
+        [InlineData("", null, "uFlSEcjwabo=")]
+        [InlineData(PropertyName, "b", "Td9cKXXB7Gk=")]
         public void WriteNameArray_WithValidValues_WritesNameArray(string name, string value, string expectedHash)
         {
             IEnumerable<string> values = value == null ? Enumerable.Empty<string>() : new[] { value };
@@ -295,7 +295,7 @@ namespace NuGet.ProjectModel.Test
             _writer.WriteObjectStart();
             _writer.WriteNameArray(PropertyName, new string[] { null });
 
-            const string expectedHash = "BqvCuFre4Siu1xS8bzI6rXbSTCoNBI/bqGRvUTFDtUAVlDGfDg5cqeBosLcw5sboEHqOFOb/MqJBOyK1Xj5Ueg==";
+            const string expectedHash = "6JqdqL+bz8M=";
             string actualHash = _writer.GetHash();
 
             Assert.Equal(expectedHash, actualHash);
@@ -327,7 +327,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [InlineData(PropertyName, "b", "6lWKPWARIKyDadU74W5+bb7W7/1mFLyZaljfm4UpudCTeiny7dbPU5hB/C63Xt6LDpqbjtLvoxS0hiWIbWGvkA==")]
+        [InlineData(PropertyName, "b", "Td9cKXXB7Gk=")]
         public void WriteNonEmptyNameArray_WithValidValues_WritesNameArray(string name, string value, string expectedHash)
         {
             IEnumerable<string> values = value == null ? Enumerable.Empty<string>() : new[] { value };
@@ -341,7 +341,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [InlineData(PropertyName, "b", "6lWKPWARIKyDadU74W5+bb7W7/1mFLyZaljfm4UpudCTeiny7dbPU5hB/C63Xt6LDpqbjtLvoxS0hiWIbWGvkA==")]
+        [InlineData(PropertyName, "b", "Td9cKXXB7Gk=")]
         public void WriteNonEmptyNameArray_WithEmptyValues_DoesNotWriteNameArray(string name, string value, string expectedHash)
         {
             IEnumerable<string> values = value == null ? Enumerable.Empty<string>() : new[] { value };
@@ -362,7 +362,7 @@ namespace NuGet.ProjectModel.Test
             _writer.WriteObjectStart();
             _writer.WriteNonEmptyNameArray(PropertyName, new string[] { null });
 
-            const string expectedHash = "BqvCuFre4Siu1xS8bzI6rXbSTCoNBI/bqGRvUTFDtUAVlDGfDg5cqeBosLcw5sboEHqOFOb/MqJBOyK1Xj5Ueg==";
+            const string expectedHash = "6JqdqL+bz8M=";
             string actualHash = _writer.GetHash();
 
             Assert.Equal(expectedHash, actualHash);
@@ -371,7 +371,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void GetHash_WithNoOtherChanges_ReturnsDefaultValue()
         {
-            const string expectedHash = "z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/SpIdNs6c5H0NE8XYXysP+DGNKHfuwvY7kxvUdBeoGlODJ6+SfaPg==";
+            const string expectedHash = "AAAAAAAAAAA=";
             string actualHash = _writer.GetHash();
 
             Assert.Equal(expectedHash, actualHash);
@@ -388,7 +388,7 @@ namespace NuGet.ProjectModel.Test
             _writer.WriteObjectEnd();
             _writer.WriteObjectEnd();
 
-            const string expectedHash = "TGP0LarTsGYQ2bqAC8lWyRQR+JsKzsO0Y+h6w7mtTj6mBOLTy8Dr0ZypSgzwzD9xuddh2ceDT7fEXve5ohuNeQ==";
+            const string expectedHash = "heVVAmQ95DE=";
             string actualHash = _writer.GetHash();
 
             Assert.Equal(expectedHash, actualHash);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug
Fixes: https://github.com/NuGet/Home/issues/13214

Regression? Last working version:

## Description
Switch calculating dependency graph spec json to a 64-bit non-crypto hash from SHA512 hash to reduce comparison/restore time but maintaining accuracy of need to restore when determining if NuGet needs to regenerate the dgspec.json file. 

We've also added an escape hatch a user can set the environment variable `NUGET_ENABLE_LEGACY_DGSPEC_HASH_FUNCTION` to `true` to bring back the SHA512 hash function.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
