### PR TITLE
Remove integration test for `--allow-insecure-connections` option

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSourcesTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSourcesTests.cs
@@ -57,40 +57,6 @@ namespace Dotnet.Integration.Test
         }
 
         [PlatformFact(Platform.Windows)]
-        public void Sources_WhenAddingSource_GotAddedWithAllowInsecureConnections()
-        {
-            using (SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext())
-            {
-                var workingPath = pathContext.WorkingDirectory;
-                var settings = pathContext.Settings;
-
-                // Arrange
-                var args = new string[]
-                {
-                    "nuget",
-                    "add",
-                    "source",
-                    "https://source.test",
-                    "--name",
-                    "test_source",
-                    "--configfile",
-                    settings.ConfigPath,
-                    "--allow-insecure-connections"
-                };
-
-                // Act
-                var result = _fixture.RunDotnetExpectSuccess(workingPath, string.Join(" ", args));
-
-                // Assert
-                var loadedSettings = Settings.LoadDefaultSettings(root: workingPath, configFileName: null, machineWideSettings: null);
-                var packageSourcesSection = loadedSettings.GetSection("packageSources");
-                var sourceItem = packageSourcesSection?.GetFirstItemWithAttribute<SourceItem>("key", "test_source");
-                Assert.Equal("True", sourceItem.AllowInsecureConnections);
-                Assert.Equal("https://source.test", sourceItem.GetValueAsPath());
-            }
-        }
-
-        [PlatformFact(Platform.Windows)]
         public void Sources_WhenAddingSourceWithCredentials_CredentialsWereAddedAndEncrypted()
         {
             using (SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext())


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
I had added an integration test for the `--allow-insecure-connections` option. However, since we have not added the option to the sdk yet, the test should not be there.
Add option to dotnet task: https://github.com/NuGet/Home/issues/13396
## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
