### PR TITLE
Use the local copy of the consumption feed - avoid unwanted auth prompt

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -7,7 +7,7 @@
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="myget-legacy@Local" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy%40Local/nuget/v3/index.json" />
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
-    <add key="vside" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/nuget/v3/index.json" />
+    <add key="vside" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption%40Local/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <clear />
@@ -23,7 +23,6 @@
       <package pattern="messagepackanalyzer" />
       <package pattern="microsoft.*" />
       <package pattern="Microsoft.VisualStudio.*" />
-      <package pattern="Microsoft.VisualStudio.Interop" />
       <package pattern="Microsoft.VisualStudio.TemplateWizardInterface" />
       <package pattern="moq" />
       <package pattern="MSTest.TestAdapter" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -23,6 +23,7 @@
       <package pattern="messagepackanalyzer" />
       <package pattern="microsoft.*" />
       <package pattern="Microsoft.VisualStudio.*" />
+      <package pattern="Microsoft.VisualStudio.Interop" />
       <package pattern="Microsoft.VisualStudio.TemplateWizardInterface" />
       <package pattern="moq" />
       <package pattern="MSTest.TestAdapter" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

https://github.com/NuGet/NuGet.Client/commit/5cb34e019ee00d70af207b666aaebb3fe25f8638 introduced a new package version that leads to indeterminism with the consumption feed which is an upstream and can trigger lookups. 

This should resolve that concurrency. 

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
