### PR TITLE
Remove Apex and end-to-end initial status from CI pipeline

### DIFF
--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -117,24 +117,25 @@ Function InitializeAllTestsToPending {
         Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Unit Tests On Linux" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
         Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional Tests On Linux" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
     }
-    if($env:RunEndToEndTests -eq "true")
-    {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "End_To_End_Tests_On_Windows Part1" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "End_To_End_Tests_On_Windows Part2" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
-    }
-    else
-    {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "End_To_End_Tests_On_Windows Part1" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "End_To_End_Tests_On_Windows Part2" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
-    }
-    if($env:RunApexTests -eq "true")
-    {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Apex Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
-    }
-    else
-    {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Apex Tests On Windows" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
-    }
+    # The Apex and end-to-end tests do not currently run
+    # if($env:RunEndToEndTests -eq "true")
+    # {
+        # Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "End_To_End_Tests_On_Windows Part1" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+        # Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "End_To_End_Tests_On_Windows Part2" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+    # }
+    # else
+    # {
+        # Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "End_To_End_Tests_On_Windows Part1" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
+        # Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "End_To_End_Tests_On_Windows Part2" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
+    # }
+    # if($env:RunApexTests -eq "true")
+    # {
+        # Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Apex Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+    # }
+    # else
+    # {
+        # Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Apex Tests On Windows" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
+    # }
 }
 
 function SetCommitStatusForTestResult {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This just removes the initial status that gets posted for a build for the Apex and end-to-end tests since they aren't currently running.  We can bring them back later when they're running again.

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
