### PR TITLE
Log when Restore gets an HTTP 404 for a version when the package is listed on the feed

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
@@ -91,6 +91,7 @@ namespace NuGet.DependencyResolver
                                                     Strings.Error_PackageNotFoundWhenExpected,
                                                         match.Provider.Source,
                                                     ex.PackageIdentity.ToString());
+                        context.Logger.LogError(message);
 
                         throw new FatalProtocolException(message, ex);
                     }

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/FindPackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/FindPackageTests.cs
@@ -1,8 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -176,6 +176,7 @@ namespace NuGet.DependencyResolver.Core.Tests
             var token = CancellationToken.None;
             var edge = new GraphEdge<RemoteResolveResult>(null, null, null);
             var actualIdentity = new LibraryIdentity("x", NuGetVersion.Parse("1.0.0-beta"), LibraryType.Package);
+            var packageIdentity = new PackageIdentity(actualIdentity.Name, actualIdentity.Version);
             var dependencies = new[] { new LibraryDependency() { LibraryRange = new LibraryRange("y", VersionRange.All, LibraryDependencyTarget.Package) } };
             var dependencyInfo = LibraryDependencyInfo.Create(actualIdentity, framework, dependencies);
 
@@ -198,6 +199,12 @@ namespace NuGet.DependencyResolver.Core.Tests
 
             // Assert
             Assert.Equal(2, hitCount);
+            Assert.Equal(1, testLogger.Errors);
+            string errorMessage = string.Format(CultureInfo.CurrentCulture,
+                                                Strings.Error_PackageNotFoundWhenExpected,
+                                                remoteProvider.Object.Source,
+                                                packageIdentity.ToString());
+            Assert.Equal(errorMessage, testLogger.ErrorMessages.Single());
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/FindPackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/FindPackageTests.cs
@@ -165,7 +165,7 @@ namespace NuGet.DependencyResolver.Core.Tests
         }
 
         [Fact]
-        public async Task FindPackage_VerifyMissingListedPackageThrowsNotFoundAndLogsErrorAsync()
+        public async Task FindPackage_VerifyMissingListedPackage_ThrowsNotFoundAndLogsErrorAsync()
         {
             // Arrange
             var range = new LibraryRange("x", VersionRange.Parse("1.0.0-beta"), LibraryDependencyTarget.Package);

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/FindPackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/FindPackageTests.cs
@@ -165,7 +165,7 @@ namespace NuGet.DependencyResolver.Core.Tests
         }
 
         [Fact]
-        public async Task FindPackage_VerifyMissingListedPackageThrowsNotFound()
+        public async Task FindPackage_VerifyMissingListedPackageThrowsNotFoundAndLogsErrorAsync()
         {
             // Arrange
             var range = new LibraryRange("x", VersionRange.Parse("1.0.0-beta"), LibraryDependencyTarget.Package);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13460

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

_I've tested Kartheek's branch, and since he's got higher priority issues right now, wanted to create the PR on his behalf._

What I've found is that, Azure DevOps (ADO) with upstream sources can return a 404 (not a 401) when a package exists but ADO permissions are not granted to the user to save the requested package version to the local feed.

My testing shows adding this simple logging is extremely useful as it provides a message to help a customer diagnose where the feed failed to find a package.

#### Normal verbosity
With normal verbosity, 
**Old behavior**: `MSB4181: The "Restore Task" task returned false but did not log an error.`
**New behavior** : 

> C:\Program Files\Microsoft Visual Studio\2022\IntPreview\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targets(170
> ,5): error : The feed 'my-test [https://pkgs.dev.azure.com/azure-public/vside/_packaging/my-test/nuget/v3/i
> ndex.json]' lists package 'Microsoft.VisualStudio.ProjectSystem.Analyzers.17.10.221' but multiple attempts to download
> the nupkg have failed. The feed is either invalid or required packages were removed while the current operation was in
> progress. Verify the package exists on the feed and try again. [C:\apps\Prototypes\ListViewSample\ListViewSample.sln]

#### Detailed verbosity

With detailed verbosity, the error message is shown immediately after the full URL.
![image](https://github.com/NuGet/NuGet.Client/assets/49205731/47878cb3-fe0d-4580-9a00-4035868e2336)


## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
