### PR TITLE
Run source build in CI pipeline

### DIFF
--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -23,6 +23,10 @@ parameters:
   displayName: Run functional tests on MacOS
   type: boolean
   default: true
+- name: RunSourceBuild
+  displayName: Run a SourceBuild build
+  type: boolean
+  default: true
 
 variables:
   DOTNET_NOLOGO: 1
@@ -257,3 +261,23 @@ stages:
         vmImage: macos-latest
         testType: Functional
         testTargetFramework: netcoreapp3.1
+
+- ${{ if eq(parameters.RunSourceBuild, true) }}:
+  - stage:
+    displayName: Source Build
+    dependsOn: []
+    jobs:
+    - job:
+      displayName: Source Build
+      timeoutInMinutes: 15
+      variables:
+        DOTNET_NUGET_SIGNATURE_VERIFICATION: true
+      pool:
+        vmImage: ubuntu-latest
+      steps:
+      - task: PowerShell@2
+        displayName: "Run source-build script"
+        inputs:
+          targetType: "inline"
+          script: |
+            ./eng/dotnet-build/build.sh --source-build

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -25,7 +25,7 @@ parameters:
 - name: RunSourceBuild
   displayName: Run source build
   type: boolean
-  default: true
+  default: false
 - name: RunTestsOnLinux
   displayName: Run tests on Linux
   type: boolean

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -75,7 +75,11 @@ Function InitializeAllTestsToPending {
     Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Build_and_UnitTest_NonRTM" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
     Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Build_and_UnitTest_RTM" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
     Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Static Analysis" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Source Build" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+    
+    if($env:RunSourceBuild -eq "true")
+    {
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Source Build" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+    }
     if($env:RunFunctionalTestsOnWindows -eq "true")
     {
         # Setup individual states for the matrixing of jobs in "Functional Tests On Windows".


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This adds a source build stage to the CI pipeline and disables it by default in the PrivateDev pipeline.  I also removed the Source Build required status check in favor of the NuGet.Client CI one.

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
