### PR TITLE
Fix target frameworks for Source Build

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -19,6 +19,7 @@
     
     <!-- Target frameworks for class libraries-->
     <TargetFrameworksLibrary>$(NetStandardVersion)</TargetFrameworksLibrary>
+    <TargetFrameworksLibrary Condition="'$(DotNetBuildFromSource)' == 'true'">$(NETCoreTargetFramework);$(TargetFrameworksLibrary)</TargetFrameworksLibrary>
     <TargetFrameworksLibrary Condition="'$(IsXPlat)' != 'true' And '$(DotNetBuildFromSource)' != 'true'">$(NETFXTargetFramework);$(TargetFrameworksLibrary)</TargetFrameworksLibrary>
 
     <!-- Target frameworks for class libraries which require signing APIs which need to target NET 5.0 -->


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13390

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
I messed up the target frameworks when building for Source Build in https://github.com/NuGet/NuGet.Client/pull/5735.  This fixes it so that our libraries target .NET 9.0 and .NET Standard 2.0 like before.

### Without Source Build 
![image](https://github.com/NuGet/NuGet.Client/assets/17556515/c789a1e7-c1c5-46d7-b6d1-09ae7c3070d1)

### With Source Build
![image](https://github.com/NuGet/NuGet.Client/assets/17556515/3bb0f046-7373-44ef-841b-36e79fd76e4c)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
