### PR TITLE
NuGetAuditSuppress for LegacyPackageReferenceProject in VS

### DIFF
--- a/build/Shared/vs-threading.MembersRequiringMainThread.txt
+++ b/build/Shared/vs-threading.MembersRequiringMainThread.txt
@@ -11,5 +11,6 @@
 [NuGet.PackageManagement.VisualStudio.EnvDTEProjectUtility]::TryGetFolder
 [NuGet.PackageManagement.VisualStudio.EnvDTEProjectUtility]::TryGetNestedFile
 [NuGet.ProjectManagement.IProjectBuildProperties]::GetPropertyValue
-[NuGet.VisualStudio.IVsProjectBuildProperties]::GetPropertyValue
+[NuGet.VisualStudio.IVsProjectAdapter]::GetBuildItemInformation
 [NuGet.VisualStudio.IVsProjectAdapter]::IsCapabilityMatch
+[NuGet.VisualStudio.IVsProjectBuildProperties]::GetPropertyValue

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -167,21 +167,13 @@ namespace NuGet.PackageManagement.VisualStudio
             string auditMode = _vsProjectAdapter.BuildProperties.GetPropertyValue(ProjectBuildProperties.NuGetAuditMode);
             HashSet<string> suppressedAdvisories = GetSuppressedAdvisories();
 
-            bool hasAnyValue = !string.IsNullOrWhiteSpace(enableAudit)
-                || !string.IsNullOrWhiteSpace(auditLevel)
-                || !string.IsNullOrWhiteSpace(auditMode)
-                || suppressedAdvisories?.Count > 0;
-
-            RestoreAuditProperties auditProperties = hasAnyValue
-                ? new RestoreAuditProperties()
-                {
-                    EnableAudit = enableAudit,
-                    AuditLevel = auditLevel,
-                    AuditMode = auditMode,
-                    SuppressedAdvisories = suppressedAdvisories,
-                }
-                : null;
-            return auditProperties;
+            return new RestoreAuditProperties()
+            {
+                EnableAudit = enableAudit,
+                AuditLevel = auditLevel,
+                AuditMode = auditMode,
+                SuppressedAdvisories = suppressedAdvisories,
+            };
         }
 
         private HashSet<string> GetSuppressedAdvisories()

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -199,7 +199,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
             else
             {
-                var suppressedAdvisories = new HashSet<string>(StringComparer.Ordinal);
+                var suppressedAdvisories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 foreach ((string itemId, _) in buildItems.NoAllocEnumerate())
                 {
                     suppressedAdvisories.Add(itemId);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -226,10 +226,15 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             var itemStorage = (IVsBuildItemStorage)VsHierarchy;
-            var callback = new VisualStudioBuildItemStorageCallback();
-            itemStorage.FindItems(itemName, metadataNames.Length, metadataNames, callback);
+            if (itemStorage != null)
+            {
+                var callback = new VisualStudioBuildItemStorageCallback();
+                itemStorage.FindItems(itemName, metadataNames.Length, metadataNames, callback);
 
-            return callback.Items;
+                return callback.Items;
+            }
+
+            return Enumerable.Empty<(string ItemId, string[] ItemMetadata)>();
         }
 
         private string GetTargetFrameworkString()

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -222,10 +222,10 @@ namespace NuGet.PackageManagement.VisualStudio
             }
             if (metadataNames == null)
             {
-                throw new ArgumentNullException(nameof(itemName));
+                throw new ArgumentNullException(nameof(metadataNames));
             }
 
-            var itemStorage = (IVsBuildItemStorage)VsHierarchy;
+            var itemStorage = VsHierarchy as IVsBuildItemStorage;
             if (itemStorage != null)
             {
                 var callback = new VisualStudioBuildItemStorageCallback();

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
@@ -71,7 +71,7 @@ namespace NuGet.VisualStudio
         /// <param name="itemName">The item name.</param>
         /// <param name="metadataNames">The metadata names to read.</param>
         /// <returns>An <see cref="IEnumerable{(string ItemId, string[] ItemMetadata)}"/> containing the itemId and the metadata values.</returns>
-        Task<IEnumerable<(string ItemId, string[] ItemMetadata)>> GetBuildItemInformationAsync(string itemName, params string[] metadataNames);
+        IEnumerable<(string ItemId, string[] ItemMetadata)> GetBuildItemInformation(string itemName, params string[] metadataNames);
 
         /// <summary>
         /// See <see cref="Microsoft.VisualStudio.Shell.PackageUtilities.IsCapabilityMatch(IVsHierarchy, string)"/>

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
@@ -59,6 +59,7 @@ namespace NuGet.ProjectManagement
         public const string NuGetAudit = nameof(NuGetAudit);
         public const string NuGetAuditLevel = nameof(NuGetAuditLevel);
         public const string NuGetAuditMode = nameof(NuGetAuditMode);
+        public const string NuGetAuditSuppress = nameof(NuGetAuditSuppress);
         public const string CentralPackageFloatingVersionsEnabled = nameof(CentralPackageFloatingVersionsEnabled);
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+~const NuGet.ProjectManagement.ProjectBuildProperties.NuGetAuditSuppress = "NuGetAuditSuppress" -> string

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
@@ -158,11 +158,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             return Task.FromResult(_projectPackageVersions);
         }
 
-        public async Task<IEnumerable<(string ItemId, string[] ItemMetadata)>> GetBuildItemInformationAsync(string itemName, params string[] metadataNames)
+        public IEnumerable<(string ItemId, string[] ItemMetadata)> GetBuildItemInformation(string itemName, params string[] metadataNames)
         {
             if (itemName == "PackageVersion")
             {
-                return await Task.FromResult(_projectPackageVersions.Select(x => (ItemId: x.PackageId, ItemMetadata: new string[] { x.Version })));
+                return _projectPackageVersions.Select(x => (ItemId: x.PackageId, ItemMetadata: new string[] { x.Version }));
             }
 
             return Enumerable.Empty<(string ItemId, string[] ItemMetadata)>();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Related: https://github.com/NuGet/Client.Engineering/issues/2709

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Make `LegacyPackageReferenceProject.GetPackageSpecs` get `NuGetAuditSuppress` items from the project system, to populate `RestoreAuditProperties`.
* change async `IVsProjectAdapter.GetBuildItemInformationAsync` to non-async `IVsProjectAdapter.GetBuildItemInformation`, in order to prevent unnecessary async state machine allocations. It was being called by another method which in turn had an unnecessary async state machine allocation, so we're saving multiple allocations per call.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
