### PR TITLE
Defer LockFileItem.Properties dictionary construction until needed

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileItem.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileItem.cs
@@ -10,6 +10,7 @@ namespace NuGet.ProjectModel
     public class LockFileItem : IEquatable<LockFileItem>
     {
         public static readonly string AliasesProperty = "aliases";
+        private static readonly object PropertiesLock = new object();
 
         public LockFileItem(string path)
         {
@@ -25,7 +26,10 @@ namespace NuGet.ProjectModel
             {
                 if (_properties == null)
                 {
-                    _properties = new Dictionary<string, string>();
+                    lock (PropertiesLock)
+                    {
+                        _properties ??= new Dictionary<string, string>();
+                    }
                 }
 
                 return _properties;

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileItem.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileItem.cs
@@ -18,7 +18,19 @@ namespace NuGet.ProjectModel
 
         public string Path { get; }
 
-        public IDictionary<string, string> Properties { get; } = new Dictionary<string, string>();
+        private Dictionary<string, string> _properties;
+        public IDictionary<string, string> Properties
+        {
+            get
+            {
+                if (_properties == null)
+                {
+                    _properties = new Dictionary<string, string>();
+                }
+
+                return _properties;
+            }
+        }
 
         public override string ToString() => Path;
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug
-- 
<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13557

-- Helps improve memory allocations during solution load

Regression? Last working version:
-- N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
-- Defers creation of a dictionary until it's needed. From the testing I've done on the Roslyn sln, nearly half of these dictionaries need not be created.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] Test exception
-- Changes are trivial enough that tests wouldn't be useful
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
