### PR TITLE
Move KnownOwner creation into SearchObject

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/KnownOwnerViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/KnownOwnerViewModel.cs
@@ -8,17 +8,14 @@ namespace NuGet.PackageManagement.UI.ViewModels
 {
     public class KnownOwnerViewModel
     {
-        private string _name;
-        private Uri _link;
-
         public KnownOwnerViewModel(KnownOwner knownOwner)
         {
-            _name = knownOwner.Name;
-            _link = knownOwner.Link;
+            Name = knownOwner.Name;
+            Link = knownOwner.Link;
         }
 
-        public string Name => _name;
+        public string Name { get; }
 
-        public Uri Link => _link;
+        public Uri Link { get; }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSearchMetadataContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSearchMetadataContextInfo.cs
@@ -14,8 +14,6 @@ namespace NuGet.VisualStudio.Internal.Contracts
 {
     public sealed class PackageSearchMetadataContextInfo
     {
-        private IOwnerDetailsUriService? _ownerDetailsUriService;
-
         public PackageIdentity? Identity { get; internal set; }
         public string? Title { get; internal set; }
         public string? Description { get; internal set; }
@@ -28,34 +26,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         public DateTimeOffset? Published { get; internal set; }
         public IReadOnlyList<string>? OwnersList { get; internal set; }
         public string? Owners { get; internal set; }
-        public IReadOnlyList<KnownOwner>? KnownOwners
-        {
-            get
-            {
-                if (_ownerDetailsUriService is null
-                    || !_ownerDetailsUriService.SupportsKnownOwners)
-                {
-                    return null;
-                }
-
-                if (OwnersList is null || OwnersList.Count == 0)
-                {
-                    return Array.Empty<KnownOwner>();
-                }
-
-                List<KnownOwner> knownOwners = new(capacity: OwnersList.Count);
-
-                foreach (string owner in OwnersList)
-                {
-                    Uri ownerDetailsUrl = _ownerDetailsUriService.GetOwnerDetailsUri(owner);
-                    KnownOwner knownOwner = new(owner, ownerDetailsUrl);
-                    knownOwners.Add(knownOwner);
-                }
-
-                return knownOwners;
-            }
-        }
-
+        public IReadOnlyList<KnownOwner>? KnownOwners { get; internal set; }
         public Uri? ReportAbuseUrl { get; internal set; }
         public Uri? PackageDetailsUrl { get; internal set; }
         public bool RequireLicenseAcceptance { get; internal set; }
@@ -73,15 +44,15 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         public static PackageSearchMetadataContextInfo Create(IPackageSearchMetadata packageSearchMetadata)
         {
-            return Create(packageSearchMetadata, isRecommended: false, recommenderVersion: null, ownerDetailsUriService: null);
+            return Create(packageSearchMetadata, isRecommended: false, recommenderVersion: null, knownOwners: null);
         }
 
-        public static PackageSearchMetadataContextInfo Create(IPackageSearchMetadata packageSearchMetadata, IOwnerDetailsUriService? ownerDetailsUriService)
+        public static PackageSearchMetadataContextInfo Create(IPackageSearchMetadata packageSearchMetadata, IReadOnlyList<KnownOwner>? knownOwners)
         {
-            return Create(packageSearchMetadata, isRecommended: false, recommenderVersion: null, ownerDetailsUriService);
+            return Create(packageSearchMetadata, isRecommended: false, recommenderVersion: null, knownOwners);
         }
 
-        public static PackageSearchMetadataContextInfo Create(IPackageSearchMetadata packageSearchMetadata, bool isRecommended, (string, string)? recommenderVersion, IOwnerDetailsUriService? ownerDetailsUriService)
+        public static PackageSearchMetadataContextInfo Create(IPackageSearchMetadata packageSearchMetadata, bool isRecommended, (string, string)? recommenderVersion, IReadOnlyList<KnownOwner>? knownOwners)
         {
             return new PackageSearchMetadataContextInfo()
             {
@@ -100,7 +71,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
                 Published = packageSearchMetadata.Published,
                 OwnersList = packageSearchMetadata.OwnersList,
                 Owners = packageSearchMetadata.Owners,
-                _ownerDetailsUriService = ownerDetailsUriService,
+                KnownOwners = knownOwners,
                 ReportAbuseUrl = packageSearchMetadata.ReportAbuseUrl,
                 PackageDetailsUrl = packageSearchMetadata.PackageDetailsUrl,
                 PackagePath =


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13420

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Follow-up on my change to use a service to calculate Known Owners in this Context class. I now understand this is actually a DTO that theoretically could be serialized and used in a service.

There shouldn't be any tangible difference here, just a refactoring.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
