### PR TITLE
Only create Known Owner hyperlinks on the Browse tab

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft;
@@ -295,7 +296,13 @@ namespace NuGet.PackageManagement.UI
                     transitiveToolTipMessage = string.Format(CultureInfo.CurrentCulture, Resources.PackageVersionWithTransitiveOrigins, metadataContextInfo.Identity.Version, string.Join(", ", metadataContextInfo.TransitiveOrigins));
                 }
 
-                ImmutableList<KnownOwnerViewModel> knownOwnerViewModels = LoadKnownOwnerViewModels(metadataContextInfo);
+                ImmutableList<KnownOwnerViewModel> knownOwnerViewModels = null;
+
+                // Only load KnownOwners for the Browse tab.
+                if (_itemFilter == ContractItemFilter.All)
+                {
+                    knownOwnerViewModels = LoadKnownOwnerViewModels(metadataContextInfo);
+                }
 
                 var listItem = new PackageItemViewModel(_searchService, _packageVulnerabilityService)
                 {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13472

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
Explicitly prevent the lookup of Known Owners on any tab other than the Browse tab.

### Browse Tab
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/cb600d71-9775-400a-a2f7-c4124867b709)

### Installed Tab
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/2af4bfef-e9df-41a7-8255-55d2756a0e81)

### Updates Tab
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/b731f730-1f38-45f6-806d-be3e90527e2a)

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
