### PR TITLE
Fix SelfSignedCertificateMockServer code analysis errors

### DIFF
--- a/test/TestUtilities/Test.Utility/SelfSignedCertificateMockServer.cs
+++ b/test/TestUtilities/Test.Utility/SelfSignedCertificateMockServer.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
-using System.Security.Authentication;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -18,7 +17,7 @@ using NuGet.Test.Server;
 
 namespace Test.Utility
 {
-    public class SelfSignedCertificateMockServer
+    public class SelfSignedCertificateMockServer : IDisposable
     {
         private readonly X509Certificate2 _certificate;
         private readonly string _packageDirectory;
@@ -198,6 +197,17 @@ namespace Test.Utility
                 var certBytes = cert.Export(X509ContentType.Pfx, "password");
                 return new X509Certificate2(certBytes, "password", X509KeyStorageFlags.Exportable);
             }
+        }
+
+        public void Dispose()
+        {
+            _tcpListener.Stop();
+
+#if NET8_0_OR_GREATER
+            _tcpListener.Dispose();
+#endif
+
+            _certificate.Dispose();
         }
     }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Fixes a new code analysis error for a recently added test class
```
Error CA1001: Type 'SelfSignedCertificateMockServer' owns disposable field(s) '_tcpListener' but is not disposable
```

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
