### PR TITLE
Fixed NullReferenceException in ResolverComparer

### DIFF
--- a/src/NuGet.Core/NuGet.Resolver/ResolverComparer.cs
+++ b/src/NuGet.Core/NuGet.Resolver/ResolverComparer.cs
@@ -31,7 +31,7 @@ namespace NuGet.Resolver
 
             _installedVersions = new Dictionary<string, NuGetVersion>();
 
-            if (_installedVersions != null)
+            if (_preferredVersions != null)
             {
                 foreach (var package in _preferredVersions)
                 {


### PR DESCRIPTION
Passing a `null` collection for the constructor argument `preferredVersions` would cause a NullReferenceException due to a simple mistake in the null-checking done.

This fixes the condition so passing `null` becomes valid again, which was clearly the (sadly undocumented) intent for this code.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
