### PR TITLE
Fix XMLDoc bug in TaskResultCache.cs

### DIFF
--- a/build/Shared/TaskResultCache.cs
+++ b/build/Shared/TaskResultCache.cs
@@ -31,7 +31,7 @@ namespace NuGet
         /// <summary>
         /// Initializes a new instance of the <see cref="ResultCache{TKey, TValue}" /> class with the specified key comparer.
         /// </summary>
-        /// <param name="comparer">An <see cref="IEqualityComparer{T}" to use when comparing keys.</param>
+        /// <param name="comparer">An <see cref="IEqualityComparer{T}" /> to use when comparing keys.</param>
         public TaskResultCache(IEqualityComparer<TKey> comparer)
         {
             _cache = new(comparer);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/NuGet.Client/pull/5616

Regression? yes?

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Fix an XML syntax error introduced https://github.com/NuGet/NuGet.Client/pull/5616 which sometimes adds a whole lot of errors in my errors list, sometimes doesn't. In any case, it was preventing IntelliSense from giving any docs for this method.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
