### PR TITLE
Enable publishing in VMR

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -179,6 +179,7 @@
       <_allowBuildFromSourcePackage Include="Microsoft.Build.Utilities.Core" />
       <_allowBuildFromSourcePackage Include="Microsoft.Build" />
       <_allowBuildFromSourcePackage Include="Microsoft.CSharp" />
+      <_allowBuildFromSourcePackage Include="Microsoft.DotNet.Build.Tasks.Feed" />
       <_allowBuildFromSourcePackage Include="Microsoft.Extensions.CommandLineUtils.Sources" />
       <_allowBuildFromSourcePackage Include="Microsoft.Extensions.FileProviders.Abstractions" />
       <_allowBuildFromSourcePackage Include="Microsoft.Extensions.FileSystemGlobbing" />

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <PublishingVersion>3</PublishingVersion>
+    <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
+    <PublishDependsOnTargets>$(PublishDependsOnTargets);_PublishPackages</PublishDependsOnTargets>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <_PackagesToPublish Remove="@(_PackagesToPublish)" />
+    <_PackagesToPublish Include="$(ArtifactsDir)nupkgs/*.nupkg" UploadPathSegment="nuget-client" Condition="'$(DotNetBuildFromSource)' == 'true'" />
+    <_SymbolsPackages Include="$(ArtifactsDir)nupkgs/*.symbols.nupkg" />
+    <_PackagesToPublish Remove="@(_SymbolsPackages)" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
+  </ItemGroup>
+
+  <Target Name="_PublishPackages">
+    <ItemGroup>
+      <!-- Do not push .nupkg files from Linux and macOS builds. They'll be packed up separately and signed on Windows.
+           Do not remove if post build sign is true, as we avoid the xplat codesign jobs, and need to have
+           the nupkgs pushed. Do not do this if building from source, since we want the source build intermediate package
+           to be published. Use DotNetBuildRepo as DotNetBuildFromSource is only set in the internal source build,
+           and Build.proj is invoked from the wrapper build. -->
+      <ItemsToPushToBlobFeed Remove="@(ItemsToPushToBlobFeed)" Condition="'$(OS)' != 'Windows_NT' and '$(PostBuildSign)' != 'true' and '$(DotNetBuildRepo)' != 'true'" />
+
+      <ItemsToPushToBlobFeed Include="@(_PackagesToPublish)">
+        <IsShipping>true</IsShipping>
+      </ItemsToPushToBlobFeed>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,31 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <PublishingVersion>3</PublishingVersion>
     <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
-    <PublishDependsOnTargets>$(PublishDependsOnTargets);_PublishPackages</PublishDependsOnTargets>
   </PropertyGroup>
 
   <ItemGroup>
-    <_PackagesToPublish Remove="@(_PackagesToPublish)" />
-    <_PackagesToPublish Include="$(ArtifactsDir)nupkgs/*.nupkg" UploadPathSegment="nuget-client" Condition="'$(DotNetBuildFromSource)' == 'true'" />
+    <ItemsToPushToBlobFeed Include="$(ArtifactsDir)nupkgs/*.nupkg"
+                           IsShipping="true"
+                           UploadPathSegment="nuget-client" />
     <_SymbolsPackages Include="$(ArtifactsDir)nupkgs/*.symbols.nupkg" />
-    <_PackagesToPublish Remove="@(_SymbolsPackages)" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
+    <ItemsToPushToBlobFeed Remove="@(_SymbolsPackages)" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
   </ItemGroup>
-
-  <Target Name="_PublishPackages">
-    <ItemGroup>
-      <!-- Do not push .nupkg files from Linux and macOS builds. They'll be packed up separately and signed on Windows.
-           Do not remove if post build sign is true, as we avoid the xplat codesign jobs, and need to have
-           the nupkgs pushed. Do not do this if building from source, since we want the source build intermediate package
-           to be published. Use DotNetBuildRepo as DotNetBuildFromSource is only set in the internal source build,
-           and Build.proj is invoked from the wrapper build. -->
-      <ItemsToPushToBlobFeed Remove="@(ItemsToPushToBlobFeed)" Condition="'$(OS)' != 'Windows_NT' and '$(PostBuildSign)' != 'true' and '$(DotNetBuildRepo)' != 'true'" />
-
-      <ItemsToPushToBlobFeed Include="@(_PackagesToPublish)">
-        <IsShipping>true</IsShipping>
-      </ItemsToPushToBlobFeed>
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,7 +1,4 @@
 <Project>
-  <PropertyGroup>
-    <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
-  </PropertyGroup>
 
   <ItemGroup>
     <ItemsToPushToBlobFeed Include="$(ArtifactsDir)nupkgs/*.nupkg"

--- a/eng/source-build/source-build.proj
+++ b/eng/source-build/source-build.proj
@@ -62,6 +62,41 @@
              Properties="Configuration=$(BuildConfiguration);DotNetBuildFromSource=true"
              Targets="PackXPlat" />
 
+    <ItemGroup>
+      <_AfterSourceBuildProperties Include="_NETCORE_ENGINEERING_TELEMETRY=AfterSourceBuild" />
+      <_AfterSourceBuildProperties Include="ArcadeBuildFromSource=true"/>
+      <_AfterSourceBuildProperties Include="ArcadeInnerBuildFromSource=true"/>
+    </ItemGroup>
+
+    <MSbuild Projects="$(ArcadeDir)/SourceBuild/AfterSourceBuild.proj"
+             Properties="@(_AfterSourceBuildProperties)"
+            />
+
+    <ItemGroup>
+      <_PublishProperties Include="_NETCORE_ENGINEERING_TELEMETRY=Publish" />
+      <_PublishProperties Include="Configuration=$(Configuration)" />
+      <_PublishProperties Include="ArcadeBuildFromSource=$(ArcadeBuildFromSource)" />
+      <_PublishProperties Include="ArcadeInnerBuildFromSource=true" />
+      <_PublishProperties Include="DotNetBuildFromSource=$(DotNetBuildFromSource)" />
+      <_PublishProperties Include="DotNetBuildFromSourceFlavor=$(DotNetBuildFromSourceFlavor)" />
+      <_PublishProperties Include="DotNetBuildInnerRepo=true" />
+      <_PublishProperties Include="DotNetBuildOrchestrator=$(DotNetBuildOrchestrator)" />
+      <_PublishProperties Include="DotNetBuildPhase=InnerRepo" />
+      <_PublishProperties Include="DotNetBuildRepo=$(DotNetBuildRepo)" />
+      <_PublishProperties Include="DotNetBuildSourceOnly=$(DotNetBuildSourceOnly)" />
+      <_PublishProperties Include="DotNetPublishUsingPipelines=true" />
+      <_PublishProperties Include="PublishToSymbolServer=false" />
+      <_PublishProperties Include="AssetsLocalStorageDir=$(SourceBuiltAssetsDir)" />
+      <_PublishProperties Include="ShippingPackagesLocalStorageDir=$(SourceBuiltShippingPackagesDir)" />
+      <_PublishProperties Include="NonShippingPackagesLocalStorageDir=$(SourceBuiltNonShippingPackagesDir)" />
+      <_PublishProperties Include="AssetManifestsLocalStorageDir=$(SourceBuiltAssetManifestsDir)" />
+    </ItemGroup>
+
+    <MSBuild Projects="$(ArcadeDir)Publish.proj"
+             Properties="@(_PublishProperties)"
+             Targets="Publish"
+             Condition="'$(DotNetBuildOrchestrator)' == 'true'" />
+
   </Target>
 
   <Target Name="ApplySourceBuildPatchFiles">

--- a/eng/source-build/source-build.proj
+++ b/eng/source-build/source-build.proj
@@ -62,7 +62,7 @@
              Properties="Configuration=$(BuildConfiguration);DotNetBuildFromSource=true"
              Targets="PackXPlat" />
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(DotNetBuildOrchestrator)' == 'true'">
       <_AfterSourceBuildProperties Include="_NETCORE_ENGINEERING_TELEMETRY=AfterSourceBuild" />
       <_AfterSourceBuildProperties Include="ArcadeBuildFromSource=true"/>
       <_AfterSourceBuildProperties Include="ArcadeInnerBuildFromSource=true"/>
@@ -70,9 +70,9 @@
 
     <MSbuild Projects="$(ArcadeDir)/SourceBuild/AfterSourceBuild.proj"
              Properties="@(_AfterSourceBuildProperties)"
-            />
+             Condition="'$(DotNetBuildOrchestrator)' == 'true'" />
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(DotNetBuildOrchestrator)' == 'true'">
       <_PublishProperties Include="_NETCORE_ENGINEERING_TELEMETRY=Publish" />
       <_PublishProperties Include="Configuration=$(Configuration)" />
       <_PublishProperties Include="ArcadeBuildFromSource=$(ArcadeBuildFromSource)" />


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/4101

Enables publishing in VMR.

NuGet.Client repo creates packages in locations that aren't collected by common publishing infra in arcade. We need to collect them here.

Also, this repo doesn't use arcade infra, therefore we need to explicitly run the `Publish.proj`.