### PR TITLE
Deprecate http: Promote from warning to error in VS Options NuGet Package Manager

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/CheckedListBoxAccessibleObject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/CheckedListBoxAccessibleObject.cs
@@ -37,7 +37,7 @@ namespace NuGet.PackageManagement.UI.Options
                 if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections)
                 {
                     var sourceMessage = string.Concat(
-                        Resources.Warning_HTTPSource,
+                        Resources.Error_HttpSource_Single,
                         packageSource.Source);
                     return new CheckedListBoxItemAccessibleObject(this, packageSource.Name, index, sourceMessage);
                 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/CheckedListBoxAccessibleObject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/CheckedListBoxAccessibleObject.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Globalization;
 using System.Windows.Forms;
 using NuGet.Configuration;
 using NuGet.VisualStudio.Internal.Contracts;
@@ -36,7 +37,8 @@ namespace NuGet.PackageManagement.UI.Options
                 PackageSource packageSource = new PackageSource(item.Source, item.Name);
                 if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections)
                 {
-                    var sourceMessage = string.Concat(
+                    var sourceMessage = string.Format(
+                        CultureInfo.CurrentCulture,
                         Resources.Error_HttpSource_Single,
                         packageSource.Source);
                     return new CheckedListBoxItemAccessibleObject(this, packageSource.Name, index, sourceMessage);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/CheckedListBoxAccessibleObject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/CheckedListBoxAccessibleObject.cs
@@ -44,6 +44,15 @@ namespace NuGet.PackageManagement.UI.Options
                     return new CheckedListBoxItemAccessibleObject(this, packageSource.Name, index, sourceMessage);
                 }
 
+                if (packageSource.AllowInsecureConnections)
+                {
+                    var insecureConnectionMessage = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.Warning_HTTPSource,
+                        packageSource.Source);
+                    return new CheckedListBoxItemAccessibleObject(this, packageSource.Name, index, insecureConnectionMessage);
+                }
+
                 return new CheckedListBoxItemAccessibleObject(this, packageSource.Name, index, packageSource.Source);
             }
             else

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourceCheckedListBox.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourceCheckedListBox.cs
@@ -20,13 +20,13 @@ namespace NuGet.PackageManagement.UI.Options
     {
         public Size CheckBoxSize { get; set; }
 
-        private static Icon WarningIcon { get; set; }
+        private static Icon ErrorIcon { get; set; }
 
-        private Icon GetWarningIcon()
+        private Icon GetErrorIcon()
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            if (WarningIcon == null)
+            if (ErrorIcon == null)
             {
                 ImageAttributes attributes = new ImageAttributes
                 {
@@ -39,12 +39,12 @@ namespace NuGet.PackageManagement.UI.Options
                 };
 
                 IVsImageService2 imageService = (IVsImageService2)Microsoft.VisualStudio.Shell.Package.GetGlobalService(typeof(SVsImageService));
-                IVsUIObject uIObj = imageService.GetImage(KnownMonikers.StatusWarning, attributes);
+                IVsUIObject uIObj = imageService.GetImage(KnownMonikers.StatusError, attributes);
 
-                WarningIcon = (Icon)GelUtilities.GetObjectData(uIObj);
+                ErrorIcon = (Icon)GelUtilities.GetObjectData(uIObj);
             }
 
-            return WarningIcon;
+            return ErrorIcon;
         }
 
         public override int ItemHeight
@@ -137,23 +137,23 @@ namespace NuGet.PackageManagement.UI.Options
 
                         var packageSource = new PackageSource(currentItem.Source, currentItem.Name);
                         packageSource.AllowInsecureConnections = currentItem.AllowInsecureConnections;
-                        var shouldShowHttpWarningIcon = packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections;
-                        Rectangle warningBounds = default;
+                        var shouldShowHttpErrorIcon = packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections;
+                        Rectangle errorBounds = default;
 
-                        if (shouldShowHttpWarningIcon)
+                        if (shouldShowHttpErrorIcon)
                         {
-                            var warningIcon = GetWarningIcon();
+                            var errorIcon = GetErrorIcon();
 
-                            warningBounds = new Rectangle(
+                            errorBounds = new Rectangle(
                                 nameBounds.Left,
                                 nameBounds.Bottom,
-                                warningIcon.Width,
-                                warningIcon.Height);
-                            graphics.DrawIcon(warningIcon, warningBounds);
+                                errorIcon.Width,
+                                errorIcon.Height);
+                            graphics.DrawIcon(errorIcon, errorBounds);
                         }
 
                         var sourceBounds = new Rectangle(
-                            shouldShowHttpWarningIcon ? warningBounds.Right : nameBounds.Left,
+                            shouldShowHttpErrorIcon ? errorBounds.Right : nameBounds.Left,
                             nameBounds.Bottom,
                             textWidth,
                             e.Bounds.Bottom - nameBounds.Bottom);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.Designer.cs
@@ -291,7 +291,7 @@ namespace NuGet.PackageManagement.UI.Options
         private ImageList images64px;
         private TableLayoutPanel tableLayoutPanel3;
         private TableLayoutPanel tableLayoutPanel4;
-        private Label HttpWarning;
-        private PictureBox HttpWarningIcon;
+        private Label HttpError;
+        private PictureBox HttpErrorIcon;
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.Designer.cs
@@ -52,8 +52,8 @@ namespace NuGet.PackageManagement.UI.Options
             this.MachineWidePackageSourcesListBox = new NuGet.PackageManagement.UI.Options.PackageSourceCheckedListBox();
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
             this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
-            this.HttpWarning = new System.Windows.Forms.Label();
-            this.HttpWarningIcon = new System.Windows.Forms.PictureBox();
+            this.HttpError = new System.Windows.Forms.Label();
+            this.HttpErrorIcon = new System.Windows.Forms.PictureBox();
             this.images32px = new System.Windows.Forms.ImageList(this.components);
             this.images64px = new System.Windows.Forms.ImageList(this.components);
             this.PackageSourcesContextMenu.SuspendLayout();
@@ -61,7 +61,7 @@ namespace NuGet.PackageManagement.UI.Options
             this.tableLayoutPanel2.SuspendLayout();
             this.tableLayoutPanel3.SuspendLayout();
             this.tableLayoutPanel4.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.HttpWarningIcon)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.HttpErrorIcon)).BeginInit();
             this.SuspendLayout();
             // 
             // HeaderLabel
@@ -212,21 +212,21 @@ namespace NuGet.PackageManagement.UI.Options
             // tableLayoutPanel4
             // 
             resources.ApplyResources(this.tableLayoutPanel4, "tableLayoutPanel4");
-            this.tableLayoutPanel4.Controls.Add(this.HttpWarning, 1, 0);
-            this.tableLayoutPanel4.Controls.Add(this.HttpWarningIcon, 0, 0);
+            this.tableLayoutPanel4.Controls.Add(this.HttpError, 1, 0);
+            this.tableLayoutPanel4.Controls.Add(this.HttpErrorIcon, 0, 0);
             this.tableLayoutPanel4.Name = "tableLayoutPanel4";
             // 
             // HttpWarning
             // 
-            resources.ApplyResources(this.HttpWarning, "HttpWarning");
-            this.HttpWarning.Name = "HttpWarning";
+            resources.ApplyResources(this.HttpError, "HttpWarning");
+            this.HttpError.Name = "HttpWarning";
             // 
             // HttpWarningIcon
             // 
-            resources.ApplyResources(this.HttpWarningIcon, "HttpWarningIcon");
-            this.HttpWarningIcon.AccessibleRole = System.Windows.Forms.AccessibleRole.Alert;
-            this.HttpWarningIcon.Name = "HttpWarningIcon";
-            this.HttpWarningIcon.TabStop = false;
+            resources.ApplyResources(this.HttpErrorIcon, "HttpWarningIcon");
+            this.HttpErrorIcon.AccessibleRole = System.Windows.Forms.AccessibleRole.Alert;
+            this.HttpErrorIcon.Name = "HttpWarningIcon";
+            this.HttpErrorIcon.TabStop = false;
             // 
             // images32px
             // 
@@ -261,7 +261,7 @@ namespace NuGet.PackageManagement.UI.Options
             this.tableLayoutPanel3.PerformLayout();
             this.tableLayoutPanel4.ResumeLayout(false);
             this.tableLayoutPanel4.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.HttpWarningIcon)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.HttpErrorIcon)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.Designer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Windows.Forms;
 
 namespace NuGet.PackageManagement.UI.Options
@@ -20,6 +21,15 @@ namespace NuGet.PackageManagement.UI.Options
                 components.Dispose();
             }
             base.Dispose(disposing);
+        }
+
+        private void LinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "https://aka.ms/nuget/how-settings-are-applied",
+                UseShellExecute = true
+            });
         }
 
         #region Component Designer generated code
@@ -52,10 +62,9 @@ namespace NuGet.PackageManagement.UI.Options
             this.MachineWidePackageSourcesListBox = new NuGet.PackageManagement.UI.Options.PackageSourceCheckedListBox();
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
             this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
-            this.AllowInsecureConnectionsWarning = new System.Windows.Forms.Label();
-            this.AllowInsecureConnectionsWarningIcon = new System.Windows.Forms.PictureBox();
-            this.HttpError = new System.Windows.Forms.Label();
-            this.HttpErrorIcon = new System.Windows.Forms.PictureBox();
+            this.HttpErrorOrWarning = new System.Windows.Forms.Label();
+            this.HttpErrorOrWarningIcon = new System.Windows.Forms.PictureBox();
+            this.configurationLink = new System.Windows.Forms.LinkLabel();
             this.images32px = new System.Windows.Forms.ImageList(this.components);
             this.images64px = new System.Windows.Forms.ImageList(this.components);
             this.PackageSourcesContextMenu.SuspendLayout();
@@ -63,7 +72,7 @@ namespace NuGet.PackageManagement.UI.Options
             this.tableLayoutPanel2.SuspendLayout();
             this.tableLayoutPanel3.SuspendLayout();
             this.tableLayoutPanel4.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.HttpErrorIcon)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.HttpErrorOrWarningIcon)).BeginInit();
             this.SuspendLayout();
             // 
             // HeaderLabel
@@ -210,33 +219,33 @@ namespace NuGet.PackageManagement.UI.Options
             this.tableLayoutPanel3.Controls.Add(this.tableLayoutPanel4, 0, 0);
             this.tableLayoutPanel3.GrowStyle = System.Windows.Forms.TableLayoutPanelGrowStyle.FixedSize;
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
+            tableLayoutPanel3.AutoSize = true;
             // 
             // tableLayoutPanel4
             // 
             resources.ApplyResources(this.tableLayoutPanel4, "tableLayoutPanel4");
-            this.tableLayoutPanel4.Controls.Add(this.HttpError, 1, 0);
-            this.tableLayoutPanel4.Controls.Add(this.HttpErrorIcon, 0, 0);
-            this.tableLayoutPanel4.Controls.Add(this.AllowInsecureConnectionsWarning, 1, 0);
-            this.tableLayoutPanel4.Controls.Add(this.AllowInsecureConnectionsWarningIcon, 0, 0);
+            this.tableLayoutPanel4.Controls.Add(this.HttpErrorOrWarning, 1, 0);
+            this.tableLayoutPanel4.Controls.Add(this.HttpErrorOrWarningIcon, 0, 0);
+            this.tableLayoutPanel4.Controls.Add(this.configurationLink, 1, 1);
             this.tableLayoutPanel4.Name = "tableLayoutPanel4";
             // 
-            // HttpError
+            // HttpErrorOrWarning
             // 
-            resources.ApplyResources(this.HttpError, "HttpError");
-            this.HttpError.Name = "HttpError";
-            resources.ApplyResources(this.AllowInsecureConnectionsWarning, "AllowInsecureConnectionsWarning");
-            this.AllowInsecureConnectionsWarning.Name = "AllowInsecureConnectionsWarning";
+            resources.ApplyResources(this.HttpErrorOrWarning, "HttpWarning");
+            this.HttpErrorOrWarning.Name = "HttpWarning";
             // 
-            // HttpErrorIcon
+            // HttpErrorOrWarningIcon
             // 
-            resources.ApplyResources(this.HttpErrorIcon, "HttpErrorIcon");
-            this.HttpErrorIcon.AccessibleRole = System.Windows.Forms.AccessibleRole.Alert;
-            this.HttpErrorIcon.Name = "HttpErrorIcon";
-            this.HttpErrorIcon.TabStop = false;
-            resources.ApplyResources(this.AllowInsecureConnectionsWarningIcon, "AllowInsecureConnectionsWarningIcon");
-            this.AllowInsecureConnectionsWarningIcon.AccessibleRole = System.Windows.Forms.AccessibleRole.Alert;
-            this.AllowInsecureConnectionsWarningIcon.Name = "AllowInsecureConnectionsWarningIcon";
-            this.AllowInsecureConnectionsWarningIcon.TabStop = false;
+            resources.ApplyResources(this.HttpErrorOrWarningIcon, "HttpWarningIcon");
+            this.HttpErrorOrWarningIcon.AccessibleRole = System.Windows.Forms.AccessibleRole.Alert;
+            this.HttpErrorOrWarningIcon.Name = "HttpWarningIcon";
+            this.HttpErrorOrWarningIcon.TabStop = false;
+            //
+            // Configuration link
+            //
+            this.configurationLink.Text = Resources.Link_configuration;
+            this.configurationLink.LinkClicked += new LinkLabelLinkClickedEventHandler(LinkLabel_LinkClicked);
+            this.configurationLink.AutoSize = true;
             // 
             // images32px
             // 
@@ -271,8 +280,7 @@ namespace NuGet.PackageManagement.UI.Options
             this.tableLayoutPanel3.PerformLayout();
             this.tableLayoutPanel4.ResumeLayout(false);
             this.tableLayoutPanel4.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.AllowInsecureConnectionsWarningIcon)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.HttpErrorIcon)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.HttpErrorOrWarningIcon)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -302,9 +310,8 @@ namespace NuGet.PackageManagement.UI.Options
         private ImageList images64px;
         private TableLayoutPanel tableLayoutPanel3;
         private TableLayoutPanel tableLayoutPanel4;
-        private Label AllowInsecureConnectionsWarning;
-        private PictureBox AllowInsecureConnectionsWarningIcon;
-        private Label HttpError;
-        private PictureBox HttpErrorIcon;
+        private Label HttpErrorOrWarning;
+        private PictureBox HttpErrorOrWarningIcon;
+        private LinkLabel configurationLink;
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.Designer.cs
@@ -52,6 +52,8 @@ namespace NuGet.PackageManagement.UI.Options
             this.MachineWidePackageSourcesListBox = new NuGet.PackageManagement.UI.Options.PackageSourceCheckedListBox();
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
             this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
+            this.AllowInsecureConnectionsWarning = new System.Windows.Forms.Label();
+            this.AllowInsecureConnectionsWarningIcon = new System.Windows.Forms.PictureBox();
             this.HttpError = new System.Windows.Forms.Label();
             this.HttpErrorIcon = new System.Windows.Forms.PictureBox();
             this.images32px = new System.Windows.Forms.ImageList(this.components);
@@ -214,19 +216,27 @@ namespace NuGet.PackageManagement.UI.Options
             resources.ApplyResources(this.tableLayoutPanel4, "tableLayoutPanel4");
             this.tableLayoutPanel4.Controls.Add(this.HttpError, 1, 0);
             this.tableLayoutPanel4.Controls.Add(this.HttpErrorIcon, 0, 0);
+            this.tableLayoutPanel4.Controls.Add(this.AllowInsecureConnectionsWarning, 1, 0);
+            this.tableLayoutPanel4.Controls.Add(this.AllowInsecureConnectionsWarningIcon, 0, 0);
             this.tableLayoutPanel4.Name = "tableLayoutPanel4";
             // 
-            // HttpWarning
+            // HttpError
             // 
-            resources.ApplyResources(this.HttpError, "HttpWarning");
-            this.HttpError.Name = "HttpWarning";
+            resources.ApplyResources(this.HttpError, "HttpError");
+            this.HttpError.Name = "HttpError";
+            resources.ApplyResources(this.AllowInsecureConnectionsWarning, "AllowInsecureConnectionsWarning");
+            this.AllowInsecureConnectionsWarning.Name = "AllowInsecureConnectionsWarning";
             // 
-            // HttpWarningIcon
+            // HttpErrorIcon
             // 
-            resources.ApplyResources(this.HttpErrorIcon, "HttpWarningIcon");
+            resources.ApplyResources(this.HttpErrorIcon, "HttpErrorIcon");
             this.HttpErrorIcon.AccessibleRole = System.Windows.Forms.AccessibleRole.Alert;
-            this.HttpErrorIcon.Name = "HttpWarningIcon";
+            this.HttpErrorIcon.Name = "HttpErrorIcon";
             this.HttpErrorIcon.TabStop = false;
+            resources.ApplyResources(this.AllowInsecureConnectionsWarningIcon, "AllowInsecureConnectionsWarningIcon");
+            this.AllowInsecureConnectionsWarningIcon.AccessibleRole = System.Windows.Forms.AccessibleRole.Alert;
+            this.AllowInsecureConnectionsWarningIcon.Name = "AllowInsecureConnectionsWarningIcon";
+            this.AllowInsecureConnectionsWarningIcon.TabStop = false;
             // 
             // images32px
             // 
@@ -261,6 +271,7 @@ namespace NuGet.PackageManagement.UI.Options
             this.tableLayoutPanel3.PerformLayout();
             this.tableLayoutPanel4.ResumeLayout(false);
             this.tableLayoutPanel4.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.AllowInsecureConnectionsWarningIcon)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.HttpErrorIcon)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -291,6 +302,8 @@ namespace NuGet.PackageManagement.UI.Options
         private ImageList images64px;
         private TableLayoutPanel tableLayoutPanel3;
         private TableLayoutPanel tableLayoutPanel4;
+        private Label AllowInsecureConnectionsWarning;
+        private PictureBox AllowInsecureConnectionsWarningIcon;
         private Label HttpError;
         private PictureBox HttpErrorIcon;
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -60,7 +60,7 @@ namespace NuGet.PackageManagement.UI.Options
             }
         }
 
-        public static Image WarningIcon
+        public static Image ErrorIcon
         {
             get
             {
@@ -76,7 +76,7 @@ namespace NuGet.PackageManagement.UI.Options
                     Flags = (uint)_ImageAttributesFlags.IAF_RequiredFlags
                 };
 
-                IVsUIObject uIObj = ImageService.GetImage(KnownMonikers.StatusWarning, attributes);
+                IVsUIObject uIObj = ImageService.GetImage(KnownMonikers.StatusError, attributes);
 
                 return (Image)GelUtilities.GetObjectData(uIObj);
             }
@@ -94,8 +94,8 @@ namespace NuGet.PackageManagement.UI.Options
 
             UpdateDPI();
 
-            HttpWarningIcon.Image = WarningIcon;
-            HttpWarning.Text = Resources.Warning_NewHTTPSource_VSOptions;
+            HttpErrorIcon.Image = ErrorIcon;
+            HttpError.Text = Resources.Error_HttpSource_Single;
         }
 
         private void UpdateDPI()
@@ -153,14 +153,14 @@ namespace NuGet.PackageManagement.UI.Options
                 addButton.Enabled = true;
             }
 
-            // Show HttpWarning for the selected source if needed
+            // Show HttpError for the selected source if needed
             if (selectedSource != null)
             {
-                SetHttpWarningVisibilityForSelectSource(selectedSource);
+                SetHttpErrorVisibilityForSelectSource(selectedSource);
             }
             else if (selectedMachineSource != null)
             {
-                SetHttpWarningVisibilityForSelectSource(selectedMachineSource);
+                SetHttpErrorVisibilityForSelectSource(selectedMachineSource);
             }
         }
 
@@ -487,7 +487,7 @@ namespace NuGet.PackageManagement.UI.Options
             selectedPackageSource.Source = source;
             _packageSources.ResetCurrentItem();
 
-            SetHttpWarningVisibilityForSelectSource(selectedPackageSource);
+            SetHttpErrorVisibilityForSelectSource(selectedPackageSource);
 
             return TryUpdateSourceResults.Successful;
         }
@@ -715,21 +715,21 @@ namespace NuGet.PackageManagement.UI.Options
             return path.IndexOfAny(Path.GetInvalidPathChars()) == -1 && Path.IsPathRooted(path);
         }
 
-        private void SetHttpWarningVisibilityForSelectSource(PackageSourceContextInfo selectedSource)
+        private void SetHttpErrorVisibilityForSelectSource(PackageSourceContextInfo selectedSource)
         {
             var source = new PackageSource(selectedSource.Source, selectedSource.Name);
             source.AllowInsecureConnections = selectedSource.AllowInsecureConnections;
 
-            // Warn if the selected source is http, and the AllowInsecureConnections for this source is set to false. 
+            // Error if the selected source is http, and the AllowInsecureConnections for this source is set to false. 
             if (source.IsHttp && !source.IsHttps && !source.AllowInsecureConnections)
             {
-                HttpWarning.Visible = true;
-                HttpWarningIcon.Visible = true;
+                HttpError.Visible = true;
+                HttpErrorIcon.Visible = true;
             }
             else
             {
-                HttpWarning.Visible = false;
-                HttpWarningIcon.Visible = false;
+                HttpError.Visible = false;
+                HttpErrorIcon.Visible = false;
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -483,13 +483,37 @@ namespace NuGet.PackageManagement.UI.Options
                 return TryUpdateSourceResults.SourceConflicted;
             }
 
-            selectedPackageSource.Name = name;
-            selectedPackageSource.Source = source;
-            _packageSources.ResetCurrentItem();
+            PackageSource packageSource = new PackageSource(source, name);
 
-            SetHttpErrorVisibilityForSelectSource(selectedPackageSource);
+            if (packageSource.IsHttp && !packageSource.IsHttps)
+            {
+                // Updating to an http source. Request user confirmation
+                bool? addHttpSource = MessageHelper.ShowQueryMessage(Resources.Warn_Adding_HttpSource, "HTTP Source", true);
 
-            return TryUpdateSourceResults.Successful;
+                if (addHttpSource == true)
+                {
+                    selectedPackageSource.Name = name;
+                    selectedPackageSource.Source = source;
+                    selectedPackageSource.AllowInsecureConnections = true;
+                    _packageSources.ResetCurrentItem();
+                    SetHttpErrorVisibilityForSelectSource(selectedPackageSource);
+
+                    return TryUpdateSourceResults.Successful;
+                }
+                else
+                {
+                    return TryUpdateSourceResults.Unchanged;
+                }
+            }
+            else
+            {
+                selectedPackageSource.Name = name;
+                selectedPackageSource.Source = source;
+                _packageSources.ResetCurrentItem();
+                SetHttpErrorVisibilityForSelectSource(selectedPackageSource);
+
+                return TryUpdateSourceResults.Successful;
+            }
         }
 
         private static void SelectAndFocus(TextBox textBox)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -89,11 +89,8 @@ namespace NuGet.PackageManagement.UI.Options
             };
 
             IVsUIObject uIObj = ImageService.GetImage(KnownMonikers.StatusWarning, attributes);
-
             WarningIcon = (Image)GelUtilities.GetObjectData(uIObj);
-
             uIObj = ImageService.GetImage(KnownMonikers.StatusError, attributes);
-
             ErrorIcon = (Image)GelUtilities.GetObjectData(uIObj);
         }
 
@@ -155,11 +152,11 @@ namespace NuGet.PackageManagement.UI.Options
             // Show HttpError for the selected source if needed
             if (selectedSource != null)
             {
-                SetHttpErrorVisibilityForSelectSource(selectedSource);
+                SetHttpErrorVisibilityForSelectedSource(selectedSource);
             }
             else if (selectedMachineSource != null)
             {
-                SetHttpErrorVisibilityForSelectSource(selectedMachineSource);
+                SetHttpErrorVisibilityForSelectedSource(selectedMachineSource);
             }
         }
 
@@ -487,7 +484,7 @@ namespace NuGet.PackageManagement.UI.Options
             if (packageSource.IsHttp && !packageSource.IsHttps)
             {
                 // Updating to an http source. Request user confirmation
-                bool? addHttpSource = MessageHelper.ShowQueryMessage(Resources.Warn_Adding_HttpSource, "HTTP Source", true);
+                bool? addHttpSource = MessageHelper.ShowQueryMessage(Resources.Warn_Adding_HttpSource, Resources.DialogTitle_HttpSource, true);
 
                 if (addHttpSource == true)
                 {
@@ -495,7 +492,7 @@ namespace NuGet.PackageManagement.UI.Options
                     selectedPackageSource.Source = source;
                     selectedPackageSource.AllowInsecureConnections = true;
                     _packageSources.ResetCurrentItem();
-                    SetHttpErrorVisibilityForSelectSource(selectedPackageSource);
+                    SetHttpErrorVisibilityForSelectedSource(selectedPackageSource);
 
                     return TryUpdateSourceResults.Successful;
                 }
@@ -509,7 +506,7 @@ namespace NuGet.PackageManagement.UI.Options
                 selectedPackageSource.Name = name;
                 selectedPackageSource.Source = source;
                 _packageSources.ResetCurrentItem();
-                SetHttpErrorVisibilityForSelectSource(selectedPackageSource);
+                SetHttpErrorVisibilityForSelectedSource(selectedPackageSource);
 
                 return TryUpdateSourceResults.Successful;
             }
@@ -738,24 +735,26 @@ namespace NuGet.PackageManagement.UI.Options
             return path.IndexOfAny(Path.GetInvalidPathChars()) == -1 && Path.IsPathRooted(path);
         }
 
-        private void SetHttpErrorVisibilityForSelectSource(PackageSourceContextInfo selectedSource)
+        private void SetHttpErrorVisibilityForSelectedSource(PackageSourceContextInfo selectedSource)
         {
             var source = new PackageSource(selectedSource.Source, selectedSource.Name);
             source.AllowInsecureConnections = selectedSource.AllowInsecureConnections;
 
-            HttpErrorOrWarning.Visible = true;
-            HttpErrorOrWarningIcon.Visible = true;
-            configurationLink.Visible = true;
-
             if (source.IsHttp && !source.IsHttps && !source.AllowInsecureConnections)
             {
-                // Error if the selected source is http, and the AllowInsecureConnections for this source is set to false. 
+                // Error if the selected source is http, and the AllowInsecureConnections for this source is set to false.
+                HttpErrorOrWarning.Visible = true;
+                HttpErrorOrWarningIcon.Visible = true;
+                configurationLink.Visible = true;
                 HttpErrorOrWarningIcon.Image = ErrorIcon;
                 HttpErrorOrWarning.Text = Resources.Error_HttpSource_Single;
             }
             else if (source.AllowInsecureConnections)
             {
                 // Warn if AllowInsecureConnections for this source is set to true.
+                HttpErrorOrWarning.Visible = true;
+                HttpErrorOrWarningIcon.Visible = true;
+                configurationLink.Visible = true;
                 HttpErrorOrWarningIcon.Image = WarningIcon;
                 HttpErrorOrWarning.Text = Resources.Warning_HTTPSource;
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -60,6 +60,28 @@ namespace NuGet.PackageManagement.UI.Options
             }
         }
 
+        public static Image WarningIcon
+        {
+            get
+            {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
+                ImageAttributes attributes = new ImageAttributes
+                {
+                    StructSize = Marshal.SizeOf(typeof(ImageAttributes)),
+                    ImageType = (uint)_UIImageType.IT_Bitmap,
+                    Format = (uint)_UIDataFormat.DF_WinForms,
+                    LogicalWidth = 16,
+                    LogicalHeight = 16,
+                    Flags = (uint)_ImageAttributesFlags.IAF_RequiredFlags
+                };
+
+                IVsUIObject uIObj = ImageService.GetImage(KnownMonikers.StatusWarning, attributes);
+
+                return (Image)GelUtilities.GetObjectData(uIObj);
+            }
+        }
+
         public static Image ErrorIcon
         {
             get
@@ -94,8 +116,13 @@ namespace NuGet.PackageManagement.UI.Options
 
             UpdateDPI();
 
+            AllowInsecureConnectionsWarningIcon.Image = WarningIcon;
+            AllowInsecureConnectionsWarning.Text = Resources.Warning_HTTPSource;
+            AllowInsecureConnectionsWarning.AutoSize = true;
+
             HttpErrorIcon.Image = ErrorIcon;
             HttpError.Text = Resources.Error_HttpSource_Single;
+            HttpError.AutoSize = true;
         }
 
         private void UpdateDPI()
@@ -754,6 +781,18 @@ namespace NuGet.PackageManagement.UI.Options
             {
                 HttpError.Visible = false;
                 HttpErrorIcon.Visible = false;
+            }
+
+            // Warn if AllowInsecureConnections for this source is set to true. 
+            if (source.AllowInsecureConnections)
+            {
+                AllowInsecureConnectionsWarning.Visible = true;
+                AllowInsecureConnectionsWarningIcon.Visible = true;
+            }
+            else
+            {
+                AllowInsecureConnectionsWarning.Visible = false;
+                AllowInsecureConnectionsWarningIcon.Visible = false;
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -754,6 +754,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;HTTP&apos; source: {1}. NuGet requires HTTPS sources. To use an HTTP source, you must explicitly set &apos;allowInsecureConnections&apos; to true in your NuGet.Config file. Please refer to https://aka.ms/nuget-https-everywhere..
+        /// </summary>
+        public static string Error_HttpSource_Single {
+            get {
+                return ResourceManager.GetString("Error_HttpSource_Single", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to find metadata of {0}.
         /// </summary>
         public static string Error_MetadataNotFound {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -754,7 +754,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are running the &apos;{0}&apos; operation with an &apos;HTTP&apos; source: {1}. NuGet requires HTTPS sources. To use an HTTP source, you must explicitly set &apos;allowInsecureConnections&apos; to true in your NuGet.Config file. Please refer to https://aka.ms/nuget-https-everywhere..
+        ///   Looks up a localized string similar to NuGet requires HTTPS sources. To use an HTTP source, you must explicitly set &apos;allowInsecureConnections&apos; to true in your NuGet.Config file..
         /// </summary>
         public static string Error_HttpSource_Single {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -2610,6 +2610,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You are attempting to add an HTTP source, which is insecure. Would you like to proceed with adding this insecure HTTP source?.
+        /// </summary>
+        public static string Warn_Adding_HttpSource {
+            get {
+                return ResourceManager.GetString("Warn_Adding_HttpSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Warning: Non-HTTPS access will be removed in a future version. Consider migrating to an &apos;HTTPS&apos; source..
         /// </summary>
         public static string Warning_HTTPSource {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -745,6 +745,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to HTTP Source.
+        /// </summary>
+        public static string DialogTitle_HttpSource {
+            get {
+                return ResourceManager.GetString("DialogTitle_HttpSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Don&apos;t show this again.
         /// </summary>
         public static string DoNotShowThisAgain {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1393,6 +1393,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Common NuGet configurations; How settings are applied..
+        /// </summary>
+        public static string Link_configuration {
+            get {
+                return ResourceManager.GetString("Link_configuration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Don&apos;t show again.
         /// </summary>
         public static string Link_DoNotShowAgain {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -2637,7 +2637,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to `AllowInsecureConnections` attribute has been enabled for this source which would allow it connecting to a NON-HTTPS source..
+        ///   Looks up a localized string similar to AllowInsecureConnections is enabled and allows http access. Note: This method is not secure. For secure options, see https://aka.ms/nuget-https-everywhere..
         /// </summary>
         public static string Warning_HTTPSource {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -2619,20 +2619,11 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Warning: Non-HTTPS access will be removed in a future version. Consider migrating to an &apos;HTTPS&apos; source..
+        ///   Looks up a localized string similar to `AllowInsecureConnections` attribute has been enabled for this source which would allow it connecting to a NON-HTTPS source..
         /// </summary>
         public static string Warning_HTTPSource {
             get {
                 return ResourceManager.GetString("Warning_HTTPSource", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Non-HTTPS access will be removed in a future version. Consider migrating to an &apos;HTTPS&apos; source..
-        /// </summary>
-        public static string Warning_NewHTTPSource_VSOptions {
-            get {
-                return ResourceManager.GetString("Warning_NewHTTPSource_VSOptions", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1042,4 +1042,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <value>The package `{0}` is available in the Global packages folder, but the source it came from `{1}` is not one of the configured sources.</value>
     <comment>{0} is the package ID. {1} is the URI of the package source found in the Global packages folder.</comment>
   </data>
+  <data name="Error_HttpSource_Single" xml:space="preserve">
+    <value>You are running the '{0}' operation with an 'HTTP' source: {1}. NuGet requires HTTPS sources. To use an HTTP source, you must explicitly set 'allowInsecureConnections' to true in your NuGet.Config file. Please refer to https://aka.ms/nuget-https-everywhere.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1043,6 +1043,6 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <comment>{0} is the package ID. {1} is the URI of the package source found in the Global packages folder.</comment>
   </data>
   <data name="Error_HttpSource_Single" xml:space="preserve">
-    <value>You are running the '{0}' operation with an 'HTTP' source: {1}. NuGet requires HTTPS sources. To use an HTTP source, you must explicitly set 'allowInsecureConnections' to true in your NuGet.Config file. Please refer to https://aka.ms/nuget-https-everywhere.</value>
+    <value>NuGet requires HTTPS sources. To use an HTTP source, you must explicitly set 'allowInsecureConnections' to true in your NuGet.Config file.</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1045,4 +1045,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Error_HttpSource_Single" xml:space="preserve">
     <value>NuGet requires HTTPS sources. To use an HTTP source, you must explicitly set 'allowInsecureConnections' to true in your NuGet.Config file.</value>
   </data>
+  <data name="Warn_Adding_HttpSource" xml:space="preserve">
+    <value>You are attempting to add an HTTP source, which is insecure. Would you like to proceed with adding this insecure HTTP source?</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1045,4 +1045,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Warn_Adding_HttpSource" xml:space="preserve">
     <value>You are attempting to add an HTTP source, which is insecure. Would you like to proceed with adding this insecure HTTP source?</value>
   </data>
+  <data name="Link_configuration" xml:space="preserve">
+    <value>Common NuGet configurations; How settings are applied.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -933,10 +933,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <comment>{0} is a version number</comment>
   </data>
   <data name="Warning_HTTPSource" xml:space="preserve">
-    <value>Warning: Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.</value>
-  </data>
-  <data name="Warning_NewHTTPSource_VSOptions" xml:space="preserve">
-    <value>Non-HTTPS access will be removed in a future version. Consider migrating to an 'HTTPS' source.</value>
+    <value>`AllowInsecureConnections` attribute has been enabled for this source which would allow it connecting to a NON-HTTPS source.</value>
   </data>
   <data name="VSOptions_Button_Add" xml:space="preserve">
     <value>Add</value>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1048,4 +1048,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Link_configuration" xml:space="preserve">
     <value>Common NuGet configurations; How settings are applied.</value>
   </data>
+  <data name="DialogTitle_HttpSource" xml:space="preserve">
+    <value>HTTP Source</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -933,7 +933,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <comment>{0} is a version number</comment>
   </data>
   <data name="Warning_HTTPSource" xml:space="preserve">
-    <value>`AllowInsecureConnections` attribute has been enabled for this source which would allow it connecting to a NON-HTTPS source.</value>
+    <value>AllowInsecureConnections is enabled and allows http access. Note: This method is not secure. For secure options, see https://aka.ms/nuget-https-everywhere.</value>
   </data>
   <data name="VSOptions_Button_Add" xml:space="preserve">
     <value>Add</value>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSourcesService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSourcesService.cs
@@ -129,6 +129,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     {
                         IsMachineWide = packageSourceContextInfo.IsMachineWide,
                         ProtocolVersion = packageSourceContextInfo.ProtocolVersion,
+                        AllowInsecureConnections = packageSourceContextInfo.AllowInsecureConnections
                     };
 
                     newPackageSources.Add(newSource);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13354

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
- PMUI shows an http warning when an http source is used. Show an error instead.
- Show warning for a source if `allowInsecureConnections` attribute is enabled.
- Allow users to add non-https sources after requesting user to confirm
- Link to explanation how to work with NuGet configs
### Here is what the PMUI would look like

https://github.com/NuGet/NuGet.Client/assets/59111203/55a7528b-b62b-476c-bd04-4dbe56ae3010

### Fixed Padding
![image](https://github.com/NuGet/NuGet.Client/assets/59111203/47889bfa-793e-42a3-b030-d3a8b1cbddaa)



## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
