### PR TITLE
NuGet.VisualStudio should depend on packages that exist on nuget.org

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -74,7 +74,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" Version="17.6.32" />
     <PackageVersion Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="$(VSServicesVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.4.2244" />
-    <PackageVersion Include="Microsoft.VisualStudio.TemplateWizardInterface" Version="$(VSFrameworkVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.TemplateWizardInterface" Version="17.10.40170" />
     <PackageVersion Include="Microsoft.VisualStudio.VCProjectEngine" Version="$(VSFrameworkVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="17.0.7-preview-0001-g5492e466a9" />
     <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.0.1600" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -23,6 +23,7 @@
       <package pattern="messagepackanalyzer" />
       <package pattern="microsoft.*" />
       <package pattern="Microsoft.VisualStudio.*" />
+      <package pattern="Microsoft.VisualStudio.TemplateWizardInterface" />
       <package pattern="moq" />
       <package pattern="MSTest.TestAdapter" />
       <package pattern="MSTest.TestFramework" />

--- a/eng/pipelines/templates/Validate_Build_Output.yml
+++ b/eng/pipelines/templates/Validate_Build_Output.yml
@@ -22,13 +22,13 @@ steps:
   inputs:
     targetType: inline
     script: |
-      $nupkgs = Get-ChildItem $(System.ArtifactsDirectory)/nupkgs/*.nupkg -Exclude *.symbols.nupkg
+      $nupkgs = Get-ChildItem $(System.ArtifactsDirectory)/nupkgs/*.nupkg -Exclude *.symbols.nupkg,NuGet.CommandLine.XPlat.*
       if ($nupkgs.Count -eq 0) { throw "Could not find nupkgs" }
       "nupkgs:"
       $nupkgs.FullName
       ""
       "Building validation tool"
-      dotnet run --project tools-local/ensure-nupkg-dependencies-on-source/ -- $nupkgs -s https://api.nuget.org/v3/index.json
+      dotnet build tools-local/ensure-nupkg-dependencies-on-source/
       if ($LASTEXITCODE -ne 0) { throw "Build was not successful" }
       ""
       "Running validation tool"

--- a/tools-local/ensure-nupkg-dependencies-on-source/Program.cs
+++ b/tools-local/ensure-nupkg-dependencies-on-source/Program.cs
@@ -32,10 +32,12 @@ internal class Program
             var sourcesList = ParseResult.GetValue<List<string>>(sourcesOption);
             if (files is not null && sourcesList is not null)
             {
-                await ExecuteAsync(files, sourcesList, CancellationToken);
+                return await ExecuteAsync(files, sourcesList, CancellationToken);
             }
+            Console.WriteLine("Error getting command arguments");
+            return -1;
         });
-        var exitCode = await rootCommand.Parse(args).InvokeAsync();
+        int exitCode = await rootCommand.Parse(args).InvokeAsync();
         return exitCode;
     }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2847

Regression? Yes
This commit broke our CI step that should have validated the dependencies: https://github.com/NuGet/NuGet.Client/commit/ff7695dfeafa05fcf1af15e7f880c7bf8507304d
This commit actually changed the dependency to a version that doesn't exist on nuget.org: https://github.com/NuGet/NuGet.Client/commit/e4899ee48ff3d7787ee345f546c818ce6b962807

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* Fix `tools-local/ensure-nupkg-dependencies-on-source`, so it will return a non-zero exit code when it finds a dependency that doesn't exist on nuget.org.
* The latest version of Microsoft.VisualStudio.TemplateWizardInterface has a different version to Microsoft.VisualStudio.Sdk, so the template wizard package is no longer using the `VsFrameworkVersion` property for a version number.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
