### PR TITLE
Update PrivateDev pipeline to not run tests by default

### DIFF
--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -13,11 +13,15 @@ parameters:
 - name: RunCrossFrameworkTestsOnWindows
   displayName: Run cross framweork tests on Windows
   type: boolean
-  default: true
+  default: false
+- name: RunUnitTestsOnWindows
+  displayName: Run unit tests on Windows
+  type: boolean
+  default: false
 - name: RunFunctionalTestsOnWindows
   displayName: Run functional tests on Windows
   type: boolean
-  default: true
+  default: false
 - name: RunSourceBuild
   displayName: Run source build
   type: boolean
@@ -25,11 +29,11 @@ parameters:
 - name: RunTestsOnLinux
   displayName: Run tests on Linux
   type: boolean
-  default: true
+  default: false
 - name: RunTestsOnMac
   displayName: Run tests on Mac
   type: boolean
-  default: true
+  default: false
 - name: RunMonoTestsOnMac
   displayName: Run Mono tests on Mac
   type: boolean
@@ -48,6 +52,7 @@ variables:
   Codeql.TSAEnabled: false
   RunBuildForPublishing: ${{ parameters.RunBuildForPublishing }}
   RunCrossFrameworkTestsOnWindows: ${{ parameters.RunCrossFrameworkTestsOnWindows }}
+  RunUnitTestsOnWindows: ${{ parameters.RunUnitTestsOnWindows }}
   RunFunctionalTestsOnWindows: ${{ parameters.RunFunctionalTestsOnWindows }}
   RunSourceBuild: ${{ parameters.RunSourceBuild }}
   RunTestsOnLinux: ${{ parameters.RunTestsOnLinux }}
@@ -77,6 +82,7 @@ extends:
         NuGetLocalizationType: ${{parameters.NuGetLocalizationType}}
         RunBuildForPublishing: ${{parameters.RunBuildForPublishing}}
         RunCrossFrameworkTestsOnWindows: ${{parameters.RunCrossFrameworkTestsOnWindows}}
+        RunUnitTestsOnWindows: ${{parameters.RunUnitTestsOnWindows}}
         RunFunctionalTestsOnWindows: ${{parameters.RunFunctionalTestsOnWindows}}
         RunSourceBuild: ${{parameters.RunSourceBuild}}
         RunTestsOnLinux: ${{parameters.RunTestsOnLinux}}

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -3,6 +3,10 @@ parameters:
   type: boolean
 - name: NuGetLocalizationType
   type: string
+- name: RunUnitTests
+  displayName: Run unit tests
+  type: boolean
+  default: true
 
 steps:
 - task: PowerShell@1
@@ -126,23 +130,25 @@ steps:
     msbuildArguments: "/restore:false /target:CopyFinalNuGetExeToOutputPath /binarylogger:$(Build.StagingDirectory)\\binlog\\06.CopyFinalNuGetExeToOutputPath.binlog"
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
-- task: MSBuild@1
-  displayName: "Run unit tests (stop on error)"
-  continueOnError: "false"
-  inputs:
-    solution: "build\\build.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /target:CoreUnitTests;UnitTestsVS /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:SkipILMergeOfNuGetExe=true /binarylogger:$(Build.StagingDirectory)\\binlog\\07.RunUnitTests.binlog"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['IsOfficialBuild'], 'true')))"
+- ${{ if eq(parameters.RunUnitTests, true) }}:
+  - task: MSBuild@1
+    displayName: "Run unit tests (stop on error)"
+    continueOnError: "false"
+    inputs:
+      solution: "build\\build.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore:false /target:CoreUnitTests;UnitTestsVS /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:SkipILMergeOfNuGetExe=true /binarylogger:$(Build.StagingDirectory)\\binlog\\07.RunUnitTests.binlog"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['IsOfficialBuild'], 'true')))"
 
-- task: MSBuild@1
-  displayName: "Run unit tests (continue on error)"
-  continueOnError: "true"
-  inputs:
-    solution: "build\\build.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /target:CoreUnitTests;UnitTestsVS /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:SkipILMergeOfNuGetExe=true /binarylogger:$(Build.StagingDirectory)\\binlog\\08.RunUnitTests.binlog"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['IsOfficialBuild'], 'true'))"
+- ${{ if eq(parameters.RunUnitTests, true) }}:
+  - task: MSBuild@1
+    displayName: "Run unit tests (continue on error)"
+    continueOnError: "true"
+    inputs:
+      solution: "build\\build.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore:false /target:CoreUnitTests;UnitTestsVS /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:SkipILMergeOfNuGetExe=true /binarylogger:$(Build.StagingDirectory)\\binlog\\08.RunUnitTests.binlog"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: PublishTestResults@2
   displayName: "Publish Test Results"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -150,15 +150,16 @@ steps:
       msbuildArguments: "/restore:false /target:CoreUnitTests;UnitTestsVS /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:SkipILMergeOfNuGetExe=true /binarylogger:$(Build.StagingDirectory)\\binlog\\08.RunUnitTests.binlog"
     condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['IsOfficialBuild'], 'true'))"
 
-- task: PublishTestResults@2
-  displayName: "Publish Test Results"
-  inputs:
-    testRunner: "VSTest"
-    testResultsFiles: "*.trx"
-    testRunTitle: "NuGet.Client Unit Tests On Windows"
-    searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
-    publishRunAttachments: "false"
-  condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'))"
+- ${{ if eq(parameters.RunUnitTests, true) }}:
+  - task: PublishTestResults@2
+    displayName: "Publish Test Results"
+    inputs:
+      testRunner: "VSTest"
+      testResultsFiles: "*.trx"
+      testRunTitle: "NuGet.Client Unit Tests On Windows"
+      searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
+      publishRunAttachments: "false"
+    condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'))"
 
 - task: PowerShell@1
   displayName: "Initialize Git Commit Status on GitHub"

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -268,6 +268,7 @@ stages:
       parameters:
         BuildRTM: true
         NuGetLocalizationType: Full
+        RunUnitTests: ${{ parameters.RunUnitTestsOnWindows }}
 
   - job: Validate_Publishing_Artifacts
     condition: "and(succeeded(), ne(variables['RunBuildForPublishing'], 'false'))"

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -17,6 +17,10 @@ parameters:
   displayName: Run cross framweork tests on Windows
   type: boolean
   default: true
+- name: RunUnitTestsOnWindows
+  displayName: Run unit tests on Windows
+  type: boolean
+  default: true
 - name: RunFunctionalTestsOnWindows
   displayName: Run functional tests on Windows
   type: boolean
@@ -207,6 +211,7 @@ stages:
       parameters:
         BuildRTM: false
         NuGetLocalizationType: ${{ parameters.NuGetLocalizationType }}
+        RunUnitTests: ${{ parameters.RunUnitTestsOnWindows }}
 
 - stage: Build_For_Publishing
   displayName: Build NuGet published to nuget.org


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2843

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This disables the tests in the PrivateDev build by default, since they are now run by the [NuGet.Client CI](https://dev.azure.com/dnceng-public/public/_build?definitionId=289&_a=summary).  You can still manually run the pipeline and select the stages to run if desired.  I also left the stages on for the Official Build for now.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
