### PR TITLE
Update .NET SDK installation in release-5.11.x

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -52,6 +52,7 @@
     <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.21117.3\tools\netcoreapp3.1\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
     <NoWarn>$(NoWarn);NU5105;MSB3277</NoWarn>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1900;NU1901;NU1902;NU1903;NU1904;NU1905</WarningsNotAsErrors>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <!-- Defaults -->

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -197,44 +197,11 @@ Function Install-DotnetCLI {
             $arch = "x86";
         }
 
-        if ($Version -eq 'latest') {
+        Trace-Log "The version of SDK should be installed is : $Version"
 
-            # When installing latest, we firstly check the latest version from the server against what we have installed locally. This also allows us to check the SDK was correctly installed.
-            # Get the latest specific version number for a certain channel from url like : https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/latest.version
-            $latestVersionLink = "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/" + $Channel + "/latest.version"
-            $latestVersionFile = Invoke-RestMethod -Method Get -Uri $latestVersionLink
-
-            $stringReader = New-Object -TypeName System.IO.StringReader -ArgumentList $latestVersionFile
-            [int]$count = 0
-            while ( $line = $stringReader.ReadLine() ) {
-                if ($count -eq 1) {
-                    $expectedVersion = $line.trim()
-                }
-                $count += 1
-            }
-
-            $httpGetUrl = "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/" + $expectedVersion + "/productVersion.txt"
-            $versionFile = Invoke-RestMethod -Method Get -Uri $httpGetUrl
-
-            $stringReader = New-Object -TypeName System.IO.StringReader -ArgumentList $versionFile
-            [int]$count = 0
-            while ( $line = $stringReader.ReadLine() ) {
-                if ($count -eq 1) {
-                    $specificVersion = $line.trim()
-                }
-                $count += 1
-            }
-        }
-        else {
-            $specificVersion = $Version
-        }
-
-        Trace-Log "The version of SDK should be installed is : $specificVersion"
-
-        $probeDotnetPath = Join-Path (Join-Path $cli.Root sdk)  $specificVersion
+        $probeDotnetPath = Join-Path (Join-Path $cli.Root sdk) $Version
 
         Trace-Log "Probing folder : $probeDotnetPath"
-
         #If "-force" is specified, or folder with specific version doesn't exist, the download command will run"
         if ($Force -or -not (Test-Path $probeDotnetPath)) {
             Trace-Log "$DotNetInstall -Channel $($cli.Channel) -InstallDir $($cli.Root) -Version $($cli.Version) -Architecture $arch -NoPath"
@@ -251,12 +218,6 @@ Function Install-DotnetCLI {
         if (-not (Test-Path $DotNetExe)) {
             Error-Log "Unable to find dotnet.exe. The CLI install may have failed." -Fatal
         }
-        if (-not(Test-Path $probeDotnetPath)) {
-            Error-Log "Unable to find specific version of sdk. The CLI install may have failed." -Fatal
-        }
-
-        # Display build info
-        & $DotNetExe --info
     }
 
     # Install the 2.x runtime because our tests target netcoreapp2x
@@ -268,6 +229,18 @@ Function Install-DotnetCLI {
     if ($LASTEXITCODE -ne 0)
     {
         throw "dotnet-install.ps1 exited with non-zero exit code"
+    }
+
+    if ($env:CI -eq "true") {
+        Write-Host "##vso[task.setvariable variable=DOTNET_ROOT;isOutput=false;issecret=false;]$CLIRoot"
+        Write-Host "##vso[task.setvariable variable=DOTNET_MULTILEVEL_LOOKUP;isOutput=false;issecret=false;]0"
+        Write-Host "##vso[task.prependpath]$CLIRoot"
+    } else {
+        $env:DOTNET_ROOT=$CLIRoot
+        $env:DOTNET_MULTILEVEL_LOOKUP=0
+        if (-not $env:path.Contains($CLIRoot)) {
+            $env:path = $CLIRoot + ";" + $env:path
+        }
     }
 
     # Display build info

--- a/build/config.props
+++ b/build/config.props
@@ -37,7 +37,7 @@
     <!-- Specifies the SDK version to download to use for testing. The first value represents the channel, the second value represents the exact SDK version to be download. If a version is not specified, the latest version from the channel will be downloaded.
     Note that multiple SDKs can be downloaded by using `;` as a separator.
     -->
-    <CliBranchForTesting Condition="'$(CliBranchForTesting)' == ''">release/5.0.2xx:5.0.200-servicing.21120.4</CliBranchForTesting>
+    <CliBranchForTesting Condition="'$(CliBranchForTesting)' == ''">5.0</CliBranchForTesting>
   </PropertyGroup>
 
   <!-- Config -->


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
The release-5.11.x branch is failing because the .NET SDK is no longer installed on CI machines and our installation does not add itself to the PATH.  This change simplifies the .NET SDK installation by just installing the latest 5.0 SDK and adds it to the path.  I also disabled the EOL warning since we know this servicing branch doesn't care.

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
