### PR TITLE
NuGet IntelliCode Package Suggestions show Author in packages list

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -298,8 +298,9 @@ namespace NuGet.PackageManagement.UI
 
                 ImmutableList<KnownOwnerViewModel> knownOwnerViewModels = null;
 
-                // Only load KnownOwners for the Browse tab.
-                if (_itemFilter == ContractItemFilter.All)
+                // Only load KnownOwners for the Browse tab and not for any Recommended packages.
+                // Recommended packages won't have KnownOwners metadata as they are not part of the search results.
+                if (_itemFilter == ContractItemFilter.All && !metadataContextInfo.IsRecommended)
                 {
                     knownOwnerViewModels = LoadKnownOwnerViewModels(metadataContextInfo);
                 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
@@ -400,6 +400,81 @@ namespace NuGet.PackageManagement.UI.Test
         }
 
         [Fact]
+        public async Task GetCurrent_HasKnownOwners_IsRecommendedPackage_DoesNotCreateKnownOwnerViewModels()
+        {
+            var versionString = "4.3.0";
+            var version = NuGetVersion.Parse(versionString);
+            var packageSearchMetadata = new PackageSearchMetadataBuilder.ClonedPackageSearchMetadata()
+            {
+                Identity = new PackageIdentity("NuGet.Versioning", version),
+                OwnersList = new List<string> { "owner1", "owner2" },
+            };
+            PackageSource packageSource = new PackageSource("https://nuget.test/v3/index.json");
+            Mock<IOwnerDetailsUriService> ownerDetailsUriService = new Mock<IOwnerDetailsUriService>();
+            ownerDetailsUriService.Setup(x => x.SupportsKnownOwners).Returns(true);
+            ownerDetailsUriService.Setup(x => x.GetOwnerDetailsUri(It.IsAny<string>())).Returns((string owner) => new Uri($"https://nuget.test/profiles/{owner}?_src=template"));
+
+            var knownOwner1 = new KnownOwner("owner1", new Uri("https://nuget.test/profiles/owner1?_src=template"));
+            var knownOwner2 = new KnownOwner("owner2", new Uri("https://nuget.test/profiles/owner2?_src=template"));
+            IReadOnlyList<KnownOwner> knownOwners = new List<KnownOwner>(capacity: 2)
+            {
+                knownOwner1,
+                knownOwner2
+            };
+
+            var packageSearchMetadataContextInfo = PackageSearchMetadataContextInfo.Create(packageSearchMetadata, isRecommended: true, recommenderVersion: (versionString, versionString), knownOwners);
+            var searchResult = new SearchResultContextInfo(new[] { packageSearchMetadataContextInfo }, new Dictionary<string, LoadingStatus> { { "Search", LoadingStatus.Loading } }, hasMoreItems: false);
+            var serviceBroker = Mock.Of<IServiceBroker>();
+            var testVersions = new List<VersionInfoContextInfo>() {
+                new VersionInfoContextInfo(version),
+            };
+
+            var searchService = new Mock<INuGetSearchService>(MockBehavior.Strict);
+            searchService.Setup(ss => ss.GetPackageVersionsAsync(
+                It.IsAny<PackageIdentity>(),
+                It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(testVersions);
+            searchService.Setup(ss => ss.GetPackageMetadataAsync(It.IsAny<PackageIdentity>(), It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((packageSearchMetadataContextInfo, It.IsAny<PackageDeprecationMetadataContextInfo>()));
+            searchService.Setup(s => s.SearchAsync(It.IsAny<IReadOnlyCollection<IProjectContextInfo>>(),
+                It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(),
+                It.IsAny<IReadOnlyCollection<string>>(),
+                It.IsAny<string>(),
+                It.IsAny<SearchFilter>(),
+                It.IsAny<NuGet.VisualStudio.Internal.Contracts.ItemFilter>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<SearchResultContextInfo>(searchResult));
+            searchService.Setup(s => s.RefreshSearchAsync(It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<SearchResultContextInfo>(searchResult));
+            var uiContext = new Mock<INuGetUIContext>();
+            uiContext.Setup(ui => ui.ServiceBroker).Returns(serviceBroker);
+            var context = new PackageLoadContext(isSolution: false, uiContext.Object);
+            var mockProgress = Mock.Of<IProgress<IItemLoaderState>>();
+
+            var loader = await PackageItemLoader.CreateAsync(
+                serviceBroker,
+                context,
+                new List<PackageSourceContextInfo>() { PackageSourceContextInfo.Create(packageSource) },
+                NuGet.VisualStudio.Internal.Contracts.ItemFilter.All,
+                searchService.Object,
+                Mock.Of<INuGetPackageFileService>(),
+                TestSearchTerm);
+
+            // Act
+            await loader.UpdateStateAndReportAsync(searchResult, Mock.Of<IProgress<IItemLoaderState>>(), CancellationToken.None);
+            IEnumerable<PackageItemViewModel> viewModels = loader.GetCurrent();
+
+            // Assert
+            ImmutableList<KnownOwnerViewModel> knownOwnerViewModels = viewModels.Single().KnownOwnerViewModels;
+            knownOwnerViewModels.Should().BeNull();
+        }
+
+        [Fact]
         public async Task GetCurrent_DoesNotHaveKnownOwners_DoesNotCreateKnownOwnerViewModelsAsync()
         {
             var version = NuGetVersion.Parse("4.3.0");


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13515
Spec update: https://github.com/NuGet/Home/pull/13514

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

No longer attempt to render Known Owner for NuGet IntelliCode Package Suggestions ("recommended") packages in the PM UI.
I've made this explicit in the spec in the update, https://github.com/NuGet/Home/pull/13514.

This effectively restores the Author for the recommended packages. 

![intellicodeShowsAuthor](https://github.com/NuGet/NuGet.Client/assets/49205731/96cdb500-390b-47ed-bbb8-1c8c923c7915)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [x] Documentation PR or issue filled https://github.com/NuGet/docs.microsoft.com-nuget/issues/3287
  - **OR**
  - [ ] N/A
