### PR TITLE
Search: Handle null metadata 

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/SearchResultPackagesConverter.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/SearchResultPackagesConverter.cs
@@ -23,7 +23,7 @@ namespace NuGet.CommandLine.XPlat
             _exactMatch = exactMatch;
         }
 
-        internal static void WriteStringIsNotNullOrWhiteSpace(Utf8JsonWriter writer, string name, string? value)
+        internal static void WriteStringIfNotNullOrWhiteSpace(Utf8JsonWriter writer, string name, string? value)
         {
             if (!string.IsNullOrWhiteSpace(value))
             {
@@ -43,11 +43,11 @@ namespace NuGet.CommandLine.XPlat
 
             if (_exactMatch)
             {
-                WriteStringIsNotNullOrWhiteSpace(writer, JsonProperties.Version, value.Identity.Version?.ToNormalizedString());
+                WriteStringIfNotNullOrWhiteSpace(writer, JsonProperties.Version, value.Identity.Version?.ToNormalizedString());
             }
             else
             {
-                WriteStringIsNotNullOrWhiteSpace(writer, JsonProperties.LatestVersion, value.Identity.Version?.ToNormalizedString());
+                WriteStringIfNotNullOrWhiteSpace(writer, JsonProperties.LatestVersion, value.Identity.Version?.ToNormalizedString());
             }
 
             if (_verbosity == PackageSearchVerbosity.Normal || _verbosity == PackageSearchVerbosity.Detailed)
@@ -57,21 +57,21 @@ namespace NuGet.CommandLine.XPlat
                     writer.WriteNumber(JsonProperties.DownloadCount, (decimal)value.DownloadCount);
                 }
 
-                WriteStringIsNotNullOrWhiteSpace(writer, JsonProperties.Owners, value.Owners);
+                WriteStringIfNotNullOrWhiteSpace(writer, JsonProperties.Owners, value.Owners);
             }
 
             if (_verbosity == PackageSearchVerbosity.Detailed)
             {
-                WriteStringIsNotNullOrWhiteSpace(writer, JsonProperties.Description, value.Description);
+                WriteStringIfNotNullOrWhiteSpace(writer, JsonProperties.Description, value.Description);
 
                 if (value.Vulnerabilities != null && value.Vulnerabilities.Any())
                 {
                     writer.WriteBoolean("vulnerable", true);
                 }
 
-                WriteStringIsNotNullOrWhiteSpace(writer, JsonProperties.ProjectUrl, value.ProjectUrl?.ToString());
+                WriteStringIfNotNullOrWhiteSpace(writer, JsonProperties.ProjectUrl, value.ProjectUrl?.ToString());
                 PackageDeprecationMetadata packageDeprecationMetadata = value.GetDeprecationMetadataAsync().Result;
-                WriteStringIsNotNullOrWhiteSpace(writer, JsonProperties.Deprecation, packageDeprecationMetadata?.Message);
+                WriteStringIfNotNullOrWhiteSpace(writer, JsonProperties.Deprecation, packageDeprecationMetadata?.Message);
             }
 
             writer.WriteEndObject();

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/SearchResultPackagesConverter.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/SearchResultPackagesConverter.cs
@@ -40,14 +40,15 @@ namespace NuGet.CommandLine.XPlat
         {
             writer.WriteStartObject();
             writer.WriteString(JsonProperties.PackageId, value.Identity.Id);
+            var version = value.Identity.Version?.ToNormalizedString();
 
             if (_exactMatch)
             {
-                WriteStringIfNotNullOrWhiteSpace(writer, JsonProperties.Version, value.Identity.Version?.ToNormalizedString());
+                WriteStringIfNotNullOrWhiteSpace(writer, JsonProperties.Version, version);
             }
             else
             {
-                WriteStringIfNotNullOrWhiteSpace(writer, JsonProperties.LatestVersion, value.Identity.Version?.ToNormalizedString());
+                WriteStringIfNotNullOrWhiteSpace(writer, JsonProperties.LatestVersion, version);
             }
 
             if (_verbosity == PackageSearchVerbosity.Normal || _verbosity == PackageSearchVerbosity.Detailed)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/SearchResultPackagesConverter.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/SearchResultPackagesConverter.cs
@@ -41,16 +41,13 @@ namespace NuGet.CommandLine.XPlat
             writer.WriteStartObject();
             writer.WriteString(JsonProperties.PackageId, value.Identity.Id);
 
-            if (value.Identity.Version is not null)
+            if (_exactMatch)
             {
-                if (_exactMatch)
-                {
-                    writer.WriteString(JsonProperties.Version, value.Identity.Version.ToNormalizedString());
-                }
-                else
-                {
-                    writer.WriteString(JsonProperties.LatestVersion, value.Identity.Version.ToNormalizedString());
-                }
+                WriteStringIsNotNullOrWhiteSpace(writer, JsonProperties.Version, value.Identity.Version?.ToNormalizedString());
+            }
+            else
+            {
+                WriteStringIsNotNullOrWhiteSpace(writer, JsonProperties.LatestVersion, value.Identity.Version?.ToNormalizedString());
             }
 
             if (_verbosity == PackageSearchVerbosity.Normal || _verbosity == PackageSearchVerbosity.Detailed)
@@ -72,17 +69,9 @@ namespace NuGet.CommandLine.XPlat
                     writer.WriteBoolean("vulnerable", true);
                 }
 
-                if (value.ProjectUrl is not null)
-                {
-                    writer.WriteString(JsonProperties.ProjectUrl, value.ProjectUrl.ToString());
-                }
-
+                WriteStringIsNotNullOrWhiteSpace(writer, JsonProperties.ProjectUrl, value.ProjectUrl?.ToString());
                 PackageDeprecationMetadata packageDeprecationMetadata = value.GetDeprecationMetadataAsync().Result;
-
-                if (packageDeprecationMetadata != null)
-                {
-                    writer.WriteString(JsonProperties.Deprecation, packageDeprecationMetadata.Message);
-                }
+                WriteStringIsNotNullOrWhiteSpace(writer, JsonProperties.Deprecation, packageDeprecationMetadata?.Message);
             }
 
             writer.WriteEndObject();

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/SearchResultPackagesConverter.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/SearchResultPackagesConverter.cs
@@ -31,13 +31,16 @@ namespace NuGet.CommandLine.XPlat
             writer.WriteStartObject();
             writer.WriteString(JsonProperties.PackageId, value.Identity.Id);
 
-            if (_exactMatch)
+            if (value.Identity.Version is not null)
             {
-                writer.WriteString(JsonProperties.Version, value.Identity.Version.ToNormalizedString());
-            }
-            else
-            {
-                writer.WriteString(JsonProperties.LatestVersion, value.Identity.Version.ToNormalizedString());
+                if (_exactMatch)
+                {
+                    writer.WriteString(JsonProperties.Version, value.Identity.Version.ToNormalizedString());
+                }
+                else
+                {
+                    writer.WriteString(JsonProperties.LatestVersion, value.Identity.Version.ToNormalizedString());
+                }
             }
 
             if (_verbosity == PackageSearchVerbosity.Normal || _verbosity == PackageSearchVerbosity.Detailed)
@@ -55,14 +58,20 @@ namespace NuGet.CommandLine.XPlat
 
             if (_verbosity == PackageSearchVerbosity.Detailed)
             {
-                writer.WriteString(JsonProperties.Description, value.Description);
+                if (value.Description is not null)
+                {
+                    writer.WriteString(JsonProperties.Description, value.Description);
+                }
 
                 if (value.Vulnerabilities != null && value.Vulnerabilities.Any())
                 {
                     writer.WriteBoolean("vulnerable", true);
                 }
 
-                writer.WriteString(JsonProperties.ProjectUrl, value.ProjectUrl.ToString());
+                if (value.ProjectUrl is not null)
+                {
+                    writer.WriteString(JsonProperties.ProjectUrl, value.ProjectUrl.ToString());
+                }
 
                 PackageDeprecationMetadata packageDeprecationMetadata = value.GetDeprecationMetadataAsync().Result;
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/SearchResultPackagesConverter.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/SearchResultPackagesConverter.cs
@@ -23,6 +23,14 @@ namespace NuGet.CommandLine.XPlat
             _exactMatch = exactMatch;
         }
 
+        internal static void WriteStringIsNotNullOrWhiteSpace(Utf8JsonWriter writer, string name, string? value)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                writer.WriteString(name, value);
+            }
+        }
+
         public override IPackageSearchMetadata Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             throw new NotImplementedException();
@@ -52,18 +60,12 @@ namespace NuGet.CommandLine.XPlat
                     writer.WriteNumber(JsonProperties.DownloadCount, (decimal)value.DownloadCount);
                 }
 
-                if (value.Owners is not null)
-                {
-                    writer.WriteString(JsonProperties.Owners, value.Owners);
-                }
+                WriteStringIsNotNullOrWhiteSpace(writer, JsonProperties.Owners, value.Owners);
             }
 
             if (_verbosity == PackageSearchVerbosity.Detailed)
             {
-                if (value.Description is not null)
-                {
-                    writer.WriteString(JsonProperties.Description, value.Description);
-                }
+                WriteStringIsNotNullOrWhiteSpace(writer, JsonProperties.Description, value.Description);
 
                 if (value.Vulnerabilities != null && value.Vulnerabilities.Any())
                 {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/SearchResultPackagesConverter.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/SearchResultPackagesConverter.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Linq;
 using System.Text.Json;

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
@@ -507,5 +507,107 @@ namespace NuGet.CommandLine.Xplat.Tests
             Assert.Equal(ExitCodes.Success, exitCode);
             Assert.Contains(expectedError, StoredErrorMessage);
         }
+
+        [Fact]
+        public async Task PackageSearchRunner_WhenPackageHasOnlyIdAndVersion_ReturnsValidNormalVerbosityOutput()
+        {
+            // Arrange
+            ISettings settings = Settings.LoadDefaultSettings(
+                Directory.GetCurrentDirectory(),
+                configFileName: null,
+                machineWideSettings: new XPlatMachineWideSetting());
+            PackageSourceProvider sourceProvider = new PackageSourceProvider(settings);
+
+            PackageSearchArgs packageSearchArgs = new()
+            {
+                Skip = 0,
+                Take = 10,
+                Prerelease = true,
+                ExactMatch = false,
+                Logger = GetLogger(),
+                SearchTerm = "NullInfoPackage",
+                Sources = new List<string> { $"{_fixture.ServerWithMultipleEndpoints.Uri}v3/index.json" },
+                Verbosity = PackageSearchVerbosity.Normal,
+                Format = PackageSearchFormat.Json
+            };
+
+            // Act
+            await PackageSearchRunner.RunAsync(
+                sourceProvider: sourceProvider,
+                packageSearchArgs,
+                cancellationToken: System.Threading.CancellationToken.None);
+
+            // Assert
+            string message = _fixture.NormalizeNewlines(Message);
+            Assert.Contains(_fixture.ExpectedSearchResultNullInfoPackage, message);
+        }
+
+        [Fact]
+        public async Task PackageSearchRunner_WhenPackageHasOnlyIdAndVersion_ReturnsValidMinimalVerbosityOutput()
+        {
+            // Arrange
+            ISettings settings = Settings.LoadDefaultSettings(
+                Directory.GetCurrentDirectory(),
+                configFileName: null,
+                machineWideSettings: new XPlatMachineWideSetting());
+            PackageSourceProvider sourceProvider = new PackageSourceProvider(settings);
+
+            PackageSearchArgs packageSearchArgs = new()
+            {
+                Skip = 0,
+                Take = 10,
+                Prerelease = true,
+                ExactMatch = false,
+                Logger = GetLogger(),
+                SearchTerm = "NullInfoPackage",
+                Sources = new List<string> { $"{_fixture.ServerWithMultipleEndpoints.Uri}v3/index.json" },
+                Verbosity = PackageSearchVerbosity.Minimal,
+                Format = PackageSearchFormat.Json
+            };
+
+            // Act
+            await PackageSearchRunner.RunAsync(
+                sourceProvider: sourceProvider,
+                packageSearchArgs,
+                cancellationToken: System.Threading.CancellationToken.None);
+
+            // Assert
+            string message = _fixture.NormalizeNewlines(Message);
+            Assert.Contains(_fixture.ExpectedSearchResultNullInfoPackage, message);
+        }
+
+        [Fact]
+        public async Task PackageSearchRunner_WhenPackageHasOnlyIdAndVersion_ReturnsValidDetailedVerbosityOutput()
+        {
+            // Arrange
+            ISettings settings = Settings.LoadDefaultSettings(
+                Directory.GetCurrentDirectory(),
+                configFileName: null,
+                machineWideSettings: new XPlatMachineWideSetting());
+            PackageSourceProvider sourceProvider = new PackageSourceProvider(settings);
+
+            PackageSearchArgs packageSearchArgs = new()
+            {
+                Skip = 0,
+                Take = 10,
+                Prerelease = true,
+                ExactMatch = false,
+                Logger = GetLogger(),
+                SearchTerm = "NullInfoPackage",
+                Sources = new List<string> { $"{_fixture.ServerWithMultipleEndpoints.Uri}v3/index.json" },
+                Verbosity = PackageSearchVerbosity.Detailed,
+                Format = PackageSearchFormat.Json
+            };
+
+            // Act
+            await PackageSearchRunner.RunAsync(
+                sourceProvider: sourceProvider,
+                packageSearchArgs,
+                cancellationToken: System.Threading.CancellationToken.None);
+
+            // Assert
+            string message = _fixture.NormalizeNewlines(Message);
+            Assert.Contains(_fixture.ExpectedSearchResultNullInfoPackage, message);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
@@ -28,7 +28,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         [InlineData(0, 20, false)]
         [InlineData(5, 10, true)]
         [InlineData(10, 20, false)]
-        public async Task PackageSearchRunner_TableFormatNormalVerbosity_OnePackageTableOutputted(int skip, int take, bool prerelease)
+        public async Task RunAsync_TableFormatNormalVerbosity_OnePackageTableOutputted(int skip, int take, bool prerelease)
         {
             // Arrange
             ISettings settings = Settings.LoadDefaultSettings(
@@ -103,7 +103,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         [InlineData(0, 20, false)]
         [InlineData(5, 10, true)]
         [InlineData(10, 20, false)]
-        public async Task PackageSearchRunner_TableFormatMinimalVerbosity_OnePackageTableOutputted(int skip, int take, bool prerelease)
+        public async Task RunAsync_TableFormatMinimalVerbosity_OnePackageTableOutputted(int skip, int take, bool prerelease)
         {
             // Arrange
             ISettings settings = Settings.LoadDefaultSettings(
@@ -174,7 +174,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         [InlineData(0, 20, false)]
         [InlineData(5, 10, true)]
         [InlineData(10, 20, false)]
-        public async Task PackageSearchRunner_TableFormatDetailedVerbosity_OnePackageTableOutputted(int skip, int take, bool prerelease)
+        public async Task RunAsync_TableFormatDetailedVerbosity_OnePackageTableOutputted(int skip, int take, bool prerelease)
         {
             // Arrange
             ISettings settings = Settings.LoadDefaultSettings(
@@ -246,7 +246,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         [InlineData(0, 20, false)]
         [InlineData(5, 10, true)]
         [InlineData(10, 20, false)]
-        public async Task PackageSearchRunner_JsonFormatNormalVerbosity_OnePackageJsonOutputted(int skip, int take, bool prerelease)
+        public async Task RunAsync_JsonFormatNormalVerbosity_OnePackageJsonOutputted(int skip, int take, bool prerelease)
         {
             // Arrange
             ISettings settings = Settings.LoadDefaultSettings(
@@ -284,7 +284,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         [InlineData(0, 20, false)]
         [InlineData(5, 10, true)]
         [InlineData(10, 20, false)]
-        public async Task PackageSearchRunner_JsonFormatMinimalVerbosity_OnePackageJsonOutputted(int skip, int take, bool prerelease)
+        public async Task RunAync_JsonFormatMinimalVerbosity_OnePackageJsonOutputted(int skip, int take, bool prerelease)
         {
             // Arrange
             ISettings settings = Settings.LoadDefaultSettings(
@@ -322,7 +322,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         [InlineData(0, 20, false)]
         [InlineData(5, 10, true)]
         [InlineData(10, 20, false)]
-        public async Task PackageSearchRunner_JsonFormatDetailedVerbosity_OnePackageJsonOutputted(int skip, int take, bool prerelease)
+        public async Task RunAsync_JsonFormatDetailedVerbosity_OnePackageJsonOutputted(int skip, int take, bool prerelease)
         {
             // Arrange
             ISettings settings = Settings.LoadDefaultSettings(
@@ -356,7 +356,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         }
 
         [Fact]
-        public async Task PackageSearchRunner_ExactMatchOptionEnabled_OnePackageTableOutputted()
+        public async Task RunAsync_ExactMatchOptionEnabled_OnePackageTableOutputted()
         {
             // Arrange
             ISettings settings = Settings.LoadDefaultSettings(
@@ -406,7 +406,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         }
 
         [Fact]
-        public async Task PackageSearchRunner_WhenSourceIsInvalid_ReturnsErrorExitCode()
+        public async Task RunAsync_WhenSourceIsInvalid_ReturnsErrorExitCode()
         {
             // Arrange
             ISettings settings = Settings.LoadDefaultSettings(
@@ -439,7 +439,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         }
 
         [Fact]
-        public async Task PackageSearchRunner_WhenSourceHasNoSearchResource_LogsSearchServiceMissingError()
+        public async Task RunAsync_WhenSourceHasNoSearchResource_LogsSearchServiceMissingError()
         {
             // Arrange
             ISettings settings = Settings.LoadDefaultSettings(
@@ -472,7 +472,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         }
 
         [Fact]
-        public async Task PackageSearchRunner_HandlesOperationCanceledException_WhenCancellationIsRequested()
+        public async Task RunAsync_HandlesOperationCanceledException_WhenCancellationIsRequested()
         {
             // Arrange
             ISettings settings = Settings.LoadDefaultSettings(
@@ -509,7 +509,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         }
 
         [Fact]
-        public async Task PackageSearchRunner_WhenPackageHasOnlyIdAndVersion_ReturnsValidNormalVerbosityOutput()
+        public async Task RunAsync_WhenPackageHasOnlyIdAndVersion_ReturnsValidNormalVerbosityOutput()
         {
             // Arrange
             ISettings settings = Settings.LoadDefaultSettings(
@@ -543,7 +543,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         }
 
         [Fact]
-        public async Task PackageSearchRunner_WhenPackageHasOnlyIdAndVersion_ReturnsValidMinimalVerbosityOutput()
+        public async Task RunAsync_WhenPackageHasOnlyIdAndVersion_ReturnsValidMinimalVerbosityOutput()
         {
             // Arrange
             ISettings settings = Settings.LoadDefaultSettings(
@@ -577,7 +577,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         }
 
         [Fact]
-        public async Task PackageSearchRunner_WhenPackageHasOnlyIdAndVersion_ReturnsValidDetailedVerbosityOutput()
+        public async Task RunAsync_WhenPackageHasOnlyIdAndVersion_ReturnsValidDetailedVerbosityOutput()
         {
             // Arrange
             ISettings settings = Settings.LoadDefaultSettings(

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchRunnerTests.cs
@@ -284,7 +284,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         [InlineData(0, 20, false)]
         [InlineData(5, 10, true)]
         [InlineData(10, 20, false)]
-        public async Task RunAync_JsonFormatMinimalVerbosity_OnePackageJsonOutputted(int skip, int take, bool prerelease)
+        public async Task RunAsync_JsonFormatMinimalVerbosity_OnePackageJsonOutputted(int skip, int take, bool prerelease)
         {
             // Arrange
             ISettings settings = Settings.LoadDefaultSettings(


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug 

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13300
Fixes: https://github.com/NuGet/Client.Engineering/issues/2728

Regression? Last working version: 8.0.2

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

This PR makes sure any null package metadata is handled before rendered. Metadata `id` is not handled because it is required not to be null but the rest could be null.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
