### PR TITLE
Eliminate first-chance ArgumentExceptions when querying a legacy project for properties that don't exist via DTE

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/INonThrowingDTEProjectProperties.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/INonThrowingDTEProjectProperties.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections;
+using System.Runtime.InteropServices;
+using EnvDTE;
+
+namespace NuGet.VisualStudio
+{
+    /// <summary>
+    /// The purpose of this interface is to avoid calls to <see cref="Item"> throwing on legacy project systems written in native code when the properties asked for do not exist. Since all DTE interfaces (the ones in the
+    /// Visual Studio interop dll) are non-preservesig any failing HRESULTS turn into managed exceptions. This is not an exceptional situation (missing properties) and can result in significant amounts of thrown/caught
+    /// exception noise. This trick relies on the fact that a managed cast on an RCW (i.e. the CLR's wrapping of a native COM object, i.e. a legacy project system written in native code) is actually a QueryInterface call
+    /// on the underlying native COM object. All QueryInterface cares about is the GUID. So when we say:
+    ///
+    /// <code>
+    /// INonThrowingDTEProjectProperties properties = someProjectProperties as INonThrowingDTEProjectProperties;
+    /// </code>
+    ///
+    /// The CLR really calls QueryInterface with the GUID associated with <see cref="INonThrowingDTEProjectProperties"/>. Since the GUID here matches the GUID on <see cref="Properties"/>, the native object will say 'yes, I do
+    /// implement that interface' and the CLR will allow us to talk to it through this interface definition. Since we have changed Item to be preservesig that means failures will come back as failing HRESULTS not as exceptions.
+    /// </summary>
+#pragma warning disable CA1010 // warning that type implementing IEnumerable should implement IEnumerable<T> as well, which makes no sense here as this is a COM interface decl
+    [ComVisible(true)]
+    [Guid("4CC8CCF5-A926-4646-B17F-B4940CAED472")]
+    public interface INonThrowingDTEProjectProperties : IEnumerable
+#pragma warning restore CA1010
+    {
+        [PreserveSig]
+        int Item([In][MarshalAs(UnmanagedType.Struct)] object index, out Property property);
+
+        object Application
+        {
+            [return: MarshalAs(UnmanagedType.IDispatch)]
+            get;
+        }
+
+        object Parent
+        {
+            [return: MarshalAs(UnmanagedType.IDispatch)]
+            get;
+        }
+
+        int Count
+        {
+            get;
+        }
+
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalType = "System.Runtime.InteropServices.CustomMarshalers.EnumeratorToEnumVariantMarshaler, CustomMarshalers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        new IEnumerator GetEnumerator();
+
+        DTE DTE
+        {
+            [return: MarshalAs(UnmanagedType.Interface)]
+            get;
+        }
+    }
+}


### PR DESCRIPTION
RESULTS:

![ExceptionReductions](https://github.com/NuGet/NuGet.Client/assets/591522/5db894aa-3a08-4a6d-b456-6cc7c8f453bd)

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:  https://github.com/NuGet/Home/issues/11535

Regression? Last working version:

## Description
Unfortunately EnvDTE is widely non-preservesig, which means every failure results in an exception. Certain failures, like the failure to find a property on a project that may well legitimately be missing don't require ArgumentExceptions to be thrown/caught. This change declares a copy of the DTE Properties interface that is identical other than it has preservesig on the Items method so that we can get failures as HRESULTs instead of exceptions. This interface will only be used against RCWs (i.e. native COM objects) so should only ever be tried against legacy project system and ones that don't implement IVsBuildPropertyStorage.

## PR Checklist

- [X] PR has a meaningful title
- [X] PR has a linked issue.
- [X] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [X] Test exception: This is a change that effects legacy (native) project systems. Adding tests would mean adding a native project to the tree that mocked a native project system, injecting it into a test flow that hits the changed paths, and writing tests for that. It adds a lot of complexity to the build/process pipeline (presumably you have no native code in NuGet today) for little gain. This path is tested well by the DDRITs that are run on NuGet insertions into VS.
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [X] N/A
