### PR TITLE
Use pooled StringBuilder

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
@@ -198,7 +198,7 @@ namespace NuGet.Frameworks
             // Check for rewrites
             var framework = mappings.GetShortNameReplacement(this);
 
-            var sb = new StringBuilder();
+            var sb = StringBuilderPool.Shared.Rent(256);
 
             if (IsSpecificFramework)
             {
@@ -292,12 +292,13 @@ namespace NuGet.Frameworks
                 sb.Append(Framework);
             }
 
-            return sb.ToString().ToLowerInvariant();
+            return StringBuilderPool.Shared.ToStringAndReturn(sb).ToLowerInvariant();
         }
 
         private static string GetDisplayVersion(Version version)
         {
-            var sb = new StringBuilder(string.Format(CultureInfo.InvariantCulture, "{0}.{1}", version.Major, version.Minor));
+            var sb = StringBuilderPool.Shared.Rent(256);
+            sb.AppendFormat(CultureInfo.InvariantCulture, "{0}.{1}", version.Major, version.Minor);
 
             if (version.Build > 0
                 || version.Revision > 0)
@@ -310,7 +311,7 @@ namespace NuGet.Frameworks
                 }
             }
 
-            return sb.ToString();
+            return StringBuilderPool.Shared.ToStringAndReturn(sb);
         }
 
         private static string GetLettersAndDigitsOnly(string s)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13285

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Use  `StringBuilderPool` in `NuGet.Frameworks` for hot code paths to reduce allocations.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception - Existing coverage
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
