### PR TITLE
Create NuGet.Client packages from dotnet pack

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -50,6 +50,7 @@
     <DotnetExePath Condition=" '$(IsXPlat)' == 'true' ">$(RepositoryRootDirectory)cli\dotnet</DotnetExePath>
     <SharedDirectory>$(BuildCommonDirectory)Shared</SharedDirectory>
     <NupkgOutputDirectory>$(ArtifactsDirectory)nupkgs\</NupkgOutputDirectory>
+    <PackageOutputPath>$(NupkgOutputDirectory)</PackageOutputPath>
     <SolutionPackagesFolder>$(RepositoryRootDirectory)packages\</SolutionPackagesFolder>
     <EnlistmentRoot>$(RepositoryRootDirectory)</EnlistmentRoot>
     <EnlistmentRootSrc>$(RepositoryRootDirectory)src</EnlistmentRootSrc>

--- a/src/NuGet.Clients/Directory.Build.props
+++ b/src/NuGet.Clients/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+</Project>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -15,6 +15,7 @@
     <SignWithMicrosoftKey>true</SignWithMicrosoftKey>
     <ComVisible>false</ComVisible>
     <!-- Pack properties-->
+    <IsPackable>true</IsPackable>
     <PackProject>true</PackProject>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);CreateCommandlineNupkg</TargetsForTfmSpecificContentInPackage>

--- a/src/NuGet.Clients/NuGet.Indexing/NuGet.Indexing.csproj
+++ b/src/NuGet.Clients/NuGet.Indexing/NuGet.Indexing.csproj
@@ -3,6 +3,7 @@
     <Description>NuGet's indexing library for the Visual Studio client search functionality.</Description>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
     <NoWarn>$(NoWarn);CS1591;RS0041</NoWarn>
+    <IsPackable>true</IsPackable>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>
     <IncludeInVsix>true</IncludeInVsix>

--- a/src/NuGet.Core/NuGet.Localization/NuGet.Localization.csproj
+++ b/src/NuGet.Core/NuGet.Localization/NuGet.Localization.csproj
@@ -4,6 +4,7 @@
     <Shipping>true</Shipping>
     <PackProject>true</PackProject>
     <PackProject Condition="!Exists('$(LocalizationRootDirectory)')">false</PackProject>
+    <IsPackable>$(PackProject)</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <Description>NuGet localization package for dotnet CLI.</Description>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
@@ -25,7 +26,7 @@
     <MakeDir
             Directories="$(LocalizationOutputDirectory)"/>
     <ItemGroup>
-      <LocalizationProjects Include="@(CoreProjects)" 
+      <LocalizationProjects Include="@(CoreProjects)"
                             Exclude="$(RepositoryRootDirectory)src\NuGet.Core\NuGet.Build.Tasks.Pack\NuGet.Build.Tasks.Pack.csproj;
                             $(RepositoryRootDirectory)src\NuGet.Core\Microsoft.Build.NuGetSdkResolver\Microsoft.Build.NuGetSdkResolver.csproj;
                             $(RepositoryRootDirectory)src\NuGet.Core\NuGet.Packaging.Core\NuGet.Packaging.Core.csproj"

--- a/test/TestExtensions/Directory.Build.props
+++ b/test/TestExtensions/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup Condition="'$(_WasCommonPropsImported)' != 'true'">
     <TestProject Condition="'$(TestProject)' == ''">false</TestProject>
     <SkipShared Condition="'$(SkipShared)' == ''">true</SkipShared>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>

--- a/test/TestExtensions/TestableVSCredentialProvider/TestableVSCredentialProvider.csproj
+++ b/test/TestExtensions/TestableVSCredentialProvider/TestableVSCredentialProvider.csproj
@@ -43,4 +43,6 @@
     <PackageReference Include="Microsoft.VSSDK.BuildTools" PrivateAssets="All" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- Define a pack target so NuGet.sln can be packed without error -->
+  <Target Name="Pack" />
 </Project>

--- a/tools-local/Directory.Build.props
+++ b/tools-local/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13463

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Make it possible to create NuGet.Client's nupkgs by `dotnet pack NuGet.sln`, in addition to running pack on `build/build.proj`.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
