### PR TITLE
Deprecate http usage: `delete` operations, promote warning to error for http sources

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
@@ -29,9 +29,8 @@ namespace NuGet.Commands
         {
             source = CommandRunnerUtility.ResolveSource(sourceProvider, source);
             PackageSource packageSource = CommandRunnerUtility.GetOrCreatePackageSource(sourceProvider, source);
-            // Only warn for V3 style sources because they have a service index which is different from the final push url.
-            if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections &&
-                (packageSource.ProtocolVersion == 3 || packageSource.Source.EndsWith("json", StringComparison.OrdinalIgnoreCase)))
+            // Throw an error if an http source is used without setting AllowInsecureConnections
+            if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections)
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_HttpSource_Single, "delete", packageSource.Source));
             }

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/DeleteRunner.cs
@@ -33,7 +33,7 @@ namespace NuGet.Commands
             if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections &&
                 (packageSource.ProtocolVersion == 3 || packageSource.Source.EndsWith("json", StringComparison.OrdinalIgnoreCase)))
             {
-                logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "delete", packageSource.Source));
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_HttpSource_Single, "delete", packageSource.Source));
             }
             var packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, packageSource, CancellationToken.None);
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
@@ -184,7 +184,7 @@ namespace NuGet.CommandLine.Test
                     return HttpStatusCode.OK;
                 });
                 using SimpleTestPathContext pathContext = new SimpleTestPathContext();
-                pathContext.Settings.AddSource("http-feed", $"{server.Uri}nuget");
+                pathContext.Settings.AddSource("http-feed", $"{server.Uri}nuget", allowInsecureConnectionsValue: "true");
                 var configFileName = "nuget.config";
                 var configFilePath = Path.Combine(pathContext.WorkingDirectory, configFileName);
 
@@ -225,7 +225,7 @@ namespace NuGet.CommandLine.Test
 
                 server.Start();
                 using SimpleTestPathContext pathContext = new SimpleTestPathContext();
-                pathContext.Settings.AddSource("http-feed", $"{server.Uri}nuget");
+                pathContext.Settings.AddSource("http-feed", $"{server.Uri}nuget", allowInsecureConnectionsValue: "true");
                 var configFileName = "nuget.config";
                 var configFilePath = Path.Combine(pathContext.WorkingDirectory, configFileName);
 
@@ -275,7 +275,7 @@ namespace NuGet.CommandLine.Test
 
                 server.Start();
                 using SimpleTestPathContext pathContext = new SimpleTestPathContext();
-                pathContext.Settings.AddSource("http-feed", $"{server.Uri}nuget");
+                pathContext.Settings.AddSource("http-feed", $"{server.Uri}nuget", allowInsecureConnectionsValue: "true");
                 var configFileName = "nuget.config";
                 var configFilePath = Path.Combine(pathContext.WorkingDirectory, configFileName);
 
@@ -397,7 +397,7 @@ namespace NuGet.CommandLine.Test
             {
                 server.Start();
                 using SimpleTestPathContext pathContext = new SimpleTestPathContext();
-                pathContext.Settings.AddSource("http-feed", $"{server.Uri}nuget");
+                pathContext.Settings.AddSource("http-feed", $"{server.Uri}nuget", allowInsecureConnectionsValue: "true");
                 var configFileName = "nuget.config";
                 var configFilePath = Path.Combine(pathContext.WorkingDirectory, configFileName);
                 server.Delete.Add("/nuget/testPackage1/1.1", request => HttpStatusCode.OK);
@@ -436,7 +436,7 @@ namespace NuGet.CommandLine.Test
         [Theory]
         [InlineData("true", false)]
         [InlineData("false", true)]
-        public void DeleteCommand_WhenDeleteWithHttpSourceAndAllowInsecureConnections_DisplayesErrorCorrectly(string allowInsecureConnections, bool shouldFail)
+        public void DeleteCommand_WhenDeleteWithHttpSourceAndAllowInsecureConnections_DisplaysErrorCorrectly(string allowInsecureConnections, bool shouldFail)
         {
             var nugetexe = Util.GetNuGetExePath();
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13341

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Show an error when the `delete` operation is used with an http source
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
