### PR TITLE
fix legacy project restore error from visual studio

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -543,8 +543,8 @@ namespace NuGet.PackageManagement.VisualStudio
                     ConfigFilePaths = GetConfigFilePaths(settings),
                     ProjectWideWarningProperties = WarningProperties.GetWarningProperties(
                         treatWarningsAsErrors,
-                        noWarn,
                         warningsAsErrors,
+                        noWarn,
                         warningsNotAsErrors),
                     RestoreLockProperties = new RestoreLockProperties(
                         restorePackagesWithLockFile,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -1573,11 +1573,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             var warningProperties = actualRestoreSpec.RestoreMetadata.ProjectWideWarningProperties;
             warningProperties.AllWarningsAsErrors.Should().BeTrue();
-            warningProperties.NoWarn.Contains(NuGetLogCode.NU1504);
+            warningProperties.NoWarn.Should().Contain(NuGetLogCode.NU1504);
             warningProperties.NoWarn.Should().HaveCount(1);
-            warningProperties.WarningsNotAsErrors.Contains(NuGetLogCode.NU1801);
+            warningProperties.WarningsNotAsErrors.Should().Contain(NuGetLogCode.NU1801);
             warningProperties.WarningsNotAsErrors.Should().HaveCount(1);
-            warningProperties.WarningsAsErrors.Contains(NuGetLogCode.NU1803);
+            warningProperties.WarningsAsErrors.Should().Contain(NuGetLogCode.NU1803);
             warningProperties.WarningsAsErrors.Should().HaveCount(1);
             // Verify
             projectBuildProperties.VerifyAll();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13571

Regression? Last working version: 6.9

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
The order of the parameters in the GetWarningProperties call is incorrect, resulting in a restore error even if NoWarn is specified.

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A