### PR TITLE
Remove redundant JTF.Run from VSCredentialProviderImporter

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
@@ -44,15 +44,15 @@ namespace NuGet.PackageManagement.VisualStudio
             var credentialProviders = new List<ICredentialProvider>();
             var webProxy = await _asyncServiceProvider.GetServiceAsync<SVsWebProxy, IVsWebProxy>();
 
-            TryAddCredentialProviders(
+            await TryAddCredentialProvidersAsync(
                 credentialProviders,
                 Strings.CredentialProviderFailed_VisualStudioAccountProvider,
-                () =>
+                async () =>
                 {
                     var importer = new VsCredentialProviderImporter(
                         (exception, failureMessage) => LogCredentialProviderError(exception, failureMessage));
 
-                    return importer.GetProviders();
+                    return await importer.GetProvidersAsync();
                 });
 
             TryAddCredentialProviders(
@@ -91,14 +91,14 @@ namespace NuGet.PackageManagement.VisualStudio
 
             // Initialize the credential service.
             var credentialService = new CredentialService(
-                new AsyncLazy<IEnumerable<ICredentialProvider>>(() => System.Threading.Tasks.Task.FromResult((IEnumerable<ICredentialProvider>)credentialProviders)),
+                new AsyncLazy<IEnumerable<ICredentialProvider>>(() => Task.FromResult((IEnumerable<ICredentialProvider>)credentialProviders)),
                 nonInteractive: nonInteractive,
                 handlesDefaultCredentials: PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders);
 
             return credentialService;
         }
 
-        private async System.Threading.Tasks.Task TryAddCredentialProvidersAsync(
+        private async Task TryAddCredentialProvidersAsync(
             List<ICredentialProvider> credentialProviders,
             string failureMessage,
             Func<Task<IEnumerable<ICredentialProvider>>> factory)

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.Sdk.TestFramework;
 using Microsoft.VisualStudio.Threading;
@@ -44,8 +43,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         public CpsPackageReferenceProjectTests(GlobalServiceProvider globalServiceProvider)
             : base(globalServiceProvider)
         {
-            var componentModel = new Mock<IComponentModel>();
-
             var mockOutputConsoleUtility = OutputConsoleUtility.GetMock();
             _outputConsoleProviderMock = mockOutputConsoleUtility.mockIOutputConsoleProvider;
             _outputConsoleProvider = new Lazy<IOutputConsoleProvider>(() => _outputConsoleProviderMock.Object);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2711

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

JTF.Run on a background thread can lead to threadpool starvation.
Since we're already in an async codepath, we should avoid the JTF.Run.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
