### PR TITLE
Fix NRE and Disallow Missing Registration Page Leaves

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
@@ -120,12 +120,6 @@ namespace NuGet.Protocol
                     {
                         var rangeUri = registrationPage.Url;
                         var leafRegistrationPage = await GetRegistratioIndexPageAsync(_client, rangeUri, packageId, lower, upper, httpSourceCacheContext, log, token);
-
-                        if (leafRegistrationPage == null)
-                        {
-                            throw new InvalidDataException(rangeUri);
-                        }
-
                         ProcessRegistrationPage(leafRegistrationPage, results, range, includePrerelease, includeUnlisted, metadataCache);
                     }
                     else

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
@@ -121,9 +121,10 @@ namespace NuGet.Protocol
                         var rangeUri = registrationPage.Url;
                         var leafRegistrationPage = await GetRegistratioIndexPageAsync(_client, rangeUri, packageId, lower, upper, httpSourceCacheContext, log, token);
 
-                        if (registrationPage == null)
+                        if (leafRegistrationPage == null)
                         {
-                            throw new InvalidDataException(registrationUri.AbsoluteUri);
+                            log.LogDebug($"{rangeUri} returned 404 NotFound. No versions in this range are available.");
+                            continue;
                         }
 
                         ProcessRegistrationPage(leafRegistrationPage, results, range, includePrerelease, includeUnlisted, metadataCache);

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
@@ -123,8 +123,7 @@ namespace NuGet.Protocol
 
                         if (leafRegistrationPage == null)
                         {
-                            log.LogDebug($"{rangeUri} returned 404 NotFound. No versions in this range are available.");
-                            continue;
+                            throw new InvalidDataException(rangeUri);
                         }
 
                         ProcessRegistrationPage(leafRegistrationPage, results, range, includePrerelease, includeUnlisted, metadataCache);
@@ -234,7 +233,7 @@ namespace NuGet.Protocol
                                 $"list_{packageIdLowerCase}_range_{lower.ToNormalizedString()}-{upper.ToNormalizedString()}",
                                 httpSourceCacheContext)
                             {
-                                IgnoreNotFounds = true,
+                                IgnoreNotFounds = false,
                             },
                             httpSourceResult => DeserializeStreamDataAsync<RegistrationPage>(httpSourceResult.Stream, token),
                             log,

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
@@ -314,7 +314,7 @@ namespace NuGet.Protocol.Tests
                 { "https://api.nuget.org/v3/index.json", JsonData.RepoSignIndexJsonData },
                 { $"https://api.nuget.org/v3/registration0/{dummyPackage}/index.json", "{\"ok\": false, \"error\": \"This feature is not supported.\"}" },
                 { $"https://api.nuget.org/v3-registration3-gz-semver2/{dummyPackage}/index.json", JsonData.PackageRegistrationCatalogWithLeafPagesUpperLower },
-                { $"https://api.nuget.org/v3/registration3-gz-semver2/{dummyPackage}/page/2.0.1/3.0.0.json", string.Empty /*404*/ },
+                { $"https://api.nuget.org/v3/registration3-gz-semver2/{dummyPackage}/page/2.0.1/3.0.0.json", "{ items: [] }" /*200*/ },
                 { $"https://api.nuget.org/v3/registration3-gz-semver2/{dummyPackage}/page/1.0.0/2.0.0.json", string.Empty /*404*/ },
             };
 
@@ -323,12 +323,16 @@ namespace NuGet.Protocol.Tests
 
             //Act
             using var sourceCacheContext = new SourceCacheContext();
-            var packages = await resource.GetMetadataAsync(dummyPackage,
-                false,
-                false,
-                sourceCacheContext,
-                Common.NullLogger.Instance,
-                CancellationToken.None);
+            var packages = Enumerable.Empty<IPackageSearchMetadata>();
+            await Assert.ThrowsAsync<HttpRequestException>(async () =>
+            {
+                packages = await resource.GetMetadataAsync(dummyPackage,
+                    false,
+                    false,
+                    sourceCacheContext,
+                    Common.NullLogger.Instance,
+                    CancellationToken.None);
+            });
 
             //Assert 
             Assert.Empty(packages);

--- a/test/TestUtilities/Test.Utility/JsonData.cs
+++ b/test/TestUtilities/Test.Utility/JsonData.cs
@@ -4833,5 +4833,33 @@ namespace Test.Utility
     ""version"": ""0.0.0""
 }";
         #endregion
+
+        #region PackageRegistrationCatalogWithLeafPagesUpperLower
+        public const string PackageRegistrationCatalogWithLeafPagesUpperLower = @"{
+    ""@id"": ""http://api.nuget.org/v3/registration3-gz-semver2/dummy.package/index.json"",
+    ""@type"": [
+        ""catalog:CatalogRoot"",
+        ""PackageRegistration"",
+        ""catalog:Permalink""
+    ],
+    ""count"": 2,
+    ""items"": [
+        {
+            ""@id"": ""https://api.nuget.org/v3/registration3-gz-semver2/dummy.package/page/2.0.1/3.0.0.json"",
+            ""@type"": ""catalog:CatalogPage"",
+            ""count"": 12,
+            ""lower"": ""2.0.1"",
+            ""upper"": ""3.0.0""
+        },
+        {
+            ""@id"": ""https://api.nuget.org/v3/registration3-gz-semver2/dummy.package/page/1.0.0/2.0.0.json"",
+            ""@type"": ""catalog:CatalogPage"",
+            ""count"": 10,
+            ""lower"": ""1.0.0"",
+            ""upper"": ""2.0.0""
+        }
+    ]
+}";
+        #endregion
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13377

Regression? Last working version: The NRE has been there since the code was written in [#3462](https://github.com/NuGet/NuGet.Client/pull/3462)

## Description

The original issue is just the wrong variable being used in the `if` check. However for some reason when doing `dotnet tool restore` in the dotnet 6 sdk the issue doesn't happen for us. But once we upgraded our project to use dotnet 8 the NRE started happening every time we ran `dotnet tool restore`. So this is sort of a "regression" for us because our in-house NuGet repo (cloudsmith) returns 404 if there are no active packages in a version range.

I think it makes sense to gracefully skip any missing leaf pages. We are already allowing 404's with the `IgnoreNotFounds = true,` flag. So I think not throwing an exception in a recoverable situation makes more sense here and it would help resolve our issue as well.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
