### PR TITLE
Set ngen architecture via property

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -100,31 +100,31 @@
     <ProjectReference Include="..\..\NuGet.Core\NuGet.Common\NuGet.Common.csproj">
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
-      <NgenArchitecture>All</NgenArchitecture>
+      <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
       <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\..\NuGet.Core\NuGet.Configuration\NuGet.Configuration.csproj">
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
-      <NgenArchitecture>All</NgenArchitecture>
+      <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
       <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\..\NuGet.Core\NuGet.DependencyResolver.Core\NuGet.DependencyResolver.Core.csproj">
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
-      <NgenArchitecture>All</NgenArchitecture>
+      <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
       <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\..\NuGet.Core\NuGet.Frameworks\NuGet.Frameworks.csproj">
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
-      <NgenArchitecture>All</NgenArchitecture>
+      <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
       <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\..\NuGet.Core\NuGet.LibraryModel\NuGet.LibraryModel.csproj">
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
-      <NgenArchitecture>All</NgenArchitecture>
+      <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
       <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\..\NuGet.Core\NuGet.PackageManagement\NuGet.PackageManagement.csproj">
@@ -133,32 +133,32 @@
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
-      <NgenArchitecture>All</NgenArchitecture>
+      <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
       <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\..\NuGet.Core\NuGet.Packaging\NuGet.Packaging.csproj">
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
-      <NgenArchitecture>All</NgenArchitecture>
+      <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
       <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\..\NuGet.Core\NuGet.ProjectModel\NuGet.ProjectModel.csproj">
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
-      <NgenArchitecture>All</NgenArchitecture>
+      <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
       <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\..\NuGet.Core\NuGet.Protocol\NuGet.Protocol.csproj">
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
-      <NgenArchitecture>All</NgenArchitecture>
+      <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
       <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\..\NuGet.Core\NuGet.Resolver\NuGet.Resolver.csproj" />
     <ProjectReference Include="..\..\NuGet.Core\NuGet.Versioning\NuGet.Versioning.csproj">
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
-      <NgenArchitecture>All</NgenArchitecture>
+      <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
       <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\NuGet.Tools\NuGet.Tools.csproj">
@@ -175,7 +175,7 @@
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
-      <NgenArchitecture>All</NgenArchitecture>
+      <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
       <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\..\NuGet.Core\NuGet.Credentials\NuGet.Credentials.csproj">
@@ -188,7 +188,7 @@
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
-      <NgenArchitecture>All</NgenArchitecture>
+      <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
       <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\NuGet.VisualStudio.Contracts\NuGet.VisualStudio.Contracts.csproj" />
@@ -198,7 +198,7 @@
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
-      <NgenArchitecture>All</NgenArchitecture>
+      <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
       <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\NuGet.PackageManagement.PowerShellCmdlets\NuGet.PackageManagement.PowerShellCmdlets.csproj">
@@ -217,7 +217,7 @@
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
-      <NgenArchitecture>All</NgenArchitecture>
+      <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
       <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\NuGet.VisualStudio.Internal.Contracts\NuGet.VisualStudio.Internal.Contracts.csproj">
@@ -234,7 +234,7 @@
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
-      <NgenArchitecture>All</NgenArchitecture>
+      <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
       <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\NuGet.VisualStudio\NuGet.VisualStudio.csproj">
@@ -242,7 +242,7 @@
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
-      <NgenArchitecture>All</NgenArchitecture>
+      <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
       <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\NuGet.Console\NuGet.Console.csproj">
@@ -305,7 +305,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- 
+  <!--
     Read the .vsixignore file and generate an IgnoreVsixFilesList item per line
   -->
   <Target Name="ReadVsixIgnoreListFromFile">
@@ -317,7 +317,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- 
+  <!--
     The VSSDK creates a VsixSourceItems item for each file to be copied into the VSIX. In this target, we remove all
     the files listed in our .vsixignore file, and error if any file listed in .vsixinclude is missing from the vsix.
   -->
@@ -384,7 +384,7 @@
       <ThirdPartyAssembly Include="$(PkgLucene_Net)\lib\NET40\Lucene.Net.dll"
                           DestinationDir="$(IntermediateOutputPath)"
                           TargetPath="$(IntermediateOutputPath)Lucene.Net.dll" />
-      
+
       <ThirdPartyAssembly Include="$(PkgNewtonsoft_Json)\lib\net45\Newtonsoft.Json.dll"
                           DestinationDir="$(IntermediateOutputPath)"
                           TargetPath="$(IntermediateOutputPath)Newtonsoft.Json.dll" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2722

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Change all `<NgenArchitecture>all` item metadata to instead get the value from a property with the same name. When the property doesn't exist, then the item effectively won't either. Makes makes it a simple 1 line change in the future to set/unset when we need, but for now we won't set it.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: no way to test within this repo that the outcome is as desired.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
