### PR TITLE
Show Package Owner profile links on Browse Tab

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1854,11 +1854,29 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to by.
+        /// </summary>
+        public static string Text_By {
+            get {
+                return ResourceManager.GetString("Text_By", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to by {0}.
         /// </summary>
         public static string Text_ByAuthor {
             get {
                 return ResourceManager.GetString("Text_ByAuthor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to by {0}.
+        /// </summary>
+        public static string Text_ByOwner {
+            get {
+                return ResourceManager.GetString("Text_ByOwner", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1042,4 +1042,10 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <value>The package `{0}` is available in the Global packages folder, but the source it came from `{1}` is not one of the configured sources.</value>
     <comment>{0} is the package ID. {1} is the URI of the package source found in the Global packages folder.</comment>
   </data>
+  <data name="Text_ByOwner" xml:space="preserve">
+    <value>by {0}</value>
+  </data>
+  <data name="Text_By" xml:space="preserve">
+    <value>by</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
@@ -23,6 +23,8 @@
     x:Key="EmptyEnumerableToVisibilityConverter" />
   <nuget:EnumerableToVisibilityConverter
     x:Key="EnumerableToVisibilityConverter" />
+  <nuget:LastItemToVisibilityConverter
+    x:Key="LastItemToVisibilityConverter" />
   <nuget:InverseBooleanConverter
     x:Key="InverseBooleanConverter" />
   <nuget:BooleanToGridRowHeightConverter
@@ -681,6 +683,29 @@
           Property="TextBlock.TextDecorations"
           Value="{x:Null}" />
       </Trigger>
+    </Style.Triggers>
+  </Style>
+
+  <Style x:Key="HyperlinkSelectorAware" TargetType="{x:Type Hyperlink}" BasedOn="{StaticResource {x:Static vs:VsResourceKeys.ThemedDialogHyperlinkStyleKey}}">
+    <Style.Triggers>
+      <MultiDataTrigger>
+        <MultiDataTrigger.Conditions>
+          <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ListBoxItem}}" Value="True" />
+          <Condition Binding="{Binding (Selector.IsSelectionActive), RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ListBoxItem}}" Value="False" />
+        </MultiDataTrigger.Conditions>
+        <Setter
+          Property="Foreground"
+          Value="{DynamicResource {x:Static nuget:Brushes.ContentInactiveSelectedTextBrushKey}}" />
+      </MultiDataTrigger>
+      <MultiDataTrigger>
+        <MultiDataTrigger.Conditions>
+          <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ListBoxItem}}" Value="True" />
+          <Condition Binding="{Binding (Selector.IsSelectionActive), RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ListBoxItem}}" Value="True" />
+        </MultiDataTrigger.Conditions>
+        <Setter
+          Property="Foreground"
+          Value="{DynamicResource {x:Static nuget:Brushes.ContentSelectedTextBrushKey}}" />
+      </MultiDataTrigger>
     </Style.Triggers>
   </Style>
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Styles/LastItemToVisibilityConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Styles/LastItemToVisibilityConverter.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace NuGet.PackageManagement.UI
+{
+    internal class LastItemToVisibilityConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values != null && values.Length == 2
+                && values[0] is int currentIndex
+                && values[1] is int length)
+            {
+                if (currentIndex < 0 || length < 1 || currentIndex >= length)
+                {
+                    return DependencyProperty.UnsetValue;
+                }
+
+                int lastIndex = length - 1;
+                return Equals(currentIndex, lastIndex) ? Visibility.Collapsed : Visibility.Visible;
+            }
+
+            return DependencyProperty.UnsetValue;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            Debug.Fail("Not Implemented");
+            return null;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/KnownOwnerViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/KnownOwnerViewModel.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.VisualStudio.Internal.Contracts;
+
+namespace NuGet.PackageManagement.UI.ViewModels
+{
+    public class KnownOwnerViewModel
+    {
+        private string _name;
+        private Uri _link;
+
+        public KnownOwnerViewModel(KnownOwner knownOwner)
+        {
+            _name = knownOwner.Name;
+            _link = knownOwner.Link;
+        }
+
+        public string Name => _name;
+
+        public Uri Link => _link;
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/AuthorAndDownloadCount.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/AuthorAndDownloadCount.xaml
@@ -1,26 +1,74 @@
-﻿<UserControl x:Class="NuGet.PackageManagement.UI.AuthorAndDownloadCount"
+<UserControl x:Class="NuGet.PackageManagement.UI.AuthorAndDownloadCount"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:local="clr-namespace:NuGet.PackageManagement.UI"
+             xmlns:nuget="clr-namespace:NuGet.PackageManagement.UI"
              mc:Ignorable="d"
              x:Name="_self"
              d:DesignHeight="300" d:DesignWidth="300">
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <nuget:SharedResources />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </UserControl.Resources>
   <StackPanel Orientation="Horizontal">
-    <!-- text "by author" is shown here -->
+    <!-- text "by owner" is shown here -->
+    <ItemsControl x:Name="_panelOwners"
+      ItemsSource="{Binding KnownOwnerViewModels}"
+      Visibility="{Binding KnownOwnerViewModels, Converter={StaticResource EnumerableToVisibilityConverter}}"
+      Focusable="False"
+      AlternationCount="{Binding RelativeSource={RelativeSource Self}, Path=Items.Count}">
+      <ItemsControl.Template>
+        <ControlTemplate>
+          <StackPanel Orientation="Horizontal">
+            <TextBlock Margin="0,0,2,0" Text="{x:Static nuget:Resources.Text_By}"/>
+            <ItemsPresenter/>
+          </StackPanel>
+        </ControlTemplate>
+      </ItemsControl.Template>
+      <ItemsControl.ItemsPanel>
+        <ItemsPanelTemplate>
+          <StackPanel Orientation="Horizontal" Margin="2,0,0,0"/>
+        </ItemsPanelTemplate>
+      </ItemsControl.ItemsPanel>
+      <ItemsControl.ItemTemplate>
+        <DataTemplate>
+          <TextBlock><Hyperlink
+              NavigateUri="{Binding Link, Mode=OneWay}"
+              ToolTip="{Binding Link, Mode=OneWay}"
+              Style="{StaticResource HyperlinkSelectorAware}"
+              Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}">
+              <Run Text="{Binding Name, Mode=OneTime}" />
+            </Hyperlink><TextBlock Margin="0,0,2,0" Text=",">
+              <TextBlock.Visibility>
+                <MultiBinding Converter="{StaticResource LastItemToVisibilityConverter}">
+                  <Binding RelativeSource="{RelativeSource Mode=TemplatedParent}" Path="(ItemsControl.AlternationIndex)" />
+                  <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}" Path="Items.Count" />
+                </MultiBinding>
+              </TextBlock.Visibility>
+            </TextBlock>
+          </TextBlock>
+        </DataTemplate>
+      </ItemsControl.ItemTemplate>
+    </ItemsControl>
+
+    <!-- text "by author" is shown here when owner is unavailable -->
     <TextBlock 
-      x:Name="_textBlockAuthor" 
-      Visibility="Collapsed"/>
-    
-    <TextBlock 
-      x:Name="_separator" 
-      xml:space="preserve" 
-      Visibility="Collapsed">, </TextBlock>
-    
+        x:Name="_textBlockAuthor"
+        Visibility="Collapsed"/>
+
+    <TextBlock
+        x:Name="_separator"
+        xml:space="preserve"
+        Margin="0,0,2,0"
+        Visibility="Collapsed">,</TextBlock>
+
     <!-- the download count -->
     <TextBlock 
-      x:Name="_textBlockDownloadCount" 
-      Visibility="Collapsed"/>
+        x:Name="_textBlockDownloadCount"
+        Visibility="Collapsed"/>
   </StackPanel>
 </UserControl>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -5,7 +5,7 @@
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"  
-  xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"  
+  xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
   x:Name="_self"
   mc:Ignorable="d"
   xmlns:nuget="clr-namespace:NuGet.PackageManagement.UI"
@@ -183,6 +183,7 @@
           <!-- author and download count -->
           <nuget:AuthorAndDownloadCount
                         Margin="5,4,0,0"
+                        KnownOwnerViewModels="{Binding KnownOwnerViewModels, Mode=OneTime}"
                         Author="{Binding ByAuthor, Mode=OneTime}"
                         DownloadCount="{Binding DownloadCount}" />
         </StackPanel>
@@ -213,7 +214,7 @@
                         Style="{StaticResource TooltipStyle}">
                         <Run
                           Text="{Binding Id}"
-                          FontWeight="Bold" /> <Run Text="{Binding ByAuthor, Mode=OneTime}"/>
+                          FontWeight="Bold" /> <Run Text="{Binding ByOwnerOrAuthor, Mode=OneTime}"/>
                         <LineBreak />
                         <Run FontWeight="Bold">
                           <Run.Style>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml
@@ -37,6 +37,9 @@
     <CommandBinding
       Command="{x:Static nuget:Commands.SearchPackageCommand}"
       Executed="ExecuteSearchPackageCommand"/>
+    <CommandBinding
+      Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
+      Executed="ExecuteOpenExternalLink" />
   </UserControl.CommandBindings>
   <UserControl.InputBindings>
     <KeyBinding

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Documents;
 using System.Windows.Input;
 using Microsoft;
 using Microsoft.ServiceHub.Framework;
@@ -304,6 +305,28 @@ namespace NuGet.PackageManagement.UI
             else
             {
                 EmitRefreshEvent(timeSpan, RefreshOperationSource.ActionsExecuted, RefreshOperationStatus.NoOp);
+            }
+        }
+
+        /// <summary>
+        /// Handles Hyperlink controls inside this DetailControl class associated with
+        /// <see cref="PackageManagerControlCommands.OpenExternalLink" />
+        /// </summary>
+        /// <param name="sender">A Hyperlink control</param>
+        /// <param name="e">Command arguments</param>
+        private void ExecuteOpenExternalLink(object sender, ExecutedRoutedEventArgs e)
+        {
+            var hyperlink = e.OriginalSource as Hyperlink;
+            if (hyperlink != null && hyperlink.NavigateUri != null)
+            {
+                Model.UIController.LaunchExternalLink(hyperlink.NavigateUri);
+                e.Handled = true;
+
+                if (e.Parameter is not null and HyperlinkType hyperlinkType)
+                {
+                    var evt = NavigatedTelemetryEvent.CreateWithExternalLink(hyperlinkType, UIUtility.ToContractsItemFilter(ActiveFilter), Model.IsSolution);
+                    TelemetryActivity.EmitTelemetryEvent(evt);
+                }
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/SourceRepositoryExtensions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/SourceRepositoryExtensions.cs
@@ -11,6 +11,7 @@ using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Model;
+using NuGet.Protocol.Resources;
 using NuGet.Versioning;
 using NuGet.VisualStudio.Internal.Contracts;
 
@@ -42,7 +43,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             var searchResource = await sourceRepository.GetResourceAsync<PackageSearchResource>(cancellationToken);
 
-            var searchResults = await searchResource?.SearchAsync(
+            IEnumerable<IPackageSearchMetadata> searchResults = await searchResource?.SearchAsync(
                 searchToken.SearchString,
                 searchToken.SearchFilter,
                 searchToken.StartIndex,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/SearchObject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/SearchObject.cs
@@ -29,6 +29,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private SearchFilter? _lastSearchFilter;
         private readonly IReadOnlyCollection<PackageSourceContextInfo> _packageSources;
         private readonly IPackageMetadataProvider _packageMetadataProvider;
+        private readonly IOwnerDetailsUriService? _ownerDetailsUriService;
         private readonly MemoryCache? _inMemoryObjectCache;
 
         private readonly CacheItemPolicy _cacheItemPolicy = new CacheItemPolicy
@@ -52,6 +53,7 @@ namespace NuGet.PackageManagement.VisualStudio
             _recommenderFeed = recommenderFeed;
             _packageSources = packageSources;
             _packageMetadataProvider = packageMetadataProvider;
+            _ownerDetailsUriService = _packageMetadataProvider as IOwnerDetailsUriService;
             _inMemoryObjectCache = searchCache;
         }
 
@@ -83,7 +85,9 @@ namespace NuGet.PackageManagement.VisualStudio
                         PackageSearchMetadataContextInfo.Create(
                             recommendedFeedResultItem,
                             isRecommended: true,
-                            recommenderVersion: (_recommenderFeed as RecommenderPackageFeed)?.VersionInfo));
+                            recommenderVersion: (_recommenderFeed as RecommenderPackageFeed)?.VersionInfo,
+                            _ownerDetailsUriService
+                            ));
                 }
 
                 foreach (IPackageSearchMetadata mainFeedResultItem in mainFeedResult.Items)
@@ -91,7 +95,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     if (!recommendedIds.Contains(mainFeedResultItem.Identity.Id))
                     {
                         CacheBackgroundData(mainFeedResultItem, filter.IncludePrerelease);
-                        recommendedPackageSearchMetadataContextInfo.Add(PackageSearchMetadataContextInfo.Create(mainFeedResultItem));
+                        recommendedPackageSearchMetadataContextInfo.Add(PackageSearchMetadataContextInfo.Create(mainFeedResultItem, _ownerDetailsUriService));
                     }
                 }
 
@@ -106,7 +110,7 @@ namespace NuGet.PackageManagement.VisualStudio
             foreach (IPackageSearchMetadata packageSearchMetadata in mainFeedResult.Items)
             {
                 CacheBackgroundData(packageSearchMetadata, filter.IncludePrerelease);
-                packageSearchMetadataContextInfoCollection.Add(PackageSearchMetadataContextInfo.Create(packageSearchMetadata));
+                packageSearchMetadataContextInfoCollection.Add(PackageSearchMetadataContextInfo.Create(packageSearchMetadata, _ownerDetailsUriService));
             }
 
             return new SearchResultContextInfo(
@@ -181,7 +185,7 @@ namespace NuGet.PackageManagement.VisualStudio
             foreach (IPackageSearchMetadata packageSearchMetadata in _lastMainFeedSearchResult.Items)
             {
                 CacheBackgroundData(packageSearchMetadata, _lastSearchFilter.IncludePrerelease);
-                packageItems.Add(PackageSearchMetadataContextInfo.Create(packageSearchMetadata));
+                packageItems.Add(PackageSearchMetadataContextInfo.Create(packageSearchMetadata, _ownerDetailsUriService));
             }
 
             return new SearchResultContextInfo(

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSearchMetadataContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSearchMetadataContextInfo.cs
@@ -14,6 +14,8 @@ namespace NuGet.VisualStudio.Internal.Contracts
 {
     public sealed class PackageSearchMetadataContextInfo
     {
+        private IOwnerDetailsUriService? _ownerDetailsUriService;
+
         public PackageIdentity? Identity { get; internal set; }
         public string? Title { get; internal set; }
         public string? Description { get; internal set; }
@@ -22,9 +24,38 @@ namespace NuGet.VisualStudio.Internal.Contracts
         public string? Tags { get; internal set; }
         public Uri? LicenseUrl { get; internal set; }
         public Uri? ReadmeUrl { get; internal set; }
-        public string? Owners { get; internal set; }
         public Uri? ProjectUrl { get; internal set; }
         public DateTimeOffset? Published { get; internal set; }
+        public IReadOnlyList<string>? OwnersList { get; internal set; }
+        public string? Owners { get; internal set; }
+        public IReadOnlyList<KnownOwner>? KnownOwners
+        {
+            get
+            {
+                if (_ownerDetailsUriService is null
+                    || !_ownerDetailsUriService.SupportsKnownOwners)
+                {
+                    return null;
+                }
+
+                if (OwnersList is null || OwnersList.Count == 0)
+                {
+                    return Array.Empty<KnownOwner>();
+                }
+
+                List<KnownOwner> knownOwners = new(capacity: OwnersList.Count);
+
+                foreach (string owner in OwnersList)
+                {
+                    Uri ownerDetailsUrl = _ownerDetailsUriService.GetOwnerDetailsUri(owner);
+                    KnownOwner knownOwner = new(owner, ownerDetailsUrl);
+                    knownOwners.Add(knownOwner);
+                }
+
+                return knownOwners;
+            }
+        }
+
         public Uri? ReportAbuseUrl { get; internal set; }
         public Uri? PackageDetailsUrl { get; internal set; }
         public bool RequireLicenseAcceptance { get; internal set; }
@@ -42,10 +73,15 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         public static PackageSearchMetadataContextInfo Create(IPackageSearchMetadata packageSearchMetadata)
         {
-            return Create(packageSearchMetadata, isRecommended: false, recommenderVersion: null);
+            return Create(packageSearchMetadata, isRecommended: false, recommenderVersion: null, ownerDetailsUriService: null);
         }
 
-        public static PackageSearchMetadataContextInfo Create(IPackageSearchMetadata packageSearchMetadata, bool isRecommended, (string, string)? recommenderVersion)
+        public static PackageSearchMetadataContextInfo Create(IPackageSearchMetadata packageSearchMetadata, IOwnerDetailsUriService? ownerDetailsUriService)
+        {
+            return Create(packageSearchMetadata, isRecommended: false, recommenderVersion: null, ownerDetailsUriService);
+        }
+
+        public static PackageSearchMetadataContextInfo Create(IPackageSearchMetadata packageSearchMetadata, bool isRecommended, (string, string)? recommenderVersion, IOwnerDetailsUriService? ownerDetailsUriService)
         {
             return new PackageSearchMetadataContextInfo()
             {
@@ -60,9 +96,11 @@ namespace NuGet.VisualStudio.Internal.Contracts
                 LicenseMetadata = packageSearchMetadata.LicenseMetadata,
                 IsRecommended = isRecommended,
                 RecommenderVersion = recommenderVersion,
-                Owners = packageSearchMetadata.Owners,
                 ProjectUrl = packageSearchMetadata.ProjectUrl,
                 Published = packageSearchMetadata.Published,
+                OwnersList = packageSearchMetadata.OwnersList,
+                Owners = packageSearchMetadata.Owners,
+                _ownerDetailsUriService = ownerDetailsUriService,
                 ReportAbuseUrl = packageSearchMetadata.ReportAbuseUrl,
                 PackageDetailsUrl = packageSearchMetadata.PackageDetailsUrl,
                 PackagePath =

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/IOwnerDetailsUriService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/IOwnerDetailsUriService.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.VisualStudio.Internal.Contracts
+{
+    public interface IOwnerDetailsUriService
+    {
+        bool SupportsKnownOwners { get; }
+        Uri GetOwnerDetailsUri(string ownerName);
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/KnownOwner.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/KnownOwner.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.VisualStudio.Internal.Contracts
+{
+    public class KnownOwner
+    {
+        private string _name;
+        private Uri _link;
+
+        public KnownOwner(string name, Uri link)
+        {
+            _name = name ?? throw new ArgumentNullException(nameof(name));
+            _link = link ?? throw new ArgumentNullException(nameof(link));
+        }
+
+        public string Name => _name;
+
+        public Uri Link => _link;
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/LastItemToVisibilityConverterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/LastItemToVisibilityConverterTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Windows;
+using Xunit;
+
+namespace NuGet.PackageManagement.UI.Test.Converters
+{
+    public class LastItemToVisibilityConverterTests
+    {
+        private LastItemToVisibilityConverter _converter;
+
+        public LastItemToVisibilityConverterTests()
+        {
+            _converter = new LastItemToVisibilityConverter();
+        }
+
+        [Theory]
+        [InlineData(0, 1, Visibility.Collapsed)]
+        [InlineData(0, 3, Visibility.Visible)]
+        [InlineData(1, 3, Visibility.Visible)]
+        [InlineData(2, 3, Visibility.Collapsed)]
+        public void LastItemToVisibilityConverter_WithValidValues_ReturnsExpectedVisibility(int? currentIndex, int? lastIndex, Visibility expectedVisibility)
+        {
+            object converted = _converter.Convert(
+                [currentIndex, lastIndex],
+                typeof(Visibility),
+                null,
+                Thread.CurrentThread.CurrentCulture);
+
+            Assert.Equal(expectedVisibility, converted);
+        }
+
+        [Theory]
+        [InlineData(1, 0)]
+        [InlineData(1, 1)]
+        [InlineData(0, -1)]
+        [InlineData(-1, 5)]
+        public void LastItemToVisibilityConverter_WithInvalidValue_ReturnsUnsetValue(int? currentIndex, int? lastIndex)
+        {
+            var converter = new LastItemToVisibilityConverter();
+
+            object converted = _converter.Convert(
+                [currentIndex, lastIndex],
+                typeof(Visibility),
+                null,
+                Thread.CurrentThread.CurrentCulture);
+
+            Assert.Equal(DependencyProperty.UnsetValue, converted);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(5, null)]
+        [InlineData(null, 20)]
+        public void LastItemToVisibilityConverter_WithMissingValue_ReturnsExpectedVisibility(int? currentIndex, int? lastIndex)
+        {
+            var converter = new LastItemToVisibilityConverter();
+
+            object converted = _converter.Convert(
+                [currentIndex, lastIndex],
+                typeof(Visibility),
+                null,
+                Thread.CurrentThread.CurrentCulture);
+
+            Assert.Equal(DependencyProperty.UnsetValue, converted);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
@@ -1273,7 +1273,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
         [MemberData(nameof(FloatingVersions_TestCases_NonPackageReferenceProject))]
         public async void WhenPackageStyleIsNotPackageReference_And_CustomVersion_UpdatesTab_IsSelectedVersionCorrect(NuGetProjectKind projectKind, ProjectModel.ProjectStyle projectStyle, string allowedVersions, string installedVersion, bool isLatest, bool includePrerelease)
         {
-            // Arange project
+            // Arrange project
             Mock<IServiceBroker> mockServiceBroker = new Mock<IServiceBroker>();
             Mock<INuGetSearchService> mockSearchService = new Mock<INuGetSearchService>();
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
@@ -3,15 +3,19 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Sdk.TestFramework;
 using Microsoft.VisualStudio.Threading;
 using Moq;
 using NuGet.Configuration;
 using NuGet.PackageManagement.UI.Utility;
+using NuGet.PackageManagement.UI.ViewModels;
+using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
@@ -240,6 +244,145 @@ namespace NuGet.PackageManagement.UI.Test
             // Assert
             string[] result = items.Select(pkg => pkg.Id).ToArray();
             Assert.Equal(inputIds, result);
+        }
+
+        [Fact]
+        public async Task GetCurrent_OwnerDetailsService_SupportsKnownOwners_CreatesKnownOwnerViewModelsAsync()
+        {
+            var version = NuGetVersion.Parse("4.3.0");
+            var packageSearchMetadata = new PackageSearchMetadataBuilder.ClonedPackageSearchMetadata()
+            {
+                Identity = new PackageIdentity("NuGet.Versioning", version),
+                OwnersList = new List<string> { "owner1", "owner2" },
+            };
+            PackageSource packageSource = new PackageSource("https://nuget.test/v3/index.json");
+            Mock<IOwnerDetailsUriService> ownerDetailsUriService = new Mock<IOwnerDetailsUriService>();
+            ownerDetailsUriService.Setup(x => x.SupportsKnownOwners).Returns(true);
+            ownerDetailsUriService.Setup(x => x.GetOwnerDetailsUri(It.IsAny<string>())).Returns((string owner) => new Uri($"https://nuget.test/profiles/{owner}?_src=template"));
+
+            var packageSearchMetadataContextInfo = PackageSearchMetadataContextInfo.Create(packageSearchMetadata, ownerDetailsUriService.Object);
+            var searchResult = new SearchResultContextInfo(new[] { packageSearchMetadataContextInfo }, new Dictionary<string, LoadingStatus> { { "Search", LoadingStatus.Loading } }, hasMoreItems: false);
+            var serviceBroker = Mock.Of<IServiceBroker>();
+            var testVersions = new List<VersionInfoContextInfo>() {
+                new VersionInfoContextInfo(version),
+            };
+
+            var searchService = new Mock<INuGetSearchService>(MockBehavior.Strict);
+            searchService.Setup(ss => ss.GetPackageVersionsAsync(
+                It.IsAny<PackageIdentity>(),
+                It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(testVersions);
+            searchService.Setup(ss => ss.GetPackageMetadataAsync(It.IsAny<PackageIdentity>(), It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((packageSearchMetadataContextInfo, It.IsAny<PackageDeprecationMetadataContextInfo>()));
+            searchService.Setup(s => s.SearchAsync(It.IsAny<IReadOnlyCollection<IProjectContextInfo>>(),
+                It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(),
+                It.IsAny<IReadOnlyCollection<string>>(),
+                It.IsAny<string>(),
+                It.IsAny<SearchFilter>(),
+                It.IsAny<NuGet.VisualStudio.Internal.Contracts.ItemFilter>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<SearchResultContextInfo>(searchResult));
+            searchService.Setup(s => s.RefreshSearchAsync(It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<SearchResultContextInfo>(searchResult));
+            var uiContext = new Mock<INuGetUIContext>();
+            uiContext.Setup(ui => ui.ServiceBroker).Returns(serviceBroker);
+            var context = new PackageLoadContext(isSolution: false, uiContext.Object);
+            var mockProgress = Mock.Of<IProgress<IItemLoaderState>>();
+
+            var loader = await PackageItemLoader.CreateAsync(
+                serviceBroker,
+                context,
+                new List<PackageSourceContextInfo>() { PackageSourceContextInfo.Create(packageSource) },
+                NuGet.VisualStudio.Internal.Contracts.ItemFilter.All,
+                searchService.Object,
+                Mock.Of<INuGetPackageFileService>(),
+                TestSearchTerm);
+
+            // Act
+            await loader.UpdateStateAndReportAsync(searchResult, Mock.Of<IProgress<IItemLoaderState>>(), CancellationToken.None);
+            IEnumerable<PackageItemViewModel> viewModels = loader.GetCurrent();
+
+            // Assert
+            ImmutableList<KnownOwnerViewModel> knownOwnerViewModels = viewModels.Single().KnownOwnerViewModels;
+            knownOwnerViewModels.Should()
+                .NotBeNull()
+                .And.HaveCount(2)
+                .And.BeEquivalentTo(new[]
+                {
+                    new KnownOwnerViewModel(new KnownOwner("owner1", new Uri("https://nuget.test/profiles/owner1?_src=template"))),
+                    new KnownOwnerViewModel(new KnownOwner("owner2", new Uri("https://nuget.test/profiles/owner2?_src=template")))
+                });
+        }
+
+        [Fact]
+        public async Task GetCurrent_OwnerDetailsService_DoesNotSupportKnownOwners_DoesNotCreateKnownOwnerViewModelsAsync()
+        {
+            var version = NuGetVersion.Parse("4.3.0");
+            var packageSearchMetadata = new PackageSearchMetadataBuilder.ClonedPackageSearchMetadata()
+            {
+                Identity = new PackageIdentity("NuGet.Versioning", version),
+                OwnersList = new List<string> { "owner1", "owner2" },
+            };
+            PackageSource packageSource = new PackageSource("https://nuget.test/v3/index.json");
+            Mock<IOwnerDetailsUriService> ownerDetailsUriService = new Mock<IOwnerDetailsUriService>();
+            ownerDetailsUriService.Setup(x => x.SupportsKnownOwners).Returns(false);
+            ownerDetailsUriService.Setup(x => x.GetOwnerDetailsUri(It.IsAny<string>())).Returns((string owner) => new Uri($"https://nuget.test/profiles/{owner}?_src=template"));
+
+            var packageSearchMetadataContextInfo = PackageSearchMetadataContextInfo.Create(packageSearchMetadata, ownerDetailsUriService.Object);
+            var searchResult = new SearchResultContextInfo(new[] { packageSearchMetadataContextInfo }, new Dictionary<string, LoadingStatus> { { "Search", LoadingStatus.Loading } }, hasMoreItems: false);
+            var serviceBroker = Mock.Of<IServiceBroker>();
+            var testVersions = new List<VersionInfoContextInfo>() {
+                new VersionInfoContextInfo(version),
+            };
+
+            var searchService = new Mock<INuGetSearchService>(MockBehavior.Strict);
+            searchService.Setup(ss => ss.GetPackageVersionsAsync(
+                It.IsAny<PackageIdentity>(),
+                It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(testVersions);
+            searchService.Setup(ss => ss.GetPackageMetadataAsync(It.IsAny<PackageIdentity>(), It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((packageSearchMetadataContextInfo, It.IsAny<PackageDeprecationMetadataContextInfo>()));
+            searchService.Setup(s => s.SearchAsync(It.IsAny<IReadOnlyCollection<IProjectContextInfo>>(),
+                It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(),
+                It.IsAny<IReadOnlyCollection<string>>(),
+                It.IsAny<string>(),
+                It.IsAny<SearchFilter>(),
+                It.IsAny<NuGet.VisualStudio.Internal.Contracts.ItemFilter>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<SearchResultContextInfo>(searchResult));
+            searchService.Setup(s => s.RefreshSearchAsync(It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<SearchResultContextInfo>(searchResult));
+            var uiContext = new Mock<INuGetUIContext>();
+            uiContext.Setup(ui => ui.ServiceBroker).Returns(serviceBroker);
+            var context = new PackageLoadContext(isSolution: false, uiContext.Object);
+            var mockProgress = Mock.Of<IProgress<IItemLoaderState>>();
+
+            var loader = await PackageItemLoader.CreateAsync(
+                serviceBroker,
+                context,
+                new List<PackageSourceContextInfo>() { PackageSourceContextInfo.Create(packageSource) },
+                NuGet.VisualStudio.Internal.Contracts.ItemFilter.All,
+                searchService.Object,
+                Mock.Of<INuGetPackageFileService>(),
+                TestSearchTerm);
+
+            // Act
+            await loader.UpdateStateAndReportAsync(searchResult, Mock.Of<IProgress<IItemLoaderState>>(), CancellationToken.None);
+            IEnumerable<PackageItemViewModel> viewModels = loader.GetCurrent();
+
+            // Assert
+            ImmutableList<KnownOwnerViewModel> knownOwnerViewModels = viewModels.Single().KnownOwnerViewModels;
+            knownOwnerViewModels.Should().BeNull();
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/12501
Spec: https://github.com/NuGet/Home/blob/dev/accepted/2023/owner-author-pmui.md

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

### Key points
- On the Browse Tab, when a single package source is selected and it provides a resource, `OwnerDetailsUriTemplateResourceV3`, hyperlinks will be shown for each package owner in the PM UI Packages List. This is referred to as **Supporting Known Owners.**
- The owner profile URLs are built from the template from that source and the link's ToolTip shows the full URL.
- No telemetry is added in this PR.
_Screenshot of single package source Supporting Known Owners_:
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/974f6e46-fc3c-43e4-8528-500c45f82aac)

- Authors will never be shown in the packages list when the source Supports Known Owners.
- In all other scenarios, Author will continue to be shown when Known Owners is not supported.
_Screenshot of single package source which does not Support Known Owners_:
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/d4fc3736-dafd-4da6-8664-e526bb8c857c)

### Commentary
- I'm introducing new ViewModels here, but no software design pattern or architectural improvements/refactoring is being done to existing Views or ViewModels in this PR. I'm happy to contribute to that type of refactoring work in a separate effort. 
- A new type, `IOwnerDetailsUriService`, provides an indicator for support for known owners, and a means to obtain an Owner Profile URL.
  - Currently, only a `MultiSourcePackageMetadataProvider` implements and provides this service:
    - A single package source is required to Support Known Owners. 
    - No metadata merging decisions are being made in this PR.
- `PackageSearchMetadataContextInfo` is the coming together of two things: Search results and package metadata. Owners belong to Search, therefore this context is where I'm materializing `KnownOwner` models.
- Package Item ToolTips:
  - Still show "by `author`" when there's no Supported Known Owners. 
  - Show "by `owner`" when there are Supported Known Owners.
    - I'm using the String here rather than calculating it from the `KnownOwnerViewModels`, as they should match. I kept this pattern here as I'd like to eventually refactor this class and use a more MVVM approach for the AuthorAndDownloadCount's view model.
- Hyperlink events are handled by the `ExecuteOpenExternalLink` event similar to the Details Pane event. Telemetry can be added for owner profile links by simply providing a new property which this event will emit.
- `KnownOwnerViewModel` represents known owners within Visual Studio UIs.
- `LastItemToVisibilityConverter` allows for adding commas after each hyperlink, except the last one.

### Accessibility

- I did not test Psuedo-localization (PLOC) since the reflow design of the packages list is already handled - that is, it's truncated if it exceeds the width of the packages list.
- Keyboard navigation visits each hyperlink
- Screen-readers announce each hyperlink as "Hyperlink <owner name>", similar to other hyperlinks.
- **Follow-up**: Add explanatory text into the ToolTip or explain that these profile URLs are owners from a particular source. https://github.com/NuGet/Home/issues/13414
- **Accessibility Insights** identified 1 bug which is a known WPF bug. I filed this to track it for when it's found by the test team:  https://github.com/NuGet/Client.Engineering/issues/2801

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled https://github.com/NuGet/docs.microsoft.com-nuget/issues/3287
  - **OR**
  - [ ] N/A
