### PR TITLE
Allow Numbers that look like letters in package ID

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Utility/PackageIdValidator.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Utility/PackageIdValidator.cs
@@ -15,7 +15,7 @@ namespace NuGet.Packaging
         /// In case update this value please update in src\NuGet.Core\NuGet.Configuration\PackageSourceMapping\PackageSourceMapping.cs too.
         /// </summary>
         public const int MaxPackageIdLength = 100;
-        private static readonly Regex IdRegex = new Regex(pattern: @"^\w+([.-]\w+)*$",
+        private static readonly Regex IdRegex = new Regex(pattern: @"^[\p{L}\p{M}\p{N}\p{Pc}]+([.-][\p{L}\p{M}\p{N}\p{Pc}]+)*$",
             options: RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant,
             matchTimeout: TimeSpan.FromSeconds(10));
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Utility/PackageIdValidator.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Utility/PackageIdValidator.cs
@@ -15,7 +15,7 @@ namespace NuGet.Packaging
         /// In case update this value please update in src\NuGet.Core\NuGet.Configuration\PackageSourceMapping\PackageSourceMapping.cs too.
         /// </summary>
         public const int MaxPackageIdLength = 100;
-        private static readonly Regex IdRegex = new Regex(pattern: @"^[\p{L}\p{M}\p{N}\p{Pc}]+([.-][\p{L}\p{M}\p{N}\p{Pc}]+)*$",
+        private static readonly Regex IdRegex = new Regex(pattern: @"^[\w\p{N}]+([.-][\w\p{N}]+)*$",
             options: RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant,
             matchTimeout: TimeSpan.FromSeconds(10));
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageIdValidatorTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageIdValidatorTest.cs
@@ -19,6 +19,23 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
+        public void ValidatePackageId_OnGB18030Characters_Succeeds()
+        {
+            // Arrange
+            string packageId = "G龦鿃C啊阿鼾齄D2丂丄狚狛D3狜狝﨨﨩D4ⅫㄨㄩD1ˊˋ〇D5U1U2U3㐀㐁䶴䶵ABCDEFKS";
+
+            // Act & Assert
+            try
+            {
+                PackageIdValidator.ValidatePackageId(packageId);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail(ex.Message);
+            }
+        }
+
+        [Fact]
         public void EmptyIsNotValid()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2826

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This PR updates the regular expression used for validating package IDs
new regex `[\w\p{N}]+([.-][\w\p{N}]+)*` has two parts
1 .`[\w\p{N}]`  
* \w :A character in the input string can belong to any of the Unicode categories that are appropriate for characters in words. It is a union of:
  * Li: Letter lowercase
  * Lu: Letter UpperCase
  * Lt: Letter TitleCase
  * Lo: Letter Other
  * Lm: Letter, Modifier
  * Mn: Mark, Nonspacing
  * Nd: Number, Decimal Digit
  * Pc: Punctuation Connector
 * \p{N} allows us to include any kind of numeric character in any script. That include letter looking like numbers
2. `([.-][\w\p{N}]+)*` Allows repetition of what I wrote in one by proceeding it with . or -
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
