### PR TITLE
Service release-6.10 with Fix ability for individual projects to enable or disable Central Package Management  (#5866)

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.props
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.props
@@ -12,29 +12,32 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project>
   <!--
     Determine the path to the 'Directory.Packages.props' file, if the user did not:
-      1. Set $(ManagePackageVersionsCentrally) to false
-      2. Set $(ImportDirectoryPackagesProps) to false
-      3. Already specify the path to a 'Directory.Packages.props' file via $(DirectoryPackagesPropsPath)
+      1. Set $(ImportDirectoryPackagesProps) to false
+      2. Already specify the path to a 'Directory.Packages.props' file via $(DirectoryPackagesPropsPath)
   -->
-  <PropertyGroup Condition="'$(ManagePackageVersionsCentrally)' != 'false' And '$(ImportDirectoryPackagesProps)' != 'false' And '$(DirectoryPackagesPropsPath)' == ''">
+  <PropertyGroup Condition="'$(ImportDirectoryPackagesProps)' != 'false' And '$(DirectoryPackagesPropsPath)' == ''">
     <_DirectoryPackagesPropsFile Condition="'$(_DirectoryPackagesPropsFile)' == ''">Directory.Packages.props</_DirectoryPackagesPropsFile>
     <_DirectoryPackagesPropsBasePath Condition="'$(_DirectoryPackagesPropsBasePath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(MSBuildProjectDirectory)', '$(_DirectoryPackagesPropsFile)'))</_DirectoryPackagesPropsBasePath>
     <DirectoryPackagesPropsPath Condition="'$(_DirectoryPackagesPropsBasePath)' != '' and '$(_DirectoryPackagesPropsFile)' != ''">$([MSBuild]::NormalizePath('$(_DirectoryPackagesPropsBasePath)', '$(_DirectoryPackagesPropsFile)'))</DirectoryPackagesPropsPath>
   </PropertyGroup>
 
   <!--
-    Default $(ManagePackageVersionsCentrally) to true, import Directory.Packages.props, and set $(CentralPackageVersionsFileImported) to true if the user did not:
-      1. Set $(ManagePackageVersionsCentrally) to false
-      2. Set $(ImportDirectoryPackagesProps) to false
-      3. The path specified in $(DirectoryPackagesPropsPath) exists
+    Default $(ManagePackageVersionsCentrally) to true if a Directory.Packages.props will be imported and a value is not already set.
   -->
-  <PropertyGroup Condition="'$(ManagePackageVersionsCentrally)' != 'false' And '$(ImportDirectoryPackagesProps)' != 'false' And Exists('$(DirectoryPackagesPropsPath)')">
+  <PropertyGroup Condition="'$(ImportDirectoryPackagesProps)' != 'false' And Exists('$(DirectoryPackagesPropsPath)')">
     <ManagePackageVersionsCentrally Condition="'$(ManagePackageVersionsCentrally)' == ''">true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
-  <Import Project="$(DirectoryPackagesPropsPath)" Condition="'$(ManagePackageVersionsCentrally)' != 'false' And '$(ImportDirectoryPackagesProps)' != 'false' And Exists('$(DirectoryPackagesPropsPath)')" />
+  <!--
+    Import Directory.Packages.props if it exists and has not already been imported.  It is imported even if $(ManagePackageVersionsCentrally)
+    is set to false so that users can enable it for particular projects.
+  -->
+  <Import Project="$(DirectoryPackagesPropsPath)" Condition="'$(ImportDirectoryPackagesProps)' != 'false' And Exists('$(DirectoryPackagesPropsPath)') And '$(CentralPackageVersionsFileImported)' != 'true'" />
 
-  <PropertyGroup Condition="'$(ManagePackageVersionsCentrally)' != 'false' And '$(ImportDirectoryPackagesProps)' != 'false' And Exists('$(DirectoryPackagesPropsPath)')">
+  <!--
+    Set a property indicating that the Directory.Packages.props file has been imported.  This is used to prevent the file from being imported again.
+  -->
+  <PropertyGroup Condition="'$(ImportDirectoryPackagesProps)' != 'false' And Exists('$(DirectoryPackagesPropsPath)')">
     <CentralPackageVersionsFileImported>true</CentralPackageVersionsFileImported>
   </PropertyGroup>
 </Project>

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -99,13 +99,14 @@ namespace Msbuild.Integration.Test
         internal CommandRunnerResult RunMsBuild(string workingDirectory, string args, bool ignoreExitCode = false)
         {
             var restoreDllPath = Path.Combine(_testDir, "NuGet.Build.Tasks.dll");
+            var nugetRestorePropsPath = Path.Combine(_testDir, "NuGet.props");
             var nugetRestoreTargetsPath = Path.Combine(_testDir, "NuGet.targets");
             // Uncomment to debug the msbuild call
             // _processEnvVars.Add("DEBUG_RESTORE_TASK", "true");
             _processEnvVars["UNIT_TEST_RESTORE_TASK"] = bool.TrueString;
             var result = CommandRunner.Run(_msbuildPath.Value,
                 workingDirectory,
-                $"/p:NuGetRestoreTargets={nugetRestoreTargetsPath} /p:RestoreTaskAssemblyFile={restoreDllPath} /p:ImportNuGetBuildTasksPackTargetsFromSdk=true {args}",
+                $"/p:NuGetPropsFile={nugetRestorePropsPath} /p:NuGetRestoreTargets={nugetRestoreTargetsPath} /p:RestoreTaskAssemblyFile={restoreDllPath} /p:ImportNuGetBuildTasksPackTargetsFromSdk=true {args}",
                 environmentVariables: _processEnvVars);
 
             if (!ignoreExitCode)

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -1526,5 +1526,61 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             replayedOutput.Should().Contain($"a known high severity vulnerability", Exactly.Twice());
             replayedOutput.Should().Contain($"a known critical severity vulnerability", Exactly.Twice());
         }
+
+        [Theory]
+        [InlineData(false, null)] // Disabled in Directory.Build.props, not set in Directory.Packages.props
+        [InlineData(false, false)] // Disabled in Directory.Build.props, disabled in Directory.Packages.props
+        [InlineData(null, false)] // Not set in Directory.Build.props, disabled in Directory.Packages.props
+        public async Task MsBuildRestore_WithCPMDisabled_IndividualProjectCanEnableCPM(bool? enabledInDirectoryBuildProps, bool? enabledInDirectoryPackagesProps)
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            var packageX = new SimpleTestPackageContext("x", "1.0.0");
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageX);
+
+            // Directory.Build.props disables CPM which happens before Directory.Packages.props is imported
+            File.WriteAllText(
+                Path.Combine(pathContext.SolutionRoot, "Directory.Build.props"),
+                $@"<Project>
+    <PropertyGroup>
+        {(enabledInDirectoryBuildProps == true ? "<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>" : enabledInDirectoryBuildProps == false ? "<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>" : "")}
+    </PropertyGroup>
+</Project>");
+
+            File.WriteAllText(
+                Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props"),
+                $@"<Project>
+    <PropertyGroup>
+        {(enabledInDirectoryPackagesProps == true ? "<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>" : enabledInDirectoryPackagesProps == false ? "<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>" : "")}
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include=""{packageX.Id}"" Version=""{packageX.Version}"" />
+    </ItemGroup>
+</Project>");
+
+            SimpleTestProjectContext projectA = SimpleTestProjectContext.CreateNETCoreWithSDK("a", pathContext.SolutionRoot, FrameworkConstants.CommonFrameworks.Net472.GetShortFolderName());
+
+            // The project enables CPM and Directory.Packages.props was already imported even if CPM was diabled
+            projectA.Properties.Add("ManagePackageVersionsCentrally", bool.TrueString);
+            projectA.Properties.Add("TreatWarningsAsErrors", bool.TrueString);
+
+            projectA.AddPackageToAllFrameworks(new SimpleTestPackageContext()
+            {
+                Id = packageX.Id,
+                Version = null
+            });
+
+            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot, projectA);
+
+            solution.Create(pathContext.SolutionRoot);
+
+            // Act
+            CommandRunnerResult result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {projectA.ProjectPath}", ignoreExitCode: true);
+
+            // Assert
+            result.Success.Should().BeTrue();
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13587

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This is a cherry-pick of https://github.com/NuGet/NuGet.Client/commit/4153cf164526a06a98382748d8e405124aea61b6 on the `release-6.10.x branch` which fixes an unintentional breaking change for users who are selectively enabling CPM on a per-project basis.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
