### PR TITLE
 Fix OptProf publishing by setting `cloudBuildResourceName`

### DIFF
--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -61,6 +61,7 @@ stages:
     - name: RunSettingsURI
       value: $[dependencies.TestMachineConfiguration.outputs['SetRunSettingsURI.RunSettingsURI']]
     optOptimizationInputsDropName: $(optDropName)
+    cloudBuildResourceName: ComponentBuildUnderTest
     # Remove this parameter if you don't want LKG support
     previousOptimizationInputsDropName: $(PreviousOptimizationInputsDropName)
     testLabPoolName: VS-Platform


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2792

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

OptProf on all branches is broken due to changes to templates in the past few weeks. Providing the component containing our build will fix the issue.

Successful OptProf (using 6.8.x branch) run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9386055&view=results

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
