### PR TITLE
Use .NET SDK sourcelink integration

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -137,7 +137,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" Condition="'$(Shipping)' == 'true' AND '$(IsXPlat)' != 'true'" />
     <GlobalPackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" version="1.0.0" Condition=" '$(DotNetBuildSourceOnly)' != 'true' " />
   </ItemGroup>
 
@@ -183,8 +182,6 @@
       <_allowBuildFromSourcePackage Include="Microsoft.Extensions.CommandLineUtils.Sources" />
       <_allowBuildFromSourcePackage Include="Microsoft.Extensions.FileProviders.Abstractions" />
       <_allowBuildFromSourcePackage Include="Microsoft.Extensions.FileSystemGlobbing" />
-      <_allowBuildFromSourcePackage Include="Microsoft.SourceLink.AzureRepos.Git" />
-      <_allowBuildFromSourcePackage Include="Microsoft.SourceLink.GitHub" />
       <_allowBuildFromSourcePackage Include="Microsoft.Web.Xdt" />
       <_allowBuildFromSourcePackage Include="Newtonsoft.Json" />
       <_allowBuildFromSourcePackage Include="System.CommandLine" />

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -45,9 +45,6 @@
     <UsagePattern IdentityGlob="Microsoft.NETCore.App.Host*/*" />
     <UsagePattern IdentityGlob="Microsoft.NETCore.Platforms/*" />
     <UsagePattern IdentityGlob="Microsoft.NETCore.Targets/*" />
-    <UsagePattern IdentityGlob="Microsoft.SourceLink.AzureRepos.Git/*2" />
-    <UsagePattern IdentityGlob="Microsoft.SourceLink.Common/*" />
-    <UsagePattern IdentityGlob="Microsoft.SourceLink.GitHub/*" />
     <UsagePattern IdentityGlob="Microsoft.VisualStudio.Setup.Configuration.Interop/*" />
     <UsagePattern IdentityGlob="Microsoft.Web.Xdt/*" />
     <UsagePattern IdentityGlob="Microsoft.Win32.Registry/*" />

--- a/global.json
+++ b/global.json
@@ -1,12 +1,7 @@
 {
-  // This empty file has no effect and is here to support Arcade-powered dotnet-build.
-  // The Arcade build process requires a global.json at the root of the repo and normally
-  // uses it to restore the necessary SDK and tools to build the repo.
-  // However, NuGet explitcly wants to use the ambient SDK (normally latest), not any particular
-  // version.  We also don't want to introduce MS.DN.Arcade.SDK into the non-dotnet-build build.
-  // eng/dotnet-build/global.json has the entry for the Arcade version we need for
-  // Arcade-powered dotnet-build.
   "sdk": {
+    "version": "8.0.100",
+    "rollForward": "major",
     "allowPrerelease": true
   },
   "msbuild-sdks": {

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "8.0.100",
-    "rollForward": "major",
+    "rollForward": "latestMajor",
     "allowPrerelease": true
   },
   "msbuild-sdks": {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13410
Contributes to https://github.com/dotnet/source-build/issues/4353

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
SourceLink has become a native feature in the .NET
SDK since 8.0 and referencing the sourcelink packages
isn't necessary anymore. This avoid restoring the
1.0.0 packages that got produced in 2020.

Also set a required minimum version of the .NET
SDK so that we can be sure that the sourcelink
feature is available. Building with a newer SDK
is of course still possible.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
