### PR TITLE
Update pull request pipeline to work for internal-only use

### DIFF
--- a/eng/pipelines/pr.job.yml
+++ b/eng/pipelines/pr.job.yml
@@ -25,6 +25,11 @@ jobs:
       value: ${{ parameters.testType }}
     - name: TestTargetFramework
       value: ${{ parameters.testTargetFramework }}
+    - name: BinlogDirectory
+      ${{ if eq(parameters.osName, 'Windows') }}:
+        value: $(Agent.TempDirectory)\binlogs\
+      ${{ else }}:
+        value: $(Agent.TempDirectory)/binlogs/
 
   pool:
     name: ${{ parameters.agentPool }}

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -56,8 +56,11 @@ stages:
       parameters:
         displayName: Unit Tests on Windows (.NET Framework 4.7.2)
         osName: Windows
-        agentPool: NetCore-Public
-        agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          agentPool: NetCore-Public
+          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+        ${{ else }}:
+          agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Unit
         testTargetFramework: net472
 
@@ -70,8 +73,11 @@ stages:
       parameters:
         displayName: Unit Tests on Windows (.NET 8.0)
         osName: Windows
-        agentPool: NetCore-Public
-        agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          agentPool: NetCore-Public
+          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+        ${{ else }}:
+          agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Unit
         testTargetFramework: net8.0
 
@@ -84,8 +90,11 @@ stages:
       parameters:
         displayName: Unit Tests on Windows (.NET Core 3.1)
         osName: Windows
-        agentPool: NetCore-Public
-        agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          agentPool: NetCore-Public
+          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+        ${{ else }}:
+          agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Unit
         testTargetFramework: netcoreapp3.1
 
@@ -98,8 +107,11 @@ stages:
       parameters:
         displayName: Functional Tests on Windows (.NET Framework 4.7.2)
         osName: Windows
-        agentPool: NetCore-Public
-        agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          agentPool: NetCore-Public
+          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+        ${{ else }}:
+          agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Functional
         testTargetFramework: net472
         timeoutInMinutes: 60
@@ -113,8 +125,11 @@ stages:
       parameters:
         displayName: Functional Tests on Windows (.NET 8.0)
         osName: Windows
-        agentPool: NetCore-Public
-        agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          agentPool: NetCore-Public
+          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+        ${{ else }}:
+          agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Functional
         testTargetFramework: net8.0
         timeoutInMinutes: 60
@@ -128,8 +143,11 @@ stages:
       parameters:
         displayName: Functional Tests on Windows (.NET Core 3.1)
         osName: Windows
-        agentPool: NetCore-Public
-        agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          agentPool: NetCore-Public
+          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+        ${{ else }}:
+          agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Functional
         testTargetFramework: netcoreapp3.1
         timeoutInMinutes: 60


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Related: https://github.com/NuGet/Client.Engineering/issues/2286

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This makes the pipeline work for any internal-only use by using a different agent pool when its using any other team project than `dnceng-public`.

I also fixed the binlogs logic by adding back the variable.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
