### PR TITLE
Don't collect dumps for lingering processes in VS DartLab tests

### DIFF
--- a/build/template.runsettingsproj
+++ b/build/template.runsettingsproj
@@ -9,7 +9,8 @@
     <TestSessionTimeout Condition=" '$(TestSessionTimeout)' == ''">9000000</TestSessionTimeout>
     <TestAdaptersPaths>C:\Test;C:\NuGet</TestAdaptersPaths>
     <ResultsDirectory>C:\Test\Results</ResultsDirectory>
-    <LingeringProcessCollector Condition=" '$(LingeringProcessCollector)' == '' ">disabled</LingeringProcessCollector>
+    <ProcDumpCollector> Condition=" '$(ProcDumpCollector)' == '' ">enabled</ProcDumpCollector>
+    <LingeringProcessCollector Condition=" '$(LingeringProcessCollector)' == '' ">enabled</LingeringProcessCollector>
     <OptProfCollector Condition=" '$(OptProfCollector)' == '' ">disabled</OptProfCollector>
     <ScreenshotCollector Condition=" '$(ScreenshotCollector)' == '' ">enabled</ScreenshotCollector>
     <TestRunParametersLogger Condition=" '$(TestRunParametersLogger)' == '' ">enabled</TestRunParametersLogger>
@@ -107,7 +108,7 @@
       <Configuration>
         <KillLingeringProcesses>true</KillLingeringProcesses>
         <LoggingBehavior>Warning</LoggingBehavior>
-        <CollectDumps>true</CollectDumps>
+        <CollectDumps>false</CollectDumps>
         <RootDumpDirectory>%SystemDrive%\Test\Logs\Dumps</RootDumpDirectory>
         <ShutdownCommands>$(LingeringProcessCollectorShutdownCommands)</ShutdownCommands>
         <WhiteList>

--- a/build/template.runsettingsproj
+++ b/build/template.runsettingsproj
@@ -9,7 +9,7 @@
     <TestSessionTimeout Condition=" '$(TestSessionTimeout)' == ''">9000000</TestSessionTimeout>
     <TestAdaptersPaths>C:\Test;C:\NuGet</TestAdaptersPaths>
     <ResultsDirectory>C:\Test\Results</ResultsDirectory>
-    <LingeringProcessCollector Condition=" '$(LingeringProcessCollector)' == '' ">enabled</LingeringProcessCollector>
+    <LingeringProcessCollector Condition=" '$(LingeringProcessCollector)' == '' ">disabled</LingeringProcessCollector>
     <OptProfCollector Condition=" '$(OptProfCollector)' == '' ">disabled</OptProfCollector>
     <ScreenshotCollector Condition=" '$(ScreenshotCollector)' == '' ">enabled</ScreenshotCollector>
     <TestRunParametersLogger Condition=" '$(TestRunParametersLogger)' == '' ">enabled</TestRunParametersLogger>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2844

Regression? no
## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Disable lingering process meory dumps. NuGet runs in-proc in VS, so the lingering process memory dumps never help us investigate any nuget issues, and just wastes the test machines disk space.

Also, enable procdump collection for crashed processes, since that is actually useful.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
