### PR TITLE
Remove Extract EndToEnd and SetupFunctionalTests scripts in Apex Tests Daily yml file

### DIFF
--- a/eng/pipelines/templates/Apex_Tests_On_Windows_Daily.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows_Daily.yml
@@ -217,18 +217,3 @@ stages:
             definition: $(resources.pipeline.ComponentBuildUnderTest.pipelineID)
             artifactName: "VS15"
             downloadPath: "$(Pipeline.Workspace)/artifacts"
-
-        - powershell: |
-            $zipPath = "$(Pipeline.Workspace)/artifacts/VS15/EndToEnd.zip"
-            $dest = "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/"
-            Write-Output "Extracting '$zipPath' to '$dest'"
-            Expand-Archive -Path "$zipPath" -DestinationPath "$dest"
-            $nugetExePath = "$(Pipeline.Workspace)/artifacts/VS15/NuGet.exe"
-            Write-Output "Copying '$nugetExePath' to '$dest'"
-            Copy-Item -Path "$nugetExePath" -Destination "$dest"
-          displayName: "Extract EndToEnd.zip"
-
-        - task: PowerShell@1
-          displayName: "SetupFunctionalTests.ps1"
-          inputs:
-            scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/SetupFunctionalTests.ps1"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2752

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Remove unnecessary scripts Extract EndToEnd and SetupFunctionalTests in Apex test.
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
