### PR TITLE
Fix runsettings procdump condition

### DIFF
--- a/build/template.runsettingsproj
+++ b/build/template.runsettingsproj
@@ -9,7 +9,7 @@
     <TestSessionTimeout Condition=" '$(TestSessionTimeout)' == ''">9000000</TestSessionTimeout>
     <TestAdaptersPaths>C:\Test;C:\NuGet</TestAdaptersPaths>
     <ResultsDirectory>C:\Test\Results</ResultsDirectory>
-    <ProcDumpCollector> Condition=" '$(ProcDumpCollector)' == '' ">enabled</ProcDumpCollector>
+    <ProcDumpCollector Condition=" '$(ProcDumpCollector)' == '' ">enabled</ProcDumpCollector>
     <LingeringProcessCollector Condition=" '$(LingeringProcessCollector)' == '' ">enabled</LingeringProcessCollector>
     <OptProfCollector Condition=" '$(OptProfCollector)' == '' ">disabled</OptProfCollector>
     <ScreenshotCollector Condition=" '$(ScreenshotCollector)' == '' ">enabled</ScreenshotCollector>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2844

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

My last PR https://github.com/NuGet/NuGet.Client/pull/5817 had a bug that wasn't caught.  This will hopefully capture memory dumps in DartLab pipelines, including Apex, E2E tests, and OptProf training.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
