### PR TITLE
Re-enable dotnet integration tests for the frameworks option for 'dotnet nuget why'

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
@@ -84,7 +84,7 @@ namespace Dotnet.Integration.Test
             Assert.Contains($"Project '{ProjectName}' does not have a dependency on '{packageZ.Id}'", result.AllOutput);
         }
 
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/13547")]
+        [Fact]
         public async void WhyCommand_WithFrameworksOption_OptionParsedSuccessfully()
         {
             // Arrange
@@ -117,7 +117,7 @@ namespace Dotnet.Integration.Test
             Assert.Contains($"Project '{ProjectName}' has the following dependency graph(s) for '{packageY.Id}'", result.AllOutput);
         }
 
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/13547")]
+        [Fact]
         public async void WhyCommand_WithFrameworksOptionAlias_OptionParsedSuccessfully()
         {
             // Arrange
@@ -184,7 +184,7 @@ namespace Dotnet.Integration.Test
             Assert.Contains($"Required argument missing for command: 'why'.", result.Errors);
         }
 
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/13547")]
+        [Fact]
         public async void WhyCommand_InvalidFrameworksOption_WarnsCorrectly()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Related to: https://github.com/NuGet/Home/issues/13547

3 integration tests were failing because the frameworks option wasn't being forwarded correctly by the dotnet SDK. We added a fix for that change to the SDK: https://github.com/dotnet/sdk/pull/41585.

We're now pulling in the latest 8.0.4 build with the fix, and these tests are passing again.

PR to disable tests: https://github.com/NuGet/NuGet.Client/pull/5852

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
