### PR TITLE
Add new ctor for PackageIdentity

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Core/PackageIdentity.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Core/PackageIdentity.cs
@@ -20,8 +20,8 @@ namespace NuGet.Packaging.Core
         /// Creates a new package identity.
         /// </summary>
         /// <param name="id">name</param>
-        /// <param name="version">version</param>
-        public PackageIdentity(string id, string version)
+        /// <param name="versionStr">version</param>
+        public PackageIdentity(string id, string versionStr)
         {
             if (id == null)
             {
@@ -29,7 +29,7 @@ namespace NuGet.Packaging.Core
             }
 
             _id = id;
-            _version = new NuGetVersion(version);
+            _version = NuGetVersion.Parse(versionStr);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/Core/PackageIdentity.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Core/PackageIdentity.cs
@@ -21,6 +21,22 @@ namespace NuGet.Packaging.Core
         /// </summary>
         /// <param name="id">name</param>
         /// <param name="version">version</param>
+        public PackageIdentity(string id, string version)
+        {
+            if (id == null)
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            _id = id;
+            _version = new NuGetVersion(version);
+        }
+
+        /// <summary>
+        /// Creates a new package identity.
+        /// </summary>
+        /// <param name="id">name</param>
+        /// <param name="version">version</param>
         public PackageIdentity(string id, NuGetVersion version)
         {
             if (id == null)

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 #nullable enable
-~NuGet.Packaging.Core.PackageIdentity.PackageIdentity(string id, string version) -> void
+~NuGet.Packaging.Core.PackageIdentity.PackageIdentity(string id, string versionStr) -> void

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+~NuGet.Packaging.Core.PackageIdentity.PackageIdentity(string id, string version) -> void

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 #nullable enable
-~NuGet.Packaging.Core.PackageIdentity.PackageIdentity(string id, string version) -> void
+~NuGet.Packaging.Core.PackageIdentity.PackageIdentity(string id, string versionStr) -> void

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+~NuGet.Packaging.Core.PackageIdentity.PackageIdentity(string id, string version) -> void

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 #nullable enable
-~NuGet.Packaging.Core.PackageIdentity.PackageIdentity(string id, string version) -> void
+~NuGet.Packaging.Core.PackageIdentity.PackageIdentity(string id, string versionStr) -> void

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+~NuGet.Packaging.Core.PackageIdentity.PackageIdentity(string id, string version) -> void

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -7172,7 +7172,7 @@ namespace NuGet.Test
                 // Main Act
                 var targets = new List<PackageIdentity>
                 {
-                    new PackageIdentity("a", null)
+                    new PackageIdentity("a", version: null)
                 };
 
                 // Assert

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageIdentityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageIdentityTests.cs
@@ -14,7 +14,7 @@ namespace NuGet.Packaging.Core.Test
             var packageIdentity = new PackageIdentity("packageA", new NuGetVersion("1.0.0"));
             Assert.Equal("packageA.1.0.0", packageIdentity.ToString());
 
-            var packageIdentityNoVersion = new PackageIdentity("packageB", null);
+            var packageIdentityNoVersion = new PackageIdentity("packageB", version: null);
             Assert.Equal("packageB", packageIdentityNoVersion.ToString());
 
             var formattedString = string.Format("This is package '{0}'", packageIdentity);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagePathResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagePathResolverTests.cs
@@ -298,7 +298,7 @@ namespace NuGet.Packaging.Test
             {
                 var target = new PackagePathResolver(testDirectory.Path);
 
-                PackageIdentity nullVersionPackageIdentity = new PackageIdentity("PackageA", null);
+                PackageIdentity nullVersionPackageIdentity = new PackageIdentity("PackageA", version: null);
 
                 // Act
                 var exception = Assert.Throws<ArgumentException>(paramName: "packageIdentity",


### PR DESCRIPTION
Syntaxic sugar allowing to instantiate like that

```csharp
var package = new PackageIdentity("Newtonsoft.json", "13.0.1");
```

Rather than

```csharp
var package = new PackageIdentity("Newtonsoft.json",  new NuGetVersion("13.0.1"));
```