### PR TITLE
Avoid enumerator boxing in PackageSpecificWarningProperties.AddRangeOfCodes and TransitiveNoWarnUtils.AddToSeen

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/PackageSpecificWarningProperties.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/PackageSpecificWarningProperties.cs
@@ -112,7 +112,7 @@ namespace NuGet.Commands
         /// <param name="framework">Target graph for which no warning should be thrown.</param>
         public void AddRangeOfCodes(IEnumerable<NuGetLogCode> codes, string libraryId, NuGetFramework framework)
         {
-            foreach (var code in codes)
+            foreach (var code in codes.NoAllocEnumerate())
             {
                 Add(code, libraryId, framework);
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/TransitiveNoWarnUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/TransitiveNoWarnUtils.cs
@@ -290,7 +290,7 @@ namespace NuGet.Commands
             NodeWarningProperties nodeWarningProperties)
         {
             // Add all the project's dependencies to the Queue with the merged WarningPropertiesCollection
-            foreach (var dependency in dependencies)
+            foreach (var dependency in dependencies.NoAllocEnumerate())
             {
                 var queueNode = new DependencyNode(
                     dependency.Name,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13281

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Use the `.NoAllocEnumerate()` for two places in `NuGet.Commands` to reduce boxing allocations in hot code paths.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Existing coverage
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
