### PR TITLE
Change the testMachineImageName's value of NuGet.Client Daily Tests pipeline

### DIFF
--- a/eng/pipelines/dailytests.yml
+++ b/eng/pipelines/dailytests.yml
@@ -32,6 +32,9 @@ parameters:
 - name: isOfficialBuild
   type: boolean
   default: false
+- name: testMachineImageName
+  type: string
+  default: Windows-11-Enterprise-23H2-WinBuildDevFiles
 
 variables:
   DOTNET_NOLOGO: 1
@@ -46,3 +49,4 @@ stages:
     dartLabEnvironment: ${{parameters.DartLabEnvironment}}
     testExecutionJobTimeoutInMinutes: 150
     testMachineCleanUpStrategy: ${{parameters.ApexAgentCleanup}}
+    testMachineImageName: ${{parameters.testMachineImageName}}

--- a/eng/pipelines/templates/Apex_Tests_On_Windows_Daily.yml
+++ b/eng/pipelines/templates/Apex_Tests_On_Windows_Daily.yml
@@ -12,6 +12,8 @@ parameters:
   - name: isOfficialBuild
     type: boolean
     default: false
+  - name: testMachineImageName
+    type: string
 
 stages:
   - template: stages\visual-studio\build-to-build-upgrade\single-runsettings.yml@DartLabTemplates
@@ -44,6 +46,7 @@ stages:
       testExecutionJobTimeoutInMinutes: ${{parameters.testExecutionJobTimeoutInMinutes}}
       testMachineCleanUpStrategy: ${{parameters.testMachineCleanUpStrategy}}
       testAgentElevated: true
+      testMachineImageName: ${{parameters.testMachineImageName}}
       preTestMachineConfigurationStepList: 
         - download: ComponentBuildUnderTest
           artifact: MicroBuildOutputs


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2840

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
For recently runs in [NuGet.Client Daily Tests](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=18097&_a=summary) pipeline failed due to an error "There is not enough space on the disk". So changing the testMachineImageName's value to "Windows-11-Enterprise-23H2-WinBuildDevFiles", and it creates a bigger disk(255GB) than the default image(126GB).

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
