### PR TITLE
Use StringBuilder.AppendInt() in more places to reduce allocations when appending integers to a StringBuilder

### DIFF
--- a/build/Shared/SharedExtensions.cs
+++ b/build/Shared/SharedExtensions.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace NuGet.Shared
 {
@@ -62,5 +63,68 @@ namespace NuGet.Shared
             }
         }
 
+
+        /// <summary>
+        /// Helper function to append an <see cref="int"/> to a <see cref="StringBuilder"/>. Calling
+        /// <see cref="StringBuilder.Append(int)"/> directly causes an allocation by first converting the
+        /// <see cref="int"/> to a string and then appending that result:
+        /// <code>
+        /// public StringBuilder Append(int value)
+        /// {
+        ///     return Append(value.ToString(CultureInfo.CurrentCulture));
+        /// }
+        /// </code>
+        ///
+        /// Note that this uses the current culture to do the conversion while <see cref="AppendInt(StringBuilder, int)"/> does
+        /// not do any cultural sensitive conversion.
+        /// </summary>
+        /// <param name="sb">The <see cref="StringBuilder"/> to append to.</param>
+        /// <param name="value">The <see cref="int"/> to append.</param>
+        public static void AppendInt(this StringBuilder sb, int value)
+        {
+            if (value == 0)
+            {
+                sb.Append('0');
+                return;
+            }
+
+            // special case min value since it'll overflow if we negate it
+            if (value == int.MinValue)
+            {
+                sb.Append("-2147483648");
+                return;
+            }
+
+            // do all math with positive integers
+            if (value < 0)
+            {
+                sb.Append('-');
+                value = -value;
+            }
+
+            // upper range of int is 1 billion, so we start dividing by that to get the digit at that position
+            int divisor = 1_000_000_000;
+
+            // remember when we found our first digit so we can keep adding intermediate zeroes
+            bool digitFound = false;
+            while (divisor > 0)
+            {
+                if (digitFound || value >= divisor)
+                {
+                    digitFound = true;
+                    int digit = value / divisor;
+                    value -= digit * divisor;
+
+                    // convert the digit to char by adding the value to '0'.
+                    // '0' + 0 = 48 + 0 = 48 = '0'
+                    // '0' + 1 = 48 + 1 = 49 = '1'
+                    // '0' + 2 = 48 + 2 = 50 = '2'
+                    // etc...
+                    sb.Append((char)('0' + digit));
+                }
+
+                divisor /= 10;
+            }
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using NuGet.Shared;
 
 namespace NuGet.Frameworks
 {
@@ -235,23 +236,23 @@ namespace NuGet.Frameworks
                 if (partCount == 1)
                     partCount = 2;
 
-                sb.Append(major);
+                sb.AppendInt(major);
                 if (partCount > 1)
-                    sb.Append('.').Append(minor);
+                    sb.Append('.').AppendInt(minor);
                 if (partCount > 2)
-                    sb.Append('.').Append(build);
+                    sb.Append('.').AppendInt(build);
                 if (partCount > 3)
-                    sb.Append('.').Append(revision);
+                    sb.Append('.').AppendInt(revision);
             }
             else
             {
-                sb.Append(major);
+                sb.AppendInt(major);
                 if (partCount > 1)
-                    sb.Append(minor);
+                    sb.AppendInt(minor);
                 if (partCount > 2)
-                    sb.Append(build);
+                    sb.AppendInt(build);
                 if (partCount > 3)
-                    sb.Append(revision);
+                    sb.AppendInt(revision);
             }
 
             return StringBuilderPool.Shared.ToStringAndReturn(sb);

--- a/src/NuGet.Core/NuGet.Versioning/VersionFormatter.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionFormatter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Text;
+using NuGet.Shared;
 
 namespace NuGet.Versioning
 {
@@ -86,16 +87,16 @@ namespace NuGet.Versioning
                     builder.Append(version.Metadata);
                     return;
                 case 'x':
-                    AppendInt(builder, version.Major);
+                    builder.AppendInt(version.Major);
                     return;
                 case 'y':
-                    AppendInt(builder, version.Minor);
+                    builder.AppendInt(version.Minor);
                     return;
                 case 'z':
-                    AppendInt(builder, version.Patch);
+                    builder.AppendInt(version.Patch);
                     return;
                 case 'r':
-                    AppendInt(builder, version is NuGetVersion nuGetVersion && nuGetVersion.IsLegacyVersion ? nuGetVersion.Version.Revision : 0);
+                    builder.AppendInt(version is NuGetVersion nuGetVersion && nuGetVersion.IsLegacyVersion ? nuGetVersion.Version.Revision : 0);
                     return;
 
                 default:
@@ -135,79 +136,16 @@ namespace NuGet.Versioning
 
         private static void AppendVersion(StringBuilder builder, SemanticVersion version)
         {
-            AppendInt(builder, version.Major);
+            builder.AppendInt(version.Major);
             builder.Append('.');
-            AppendInt(builder, version.Minor);
+            builder.AppendInt(version.Minor);
             builder.Append('.');
-            AppendInt(builder, version.Patch);
+            builder.AppendInt(version.Patch);
 
             if (version is NuGetVersion nuGetVersion && nuGetVersion.IsLegacyVersion)
             {
                 builder.Append('.');
-                AppendInt(builder, nuGetVersion.Version.Revision);
-            }
-        }
-
-        /// <summary>
-        /// Helper function to append an <see cref="int"/> to a <see cref="StringBuilder"/>. Calling
-        /// <see cref="StringBuilder.Append(int)"/> directly causes an allocation by first converting the
-        /// <see cref="int"/> to a string and then appending that result:
-        /// <code>
-        /// public StringBuilder Append(int value)
-        /// {
-        ///     return Append(value.ToString(CultureInfo.CurrentCulture));
-        /// }
-        /// </code>
-        ///
-        /// Note that this uses the current culture to do the conversion while <see cref="AppendInt(StringBuilder, int)"/> does
-        /// not do any cultural sensitive conversion.
-        /// </summary>
-        /// <param name="sb">The <see cref="StringBuilder"/> to append to.</param>
-        /// <param name="value">The <see cref="int"/> to append.</param>
-        private static void AppendInt(StringBuilder sb, int value)
-        {
-            if (value == 0)
-            {
-                sb.Append('0');
-                return;
-            }
-
-            // special case min value since it'll overflow if we negate it
-            if (value == int.MinValue)
-            {
-                sb.Append("-2147483648");
-                return;
-            }
-
-            // do all math with positive integers
-            if (value < 0)
-            {
-                sb.Append('-');
-                value = -value;
-            }
-
-            // upper range of int is 1 billion, so we start dividing by that to get the digit at that position
-            int divisor = 1_000_000_000;
-
-            // remember when we found our first digit so we can keep adding intermediate zeroes
-            bool digitFound = false;
-            while (divisor > 0)
-            {
-                if (digitFound || value >= divisor)
-                {
-                    digitFound = true;
-                    int digit = value / divisor;
-                    value -= digit * divisor;
-
-                    // convert the digit to char by adding the value to '0'.
-                    // '0' + 0 = 48 + 0 = 48 = '0'
-                    // '0' + 1 = 48 + 1 = 49 = '1'
-                    // '0' + 2 = 48 + 2 = 50 = '2'
-                    // etc...
-                    sb.Append((char)('0' + digit));
-                }
-
-                divisor /= 10;
+                builder.AppendInt(nuGetVersion.Version.Revision);
             }
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13282

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
`StringBuilder.Append(int)` allocates a string in order to append an integer so this code adds an extension method which uses `char`s instead to avoid allocating unnecessary strings.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Existing coverage
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
