### PR TITLE
use `--allow-insecure-connections` for dotnet nuget add command

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Verbs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Verbs.cs
@@ -52,7 +52,7 @@ namespace NuGet.CommandLine.XPlat
                         Strings.Option_ConfigFile,
                         CommandOptionType.SingleValue);
                     CommandOption allowInsecureConnections = SourceCmd.Option(
-                        "--allowInsecureConnections",
+                        "--allow-insecure-connections",
                         Strings.SourcesCommandAllowInsecureConnectionsDescription,
                         CommandOptionType.NoValue);
                     SourceCmd.HelpOption("-h|--help");
@@ -396,7 +396,7 @@ namespace NuGet.CommandLine.XPlat
                         Strings.Option_ConfigFile,
                         CommandOptionType.SingleValue);
                     CommandOption allowInsecureConnections = SourceCmd.Option(
-                        "--allowInsecureConnections",
+                        "--allow-insecure-connections",
                         Strings.SourcesCommandAllowInsecureConnectionsDescription,
                         CommandOptionType.NoValue);
                     SourceCmd.HelpOption("-h|--help");

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSourcesTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSourcesTests.cs
@@ -82,14 +82,14 @@ namespace Dotnet.Integration.Test
                     settings.ConfigPath,
                     "--allow-insecure-connections"
                 };
+                var loadedSettings = Settings.LoadDefaultSettings(root: workingPath, configFileName: null, machineWideSettings: null);
+                var packageSourcesSection = loadedSettings.GetSection("packageSources");
+                var sourceItem = packageSourcesSection?.GetFirstItemWithAttribute<SourceItem>("key", "test_source");
 
                 // Act
                 var result = _fixture.RunDotnetExpectSuccess(workingPath, string.Join(" ", args));
 
                 // Assert
-                var loadedSettings = Settings.LoadDefaultSettings(root: workingPath, configFileName: null, machineWideSettings: null);
-                var packageSourcesSection = loadedSettings.GetSection("packageSources");
-                var sourceItem = packageSourcesSection?.GetFirstItemWithAttribute<SourceItem>("key", "test_source");
                 Assert.Equal("True", sourceItem.AllowInsecureConnections);
                 Assert.Equal("https://source.test", sourceItem.GetValueAsPath());
             }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSourcesTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSourcesTests.cs
@@ -62,6 +62,40 @@ namespace Dotnet.Integration.Test
         }
 
         [PlatformFact(Platform.Windows)]
+        public void Sources_WhenAddingSource_GotAddedWithAllowInsecureConnections()
+        {
+            using (SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext())
+            {
+                var workingPath = pathContext.WorkingDirectory;
+                var settings = pathContext.Settings;
+
+                // Arrange
+                var args = new string[]
+                {
+                    "nuget",
+                    "add",
+                    "source",
+                    "https://source.test",
+                    "--name",
+                    "test_source",
+                    "--configfile",
+                    settings.ConfigPath,
+                    "--allow-insecure-connections"
+                };
+
+                // Act
+                var result = _fixture.RunDotnetExpectSuccess(workingPath, string.Join(" ", args));
+
+                // Assert
+                var loadedSettings = Settings.LoadDefaultSettings(root: workingPath, configFileName: null, machineWideSettings: null);
+                var packageSourcesSection = loadedSettings.GetSection("packageSources");
+                var sourceItem = packageSourcesSection?.GetFirstItemWithAttribute<SourceItem>("key", "test_source");
+                Assert.Equal("True", sourceItem.AllowInsecureConnections);
+                Assert.Equal("https://source.test", sourceItem.GetValueAsPath());
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
         public void Sources_WhenAddingSourceWithCredentials_CredentialsWereAddedAndEncrypted()
         {
             using (SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext())


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13396

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

There is no need to add `--allow-insecure-connections` to dotnet sdk as the parsing for the `nuget add source` command is done in the xplat binnary. Instead this PR renames the option to `--allow-insecure-connections` so that it follows the dotnet conventions for naming options

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
