### PR TITLE
Treat empty NuGetAuditSupress list as null in CPS nominations

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -332,11 +332,14 @@ namespace NuGet.SolutionRestoreManager
                 HashSet<string>? suppressedAdvisories = null;
                 if (tfms[0].Items?.TryGetValue(ProjectItems.NuGetAuditSuppress, out IReadOnlyList<IVsReferenceItem2>? suppressItems) ?? false)
                 {
-                    suppressedAdvisories = new(suppressItems.Count, StringComparer.Ordinal);
-                    for (int i = 0; i < suppressItems.Count; i++)
+                    if (suppressItems.Count > 0)
                     {
-                        string url = suppressItems[i].Name;
-                        suppressedAdvisories.Add(url);
+                        suppressedAdvisories = new(suppressItems.Count, StringComparer.Ordinal);
+                        for (int i = 0; i < suppressItems.Count; i++)
+                        {
+                            string url = suppressItems[i].Name;
+                            suppressedAdvisories.Add(url);
+                        }
                     }
                 }
 
@@ -357,9 +360,11 @@ namespace NuGet.SolutionRestoreManager
                     IReadOnlyList<IVsReferenceItem2>? suppressItems = null;
                     _ = items?.TryGetValue(ProjectItems.NuGetAuditSuppress, out suppressItems);
 
-                    if (suppressItems is null || suppressedAdvisories is null)
+                    int expectedCount = suppressedAdvisories?.Count ?? 0;
+                    int actualCount = suppressItems?.Count ?? 0;
+                    if (expectedCount == 0 || actualCount == 0)
                     {
-                        if (suppressItems is null && suppressedAdvisories is null)
+                        if (expectedCount == 0 && actualCount == 0)
                         {
                             return true;
                         }
@@ -369,7 +374,7 @@ namespace NuGet.SolutionRestoreManager
                         }
                     }
 
-                    if (suppressedAdvisories.Count != suppressItems.Count) { return false; }
+                    if (suppressedAdvisories!.Count != suppressItems!.Count) { return false; }
 
                     for (int i = 0; i < suppressItems.Count; i++)
                     {

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VSNominationUtilitiesTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VSNominationUtilitiesTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System;
 using Xunit;
 using FluentAssertions;
+using System.Collections.Immutable;
 
 namespace NuGet.SolutionRestoreManager.Test
 {
@@ -21,6 +22,60 @@ namespace NuGet.SolutionRestoreManager.Test
             {
                 new VsTargetFrameworkInfo4(
                     items: new Dictionary<string, IReadOnlyList<IVsReferenceItem2>>(StringComparer.OrdinalIgnoreCase),
+                    properties: new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [ProjectBuildProperties.NuGetAudit] = "true"
+                    }),
+            };
+
+            // Act
+            var actual = VSNominationUtilities.GetRestoreAuditProperties(targetFrameworks);
+
+            // Assert
+            actual.SuppressedAdvisories.Should().BeNull();
+        }
+
+        [Fact]
+        public void GetRestoreAuditProperties_WithEmptySuppressionsList_ReturnsNull()
+        {
+            // Arrange
+            var targetFrameworks = new VsTargetFrameworkInfo4[]
+            {
+                new VsTargetFrameworkInfo4(
+                    items: new Dictionary<string, IReadOnlyList<IVsReferenceItem2>>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [ProjectItems.NuGetAuditSuppress] = ImmutableArray<IVsReferenceItem2>.Empty,
+                    },
+                    properties: new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [ProjectBuildProperties.NuGetAudit] = "true"
+                    }),
+            };
+
+            // Act
+            var actual = VSNominationUtilities.GetRestoreAuditProperties(targetFrameworks);
+
+            // Assert
+            actual.SuppressedAdvisories.Should().BeNull();
+        }
+
+        [Fact]
+        public void GetRestoreAuditProperties_NullAndEmptySuppressions_ReturnsNull()
+        {
+            // Arrange
+            var targetFrameworks = new VsTargetFrameworkInfo4[]
+            {
+                new VsTargetFrameworkInfo4(
+                    items: new Dictionary<string, IReadOnlyList<IVsReferenceItem2>>(StringComparer.OrdinalIgnoreCase),
+                    properties: new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [ProjectBuildProperties.NuGetAudit] = "true"
+                    }),
+                new VsTargetFrameworkInfo4(
+                    items: new Dictionary<string, IReadOnlyList<IVsReferenceItem2>>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [ProjectItems.NuGetAuditSuppress] = ImmutableArray<IVsReferenceItem2>.Empty,
+                    },
                     properties: new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)
                     {
                         [ProjectBuildProperties.NuGetAudit] = "true"
@@ -112,7 +167,10 @@ namespace NuGet.SolutionRestoreManager.Test
             {
                 new VsTargetFrameworkInfo4(
                     items: new Dictionary<string, IReadOnlyList<IVsReferenceItem2>>(StringComparer.OrdinalIgnoreCase),
-                    properties: new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)),
+                    properties: new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [ProjectBuildProperties.NuGetAudit] = "true"
+                    }),
                 new VsTargetFrameworkInfo4(
                     items: new Dictionary<string, IReadOnlyList<IVsReferenceItem2>>(StringComparer.OrdinalIgnoreCase)
                     {
@@ -122,7 +180,10 @@ namespace NuGet.SolutionRestoreManager.Test
                                 new VsReferenceItem2(cve2Url, metadata: EmptyMetadata),
                             ]
                     },
-                    properties: new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)),
+                    properties: new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [ProjectBuildProperties.NuGetAudit] = "true"
+                    }),
             };
 
             // Act & Assert


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13505

Regression? introduced by https://github.com/dotnet/project-system/pull/9470, but the regression was not observable until https://github.com/dotnet/project-system/pull/9470 is also inserted into VS

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

On command line restores, when no NuGetAuditSuppress items are defined, we populate the `RestoreAuditProperties` object with a null for the suppressions list. However, dotnet/project-system will provide empty lists, rather than null, and NuGet's initial VS nomination code would convert project-system's empty list into NuGet's data structure's empty list. Finally, when NuGet does no-op checks, RestoreAuditProperties.Equals would consider the two instances different because a null suppressions list was not considered equal to an empty list.

So, this could be solved in two ways. Either change the Equals comparison to treat empty lists as the same as null and/or don't create empty lists during project nominations.

The advantage of not creating empty lists during nominations is that it reduces an unnecessary allocation, thereby delaying the next garbage collection just a little bit.
 
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
