### PR TITLE
Account for the scenario, where the files are not changed and the solution is not no-op with the progress reporter set.

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -157,8 +157,8 @@ NuGet.Commands.IProjectFactory
 ~NuGet.Commands.IProjectFactory.Logger.set -> void
 NuGet.Commands.IProjectFactory.SetIncludeSymbols(bool includeSymbols) -> void
 NuGet.Commands.IRestoreProgressReporter
-~NuGet.Commands.IRestoreProgressReporter.EndProjectUpdate(string projectPath, System.Collections.Generic.IReadOnlyList<string> updatedFiles) -> void
-~NuGet.Commands.IRestoreProgressReporter.StartProjectUpdate(string projectPath, System.Collections.Generic.IReadOnlyList<string> updatedFiles) -> void
+NuGet.Commands.IRestoreProgressReporter.EndProjectUpdate(string! projectPath, System.Collections.Generic.IReadOnlyList<string!>! updatedFiles) -> void
+NuGet.Commands.IRestoreProgressReporter.StartProjectUpdate(string! projectPath, System.Collections.Generic.IReadOnlyList<string!>! updatedFiles) -> void
 NuGet.Commands.IRestoreRequestProvider
 ~NuGet.Commands.IRestoreRequestProvider.CreateRequests(string inputPath, NuGet.Commands.RestoreArgs restoreContext) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Commands.RestoreSummaryRequest>>
 ~NuGet.Commands.IRestoreRequestProvider.Supports(string path) -> System.Threading.Tasks.Task<bool>

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Shipped.txt
@@ -157,8 +157,8 @@ NuGet.Commands.IProjectFactory
 ~NuGet.Commands.IProjectFactory.Logger.set -> void
 NuGet.Commands.IProjectFactory.SetIncludeSymbols(bool includeSymbols) -> void
 NuGet.Commands.IRestoreProgressReporter
-~NuGet.Commands.IRestoreProgressReporter.EndProjectUpdate(string projectPath, System.Collections.Generic.IReadOnlyList<string> updatedFiles) -> void
-~NuGet.Commands.IRestoreProgressReporter.StartProjectUpdate(string projectPath, System.Collections.Generic.IReadOnlyList<string> updatedFiles) -> void
+NuGet.Commands.IRestoreProgressReporter.EndProjectUpdate(string! projectPath, System.Collections.Generic.IReadOnlyList<string!>! updatedFiles) -> void
+NuGet.Commands.IRestoreProgressReporter.StartProjectUpdate(string! projectPath, System.Collections.Generic.IReadOnlyList<string!>! updatedFiles) -> void
 NuGet.Commands.IRestoreRequestProvider
 ~NuGet.Commands.IRestoreRequestProvider.CreateRequests(string inputPath, NuGet.Commands.RestoreArgs restoreContext) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Commands.RestoreSummaryRequest>>
 ~NuGet.Commands.IRestoreRequestProvider.Supports(string path) -> System.Threading.Tasks.Task<bool>

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -157,8 +157,8 @@ NuGet.Commands.IProjectFactory
 ~NuGet.Commands.IProjectFactory.Logger.set -> void
 NuGet.Commands.IProjectFactory.SetIncludeSymbols(bool includeSymbols) -> void
 NuGet.Commands.IRestoreProgressReporter
-~NuGet.Commands.IRestoreProgressReporter.EndProjectUpdate(string projectPath, System.Collections.Generic.IReadOnlyList<string> updatedFiles) -> void
-~NuGet.Commands.IRestoreProgressReporter.StartProjectUpdate(string projectPath, System.Collections.Generic.IReadOnlyList<string> updatedFiles) -> void
+NuGet.Commands.IRestoreProgressReporter.EndProjectUpdate(string! projectPath, System.Collections.Generic.IReadOnlyList<string!>! updatedFiles) -> void
+NuGet.Commands.IRestoreProgressReporter.StartProjectUpdate(string! projectPath, System.Collections.Generic.IReadOnlyList<string!>! updatedFiles) -> void
 NuGet.Commands.IRestoreRequestProvider
 ~NuGet.Commands.IRestoreRequestProvider.CreateRequests(string inputPath, NuGet.Commands.RestoreArgs restoreContext) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Commands.RestoreSummaryRequest>>
 ~NuGet.Commands.IRestoreRequestProvider.Supports(string path) -> System.Threading.Tasks.Task<bool>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/IRestoreProgressReporter.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/IRestoreProgressReporter.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+#nullable enable
 
 using System.Collections.Generic;
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -273,7 +273,7 @@ namespace NuGet.Commands
             IReadOnlyList<string> filesToBeUpdated = result.GetDirtyFiles();
             try
             {
-                if (!isNoOp)
+                if (!isNoOp && filesToBeUpdated?.Count > 0)
                 {
                     progressReporter?.StartProjectUpdate(summaryRequest.InputPath, filesToBeUpdated);
                 }
@@ -286,7 +286,7 @@ namespace NuGet.Commands
             }
             finally
             {
-                if (!isNoOp)
+                if (!isNoOp && filesToBeUpdated?.Count > 0)
                 {
                     progressReporter?.EndProjectUpdate(summaryRequest.InputPath, filesToBeUpdated);
                 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13452
Fixes: https://github.com/NuGet/Home/issues/13451

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Avoid calling the progress reporter if no files exist. 

There's a bunch of things that could've gone better that I can think of as mitigations that's better than the test I just added, but that's more work than what we can do for now.

* If the code in RestoreRunner wasn't public and were easily able to just propagate the progress reporter in every codepath. Majority of the tests don't really test the progress reporter which was the component that was throwing. - One idea, not exactly this issue, but relevant: https://github.com/NuGet/Home/issues/13077
* Another thing that would've helped is if E2E tests were running, cause there's an end to end test like this.  https://github.com/NuGet/NuGet.Client/blob/dev/test/EndToEnd/tests/BuildIntegratedTest.ps1, https://github.com/NuGet/Client.Engineering/issues/2699. Fortunately Jeff is working on it: https://github.com/NuGet/Client.Engineering/pull/2830: 
* Nullable checks in NuGet.Commands https://github.com/NuGet/Client.Engineering/issues/2255. 

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
