### PR TITLE
Disable flaky VulnerablePackagesInfoBar tests in VulnerablePackagesInfoBarTests.cs

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VulnerablePackagesInfoBarTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VulnerablePackagesInfoBarTests.cs
@@ -62,7 +62,7 @@ namespace NuGet.SolutionRestoreManager.Test
             infoBar._wasInfoBarClosed.Should().BeFalse();
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/13391")]
         public async Task OnSolutionClosed_ResetsInfoBarStatusProperties()
         {
             // Arrange
@@ -82,7 +82,7 @@ namespace NuGet.SolutionRestoreManager.Test
             infoBar._wasInfoBarClosed.Should().BeFalse();
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/13391")]
         public async Task OnSolutionClosed_WithInfoBarVisible_ClosesInfoBar()
         {
             // Arrange
@@ -108,7 +108,7 @@ namespace NuGet.SolutionRestoreManager.Test
             infoBarUIElement.Verify(ui => ui.Close(), Times.Once());
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/13391")]
         public async Task OnSolutionClosed_WithInfoBarNotVisible_DoesNotAttemptToCloseInfoBar()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Related: https://github.com/NuGet/Home/issues/13391

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
