### PR TITLE
Reduce boxing when enumerating lists

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
@@ -123,7 +123,29 @@ namespace NuGet.Frameworks
             }
             else if (reverse.ContainsKey(key))
             {
-                value = reverse.Where(p => StringComparer.OrdinalIgnoreCase.Equals(p.Key, key)).Select(s => s.Key).Single();
+                bool found = false;
+                string? match = null;
+                foreach (var p in reverse)
+                {
+                    if (StringComparer.OrdinalIgnoreCase.Equals(p.Key, key))
+                    {
+                        if (found)
+                        {
+                            throw new InvalidOperationException();
+                        }
+
+                        match = p.Key;
+                        found = true;
+                    }
+                }
+
+                if (!found || match == null)
+                {
+                    throw new InvalidOperationException();
+                }
+
+                value = match;
+
                 return true;
             }
 

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
@@ -123,30 +123,14 @@ namespace NuGet.Frameworks
             }
             else if (reverse.ContainsKey(key))
             {
-                bool found = false;
-                string? match = null;
-                foreach (var p in reverse)
+                foreach (var item in reverse.NoAllocEnumerate())
                 {
-                    if (StringComparer.OrdinalIgnoreCase.Equals(p.Key, key))
+                    if (StringComparer.OrdinalIgnoreCase.Equals(item.Key, key))
                     {
-                        if (found)
-                        {
-                            throw new InvalidOperationException();
-                        }
-
-                        match = p.Key;
-                        found = true;
+                        value = item.Key;
+                        return true;
                     }
                 }
-
-                if (!found || match == null)
-                {
-                    throw new InvalidOperationException();
-                }
-
-                value = match;
-
-                return true;
             }
 
             value = null;

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemCollection.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemCollection.cs
@@ -304,7 +304,7 @@ namespace NuGet.ContentModel
             }
 
             // If no related files found.
-            if (relatedFileExtensionList is null || !relatedFileExtensionList.Any())
+            if (relatedFileExtensionList is null || relatedFileExtensionList.Count == 0)
             {
                 _assemblyRelatedExtensions.TryAdd(assemblyPrefix, null);
                 return null;

--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/JsonObjectWriter.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/JsonObjectWriter.cs
@@ -165,7 +165,7 @@ namespace NuGet.RuntimeModel
             // Manually enumerate the IEnumerable so we only write the name
             // when there are corresponding values and avoid potentially expensive
             // multiple enumeration.
-            var enumerator = values.GetEnumerator();
+            var enumerator = values.NoAllocEnumerate().GetEnumerator();
             if (!enumerator.MoveNext())
             {
                 return;

--- a/src/NuGet.Core/NuGet.ProjectModel/HashObjectWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/HashObjectWriter.cs
@@ -190,7 +190,7 @@ namespace NuGet.ProjectModel
             // Manually enumerate the IEnumerable so we only write the name
             // when there are corresponding values and avoid potentially expensive
             // multiple enumeration.
-            var enumerator = values.GetEnumerator();
+            var enumerator = values.NoAllocEnumerate().GetEnumerator();
             if (!enumerator.MoveNext())
             {
                 return;

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -889,7 +889,8 @@ namespace NuGet.ProjectModel
 
         private static void WritePathArray(JsonWriter writer, string property, IEnumerable<string> items)
         {
-            if (items.Any())
+            using var itemsEnumerator = items.NoAllocEnumerate().GetEnumerator();
+            if (itemsEnumerator.MoveNext())
             {
                 var orderedItems = items
                     .Select(f => GetPathWithForwardSlashes(f))


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13279

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Reduces boxing by expanding LINQ queries, using `.Count` instead of `.Any()`, and uses `.NoAllocEnumerate()` where possible.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Existing coverage
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
