### PR TITLE
Show help output for parsing errors only in 'dotnet' commands

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -191,9 +191,12 @@ namespace NuGet.CommandLine.XPlat
                     // Log the stack trace as verbose output.
                     log.LogVerbose(e.ToString());
 
-                    exitCode = 1;
+                    if (e.GetType().Name == "CommandParsingException")
+                    {
+                        ShowBestHelp(app, args);
+                    }
 
-                    ShowBestHelp(app, args);
+                    exitCode = 1;
                 }
             }
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -191,7 +191,7 @@ namespace NuGet.CommandLine.XPlat
                     // Log the stack trace as verbose output.
                     log.LogVerbose(e.ToString());
 
-                    if (e.GetType().Name == "CommandParsingException")
+                    if (e is CommandParsingException)
                     {
                         ShowBestHelp(app, args);
                     }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatHelpOutputTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatHelpOutputTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NuGet.CommandLine.XPlat;
+using Xunit;
+
+namespace NuGet.XPlat.FuncTest
+{
+    public class XPlatHelpOutputTests
+    {
+        public static IEnumerable<object[]> ParseSuccessfully
+        {
+            get
+            {
+                yield return new object[] { new string[] { "remove", "source", "SourceDosNotExist" } };
+                yield return new object[] { new string[] { "enable", "source", "SourceDosNotExist" } };
+                yield return new object[] { new string[] { "disable", "source", "SourceDosNotExist" } };
+            }
+        }
+
+        public static IEnumerable<object[]> FailParsing
+        {
+            get
+            {
+                yield return new object[] { new string[] { "removee", "sources", "source" } };
+                yield return new object[] { new string[] { "addd", "sources", "source" } };
+                yield return new object[] { new string[] { "enablee", "sources", "source" } };
+                yield return new object[] { new string[] { "disablee", "sources", "source" } };
+                yield return new object[] { new string[] { "listt", "sources", "source" } };
+                yield return new object[] { new string[] { "add", "Test", "Case" } };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(FailParsing))]
+        public void MainInternal_OnParsingError_ShowsHelp(string[] args)
+        {
+            // Arrange
+            var originalConsoleOut = Console.Out;
+            using var consoleOutput = new StringWriter();
+            Console.SetOut(consoleOutput);
+            var log = new TestCommandOutputLogger();
+
+            // Act
+            var exitCode = Program.MainInternal(args.ToArray(), log);
+            Console.SetOut(originalConsoleOut);
+
+            // Assert
+            var output = consoleOutput.ToString();
+            Assert.Contains("Usage", output);
+            Assert.Equal(1, exitCode);
+        }
+
+        [Theory]
+        [MemberData(nameof(ParseSuccessfully))]
+        public void MainInternal_OnParsingSuccess_DoesNotShowsHelp(string[] args)
+        {
+            // Arrange
+            var originalConsoleOut = Console.Out;
+            using var consoleOutput = new StringWriter();
+            Console.SetOut(consoleOutput);
+            var log = new TestCommandOutputLogger();
+
+            // Act
+            var exitCode = Program.MainInternal(args.ToArray(), log);
+            Console.SetOut(originalConsoleOut);
+
+            // Assert
+            var output = consoleOutput.ToString();
+            Assert.DoesNotContain("Usage", output);
+            Assert.Equal(1, exitCode);
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13251

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
* This PR makes sure that help output is shown in dotnet commands when there is parsing problems with the command arguments.
### Example
#### Previously `dotnet nuget remove source doesnotexist` would have the following output
```
error: Unable to find any package source(s) matching name: doesnotexist.


Usage: dotnet nuget remove source [arguments] [options]

Arguments:
  name  Name of the source.

Options:
  --configfile  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior.
  -h|--help     Show help information
```

#### Now `dotnet nuget remove source doesnotexist` would have the following output
```
error: Unable to find any package source(s) matching name: doesnotexist.
```
## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
