### PR TITLE
Add NuGetAuditSuppress to PackageSpec in VS nominations

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/ProjectRestoreInfo3Adapter.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/ProjectRestoreInfo3Adapter.cs
@@ -155,16 +155,16 @@ namespace NuGet.SolutionRestoreManager
             return result;
         }
 
-        private static IReadOnlyDictionary<string, string?>? ToPropertiesDictionary(IVsReferenceProperties? properties)
+        private static IReadOnlyDictionary<string, string>? ToPropertiesDictionary(IVsReferenceProperties? properties)
         {
             if (properties is null) { return null; }
 
-            var result = new Dictionary<string, string?>(properties.Count, StringComparer.OrdinalIgnoreCase);
+            var result = new Dictionary<string, string>(properties.Count, StringComparer.OrdinalIgnoreCase);
 
             for (var i = 0; i < properties.Count; i++)
             {
-                var property = properties.Item(i) ?? throw new Exception($"Property index {i} returned null");
-                result.Add(property.Name, property.Value);
+                IVsReferenceProperty property = properties.Item(i) ?? throw new Exception($"Property index {i} returned null");
+                result.Add(property.Name, property.Value ?? string.Empty);
             }
 
             return result;
@@ -228,14 +228,14 @@ namespace NuGet.SolutionRestoreManager
 
             public IReadOnlyDictionary<string, IReadOnlyList<IVsReferenceItem2>>? Items { get; init; }
 
-            public required IReadOnlyDictionary<string, string?> Properties { get; init; }
+            public required IReadOnlyDictionary<string, string> Properties { get; init; }
         }
 
         private record VsReferenceItem2Adapter : IVsReferenceItem2
         {
             public required string Name { get; init; }
 
-            public IReadOnlyDictionary<string, string?>? Metadata { get; init; }
+            public IReadOnlyDictionary<string, string>? Metadata { get; init; }
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
@@ -115,6 +115,15 @@ namespace NuGet.SolutionRestoreManager {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; items do not have the same value(s) across all target frameworks. Remove any condition from MSBuild files for &apos;{0}&apos; items..
+        /// </summary>
+        internal static string ItemValuesAreDifferentAcrossTargetFrameworks {
+            get {
+                return ResourceManager.GetString("ItemValuesAreDifferentAcrossTargetFrameworks", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to All packages are already installed and there is nothing to restore..
         /// </summary>
         internal static string NothingToRestore {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
@@ -193,4 +193,8 @@ To prevent NuGet from restoring packages during build, open the Visual Studio Op
   <data name="PropertyDoesNotHaveSingleValue" xml:space="preserve">
     <value>The property {0} was expected to have a single value across all target frameworks, but instead had the following values: {1}</value>
   </data>
+  <data name="ItemValuesAreDifferentAcrossTargetFrameworks" xml:space="preserve">
+    <value>'{0}' items do not have the same value(s) across all target frameworks. Remove any condition from MSBuild files for '{0}' items.</value>
+    <comment>{0} - MSBuild item type. For example, NuGetAuditSuppress</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -314,13 +314,13 @@ namespace NuGet.SolutionRestoreManager
             string? auditMode = GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.NuGetAuditMode, s => s);
             HashSet<string>? suppressedAdvisories = GetSuppressedAdvisories(tfms);
 
-            return !string.IsNullOrEmpty(enableAudit) || !string.IsNullOrEmpty(auditLevel) || !string.IsNullOrEmpty(auditMode)
+            return !string.IsNullOrEmpty(enableAudit) || !string.IsNullOrEmpty(auditLevel) || !string.IsNullOrEmpty(auditMode) || suppressedAdvisories is not null
                 ? new RestoreAuditProperties()
                 {
                     EnableAudit = enableAudit,
                     AuditLevel = auditLevel,
                     AuditMode = auditMode,
-                    SuppressedAdvisories = GetSuppressedAdvisories(tfms),
+                    SuppressedAdvisories = suppressedAdvisories,
                 }
                 : null;
 
@@ -345,7 +345,8 @@ namespace NuGet.SolutionRestoreManager
                 {
                     if (!AreSameAdvisories(suppressedAdvisories, tfms[i].Items))
                     {
-                        throw new Exception("Different TargetFrameworks have different NuGetAuditSupress items");
+                        string message = string.Format(Resources.ItemValuesAreDifferentAcrossTargetFrameworks, ProjectItems.NuGetAuditSuppress);
+                        throw new InvalidOperationException(message);
                     }
                 }
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -148,7 +148,7 @@ namespace NuGet.SolutionRestoreManager
             return tfi;
         }
 
-        internal static NuGetFramework GetTargetFramework(IReadOnlyDictionary<string, string?> properties, string projectFullPath)
+        internal static NuGetFramework GetTargetFramework(IReadOnlyDictionary<string, string> properties, string projectFullPath)
         {
             var targetFrameworkMoniker = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetFrameworkMoniker);
             var targetPlatformMoniker = GetPropertyValueOrNull(properties, ProjectBuildProperties.TargetPlatformMoniker);
@@ -678,7 +678,7 @@ namespace NuGet.SolutionRestoreManager
         }
 
         private static string? GetPropertyValueOrNull(
-            IReadOnlyDictionary<string, string?> properties, string propertyName)
+            IReadOnlyDictionary<string, string> properties, string propertyName)
         {
             try
             {

--- a/src/NuGet.Clients/NuGet.VisualStudio/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Clients/NuGet.VisualStudio/PublicAPI.Unshipped.txt
@@ -2,7 +2,7 @@
 NuGet.SolutionRestoreManager.IVsProjectRestoreInfo3
 NuGet.SolutionRestoreManager.IVsProjectRestoreInfo3.MSBuildProjectExtensionsPath.get -> string!
 NuGet.SolutionRestoreManager.IVsReferenceItem2
-NuGet.SolutionRestoreManager.IVsReferenceItem2.Metadata.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string?>?
+NuGet.SolutionRestoreManager.IVsReferenceItem2.Metadata.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>?
 NuGet.SolutionRestoreManager.IVsSolutionRestoreService5
 NuGet.SolutionRestoreManager.IVsTargetFrameworkInfo4
 NuGet.SolutionRestoreManager.IVsProjectRestoreInfo3.OriginalTargetFrameworks.get -> string?
@@ -11,4 +11,4 @@ NuGet.SolutionRestoreManager.IVsProjectRestoreInfo3.ToolReferences.get -> System
 NuGet.SolutionRestoreManager.IVsReferenceItem2.Name.get -> string!
 NuGet.SolutionRestoreManager.IVsSolutionRestoreService5.NominateProjectAsync(string! projectUniqueName, NuGet.SolutionRestoreManager.IVsProjectRestoreInfo3! projectRestoreInfo, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
 NuGet.SolutionRestoreManager.IVsTargetFrameworkInfo4.Items.get -> System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<NuGet.SolutionRestoreManager.IVsReferenceItem2!>!>?
-NuGet.SolutionRestoreManager.IVsTargetFrameworkInfo4.Properties.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string?>!
+NuGet.SolutionRestoreManager.IVsTargetFrameworkInfo4.Properties.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!

--- a/src/NuGet.Clients/NuGet.VisualStudio/SolutionRestoreManager/IVsReferenceItem2.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/SolutionRestoreManager/IVsReferenceItem2.cs
@@ -20,6 +20,6 @@ namespace NuGet.SolutionRestoreManager
         /// <summary>
         /// Collection of item metadata.
         /// </summary>
-        IReadOnlyDictionary<string, string?>? Metadata { get; }
+        IReadOnlyDictionary<string, string>? Metadata { get; }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio/SolutionRestoreManager/IVsReferenceItem2.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/SolutionRestoreManager/IVsReferenceItem2.cs
@@ -20,6 +20,9 @@ namespace NuGet.SolutionRestoreManager
         /// <summary>
         /// Collection of item metadata.
         /// </summary>
+        /// <remarks>
+        /// The dictionary should be <see cref="System.StringComparer.OrdinalIgnoreCase"/> for key comparisons to match MSBuild's behaviour.
+        /// </remarks>
         IReadOnlyDictionary<string, string>? Metadata { get; }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio/SolutionRestoreManager/IVsTargetFrameworkInfo4.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/SolutionRestoreManager/IVsTargetFrameworkInfo4.cs
@@ -23,6 +23,6 @@ namespace NuGet.SolutionRestoreManager
         /// Collection of project level properties evaluated per each Target Framework,
         /// e.g. PackageTargetFallback.
         /// </summary>
-        IReadOnlyDictionary<string, string?> Properties { get; }
+        IReadOnlyDictionary<string, string> Properties { get; }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio/SolutionRestoreManager/IVsTargetFrameworkInfo4.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/SolutionRestoreManager/IVsTargetFrameworkInfo4.cs
@@ -23,6 +23,9 @@ namespace NuGet.SolutionRestoreManager
         /// Collection of project level properties evaluated per each Target Framework,
         /// e.g. PackageTargetFallback.
         /// </summary>
+        /// <remarks>
+        /// The dictionary should be <see cref="System.StringComparer.OrdinalIgnoreCase"/> for key comparisons to match MSBuild's behaviour.
+        /// </remarks>
         IReadOnlyDictionary<string, string> Properties { get; }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VSNominationUtilitiesTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VSNominationUtilitiesTests.cs
@@ -1,0 +1,195 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.ProjectManagement;
+using System.Collections.Generic;
+using System;
+using Xunit;
+using FluentAssertions;
+
+namespace NuGet.SolutionRestoreManager.Test
+{
+    public class VSNominationUtilitiesTests
+    {
+        private static readonly IReadOnlyDictionary<string, string> EmptyMetadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        [Fact]
+        public void GetRestoreAuditProperties_WithoutSuppressions_ReturnsNull()
+        {
+            // Arrange
+            var targetFrameworks = new VsTargetFrameworkInfo4[]
+            {
+                new VsTargetFrameworkInfo4(
+                    items: new Dictionary<string, IReadOnlyList<IVsReferenceItem2>>(StringComparer.OrdinalIgnoreCase),
+                    properties: new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [ProjectBuildProperties.NuGetAudit] = "true"
+                    }),
+            };
+
+            // Act
+            var actual = VSNominationUtilities.GetRestoreAuditProperties(targetFrameworks);
+
+            // Assert
+            actual.SuppressedAdvisories.Should().BeNull();
+        }
+
+        [Fact]
+        public void GetRestoreAuditProperties_OneTfmWithSuppressions_ReturnsSuppressions()
+        {
+            // Arrange
+            var cve1Url = "https://cve.test/1";
+            var cve2Url = "https://cve.test/2";
+            var targetFrameworks = new VsTargetFrameworkInfo4[]
+            {
+                new VsTargetFrameworkInfo4(
+                    items: new Dictionary<string, IReadOnlyList<IVsReferenceItem2>>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [ProjectItems.NuGetAuditSuppress] =
+                            [
+                                new VsReferenceItem2(cve1Url, metadata: EmptyMetadata),
+                                new VsReferenceItem2(cve2Url, metadata: EmptyMetadata),
+                            ]
+                    },
+                    properties: new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)),
+            };
+
+            // Act
+            var actual = VSNominationUtilities.GetRestoreAuditProperties(targetFrameworks);
+
+            // Assert
+            actual.SuppressedAdvisories.Should().HaveCount(2);
+            actual.SuppressedAdvisories.Should().Contain(cve1Url);
+            actual.SuppressedAdvisories.Should().Contain(cve2Url);
+        }
+
+        [Fact]
+        public void GetRestoreAuditProperties_TwoTfmWithSuppressions_ReturnsSuppressions()
+        {
+            // Arrange
+            var cve1Url = "https://cve.test/1";
+            var cve2Url = "https://cve.test/2";
+            var targetFrameworks = new VsTargetFrameworkInfo4[]
+            {
+                new VsTargetFrameworkInfo4(
+                    items: new Dictionary<string, IReadOnlyList<IVsReferenceItem2>>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [ProjectItems.NuGetAuditSuppress] =
+                            [
+                                new VsReferenceItem2(cve1Url, metadata: EmptyMetadata),
+                                new VsReferenceItem2(cve2Url, metadata: EmptyMetadata),
+                            ]
+                    },
+                    properties: new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)),
+                new VsTargetFrameworkInfo4(
+                    items: new Dictionary<string, IReadOnlyList<IVsReferenceItem2>>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [ProjectItems.NuGetAuditSuppress] =
+                            [
+                                new VsReferenceItem2(cve1Url, metadata: EmptyMetadata),
+                                new VsReferenceItem2(cve2Url, metadata: EmptyMetadata),
+                            ]
+                    },
+                    properties: new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)),
+            };
+
+            // Act
+            var actual = VSNominationUtilities.GetRestoreAuditProperties(targetFrameworks);
+
+            // Assert
+            actual.SuppressedAdvisories.Should().HaveCount(2);
+            actual.SuppressedAdvisories.Should().Contain(cve1Url);
+            actual.SuppressedAdvisories.Should().Contain(cve2Url);
+        }
+
+        [Fact]
+        public void GetRestoreAuditProperties_FirstTfmHasNoSuppressions_Throws()
+        {
+            // Arrange
+            var cve1Url = "https://cve.test/1";
+            var cve2Url = "https://cve.test/2";
+            var targetFrameworks = new VsTargetFrameworkInfo4[]
+            {
+                new VsTargetFrameworkInfo4(
+                    items: new Dictionary<string, IReadOnlyList<IVsReferenceItem2>>(StringComparer.OrdinalIgnoreCase),
+                    properties: new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)),
+                new VsTargetFrameworkInfo4(
+                    items: new Dictionary<string, IReadOnlyList<IVsReferenceItem2>>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [ProjectItems.NuGetAuditSuppress] =
+                            [
+                                new VsReferenceItem2(cve1Url, metadata: EmptyMetadata),
+                                new VsReferenceItem2(cve2Url, metadata: EmptyMetadata),
+                            ]
+                    },
+                    properties: new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)),
+            };
+
+            // Act & Assert
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => VSNominationUtilities.GetRestoreAuditProperties(targetFrameworks));
+            exception.Message.Should().Contain(ProjectItems.NuGetAuditSuppress);
+        }
+
+        [Fact]
+        public void GetRestoreAuditProperties_SecondTfmHasNoSuppressions_Throws()
+        {
+            // Arrange
+            var cve1Url = "https://cve.test/1";
+            var cve2Url = "https://cve.test/2";
+            var targetFrameworks = new VsTargetFrameworkInfo4[]
+            {
+                new VsTargetFrameworkInfo4(
+                    items: new Dictionary<string, IReadOnlyList<IVsReferenceItem2>>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [ProjectItems.NuGetAuditSuppress] =
+                            [
+                                new VsReferenceItem2(cve1Url, metadata: EmptyMetadata),
+                                new VsReferenceItem2(cve2Url, metadata: EmptyMetadata),
+                            ]
+                    },
+                    properties: new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)),
+                new VsTargetFrameworkInfo4(
+                    items: new Dictionary<string, IReadOnlyList<IVsReferenceItem2>>(StringComparer.OrdinalIgnoreCase),
+                    properties: new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)),
+            };
+
+            // Act & Assert
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => VSNominationUtilities.GetRestoreAuditProperties(targetFrameworks));
+            exception.Message.Should().Contain(ProjectItems.NuGetAuditSuppress);
+        }
+
+        [Fact]
+        public void GetRestoreAuditProperties_TwoTfmWithDifferentSuppressions_Throws()
+        {
+            // Arrange
+            var cve1Url = "https://cve.test/1";
+            var cve2Url = "https://cve.test/2";
+            var targetFrameworks = new VsTargetFrameworkInfo4[]
+            {
+                new VsTargetFrameworkInfo4(
+                    items: new Dictionary<string, IReadOnlyList<IVsReferenceItem2>>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [ProjectItems.NuGetAuditSuppress] =
+                            [
+                                new VsReferenceItem2(cve1Url, metadata: EmptyMetadata),
+                            ]
+                    },
+                    properties: new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)),
+                new VsTargetFrameworkInfo4(
+                    items: new Dictionary<string, IReadOnlyList<IVsReferenceItem2>>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [ProjectItems.NuGetAuditSuppress] =
+                            [
+                                new VsReferenceItem2(cve2Url, metadata: EmptyMetadata),
+                            ]
+                    },
+                    properties: new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)),
+            };
+
+            // Act & Assert
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => VSNominationUtilities.GetRestoreAuditProperties(targetFrameworks));
+            exception.Message.Should().Contain(ProjectItems.NuGetAuditSuppress);
+        }
+
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2709

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Process NuGetAuditSuppress items from CPS/project-system nominations in VS.

Also, make project property and item metadata dictionaries values not nullable, to match MSBuild APIs. This avoids project-system needing to suppress nullable warnings (therefore less risk of bugs).

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled: https://github.com/NuGet/Home/issues/13493
  - **OR**
  - [ ] N/A
