### PR TITLE
Specify list size in TopologicalSortUtility.CalculateRelationships

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/TopologicalSortUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/TopologicalSortUtility.cs
@@ -143,8 +143,9 @@ namespace NuGet.Packaging
             {
                 var dependencies = package.DependencyIds ?? Array.Empty<string>();
 
-                foreach (var id in dependencies)
+                for (var i = 0; i < dependencies.Length; i++)
                 {
+                    var id = dependencies[i];
                     if (lookup.TryGetValue(id, out var dependencyPackage))
                     {
                         // Mark the current package as a parent
@@ -160,7 +161,7 @@ namespace NuGet.Packaging
                         var packageChildren = package.Children;
                         if (packageChildren == null)
                         {
-                            packageChildren = new List<ItemDependencyInfo>();
+                            packageChildren = new List<ItemDependencyInfo>(dependencies.Length - i);
                             package.Children = packageChildren;
                         }
                         packageChildren.Add(dependencyPackage);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13284

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Performance improvement by setting a list capacity in `TopologicalSortUtility.CalculateRelationships()`

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Existing coverage
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
