### PR TITLE
Dispose certificates on failure in SignatureUtility.GetCertificates

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SignatureUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SignatureUtility.cs
@@ -560,6 +560,7 @@ namespace NuGet.Packaging.Signing
 
             if (certificates == null || certificates.Count == 0)
             {
+                certificates?.Dispose();
                 throw new SignatureException(errors.ChainBuildingFailed, Strings.CertificateChainBuildFailed);
             }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13535

Regression? Last working version:

## Description

If we get a non-null IX509CertificateChain instance, call `Dispose` on it if we hit an error condition.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception: Caught by static analysis tools
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
