### PR TITLE
Ensure that Process objects are disposed when launching authentication plug-ins

### DIFF
--- a/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
@@ -250,7 +250,7 @@ namespace NuGet.Credentials
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var process = Process.Start(startInfo);
+            using var process = Process.Start(startInfo);
             if (process == null)
             {
                 throw PluginException.CreateNotStartedMessage(Path);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginLogger.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginLogger.cs
@@ -104,7 +104,7 @@ namespace NuGet.Protocol.Plugins
                     processId = process.Id;
                 }
 
-                var fileName = $"NuGet_PluginLogFor_{Path.GetFileNameWithoutExtension(file.Name)}_{DateTime.UtcNow.Ticks:x}_{Process.GetCurrentProcess().Id}.log";
+                var fileName = $"NuGet_PluginLogFor_{Path.GetFileNameWithoutExtension(file.Name)}_{DateTime.UtcNow.Ticks:x}_{processId}.log";
                 var filePath = Path.Combine(_logDirectoryPath, fileName);
                 var stream = File.Open(filePath, FileMode.Create, FileAccess.Write, FileShare.Read);
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13280

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Add a `using` to the `Process` object created when launching an authentication plug-in to ensure its resources are freed.  

Also updates a code path where the wrong process ID was being used for the plug-in log file name.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Existing coverage
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
