### PR TITLE
Fix `MicroBuildOutputFolderOverride` on publishing of BootstrapperInfo.json

### DIFF
--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -133,7 +133,7 @@ stages:
       - output: pipelineArtifact
         displayName: 'Publish BootstrapperInfo.json as a build artifact'
         condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-        targetPath: ${MicroBuildOutputFolderOverride}\MicroBuild\Output
+        targetPath: $(env:MicroBuildOutputFolderOverride)\MicroBuild\Output
         artifactName: MicroBuildOutputs
 
       - output: artifactsDrop

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -133,7 +133,7 @@ stages:
       - output: pipelineArtifact
         displayName: 'Publish BootstrapperInfo.json as a build artifact'
         condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-        targetPath: $(env:MicroBuildOutputFolderOverride)\MicroBuild\Output
+        targetPath: $(MicroBuildOutputFolderOverride)\MicroBuild\Output
         artifactName: MicroBuildOutputs
 
       - output: artifactsDrop

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -133,7 +133,7 @@ stages:
       - output: pipelineArtifact
         displayName: 'Publish BootstrapperInfo.json as a build artifact'
         condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-        targetPath: ${env:MicroBuildOutputFolderOverride}\MicroBuild\Output
+        targetPath: ${MicroBuildOutputFolderOverride}\MicroBuild\Output
         artifactName: MicroBuildOutputs
 
       - output: artifactsDrop


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2746

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Fixing a mistaken use of the env: prefix on this envvar. The result was that MicroBuildOutputs were empty which is what this change attempted to correct. The PR merged before my commit dropping `env:`.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
