### PR TITLE
Enable Nullable and throw in KnownOwnerViewModel

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/KnownOwnerViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/KnownOwnerViewModel.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using NuGet.VisualStudio.Internal.Contracts;
 
@@ -10,6 +12,11 @@ namespace NuGet.PackageManagement.UI.ViewModels
     {
         public KnownOwnerViewModel(KnownOwner knownOwner)
         {
+            if (knownOwner is null)
+            {
+                throw new ArgumentNullException(nameof(knownOwner));
+            }
+
             Name = knownOwner.Name;
             Link = knownOwner.Link;
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/KnownOwnerViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/KnownOwnerViewModelTests.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.PackageManagement.UI.ViewModels;
+using Xunit;
+
+namespace NuGet.PackageManagement.UI.Test.ViewModels
+{
+    public class KnownOwnerViewModelTests
+    {
+        [Fact]
+        public void Constructor_WithNullKnownOwner_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new KnownOwnerViewModel(knownOwner: null));
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13425

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Enable Nullable, and throw when null is passed to this constructor.
There is no customer impact or known problems here, just more of a preventative for future PM UI development.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
