### PR TITLE
Make sure narrator reads source errors and warnings correctly when listing package sources in PMUI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/CheckedListBoxAccessibleObject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/CheckedListBoxAccessibleObject.cs
@@ -35,6 +35,8 @@ namespace NuGet.PackageManagement.UI.Options
             {
                 var item = (PackageSourceContextInfo)CheckedListBox.Items[index];
                 PackageSource packageSource = new PackageSource(item.Source, item.Name);
+                packageSource.AllowInsecureConnections = item.AllowInsecureConnections;
+
                 if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections)
                 {
                     var sourceMessage = string.Format(


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13555

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

This PR makes sure the narrator reads the right error message based on the value `allowInsecureConnections`
- previously the information was not being propagated as a result the narrator always reads http warnings even when it is not supposed to.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
