### PR TITLE
Allow HTTPS sources that have SSL certificate problems

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSourcesService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSourcesService.cs
@@ -94,6 +94,7 @@ namespace NuGet.PackageManagement.VisualStudio
                         && packageSource.Source.Equals(packageSourceContextInfo.Source, StringComparison.InvariantCulture)
                         && packageSource.ProtocolVersion == packageSourceContextInfo.ProtocolVersion
                         && packageSource.AllowInsecureConnections == packageSourceContextInfo.AllowInsecureConnections
+                        && packageSource.DisableTLSCertificateValidation == packageSourceContextInfo.DisableTLSCertificateValidation
                         && packageSource.IsEnabled == packageSourceContextInfo.IsEnabled)
                     {
                         newPackageSources.Add(packageSource);
@@ -113,6 +114,7 @@ namespace NuGet.PackageManagement.VisualStudio
                             Description = packageSource.Description,
                             ProtocolVersion = packageSourceContextInfo.ProtocolVersion,
                             AllowInsecureConnections = packageSourceContextInfo.AllowInsecureConnections,
+                            DisableTLSCertificateValidation = packageSourceContextInfo.DisableTLSCertificateValidation,
                             MaxHttpRequestsPerSource = packageSource.MaxHttpRequestsPerSource,
                         };
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSourceContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSourceContextInfo.cs
@@ -33,6 +33,11 @@ namespace NuGet.VisualStudio.Internal.Contracts
         }
 
         public PackageSourceContextInfo(string source, string name, bool isEnabled, int protocolVersion, bool allowInsecureConnections)
+            : this(source, name, isEnabled, protocolVersion, allowInsecureConnections, disableTLSCertificateValidation: false)
+        {
+        }
+
+        public PackageSourceContextInfo(string source, string name, bool isEnabled, int protocolVersion, bool allowInsecureConnections, bool disableTLSCertificateValidation)
         {
             Assumes.NotNullOrEmpty(name);
             Assumes.NotNullOrEmpty(source);
@@ -42,12 +47,14 @@ namespace NuGet.VisualStudio.Internal.Contracts
             IsEnabled = isEnabled;
             ProtocolVersion = protocolVersion;
             AllowInsecureConnections = allowInsecureConnections;
+            DisableTLSCertificateValidation = disableTLSCertificateValidation;
 
             var hash = new HashCodeCombiner();
             hash.AddStringIgnoreCase(Name);
             hash.AddStringIgnoreCase(Source);
             hash.AddObject(ProtocolVersion);
             hash.AddObject(AllowInsecureConnections);
+            hash.AddObject(DisableTLSCertificateValidation);
             _hashCode = hash.CombinedHash;
             OriginalHashCode = _hashCode;
         }
@@ -56,6 +63,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         public string Source { get; set; }
         public int ProtocolVersion { get; set; }
         public bool AllowInsecureConnections { get; set; }
+        public bool DisableTLSCertificateValidation { get; set; }
         public bool IsMachineWide { get; internal set; }
         public bool IsEnabled { get; set; }
         public string? Description { get; internal set; }
@@ -94,7 +102,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         public PackageSourceContextInfo Clone()
         {
-            return new PackageSourceContextInfo(Source, Name, IsEnabled, ProtocolVersion, AllowInsecureConnections)
+            return new PackageSourceContextInfo(Source, Name, IsEnabled, ProtocolVersion, AllowInsecureConnections, DisableTLSCertificateValidation)
             {
                 IsMachineWide = IsMachineWide,
                 Description = Description,
@@ -104,7 +112,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         public static PackageSourceContextInfo Create(PackageSource packageSource)
         {
-            return new PackageSourceContextInfo(packageSource.Source, packageSource.Name, packageSource.IsEnabled, packageSource.ProtocolVersion, packageSource.AllowInsecureConnections)
+            return new PackageSourceContextInfo(packageSource.Source, packageSource.Name, packageSource.IsEnabled, packageSource.ProtocolVersion, packageSource.AllowInsecureConnections, packageSource.DisableTLSCertificateValidation)
             {
                 IsMachineWide = packageSource.IsMachineWide,
                 Description = packageSource.Description,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceContextInfoFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/PackageSourceContextInfoFormatter.cs
@@ -14,6 +14,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         private const string IsEnabledPropertyName = "isenabled";
         private const string ProtocolVersionPropertyName = "protocolversion";
         private const string AllowInsecureConnectionsPropertyName = "allowInsecureConnections";
+        private const string DisableTLSCertificateValidationPropertyName = "disableTLSCertificateValidation";
         private const string IsMachineWidePropertyName = "ismachinewide";
         private const string NamePropertyName = "name";
         private const string DescriptionPropertyName = "description";
@@ -35,6 +36,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             int originalHashCode = 0;
             int protocolVersion = PackageSource.DefaultProtocolVersion;
             bool allowInsecureConnections = false;
+            bool disableTLSCertificateValidation = false;
 
             int propertyCount = reader.ReadMapHeader();
             for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
@@ -65,6 +67,9 @@ namespace NuGet.VisualStudio.Internal.Contracts
                     case AllowInsecureConnectionsPropertyName:
                         allowInsecureConnections = reader.ReadBoolean();
                         break;
+                    case DisableTLSCertificateValidationPropertyName:
+                        disableTLSCertificateValidation = reader.ReadBoolean();
+                        break;
                     default:
                         reader.Skip();
                         break;
@@ -74,7 +79,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             Assumes.NotNullOrEmpty(source);
             Assumes.NotNullOrEmpty(name);
 
-            return new PackageSourceContextInfo(source, name, isEnabled, protocolVersion, allowInsecureConnections)
+            return new PackageSourceContextInfo(source, name, isEnabled, protocolVersion, allowInsecureConnections, disableTLSCertificateValidation)
             {
                 IsMachineWide = isMachineWide,
                 Description = description,
@@ -84,13 +89,15 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         protected override void SerializeCore(ref MessagePackWriter writer, PackageSourceContextInfo value, MessagePackSerializerOptions options)
         {
-            writer.WriteMapHeader(count: 8);
+            writer.WriteMapHeader(count: 9);
             writer.Write(SourcePropertyName);
             writer.Write(value.Source);
             writer.Write(ProtocolVersionPropertyName);
             writer.Write(value.ProtocolVersion);
             writer.Write(AllowInsecureConnectionsPropertyName);
             writer.Write(value.AllowInsecureConnections);
+            writer.Write(DisableTLSCertificateValidationPropertyName);
+            writer.Write(value.DisableTLSCertificateValidation);
             writer.Write(IsEnabledPropertyName);
             writer.Write(value.IsEnabled);
             writer.Write(IsMachineWidePropertyName);

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -19,6 +19,7 @@ namespace NuGet.Configuration
         public const int MaxProtocolVersion = 3;
 
         internal const bool DefaultAllowInsecureConnections = false;
+        internal const bool DefaultDisableTLSCertificateValidation = false;
 
         private int _hashCode;
         private string _source;
@@ -107,6 +108,11 @@ namespace NuGet.Configuration
         /// </summary>
         public bool AllowInsecureConnections { get; set; } = DefaultAllowInsecureConnections;
 
+        ///<summary>
+        /// Gets or sets disableTLSCertificateValidation of the source. Defaults to false.
+        ///</summary>
+        public bool DisableTLSCertificateValidation { get; set; } = DefaultDisableTLSCertificateValidation;
+
         /// <summary>
         /// Whether the source is using the HTTP protocol, including HTTPS.
         /// </summary>
@@ -160,11 +166,16 @@ namespace NuGet.Configuration
             }
 
             string? allowInsecureConnections = null;
+            string? disableTLSCertificateValidation = null;
             if (AllowInsecureConnections != DefaultAllowInsecureConnections)
             {
                 allowInsecureConnections = $"{AllowInsecureConnections}";
             }
-            return new SourceItem(Name, Source, protocolVersion, allowInsecureConnections);
+            if (DisableTLSCertificateValidation != DefaultDisableTLSCertificateValidation)
+            {
+                disableTLSCertificateValidation = $"{DisableTLSCertificateValidation}";
+            }
+            return new SourceItem(Name, Source, protocolVersion, allowInsecureConnections, disableTLSCertificateValidation);
         }
 
         public bool Equals(PackageSource? other)
@@ -202,6 +213,7 @@ namespace NuGet.Configuration
                 IsMachineWide = IsMachineWide,
                 ProtocolVersion = ProtocolVersion,
                 AllowInsecureConnections = AllowInsecureConnections,
+                DisableTLSCertificateValidation = DisableTLSCertificateValidation,
             };
         }
     }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -244,6 +244,7 @@ namespace NuGet.Configuration
 
             packageSource.ProtocolVersion = ReadProtocolVersion(setting);
             packageSource.AllowInsecureConnections = ReadAllowInsecureConnections(setting);
+            packageSource.DisableTLSCertificateValidation = ReadDisableTLSCertificateValidation(setting);
 
             return packageSource;
         }
@@ -256,6 +257,16 @@ namespace NuGet.Configuration
             }
 
             return PackageSource.DefaultProtocolVersion;
+        }
+
+        private static bool ReadDisableTLSCertificateValidation(SourceItem setting)
+        {
+            if (bool.TryParse(setting.DisableTLSCertificateValidation, out var disableTLSCertificateValidation))
+            {
+                return disableTLSCertificateValidation;
+            }
+
+            return PackageSource.DefaultDisableTLSCertificateValidation;
         }
 
         private static bool ReadAllowInsecureConnections(SourceItem setting)

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -1,21 +1,4 @@
 #nullable enable
-NuGet.Configuration.ConfigurationDefaults.DefaultAuditSources.get -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSource!>!
-NuGet.Configuration.IPackageSourceProvider.LoadAuditSources() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSource!>!
-NuGet.Configuration.NuGetPathContext.FallbackPackageFolders.init -> void
-NuGet.Configuration.NuGetPathContext.HttpCacheFolder.init -> void
-NuGet.Configuration.NuGetPathContext.UserPackageFolder.init -> void
-NuGet.Configuration.PackageSourceProvider.LoadAuditSources() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSource!>!
-NuGet.Configuration.PackageSourceProvider.PackageSourceProvider(NuGet.Configuration.ISettings! settings, NuGet.Configuration.ConfigurationDefaults! configurationDefaults) -> void
-NuGet.Configuration.PackageSourceProvider.PackageSourceProvider(NuGet.Configuration.ISettings! settings, NuGet.Configuration.ConfigurationDefaults! configurationDefaults, bool enablePackageSourcesChangedEvent) -> void
-NuGet.Configuration.SettingElementType.AuditSources = 20 -> NuGet.Configuration.SettingElementType
-NuGet.Configuration.SettingElement.ConfigPath.get -> string?
-NuGet.Configuration.SettingItem.GetAttributes() -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
-NuGet.Configuration.Settings.GetAllSettingSections() -> System.Collections.Generic.IEnumerable<string!>!
-NuGet.Configuration.SettingsGroup<T>.SettingsGroup(string! name) -> void
-NuGet.Configuration.SettingsGroup<T>.SettingsGroup(string! name, System.Collections.Generic.IReadOnlyDictionary<string!, string!>? attributes, System.Collections.Generic.IEnumerable<T!>? children) -> void
-override NuGet.Configuration.SettingsGroup<T>.ElementName.get -> string!
-static NuGet.Configuration.ConfigurationConstants.GetConfigKeys() -> System.Collections.Generic.IReadOnlyList<string!>!
-static readonly NuGet.Configuration.ConfigurationConstants.AuditSources -> string!
 NuGet.Configuration.PackageSource.DisableTLSCertificateValidation.get -> bool
 NuGet.Configuration.PackageSource.DisableTLSCertificateValidation.set -> void
 NuGet.Configuration.SourceItem.DisableTLSCertificateValidation.get -> string?

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -1,1 +1,24 @@
 #nullable enable
+NuGet.Configuration.ConfigurationDefaults.DefaultAuditSources.get -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSource!>!
+NuGet.Configuration.IPackageSourceProvider.LoadAuditSources() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSource!>!
+NuGet.Configuration.NuGetPathContext.FallbackPackageFolders.init -> void
+NuGet.Configuration.NuGetPathContext.HttpCacheFolder.init -> void
+NuGet.Configuration.NuGetPathContext.UserPackageFolder.init -> void
+NuGet.Configuration.PackageSourceProvider.LoadAuditSources() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSource!>!
+NuGet.Configuration.PackageSourceProvider.PackageSourceProvider(NuGet.Configuration.ISettings! settings, NuGet.Configuration.ConfigurationDefaults! configurationDefaults) -> void
+NuGet.Configuration.PackageSourceProvider.PackageSourceProvider(NuGet.Configuration.ISettings! settings, NuGet.Configuration.ConfigurationDefaults! configurationDefaults, bool enablePackageSourcesChangedEvent) -> void
+NuGet.Configuration.SettingElementType.AuditSources = 20 -> NuGet.Configuration.SettingElementType
+NuGet.Configuration.SettingElement.ConfigPath.get -> string?
+NuGet.Configuration.SettingItem.GetAttributes() -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+NuGet.Configuration.Settings.GetAllSettingSections() -> System.Collections.Generic.IEnumerable<string!>!
+NuGet.Configuration.SettingsGroup<T>.SettingsGroup(string! name) -> void
+NuGet.Configuration.SettingsGroup<T>.SettingsGroup(string! name, System.Collections.Generic.IReadOnlyDictionary<string!, string!>? attributes, System.Collections.Generic.IEnumerable<T!>? children) -> void
+override NuGet.Configuration.SettingsGroup<T>.ElementName.get -> string!
+static NuGet.Configuration.ConfigurationConstants.GetConfigKeys() -> System.Collections.Generic.IReadOnlyList<string!>!
+static readonly NuGet.Configuration.ConfigurationConstants.AuditSources -> string!
+NuGet.Configuration.PackageSource.DisableTLSCertificateValidation.get -> bool
+NuGet.Configuration.PackageSource.DisableTLSCertificateValidation.set -> void
+~NuGet.Configuration.SourceItem.DisableTLSCertificateValidation.get -> string
+~NuGet.Configuration.SourceItem.DisableTLSCertificateValidation.set -> void
+~NuGet.Configuration.SourceItem.SourceItem(string key, string value, string protocolVersion, string allowInsecureConnections, string disableTLSCertificateValidation) -> void
+~static readonly NuGet.Configuration.ConfigurationConstants.DisableTLSCertificateValidation -> string

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -18,7 +18,7 @@ static NuGet.Configuration.ConfigurationConstants.GetConfigKeys() -> System.Coll
 static readonly NuGet.Configuration.ConfigurationConstants.AuditSources -> string!
 NuGet.Configuration.PackageSource.DisableTLSCertificateValidation.get -> bool
 NuGet.Configuration.PackageSource.DisableTLSCertificateValidation.set -> void
-~NuGet.Configuration.SourceItem.DisableTLSCertificateValidation.get -> string
-~NuGet.Configuration.SourceItem.DisableTLSCertificateValidation.set -> void
-~NuGet.Configuration.SourceItem.SourceItem(string key, string value, string protocolVersion, string allowInsecureConnections, string disableTLSCertificateValidation) -> void
-~static readonly NuGet.Configuration.ConfigurationConstants.DisableTLSCertificateValidation -> string
+NuGet.Configuration.SourceItem.DisableTLSCertificateValidation.get -> string?
+NuGet.Configuration.SourceItem.DisableTLSCertificateValidation.set -> void
+NuGet.Configuration.SourceItem.SourceItem(string! key, string! value, string? protocolVersion, string? allowInsecureConnections, string? disableTLSCertificateValidation) -> void
+static readonly NuGet.Configuration.ConfigurationConstants.DisableTLSCertificateValidation -> string!

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
@@ -35,8 +35,22 @@ namespace NuGet.Configuration
             set => AddOrUpdateAttribute(ConfigurationConstants.AllowInsecureConnections, value);
         }
 
+        public string DisableTLSCertificateValidation
+        {
+            get
+            {
+                if (Attributes.TryGetValue(ConfigurationConstants.DisableTLSCertificateValidation, out var attribute))
+                {
+                    return Settings.ApplyEnvironmentTransform(attribute);
+                }
+
+                return null;
+            }
+            set => AddOrUpdateAttribute(ConfigurationConstants.DisableTLSCertificateValidation, value);
+        }
+
         public SourceItem(string key, string value)
-            : this(key, value, protocolVersion: "", allowInsecureConnections: "")
+            : this(key, value, protocolVersion: "", allowInsecureConnections: "", disableTLSCertificateValidation: "")
         {
         }
 
@@ -46,6 +60,17 @@ namespace NuGet.Configuration
         }
 
         public SourceItem(string key, string value, string? protocolVersion, string? allowInsecureConnections)
+        public SourceItem(string key, string value, string protocolVersion)
+            : this(key, value, protocolVersion, allowInsecureConnections: "", disableTLSCertificateValidation: "")
+        {
+        }
+
+        public SourceItem(string key, string value, string protocolVersion, string allowInsecureConnections)
+            : this(key, value, protocolVersion, allowInsecureConnections, disableTLSCertificateValidation: "")
+        {
+        }
+
+        public SourceItem(string key, string value, string protocolVersion, string allowInsecureConnections, string disableTLSCertificateValidation)
             : base(key, value)
         {
             if (!string.IsNullOrEmpty(protocolVersion))
@@ -56,6 +81,10 @@ namespace NuGet.Configuration
             {
                 AllowInsecureConnections = allowInsecureConnections;
             }
+            if (!string.IsNullOrEmpty(disableTLSCertificateValidation))
+            {
+                DisableTLSCertificateValidation = disableTLSCertificateValidation;
+            }
         }
 
         internal SourceItem(XElement element, SettingsFile origin)
@@ -65,7 +94,7 @@ namespace NuGet.Configuration
 
         public override SettingBase Clone()
         {
-            var newSetting = new SourceItem(Key, Value, ProtocolVersion, AllowInsecureConnections);
+            var newSetting = new SourceItem(Key, Value, ProtocolVersion, AllowInsecureConnections, DisableTLSCertificateValidation);
 
             if (Origin != null)
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
@@ -35,7 +35,7 @@ namespace NuGet.Configuration
             set => AddOrUpdateAttribute(ConfigurationConstants.AllowInsecureConnections, value);
         }
 
-        public string DisableTLSCertificateValidation
+        public string? DisableTLSCertificateValidation
         {
             get
             {
@@ -55,22 +55,16 @@ namespace NuGet.Configuration
         }
 
         public SourceItem(string key, string value, string? protocolVersion)
-            : this(key, value, protocolVersion, allowInsecureConnections: "")
-        {
-        }
-
-        public SourceItem(string key, string value, string? protocolVersion, string? allowInsecureConnections)
-        public SourceItem(string key, string value, string protocolVersion)
             : this(key, value, protocolVersion, allowInsecureConnections: "", disableTLSCertificateValidation: "")
         {
         }
 
-        public SourceItem(string key, string value, string protocolVersion, string allowInsecureConnections)
+        public SourceItem(string key, string value, string? protocolVersion, string? allowInsecureConnections)
             : this(key, value, protocolVersion, allowInsecureConnections, disableTLSCertificateValidation: "")
         {
         }
 
-        public SourceItem(string key, string value, string protocolVersion, string allowInsecureConnections, string disableTLSCertificateValidation)
+        public SourceItem(string key, string value, string? protocolVersion, string? allowInsecureConnections, string? disableTLSCertificateValidation)
             : base(key, value)
         {
             if (!string.IsNullOrEmpty(protocolVersion))

--- a/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -53,6 +53,8 @@ namespace NuGet.Configuration
 
         public static readonly string DisabledPackageSources = "disabledPackageSources";
 
+        public static readonly string DisableTLSCertificateValidation = "disableTLSCertificateValidation";
+
         public static readonly string DoNotShowPackageManagementSelectionKey = "disabled";
 
         public static readonly string Enabled = "enabled";

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSourceContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSourceContextInfoFormatterTests.cs
@@ -19,6 +19,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
 
         public static TheoryData TestData => new TheoryData<PackageSourceContextInfo>
             {
+                { new PackageSourceContextInfo("source", "name", isEnabled: true, protocolVersion: 3, allowInsecureConnections: true, disableTLSCertificateValidation: true) },
                 { new PackageSourceContextInfo("source", "name", isEnabled: true, protocolVersion: 3, allowInsecureConnections: true) },
                 { new PackageSourceContextInfo("source", "name", isEnabled: true, protocolVersion: 3) },
                 { new PackageSourceContextInfo("source", "name", isEnabled: true) },

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTLSCertificateValidationTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTLSCertificateValidationTests.cs
@@ -1,0 +1,146 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading.Tasks;
+using NuGet.Packaging;
+using NuGet.Test.Utility;
+using NuGet.XPlat.FuncTest;
+using Test.Utility;
+using Xunit;
+
+namespace Dotnet.Integration.Test
+{
+    [Collection(DotnetIntegrationCollection.Name)]
+    public class DotnetRestoreTLSCertificateValidationTests
+    {
+        private readonly DotnetIntegrationTestFixture _msbuildFixture;
+
+        public DotnetRestoreTLSCertificateValidationTests(DotnetIntegrationTestFixture fixture)
+        {
+            _msbuildFixture = fixture;
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task DotnetRestore_withTLSCertificateValidationDisabled_DoesnotThrowException()
+        {
+            // Arrange
+            using var pathContext = _msbuildFixture.CreateSimpleTestPathContext();
+            var packageA100 = new SimpleTestPackageContext("A", "1.0.0");
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageA100);
+            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, packageA100, "net472");
+            var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectA.ProjectName);
+            SelfSignedCertificateMockServer tcpListenerServer = new SelfSignedCertificateMockServer(pathContext.PackageSource);
+            var serverTask = tcpListenerServer.StartServerAsync();
+            var configFile = @$"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+        <add key=""source1"" value=""{tcpListenerServer.URI}v3/index.json"" disableTLSCertificateValidation=""true""/>
+    </packageSources>
+</configuration>
+";
+
+            // Act & Assert
+            File.WriteAllText(Path.Combine(workingDirectory, "NuGet.Config"), configFile);
+            _msbuildFixture.RunDotnetExpectSuccess(workingDirectory, $"restore {projectA.ProjectName}.csproj --configfile ./NuGet.config");
+            tcpListenerServer.StopServer();
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task DotnetRestore_withTLSCertificateValidationEnabled_ThrowException()
+        {
+            // Arrange
+            using var pathContext = _msbuildFixture.CreateSimpleTestPathContext();
+            var packageB100 = new SimpleTestPackageContext("myPackg", "1.0.0");
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageB100);
+            var projectB = XPlatTestUtils.CreateProject("ProjectB", pathContext, packageB100, "net472");
+            var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectB.ProjectName);
+            SelfSignedCertificateMockServer tcpListenerServer = new SelfSignedCertificateMockServer(pathContext.PackageSource);
+            var serverTask = tcpListenerServer.StartServerAsync();
+            var configFile = @$"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+        <add key=""source1"" value=""{tcpListenerServer.URI}v3/index.json""/>
+    </packageSources>
+</configuration>
+";
+            File.WriteAllText(Path.Combine(workingDirectory, "NuGet.Config"), configFile);
+
+            // Act & Assert
+            var _result = _msbuildFixture.RunDotnetExpectFailure(workingDirectory, $"restore {projectB.ProjectName}.csproj --configfile ./NuGet.config");
+            Assert.Contains("SSL connection could not be established", _result.AllOutput);
+            tcpListenerServer.StopServer();
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task DotnetRestore_withAnotherSourceTLSCertificateValidationDisbaled_ThrowException()
+        {
+            // Arrange
+            using var pathContext = _msbuildFixture.CreateSimpleTestPathContext();
+            var packageB100 = new SimpleTestPackageContext("myPackg", "1.0.0");
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageB100);
+            var projectB = XPlatTestUtils.CreateProject("ProjectB", pathContext, packageB100, "net472");
+            var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectB.ProjectName);
+            SelfSignedCertificateMockServer tcpListenerServer1 = new SelfSignedCertificateMockServer(pathContext.PackageSource);
+            SelfSignedCertificateMockServer tcpListenerServer2 = new SelfSignedCertificateMockServer(pathContext.PackageSource);
+            var serverTask = tcpListenerServer1.StartServerAsync();
+            var serverTask2 = tcpListenerServer2.StartServerAsync();
+            var configFile = @$"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+        <add key=""source1"" value=""{tcpListenerServer1.URI}v3/index.json""/>
+        <add key=""source2"" value=""{tcpListenerServer2.URI}v3/index.json"" disableTLSCertificateValidation=""true""/>
+    </packageSources>
+</configuration>
+";
+            File.WriteAllText(Path.Combine(workingDirectory, "NuGet.Config"), configFile);
+
+            // Act & Assert
+            var _result = _msbuildFixture.RunDotnetExpectFailure(workingDirectory, $"restore {projectB.ProjectName}.csproj --configfile ./NuGet.config");
+            Assert.Contains("SSL connection could not be established", _result.AllOutput);
+            tcpListenerServer1.StopServer();
+            tcpListenerServer2.StopServer();
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task DotnetRestore_withAnotherSourceTLSCertificateValidationEnabled_DoesNotThrowException()
+        {
+            // Arrange
+            using var pathContext = _msbuildFixture.CreateSimpleTestPathContext();
+            var packageB100 = new SimpleTestPackageContext("myPackg", "1.0.0");
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageB100);
+            var projectB = XPlatTestUtils.CreateProject("ProjectB", pathContext, packageB100, "net472");
+            var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectB.ProjectName);
+            SelfSignedCertificateMockServer tcpListenerServer1 = new SelfSignedCertificateMockServer(pathContext.PackageSource);
+            SelfSignedCertificateMockServer tcpListenerServer2 = new SelfSignedCertificateMockServer(pathContext.PackageSource);
+            var serverTask = tcpListenerServer1.StartServerAsync();
+            var serverTask2 = tcpListenerServer2.StartServerAsync();
+            var configFile = @$"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+        <add key=""source1"" value=""{tcpListenerServer1.URI}v3/index.json""/>
+        <add key=""source2"" value=""{tcpListenerServer2.URI}v3/index.json"" disableTLSCertificateValidation=""true""/>
+    </packageSources>
+</configuration>
+";
+            File.WriteAllText(Path.Combine(workingDirectory, "NuGet.Config"), configFile);
+
+            // Act & Assert
+            var _result = _msbuildFixture.RunDotnetExpectSuccess(workingDirectory, $"restore {projectB.ProjectName}.csproj --configfile ./NuGet.config --source {tcpListenerServer2.URI}v3/index.json");
+            tcpListenerServer1.StopServer();
+            tcpListenerServer2.StopServer();
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -888,6 +888,88 @@ namespace NuGet.Configuration.Test
             Assert.Equal(bool.Parse(allowInsecureConnections), loadedSource.AllowInsecureConnections);
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LoadPackageSources_ReadsSourcesWithNullDisableTLSCertificateVerificationFromPackageSourceSections_LoadsDefault(bool useStaticMethod)
+        {
+            // Arrange
+            var settings = new Mock<ISettings>();
+            var sourceItem = new SourceItem("Source", "https://some-source.test", protocolVersion: null, allowInsecureConnections: null, disableTLSCertificateValidation: null);
+
+            settings.Setup(s => s.GetSection("packageSources"))
+                .Returns(new VirtualSettingSection("packageSources",
+                    sourceItem));
+
+            settings.Setup(s => s.GetConfigFilePaths())
+                .Returns(new List<string>());
+
+            // Act
+            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+
+            // Assert
+            var loadedSource = values.Single();
+            Assert.Equal("Source", loadedSource.Name);
+            Assert.Equal("https://some-source.test", loadedSource.Source);
+            Assert.Equal(PackageSource.DefaultDisableTLSCertificateValidation, loadedSource.DisableTLSCertificateValidation);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LoadPackageSources_ReadsSourcesWithInvalidDisableTLSCertificateVerificationFromPackageSourceSections_LoadsDefault(bool useStaticMethod)
+        {
+            // Arrange
+            var settings = new Mock<ISettings>();
+            var sourceItem = new SourceItem("Source", "https://some-source.test", protocolVersion: null, allowInsecureConnections: null, disableTLSCertificateValidation: "invalidValue");
+
+            settings.Setup(s => s.GetSection("packageSources"))
+                .Returns(new VirtualSettingSection("packageSources",
+                    sourceItem));
+
+            settings.Setup(s => s.GetConfigFilePaths())
+                .Returns(new List<string>());
+
+            // Act
+            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+
+            // Assert
+            var loadedSource = values.Single();
+            Assert.Equal("Source", loadedSource.Name);
+            Assert.Equal("https://some-source.test", loadedSource.Source);
+            Assert.Equal(PackageSource.DefaultDisableTLSCertificateValidation, loadedSource.DisableTLSCertificateValidation);
+        }
+
+        [Theory]
+        [InlineData(true, "true")]
+        [InlineData(true, "TRUE")]
+        [InlineData(true, "false")]
+        [InlineData(false, "false")]
+        [InlineData(false, "fALSE")]
+        [InlineData(false, "true")]
+        public void LoadPackageSources_ReadsSourcesWithNotNullDisableTLSCertificateVerificationFromPackageSourceSections_LoadsValue(bool useStaticMethod, string disableTLSCertificateValidation)
+        {
+            // Arrange
+            var settings = new Mock<ISettings>();
+            var sourceItem = new SourceItem("Source", "https://some-source.test", protocolVersion: null, allowInsecureConnections: null, disableTLSCertificateValidation: disableTLSCertificateValidation);
+
+            settings.Setup(s => s.GetSection("packageSources"))
+                .Returns(new VirtualSettingSection("packageSources",
+                    sourceItem));
+
+            settings.Setup(s => s.GetConfigFilePaths())
+                .Returns(new List<string>());
+
+            // Act
+            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+
+            // Assert
+            var loadedSource = values.Single();
+            Assert.Equal("Source", loadedSource.Name);
+            Assert.Equal("https://some-source.test", loadedSource.Source);
+            Assert.Equal(bool.Parse(disableTLSCertificateValidation), loadedSource.DisableTLSCertificateValidation);
+        }
+
         [Fact]
         public void DisablePackageSourceAddEntryToSettings()
         {

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -888,10 +888,8 @@ namespace NuGet.Configuration.Test
             Assert.Equal(bool.Parse(allowInsecureConnections), loadedSource.AllowInsecureConnections);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void LoadPackageSources_ReadsSourcesWithNullDisableTLSCertificateVerificationFromPackageSourceSections_LoadsDefault(bool useStaticMethod)
+        [Fact]
+        public void LoadPackageSources_ReadsSourcesWithNullDisableTLSCertificateVerificationFromPackageSourceSections_LoadsDefault()
         {
             // Arrange
             var settings = new Mock<ISettings>();
@@ -905,7 +903,7 @@ namespace NuGet.Configuration.Test
                 .Returns(new List<string>());
 
             // Act
-            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+            List<PackageSource> values = LoadPackageSources(settings.Object);
 
             // Assert
             var loadedSource = values.Single();
@@ -914,10 +912,8 @@ namespace NuGet.Configuration.Test
             Assert.Equal(PackageSource.DefaultDisableTLSCertificateValidation, loadedSource.DisableTLSCertificateValidation);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void LoadPackageSources_ReadsSourcesWithInvalidDisableTLSCertificateVerificationFromPackageSourceSections_LoadsDefault(bool useStaticMethod)
+        [Fact]
+        public void LoadPackageSources_ReadsSourcesWithInvalidDisableTLSCertificateVerificationFromPackageSourceSections_LoadsDefault()
         {
             // Arrange
             var settings = new Mock<ISettings>();
@@ -931,7 +927,7 @@ namespace NuGet.Configuration.Test
                 .Returns(new List<string>());
 
             // Act
-            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+            List<PackageSource> values = LoadPackageSources(settings.Object);
 
             // Assert
             var loadedSource = values.Single();
@@ -941,13 +937,11 @@ namespace NuGet.Configuration.Test
         }
 
         [Theory]
-        [InlineData(true, "true")]
-        [InlineData(true, "TRUE")]
-        [InlineData(true, "false")]
-        [InlineData(false, "false")]
-        [InlineData(false, "fALSE")]
-        [InlineData(false, "true")]
-        public void LoadPackageSources_ReadsSourcesWithNotNullDisableTLSCertificateVerificationFromPackageSourceSections_LoadsValue(bool useStaticMethod, string disableTLSCertificateValidation)
+        [InlineData("true")]
+        [InlineData("TRUE")]
+        [InlineData("false")]
+        [InlineData("fALSE")]
+        public void LoadPackageSources_ReadsSourcesWithNotNullDisableTLSCertificateVerificationFromPackageSourceSections_LoadsValue(string disableTLSCertificateValidation)
         {
             // Arrange
             var settings = new Mock<ISettings>();
@@ -961,7 +955,7 @@ namespace NuGet.Configuration.Test
                 .Returns(new List<string>());
 
             // Act
-            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
+            List<PackageSource> values = LoadPackageSources(settings.Object);
 
             // Assert
             var loadedSource = values.Single();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
@@ -18,7 +18,8 @@ namespace NuGet.Configuration.Test
             {
                 Credentials = credentials,
                 ProtocolVersion = 43,
-                AllowInsecureConnections = true
+                AllowInsecureConnections = true,
+                DisableTLSCertificateValidation = true
             };
 
             // Act
@@ -32,6 +33,7 @@ namespace NuGet.Configuration.Test
             Assert.Equal(source.IsEnabled, result.IsEnabled);
             Assert.Equal(source.ProtocolVersion, result.ProtocolVersion);
             Assert.Equal(source.AllowInsecureConnections, result.AllowInsecureConnections);
+            Assert.Equal(source.DisableTLSCertificateValidation, result.DisableTLSCertificateValidation);
 
             // source credential
             result.Credentials.Should().NotBeNull();
@@ -46,11 +48,12 @@ namespace NuGet.Configuration.Test
             var source = new PackageSource("Source", "SourceName", isEnabled: false)
             {
                 ProtocolVersion = 43,
-                AllowInsecureConnections = true
+                AllowInsecureConnections = true,
+                DisableTLSCertificateValidation = true
             };
             var result = source.AsSourceItem();
 
-            var expectedItem = new SourceItem("SourceName", "Source", "43", "True");
+            var expectedItem = new SourceItem("SourceName", "Source", "43", "True", "True");
 
             SettingsTestUtils.DeepEquals(result, expectedItem).Should().BeTrue();
         }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
@@ -59,6 +59,9 @@ namespace NuGet.Configuration.Test
         <add key='nuget3' value='http://serviceIndex.test3/api/index.json' protocolVersion='3' ALLOWInsecureConnections='true' />
         <add key='nuget4' value='http://serviceIndex.test4/api/index.json' allowInsecureConnections='true' />
         <add key='nuget5' value='http://serviceIndex.test5/api/index.json' allowInsecureConnections='false' protocolVersion='2' />
+        <add key='nuget6' value='http://serviceIndex.test6/api/index.json' protocolVersion='3' ALLOWInsecureConnections='true' DiSaBleTLSCertificateValidation='true'/>
+        <add key='nuget7' value='http://serviceIndex.test7/api/index.json' allowInsecureConnections='true' disableTLSCertificateValidation='false'/>
+        <add key='nuget8' value='http://serviceIndex.test8/api/index.json' allowInsecureConnections='false' protocolVersion='2' disableTLSCertificateValidation='true'/>
     </packageSources>
 </configuration>";
 
@@ -69,6 +72,9 @@ namespace NuGet.Configuration.Test
                 new SourceItem("nuget3","http://serviceIndex.test3/api/index.json", protocolVersion: "3", allowInsecureConnections: "true" ),
                 new SourceItem("nuget4","http://serviceIndex.test4/api/index.json", protocolVersion: null, allowInsecureConnections: "true"  ),
                 new SourceItem("nuget5","http://serviceIndex.test5/api/index.json", protocolVersion: "2", allowInsecureConnections: "false"),
+                new SourceItem("nuget6","http://serviceIndex.test6/api/index.json", protocolVersion: "3", allowInsecureConnections: "true", disableTLSCertificateValidation: "true"),
+                new SourceItem("nuget7","http://serviceIndex.test7/api/index.json", protocolVersion: null, allowInsecureConnections: "true", disableTLSCertificateValidation: "false"),
+                new SourceItem("nuget8","http://serviceIndex.test8/api/index.json", protocolVersion: "2", allowInsecureConnections: "false", disableTLSCertificateValidation: "true"),
             };
 
             var nugetConfigPath = "NuGet.Config";
@@ -86,7 +92,7 @@ namespace NuGet.Configuration.Test
                 var children = section!.Items.Cast<SourceItem>().ToList();
 
                 children.Should().NotBeEmpty();
-                children.Count.Should().Be(5);
+                children.Count.Should().Be(8);
 
                 for (var i = 0; i < children.Count; i++)
                 {
@@ -95,6 +101,7 @@ namespace NuGet.Configuration.Test
                     children[i].Value.Should().Be(expectedValues[i].Value, because: $"SourceItem[{i}].Value is {children[i].Value}, but it's expected to be {expectedValues[i].Value}");
                     children[i].ProtocolVersion.Should().Be(expectedValues[i].ProtocolVersion, because: $"SourceItem[{i}].ProtocolVersion is {children[i].ProtocolVersion}, but it's expected to be {expectedValues[i].ProtocolVersion}");
                     children[i].AllowInsecureConnections.Should().Be(expectedValues[i].AllowInsecureConnections, because: $"SourceItem[{i}].AllowInsecureConnections is {children[i].AllowInsecureConnections}, but it's expected to be {expectedValues[i].AllowInsecureConnections}");
+                    children[i].DisableTLSCertificateValidation.Should().Be(expectedValues[i].DisableTLSCertificateValidation, because: $"SourceItem[{i}].DisableTLSCertificateValidation is {children[i].DisableTLSCertificateValidation}, but it's expected to be {expectedValues[i].DisableTLSCertificateValidation}");
                 }
             }
         }
@@ -107,7 +114,10 @@ namespace NuGet.Configuration.Test
                     new SourceItem("nuget1", "http://serviceIndex.test1/api/index.json", protocolVersion: "3", allowInsecureConnections: "true"),
                     new SourceItem("nuget2", "http://serviceIndex.test2/api/index.json", protocolVersion: "2", allowInsecureConnections: "false"),
                     new SourceItem("nuget3", "http://serviceIndex.test3/api/index.json", protocolVersion: null, allowInsecureConnections: "true"),
-                    new SourceItem("nuget4", "http://serviceIndex.test4/api/index.json", protocolVersion: "3")));
+                    new SourceItem("nuget4", "http://serviceIndex.test4/api/index.json", protocolVersion: "3"),
+                    new SourceItem("nuget5", "http://serviceIndex.test5/api/index.json", protocolVersion: "3", allowInsecureConnections: "true", disableTLSCertificateValidation: "false"),
+                    new SourceItem("nuget6", "http://serviceIndex.test6/api/index.json", protocolVersion: "2", allowInsecureConnections: "false", disableTLSCertificateValidation: "false"),
+                    new SourceItem("nuget7", "http://serviceIndex.test7/api/index.json", protocolVersion: null, allowInsecureConnections: "true", disableTLSCertificateValidation: "true")));
             var resultXml = SettingsTestUtils.RemoveWhitespace(configuration.AsXNode().ToString());
 
             var expectedXNode = new XElement("configuration",
@@ -129,7 +139,24 @@ namespace NuGet.Configuration.Test
                     new XElement("add",
                         new XAttribute("key", "nuget4"),
                         new XAttribute("value", "http://serviceIndex.test4/api/index.json"),
-                        new XAttribute("protocolVersion", "3"))));
+                        new XAttribute("protocolVersion", "3")),
+                    new XElement("add",
+                        new XAttribute("key", "nuget5"),
+                        new XAttribute("value", "http://serviceIndex.test5/api/index.json"),
+                        new XAttribute("protocolVersion", "3"),
+                        new XAttribute("allowInsecureConnections", "true"),
+                        new XAttribute("disableTLSCertificateValidation", "false")),
+                    new XElement("add",
+                        new XAttribute("key", "nuget6"),
+                        new XAttribute("value", "http://serviceIndex.test6/api/index.json"),
+                        new XAttribute("protocolVersion", "2"),
+                        new XAttribute("allowInsecureConnections", "false"),
+                        new XAttribute("disableTLSCertificateValidation", "false")),
+                    new XElement("add",
+                        new XAttribute("key", "nuget7"),
+                        new XAttribute("value", "http://serviceIndex.test7/api/index.json"),
+                        new XAttribute("allowInsecureConnections", "true"),
+                        new XAttribute("disableTLSCertificateValidation", "true"))));
             var expectedXml = SettingsTestUtils.RemoveWhitespace(expectedXNode.ToString());
 
             resultXml.Should().Be(expectedXml, because: resultXml);

--- a/test/TestUtilities/Test.Utility/SelfSignedCertificateMockServer.cs
+++ b/test/TestUtilities/Test.Utility/SelfSignedCertificateMockServer.cs
@@ -1,0 +1,212 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using NuGet.Test.Server;
+
+namespace Test.Utility
+{
+    public class SelfSignedCertificateMockServer
+    {
+        private readonly X509Certificate2 _certificate;
+        private readonly string _packageDirectory;
+        private TcpListener _tcpListener;
+        private bool _runServer = true;
+        public string URI;
+
+        public SelfSignedCertificateMockServer(string packageDirectory)
+        {
+            _packageDirectory = packageDirectory;
+            _certificate = GenerateSelfSignedCertificate();
+        }
+
+        public async Task StartServerAsync()
+        {
+            var portReserver = new PortReserver();
+            var portNumber = await portReserver.ExecuteAsync((p, t) => Task.FromResult(p), CancellationToken.None);
+            _tcpListener = new TcpListener(IPAddress.Loopback, portNumber);
+            URI = $"https://{_tcpListener.LocalEndpoint}/";
+            _tcpListener.Start();
+
+            while (_runServer)
+            {
+                var client = await _tcpListener.AcceptTcpClientAsync();
+                _ = Task.Run(() => HandleClient(client));
+            }
+        }
+
+        public void StopServer()
+        {
+            _runServer = false;
+            _tcpListener.Stop();
+        }
+
+        private async Task HandleClient(TcpClient client)
+        {
+            using (client)
+            using (var sslStream = new SslStream(client.GetStream(), false))
+            {
+                await sslStream.AuthenticateAsServerAsync(_certificate, clientCertificateRequired: false, checkCertificateRevocation: true);
+                using (var reader = new StreamReader(sslStream, Encoding.ASCII, false, 128))
+                using (var writer = new StreamWriter(sslStream, Encoding.ASCII, 128, false))
+                {
+                    try
+                    {
+                        var requestLine = await reader.ReadLineAsync();
+                        var requestParts = requestLine?.Split(' ');
+
+                        if (requestParts == null || requestParts.Length < 2)
+                        {
+                            throw new InvalidOperationException("Invalid HTTP request line.");
+                        }
+
+                        string path = requestParts[1];
+                        var parts = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+
+                        if (path == "/v3/index.json")
+                        {
+                            SendIndexJsonResponse(writer);
+                        }
+                        else if (parts.Length > 1 && parts[0] == "v3")
+                        {
+                            if (parts[1] == "package")
+                            {
+                                if (parts.Length == 4)
+                                {
+                                    ProcessPackageRequest(parts[2], writer);
+                                }
+                                else
+                                {
+                                    SendPackageFile(parts[2], parts[3], parts[4], writer, sslStream);
+                                }
+                            }
+                            else
+                            {
+                                await writer.WriteLineAsync("HTTP/1.1 404 Not Found");
+                            }
+                        }
+                        else
+                        {
+                            await writer.WriteLineAsync("HTTP/1.1 404 Not Found");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine("Error processing request: " + ex.Message);
+                    }
+                }
+            }
+        }
+
+        private void ProcessPackageRequest(string id, StreamWriter writer)
+        {
+            try
+            {
+                var versions = GetVersionsFromDirectory(id);
+
+                var json = JsonConvert.SerializeObject(new { versions });
+                writer.WriteLine("HTTP/1.1 200 OK");
+                writer.WriteLine("Content-Type: application/json");
+                writer.WriteLine();
+                writer.WriteLine(json);
+                writer.Flush();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error processing request: {ex.Message}");
+            }
+        }
+
+        private void SendPackageFile(string id, string version, string nupkg, StreamWriter writer, SslStream sslStream)
+        {
+            var filePath = Path.Combine(_packageDirectory, id, version, nupkg);
+
+            if (!File.Exists(filePath))
+            {
+                writer.WriteLine("HTTP/1.1 404 Not Found");
+                return;
+            }
+
+            using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
+            {
+                writer.WriteLine("HTTP/1.1 200 OK");
+                writer.WriteLine("Content-Type: application/octet-stream");
+                writer.WriteLine($"Content-Disposition: attachment; filename=\"{id}.{version}.nupkg\"");
+                writer.WriteLine($"Content-Length: {new FileInfo(filePath).Length}");
+                writer.WriteLine();
+                writer.Flush();
+
+                fileStream.CopyTo(sslStream);
+            }
+        }
+
+        private string[] GetVersionsFromDirectory(string id)
+        {
+            var directoryPath = Path.Combine(_packageDirectory, id);
+
+            if (!Directory.Exists(directoryPath))
+            {
+                throw new DirectoryNotFoundException($"Directory not found: {directoryPath}");
+            }
+
+            var dirInfo = new DirectoryInfo(directoryPath);
+            return dirInfo.GetDirectories().Select(d => d.Name).ToArray();
+        }
+
+        private void SendIndexJsonResponse(StreamWriter writer)
+        {
+            var indexResponse = new
+            {
+                version = "3.0.0",
+                resources = new object[]
+                {
+                new Resource { Type = "SearchQueryService", Id = $"{URI}v3/query" },
+                new Resource { Type = "RegistrationsBaseUrl", Id = $"{URI}v3/registration" },
+                new Resource { Type = "PackageBaseAddress/3.0.0", Id = $"{URI}v3/package" },
+                new Resource { Type = "PackagePublish/2.0.0", Id = $"{URI}v3/packagepublish" }
+                }
+            };
+
+            string jsonResponse = JsonConvert.SerializeObject(indexResponse);
+            writer.WriteLine("HTTP/1.1 200 OK");
+            writer.WriteLine("Content-Type: application/json");
+            writer.WriteLine();
+            writer.WriteLine(jsonResponse);
+            writer.Flush();
+        }
+
+        private static X509Certificate2 GenerateSelfSignedCertificate()
+        {
+            using (var rsa = RSA.Create(2048))
+            {
+                var request = new CertificateRequest("cn=test", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+                var start = DateTime.UtcNow;
+                var end = DateTime.UtcNow.AddYears(1);
+                var cert = request.CreateSelfSigned(start, end);
+                var certBytes = cert.Export(X509ContentType.Pfx, "password");
+                return new X509Certificate2(certBytes, "password", X509KeyStorageFlags.Exportable);
+            }
+        }
+    }
+
+    internal class Resource
+    {
+        [JsonProperty("@type")]
+        public string Type { get; set; }
+
+        [JsonProperty("@id")]
+        public string Id { get; set; }
+    }
+}

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -226,6 +226,13 @@ namespace NuGet.Test.Utility
             Save();
         }
 
+        public void AddSource(string sourceName, string sourceUri, string attributeName, string attributeValue)
+        {
+            var section = GetOrAddSection(XML, "packageSources");
+            AddEntry(section, sourceName, sourceUri, attributeName, attributeValue);
+            Save();
+        }
+
         public void AddPackageSourceMapping(string sourceName, params string[] patterns)
         {
             XElement packageSourceMappingSection = GetOrAddSection(XML, "packageSourceMapping");

--- a/test/TestUtilities/Test.Utility/TestServer/ITestServer.cs
+++ b/test/TestUtilities/Test.Utility/TestServer/ITestServer.cs
@@ -11,7 +11,8 @@ namespace NuGet.Test.Server
         ConnectFailure,
         ServerProtocolViolation,
         NameResolutionFailure,
-        SlowResponseBody
+        SlowResponseBody,
+        InvalidTLSCertificate,
     }
 
     public interface ITestServer

--- a/test/TestUtilities/Test.Utility/TestServer/TcpListenerServer.cs
+++ b/test/TestUtilities/Test.Utility/TestServer/TcpListenerServer.cs
@@ -5,14 +5,18 @@ using System;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Net.Security;
 
 namespace NuGet.Test.Server
 {
     public class TcpListenerServer : ITestServer
     {
+        private X509Certificate2 _tlsCertificate;
         public async Task<T> ExecuteAsync<T>(Func<string, Task<T>> action)
         {
             Func<TcpListener, CancellationToken, Task> startServer;
@@ -24,6 +28,10 @@ namespace NuGet.Test.Server
 
                 case TestServerMode.SlowResponseBody:
                     startServer = StartSlowResponseBody;
+                    break;
+                case TestServerMode.InvalidTLSCertificate:
+                    startServer = StartInvalidTlsCertificateServer;
+                    _tlsCertificate = GenerateSelfSignedCertificate();
                     break;
 
                 default:
@@ -39,7 +47,16 @@ namespace NuGet.Test.Server
                     var tcpListener = new TcpListener(IPAddress.Loopback, port);
                     tcpListener.Start();
                     var serverTask = startServer(tcpListener, serverCts.Token);
-                    var address = $"http://localhost:{port}/";
+                    string address;
+
+                    if (Mode == TestServerMode.InvalidTLSCertificate)
+                    {
+                        address = $"https://localhost:{port}/";
+                    }
+                    else
+                    {
+                        address = $"http://localhost:{port}/";
+                    }
 
                     // execute the caller's action
                     var result = await action(address);
@@ -51,6 +68,50 @@ namespace NuGet.Test.Server
                     return result;
                 },
                 CancellationToken.None);
+        }
+
+        public TcpListenerServer()
+        { }
+
+        private static X509Certificate2 GenerateSelfSignedCertificate()
+        {
+            using (var rsa = RSA.Create(2048))
+            {
+                var request = new CertificateRequest("cn=test", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+                var start = DateTime.UtcNow;
+                var end = DateTime.UtcNow.AddYears(1);
+                var cert = request.CreateSelfSigned(start, end);
+                var certBytes = cert.Export(X509ContentType.Pfx, "password");
+
+                return new X509Certificate2(certBytes, "password", X509KeyStorageFlags.Exportable);
+            }
+        }
+
+        private async Task StartInvalidTlsCertificateServer(TcpListener tcpListener, CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                using (var client = await Task.Run(tcpListener.AcceptTcpClientAsync, token))
+                using (var sslStream = new SslStream(client.GetStream(), false))
+                {
+                    sslStream.AuthenticateAsServer(_tlsCertificate, clientCertificateRequired: false, checkCertificateRevocation: true);
+                    using (var reader = new StreamReader(sslStream, Encoding.ASCII, false, 128))
+                    using (var writer = new StreamWriter(sslStream, Encoding.ASCII, 128, false))
+                    {
+                        while (!string.IsNullOrEmpty(reader.ReadLine()))
+                        {
+                        }
+
+                        string content = "{}";
+                        writer.WriteLine("HTTP/1.1 200 OK");
+                        writer.WriteLine($"Date: {DateTimeOffset.UtcNow:R}");
+                        writer.WriteLine($"Content-Length: {content.Length}");
+                        writer.WriteLine("Content-Type: application/json");
+                        writer.WriteLine();
+                        writer.WriteLine(content);
+                    }
+                }
+            }
         }
 
         public TestServerMode Mode { get; set; } = TestServerMode.ServerProtocolViolation;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/4387

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This PR is merging a feature branch that:
- Adds disableTLSCertificateValidation option : https://github.com/NuGet/NuGet.Client/pull/5504
- Makes use of it to allow insecure connection with sources with no valid TLS certificate : https://github.com/NuGet/NuGet.Client/pull/5514
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled (https://github.com/NuGet/Home/issues/13478)
  - **OR**
  - [ ] N/A
