### PR TITLE
Remove check that was preventing shipping APIs tool from running. 

### DIFF
--- a/tools-local/ship-public-apis/Program.cs
+++ b/tools-local/ship-public-apis/Program.cs
@@ -30,7 +30,7 @@ namespace NuGet.Internal.Tools.ShipPublicApis
             {
                 var path_Argument = ParseResult.GetValue<DirectoryInfo>(pathArgument);
                 var resort_Option = ParseResult.GetValue<bool>(resortOption);
-                if (path_Argument is not null && resort_Option)
+                if (path_Argument is not null)
                 {
                     await MainAsync(path_Argument, resort_Option);
                 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13153

Regression? Last working version: Regressed by: [ff7695dfeafa05fcf1af15e7f880c7bf8507304d](https://github.com/NuGet/NuGet.Client/commit/ff7695dfeafa05fcf1af15e7f880c7bf8507304d)

## Description

Port of https://github.com/NuGet/NuGet.Client/pull/5595. 

Remove the check that was always evaluating to false and preventing the tool from doing its main work to copy the unshipped to shipped files.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
Internal tool used for engineering work and is not under automated test. Tested manually by running the tool after the fix and verified it produced output and changed the appropriate files.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
