### PR TITLE
address search flaky test

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetPackageSearchTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetPackageSearchTests.cs
@@ -34,16 +34,16 @@ namespace Dotnet.Integration.Test
             using (var pathContext = new SimpleTestPathContext())
             {
                 // Arrange
-                var args = new string[] { "package", "search", "json", "--source", $"{_packageSearchRunnerFixture.ServerWithMultipleEndpoints.Uri}v3/index.json", "--format", "json" };
+                var args = new string[] { "package", "search", "json", "--take", "10", "--prerelease", "--source", $"{_packageSearchRunnerFixture.ServerWithMultipleEndpoints.Uri}v3/index.json", "--format", "json" };
 
                 // Act
                 var result = _testFixture.RunDotnetExpectSuccess(pathContext.PackageSource, string.Join(" ", args));
 
                 // Assert
                 Assert.Equal(0, result.ExitCode);
-                Assert.Contains("\"total downloads\": 531607259,", result.AllOutput);
-                Assert.Contains("\"owners\": \"James Newton-King\",", result.AllOutput);
-                Assert.Contains("\"total downloads\": 531607259,", result.AllOutput);
+                Assert.Contains("\"id\": \"Fake.Newtonsoft.Json\",", result.AllOutput);
+                Assert.Contains("\"owners\": \"James Newton-King\"", result.AllOutput);
+                Assert.Contains("\"totalDownloads\": 531607259,", result.AllOutput);
                 Assert.Contains("\"latestVersion\": \"12.0.3\"", result.AllOutput);
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2728

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
The integration test does a search on a mock server. The mock server has only a limited number of links it responds to. During a search an api request is generated to a specific  url by using the arguments it is provided. This PR makes sure the test search has the right arguments so that the mockserver gives a response and can be used to confirm the search results.
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
