### PR TITLE
`NuGet.CommandLine.Test` & `Nupkg` artifacts have unique artifact name

### DIFF
--- a/eng/pipelines/backup_build_artifacts.yml
+++ b/eng/pipelines/backup_build_artifacts.yml
@@ -53,7 +53,7 @@ jobs:
           buildType: specific
           project: $(resources.pipeline.officialbuild.projectID)
           definition: $(resources.pipeline.officialbuild.pipelineID)
-          artifactName: 'nupkgs - NonRTM'
+          artifactName: 'nupkgs - NonRTM - $(System.JobDisplayName) - Attempt $(System.JobAttempt)'
           targetPath: $(Build.ArtifactStagingDirectory)/backup/VS15/nupkgs
 
       - task: DownloadPipelineArtifact@2
@@ -63,7 +63,7 @@ jobs:
           buildType: specific
           project: $(resources.pipeline.officialbuild.projectID)
           definition: $(resources.pipeline.officialbuild.pipelineID)
-          artifactName: 'nupkgs - RTM'
+          artifactName: 'nupkgs - RTM - $(System.JobDisplayName) - Attempt $(System.JobAttempt)'
           targetPath: $(Build.ArtifactStagingDirectory)/backup/VS15-RTM/nupkgs
 
       - task: DownloadPipelineArtifact@2

--- a/eng/pipelines/templates/Tests_On_Mac.yml
+++ b/eng/pipelines/templates/Tests_On_Mac.yml
@@ -2,7 +2,7 @@ steps:
 - task: DownloadPipelineArtifact@2
   displayName: "Download NuGet.CommandLine.Test artifacts"
   inputs:
-    artifactName: "NuGet.CommandLine.Test"
+    artifactName: "NuGet.CommandLine.Test - $(System.JobDisplayName) - Attempt $(System.JobAttempt)"
     downloadPath: "$(Build.Repository.LocalPath)/artifacts/NuGet.CommandLine.Test"
   condition: "and(succeeded(), eq(variables['TestRunDisplayName'], 'Mono Tests'))"
 

--- a/eng/pipelines/templates/Validate_Build_Output.yml
+++ b/eng/pipelines/templates/Validate_Build_Output.yml
@@ -13,7 +13,7 @@ steps:
   displayName: "Download nupkgs"
   name: DownloadNupkgs
   inputs:
-    artifactName: "nupkgs - RTM"
+    artifactName: "nupkgs - RTM - $(System.JobDisplayName) - Attempt $(System.JobAttempt)"
     downloadPath: "$(System.ArtifactsDirectory)/nupkgs"
 
 - task: PowerShell@2

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -124,7 +124,7 @@ stages:
         displayName: 'Publish NuGet.CommandLine.Test as artifact'
         condition: "succeeded()"
         targetPath: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472"
-        artifactName: "NuGet.CommandLine.Test"
+        artifactName: "NuGet.CommandLine.Test  - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
 
       - output: pipelineArtifact
         displayName: 'Publish nupkgs'

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -124,13 +124,13 @@ stages:
         displayName: 'Publish NuGet.CommandLine.Test as artifact'
         condition: "succeeded()"
         targetPath: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472"
-        artifactName: "NuGet.CommandLine.Test  - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
+        artifactName: "NuGet.CommandLine.Test - $(System.JobDisplayName) - Attempt $(System.JobAttempt)"
 
       - output: pipelineArtifact
         displayName: 'Publish nupkgs'
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)"
-        artifactName: "nupkgs - $(RtmLabel)"
+        artifactName: "nupkgs - $(RtmLabel) - $(System.JobDisplayName) - Attempt $(System.JobAttempt)"
 
       - output: pipelineArtifact
         displayName: 'Publish BootstrapperInfo.json as a build artifact'
@@ -240,7 +240,7 @@ stages:
         displayName: 'Publish nupkgs'
         condition: "succeeded()"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)"
-        artifactName: "nupkgs - $(RtmLabel)"
+        artifactName: "nupkgs - $(RtmLabel) - $(System.JobDisplayName) - Attempt $(System.JobAttempt)"
 
       - output: pipelineArtifact
         displayName: 'Publish NuGet.exe VSIX and EndToEnd.zip as artifact'


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2764

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
