### PR TITLE
Fix sources equality check in ProjectRestoreMetadata

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -190,7 +190,7 @@ namespace NuGet.ProjectModel
                    osStringComparer.Equals(OutputPath, other.OutputPath) &&
                    osStringComparer.Equals(ProjectName, other.ProjectName) &&
                    osStringComparer.Equals(ProjectUniqueName, other.ProjectUniqueName) &&
-                   Sources.Distinct().OrderedEquals(other.Sources.Distinct(), source => source.Source, StringComparer.OrdinalIgnoreCase) &&
+                   GetSources(Sources).SetEqualsWithNullCheck(GetSources(other.Sources), StringComparer.OrdinalIgnoreCase) &&
                    osStringComparer.Equals(PackagesPath, other.PackagesPath) &&
                    ConfigFilePaths.OrderedEquals(other.ConfigFilePaths, filePath => filePath, osStringComparer, osStringComparer) &&
                    FallbackFolders.OrderedEquals(other.FallbackFolders, fallbackFolder => fallbackFolder, osStringComparer, osStringComparer) &&
@@ -208,6 +208,16 @@ namespace NuGet.ProjectModel
                    EqualityUtility.EqualsWithNullCheck(CentralPackageVersionOverrideDisabled, other.CentralPackageVersionOverrideDisabled) &&
                    EqualityUtility.EqualsWithNullCheck(CentralPackageTransitivePinningEnabled, other.CentralPackageTransitivePinningEnabled) &&
                    RestoreAuditProperties == other.RestoreAuditProperties;
+        }
+
+        private HashSet<string> GetSources(IList<PackageSource> sources)
+        {
+            var setSources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; i < sources.Count; i++)
+            {
+                setSources.Add(sources[i].Source);
+            }
+            return setSources;
         }
 
         public virtual ProjectRestoreMetadata Clone()

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -212,7 +212,7 @@ namespace NuGet.ProjectModel
 
         private HashSet<string> GetSources(IList<PackageSource> sources)
         {
-            var setSources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var setSources = new HashSet<string>(sources.Count, StringComparer.OrdinalIgnoreCase);
             for (var i = 0; i < sources.Count; i++)
             {
                 setSources.Add(sources[i].Source);

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -212,7 +212,11 @@ namespace NuGet.ProjectModel
 
         private HashSet<string> GetSources(IList<PackageSource> sources)
         {
+#if NETSTANDARD2_0
+            var setSources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+#else
             var setSources = new HashSet<string>(sources.Count, StringComparer.OrdinalIgnoreCase);
+#endif
             for (var i = 0; i < sources.Count; i++)
             {
                 setSources.Add(sources[i].Source);

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -190,7 +190,7 @@ namespace NuGet.ProjectModel
                    osStringComparer.Equals(OutputPath, other.OutputPath) &&
                    osStringComparer.Equals(ProjectName, other.ProjectName) &&
                    osStringComparer.Equals(ProjectUniqueName, other.ProjectUniqueName) &&
-                   Sources.OrderedEquals(other.Sources.Distinct(), source => source.Source, StringComparer.OrdinalIgnoreCase) &&
+                   Sources.Distinct().OrderedEquals(other.Sources.Distinct(), source => source.Source, StringComparer.OrdinalIgnoreCase) &&
                    osStringComparer.Equals(PackagesPath, other.PackagesPath) &&
                    ConfigFilePaths.OrderedEquals(other.ConfigFilePaths, filePath => filePath, osStringComparer, osStringComparer) &&
                    FallbackFolders.OrderedEquals(other.FallbackFolders, fallbackFolder => fallbackFolder, osStringComparer, osStringComparer) &&

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTests.cs
@@ -438,6 +438,19 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Fact]
+        public void ProjectRestoreMetadataEqualityAccountsForDuplicates()
+        {
+            // Arrange
+            var left = CreateProjectRestoreMetadata();
+            var right = CreateProjectRestoreMetadata();
+            left.Sources = new List<PackageSource>() { new PackageSource("http://api.nuget.org/v3/index.json"), new PackageSource("C:\\source"), new PackageSource("http://api.nuget.org/v3/index.json") };
+            right.Sources = new List<PackageSource>() { new PackageSource("C:\\source"), new PackageSource("http://api.nuget.org/v3/index.json"), new PackageSource("http://api.nuget.org/v3/index.json") };
+
+            // Act & Assert
+            Assert.Equal(left, right);
+        }
+
+        [Fact]
         public void ProjectRestoreMetadataCloneChangeCentralPackageVersionsEnabledTest()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13294
Fixes: https://github.com/NuGet/Home/issues/13269

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The recent changes from https://github.com/NuGet/NuGet.Client/commit/1942c17866695ae1175ec3d8b42a6b41bcd6a9c9#diff-93482a8631efd30f5df833baa903bcf342fb99a2e93cf9a3dea6a672b44d3a61L81 and the changes moving from Newtonsoft.Json to System.Text.Json for assets file reading. 

If there are duplicate objects, Newtonsoft.Json dedups, while System.Text.Json *does not*. 

```json
      "sources": {
        "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
        "C:\\Program Files\\dotnet\\library-packs": {},
        "https://api.nuget.org/v3/index.json": {},
        "https://api.nuget.org/v3/index.json": {}
      }
```

Deduping the sources based on the source value will allow the comparison to work in *both* STJ and NJ scenarios. 
Eventually, we'd probably want to remove the deduplication, but given that we want this codepath to work with both, this is the best approach. 

Note that previous ordering and current deduplication costs are comparable.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
