### PR TITLE
Run Apex/E2E tests on the VS target release branch instead of the main branch for NuGet release branches.

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -35,6 +35,8 @@
     <!-- This branches are used for creating insertion PRs -->
     <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetBranch>
     <VsTargetChannel Condition="'$(IsEscrowMode)' == 'true'">int.d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetChannel>
+    <!-- Run Apex/E2E tests on the target release branch -->
+    <VsTargetChannelForTests Condition="'$(IsEscrowMode)' == 'true'">$(VsTargetChannel)</VsTargetChannelForTests>
   </PropertyGroup>
 
  <PropertyGroup Condition=" '$(PreReleaseVersion)' == '' ">


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2818

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Currently, in all our release branches, we run Apex/E2E tests on the VS main branch instead of the target release branch [build/config.props](https://github.com/NuGet/NuGet.Client/blob/988fff9e4cd4bac01da982727386abc0b47efb66/build/config.props#L27-L37). Given that the `VSTargetChannel` property is overridden for release branches, I think we should also update the `VsTargetChannelForTests` property so that Apex/E2E tests run on the VS target release branch instead of the main branch.

Once this change is merged into the dev branch, I will cherry-pick the commit into the applicable release branches.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  - [x] N/A