### PR TITLE
Add back Extract EndToEnd.zip and SetupFunctionalTests script

### DIFF
--- a/eng/pipelines/templates/Apex_Tests_On_Windows_Daily.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows_Daily.yml
@@ -219,11 +219,11 @@ stages:
             downloadPath: "$(Pipeline.Workspace)/artifacts"
 
         - powershell: |
-            $zipPath = "$(Build.Repository.Localpath)/artifacts/EndToEnd.zip"
+            $zipPath = "$(Pipeline.Workspace)/artifacts/EndToEnd.zip"
             $dest = "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/"
             Write-Output "Extracting '$zipPath' to '$dest'"
             Expand-Archive -Path "$zipPath" -DestinationPath "$dest"
-            $nugetExePath = "$(Build.Repository.Localpath)/artifacts/NuGet.exe"
+            $nugetExePath = "$(Pipeline.Workspace)/artifacts/NuGet.exe"
             Write-Output "Copying '$nugetExePath' to '$dest'"
             Copy-Item -Path "$nugetExePath" -Destination "$dest"
           displayName: "Extract EndToEnd.zip"

--- a/eng/pipelines/templates/Apex_Tests_On_Windows_Daily.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows_Daily.yml
@@ -217,3 +217,18 @@ stages:
             definition: $(resources.pipeline.ComponentBuildUnderTest.pipelineID)
             artifactName: "VS15"
             downloadPath: "$(Pipeline.Workspace)/artifacts"
+
+        - powershell: |
+            $zipPath = "$(Build.Repository.Localpath)/artifacts/EndToEnd.zip"
+            $dest = "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/"
+            Write-Output "Extracting '$zipPath' to '$dest'"
+            Expand-Archive -Path "$zipPath" -DestinationPath "$dest"
+            $nugetExePath = "$(Build.Repository.Localpath)/artifacts/NuGet.exe"
+            Write-Output "Copying '$nugetExePath' to '$dest'"
+            Copy-Item -Path "$nugetExePath" -Destination "$dest"
+          displayName: "Extract EndToEnd.zip"
+
+        - task: PowerShell@1
+          displayName: "SetupFunctionalTests.ps1"
+          inputs:
+            scriptName: "$(System.DefaultWorkingDirectory)/artifacts/EndToEnd/scripts/SetupFunctionalTests.ps1"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2768

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Add back Extract EndToEnd.zip and SetupFunctionalTests script due to test cases blocked by “Preview Changes” window. And verified that the “Preview Changes” window is bypassed in NuGet.Client Daily Tests pipeline.
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
