### PR TITLE
Deprecate http usage: `nuget search` promote warning to error for http sources

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SearchCommand.cs
@@ -66,7 +66,8 @@ namespace NuGet.CommandLine
             var taskList = new List<(Task<IEnumerable<IPackageSearchMetadata>>, PackageSource)>();
             IList<PackageSource> listEndpoints = GetEndpointsAsync();
 
-            WarnForHTTPSources(listEndpoints);
+            AvoidHttpSources(listEndpoints);
+
             foreach (PackageSource source in listEndpoints)
             {
                 SourceRepository repository = Repository.Factory.GetCoreV3(source);
@@ -126,7 +127,7 @@ namespace NuGet.CommandLine
             }
         }
 
-        private void WarnForHTTPSources(IList<PackageSource> packageSources)
+        private void AvoidHttpSources(IList<PackageSource> packageSources)
         {
             List<PackageSource> httpPackageSources = null;
             foreach (PackageSource packageSource in packageSources)
@@ -145,17 +146,17 @@ namespace NuGet.CommandLine
             {
                 if (httpPackageSources.Count == 1)
                 {
-                    Console.LogWarning(
+                    throw new ArgumentException(
                         string.Format(CultureInfo.CurrentCulture,
-                        NuGetResources.Warning_HttpServerUsage,
+                        NuGetResources.Error_HttpSource_Single,
                         "search",
                         httpPackageSources[0]));
                 }
                 else
                 {
-                    Console.LogWarning(
+                    throw new ArgumentException(
                         string.Format(CultureInfo.CurrentCulture,
-                        NuGetResources.Warning_HttpSources_Multiple,
+                        NuGetResources.Error_HttpSources_Multiple,
                         "search",
                         Environment.NewLine + string.Join(Environment.NewLine, httpPackageSources.Select(e => e.Name))));
                 }

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -367,7 +367,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;HTTP&apos; source: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option..
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;HTTP&apos; source: {1}. NuGet requires HTTPS sources. To use an HTTP source, you must explicitly set &apos;allowInsecureConnections&apos; to true in your NuGet.Config file. Please refer to https://aka.ms/nuget-https-everywhere..
         /// </summary>
         public static string Error_HttpSource_Single {
             get {
@@ -376,7 +376,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with &apos;HTTP&apos; sources: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option..
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with &apos;HTTP&apos; sources: {1}. NuGet requires HTTPS sources. To use HTTP sources, you must explicitly set &apos;allowInsecureConnections&apos; to true in your NuGet.Config file. Please refer to https://aka.ms/nuget-https-everywhere..
         /// </summary>
         public static string Error_HttpSources_Multiple {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -367,6 +367,24 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;HTTP&apos; source: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option..
+        /// </summary>
+        public static string Error_HttpSource_Single {
+            get {
+                return ResourceManager.GetString("Error_HttpSource_Single", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with &apos;HTTP&apos; sources: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option..
+        /// </summary>
+        public static string Error_HttpSources_Multiple {
+            get {
+                return ResourceManager.GetString("Error_HttpSources_Multiple", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid characters in one of the following path segments: &apos;{0}&apos;.
         /// </summary>
         public static string Error_InvalidCharactersInPathSegment {
@@ -1716,25 +1734,6 @@ namespace NuGet.CommandLine {
         public static string Warning_FileDoesNotExist {
             get {
                 return ResourceManager.GetString("Warning_FileDoesNotExist", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;HTTP&apos; source, &apos;{1}&apos;. Non-HTTPS access will be removed in a future version. Consider migrating to an &apos;HTTPS&apos; source..
-        /// </summary>
-        public static string Warning_HttpServerUsage {
-            get {
-                return ResourceManager.GetString("Warning_HttpServerUsage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with &apos;HTTP&apos; sources: {1}
-        ///Non-HTTPS access will be removed in a future version. Consider migrating to &apos;HTTPS&apos; sources..
-        /// </summary>
-        public static string Warning_HttpSources_Multiple {
-            get {
-                return ResourceManager.GetString("Warning_HttpSources_Multiple", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -711,14 +711,6 @@ You can set the '{1}' environment variable to 'true' to temporarily reenable thi
   <data name="Error_NuGetExeNeedsToBeUnblockedAfterDownloading" xml:space="preserve">
     <value>NuGet.exe file on path {0} needs to be unblocked after downloading.</value>
   </data>
-  <data name="Warning_HttpServerUsage" xml:space="preserve">
-    <value>You are running the '{0}' operation with an 'HTTP' source, '{1}'. Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.</value>
-    <comment>0 - The command name. Ex. Push/Delete. 1 - server uri.</comment>
-  </data>
-  <data name="Warning_HttpSources_Multiple" xml:space="preserve">
-    <value>You are running the '{0}' operation with 'HTTP' sources: {1}
-Non-HTTPS access will be removed in a future version. Consider migrating to 'HTTPS' sources.</value>
-  </data>
   <data name="Error_SourceProviderIsNull" xml:space="preserve">
     <value>Property SourceProvider is null.</value>
     <comment>Don't localize 'SourceProvider'</comment>
@@ -743,5 +735,11 @@ Do not localize `SDK`, `dotnet pack`, msbuild -t:pack` and 'true'.</comment>
     <comment>{0} - name of the assembly running the command, e.g., NuGet
 {1} - current command marked as deprecated, e.g., list
 {2} - replacement command. For example, search</comment>
+  </data>
+  <data name="Error_HttpSources_Multiple" xml:space="preserve">
+    <value>You are running the '{0}' operation with 'HTTP' sources: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option.</value>
+  </data>
+  <data name="Error_HttpSource_Single" xml:space="preserve">
+    <value>You are running the '{0}' operation with an 'HTTP' source: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option.</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -737,9 +737,9 @@ Do not localize `SDK`, `dotnet pack`, msbuild -t:pack` and 'true'.</comment>
 {2} - replacement command. For example, search</comment>
   </data>
   <data name="Error_HttpSources_Multiple" xml:space="preserve">
-    <value>You are running the '{0}' operation with 'HTTP' sources: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option.</value>
+    <value>You are running the '{0}' operation with 'HTTP' sources: {1}. NuGet requires HTTPS sources. To use HTTP sources, you must explicitly set 'allowInsecureConnections' to true in your NuGet.Config file. Please refer to https://aka.ms/nuget-https-everywhere.</value>
   </data>
   <data name="Error_HttpSource_Single" xml:space="preserve">
-    <value>You are running the '{0}' operation with an 'HTTP' source: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option.</value>
+    <value>You are running the '{0}' operation with an 'HTTP' source: {1}. NuGet requires HTTPS sources. To use an HTTP source, you must explicitly set 'allowInsecureConnections' to true in your NuGet.Config file. Please refer to https://aka.ms/nuget-https-everywhere.</value>
   </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
@@ -1,9 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using NuGet.CommandLine.Test;
-using NuGet.Configuration.Test;
+using NuGet.Configuration;
 using NuGet.Test.Utility;
 using Test.Utility;
 using Xunit;
@@ -21,10 +25,15 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (MockServer server = new MockServer())
             using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
-                CommandRunner.Run(
-                    nugetexe,
-                    config.WorkingDirectory,
-                    $"source add -name mockSource -source {server.Uri}v3/index.json -configfile {config.NuGetConfig}");
+                // Arrange the NuGet.Config file
+                string nugetConfigContent =
+    $@"<configuration>
+    <packageSources>
+        <clear />
+        <add key='mockSource' value='{server.Uri}v3/index.json' allowInsecureConnections='true' />
+    </packageSources>
+</configuration>";
+                File.WriteAllText(config.NuGetConfig, nugetConfigContent);
 
                 string index = $@"
                 {{
@@ -130,10 +139,15 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (MockServer server = new MockServer())
             using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
-                CommandRunner.Run(
-                    nugetexe,
-                    config.WorkingDirectory,
-                    $"source add -name mockSource -source {server.Uri}v3/index.json -configfile {config.NuGetConfig}");
+                // Arrange the NuGet.Config file
+                string nugetConfigContent =
+    $@"<configuration>
+    <packageSources>
+        <clear />
+        <add key='mockSource' value='{server.Uri}v3/index.json' allowInsecureConnections='true' />
+    </packageSources>
+</configuration>";
+                File.WriteAllText(config.NuGetConfig, nugetConfigContent);
 
                 string index = $@"
                 {{
@@ -245,10 +259,15 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (MockServer server = new MockServer())
             using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
-                CommandRunner.Run(
-                    nugetexe,
-                    config.WorkingDirectory,
-                    $"source add -name mockSource -source {server.Uri}v3/index.json -configfile {config.NuGetConfig}");
+                // Arrange the NuGet.Config file
+                string nugetConfigContent =
+    $@"<configuration>
+    <packageSources>
+        <clear />
+        <add key='mockSource' value='{server.Uri}v3/index.json' allowInsecureConnections='true' />
+    </packageSources>
+</configuration>";
+                File.WriteAllText(config.NuGetConfig, nugetConfigContent);
 
                 string index = $@"
                 {{
@@ -360,10 +379,15 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (MockServer server = new MockServer())
             using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
-                CommandRunner.Run(
-                    nugetexe,
-                    config.WorkingDirectory,
-                    $"source add -name mockSource -source {server.Uri}v3/index.json -configfile {config.NuGetConfig}");
+                // Arrange the NuGet.Config file
+                string nugetConfigContent =
+    $@"<configuration>
+    <packageSources>
+        <clear />
+        <add key='mockSource' value='{server.Uri}v3/index.json' allowInsecureConnections='true' />
+    </packageSources>
+</configuration>";
+                File.WriteAllText(config.NuGetConfig, nugetConfigContent);
 
                 string index = $@"
                 {{
@@ -475,10 +499,15 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (MockServer server = new MockServer())
             using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
-                CommandRunner.Run(
-                    nugetexe,
-                    config.WorkingDirectory,
-                    $"source add -name mockSource -source {server.Uri}v3/index.json -configfile {config.NuGetConfig}");
+                // Arrange the NuGet.Config file
+                string nugetConfigContent =
+    $@"<configuration>
+    <packageSources>
+        <clear />
+        <add key='mockSource' value='{server.Uri}v3/index.json' allowInsecureConnections='true' />
+    </packageSources>
+</configuration>";
+                File.WriteAllText(config.NuGetConfig, nugetConfigContent);
 
                 string index = $@"
                 {{
@@ -638,10 +667,15 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (MockServer server = new MockServer())
             using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
-                CommandRunner.Run(
-                    nugetexe,
-                    config.WorkingDirectory,
-                    $"source add -name mockSource -source {server.Uri}v3/index.json -configfile {config.NuGetConfig}");
+                // Arrange the NuGet.Config file
+                string nugetConfigContent =
+    $@"<configuration>
+    <packageSources>
+        <clear />
+        <add key='mockSource' value='{server.Uri}v3/index.json' allowInsecureConnections='true' />
+    </packageSources>
+</configuration>";
+                File.WriteAllText(config.NuGetConfig, nugetConfigContent);
 
                 string index = $@"
                 {{
@@ -749,10 +783,15 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (MockServer server = new MockServer())
             using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
-                CommandRunner.Run(
-                    nugetexe,
-                    config.WorkingDirectory,
-                    $"source add -name mockSource -source {server.Uri}v3/index.json -configfile {config.NuGetConfig}");
+                // Arrange the NuGet.Config file
+                string nugetConfigContent =
+    $@"<configuration>
+    <packageSources>
+        <clear />
+        <add key='mockSource' value='{server.Uri}v3/index.json' allowInsecureConnections='true' />
+    </packageSources>
+</configuration>";
+                File.WriteAllText(config.NuGetConfig, nugetConfigContent);
 
                 string index = $@"
                 {{
@@ -860,10 +899,15 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (MockServer server = new MockServer())
             using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
-                CommandRunner.Run(
-                    nugetexe,
-                    config.WorkingDirectory,
-                    $"source add -name mockSource -source {server.Uri}v3/index.json -configfile {config.NuGetConfig}");
+                // Arrange the NuGet.Config file
+                string nugetConfigContent =
+    $@"<configuration>
+    <packageSources>
+        <clear />
+        <add key='mockSource' value='{server.Uri}v3/index.json' allowInsecureConnections='true' />
+    </packageSources>
+</configuration>";
+                File.WriteAllText(config.NuGetConfig, nugetConfigContent);
 
                 string index = $@"
                 {{
@@ -923,12 +967,13 @@ namespace NuGet.CommandLine.FuncTest.Commands
         }
 
         [Fact]
-        public void SearchCommand_WhenSearchWithHttpSource_Warns()
+        public void SearchCommand_WhenSearchWithHttpSource_DisplaysAnErrorMessage()
         {
             // Arrange
             string nugetexe = Util.GetNuGetExePath();
 
             using MockServer server = new MockServer();
+            PackageSource source = new PackageSource(server.Uri + "v3/index.json", "mockSource");
             using SimpleTestPathContext config = new SimpleTestPathContext();
             CommandRunner.Run(
                 nugetexe,
@@ -968,7 +1013,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 }}";
 
             server.Get.Add("/search/query?q=json&skip=0&take=20&prerelease=false&semVerLevel=2.0.0", r => queryResult);
-
+            string expectedErrorMessage = string.Format(NuGetResources.Error_HttpSource_Single, "search", source);
             server.Start();
 
             // Act
@@ -986,10 +1031,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
             server.Stop();
 
             // Assert
-            Assert.True(result.Success, $"{result.AllOutput}");
-            Assert.Contains("No results found.", $"{result.AllOutput}");
-            Assert.DoesNotContain(">", $"{result.AllOutput}");
-            Assert.Contains("WARNING: You are running the 'search' operation with an 'HTTP' source", result.AllOutput);
+            Assert.False(result.Success);
+            Assert.Contains(expectedErrorMessage, result.AllOutput);
         }
 
         [Theory]
@@ -1001,7 +1044,10 @@ namespace NuGet.CommandLine.FuncTest.Commands
             string nugetexe = Util.GetNuGetExePath();
 
             using MockServer server1 = new MockServer();
+            PackageSource source1 = new PackageSource(server1.Uri + "v3/index.json", "http-feed1");
             using MockServer server2 = new MockServer();
+            PackageSource source2 = new PackageSource(server2.Uri + "v3/index.json", "http-feed2");
+            List<PackageSource> sources = new List<PackageSource>() { source1, source2 };
             using SimpleTestPathContext config = new SimpleTestPathContext();
 
             // Arrange the NuGet.Config file
@@ -1103,23 +1149,18 @@ $@"<configuration>
             server2.Stop();
 
             // Assert
-            Assert.True(result.Success, $"{result.AllOutput}");
-            Assert.Contains("No results found.", $"{result.AllOutput}");
-            Assert.DoesNotContain(">", $"{result.AllOutput}");
+            string expectedError = string.Format(CultureInfo.CurrentCulture, NuGetResources.Error_HttpSources_Multiple, "search", Environment.NewLine + string.Join(Environment.NewLine, sources.Select(e => e.Name)));
 
-            string actualOutputWithoutSpace = SettingsTestUtils.RemoveWhitespace(result.Output);
-            string expectedWarningWithoutSpace = SettingsTestUtils.RemoveWhitespace($@"
-WARNING: You are running the 'search' operation with 'HTTP' sources:  
-http-feed1
-http-feed2
-Non-HTTPS access will be removed in a future version. Consider migrating to 'HTTPS' sources.");
             if (isHttpWarningExpected)
             {
-                Assert.Contains(expectedWarningWithoutSpace, actualOutputWithoutSpace);
+                Assert.False(result.Success);
+                Assert.Contains(expectedError, result.AllOutput);
             }
             else
             {
-                Assert.DoesNotContain(expectedWarningWithoutSpace, actualOutputWithoutSpace);
+                Assert.True(result.Success);
+                Assert.Contains("No results found.", $"{result.AllOutput}");
+                Assert.DoesNotContain(expectedError, result.AllOutput);
             }
         }
     }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SearchCommandTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using NuGet.CommandLine.Test;
 using NuGet.Configuration;
@@ -26,14 +25,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
                 // Arrange the NuGet.Config file
-                string nugetConfigContent =
-    $@"<configuration>
-    <packageSources>
-        <clear />
-        <add key='mockSource' value='{server.Uri}v3/index.json' allowInsecureConnections='true' />
-    </packageSources>
-</configuration>";
-                File.WriteAllText(config.NuGetConfig, nugetConfigContent);
+                config.Settings.AddSource("mockSource", $"{server.Uri}v3/index.json", allowInsecureConnectionsValue: "true");
 
                 string index = $@"
                 {{
@@ -140,14 +132,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
                 // Arrange the NuGet.Config file
-                string nugetConfigContent =
-    $@"<configuration>
-    <packageSources>
-        <clear />
-        <add key='mockSource' value='{server.Uri}v3/index.json' allowInsecureConnections='true' />
-    </packageSources>
-</configuration>";
-                File.WriteAllText(config.NuGetConfig, nugetConfigContent);
+                config.Settings.AddSource("mockSource", $"{server.Uri}v3/index.json", allowInsecureConnectionsValue: "true");
 
                 string index = $@"
                 {{
@@ -260,14 +245,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
                 // Arrange the NuGet.Config file
-                string nugetConfigContent =
-    $@"<configuration>
-    <packageSources>
-        <clear />
-        <add key='mockSource' value='{server.Uri}v3/index.json' allowInsecureConnections='true' />
-    </packageSources>
-</configuration>";
-                File.WriteAllText(config.NuGetConfig, nugetConfigContent);
+                config.Settings.AddSource("mockSource", $"{server.Uri}v3/index.json", allowInsecureConnectionsValue: "true");
 
                 string index = $@"
                 {{
@@ -380,14 +358,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
                 // Arrange the NuGet.Config file
-                string nugetConfigContent =
-    $@"<configuration>
-    <packageSources>
-        <clear />
-        <add key='mockSource' value='{server.Uri}v3/index.json' allowInsecureConnections='true' />
-    </packageSources>
-</configuration>";
-                File.WriteAllText(config.NuGetConfig, nugetConfigContent);
+                config.Settings.AddSource("mockSource", $"{server.Uri}v3/index.json", allowInsecureConnectionsValue: "true");
 
                 string index = $@"
                 {{
@@ -500,14 +471,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
                 // Arrange the NuGet.Config file
-                string nugetConfigContent =
-    $@"<configuration>
-    <packageSources>
-        <clear />
-        <add key='mockSource' value='{server.Uri}v3/index.json' allowInsecureConnections='true' />
-    </packageSources>
-</configuration>";
-                File.WriteAllText(config.NuGetConfig, nugetConfigContent);
+                config.Settings.AddSource("mockSource", $"{server.Uri}v3/index.json", allowInsecureConnectionsValue: "true");
 
                 string index = $@"
                 {{
@@ -668,14 +632,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
                 // Arrange the NuGet.Config file
-                string nugetConfigContent =
-    $@"<configuration>
-    <packageSources>
-        <clear />
-        <add key='mockSource' value='{server.Uri}v3/index.json' allowInsecureConnections='true' />
-    </packageSources>
-</configuration>";
-                File.WriteAllText(config.NuGetConfig, nugetConfigContent);
+                config.Settings.AddSource("mockSource", $"{server.Uri}v3/index.json", allowInsecureConnectionsValue: "true");
 
                 string index = $@"
                 {{
@@ -784,14 +741,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
                 // Arrange the NuGet.Config file
-                string nugetConfigContent =
-    $@"<configuration>
-    <packageSources>
-        <clear />
-        <add key='mockSource' value='{server.Uri}v3/index.json' allowInsecureConnections='true' />
-    </packageSources>
-</configuration>";
-                File.WriteAllText(config.NuGetConfig, nugetConfigContent);
+                config.Settings.AddSource("mockSource", $"{server.Uri}v3/index.json", allowInsecureConnectionsValue: "true");
 
                 string index = $@"
                 {{
@@ -900,14 +850,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
                 // Arrange the NuGet.Config file
-                string nugetConfigContent =
-    $@"<configuration>
-    <packageSources>
-        <clear />
-        <add key='mockSource' value='{server.Uri}v3/index.json' allowInsecureConnections='true' />
-    </packageSources>
-</configuration>";
-                File.WriteAllText(config.NuGetConfig, nugetConfigContent);
+                config.Settings.AddSource("mockSource", $"{server.Uri}v3/index.json", allowInsecureConnectionsValue: "true");
 
                 string index = $@"
                 {{
@@ -1038,7 +981,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
         [Theory]
         [InlineData("true", false)]
         [InlineData("false", true)]
-        public void SearchCommand_WhenSearchWithHttpSourcesWithAllowInsecureConnections_WarnsCorrectly(string allowInsecureConnections, bool isHttpWarningExpected)
+        public void SearchCommand_WhenSearchWithHttpSourcesWithAllowInsecureConnections_DisplaysErrorCorrectly(string allowInsecureConnections, bool isHttpWarningExpected)
         {
             // Arrange
             string nugetexe = Util.GetNuGetExePath();
@@ -1051,15 +994,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using SimpleTestPathContext config = new SimpleTestPathContext();
 
             // Arrange the NuGet.Config file
-            string nugetConfigContent =
-$@"<configuration>
-    <packageSources>
-        <clear />
-        <add key='http-feed1' value='{server1.Uri}v3/index.json' allowInsecureConnections=""{allowInsecureConnections}"" />
-        <add key='http-feed2' value='{server2.Uri}v3/index.json' allowInsecureConnections=""{allowInsecureConnections}"" />
-    </packageSources>
-</configuration>";
-            File.WriteAllText(config.NuGetConfig, nugetConfigContent);
+            config.Settings.AddSource("http-feed1", $"{server1.Uri}v3/index.json", allowInsecureConnectionsValue: allowInsecureConnections);
+            config.Settings.AddSource("http-feed2", $"{server2.Uri}v3/index.json", allowInsecureConnectionsValue: allowInsecureConnections);
 
             string index = $@"
                 {{


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13316

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This PR introduces changes to replace the current warning mechanism with an error message whenever an HTTP source is utilized. This modification aims to enhance security and encourage best practices by strictly enforcing the use of HTTPS over HTTP for source connections.

Example
```powershell 
> nuget search -source http://mysource
```
```output
You are running the 'search' operation with 'HTTP' sources:  http://mysource. NuGet requires HTTPS sources. To use HTTP sources, you must explicitly set 'allowInsecureConnections' to true in your NuGet.Config file. Please refer to https://aka.ms/nuget-https-everywhere.
```
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
