### PR TITLE
fix compile errors in NuGet.CommandLine project that broke the builds locally

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -761,6 +761,7 @@ namespace NuGet.CommandLine
 
                 projectFactory.InitializeProperties(builder);
 
+#pragma warning disable CS0612 // Type or member is obsolete
                 if (!projectFactory.ProcessJsonFile(builder, project.DirectoryPath, null))
                 {
                     projectFactory.ProcessNuspec(builder, null);
@@ -772,6 +773,7 @@ namespace NuGet.CommandLine
                         string.Format(CultureInfo.CurrentCulture, NuGetResources.ProjectJsonPack_Deprecated, builder.Id),
                         NuGetLogCode.NU5126));
                 }
+#pragma warning restore CS0612 // Type or member is obsolete
 
                 VersionRange versionRange = null;
                 if (dependencies.ContainsKey(builder.Id))

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Solution.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Solution.cs
@@ -135,7 +135,7 @@ namespace NuGet.Common
 
                 try
                 {
-                    var projectShouldBuild = !isSolutionFilter || projectShouldBuildMethod.Invoke(solutionFile, new object[] { project.RelativePath });
+                    var projectShouldBuild = !isSolutionFilter || (bool)projectShouldBuildMethod.Invoke(solutionFile, new object[] { project.RelativePath });
                     if (projectShouldBuild)
                     {
                         var relativePath = project.RelativePath.Replace('\\', Path.DirectorySeparatorChar);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2742

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

When I cloned the NuGet.Client repository on my devbox and ARM64 machine, I encountered the following errors that broke our local builds in the latest VS internal preview version.

| Code   | Description                                                                 | Project           | File             | Line |
|--------|-----------------------------------------------------------------------------|-------------------|------------------|------|
| CS0612 | 'ProjectFactory.ProcessJsonFile(PackageBuilder, string, string)' is obsolete | NuGet.CommandLine | ProjectFactory.cs| 764  |                  
| CS0019 | OR Operator cannot be applied to operands of type 'bool' and 'object' | NuGet.CommandLine | Solution.cs      | 138  |                  


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A
