### PR TITLE
Avoid boxing in FrameworkDependency's CompareTo and Equals methods

### DIFF
--- a/src/NuGet.Core/NuGet.LibraryModel/FrameworkDependency.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/FrameworkDependency.cs
@@ -33,7 +33,9 @@ namespace NuGet.LibraryModel
 
             if (compare == 0)
             {
-                return PrivateAssets.CompareTo(other.PrivateAssets);
+                int thisPrivateAssets = (int)PrivateAssets;
+                int otherPrivateAssets = (int)other.PrivateAssets;
+                return thisPrivateAssets.CompareTo(otherPrivateAssets);
             }
 
             return compare;
@@ -52,7 +54,7 @@ namespace NuGet.LibraryModel
             }
 
             return ComparisonUtility.FrameworkReferenceNameComparer.Equals(Name, other.Name) &&
-                   PrivateAssets.Equals(other.PrivateAssets);
+                   PrivateAssets == other.PrivateAssets;
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13442

## Description
Avoids boxing in `CompareTo` and `Equals` when evaluating enums

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
