### PR TITLE
use default values for httpclienthandler properties

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagConstants.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagConstants.cs
@@ -32,5 +32,6 @@ namespace NuGet.VisualStudio
 
         public static readonly NuGetFeatureFlagConstants BulkRestoreCoordination = new("NuGet.BulkRestoreCoordination", "NUGET_BULK_RESTORE_COORDINATION", defaultState: true);
         public static readonly NuGetFeatureFlagConstants NuGetSolutionCacheInitilization = new("NuGet.SolutionCacheInitialization", "NUGET_SOLUTION_CACHE_INITIALIZATION", defaultState: true);
+        public static readonly NuGetFeatureFlagConstants DoNotUseDefaultNetworkCredentials = new("NuGet.DoNotUseDefaultNetworkCredentials", "NUGET_DONOTUSE_DEFAULTNETWORKCREDENTIALS", defaultState: true);
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/NuGetFeatureFlagConstantsTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/NuGetFeatureFlagConstantsTests.cs
@@ -32,5 +32,11 @@ namespace NuGet.VisualStudio.Common.Test
 
             constant.DefaultState.Should().Be(defaultFeatureFlag);
         }
+
+        [Fact]
+        public void DefaultNetworkCredentialsNotUsed_DefaultState()
+        {
+            Assert.True(NuGetFeatureFlagConstants.DoNotUseDefaultNetworkCredentials.DefaultState);
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2853

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Use default values for httpclienthandler properties. For more details please refer to https://github.com/NuGet/Client.Engineering/issues/2852.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added

- **Documentation**
  - [x] N/A
