### PR TITLE
Reduce allocations in GetPackageInfo by conditionally calling GetNupkgMetadataPath

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/FallbackPackagePathResolver.cs
+++ b/src/NuGet.Core/NuGet.Packaging/FallbackPackagePathResolver.cs
@@ -121,9 +121,18 @@ namespace NuGet.Packaging
             foreach (var resolver in _pathResolvers)
             {
                 var hashPath = resolver.GetHashPath(packageId, version);
+
+                if (File.Exists(hashPath))
+                {
+                    // If the hash exists we can use this path
+                    return new FallbackPackagePathInfo(packageId, version, resolver);
+                }
+
+                // Perf: As hashPath is commonly found and the GetNupkgMetadataPath call is relatively
+                // expensive, only request nupkgMetadataFilePath if hashPath isn't found
                 var nupkgMetadataFilePath = resolver.GetNupkgMetadataPath(packageId, version);
 
-                if (File.Exists(hashPath) || File.Exists(nupkgMetadataFilePath))
+                if (File.Exists(nupkgMetadataFilePath))
                 {
                     // If the hash exists we can use this path
                     return new FallbackPackagePathInfo(packageId, version, resolver);


### PR DESCRIPTION
Reduce allocations in GetPackageInfo by conditionally calling GetNupkgMetadataPath

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13556
--  Helps alleviate memory allocations during solution load

Regression? Last working version:
--  N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

-- Trivial performance optimization to not call GetNupkgMetadataPath in the common case where it's results aren't going to affect the result of the method.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

-- Trivial changes, test changes wouldn't be useful

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
