### PR TITLE
Stop publishing NuGet.Packaging.Core to the Build Asset Registry

### DIFF
--- a/build/publish.proj
+++ b/build/publish.proj
@@ -29,7 +29,7 @@
 
     <ItemGroup>
       <ItemsToPush Include="$(NuGetClientNupkgsDirectoryPath)/*.nupkg" />
-      <ItemsToPush Exclude="$(NuGetClientNupkgsDirectoryPath)/NuGet.Packaging.Core.*" />
+      <ItemsToPush Remove="$(NuGetClientNupkgsDirectoryPath)/NuGet.Packaging.Core.*" />
     </ItemGroup>
 
     <Error Condition="@(ItemsToPush->Count()) == 0" Text="There were no packages found at '$(NuGetClientNupkgsDirectoryPath)'." />

--- a/build/publish.proj
+++ b/build/publish.proj
@@ -29,6 +29,7 @@
 
     <ItemGroup>
       <ItemsToPush Include="$(NuGetClientNupkgsDirectoryPath)/*.nupkg" />
+      <ItemsToPush Exclude="$(NuGetClientNupkgsDirectoryPath)/NuGet.Packaging.Core.*" />
     </ItemGroup>
 
     <Error Condition="@(ItemsToPush->Count()) == 0" Text="There were no packages found at '$(NuGetClientNupkgsDirectoryPath)'." />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Related: https://github.com/NuGet/Home/issues/12495

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

This package should be unused, but this would help us catch it.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
