### PR TITLE
Create OwnerDetailsUriTemplateResourceV3 and provider

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Providers/OwnerDetailsUriResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/OwnerDetailsUriResourceV3Provider.cs
@@ -29,8 +29,12 @@ namespace NuGet.Protocol.Providers
             ServiceIndexResourceV3? serviceIndex = await source.GetResourceAsync<ServiceIndexResourceV3>(token);
             if (serviceIndex != null)
             {
-                Uri uriTemplate = serviceIndex.GetServiceEntryUri(ServiceTypes.OwnerDetailsUriTemplate);
-                resource = OwnerDetailsUriTemplateResourceV3.CreateOrNull(uriTemplate);
+                Uri? uriTemplate = serviceIndex.GetServiceEntryUri(ServiceTypes.OwnerDetailsUriTemplate);
+
+                if (uriTemplate != null)
+                {
+                    resource = OwnerDetailsUriTemplateResourceV3.CreateOrNull(uriTemplate);
+                }
             }
 
             return new Tuple<bool, INuGetResource?>(resource != null, resource);

--- a/src/NuGet.Core/NuGet.Protocol/Providers/OwnerDetailsUriResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/OwnerDetailsUriResourceV3Provider.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Resources;
+
+namespace NuGet.Protocol.Providers
+{
+    /// <summary>NuGet.Protocol resource provider for <see cref="OwnerDetailsUriTemplateResourceV3"/> in V3 HTTP feeds.</summary>
+    /// <remarks>When successful, returns an instance of <see cref="OwnerDetailsUriTemplateResourceV3"/>.</remarks>
+    public class OwnerDetailsUriResourceV3Provider : ResourceProvider
+    {
+        public OwnerDetailsUriResourceV3Provider()
+            : base(typeof(OwnerDetailsUriTemplateResourceV3),
+                  nameof(OwnerDetailsUriTemplateResourceV3),
+                  NuGetResourceProviderPositions.Last)
+        {
+        }
+
+        /// <inheritdoc cref="ResourceProvider.TryCreate(SourceRepository, CancellationToken)"/>
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
+        {
+            OwnerDetailsUriTemplateResourceV3? resource = null;
+            ServiceIndexResourceV3? serviceIndex = await source.GetResourceAsync<ServiceIndexResourceV3>(token);
+            if (serviceIndex != null)
+            {
+                Uri uriTemplate = serviceIndex.GetServiceEntryUri(ServiceTypes.OwnerDetailsUriTemplate);
+                resource = OwnerDetailsUriTemplateResourceV3.CreateOrNull(uriTemplate);
+            }
+
+            return new Tuple<bool, INuGetResource?>(resource != null, resource);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,4 +1,11 @@
 #nullable enable
+NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider
+NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.OwnerDetailsUriResourceV3Provider() -> void
+NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3
+NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.GetUri(string! owner) -> System.Uri!
+NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.OwnerDetailsUriTemplateResourceV3(string! template) -> void
+override NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
+static NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.CreateOrNull(System.Uri? uriTemplate) -> NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3?
 ~NuGet.Protocol.Core.Types.IPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.set -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -3,7 +3,6 @@ NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider
 NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.OwnerDetailsUriResourceV3Provider() -> void
 NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3
 NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.GetUri(string! owner) -> System.Uri!
-NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.OwnerDetailsUriTemplateResourceV3(string! template) -> void
 override NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 static NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.CreateOrNull(System.Uri? uriTemplate) -> NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3?
 ~NuGet.Protocol.Core.Types.IPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -4,7 +4,7 @@ NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.OwnerDetailsUriResour
 NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3
 NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.GetUri(string! owner) -> System.Uri!
 override NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-static NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.CreateOrNull(System.Uri? uriTemplate) -> NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3?
+static NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.CreateOrNull(System.Uri! uriTemplate) -> NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3?
 ~NuGet.Protocol.Core.Types.IPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.set -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,11 @@
 #nullable enable
+NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider
+NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.OwnerDetailsUriResourceV3Provider() -> void
+NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3
+NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.GetUri(string! owner) -> System.Uri!
+NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.OwnerDetailsUriTemplateResourceV3(string! template) -> void
+override NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
+static NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.CreateOrNull(System.Uri? uriTemplate) -> NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3?
 ~NuGet.Protocol.Core.Types.IPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.set -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -3,7 +3,6 @@ NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider
 NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.OwnerDetailsUriResourceV3Provider() -> void
 NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3
 NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.GetUri(string! owner) -> System.Uri!
-NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.OwnerDetailsUriTemplateResourceV3(string! template) -> void
 override NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 static NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.CreateOrNull(System.Uri? uriTemplate) -> NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3?
 ~NuGet.Protocol.Core.Types.IPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -4,7 +4,7 @@ NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.OwnerDetailsUriResour
 NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3
 NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.GetUri(string! owner) -> System.Uri!
 override NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-static NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.CreateOrNull(System.Uri? uriTemplate) -> NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3?
+static NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.CreateOrNull(System.Uri! uriTemplate) -> NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3?
 ~NuGet.Protocol.Core.Types.IPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.set -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,11 @@
 #nullable enable
+NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider
+NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.OwnerDetailsUriResourceV3Provider() -> void
+NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3
+NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.GetUri(string! owner) -> System.Uri!
+NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.OwnerDetailsUriTemplateResourceV3(string! template) -> void
+override NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
+static NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.CreateOrNull(System.Uri? uriTemplate) -> NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3?
 ~NuGet.Protocol.Core.Types.IPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.set -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -3,7 +3,6 @@ NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider
 NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.OwnerDetailsUriResourceV3Provider() -> void
 NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3
 NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.GetUri(string! owner) -> System.Uri!
-NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.OwnerDetailsUriTemplateResourceV3(string! template) -> void
 override NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 static NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.CreateOrNull(System.Uri? uriTemplate) -> NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3?
 ~NuGet.Protocol.Core.Types.IPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -4,7 +4,7 @@ NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.OwnerDetailsUriResour
 NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3
 NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.GetUri(string! owner) -> System.Uri!
 override NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-static NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.CreateOrNull(System.Uri? uriTemplate) -> NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3?
+static NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.CreateOrNull(System.Uri! uriTemplate) -> NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3?
 ~NuGet.Protocol.Core.Types.IPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.set -> void

--- a/src/NuGet.Core/NuGet.Protocol/Repository.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Repository.cs
@@ -81,6 +81,7 @@ namespace NuGet.Protocol.Core.Types
                 yield return new Lazy<INuGetResourceProvider>(() => new PluginResourceProvider());
                 yield return new Lazy<INuGetResourceProvider>(() => new RepositorySignatureResourceProvider());
                 yield return new Lazy<INuGetResourceProvider>(() => new VulnerabilityInfoResourceV3Provider());
+                yield return new Lazy<INuGetResourceProvider>(() => new OwnerDetailsUriResourceV3Provider());
 
                 // Local repository providers
                 yield return new Lazy<INuGetResourceProvider>(() => new FindLocalPackagesResourceUnzippedProvider());

--- a/src/NuGet.Core/NuGet.Protocol/Resources/OwnerDetailsUriTemplateResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/OwnerDetailsUriTemplateResourceV3.cs
@@ -15,7 +15,7 @@ namespace NuGet.Protocol.Resources
     {
         private readonly string _template;
 
-        public OwnerDetailsUriTemplateResourceV3(string template)
+        private OwnerDetailsUriTemplateResourceV3(string template)
         {
             _template = template ?? throw new ArgumentNullException(nameof(template));
         }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/OwnerDetailsUriTemplateResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/OwnerDetailsUriTemplateResourceV3.cs
@@ -1,0 +1,76 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.Protocol.Resources
+{
+    /// <summary>Owner Details Uri Template for NuGet V3 HTTP feeds.</summary>
+    /// <remarks>Not intended to be created directly. Use <see cref="SourceRepository.GetResourceAsync{T}(CancellationToken)"/>
+    /// with <see cref="OwnerDetailsUriTemplateResourceV3"/> for T, and typecast to this class.
+    public class OwnerDetailsUriTemplateResourceV3 : INuGetResource
+    {
+        private readonly string _template;
+
+        public OwnerDetailsUriTemplateResourceV3(string template)
+        {
+            _template = template ?? throw new ArgumentNullException(nameof(template));
+        }
+
+        /// <summary>
+        /// Creates the specified Owner Details Uri template provided by the server if it exists and is valid.
+        /// </summary>
+        /// <param name="uriTemplate">The Absolute Uri template provided by the server.</param>
+        /// <returns>A valid Owner Details Uri template, or null.</returns>
+        public static OwnerDetailsUriTemplateResourceV3? CreateOrNull(Uri? uriTemplate)
+        {
+            if (uriTemplate == null || uriTemplate.OriginalString.Length == 0 || !uriTemplate.IsAbsoluteUri)
+            {
+                return null;
+            }
+
+            string absoluteUri = uriTemplate.OriginalString;
+            if (string.IsNullOrWhiteSpace(absoluteUri)
+                || !IsValidUriTemplate(absoluteUri))
+            {
+                return null;
+            }
+
+            return new OwnerDetailsUriTemplateResourceV3(absoluteUri);
+        }
+
+        private static bool IsValidUriTemplate(string absoluteUri)
+        {
+            Uri? uri;
+            var isValidUri = Uri.TryCreate(absoluteUri, UriKind.Absolute, out uri);
+
+            // Only allow HTTPS owner details URLs.
+            if (isValidUri && uri?.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) != true)
+            {
+                return false;
+            }
+
+            return isValidUri;
+        }
+
+        /// <summary>
+        /// Gets a URL for viewing package Owner URL outside of Visual Studio. The URL will not be verified to exist.
+        /// </summary>
+        /// <param name="owner">The owner username.</param>
+        /// <returns>The first URL from the resource, with the URI template applied.</returns>
+        public Uri GetUri(string owner)
+        {
+            var uriString = _template
+#if NETCOREAPP
+               .Replace("{owner}", owner, StringComparison.OrdinalIgnoreCase);
+#else
+               .Replace("{owner}", owner);
+#endif
+
+            return new Uri(uriString);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Resources/OwnerDetailsUriTemplateResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/OwnerDetailsUriTemplateResourceV3.cs
@@ -25,35 +25,21 @@ namespace NuGet.Protocol.Resources
         /// </summary>
         /// <param name="uriTemplate">The Absolute Uri template provided by the server.</param>
         /// <returns>A valid Owner Details Uri template, or null.</returns>
-        public static OwnerDetailsUriTemplateResourceV3? CreateOrNull(Uri? uriTemplate)
+        public static OwnerDetailsUriTemplateResourceV3? CreateOrNull(Uri uriTemplate)
         {
-            if (uriTemplate == null || uriTemplate.OriginalString.Length == 0 || !uriTemplate.IsAbsoluteUri)
+            if (uriTemplate is null)
+            {
+                throw new ArgumentNullException(nameof(uriTemplate));
+            }
+
+            if (uriTemplate.OriginalString.Length == 0
+                || !uriTemplate.IsAbsoluteUri
+                || !uriTemplate.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
             {
                 return null;
             }
 
-            string absoluteUri = uriTemplate.OriginalString;
-            if (string.IsNullOrWhiteSpace(absoluteUri)
-                || !IsValidUriTemplate(absoluteUri))
-            {
-                return null;
-            }
-
-            return new OwnerDetailsUriTemplateResourceV3(absoluteUri);
-        }
-
-        private static bool IsValidUriTemplate(string absoluteUri)
-        {
-            Uri? uri;
-            var isValidUri = Uri.TryCreate(absoluteUri, UriKind.Absolute, out uri);
-
-            // Only allow HTTPS owner details URLs.
-            if (isValidUri && uri?.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) != true)
-            {
-                return false;
-            }
-
-            return isValidUri;
+            return new OwnerDetailsUriTemplateResourceV3(uriTemplate.OriginalString);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/ServiceTypes.cs
+++ b/src/NuGet.Core/NuGet.Protocol/ServiceTypes.cs
@@ -17,6 +17,7 @@ namespace NuGet.Protocol
         public static readonly string Version500 = "/5.0.0";
         public static readonly string Version510 = "/5.1.0";
         internal const string Version670 = "/6.7.0";
+        internal const string Version6110 = "/6.11.0";
 
         public static readonly string[] SearchQueryService = { "SearchQueryService" + Versioned, "SearchQueryService" + Version340, "SearchQueryService" + Version300beta };
         public static readonly string[] RegistrationsBaseUrl = { $"RegistrationsBaseUrl{Versioned}", $"RegistrationsBaseUrl{Version360}", $"RegistrationsBaseUrl{Version340}", $"RegistrationsBaseUrl{Version300rc}", $"RegistrationsBaseUrl{Version300beta}", "RegistrationsBaseUrl" };
@@ -29,5 +30,6 @@ namespace NuGet.Protocol
         public static readonly string[] RepositorySignatures = { "RepositorySignatures" + Version500, "RepositorySignatures" + Version490, "RepositorySignatures" + Version470 };
         public static readonly string[] SymbolPackagePublish = { "SymbolPackagePublish" + Version490 };
         internal static readonly string[] VulnerabilityInfo = { "VulnerabilityInfo" + Version670 };
+        internal static readonly string[] OwnerDetailsUriTemplate = { "OwnerDetailsUriTemplate" + Version6110 };
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/OwnerDetailsUriResourceV3ProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/OwnerDetailsUriResourceV3ProviderTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Configuration;
+using NuGet.Packaging;
+using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Providers;
+using Xunit;
+
+namespace NuGet.Protocol.Tests.Providers
+{
+    public class OwnerDetailsUriResourceV3ProviderTests
+    {
+        [Fact]
+        public async Task TryCreate_NoResourceInServiceIndex_ReturnsFalseAsync()
+        {
+            // Arrange
+            var serviceIndexProvider = MockServiceIndexResourceV3Provider.Create();
+            var target = new OwnerDetailsUriResourceV3Provider();
+            var providers = new INuGetResourceProvider[] { serviceIndexProvider, target };
+
+            PackageSource packageSource = new PackageSource("https://nuget.test/v3/index.json");
+            SourceRepository sourceRepository = new SourceRepository(packageSource, providers);
+
+            // Act
+            Tuple<bool, INuGetResource?> result = await target.TryCreate(sourceRepository, CancellationToken.None);
+
+            // Assert
+            bool providerHandlesInputSource = result.Item1;
+            INuGetResource? resource = result.Item2;
+
+            providerHandlesInputSource.Should().BeFalse();
+            resource.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task TryCreate_ResourceInServiceIndex_ReturnsTrueAsync()
+        {
+            // Arrange
+            var ownerDetailsResourceEntry = new ServiceIndexEntry(new Uri("https://nuget.test/profiles/{owner}?_src=template"), ServiceTypes.OwnerDetailsUriTemplate[0], MinClientVersionUtility.GetNuGetClientVersion());
+            var serviceIndexProvider = MockServiceIndexResourceV3Provider.Create();
+            var target = new OwnerDetailsUriResourceV3Provider();
+            var providers = new INuGetResourceProvider[] { serviceIndexProvider, target };
+
+            PackageSource packageSource = new PackageSource("https://nuget.test/v3/index.json");
+            SourceRepository sourceRepository = new SourceRepository(packageSource, providers);
+
+            // Act
+            Tuple<bool, INuGetResource?> result = await target.TryCreate(sourceRepository, CancellationToken.None);
+
+            // Assert
+            bool providerHandlesInputSource = result.Item1;
+            INuGetResource? resource = result.Item2;
+
+            providerHandlesInputSource.Should().BeFalse();
+            resource.Should().BeNull();
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RepositoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RepositoryTests.cs
@@ -63,7 +63,7 @@ namespace NuGet.Protocol.Tests
 
             int actualCount = resourceProviders.Count();
 
-            Assert.Equal(47, actualCount);
+            Assert.Equal(48, actualCount);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/OwnerDetailsUriTemplateResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/OwnerDetailsUriTemplateResourceV3Tests.cs
@@ -28,23 +28,10 @@ namespace NuGet.Protocol.Tests.Resources
         }
 
         [Fact]
-        public void CreateOrNull_WhenEmptyTemplate_CreatesNullResource()
-        {
-            // Arrange
-            var template = new Uri(string.Empty);
-
-            // Act
-            var target = OwnerDetailsUriTemplateResourceV3.CreateOrNull(template);
-
-            // Assert
-            target.Should().BeNull();
-        }
-
-        [Fact]
         public void CreateOrNull_WhenTemplateNotAbsoluteUri_CreatesNullResource()
         {
             // Arrange
-            var template = new Uri("/owner/profile");
+            var template = new Uri("/owner/profile", UriKind.Relative);
 
             // Act
             var target = OwnerDetailsUriTemplateResourceV3.CreateOrNull(template);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/OwnerDetailsUriTemplateResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/OwnerDetailsUriTemplateResourceV3Tests.cs
@@ -1,0 +1,135 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using FluentAssertions;
+using NuGet.Protocol.Resources;
+using Xunit;
+
+namespace NuGet.Protocol.Tests.Resources
+{
+    public class OwnerDetailsUriTemplateResourceV3Tests
+    {
+        private readonly Uri _template = new Uri("https://nuget.test/profiles/{owner}?_src=template");
+
+        [Fact]
+        public void CreateOrNull_WhenNullTemplate_CreatesNullResource()
+        {
+            // Arrange
+            Uri? template = null;
+
+            // Act
+            var target = OwnerDetailsUriTemplateResourceV3.CreateOrNull(template);
+
+            // Assert
+            target.Should().BeNull();
+        }
+
+        [Fact]
+        public void CreateOrNull_WhenEmptyTemplate_CreatesNullResource()
+        {
+            // Arrange
+            var template = new Uri(string.Empty);
+
+            // Act
+            var target = OwnerDetailsUriTemplateResourceV3.CreateOrNull(template);
+
+            // Assert
+            target.Should().BeNull();
+        }
+
+        [Fact]
+        public void CreateOrNull_WhenTemplateNotAbsoluteUri_CreatesNullResource()
+        {
+            // Arrange
+            var template = new Uri("/owner/profile");
+
+            // Act
+            var target = OwnerDetailsUriTemplateResourceV3.CreateOrNull(template);
+
+            // Assert
+            target.Should().BeNull();
+        }
+
+        [Fact]
+        public void CreateOrNull_WhenTemplateNotHttps_CreatesNullResource()
+        {
+            // Arrange
+            var template = new Uri("http://nuget.test/profiles/{owner}?_src=template");
+
+            // Act
+            var target = OwnerDetailsUriTemplateResourceV3.CreateOrNull(template);
+
+            // Assert
+            target.Should().BeNull();
+        }
+
+        [Fact]
+        public void CreateOrNull_WhenValidTemplateHttps_CreatesResource()
+        {
+            // Arrange
+            var template = new Uri("https://nuget.test/profiles/{owner}?_src=template");
+
+            // Act
+            var target = OwnerDetailsUriTemplateResourceV3.CreateOrNull(template);
+
+            // Assert
+            target.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void GetUri_WithSpacesInOwnerParameter_CreatesValidOwnerUriWithEncoding()
+        {
+            // Arrange
+            string owner = "Microsoft Microsoft Microsoft";
+            string formattedOwner = "Microsoft%20Microsoft%20Microsoft";
+
+            var target = OwnerDetailsUriTemplateResourceV3.CreateOrNull(_template);
+
+            // Act
+            Uri ownerUri = target!.GetUri(owner);
+
+            // Assert
+            ownerUri.Should().NotBeNull();
+            ownerUri.IsAbsoluteUri.Should().BeTrue();
+            ownerUri.AbsoluteUri.Should().Be($"https://nuget.test/profiles/{formattedOwner}?_src=template");
+        }
+
+        [Theory]
+        [InlineData("microsoft")]
+        [InlineData("MiCroSoFT")]
+        public void GetUri_WithValidOwnerParameter_CreatesValidOwnerUriWithSameCasing(string owner)
+        {
+            // Arrange
+            var target = OwnerDetailsUriTemplateResourceV3.CreateOrNull(_template);
+
+            // Act
+            Uri ownerUri = target!.GetUri(owner);
+
+            // Assert
+            ownerUri.Should().NotBeNull();
+            ownerUri.IsAbsoluteUri.Should().BeTrue();
+            ownerUri.AbsoluteUri.Should().Be($"https://nuget.test/profiles/{owner}?_src=template");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void GetUri_WithInvalidOwnerParameter_ReturnsOriginalTemplate(string owner)
+        {
+            // Arrange
+            var target = OwnerDetailsUriTemplateResourceV3.CreateOrNull(_template);
+            string templateWithoutOwner = "https://nuget.test/profiles/?_src=template";
+
+            // Act
+            Uri ownerUri = target!.GetUri(owner);
+
+            // Assert
+            ownerUri.Should().NotBeNull();
+            ownerUri.IsAbsoluteUri.Should().BeTrue();
+            ownerUri.AbsoluteUri.Should().Be(templateWithoutOwner);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/OwnerDetailsUriTemplateResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/OwnerDetailsUriTemplateResourceV3Tests.cs
@@ -15,16 +15,13 @@ namespace NuGet.Protocol.Tests.Resources
         private readonly Uri _template = new Uri("https://nuget.test/profiles/{owner}?_src=template");
 
         [Fact]
-        public void CreateOrNull_WhenNullTemplate_CreatesNullResource()
+        public void CreateOrNull_WhenNullTemplate_Throws()
         {
             // Arrange
             Uri? template = null;
 
-            // Act
-            var target = OwnerDetailsUriTemplateResourceV3.CreateOrNull(template);
-
-            // Assert
-            target.Should().BeNull();
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => OwnerDetailsUriTemplateResourceV3.CreateOrNull(template!));
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/OwnerDetailsUriTemplateResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/OwnerDetailsUriTemplateResourceV3Tests.cs
@@ -56,11 +56,8 @@ namespace NuGet.Protocol.Tests.Resources
         [Fact]
         public void CreateOrNull_WhenValidTemplateHttps_CreatesResource()
         {
-            // Arrange
-            var template = new Uri("https://nuget.test/profiles/{owner}?_src=template");
-
-            // Act
-            var target = OwnerDetailsUriTemplateResourceV3.CreateOrNull(template);
+            // Arrange & Act
+            var target = OwnerDetailsUriTemplateResourceV3.CreateOrNull(_template);
 
             // Assert
             target.Should().NotBeNull();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13409

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

**_Note: this resource is not yet consumed by the Client, but will be in https://github.com/NuGet/NuGet.Client/pull/5766_**

Adds a resource, `OwnerDetailsUriTemplateResourceV3`, similar to the [PackageDetailsUriResourceV3](https://github.com/NuGet/NuGet.Client/blob/784274cc9b2002ca73055e8134064261118d8a01/src/NuGet.Core/NuGet.Protocol/Resources/PackageDetailsUriResourceV3.cs).
- A template must use a Uri scheme of HTTPS and be an Absolute Uri.
- `GetUri` will replace a template's substring, `{owner}`, with each Owner returned from the NuGet Search API.
  - Client will not enforce that the template must have this substring. The linked documentation change will suggest that practice.

A new resource provider, `OwnerDetailsUriResourceV3Provider`, retrieves the resource from the service index, if available.

I've tested in Visual Studio by consuming this resource from package source, https://apidev.nugettest.org/v3/index.json, which @martinrrm has been developing for nuget.org (Thank you! 🙏).

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled https://github.com/NuGet/docs.microsoft.com-nuget/pull/3282
  - **OR**
  - [ ] N/A
