### PR TITLE
Make OptProf MicroBuild plug-in work again for Official Builds

### DIFF
--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -107,11 +107,14 @@ stages:
         swix:
           enabled: true
         optprof:
-          enabled: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
-          OptimizationInputsLookupMethod: DropPrefix
-          DropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
-          ShouldSkipOptimize: $(ShouldSkipOptimize)
-          AccessToken: $(System.AccessToken)
+        ${{ if and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) }}:
+            enabled: true
+            OptimizationInputsLookupMethod: DropPrefix
+            DropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
+            ShouldSkipOptimize: $(ShouldSkipOptimize)
+            AccessToken: $(System.AccessToken)
+          ${{ else }}:
+            enabled: false
       outputs:
       - output: pipelineArtifact
         displayName: 'Publish buildinfo.json as an artifact'

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -108,13 +108,13 @@ stages:
           enabled: true
         optprof:
         ${{ if and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) }}:
-            enabled: true
-            OptimizationInputsLookupMethod: DropPrefix
-            DropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
-            ShouldSkipOptimize: $(ShouldSkipOptimize)
-            AccessToken: $(System.AccessToken)
-          ${{ else }}:
-            enabled: false
+          enabled: true
+          OptimizationInputsLookupMethod: DropPrefix
+          DropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
+          ShouldSkipOptimize: $(ShouldSkipOptimize)
+          AccessToken: $(System.AccessToken)
+        ${{ else }}:
+          enabled: false
       outputs:
       - output: pipelineArtifact
         displayName: 'Publish buildinfo.json as an artifact'

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -92,6 +92,7 @@ stages:
       VsTargetChannel: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
       VsTargetChannelForTests: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannelForTests']]
       VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
+      isOfficialBuild: ${{ parameters.isOfficialBuild }}
       BuildRTM: "false"
       SemanticVersion: $[stageDependencies.Initialize.GetSemanticVersion.outputs['setsemanticversion.SemanticVersion']]
     pool:
@@ -106,7 +107,7 @@ stages:
         swix:
           enabled: true
         optprof:
-          enabled: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+          enabled: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
           OptimizationInputsLookupMethod: DropPrefix
           DropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
           ShouldSkipOptimize: $(ShouldSkipOptimize)
@@ -114,31 +115,31 @@ stages:
       outputs:
       - output: pipelineArtifact
         displayName: 'Publish buildinfo.json as an artifact'
-        condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+        condition: "succeeded()"
         targetPath: '$(Build.Repository.LocalPath)\artifacts\buildinfo.json'
         artifactName: 'BuildInfo'
 
       - output: pipelineArtifact
         displayName: 'Publish NuGet.CommandLine.Test as artifact'
-        condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
+        condition: "succeeded()"
         targetPath: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472"
         artifactName: "NuGet.CommandLine.Test"
 
       - output: pipelineArtifact
         displayName: 'Publish nupkgs'
-        condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"
+        condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)"
         artifactName: "nupkgs - $(RtmLabel)"
 
       - output: pipelineArtifact
         displayName: 'Publish BootstrapperInfo.json as a build artifact'
-        condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+        condition: "succeeded()"
         targetPath: $(MicroBuildOutputFolderOverride)\MicroBuild\Output
         artifactName: MicroBuildOutputs
 
       - output: artifactsDrop
         displayName: 'Publish the .runsettings files to artifact services'
-        condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+        condition: "succeeded()"
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
         buildNumber: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)'
         sourcePath: 'artifacts\RunSettings'
@@ -148,7 +149,7 @@ stages:
 
       - output: artifactsDrop
         displayName: 'OptProfV2:  publish profiling inputs to artifact services'
-        condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+        condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
         buildNumber: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)'
         sourcePath: '$(Build.ArtifactStagingDirectory)\OptProf\ProfilingInputs'
@@ -163,7 +164,7 @@ stages:
 
       - output: pipelineArtifact
         displayName: 'Publish localizationArtifacts artifact'
-        condition: "and(eq(variables['BuildRTM'], 'false'), or(eq(variables['OverridePublishLocalizationArtifact'], 'true'), and(succeededOrFailed(), eq(variables['IsOfficialBuild'], 'true'))))"
+        condition: "or(eq(variables['OverridePublishLocalizationArtifact'], 'true'), and(succeededOrFailed(), eq(variables['IsOfficialBuild'], 'true')))"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\localizationArtifacts\\"
         artifactName: "localizationArtifacts"
 
@@ -175,7 +176,7 @@ stages:
 
       - output: artifactsDrop
         displayName: 'Upload VSTS Drop'
-        condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
+        condition: "succeeded()"
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
         buildNumber: 'Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
         sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
@@ -185,7 +186,7 @@ stages:
 
       - output: pipelineArtifact
         displayName: 'LocValidation: Publish Logs as an artifact'
-        condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+        condition: "succeeded()"
         artifactName: LocValidationLogs
         targetPath: "$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs"
 
@@ -236,7 +237,7 @@ stages:
       outputs:
       - output: pipelineArtifact
         displayName: 'Publish nupkgs'
-        condition: "and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true')))"
+        condition: "succeeded()"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)"
         artifactName: "nupkgs - $(RtmLabel)"
 

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -112,8 +112,6 @@ stages:
           DropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
           ShouldSkipOptimize: $(ShouldSkipOptimize)
           AccessToken: $(System.AccessToken)
-        ${{ else }}:
-          enabled: false
       outputs:
       - output: pipelineArtifact
         displayName: 'Publish buildinfo.json as an artifact'

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -107,10 +107,10 @@ stages:
         swix:
           enabled: true
         optprof:
-          enabled: $(IsOfficialBuild)
+          enabled: true
           OptimizationInputsLookupMethod: DropPrefix
           DropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
-          ShouldSkipOptimize: $(ShouldSkipOptimize)
+          ShouldSkipOptimize: false
           AccessToken: $(System.AccessToken)
       outputs:
       - output: pipelineArtifact

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -110,7 +110,7 @@ stages:
           enabled: true
           OptimizationInputsLookupMethod: DropPrefix
           DropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
-          ShouldSkipOptimize: false
+          ShouldSkipOptimize: ${{ parameters.ShouldSkipOptimize }}
           AccessToken: $(System.AccessToken)
       outputs:
       - output: pipelineArtifact

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -108,7 +108,7 @@ stages:
         swix:
           enabled: true
         optprof:
-          enabled: true
+          enabled: ${{ variables['isOfficialBuild'] }}
           OptimizationInputsLookupMethod: DropPrefix
           DropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
           ShouldSkipOptimize: ${{ variables['ShouldSkipOptimize'] }}

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -107,7 +107,7 @@ stages:
         swix:
           enabled: true
         optprof:
-        ${{ if and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) }}:
+        ${{ if eq(variables['IsOfficialBuild'], 'true') }}:
           enabled: true
           OptimizationInputsLookupMethod: DropPrefix
           DropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -93,6 +93,7 @@ stages:
       VsTargetChannelForTests: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannelForTests']]
       VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
       isOfficialBuild: ${{ parameters.isOfficialBuild }}
+      ShouldSkipOptimize: ${{ variables['ShouldSkipOptimize'] }}
       BuildRTM: "false"
       SemanticVersion: $[stageDependencies.Initialize.GetSemanticVersion.outputs['setsemanticversion.SemanticVersion']]
     pool:
@@ -110,7 +111,7 @@ stages:
           enabled: true
           OptimizationInputsLookupMethod: DropPrefix
           DropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
-          ShouldSkipOptimize: ${{ parameters.ShouldSkipOptimize }}
+          ShouldSkipOptimize: ${{ variables['ShouldSkipOptimize'] }}
           AccessToken: $(System.AccessToken)
       outputs:
       - output: pipelineArtifact

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -107,8 +107,7 @@ stages:
         swix:
           enabled: true
         optprof:
-        ${{ if eq(variables['IsOfficialBuild'], 'true') }}:
-          enabled: true
+          enabled: $(IsOfficialBuild)
           OptimizationInputsLookupMethod: DropPrefix
           DropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
           ShouldSkipOptimize: $(ShouldSkipOptimize)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2749
 
Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Follow-up to https://github.com/NuGet/NuGet.Client/pull/5706

Copies pipeline parameter to a template variable in the parent YAML so that `Conditions` work. Most relevantly, this means OptProf MicroBuild plugin will be invoked by the 1ES templates.

Also remove outputs with conditions would never be true (ie, values never satisfy conditions for BuildRTM and IsOfficialBuild).

[Sample official build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9306988&view=logs&j=d80b2849-30d4-52dd-74cd-d6536ba98fe0&t=834cc09b-7de8-53f7-7930-d1ac3e92b356)

[Sample OptProf](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9306989&view=results)
[Sample OptProf 2](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9307253&view=results)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
