### PR TITLE
remove redundant .GetTypeInfo()

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -277,7 +277,7 @@ namespace NuGet.CommandLine.XPlat
 
             app.FullName = Strings.App_FullName;
             app.HelpOption(XPlatUtility.HelpOption);
-            app.VersionOption("--version", typeof(Program).GetTypeInfo().Assembly.GetName().Version.ToString());
+            app.VersionOption("--version", typeof(Program).Assembly.GetName().Version.ToString());
 
             return app;
         }

--- a/src/NuGet.Core/NuGet.Common/ClientVersionUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/ClientVersionUtility.cs
@@ -23,7 +23,7 @@ namespace NuGet.Common
             {
                 string version = string.Empty;
 
-                var assembly = typeof(ClientVersionUtility).GetTypeInfo().Assembly;
+                var assembly = typeof(ClientVersionUtility).Assembly;
 
                 var informationalVersionAttr = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
                 if (informationalVersionAttr != null)

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -492,7 +492,7 @@ namespace NuGet.Packaging
         private static string CreatorInfo()
         {
             List<string> creatorInfo = new List<string>();
-            var assembly = typeof(PackageBuilder).GetTypeInfo().Assembly;
+            var assembly = typeof(PackageBuilder).Assembly;
             creatorInfo.Add(assembly.FullName);
 #if !IS_CORECLR // CORECLR_TODO: Environment.OSVersion
             creatorInfo.Add(Environment.OSVersion.ToString());

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
@@ -22,7 +22,7 @@ namespace NuGet.Protocol.Plugins
         public static string GetInternalPlugins()
         {
             return InternalPluginDiscoveryRoot?.Value ??
-                GetNuGetPluginsDirectoryRelativeToNuGetAssembly(typeof(PluginDiscoveryUtility).GetTypeInfo().Assembly.Location); // NuGet.*.dll
+                GetNuGetPluginsDirectoryRelativeToNuGetAssembly(typeof(PluginDiscoveryUtility).Assembly.Location); // NuGet.*.dll
         }
 
         /// <summary>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -38,7 +38,7 @@ namespace NuGet.CommandLine.Test
 
         public static string GetResource(string name)
         {
-            using (var reader = new StreamReader(typeof(Util).GetTypeInfo().Assembly.GetManifestResourceStream(name)))
+            using (var reader = new StreamReader(typeof(Util).Assembly.GetManifestResourceStream(name)))
             {
                 return reader.ReadToEnd();
             }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
@@ -783,7 +783,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                 Directory.CreateDirectory(Path.Combine(testDir, "obj"));
                 File.WriteAllBytes(dllPath, new byte[0]);
                 var path = string.Join(".", typeof(PackTaskLogicTests).Namespace, "compiler.resources", "project.assets.json");
-                using (var reader = new StreamReader(GetType().GetTypeInfo().Assembly.GetManifestResourceStream(path)))
+                using (var reader = new StreamReader(GetType().Assembly.GetManifestResourceStream(path)))
                 {
                     var contents = reader.ReadToEnd();
                     File.WriteAllText(Path.Combine(testDir, "obj", "project.assets.json"), contents);

--- a/test/NuGet.Core.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderBuilderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderBuilderTests.cs
@@ -111,7 +111,7 @@ namespace NuGet.Credentials.Test
 
                 var credentialProviders = (await providerBuilder.BuildAllAsync()).ToArray();
                 Assert.Equal(1, credentialProviders.Count());
-                var bla = typeof(SecurePluginCredentialProvider).GetTypeInfo().GetField("_canShowDialog", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
+                var bla = typeof(SecurePluginCredentialProvider).GetField("_canShowDialog", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
                 Assert.Equal(canShowDialog, bla.GetValue(credentialProviders.Single()));
             }
         }

--- a/test/TestUtilities/Test.Utility/ProtocolUtility.cs
+++ b/test/TestUtilities/Test.Utility/ProtocolUtility.cs
@@ -19,7 +19,7 @@ namespace Test.Utility
     {
         public static string GetResource(string name, Type type)
         {
-            using (var reader = new StreamReader(type.GetTypeInfo().Assembly.GetManifestResourceStream(name)))
+            using (var reader = new StreamReader(type.Assembly.GetManifestResourceStream(name)))
             {
                 return reader.ReadToEnd();
             }

--- a/test/TestUtilities/Test.Utility/ResourceTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/ResourceTestUtility.cs
@@ -11,7 +11,7 @@ namespace NuGet.Test.Utility
     {
         public static string GetResource(string name, Type type)
         {
-            using (var reader = new StreamReader(type.GetTypeInfo().Assembly.GetManifestResourceStream(name)))
+            using (var reader = new StreamReader(type.Assembly.GetManifestResourceStream(name)))
             {
                 return reader.ReadToEnd();
             }
@@ -26,7 +26,7 @@ namespace NuGet.Test.Utility
 
         public static byte[] GetResourceBytes(string name, Type type)
         {
-            using (var reader = new BinaryReader(type.GetTypeInfo().Assembly.GetManifestResourceStream(name)))
+            using (var reader = new BinaryReader(type.Assembly.GetManifestResourceStream(name)))
             {
                 return reader.ReadBytes((int)reader.BaseStream.Length);
             }

--- a/test/TestUtilities/Test.Utility/TestFileSystemUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestFileSystemUtility.cs
@@ -84,7 +84,7 @@ namespace NuGet.Test.Utility
             }
 
             // Second, check next to this assembly
-            var assemblyFileInfo = new FileInfo(typeof(TestFileSystemUtility).GetTypeInfo().Assembly.Location);
+            var assemblyFileInfo = new FileInfo(typeof(TestFileSystemUtility).Assembly.Location);
 
             DirectoryInfo repoRoot = GetRepositoryRootFromStartingDirectory(assemblyFileInfo.Directory);
 
@@ -166,7 +166,7 @@ namespace NuGet.Test.Utility
 
         public static bool DeleteRandomTestFolder(string randomTestPath)
         {
-            // Avoid cleaning up test folders if 
+            // Avoid cleaning up test folders if
             if (!SkipCleanupLazy.Value && Directory.Exists(randomTestPath))
             {
                 AssertNotTempPath(randomTestPath);


### PR DESCRIPTION
Very minor performance tweak

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
