### PR TITLE
Test coverage for Unauthorized file access occurring on a locked file

### DIFF
--- a/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
+++ b/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
@@ -117,8 +117,12 @@ namespace NuGet.Common
             }
         }
 
-        public static void ExecuteWithFileLocked(string filePath,
-            Action action)
+        public static void ExecuteWithFileLocked(string filePath, Action action)
+        {
+            ExecuteWithFileLocked(filePath, action, AcquireFileStream, NumberOfRetries);
+        }
+
+        internal static void ExecuteWithFileLocked(string filePath, Action action, Func<string, FileStream> acquireFileStream, int numberOfRetries)
         {
             if (string.IsNullOrEmpty(filePath))
             {
@@ -129,7 +133,7 @@ namespace NuGet.Common
             try
             {
                 // limit the number of unauthorized, this should be around 30 seconds.
-                var unauthorizedAttemptsLeft = NumberOfRetries;
+                var unauthorizedAttemptsLeft = numberOfRetries;
 
                 while (true)
                 {
@@ -141,7 +145,7 @@ namespace NuGet.Common
                         {
                             lockPath = FileLockPath(filePath);
 
-                            fs = AcquireFileStream(lockPath);
+                            fs = acquireFileStream(lockPath);
                         }
                         catch (DirectoryNotFoundException)
                         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13310

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

- Overload method so that tests can mock the file access & number of retries
- Test the expected thrown exception when Unauthorized file access occurs on a locked file

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
