### PR TITLE
Make NuGetAuditMode default to all with .NET 9 SDK

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -287,7 +287,7 @@ namespace NuGet.CommandLine
             // Checking the SDK uses MSBuild intrinsic functions that were added in 16.5
             if (toolset.ParsedVersion.CompareTo(new Version(16, 5)) < 0)
             {
-                AddProperty(args, "NuGetExeSkipSDKCheck", bool.TrueString);
+                AddProperty(args, "NuGetExeSkipSdkAnalysisLevelCheck", bool.TrueString);
             }
 
             // Add additional args to msbuild if needed

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -284,6 +284,12 @@ namespace NuGet.CommandLine
                 AddProperty(args, "RestoreUseSkipNonexistentTargets", bool.FalseString);
             }
 
+            // Checking the SDK uses MSBuild intrinsic functions that were added in 16.5
+            if (toolset.ParsedVersion.CompareTo(new Version(16, 5)) < 0)
+            {
+                AddProperty(args, "NuGetExeSkipSDKCheck", bool.TrueString);
+            }
+
             // Add additional args to msbuild if needed
             var msbuildAdditionalArgs = reader.GetEnvironmentVariable("NUGET_RESTORE_MSBUILD_ARGS");
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -73,6 +73,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Report on low severity vulnerabilities, and higher. Allowed values are: low, moderate, high, critical -->
     <NuGetAuditLevel Condition=" '$(NuGetAuditLevel)' == '' ">low</NuGetAuditLevel>
     <!-- Report known vulnerabilities on direct dependencies only. Allowed values are: direct, all -->
+    <NuGetAuditMode Condition="'$(NuGetAudit)' == ''
+                    AND '$(NuGetExeSkipSDKCheck)' != 'true'
+                    AND $([MSBuild]::VersionGreaterThanOrEquals($([MSBuild]::ValueOrDefault('$(NETCoreSdkVersion)', '0.0')), '9.0'))"
+                    >all</NuGetAuditMode>
     <NuGetAuditMode Condition=" '$(NuGetAuditMode)' == '' ">direct</NuGetAuditMode>
   </PropertyGroup>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -73,9 +73,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Report on low severity vulnerabilities, and higher. Allowed values are: low, moderate, high, critical -->
     <NuGetAuditLevel Condition=" '$(NuGetAuditLevel)' == '' ">low</NuGetAuditLevel>
     <!-- Report known vulnerabilities on direct dependencies only. Allowed values are: direct, all -->
-    <NuGetAuditMode Condition="'$(NuGetAudit)' == ''
-                    AND '$(NuGetExeSkipSDKCheck)' != 'true'
-                    AND $([MSBuild]::VersionGreaterThanOrEquals($([MSBuild]::ValueOrDefault('$(NETCoreSdkVersion)', '0.0')), '9.0'))"
+    <NuGetAuditMode Condition="'$(NuGetAuditMode)' == ''
+                    AND '$(NuGetExeSkipSdkAnalysisLevelCheck)' != 'true'
+                    AND $([MSBuild]::VersionGreaterThanOrEquals($([MSBuild]::ValueOrDefault('$(NETCoreSdkVersion)', '0.0')), '9.0.100'))"
                     >all</NuGetAuditMode>
     <NuGetAuditMode Condition=" '$(NuGetAuditMode)' == '' ">direct</NuGetAuditMode>
   </PropertyGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -75,7 +75,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Report known vulnerabilities on direct dependencies only. Allowed values are: direct, all -->
     <NuGetAuditMode Condition="'$(NuGetAuditMode)' == ''
                     AND '$(NuGetExeSkipSdkAnalysisLevelCheck)' != 'true'
-                    AND $([MSBuild]::VersionGreaterThanOrEquals($([MSBuild]::ValueOrDefault('$(NETCoreSdkVersion)', '0.0')), '9.0.100'))"
+                    AND $([MSBuild]::VersionGreaterThanOrEquals($([MSBuild]::ValueOrDefault('$(SdkAnalysisLevel)', '0.0')), '9.0.100'))"
                     >all</NuGetAuditMode>
     <NuGetAuditMode Condition=" '$(NuGetAuditMode)' == '' ">direct</NuGetAuditMode>
   </PropertyGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13293

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The .NET SDK introduced the concept of SdkAnalysisLevel, to be similar to how the C# compiler has analysis levels, allowing customers to install newer tooling without getting breaking changes while their project continues to use the older analysis level.  So, we'll use SdkAnalysisLevel `9.0.100` to detect anyone using the .NET 9 or higher SDK, and default to NuGetAuditMode all. Everything else (projects using .NET 8 SDK or below, and non-SDK style projects), will continue to use the `direct` default for now.

We tried a similar thing when introducing NuGetAudit initially, and we got feedback from customers using nuget.exe with Visual Studio 2019 still that it broke. So, in addition, NuGet.exe needs to detect when it's using a version of MSBuild that doesn't support version comparison intrinsic functions, so that our MSBuild script can use MSBuild's lazy evaluation to avoid using the function on MSBuild versions that don't support it.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: Impractical to have a bunch of different MSBuild versions and .NET SDK versions
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A: There's going to be a LOT of NuGetAudit documentation and blog posts and announcements needed, but I'm not creating a tracking issue just for this.
