### PR TITLE
resume running CodeQL on official builds

### DIFF
--- a/eng/pipelines/dailytests.yml
+++ b/eng/pipelines/dailytests.yml
@@ -35,8 +35,6 @@ parameters:
 
 variables:
   DOTNET_NOLOGO: 1
-  Codeql.Enabled: ${{ parameters.isOfficialBuild }}
-  Codeql.TSAEnabled: ${{ parameters.isOfficialBuild }}
 
 stages:
 # Dartlab's template defines this in its own stage

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -39,8 +39,8 @@ variables:
   BINLOG_DIRECTORY: $(Build.StagingDirectory)/binlog
   DOTNET_NOLOGO: 1
   NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY: 3,1000
-  Codeql.Enabled: false
-  Codeql.TSAEnabled: false
+  Codeql.Enabled: true
+  Codeql.TSAEnabled: true
   RunBuildForPublishing: ${{ parameters.RunBuildForPublishing }}
   RunCrossFrameworkTestsOnWindows: ${{ parameters.RunCrossFrameworkTestsOnWindows }}
   RunFunctionalTestsOnWindows: ${{ parameters.RunFunctionalTestsOnWindows }}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2860

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Due to recent updates to CI infrastructure, I think we stopped running CodeQL on official builds. This PR enables the static analysis tool on official builds. I queued an [official build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9663517&view=logs&j=f7555f7a-bf12-5d3d-75e8-f9a22a19c465&t=687b0691-65cb-51b9-c1aa-fae6dc357531) for this private branch and noticed that CodeQL step ran successfully.

I also removed CodeQL related variables from `Dailytests.yml` because the pipeline is used to run Apex tests.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] N/A