### PR TITLE
Fix packages.config to project mapping in NuGet.exe

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -276,16 +276,16 @@ namespace NuGet.CommandLine
 
             if (packageRestoreInputs.RestoringWithSolutionFile)
             {
-                Dictionary<string, List<string>> configToProjectPath = GetPackagesConfigToProjectsPath(packageRestoreInputs);
+                Dictionary<string, HashSet<string>> configToProjectPath = GetPackagesConfigToProjectsPath(packageRestoreInputs);
                 Dictionary<PackageReference, List<string>> packageReferenceToProjects = new(PackageReferenceComparer.Instance);
 
-                foreach (string configFile in packageRestoreInputs.PackagesConfigFiles)
+                foreach (string configFile in packageRestoreInputs.PackagesConfigFiles.Distinct())
                 {
                     foreach (PackageReference packageReference in GetInstalledPackageReferences(configFile))
                     {
-                        if (!configToProjectPath.TryGetValue(configFile, out List<string> projectPath))
+                        if (!configToProjectPath.TryGetValue(configFile, out HashSet<string> projectPath))
                         {
-                            projectPath = new List<string> { configFile };
+                            projectPath = new HashSet<string> { configFile };
                         }
 
                         if (!packageReferenceToProjects.TryGetValue(packageReference, out List<string> value))
@@ -469,9 +469,9 @@ namespace NuGet.CommandLine
             }
         }
 
-        private Dictionary<string, List<string>> GetPackagesConfigToProjectsPath(PackageRestoreInputs packageRestoreInputs)
+        private Dictionary<string, HashSet<string>> GetPackagesConfigToProjectsPath(PackageRestoreInputs packageRestoreInputs)
         {
-            Dictionary<string, List<string>> configToProjectPath = new();
+            Dictionary<string, HashSet<string>> configToProjectPath = new();
             foreach (PackageSpec project in packageRestoreInputs.ProjectReferenceLookup.Projects)
             {
                 if (project.RestoreMetadata?.ProjectStyle == ProjectStyle.PackagesConfig)
@@ -484,7 +484,7 @@ namespace NuGet.CommandLine
                     }
                     else
                     {
-                        configToProjectPath.Add(packagesConfig, new List<string> { project.FilePath });
+                        configToProjectPath.Add(packagesConfig, new HashSet<string> { project.FilePath });
                     }
                 }
             }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -478,7 +478,7 @@ namespace NuGet.CommandLine
                 {
                     var packagesConfig = ((PackagesConfigProjectRestoreMetadata)project.RestoreMetadata).PackagesConfigPath;
 
-                    if (configToProjectPath.TryGetValue(packagesConfig, out var existingValue))
+                    if (configToProjectPath.TryGetValue(packagesConfig, out HashSet<string> existingValue))
                     {
                         existingValue.Add(project.FilePath);
                     }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -481,14 +481,6 @@ namespace NuGet.CommandLine
                     if (configToProjectPath.TryGetValue(packagesConfig, out var existingValue))
                     {
                         existingValue.Add(project.FilePath);
-
-                        var message = string.Format(
-                            CultureInfo.CurrentCulture,
-                            LocalizedResourceManager.GetString("Warning_RestoreMultipleProjectsOnePackagesConfigFile"),
-                            packagesConfig,
-                            existingValue,
-                            project.FilePath);
-                        Console.LogWarning(message);
                     }
                     else
                     {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -1811,15 +1811,6 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Multiple projects are associated with one `packages.config` file. This will lead to NuGetAudit configuration not being respected in the second project. It is recommended that each project has their own packages.config file. packages.config: &apos;{0}&apos;, projects: &apos;{1}&apos;, &apos;{2}&apos;..
-        /// </summary>
-        public static string Warning_RestoreMultipleProjectsOnePackagesConfigFile {
-            get {
-                return ResourceManager.GetString("Warning_RestoreMultipleProjectsOnePackagesConfigFile", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Version &quot;{0}&quot; does not follow semantic versioning guidelines..
         /// </summary>
         public static string Warning_SemanticVersion {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -720,6 +720,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Skipping installation of package &quot;{0}&quot; because higher version &quot;{1}&quot; is already installed..
+        /// </summary>
+        public static string InstallCommandHigherVersionAlreadyExists {
+            get {
+                return ResourceManager.GetString("InstallCommandHigherVersionAlreadyExists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; contains invalid package references. .
         /// </summary>
         public static string InstallCommandInvalidPackageReference {
@@ -743,15 +752,6 @@ namespace NuGet.CommandLine {
         public static string InstallCommandPackageAlreadyExists {
             get {
                 return ResourceManager.GetString("InstallCommandPackageAlreadyExists", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Skipping installation of package &quot;{0}&quot; because higher version &quot;{1}&quot; is already installed..
-        /// </summary>
-        public static string InstallCommandHigherVersionAlreadyExists {
-            get {
-                return ResourceManager.GetString("InstallCommandHigherVersionAlreadyExists", resourceCulture);
             }
         }
         
@@ -1807,6 +1807,15 @@ namespace NuGet.CommandLine {
         public static string Warning_ReadingProjectsFailed {
             get {
                 return ResourceManager.GetString("Warning_ReadingProjectsFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Multiple projects are associated with one `packages.config` file. This will lead to NuGetAudit configuration not being respected in the second project. It is recommended that each project has their own packages.config file. packages.config: &apos;{0}&apos;, projects: &apos;{1}&apos;, &apos;{2}&apos;..
+        /// </summary>
+        public static string Warning_RestoreMultipleProjectsOnePackagesConfigFile {
+            get {
+                return ResourceManager.GetString("Warning_RestoreMultipleProjectsOnePackagesConfigFile", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -747,4 +747,7 @@ Do not localize `SDK`, `dotnet pack`, msbuild -t:pack` and 'true'.</comment>
 {1} - current command marked as deprecated, e.g., list
 {2} - replacement command. For example, search</comment>
   </data>
+  <data name="Warning_RestoreMultipleProjectsOnePackagesConfigFile" xml:space="preserve">
+    <value>Multiple projects are associated with one `packages.config` file. This will lead to NuGetAudit configuration not being respected in the second project. It is recommended that each project has their own packages.config file. packages.config: '{0}', projects: '{1}', '{2}'.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -747,7 +747,4 @@ Do not localize `SDK`, `dotnet pack`, msbuild -t:pack` and 'true'.</comment>
 {1} - current command marked as deprecated, e.g., list
 {2} - replacement command. For example, search</comment>
   </data>
-  <data name="Warning_RestoreMultipleProjectsOnePackagesConfigFile" xml:space="preserve">
-    <value>Multiple projects are associated with one `packages.config` file. This will lead to NuGetAudit configuration not being respected in the second project. It is recommended that each project has their own packages.config file. packages.config: '{0}', projects: '{1}', '{2}'.</value>
-  </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -3601,7 +3601,7 @@ EndProject";
                 "a",
                 ProjectStyle.PackagesConfig,
                 pathContext.SolutionRoot);
-            //projectA.Properties.Add("NuGetAuditLevel", "critical");
+            projectA.Properties.Add("NuGetAuditLevel", "critical");
 
             var projectB = new SimpleTestProjectContext(
                 "b",
@@ -3611,7 +3611,7 @@ EndProject";
             projectB.ProjectPath = Path.Combine(pathContext.SolutionRoot, "a", $"b.csproj");
 
             solution.Projects.Add(projectA);
-            //solution.Projects.Add(projectB);
+            solution.Projects.Add(projectB);
             solution.Create(pathContext.SolutionRoot);
 
             Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
@@ -3639,14 +3639,14 @@ EndProject";
             File.Exists(packageFileA).Should().BeTrue();
             File.Exists(packageFileA120).Should().BeTrue();
             File.Exists(packageFileB).Should().BeTrue();
-            r.AllOutput.Should().Contain($"Package 'packageA' 1.2.0 has a known critical severity vulnerability", Exactly.Once());
+            r.AllOutput.Should().Contain($"Package 'packageA' 1.2.0 has a known critical severity vulnerability", Exactly.Twice());
             r.AllOutput.Should().Contain($"Package 'packageA' 1.2.0 has a known high severity vulnerability", Exactly.Once());
             r.AllOutput.Should().Contain($"Package 'packageA' 1.1.0 has a known high severity vulnerability", Exactly.Once());
             // Make sure that we're not missing out asserting any reported vulnerabilities.
             r.AllOutput.Should().NotContain($"a known low severity vulnerability");
             r.AllOutput.Should().NotContain($"a known moderate severity vulnerability");
             r.AllOutput.Should().Contain($"a known high severity vulnerability", Exactly.Twice());
-            r.AllOutput.Should().Contain($"a known critical severity vulnerability", Exactly.Once());
+            r.AllOutput.Should().Contain($"a known critical severity vulnerability", Exactly.Twice());
         }
 
         private static byte[] GetResource(string name)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -23,6 +23,7 @@ using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
+using NuGet.VisualStudio;
 using Test.Utility;
 using Xunit;
 
@@ -3336,6 +3337,7 @@ EndProject";
             r.AllOutput.Should().Contain($"Package 'packageA' 1.1.0 has a known high severity vulnerability");
         }
 
+
         [SkipMono()]
         public void RestoreCommand_WithProjectWithPackagesConfig_DefaultSettings_PackageWithVulnerabilities_RaisesWarnings()
         {
@@ -3571,6 +3573,80 @@ EndProject";
             r.AllOutput.Should().Contain($"Package 'packageA' 1.2.0 has a known critical severity vulnerability");
             r.AllOutput.Should().Contain($"Package 'packageA' 1.2.0 has a known high severity vulnerability");
             r.AllOutput.Should().NotContain($"Package 'packageA' 1.1.0 has a known high severity vulnerability");
+        }
+
+        [SkipMono()]
+        public void RestoreCommand_WithMultipleProjectsInSameDirectory_RaisesAppropriateWarnings()
+        {
+            // Arrange
+            var nugetexe = Util.GetNuGetExePath();
+            using var pathContext = new SimpleTestPathContext();
+            using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource, sourceReportsVulnerabilities: true);
+
+            mockServer.Vulnerabilities.Add(
+                "packageA",
+                new List<(Uri, PackageVulnerabilitySeverity, VersionRange)> {
+                    (new Uri("https://contoso.com/advisories/12345"), PackageVulnerabilitySeverity.High, VersionRange.Parse("[1.0.0, 2.0.0)")),
+                    (new Uri("https://contoso.com/advisories/12346"), PackageVulnerabilitySeverity.Critical, VersionRange.Parse("[1.2.0, 2.0.0)"))
+                });
+            pathContext.Settings.RemoveSource("source");
+            pathContext.Settings.AddSource("source", mockServer.ServiceIndexUri);
+
+            Util.CreateTestPackage("packageA", "1.1.0", pathContext.PackageSource);
+            Util.CreateTestPackage("packageA", "1.2.0", pathContext.PackageSource);
+            Util.CreateTestPackage("packageB", "2.2.0", pathContext.PackageSource);
+
+            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+            var projectA = new SimpleTestProjectContext(
+                "a",
+                ProjectStyle.PackagesConfig,
+                pathContext.SolutionRoot);
+            //projectA.Properties.Add("NuGetAuditLevel", "critical");
+
+            var projectB = new SimpleTestProjectContext(
+                "b",
+                ProjectStyle.PackagesConfig,
+                pathContext.SolutionRoot);
+            //projectB.Properties.Add("NuGetAuditLevel", "high");
+            projectB.ProjectPath = Path.Combine(pathContext.SolutionRoot, "a", $"b.csproj");
+
+            solution.Projects.Add(projectA);
+            //solution.Projects.Add(projectB);
+            solution.Create(pathContext.SolutionRoot);
+
+            Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+@"<packages>
+  <package id=""packageA"" version=""1.1.0"" />
+  <package id=""packageA"" version=""1.2.0"" />
+  <package id=""packageB"" version=""2.2.0"" />
+</packages>");
+
+            mockServer.Start();
+
+            // Act
+            var r = CommandRunner.Run(
+                nugetexe,
+                pathContext.WorkingDirectory,
+                $"restore {solution.SolutionPath}");
+
+            mockServer.Stop();
+
+            // Assert
+            r.Success.Should().BeTrue(because: r.AllOutput);
+            var packageFileA = Path.Combine(pathContext.SolutionRoot, "packages", "packageA.1.1.0", "packageA.1.1.0.nupkg");
+            var packageFileA120 = Path.Combine(pathContext.SolutionRoot, "packages", "packageA.1.2.0", "packageA.1.2.0.nupkg");
+            var packageFileB = Path.Combine(pathContext.SolutionRoot, "packages", "packageB.2.2.0", "packageB.2.2.0.nupkg");
+            File.Exists(packageFileA).Should().BeTrue();
+            File.Exists(packageFileA120).Should().BeTrue();
+            File.Exists(packageFileB).Should().BeTrue();
+            r.AllOutput.Should().Contain($"Package 'packageA' 1.2.0 has a known critical severity vulnerability", Exactly.Once());
+            r.AllOutput.Should().Contain($"Package 'packageA' 1.2.0 has a known high severity vulnerability", Exactly.Once());
+            r.AllOutput.Should().Contain($"Package 'packageA' 1.1.0 has a known high severity vulnerability", Exactly.Once());
+            // Make sure that we're not missing out asserting any reported vulnerabilities.
+            r.AllOutput.Should().NotContain($"a known low severity vulnerability");
+            r.AllOutput.Should().NotContain($"a known moderate severity vulnerability");
+            r.AllOutput.Should().Contain($"a known high severity vulnerability", Exactly.Twice());
+            r.AllOutput.Should().Contain($"a known critical severity vulnerability", Exactly.Once());
         }
 
         private static byte[] GetResource(string name)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -3607,7 +3607,7 @@ EndProject";
                 "b",
                 ProjectStyle.PackagesConfig,
                 pathContext.SolutionRoot);
-            //projectB.Properties.Add("NuGetAuditLevel", "high");
+            projectB.Properties.Add("NuGetAuditLevel", "high");
             projectB.ProjectPath = Path.Combine(pathContext.SolutionRoot, "a", $"b.csproj");
 
             solution.Projects.Add(projectA);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -3618,7 +3618,6 @@ EndProject";
   <package id=""packageA"" version=""1.2.0"" />
   <package id=""packageB"" version=""2.2.0"" />
 </packages>");
-
             mockServer.Start();
 
             // Act

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -3337,7 +3337,6 @@ EndProject";
             r.AllOutput.Should().Contain($"Package 'packageA' 1.1.0 has a known high severity vulnerability");
         }
 
-
         [SkipMono()]
         public void RestoreCommand_WithProjectWithPackagesConfig_DefaultSettings_PackageWithVulnerabilities_RaisesWarnings()
         {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -23,7 +23,6 @@ using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
-using NuGet.VisualStudio;
 using Test.Utility;
 using Xunit;
 

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Web.Http;
 using System.Xml.Linq;
 using FluentAssertions;
 using NuGet.Commands;
@@ -21,7 +20,6 @@ using NuGet.Versioning;
 using Test.Utility;
 using Xunit;
 using Xunit.Abstractions;
-using static Microsoft.TeamFoundation.Common.Internal.NativeMethods;
 using static NuGet.Frameworks.FrameworkConstants;
 
 namespace Msbuild.Integration.Test

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -1615,10 +1615,9 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             File.Exists(packageFileA).Should().BeTrue();
             File.Exists(packageFileA120).Should().BeTrue();
             File.Exists(packageFileB).Should().BeTrue();
-            // MSBuild replays warnings at the bottom, so only look there.
 
-            var allOutput = r.AllOutput;
-           var replayedOutput = allOutput.Substring(allOutput.IndexOf($"\"{solution.SolutionPath}\" (Restore "));
+            // MSBuild replays warnings at the bottom, so only look there.
+            var replayedOutput = r.AllOutput.Substring(r.AllOutput.IndexOf($"\"{solution.SolutionPath}\" (Restore "));
 
             replayedOutput.Should().Contain($"Package 'packageA' 1.2.0 has a known critical severity vulnerability", Exactly.Twice());
             replayedOutput.Should().Contain($"Package 'packageA' 1.2.0 has a known high severity vulnerability", Exactly.Once());

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Web.Http;
 using System.Xml.Linq;
 using FluentAssertions;
 using NuGet.Commands;
@@ -1616,14 +1617,19 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             File.Exists(packageFileA).Should().BeTrue();
             File.Exists(packageFileA120).Should().BeTrue();
             File.Exists(packageFileB).Should().BeTrue();
-            r.AllOutput.Should().Contain($"Package 'packageA' 1.2.0 has a known critical severity vulnerability", Exactly.Twice());
-            r.AllOutput.Should().Contain($"Package 'packageA' 1.2.0 has a known high severity vulnerability", Exactly.Once());
-            r.AllOutput.Should().Contain($"Package 'packageA' 1.1.0 has a known high severity vulnerability", Exactly.Once());
+            // MSBuild replays warnings at the bottom, so only look there.
+
+            var allOutput = r.AllOutput;
+           var replayedOutput = allOutput.Substring(allOutput.IndexOf($"\"{solution.SolutionPath}\" (Restore "));
+
+            replayedOutput.Should().Contain($"Package 'packageA' 1.2.0 has a known critical severity vulnerability", Exactly.Twice());
+            replayedOutput.Should().Contain($"Package 'packageA' 1.2.0 has a known high severity vulnerability", Exactly.Once());
+            replayedOutput.Should().Contain($"Package 'packageA' 1.1.0 has a known high severity vulnerability", Exactly.Once());
             // Make sure that we're not missing out asserting any reported vulnerabilities.
-            r.AllOutput.Should().NotContain($"a known low severity vulnerability");
-            r.AllOutput.Should().NotContain($"a known moderate severity vulnerability");
-            r.AllOutput.Should().Contain($"a known high severity vulnerability", Exactly.Twice());
-            r.AllOutput.Should().Contain($"a known critical severity vulnerability", Exactly.Twice());
+            replayedOutput.Should().NotContain($"a known low severity vulnerability");
+            replayedOutput.Should().NotContain($"a known moderate severity vulnerability");
+            replayedOutput.Should().Contain($"a known high severity vulnerability", Exactly.Twice());
+            replayedOutput.Should().Contain($"a known critical severity vulnerability", Exactly.Twice());
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -20,6 +20,7 @@ using NuGet.Versioning;
 using Test.Utility;
 using Xunit;
 using Xunit.Abstractions;
+using static Microsoft.TeamFoundation.Common.Internal.NativeMethods;
 using static NuGet.Frameworks.FrameworkConstants;
 
 namespace Msbuild.Integration.Test
@@ -1531,6 +1532,98 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             Assert.Contains($"Package 'packageA' 1.2.0 has a known critical severity vulnerability", result.AllOutput);
             Assert.Contains($"Package 'packageA' 1.2.0 has a known high severity vulnerability", result.AllOutput);
             Assert.DoesNotContain($"Package 'packageA' 1.1.0 has a known high severity vulnerability", result.AllOutput);
+        }
+
+        [Fact]
+        public async Task MsbuildRestore_WithMultipleProjectsInSameDirectory_RaisesAppropriateWarnings()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource, sourceReportsVulnerabilities: true);
+
+            mockServer.Vulnerabilities.Add(
+                "packageA",
+                new List<(Uri, PackageVulnerabilitySeverity, VersionRange)> {
+                    (new Uri("https://contoso.com/advisories/12345"), PackageVulnerabilitySeverity.High, VersionRange.Parse("[1.0.0, 2.0.0)")),
+                    (new Uri("https://contoso.com/advisories/12346"), PackageVulnerabilitySeverity.Critical, VersionRange.Parse("[1.2.0, 2.0.0)"))
+                });
+            pathContext.Settings.RemoveSource("source");
+            pathContext.Settings.AddSource("source", mockServer.ServiceIndexUri);
+
+            var packageA1 = new SimpleTestPackageContext()
+            {
+                Id = "packageA",
+                Version = "1.1.0"
+            };
+            var packageA2 = new SimpleTestPackageContext()
+            {
+                Id = "packageA",
+                Version = "1.2.0"
+            };
+            var packageB = new SimpleTestPackageContext()
+            {
+                Id = "packageB",
+                Version = "2.2.0"
+            };
+
+            await SimpleTestPackageUtility.CreatePackagesAsync(
+                pathContext.PackageSource,
+                packageA1,
+                packageA2,
+                packageB);
+
+            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+            var projectA = new SimpleTestProjectContext(
+                "a",
+                ProjectStyle.PackagesConfig,
+                pathContext.SolutionRoot);
+            projectA.Properties.Add("NuGetAuditLevel", "critical");
+
+            var projectB = new SimpleTestProjectContext(
+                "b",
+                ProjectStyle.PackagesConfig,
+                pathContext.SolutionRoot);
+            projectB.Properties.Add("NuGetAuditLevel", "high");
+            projectB.ProjectPath = Path.Combine(pathContext.SolutionRoot, "a", $"b.csproj");
+
+            solution.Projects.Add(projectA);
+            solution.Projects.Add(projectB);
+            solution.Create(pathContext.SolutionRoot);
+
+
+            using (var writer = new StreamWriter(Path.Combine(Path.GetDirectoryName(projectB.ProjectPath), "packages.config")))
+            {
+                writer.Write(
+@"<packages>
+  <package id=""packageA"" version=""1.1.0"" />
+  <package id=""packageA"" version=""1.2.0"" />
+  <package id=""packageB"" version=""2.2.0"" />
+</packages>");
+            }
+            mockServer.Start();
+
+            // Act
+            string args = $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true";
+            CommandRunnerResult r = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, args, ignoreExitCode: true, testOutputHelper: _testOutputHelper);
+
+            mockServer.Stop();
+
+            // Assert
+            r.Success.Should().BeTrue(because: r.AllOutput);
+            var packageFileA = Path.Combine(pathContext.SolutionRoot, "packages", "packageA.1.1.0", "packageA.1.1.0.nupkg");
+            var packageFileA120 = Path.Combine(pathContext.SolutionRoot, "packages", "packageA.1.2.0", "packageA.1.2.0.nupkg");
+            var packageFileB = Path.Combine(pathContext.SolutionRoot, "packages", "packageB.2.2.0", "packageB.2.2.0.nupkg");
+            File.Exists(packageFileA).Should().BeTrue();
+            File.Exists(packageFileA120).Should().BeTrue();
+            File.Exists(packageFileB).Should().BeTrue();
+            r.AllOutput.Should().Contain($"Package 'packageA' 1.2.0 has a known critical severity vulnerability", Exactly.Twice());
+            r.AllOutput.Should().Contain($"Package 'packageA' 1.2.0 has a known high severity vulnerability", Exactly.Once());
+            r.AllOutput.Should().Contain($"Package 'packageA' 1.1.0 has a known high severity vulnerability", Exactly.Once());
+            // Make sure that we're not missing out asserting any reported vulnerabilities.
+            r.AllOutput.Should().NotContain($"a known low severity vulnerability");
+            r.AllOutput.Should().NotContain($"a known moderate severity vulnerability");
+            r.AllOutput.Should().Contain($"a known high severity vulnerability", Exactly.Twice());
+            r.AllOutput.Should().Contain($"a known critical severity vulnerability", Exactly.Twice());
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13456

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

The implementation for PC vulnerability checking did not account for the fact that multiple projects might be in the same folder and lead to duplicate packages.config to project mapping. 

This fixes that and adds test cases in both nuget.exe restore and msbuild -t:restore. 

I've add some in  line comments to aid with reviewing.

Please note that this will be patched in 6.10, so take that into consideration when reviewing (ie. focus on correctness, extra clean-up can be done as follow-up and review the tests for correctness).

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
