### PR TITLE
Change hash in VS feedback provider

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGetFeedbackDiagnosticFileProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGetFeedbackDiagnosticFileProvider.cs
@@ -9,6 +9,8 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Internal.VisualStudio.Shell.Embeddable.Feedback;
 using NuGet.Common;
@@ -204,16 +206,59 @@ namespace NuGet.VisualStudio.Common
                 if (anyNonMSFeed)
                 {
                     List<PackageSource> sources = new();
+                    using HMACSHA256 hmac = CreateHMACSHA256();
 
                     foreach (PackageSource source in Project.RestoreMetadata.Sources)
                     {
-                        sources.Add(string.IsNullOrWhiteSpace(PackageSourceTelemetry.GetMsFeed(source)) ?
-                            new PackageSource(CryptoHashUtility.GenerateUniqueToken(source.Source)) : source);
+                        PackageSource newSource = source;
+                        if (string.IsNullOrWhiteSpace(PackageSourceTelemetry.GetMsFeed(source)))
+                        {
+                            string sourceString = ComputeHash(hmac, source.Source);
+                            newSource = new PackageSource(sourceString);
+                        }
+                        sources.Add(newSource);
                     }
 
                     Project.RestoreMetadata.Sources = sources;
                 }
             }
+        }
+
+        internal static HMACSHA256 CreateHMACSHA256()
+        {
+            const string key = "959069c9-9e93-4fa1-bf16-3f8120d7db0c";
+            return new HMACSHA256(Encoding.UTF8.GetBytes(key));
+        }
+
+        internal static string ComputeHash(HMACSHA256 hmac, string input)
+        {
+            byte[] bytes = hmac.ComputeHash(Encoding.UTF8.GetBytes(input));
+#if NET5_0_OR_GREATER
+            string hexString = Convert.ToHexString(bytes);
+#else
+            string hexString = ToHexString(bytes);
+#endif
+
+            return hexString;
+
+#if !NET5_0_OR_GREATER
+            string ToHexString(byte[] bytes)
+            {
+                char[] chars = new char[bytes.Length * 2];
+                for (int i = 0; i < bytes.Length; i++)
+                {
+                    int b = bytes[i];
+                    chars[i * 2] = (char)HexChar(b >> 4);
+                    chars[i * 2 + 1] = (char)HexChar(b & 0xF);
+                }
+                return new string(chars);
+
+                int HexChar(int c)
+                {
+                    return c < 10 ? '0' + c : 'A' + c - 10;
+                }
+            }
+#endif
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/CryptoHashUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/CryptoHashUtility.cs
@@ -327,19 +327,5 @@ namespace NuGet.Common
                         nameof(signatureAlgorithmName));
             }
         }
-
-        public static string GenerateUniqueToken(string caseInsensitiveKey)
-        {
-            if (string.IsNullOrEmpty(caseInsensitiveKey))
-            {
-                throw new ArgumentNullException(nameof(caseInsensitiveKey));
-            }
-
-            // SHA256 is case sensitive; given that our key is case insensitive, we upper case it
-            var pathBytes = Encoding.UTF8.GetBytes(caseInsensitiveKey.ToUpperInvariant());
-            var hashProvider = new CryptoHashProvider("SHA256");
-
-            return Convert.ToBase64String(hashProvider.CalculateHash(pathBytes)).ToUpperInvariant();
-        }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI.Shipped.txt
@@ -530,7 +530,6 @@ static NuGet.Common.CryptoHashUtility.ConvertToOid(this NuGet.Common.HashAlgorit
 static NuGet.Common.CryptoHashUtility.ConvertToOidString(this NuGet.Common.HashAlgorithmName hashAlgorithmName) -> string!
 static NuGet.Common.CryptoHashUtility.ConvertToOidString(this NuGet.Common.SignatureAlgorithmName signatureAlgorithmName) -> string!
 static NuGet.Common.CryptoHashUtility.ConvertToSystemSecurityHashAlgorithmName(this NuGet.Common.HashAlgorithmName hashAlgorithmName) -> System.Security.Cryptography.HashAlgorithmName
-static NuGet.Common.CryptoHashUtility.GenerateUniqueToken(string! caseInsensitiveKey) -> string!
 static NuGet.Common.CryptoHashUtility.GetHashAlgorithm(NuGet.Common.HashAlgorithmName hashAlgorithmName) -> System.Security.Cryptography.HashAlgorithm!
 static NuGet.Common.CryptoHashUtility.GetHashAlgorithm(string! hashAlgorithmName) -> System.Security.Cryptography.HashAlgorithm!
 static NuGet.Common.CryptoHashUtility.GetHashAlgorithmName(string! hashAlgorithm) -> NuGet.Common.HashAlgorithmName


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2185

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Change how the feedback file provider hashes package sources in the dgspec, just in case we need to correlate the source to VS telemetry
* Remove the public API for the previous hash implementation. It was only used in one place, so probably should have never been made public in the first place. It has been public for quite some time now, but it's really not related to NuGet functionality, so if anyone is referencing NuGet.Common in their own apps, my suggestion is to copy the code. It would be more problematic if a library is calling the API, as an updated NuGet.Common will cause `MethodNotFoundException` at runtime, but I really think it's low risk that anyone would call this API.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
