### PR TITLE
Update command add option/argument to supported api

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigCommand.cs
@@ -36,7 +36,7 @@ namespace NuGet.CommandLine.XPlat
             Description = Strings.ConfigSetConfigValueDescription,
         };
 
-        private static CliArgument<string> AllOrConfigKeyOption = new CliArgument<string>(name: "all-or-config-key")
+        private static CliArgument<string> AllOrConfigKeyArgument = new CliArgument<string>(name: "all-or-config-key")
         {
             Arity = ArgumentArity.ZeroOrOne,
             HelpName = Strings.ConfigGetAllOrConfigKeyDescription,
@@ -130,8 +130,8 @@ namespace NuGet.CommandLine.XPlat
 
         private static void RegisterOptionsForCommandConfigPaths(CliCommand cmd, Func<ILogger> getLogger)
         {
-            cmd.Add(WorkingDirectory);
-            cmd.Add(HelpOption);
+            cmd.Options.Add(WorkingDirectory);
+            cmd.Options.Add(HelpOption);
             // Create handler delegate handler for cmd
             cmd.SetAction((parseResult, cancellationToken) =>
             {
@@ -160,10 +160,10 @@ namespace NuGet.CommandLine.XPlat
 
         private static void RegisterOptionsForCommandConfigGet(CliCommand cmd, Func<ILogger> getLogger)
         {
-            cmd.Add(AllOrConfigKeyOption);
-            cmd.Add(WorkingDirectory);
-            cmd.Add(ShowPathOption);
-            cmd.Add(HelpOption);
+            cmd.Arguments.Add(AllOrConfigKeyArgument);
+            cmd.Options.Add(WorkingDirectory);
+            cmd.Options.Add(ShowPathOption);
+            cmd.Options.Add(HelpOption);
 
             // Create handler delegate handler for cmd
             cmd.SetAction((parseResult, cancellationToken) =>
@@ -171,7 +171,7 @@ namespace NuGet.CommandLine.XPlat
                 int exitCode;
                 var args = new ConfigGetArgs()
                 {
-                    AllOrConfigKey = parseResult.GetValue(AllOrConfigKeyOption),
+                    AllOrConfigKey = parseResult.GetValue(AllOrConfigKeyArgument),
                     WorkingDirectory = parseResult.GetValue(WorkingDirectory),
                     ShowPath = parseResult.GetValue(ShowPathOption),
                 };
@@ -194,10 +194,10 @@ namespace NuGet.CommandLine.XPlat
 
         private static void RegisterOptionsForCommandConfigSet(CliCommand cmd, Func<ILogger> getLogger)
         {
-            cmd.Add(SetConfigKeyArgument);
-            cmd.Add(ConfigValueArgument);
-            cmd.Add(ConfigFileOption);
-            cmd.Add(HelpOption);
+            cmd.Arguments.Add(SetConfigKeyArgument);
+            cmd.Arguments.Add(ConfigValueArgument);
+            cmd.Options.Add(ConfigFileOption);
+            cmd.Options.Add(HelpOption);
             // Create handler delegate handler for cmd
             cmd.SetAction((parseResult, cancellationToken) =>
             {
@@ -227,9 +227,9 @@ namespace NuGet.CommandLine.XPlat
 
         private static void RegisterOptionsForCommandConfigUnset(CliCommand cmd, Func<ILogger> getLogger)
         {
-            cmd.Add(UnsetConfigKeyArgument);
-            cmd.Add(ConfigFileOption);
-            cmd.Add(HelpOption);
+            cmd.Arguments.Add(UnsetConfigKeyArgument);
+            cmd.Options.Add(ConfigFileOption);
+            cmd.Options.Add(HelpOption);
             // Create handler delegate handler for cmd
             cmd.SetAction((parseResult, cancellationToken) =>
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13286

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Starting .NET 9, CliComand.Add() started throwing errors, we have two different implementations when adding Options or Arguments to a command, for `dotnet nuget config` we use `CliComand.Add(CliOption | CliArgument)` and for `dotnet package search` we use `CliComand.Options.Add(CliOption)` and `CliComand.Arguments.Add(CliArgument)`, since the change it's only affecting .NET 9 I believe there is a change in the API or package source being used that is affecting this. 


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. --> There are already tests for this in our code

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
