### PR TITLE
Fixed project path bug for packages.config NuGetAuditLevel

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -456,7 +456,7 @@ namespace NuGet.Build.Tasks
                         value ??= new();
                         packageReferenceToProjects.Add(packageReference, value);
                     }
-                    value.Add(pcRestoreMetadata.PackagesConfigPath);
+                    value.Add(pcRestoreMetadata.ProjectPath);
                 }
                 restoreAuditProperties.Add(packageSpec.FilePath, packageSpec.RestoreMetadata.RestoreAuditProperties);
             }

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -456,7 +456,7 @@ namespace NuGet.Build.Tasks
                         value ??= new();
                         packageReferenceToProjects.Add(packageReference, value);
                     }
-                    value.Add(pcRestoreMetadata.ProjectPath);
+                    value.Add(packageSpec.FilePath);
                 }
                 restoreAuditProperties.Add(packageSpec.FilePath, packageSpec.RestoreMetadata.RestoreAuditProperties);
             }

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -20,6 +20,7 @@ using NuGet.Versioning;
 using Test.Utility;
 using Xunit;
 using Xunit.Abstractions;
+using static NuGet.Frameworks.FrameworkConstants;
 
 namespace Msbuild.Integration.Test
 {
@@ -1459,20 +1460,18 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             // set up solution, projects and packages
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
 
-            var net472 = NuGetFramework.Parse("net472");
-
             var projectA = new SimpleTestProjectContext(
                 "A",
                 ProjectStyle.PackagesConfig,
                 pathContext.SolutionRoot);
-            projectA.Frameworks.Add(new SimpleTestProjectFrameworkContext(net472));
+            projectA.Frameworks.Add(new SimpleTestProjectFrameworkContext(CommonFrameworks.Net472));
             projectA.Properties.Add("NuGetAuditLevel", "critical");
 
             var projectB = new SimpleTestProjectContext(
                 "B",
                 ProjectStyle.PackagesConfig,
                 pathContext.SolutionRoot);
-            projectB.Frameworks.Add(new SimpleTestProjectFrameworkContext(net472));
+            projectB.Frameworks.Add(new SimpleTestProjectFrameworkContext(CommonFrameworks.Net472));
             projectB.Properties.Add("NuGetAuditLevel", "high");
 
             var packageA1 = new SimpleTestPackageContext()
@@ -1490,15 +1489,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 Id = "packageB",
                 Version = "2.2.0"
             };
-
-            packageA1.Files.Clear();
-            packageA1.AddFile("lib/net472/packageA.dll");
-
-            packageA2.Files.Clear();
-            packageA2.AddFile("lib/net472/packageA.dll");
-
-            packageB.Files.Clear();
-            packageB.AddFile("lib/net472/packageB.dll");
 
             solution.Projects.Add(projectA);
             solution.Projects.Add(projectB);
@@ -1522,7 +1512,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 </packages>");
             }
 
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+            await SimpleTestPackageUtility.CreatePackagesAsync(
                 pathContext.PackageSource,
                 packageA1,
                 packageA2,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13454

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

When generating the configuration for audit, the packages.config path was incorrectly used, while it should have been the project path. 
There were tests for this for nuget.exe, but unfortunately no E2E for msbuild -t:restore. 


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
