### PR TITLE
Fix missing dependencies in VMR build

### DIFF
--- a/eng/source-build/source-build.proj
+++ b/eng/source-build/source-build.proj
@@ -15,23 +15,24 @@
   <Target Name="SourceBuildPreBuild" DependsOnTargets="ApplySourceBuildPatchFiles">
     <Message Text="Running source-build PreBuild target" Importance="High" />
 
-  </Target>
-
-  <Target Name="SourceBuildPostBuild" DependsOnTargets="SourceBuildInnerBuild">
-    <Message Text="Running source-build PostBuild target" Importance="High" />
-
     <ItemGroup>
-      <_CommonProperties Include="_NETCORE_ENGINEERING_TELEMETRY=AfterSourceBuild" />
-      <_CommonProperties Include="ArcadeBuildFromSource=true"/>
-      <_CommonProperties Include="CloneSubmodulesToInnerSourceBuildRepo=false"/>
+      <_RestoreProperties Include="_NETCORE_ENGINEERING_TELEMETRY=Restore" />
+      <_RestoreProperties Include="ArcadeBuildFromSource=true"/>
+      <_RestoreProperties Include="CloneSubmodulesToInnerSourceBuildRepo=false"/>
+      <_RestoreProperties Include="DotNetBuildInnerRepo=true" />
     </ItemGroup>
 
     <MSbuild Projects="$(ArcadeDir)/Build.proj"
-             Properties="@(_CommonProperties);Restore=true;Build=false;Pack=false;Publish=false;Rebuild=false;Test=false;IntegrationTest=false;PerformanceTest=false;PreventPrebuiltBuild=false;BaseInnerSourceBuildCommand=echo skipping internal build with args: "
+             Properties="@(_RestoreProperties);Restore=true;Build=false;Pack=false;Publish=false;Rebuild=false;Test=false;IntegrationTest=false;PerformanceTest=false;PreventPrebuiltBuild=false;BaseInnerSourceBuildCommand=echo skipping internal build with args: "
              Targets="Execute"
             />
 
     <Message Text="Finished restoring Arcade" Importance="High" />
+
+  </Target>
+
+  <Target Name="SourceBuildPostBuild" DependsOnTargets="SourceBuildInnerBuild">
+    <Message Text="Running source-build PostBuild target" Importance="High" />
 
     <ItemGroup>
       <_AfterSourceBuildProperties Include="CurrentRepoSourceBuildArtifactsPackagesDir=$(ProjectRoot)artifacts/nupkgs/" />
@@ -41,8 +42,14 @@
       <_AfterSourceBuildProperties Include="FailOnPrebuiltBaselineError=true" />
     </ItemGroup>
 
+    <ItemGroup>
+      <_AfterSourceBuildProperties Include="_NETCORE_ENGINEERING_TELEMETRY=AfterSourceBuild" />
+      <_AfterSourceBuildProperties Include="ArcadeBuildFromSource=true"/>
+      <_AfterSourceBuildProperties Include="CloneSubmodulesToInnerSourceBuildRepo=false"/>
+    </ItemGroup>
+
     <MSbuild Projects="$(ArcadeDir)/SourceBuild/AfterSourceBuild.proj"
-             Properties="@(_CommonProperties);@(_AfterSourceBuildProperties)"
+             Properties="@(_AfterSourceBuildProperties);@(_AfterSourceBuildProperties)"
             />
 
   </Target>


### PR DESCRIPTION
Move the arcade restore to SourceBuildPreBuild, because AfterSourceBuild.proj (called from SourceBuildInnerBuild) needs microsoft.dotnet.sourcebuild.tasks.

Set DotNetBuildInnerRepo=true when restoring. This tells arcade to restore microsoft.dotnet.build.tasks.feed, which is needed by Publish.proj.

https://github.com/dotnet/source-build/issues/4333

FYI @mmitche 

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
