### PR TITLE
Deprecate http usage: `nuget list` promote warning to error for http sources

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/ListCommand/ListCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/ListCommand/ListCommandRunner.cs
@@ -49,7 +49,7 @@ namespace NuGet.Commands
                 }
             }
 
-            WarnForHTTPSources(listArgs);
+            AvoidHttpSources(listArgs);
 
             var allPackages = new List<IEnumerableAsync<IPackageSearchMetadata>>();
             var log = listArgs.IsDetailed ? listArgs.Logger : NullLogger.Instance;
@@ -64,7 +64,7 @@ namespace NuGet.Commands
             await PrintPackages(listArgs, new AggregateEnumerableAsync<IPackageSearchMetadata>(allPackages, comparer, comparer).GetEnumeratorAsync());
         }
 
-        private static void WarnForHTTPSources(ListArgs listArgs)
+        private static void AvoidHttpSources(ListArgs listArgs)
         {
             List<PackageSource> httpPackageSources = null;
             foreach (PackageSource packageSource in listArgs.ListEndpoints)
@@ -83,17 +83,17 @@ namespace NuGet.Commands
             {
                 if (httpPackageSources.Count == 1)
                 {
-                    listArgs.Logger.LogWarning(
+                    throw new ArgumentException(
                         string.Format(CultureInfo.CurrentCulture,
-                        Strings.Warning_HttpServerUsage,
+                        Strings.Error_HttpSource_Single,
                         "list",
                         httpPackageSources[0]));
                 }
                 else
                 {
-                    listArgs.Logger.LogWarning(
+                    throw new ArgumentException(
                         string.Format(CultureInfo.CurrentCulture,
-                        Strings.Warning_HttpServerUsage_MultipleSources,
+                        Strings.Error_HttpSources_Multiple,
                         "list",
                         Environment.NewLine + string.Join(Environment.NewLine, httpPackageSources.Select(e => e.Name))));
                 }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -385,6 +385,24 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;HTTP&apos; source: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option..
+        /// </summary>
+        internal static string Error_HttpSource_Single {
+            get {
+                return ResourceManager.GetString("Error_HttpSource_Single", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with &apos;HTTP&apos; sources: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option..
+        /// </summary>
+        internal static string Error_HttpSources_Multiple {
+            get {
+                return ResourceManager.GetString("Error_HttpSources_Multiple", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The package {0} {1} has a package type {2} that is incompatible with this project..
         /// </summary>
         internal static string Error_IncompatiblePackageType {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -385,7 +385,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;HTTP&apos; source: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option..
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;HTTP&apos; source: {1}. NuGet requires HTTPS sources. To use an HTTP source, you must explicitly set &apos;allowInsecureConnections&apos; to true in your NuGet.Config file. Please refer to https://aka.ms/nuget-https-everywhere..
         /// </summary>
         internal static string Error_HttpSource_Single {
             get {
@@ -394,7 +394,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with &apos;HTTP&apos; sources: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option..
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with &apos;HTTP&apos; sources: {1}. NuGet requires HTTPS sources. To use HTTP sources, you must explicitly set &apos;allowInsecureConnections&apos; to true in your NuGet.Config file. Please refer to https://aka.ms/nuget-https-everywhere..
         /// </summary>
         internal static string Error_HttpSources_Multiple {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1099,4 +1099,12 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
   <data name="SourcesCommandValidProtocolVersion" xml:space="preserve">
     <value>The protocol version specified is invalid. Valid protocol versions are from {0} to {1}.</value>
   </data>
+  <data name="Error_HttpSources_Multiple" xml:space="preserve">
+    <value>You are running the '{0}' operation with 'HTTP' sources: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option.</value>
+    <comment>0 - The command name. Ex. Push/Delete. 1 - list of server URIs</comment>
+  </data>
+  <data name="Error_HttpSource_Single" xml:space="preserve">
+    <value>You are running the '{0}' operation with an 'HTTP' source: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option.</value>
+    <comment>0 - The command name. Ex. Push/Delete. 1 - server URI.</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1100,11 +1100,11 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
     <value>The protocol version specified is invalid. Valid protocol versions are from {0} to {1}.</value>
   </data>
   <data name="Error_HttpSources_Multiple" xml:space="preserve">
-    <value>You are running the '{0}' operation with 'HTTP' sources: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option.</value>
+    <value>You are running the '{0}' operation with 'HTTP' sources: {1}. NuGet requires HTTPS sources. To use HTTP sources, you must explicitly set 'allowInsecureConnections' to true in your NuGet.Config file. Please refer to https://aka.ms/nuget-https-everywhere.</value>
     <comment>0 - The command name. Ex. Push/Delete. 1 - list of server URIs</comment>
   </data>
   <data name="Error_HttpSource_Single" xml:space="preserve">
-    <value>You are running the '{0}' operation with an 'HTTP' source: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option.</value>
+    <value>You are running the '{0}' operation with an 'HTTP' source: {1}. NuGet requires HTTPS sources. To use an HTTP source, you must explicitly set 'allowInsecureConnections' to true in your NuGet.Config file. Please refer to https://aka.ms/nuget-https-everywhere.</value>
     <comment>0 - The command name. Ex. Push/Delete. 1 - server URI.</comment>
   </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
@@ -20,8 +20,8 @@ namespace NuGet.CommandLine.Test
 {
     public class NuGetListCommandTest
     {
-        string _httpErrorSingle = "You are running the '{0}' operation with an 'HTTP' source: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option.";
-        string _httpErrorMultiple = "You are running the '{0}' operation with 'HTTP' sources: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option.";
+        string _httpErrorSingle = "You are running the '{0}' operation with an 'HTTP' source: {1}. NuGet requires HTTPS sources. To use an HTTP source, you must explicitly set 'allowInsecureConnections' to true in your NuGet.Config file. Please refer to https://aka.ms/nuget-https-everywhere.";
+        string _httpErrorMultiple = "You are running the '{0}' operation with 'HTTP' sources: {1}. NuGet requires HTTPS sources. To use HTTP sources, you must explicitly set 'allowInsecureConnections' to true in your NuGet.Config file. Please refer to https://aka.ms/nuget-https-everywhere.";
 
         [Fact]
         public void ListCommand_WithNugetShowStack_ShowsStack()

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
@@ -188,7 +188,7 @@ namespace NuGet.CommandLine.Test
             var nugetexe = Util.GetNuGetExePath();
 
             using (var packageDirectory = TestDirectory.Create())
-            using (var randomTestFolder = TestDirectory.Create())
+            using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
                 // Arrange
                 var packageFileName1 = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
@@ -213,21 +213,13 @@ namespace NuGet.CommandLine.Test
                     server.Get.Add("/nuget", r => "OK");
 
                     server.Start();
-
-                    string configFile =
-                        $"<configuration>" +
-                        $"<packageSources>" +
-                        $"<clear />" +
-                        $"<add key=\"mockServer\" value=\"{server.Uri}nuget\" allowInsecureConnections='true'/>" +
-                        $"</packageSources>" +
-                        $"</configuration>";
-                    File.WriteAllText(Path.Combine(randomTestFolder, "nuget.config"), configFile);
+                    config.Settings.AddSource("mockServer", $"{server.Uri}nuget", allowInsecureConnectionsValue: "true");
 
                     // Act
                     var args = "list test -Source " + server.Uri + "nuget";
                     var result = CommandRunner.Run(
                         nugetexe,
-                        randomTestFolder,
+                        config.WorkingDirectory,
                         args);
                     server.Stop();
 
@@ -253,7 +245,7 @@ namespace NuGet.CommandLine.Test
             var nugetexe = Util.GetNuGetExePath();
 
             using (var packageDirectory = TestDirectory.Create())
-            using (var randomTestFolder = TestDirectory.Create())
+            using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
                 // Arrange
                 var packageFileName1 = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
@@ -278,20 +270,13 @@ namespace NuGet.CommandLine.Test
                     server.Get.Add("/nuget", r => "OK");
 
                     server.Start();
-                    string configFile =
-                        $"<configuration>" +
-                        $"<packageSources>" +
-                        $"<clear />" +
-                        $"<add key=\"mockServer\" value=\"{server.Uri}nuget\" allowInsecureConnections='true'/>" +
-                        $"</packageSources>" +
-                        $"</configuration>";
-                    File.WriteAllText(Path.Combine(randomTestFolder, "nuget.config"), configFile);
+                    config.Settings.AddSource("mockServer", $"{server.Uri}nuget", allowInsecureConnectionsValue: "true");
 
                     // Act
                     var args = "list test -Source " + server.Uri + "nuget";
                     var r1 = CommandRunner.Run(
                         nugetexe,
-                        randomTestFolder,
+                        config.WorkingDirectory,
                         args);
                     server.Stop();
 
@@ -321,7 +306,7 @@ namespace NuGet.CommandLine.Test
             var nugetexe = Util.GetNuGetExePath();
 
             using (var packageDirectory = TestDirectory.Create())
-            using (var randomTestFolder = TestDirectory.Create())
+            using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
                 // Arrange
                 var packageFileName1 = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
@@ -346,20 +331,13 @@ namespace NuGet.CommandLine.Test
                     server.Get.Add("/nuget", r => "OK");
 
                     server.Start();
-                    string configFile =
-                        $"<configuration>" +
-                        $"<packageSources>" +
-                        $"<clear />" +
-                        $"<add key=\"mockServer\" value=\"{server.Uri}nuget\" allowInsecureConnections='true'/>" +
-                        $"</packageSources>" +
-                        $"</configuration>";
-                    File.WriteAllText(Path.Combine(randomTestFolder, "nuget.config"), configFile);
+                    config.Settings.AddSource("mockServer", $"{server.Uri}nuget", allowInsecureConnectionsValue: "true");
 
                     // Act
                     var args = "list test -IncludeDelisted -Source " + server.Uri + "nuget";
                     var r1 = CommandRunner.Run(
                         nugetexe,
-                        randomTestFolder,
+                        config.WorkingDirectory,
                         args);
                     server.Stop();
 
@@ -386,7 +364,7 @@ namespace NuGet.CommandLine.Test
             var nugetexe = Util.GetNuGetExePath();
 
             using (var packageDirectory = TestDirectory.Create())
-            using (var randomTestFolder = TestDirectory.Create())
+            using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
                 // Arrange
                 var packageFileName1 = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
@@ -411,20 +389,13 @@ namespace NuGet.CommandLine.Test
                     server.Get.Add("/nuget", r => "OK");
 
                     server.Start();
-                    string configFile =
-                        $"<configuration>" +
-                        $"<packageSources>" +
-                        $"<clear />" +
-                        $"<add key=\"mockServer\" value=\"{server.Uri}nuget\" allowInsecureConnections='true'/>" +
-                        $"</packageSources>" +
-                        $"</configuration>";
-                    File.WriteAllText(Path.Combine(randomTestFolder, "nuget.config"), configFile);
+                    config.Settings.AddSource("mockServer", $"{server.Uri}nuget", allowInsecureConnectionsValue: "true");
 
                     // Act
                     var args = "list test -Verbosity detailed -Source " + server.Uri + "nuget";
                     var r1 = CommandRunner.Run(
                         nugetexe,
-                        randomTestFolder,
+                        config.WorkingDirectory,
                         args);
                     server.Stop();
 
@@ -450,7 +421,7 @@ namespace NuGet.CommandLine.Test
             var nugetexe = Util.GetNuGetExePath();
 
             using (var packageDirectory = TestDirectory.Create())
-            using (var randomTestFolder = TestDirectory.Create())
+            using (SimpleTestPathContext config = new SimpleTestPathContext())
             {
                 // Arrange
                 var packageFileName1 = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
@@ -475,20 +446,13 @@ namespace NuGet.CommandLine.Test
                     server.Get.Add("/nuget", r => "OK");
 
                     server.Start();
-                    string configFile =
-                        $"<configuration>" +
-                        $"<packageSources>" +
-                        $"<clear />" +
-                        $"<add key=\"mockServer\" value=\"{server.Uri}nuget\" allowInsecureConnections='true'/>" +
-                        $"</packageSources>" +
-                        $"</configuration>";
-                    File.WriteAllText(Path.Combine(randomTestFolder, "nuget.config"), configFile);
+                    config.Settings.AddSource("mockServer", $"{server.Uri}nuget", allowInsecureConnectionsValue: "true");
 
                     // Act
                     var args = "list test -AllVersions -Source " + server.Uri + "nuget";
                     var r1 = CommandRunner.Run(
                         nugetexe,
-                        randomTestFolder,
+                        config.WorkingDirectory,
                         args);
                     server.Stop();
 
@@ -542,14 +506,7 @@ namespace NuGet.CommandLine.Test
                     server.Get.Add("/nuget", r => "OK");
 
                     server.Start();
-                    string configFile =
-                        $"<configuration>" +
-                        $"<packageSources>" +
-                        $"<clear />" +
-                        $"<add key=\"mockServer\" value=\"{server.Uri}nuget\" allowInsecureConnections='true'/>" +
-                        $"</packageSources>" +
-                        $"</configuration>";
-                    File.WriteAllText(Path.Combine(solutionFolder, "nuget.config"), configFile);
+                    pathContext.Settings.AddSource("mockServer", $"{server.Uri}nuget", allowInsecureConnectionsValue: "true");
 
                     // Act
                     var args = "list test -Prerelease -Source " + server.Uri + "nuget";
@@ -609,14 +566,7 @@ namespace NuGet.CommandLine.Test
                     server.Get.Add("/nuget", r => "OK");
 
                     server.Start();
-                    string configFile =
-                        $"<configuration>" +
-                        $"<packageSources>" +
-                        $"<clear />" +
-                        $"<add key=\"mockServer\" value=\"{server.Uri}nuget\" allowInsecureConnections='true'/>" +
-                        $"</packageSources>" +
-                        $"</configuration>";
-                    File.WriteAllText(Path.Combine(solutionFolder, "nuget.config"), configFile);
+                    pathContext.Settings.AddSource("mockServer", $"{server.Uri}nuget", allowInsecureConnectionsValue: "true");
 
                     // Act
                     var args = "list test -AllVersions -Prerelease -Source " + server.Uri + "nuget";
@@ -714,14 +664,7 @@ namespace NuGet.CommandLine.Test
 
                         serverV3.Start();
                         serverV2.Start();
-                        string configFile =
-                        $"<configuration>" +
-                        $"<packageSources>" +
-                        $"<clear />" +
-                        $"<add key=\"mockServer\" value=\"{serverV3.Uri}index.json\" allowInsecureConnections='true'/>" +
-                        $"</packageSources>" +
-                        $"</configuration>";
-                        File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "nuget.config"), configFile);
+                        pathContext.Settings.AddSource("mockServer", $"{serverV3.Uri}index.json", allowInsecureConnectionsValue: "true");
 
                         // Act
                         var args = "list test -Source " + serverV3.Uri + "index.json";
@@ -782,14 +725,7 @@ namespace NuGet.CommandLine.Test
                     });
 
                     serverV3.Start();
-                    string configFile =
-                        $"<configuration>" +
-                        $"<packageSources>" +
-                        $"<clear />" +
-                        $"<add key=\"mockServer\" value=\"{serverV3.Uri}index.json\" allowInsecureConnections='true'/>" +
-                        $"</packageSources>" +
-                        $"</configuration>";
-                    File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "nuget.config"), configFile);
+                    pathContext.Settings.AddSource("mockServer", $"{serverV3.Uri}index.json", allowInsecureConnectionsValue: "true");
 
                     // Act
                     var args = "list test -Source " + serverV3.Uri + "index.json";
@@ -844,14 +780,7 @@ namespace NuGet.CommandLine.Test
                     });
 
                     serverV3.Start();
-                    string configFile =
-                        $"<configuration>" +
-                        $"<packageSources>" +
-                        $"<clear />" +
-                        $"<add key=\"mockServer\" value=\"{serverV3.Uri}index.json\" allowInsecureConnections='true'/>" +
-                        $"</packageSources>" +
-                        $"</configuration>";
-                    File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "nuget.config"), configFile);
+                    pathContext.Settings.AddSource("mockServer", $"{serverV3.Uri}index.json", allowInsecureConnectionsValue: "true");
 
                     // Act
                     var args = "list test -Source " + serverV3.Uri + "index.json";
@@ -1222,9 +1151,9 @@ namespace NuGet.CommandLine.Test
             var nugetexe = Util.GetNuGetExePath();
 
             // Arrange
-            using var packageDirectory = TestDirectory.Create();
+            using var pathContext = new SimpleTestPathContext();
             using var server = new MockServer();
-            var packageFileName1 = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
+            var packageFileName1 = Util.CreateTestPackage("testPackage1", "1.1.0", pathContext.WorkingDirectory);
 
             server.Get.Add("/nuget/$metadata", r =>
                 Util.GetMockServerResource());
@@ -1241,13 +1170,9 @@ namespace NuGet.CommandLine.Test
             server.Start();
 
             // create the config file
-            Util.CreateFile(packageDirectory, "nuget.config", $@"
-<configuration>
-    <packageSources>
-        <add key='http-feed' value='{server.Uri}nuget' allowInsecureConnections=""{allowInsecureConnections}"" />
-    </packageSources>
-</configuration>");
-            var configFile = Path.Combine(packageDirectory, "nuget.config");
+            pathContext.Settings.AddSource("http-feed", $"{server.Uri}nuget", allowInsecureConnectionsValue: allowInsecureConnections);
+
+            var configFile = Path.Combine(pathContext.WorkingDirectory, "nuget.config");
             PackageSource source = new PackageSource(server.Uri + "nuget", "http-feed");
             string expectedError = string.Format(CultureInfo.CurrentCulture, _httpErrorSingle, "list", source);
 
@@ -1255,7 +1180,7 @@ namespace NuGet.CommandLine.Test
             var args = "list test -ConfigFile " + configFile;
             var result = CommandRunner.Run(
                 nugetexe,
-                packageDirectory,
+                pathContext.WorkingDirectory,
                 args);
             server.Stop();
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
 using FluentAssertions;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.Packaging;
 using NuGet.Test.Utility;
 using Test.Utility;
@@ -18,6 +20,9 @@ namespace NuGet.CommandLine.Test
 {
     public class NuGetListCommandTest
     {
+        string _httpErrorSingle = "You are running the '{0}' operation with an 'HTTP' source: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option.";
+        string _httpErrorMultiple = "You are running the '{0}' operation with 'HTTP' sources: {1}. To continue with the HTTP source, enable the `-allowInsecureConnections` option.";
+
         [Fact]
         public void ListCommand_WithNugetShowStack_ShowsStack()
         {
@@ -209,6 +214,15 @@ namespace NuGet.CommandLine.Test
 
                     server.Start();
 
+                    string configFile =
+                        $"<configuration>" +
+                        $"<packageSources>" +
+                        $"<clear />" +
+                        $"<add key=\"mockServer\" value=\"{server.Uri}nuget\" allowInsecureConnections='true'/>" +
+                        $"</packageSources>" +
+                        $"</configuration>";
+                    File.WriteAllText(Path.Combine(randomTestFolder, "nuget.config"), configFile);
+
                     // Act
                     var args = "list test -Source " + server.Uri + "nuget";
                     var result = CommandRunner.Run(
@@ -223,7 +237,7 @@ namespace NuGet.CommandLine.Test
                     // verify that only package id & version is displayed
                     var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, RemoveDeprecationWarning(RemoveHttpWarning(result.Output)));
+                    Assert.Equal(expectedOutput, RemoveDeprecationWarning(result.Output));
 
                     Assert.Contains("$filter=IsLatestVersion", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -264,6 +278,14 @@ namespace NuGet.CommandLine.Test
                     server.Get.Add("/nuget", r => "OK");
 
                     server.Start();
+                    string configFile =
+                        $"<configuration>" +
+                        $"<packageSources>" +
+                        $"<clear />" +
+                        $"<add key=\"mockServer\" value=\"{server.Uri}nuget\" allowInsecureConnections='true'/>" +
+                        $"</packageSources>" +
+                        $"</configuration>";
+                    File.WriteAllText(Path.Combine(randomTestFolder, "nuget.config"), configFile);
 
                     // Act
                     var args = "list test -Source " + server.Uri + "nuget";
@@ -279,7 +301,7 @@ namespace NuGet.CommandLine.Test
                     // verify that only testPackage2 is listed since the package testPackage1
                     // is not listed.
                     var expectedOutput = "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, RemoveDeprecationWarning(RemoveHttpWarning(r1.Output)));
+                    Assert.Equal(expectedOutput, RemoveDeprecationWarning(r1.Output));
 
                     Assert.Contains("$filter=IsLatestVersion", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -324,6 +346,14 @@ namespace NuGet.CommandLine.Test
                     server.Get.Add("/nuget", r => "OK");
 
                     server.Start();
+                    string configFile =
+                        $"<configuration>" +
+                        $"<packageSources>" +
+                        $"<clear />" +
+                        $"<add key=\"mockServer\" value=\"{server.Uri}nuget\" allowInsecureConnections='true'/>" +
+                        $"</packageSources>" +
+                        $"</configuration>";
+                    File.WriteAllText(Path.Combine(randomTestFolder, "nuget.config"), configFile);
 
                     // Act
                     var args = "list test -IncludeDelisted -Source " + server.Uri + "nuget";
@@ -340,7 +370,7 @@ namespace NuGet.CommandLine.Test
                     var expectedOutput =
                         "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, RemoveDeprecationWarning(RemoveHttpWarning(r1.Output)));
+                    Assert.Equal(expectedOutput, RemoveDeprecationWarning(r1.Output));
 
                     Assert.Contains("$filter=IsLatestVersion", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -381,6 +411,14 @@ namespace NuGet.CommandLine.Test
                     server.Get.Add("/nuget", r => "OK");
 
                     server.Start();
+                    string configFile =
+                        $"<configuration>" +
+                        $"<packageSources>" +
+                        $"<clear />" +
+                        $"<add key=\"mockServer\" value=\"{server.Uri}nuget\" allowInsecureConnections='true'/>" +
+                        $"</packageSources>" +
+                        $"</configuration>";
+                    File.WriteAllText(Path.Combine(randomTestFolder, "nuget.config"), configFile);
 
                     // Act
                     var args = "list test -Verbosity detailed -Source " + server.Uri + "nuget";
@@ -437,6 +475,14 @@ namespace NuGet.CommandLine.Test
                     server.Get.Add("/nuget", r => "OK");
 
                     server.Start();
+                    string configFile =
+                        $"<configuration>" +
+                        $"<packageSources>" +
+                        $"<clear />" +
+                        $"<add key=\"mockServer\" value=\"{server.Uri}nuget\" allowInsecureConnections='true'/>" +
+                        $"</packageSources>" +
+                        $"</configuration>";
+                    File.WriteAllText(Path.Combine(randomTestFolder, "nuget.config"), configFile);
 
                     // Act
                     var args = "list test -AllVersions -Source " + server.Uri + "nuget";
@@ -452,7 +498,7 @@ namespace NuGet.CommandLine.Test
                     // verify that the output is detailed
                     var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, RemoveDeprecationWarning(RemoveHttpWarning(r1.Output)));
+                    Assert.Equal(expectedOutput, RemoveDeprecationWarning(r1.Output));
 
                     Assert.DoesNotContain("$filter", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -496,6 +542,14 @@ namespace NuGet.CommandLine.Test
                     server.Get.Add("/nuget", r => "OK");
 
                     server.Start();
+                    string configFile =
+                        $"<configuration>" +
+                        $"<packageSources>" +
+                        $"<clear />" +
+                        $"<add key=\"mockServer\" value=\"{server.Uri}nuget\" allowInsecureConnections='true'/>" +
+                        $"</packageSources>" +
+                        $"</configuration>";
+                    File.WriteAllText(Path.Combine(solutionFolder, "nuget.config"), configFile);
 
                     // Act
                     var args = "list test -Prerelease -Source " + server.Uri + "nuget";
@@ -511,7 +565,7 @@ namespace NuGet.CommandLine.Test
                     // verify that the output is detailed
                     var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, RemoveDeprecationWarning(RemoveHttpWarning(r1.Output)));
+                    Assert.Equal(expectedOutput, RemoveDeprecationWarning(r1.Output));
 
                     Assert.Contains("$filter=IsAbsoluteLatestVersion", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -555,6 +609,14 @@ namespace NuGet.CommandLine.Test
                     server.Get.Add("/nuget", r => "OK");
 
                     server.Start();
+                    string configFile =
+                        $"<configuration>" +
+                        $"<packageSources>" +
+                        $"<clear />" +
+                        $"<add key=\"mockServer\" value=\"{server.Uri}nuget\" allowInsecureConnections='true'/>" +
+                        $"</packageSources>" +
+                        $"</configuration>";
+                    File.WriteAllText(Path.Combine(solutionFolder, "nuget.config"), configFile);
 
                     // Act
                     var args = "list test -AllVersions -Prerelease -Source " + server.Uri + "nuget";
@@ -570,7 +632,7 @@ namespace NuGet.CommandLine.Test
                     // verify that the output is detailed
                     var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    RemoveDeprecationWarning(RemoveHttpWarning(r1.Output)).Should().Be(expectedOutput);
+                    RemoveDeprecationWarning(r1.Output).Should().Be(expectedOutput);
 
                     Assert.DoesNotContain("$filter", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -652,6 +714,14 @@ namespace NuGet.CommandLine.Test
 
                         serverV3.Start();
                         serverV2.Start();
+                        string configFile =
+                        $"<configuration>" +
+                        $"<packageSources>" +
+                        $"<clear />" +
+                        $"<add key=\"mockServer\" value=\"{serverV3.Uri}index.json\" allowInsecureConnections='true'/>" +
+                        $"</packageSources>" +
+                        $"</configuration>";
+                        File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "nuget.config"), configFile);
 
                         // Act
                         var args = "list test -Source " + serverV3.Uri + "index.json";
@@ -669,7 +739,7 @@ namespace NuGet.CommandLine.Test
                         // verify that only package id & version is displayed
                         var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                             "testPackage2 2.1.0" + Environment.NewLine;
-                        Assert.Equal(expectedOutput, RemoveDeprecationWarning(RemoveHttpWarning(result.Output)));
+                        Assert.Equal(expectedOutput, RemoveDeprecationWarning(result.Output));
 
                         Assert.Contains("$filter=IsLatestVersion", searchRequest);
                         Assert.Contains("searchTerm='test", searchRequest);
@@ -712,6 +782,14 @@ namespace NuGet.CommandLine.Test
                     });
 
                     serverV3.Start();
+                    string configFile =
+                        $"<configuration>" +
+                        $"<packageSources>" +
+                        $"<clear />" +
+                        $"<add key=\"mockServer\" value=\"{serverV3.Uri}index.json\" allowInsecureConnections='true'/>" +
+                        $"</packageSources>" +
+                        $"</configuration>";
+                    File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "nuget.config"), configFile);
 
                     // Act
                     var args = "list test -Source " + serverV3.Uri + "index.json";
@@ -766,6 +844,14 @@ namespace NuGet.CommandLine.Test
                     });
 
                     serverV3.Start();
+                    string configFile =
+                        $"<configuration>" +
+                        $"<packageSources>" +
+                        $"<clear />" +
+                        $"<add key=\"mockServer\" value=\"{serverV3.Uri}index.json\" allowInsecureConnections='true'/>" +
+                        $"</packageSources>" +
+                        $"</configuration>";
+                    File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "nuget.config"), configFile);
 
                     // Act
                     var args = "list test -Source " + serverV3.Uri + "index.json";
@@ -1001,7 +1087,7 @@ namespace NuGet.CommandLine.Test
 
                     var source = serverV3.Uri + "index.json";
                     var packageSourcesSection = SimpleTestSettingsContext.GetOrAddSection(settings.XML, "packageSources");
-                    SimpleTestSettingsContext.AddEntry(packageSourcesSection, "vsts", source, additionalAtrributeName: "protocolVersion", additionalAttributeValue: "3");
+                    SimpleTestSettingsContext.AddEntry(packageSourcesSection, "vsts", source, additionalAtrributeName: "protocolVersion", additionalAttributeValue: "3", additionalAtrributeName2: "allowInsecureConnections", additionalAttributeValue2: "true");
 
                     //var packageSourceCredentialsSection = SimpleTestSettingsContext.GetOrAddSection(settings.XML, "packageSourceCredentials");
                     SimpleTestSettingsContext.AddPackageSourceCredentialsSection(settings.XML, "vsts", "user", "password", clearTextPassword: true);
@@ -1103,7 +1189,7 @@ namespace NuGet.CommandLine.Test
 
                     var source = $"{serverV3.Uri}api/v2";
                     var packageSourcesSection = SimpleTestSettingsContext.GetOrAddSection(settings.XML, "packageSources");
-                    SimpleTestSettingsContext.AddEntry(packageSourcesSection, "vsts", source, additionalAtrributeName: "protocolVersion", additionalAttributeValue: "2");
+                    SimpleTestSettingsContext.AddEntry(packageSourcesSection, "vsts", source, additionalAtrributeName: "protocolVersion", additionalAttributeValue: "2", additionalAtrributeName2: "allowInsecureConnections", additionalAttributeValue2: "true");
 
                     SimpleTestSettingsContext.AddPackageSourceCredentialsSection(settings.XML, "vsts", "user", "password", clearTextPassword: true);
                     settings.Save();
@@ -1131,7 +1217,7 @@ namespace NuGet.CommandLine.Test
         [PlatformTheory(Platform.Windows)]
         [InlineData("true", false)]
         [InlineData("false", true)]
-        public void ListCommand_WhenListWithHttpSourceAndAllowInsecureConnections_WarnsCorrectly(string allowInsecureConnections, bool isHttpWarningExpected)
+        public void ListCommand_WhenListWithHttpSourceAndAllowInsecureConnections_ProducesAnErrorCorrectly(string allowInsecureConnections, bool isHttpErrorExpected)
         {
             var nugetexe = Util.GetNuGetExePath();
 
@@ -1162,6 +1248,8 @@ namespace NuGet.CommandLine.Test
     </packageSources>
 </configuration>");
             var configFile = Path.Combine(packageDirectory, "nuget.config");
+            PackageSource source = new PackageSource(server.Uri + "nuget", "http-feed");
+            string expectedError = string.Format(CultureInfo.CurrentCulture, _httpErrorSingle, "list", source);
 
             // Act
             var args = "list test -ConfigFile " + configFile;
@@ -1172,23 +1260,23 @@ namespace NuGet.CommandLine.Test
             server.Stop();
 
             // Assert
-            Assert.Equal(0, result.ExitCode);
-
-            // verify that only package id & version is displayed
-            var expectedOutput = "testPackage1 1.1.0";
-            Assert.Contains(expectedOutput, result.Output);
-            if (isHttpWarningExpected)
+            if (isHttpErrorExpected)
             {
-                Assert.Contains("WARNING: You are running the 'list' operation with an 'HTTP' source", result.AllOutput);
+                Assert.False(result.Success);
+                Assert.Contains(expectedError, result.AllOutput);
             }
             else
             {
-                Assert.DoesNotContain("WARNING: You are running the 'list' operation with an 'HTTP' source", result.AllOutput);
+                Assert.Equal(0, result.ExitCode);
+                Assert.DoesNotContain(expectedError, result.AllOutput);
+                // verify that only package id & version is displayed
+                var expectedOutput = "testPackage1 1.1.0";
+                Assert.Contains(expectedOutput, result.Output);
             }
         }
 
         [Fact]
-        public void ListCommand_WhenListWithHttpSources_Warns()
+        public void ListCommand_WhenListWithHttpSources_DisplaysAnError()
         {
             var nugetexe = Util.GetNuGetExePath();
 
@@ -1226,8 +1314,16 @@ namespace NuGet.CommandLine.Test
 
             server2.Start();
 
+            PackageSource source1 = new PackageSource(server1.Uri + "nuget", "http-feed1");
+            PackageSource source2 = new PackageSource(server2.Uri + "nuget", "http-feed2");
+            List<PackageSource> sources = new List<PackageSource>() { source1, source2 };
+            string expectedError = string.Format(CultureInfo.CurrentCulture,
+                        _httpErrorMultiple,
+                        "list",
+                        Environment.NewLine + string.Join(Environment.NewLine, sources.Select(e => e.SourceUri)));
+
             // Act
-            var args = "list test -Source " + server1.Uri + "nuget" + " -Source " + server1.Uri + "nuget";
+            var args = "list test -Source " + server1.Uri + "nuget" + " -Source " + server2.Uri + "nuget";
             var result = CommandRunner.Run(
                 nugetexe,
                 packageDirectory,
@@ -1236,12 +1332,9 @@ namespace NuGet.CommandLine.Test
             server2.Stop();
 
             // Assert
-            Assert.Equal(0, result.ExitCode);
+            Assert.Equal(1, result.ExitCode);
 
-            // verify that only package id & version is displayed
-            var expectedOutput = "testPackage1 1.1.0";
-            Assert.Contains(expectedOutput, result.Output);
-            Assert.Contains("WARNING: You are running the 'list' operation with 'HTTP' sources", result.AllOutput);
+            Assert.Contains(expectedError, result.AllOutput);
         }
 
         [Fact]
@@ -1268,16 +1361,6 @@ namespace NuGet.CommandLine.Test
                 Assert.Equal(0, result.ExitCode);
                 Assert.Equal($"WARNING: {deprecation}{Environment.NewLine}testPackage1 1.1.0{Environment.NewLine}testPackage2 2.0.0{Environment.NewLine}", result.Output);
             }
-        }
-
-        private static string RemoveHttpWarning(string input)
-        {
-            string[] lines = input.Split(
-                new string[] { "\r\n", "\r", "\n" },
-                StringSplitOptions.None
-            );
-
-            return string.Join(Environment.NewLine, lines.Select(e => e).Where(e => !e.StartsWith("WARNING: You are running the")));
         }
 
         private static string RemoveDeprecationWarning(string input)

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -164,6 +164,16 @@ namespace NuGet.Test.Utility
             section.Add(setting);
         }
 
+        public static void AddEntry(XElement section, string key, string value, string additionalAtrributeName, string additionalAttributeValue, string additionalAtrributeName2, string additionalAttributeValue2)
+        {
+            var setting = new XElement(XName.Get("add"));
+            setting.Add(new XAttribute(XName.Get("key"), key));
+            setting.Add(new XAttribute(XName.Get("value"), value));
+            setting.Add(new XAttribute(XName.Get(additionalAtrributeName), additionalAttributeValue));
+            setting.Add(new XAttribute(XName.Get(additionalAtrributeName2), additionalAttributeValue2));
+            section.Add(setting);
+        }
+
         public static void AddSetting(XDocument doc, string key, string value)
         {
             RemoveSetting(doc, key);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13323

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This PR introduces changes to replace the current warning mechanism with an error message whenever an HTTP source is utilized. This modification aims to enhance security and encourage best practices by strictly enforcing the use of HTTPS over HTTP for source connections.

Example
```powershell 
> nuget list -source http://mysource
```
```output
You are running the 'list' operation with 'HTTP' sources:  http://mysource. NuGet requires HTTPS sources. To use HTTP sources, you must explicitly set 'allowInsecureConnections' to true in your NuGet.Config file. Please refer to https://aka.ms/nuget-https-everywhere.
```
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
