### PR TITLE
Attempt to make functional tests more reliable

### DIFF
--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -9,9 +9,8 @@
     <VSTestNoLogo Condition="'$(VSTestNoLogo)' == ''">true</VSTestNoLogo>
     <VSTestVerbosity Condition="'$(SYSTEM_DEBUG)' == 'true'">detailed</VSTestVerbosity>
     <VSTestVerbosity Condition="'$(VSTestVerbosity)' == ''">quiet</VSTestVerbosity>
-    <VSTestSetting Condition="'$(VSTestSetting)' == '' And '$(CI)' == 'true'">$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', 'build', 'xunit.runsettings'))</VSTestSetting>
+    <VSTestSetting Condition="'$(VSTestSetting)' == ''">$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', 'build', 'xunit.runsettings'))</VSTestSetting>
     <VSTestResultsDirectory Condition="'$(VSTestResultsDirectory)' == ''">$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', 'TestResults'))</VSTestResultsDirectory>
-    <VSTestLogger Condition="'$(VSTestLogger)' == ''">console%3Bverbosity=$(VSTestVerbosity)</VSTestLogger>
 
     <!--
       Build tests for all supported target frameworks by default, otherwise build tests for just the specified target framework.
@@ -188,15 +187,24 @@
 
     <ItemGroup>
       <!--
-        Splits the command-line arguments for the test runner into an item group.
+        Adds the console logger with verbosity and then adds any specified from the command-line.
       -->
-      <VSTestLogger Include="$(VSTestLogger)" />
+      <VSTestLogger Include="console%3Bverbosity=$(VSTestVerbosity);$(VSTestLogger)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <VSTestCommand Include="dotnet test" />
+      <VSTestCommand Include="@(TestAssembly->'&quot;%(Identity)&quot;', ' ')" />
+      <VSTestCommand Include="--nologo" Condition="'$(VSTestNoLogo)' == 'true'" />
+      <VSTestCommand Include="--settings &quot;$(VSTestSetting)&quot;" Condition="'$(VSTestSetting)' != ''" />
+      <VSTestCommand Include="--ResultsDirectory &quot;$(VSTestResultsDirectory)&quot;" Condition="'$(VSTestResultsDirectory)' != ''" />
+      <VSTestCommand Include="--diag &quot;$(BinlogDirectory)vstest.diag.log&quot; " Condition="'$(BinlogDirectory)' != ''" />
     </ItemGroup>
 
     <!--
       Runs the tests via 'dotnet test'.
     -->
-    <Exec Command="dotnet test @(TestAssembly->'&quot;%(Identity)&quot;', ' ') --logger &quot;console;verbosity=$(VSTestVerbosity)&quot; --logger @(VSTestLogger->'&quot;%(Identity)&quot;', ' --logger ') --settings &quot;$(VSTestSetting)&quot; --ResultsDirectory &quot;$(VSTestResultsDirectory)&quot;"
+    <Exec Command="@(VSTestCommand->'%(Identity)', ' ') --logger @(VSTestLogger->Distinct()->'&quot;%(Identity)&quot;', ' --logger ')"
           IgnoreStandardErrorWarningFormat="true"
           IgnoreExitCode="true"
           LogStandardErrorAsError="false">

--- a/build/TestShared/xunit.runner.json
+++ b/build/TestShared/xunit.runner.json
@@ -1,7 +1,0 @@
-{
-  "diagnosticMessages": true,
-  "methodDisplay": "classAndMethod",
-  "parallelizeAssembly": true,
-  "parallelizeTestCollections": true,
-  "longRunningTestSeconds": 120
-}

--- a/build/build.proj
+++ b/build/build.proj
@@ -329,7 +329,7 @@
     ============================================================
     RunTestsOnProjects
     Finds all test assemblies and allows Xunit to run them as
-    efficiently as the xunit.runner.json settings allow.
+    efficiently as the xunit.runsettings allow.
     ============================================================
   -->
   <Target Name="RunTestsOnProjects">

--- a/build/test.targets
+++ b/build/test.targets
@@ -16,7 +16,8 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TestResultsDirectory>$(BuildCommonDirectory)TestResults\</TestResultsDirectory>
+    <VSTestResultsDirectory>$(RepositoryRootDirectory).test\TestResults\</VSTestResultsDirectory>
+    <RunSettingsFilePath Condition="'$(RunSettingsFilePath)' == ''">$(MSBuildThisFileDirectory)xunit.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <!-- Workaround for test projects not automatically creating binding redirects -->
@@ -24,12 +25,5 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(UseParallelXunit)' == 'true' ">
-    <None Include="$(BuildCommonDirectory)TestShared\xunit.runner.json">
-      <Link>xunit.runner.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
 
 </Project>

--- a/build/xunit.runsettings
+++ b/build/xunit.runsettings
@@ -1,20 +1,60 @@
 <RunSettings>
-    <RunConfiguration>
-        <!-- Use as many testhosts as logical processors -->
-        <MaxCpuCount>0</MaxCpuCount>
-        <!-- Consider it an error if no tests are discovered -->
-        <TreatNoTestsAsError>true</TreatNoTestsAsError>
-    </RunConfiguration>
-    <DataCollectionRunSettings>
-        <DataCollectors>
-            <DataCollector friendlyName="blame" enabled="True">
-                <Configuration>
-                    <!-- Enables crash dump-->
-                    <CollectDump DumpType="Mini" />
-                    <!-- Enables hang dump-->
-                    <CollectDumpOnTestSessionHang TestTimeout="15min" HangDumpType="Mini" />
-                </Configuration>
-            </DataCollector>
-        </DataCollectors>
-    </DataCollectionRunSettings>
+  <!-- https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#runconfiguration-element -->
+  <RunConfiguration>
+    <!--
+      This setting controls the level of parallelism on process-level. Use 0 to enable the maximum process-level parallelism.
+
+      This setting determines the maximum number of test DLLs, or other test containers that can run in parallel. Each DLL runs in its own testhost process, and is isolated on the process level from the tests in other test DLLs. This setting doesn't force tests in each test DLL to run in parallel. Controlling the parallel execution within a DLL (on the thread-level) is up to the test framework such as MSTest, XUnit or NUnit.
+
+      The default value is 1, meaning that only one testhost runs at the same time. A special value 0 allows as many testhosts as you have logical processors (for example, 6, for a computer with 6 physical cores without multi-threading, or 12, for a computer with six physical cores with multi-threading).
+
+      The number of distinct DLLs in the run determines the actual number of testhosts started.
+    -->
+    <MaxCpuCount>4</MaxCpuCount>
+
+    <!-- Specify a Boolean value, which defines the exit code when no tests are discovered. If the value is true and no tests are discovered, a nonzero exit code is returned. Otherwise, zero is returned. -->
+    <TreatNoTestsAsError>true</TreatNoTestsAsError>
+
+    <EnvironmentVariables>
+      <!-- Changes the default timeout in VSTest for shutdown to 1000ms instead of 100ms which can cause intermittent failures in CI. -->
+      <VSTEST_TESTHOST_SHUTDOWN_TIMEOUT>1000</VSTEST_TESTHOST_SHUTDOWN_TIMEOUT>
+    </EnvironmentVariables>
+  </RunConfiguration>
+
+  <!-- https://xunit.net/docs/runsettings -->
+  <xUnit>
+    <!-- Set this value to true to include diagnostic information during test discovery and execution. Each runner has a unique method of presenting diagnostic messages. -->
+    <DiagnosticMessages>true</DiagnosticMessages>
+
+    <!-- Set this value to enable long-running (hung) test detection. When the runner is idle waiting for tests to finished, it will report that fact once the timeout has passed. Use a value of 0 to disable the feature, or a positive integer value to enable the feature (time in seconds). -->
+    <LongRunningTestSeconds>120</LongRunningTestSeconds>
+
+    <!-- Set this to override the maximum number of threads to be used when parallelizing tests within this assembly. Use a value of 0 or "default" to indicate that you would like the default behavior; use a value of -1 or "unlimited" to indicate that you do not wish to limit the number of threads used for parallelization. -->
+    <MaxParallelThreads>4</MaxParallelThreads>
+
+    <!-- Set this to true if this assembly is willing to participate in parallelization with other assemblies. Test runners can use this information to automatically enable parallelization across assemblies if all the assemblies agree to it. -->
+    <ParallelizeAssembly>false</ParallelizeAssembly>
+
+    <!-- Set this to true if the assembly is willing to run tests inside this assembly in parallel against each other. Tests in the same test collection will be run sequentially against each other, but tests in different test collections will be run in parallel against each other. Set this to false to disable all parallelization within this test assembly. -->
+    <ParallelizeTestCollections>false</ParallelizeTestCollections>
+
+    <!-- Set this to true to use shadow copying when running tests in separate App Domains; set to false to run tests without shadow copying. When running tests without App Domains, this value is ignored. -->
+    <ShadowCopy>false</ShadowCopy>
+  </xUnit>
+
+  <!-- https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#datacollectors-element-diagnostic-data-adapters -->
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <!-- Enables blame -->
+      <DataCollector friendlyName="blame" enabled="True">
+        <Configuration>
+          <!-- Enables crash dump, with dump type "Full" or "Mini". Requires ProcDump in PATH for .NET Framework. -->
+          <CollectDump DumpType="Mini" />
+
+          <!-- Enables hang dump or testhost and its child processes when a test hangs for more than 10 minutes. Dump type "Full", "Mini" or "None" (just kill the processes). -->
+          <CollectDumpOnTestSessionHang TestTimeout="3min" HangDumpType="Mini" />
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
 </RunSettings>

--- a/build/xunit.runsettings
+++ b/build/xunit.runsettings
@@ -41,20 +41,4 @@
     <!-- Set this to true to use shadow copying when running tests in separate App Domains; set to false to run tests without shadow copying. When running tests without App Domains, this value is ignored. -->
     <ShadowCopy>false</ShadowCopy>
   </xUnit>
-
-  <!-- https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#datacollectors-element-diagnostic-data-adapters -->
-  <DataCollectionRunSettings>
-    <DataCollectors>
-      <!-- Enables blame -->
-      <DataCollector friendlyName="blame" enabled="True">
-        <Configuration>
-          <!-- Enables crash dump, with dump type "Full" or "Mini". Requires ProcDump in PATH for .NET Framework. -->
-          <CollectDump DumpType="Mini" />
-
-          <!-- Enables hang dump or testhost and its child processes when a test hangs for more than 10 minutes. Dump type "Full", "Mini" or "None" (just kill the processes). -->
-          <CollectDumpOnTestSessionHang TestTimeout="3min" HangDumpType="Mini" />
-        </Configuration>
-      </DataCollector>
-    </DataCollectors>
-  </DataCollectionRunSettings>
 </RunSettings>

--- a/eng/pipelines/pr.job.yml
+++ b/eng/pipelines/pr.job.yml
@@ -78,7 +78,7 @@ jobs:
     condition: succeeded()
     inputs:
       command: test
-      arguments: --no-restore --restore:false --no-build --framework $(TestTargetFramework) --blame --logger trx --binarylogger:"$(BinlogDirectory)02-RunTests.binlog"
+      arguments: --no-restore --restore:false --no-build --framework $(TestTargetFramework) --binarylogger:"$(BinlogDirectory)02-RunTests.binlog"
       testRunTitle: ${{ parameters.osName }} $(TestType) Tests ($(TestTargetFramework))
 
   - task: PublishPipelineArtifact@1

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/NuGet.CommandLine.FuncTest.csproj
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/NuGet.CommandLine.FuncTest.csproj
@@ -22,11 +22,6 @@
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="xunit.runner.json"
-          CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-
   <Target Name="CopyFinalNuGetExeToOutputPath"
           AfterTargets="PrepareForRun"
           Inputs="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe"

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>An end-to-end test suite for NuGet.CommandLine. Contains tests for every nuget.exe CLI command. Overlaps in tests with NuGet.CommandLine.FuncTest.</Description>
     <TestProjectType Condition="'$(IsXPlat)' != 'true'">Functional</TestProjectType>
   </PropertyGroup>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -1608,6 +1608,7 @@ public class B
                     nugetexe,
                     proj1Directory,
                     "pack proj1.csproj -build -IncludeReferencedProjects",
+                    timeOutInMilliseconds: (int)TimeSpan.FromMinutes(4).TotalMilliseconds,
                     testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -19,11 +19,19 @@ using NuGet.Packaging.Rules;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.CommandLine.Test
 {
     public class NuGetPackCommandTest
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public NuGetPackCommandTest(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
         [Fact]
         public void PackCommand_IncludeExcludePackageFromNuspec()
         {
@@ -72,7 +80,8 @@ namespace NuGet.CommandLine.Test
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -150,7 +159,8 @@ namespace NuGet.CommandLine.Test
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -203,7 +213,8 @@ namespace NuGet.CommandLine.Test
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -268,7 +279,8 @@ namespace NuGet.CommandLine.Test
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -315,7 +327,8 @@ namespace NuGet.CommandLine.Test
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -376,7 +389,8 @@ namespace NuGet.CommandLine.Test
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -430,7 +444,8 @@ namespace NuGet.CommandLine.Test
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -497,7 +512,8 @@ namespace NuGet.CommandLine.Test
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec -symbols -SymbolPackageFormat snupkg");
+                    "pack packageA.nuspec -symbols -SymbolPackageFormat snupkg",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -581,7 +597,8 @@ namespace NuGet.CommandLine.Test
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec -symbols -SymbolPackageFormat snupkg");
+                    "pack packageA.nuspec -symbols -SymbolPackageFormat snupkg",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(r.Success, r.AllOutput);
 
                 // Assert
@@ -663,7 +680,8 @@ namespace NuGet.CommandLine.Test
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec -symbols -SymbolPackageFormat snupkg");
+                    "pack packageA.nuspec -symbols -SymbolPackageFormat snupkg",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -741,7 +759,8 @@ namespace NuGet.CommandLine.Test
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -859,7 +878,8 @@ namespace Proj2
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj2Directory,
-                    "pack proj2.csproj -build -IncludeReferencedProjects");
+                    "pack proj2.csproj -build -IncludeReferencedProjects",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -949,7 +969,8 @@ namespace Proj1
                     nugetexe,
                     proj1Directory,
                     $"restore {project1Path}",
-                    environmentVariables: environmentVariables);
+                    environmentVariables: environmentVariables,
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(t.Success, t.AllOutput);
 
                 // Act
@@ -957,7 +978,8 @@ namespace Proj1
                     nugetexe,
                     proj1Directory,
                     "pack proj1.csproj -build ",
-                    environmentVariables: environmentVariables);
+                    environmentVariables: environmentVariables,
+                    testOutputHelper: _testOutputHelper);
 
                 // Assert
                 if (packEnabled)
@@ -1055,14 +1077,16 @@ namespace Proj1
                 var t = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    "restore packages.config -PackagesDirectory " + packagesDirectory);
+                    "restore packages.config -PackagesDirectory " + packagesDirectory,
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(t.Success, t.AllOutput);
 
                 // Act
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    "pack proj1.csproj -build ");
+                    "pack proj1.csproj -build ",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -1156,7 +1180,8 @@ namespace Proj2
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj2Directory,
-                    $"pack proj2.csproj -build -IncludeReferencedProjects -symbols -SymbolPackageFormat {extension}");
+                    $"pack proj2.csproj -build -IncludeReferencedProjects -symbols -SymbolPackageFormat {extension}",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -1229,7 +1254,8 @@ namespace Proj2
                 var result = CommandRunner.Run(
                     nugetexe,
                     projDirectory,
-                    $"pack A.csproj -build -symbols -SymbolPackageFormat {extension}");
+                    $"pack A.csproj -build -symbols -SymbolPackageFormat {extension}",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(result.ExitCode == 0, result.Output + " " + result.Errors);
 
                 // Assert
@@ -1300,7 +1326,8 @@ public class B
                 var result = CommandRunner.Run(
                     nugetexe,
                     projDirectory,
-                    $"pack A.csproj -build -symbols -SymbolPackageFormat {extension}");
+                    $"pack A.csproj -build -symbols -SymbolPackageFormat {extension}",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(result.ExitCode == 0, result.Output + " " + result.Errors);
 
                 // Assert
@@ -1370,7 +1397,8 @@ public class B
                 var result = CommandRunner.Run(
                     nugetexe,
                     projDirectory,
-                    "pack A.csproj -build");
+                    "pack A.csproj -build",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(result.ExitCode == 0, result.Output + " " + result.Errors);
 
                 // Assert
@@ -1466,7 +1494,8 @@ public class B
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    "pack proj1.csproj -build -IncludeReferencedProjects");
+                    "pack proj1.csproj -build -IncludeReferencedProjects",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -1578,7 +1607,8 @@ public class B
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    "pack proj1.csproj -build -IncludeReferencedProjects");
+                    "pack proj1.csproj -build -IncludeReferencedProjects",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj2"), r.Output);
@@ -1691,7 +1721,8 @@ public class B
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    $@"pack proj1.csproj -build -IncludeReferencedProjects  -MSBuildVersion {version}");
+                    $@"pack proj1.csproj -build -IncludeReferencedProjects  -MSBuildVersion {version}",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -1795,7 +1826,8 @@ public class B
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    $@"pack proj1.csproj -build -IncludeReferencedProjects  -MSBuildVersion 15.0");
+                    $@"pack proj1.csproj -build -IncludeReferencedProjects  -MSBuildVersion 15.0",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -1909,7 +1941,8 @@ public class B
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    $@"pack proj1.csproj -build -IncludeReferencedProjects  -MSBuildVersion {version}");
+                    $@"pack proj1.csproj -build -IncludeReferencedProjects  -MSBuildVersion {version}",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -2019,7 +2052,8 @@ public class B
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    $@"pack proj1.csproj -build -IncludeReferencedProjects  -MSBuildVersion 15.0");
+                    $@"pack proj1.csproj -build -IncludeReferencedProjects  -MSBuildVersion 15.0",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -2132,7 +2166,8 @@ public class B
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    "pack proj1.csproj -build -IncludeReferencedProjects -Properties prefix=" + prefixTokenValue);
+                    "pack proj1.csproj -build -IncludeReferencedProjects -Properties prefix=" + prefixTokenValue,
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -2168,7 +2203,7 @@ public class B
                 var projectDirectory = Path.Combine(workingDirectory, "Foo");
 
                 // Act
-                var r = CommandRunner.Run(nugetexe, projectDirectory, "pack Foo.csproj -build");
+                var r = CommandRunner.Run(nugetexe, projectDirectory, "pack Foo.csproj -build", testOutputHelper: _testOutputHelper);
 
                 // The assembly version was used, not the informational version
                 var outputPackageFileName = Path.Combine(projectDirectory, $"Foo.{version}.nupkg");
@@ -2196,7 +2231,7 @@ public class B
                 var projectDirectory = Path.Combine(workingDirectory, "Foo");
 
                 // Act
-                var r = CommandRunner.Run(nugetexe, projectDirectory, "pack Foo.csproj -build");
+                var r = CommandRunner.Run(nugetexe, projectDirectory, "pack Foo.csproj -build", testOutputHelper: _testOutputHelper);
 
                 // The informational version without the build metadata part was used
                 var outputPackageFileName = Path.Combine(projectDirectory, $"Foo.{semverVersion}.nupkg");
@@ -2374,7 +2409,8 @@ namespace " + projectName + @"
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    "pack proj1.csproj -build -IncludeReferencedProjects");
+                    "pack proj1.csproj -build -IncludeReferencedProjects",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -2436,7 +2472,8 @@ namespace " + projectName + @"
                 var commandRunner = CommandRunner.Run(
                     Util.GetNuGetExePath(),
                     workingDirectory,
-                    "pack packageA.nuspec -InstallPackageToOutputPath");
+                    "pack packageA.nuspec -InstallPackageToOutputPath",
+                    testOutputHelper: _testOutputHelper);
 
                 // Assert
 
@@ -2508,7 +2545,8 @@ namespace " + projectName + @"
                 var commandRunner = CommandRunner.Run(
                     Util.GetNuGetExePath(),
                     workingDirectory,
-                    arguments);
+                    arguments,
+                    testOutputHelper: _testOutputHelper);
 
                 // Assert
 
@@ -2609,7 +2647,8 @@ namespace " + projectName + @"
                 var commandRunner = CommandRunner.Run(
                     Util.GetNuGetExePath(),
                     workingDirectory,
-                    "@" + responseFilePath);
+                    "@" + responseFilePath,
+                    testOutputHelper: _testOutputHelper);
 
                 // Assert
 
@@ -2672,7 +2711,8 @@ namespace " + projectName + @"
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    $"pack proj1.csproj -build -IncludeReferencedProjects -outputDirectory \"{outputDirectory}\"");
+                    $"pack proj1.csproj -build -IncludeReferencedProjects -outputDirectory \"{outputDirectory}\"",
+                    testOutputHelper: _testOutputHelper);
 
                 Assert.True(0 == r.ExitCode, r.Output + Environment.NewLine + r.Errors);
 
@@ -2721,7 +2761,8 @@ namespace " + projectName + @"
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    "pack proj1.csproj -build -IncludeReferencedProjects");
+                    "pack proj1.csproj -build -IncludeReferencedProjects",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -2763,7 +2804,8 @@ namespace " + projectName + @"
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    "pack proj1.csproj -build -IncludeReferencedProjects");
+                    "pack proj1.csproj -build -IncludeReferencedProjects",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -2885,13 +2927,15 @@ namespace Proj2
                 var r = CommandRunner.Run(
                     msbuild,
                     proj2Directory,
-                    "proj2.csproj /p:Config=Release");
+                    "proj2.csproj /p:Config=Release",
+                    testOutputHelper: _testOutputHelper);
 
                 // Act
                 r = CommandRunner.Run(
                     nugetexe,
                     proj2Directory,
-                    "pack proj2.csproj -p Config=Release");
+                    "pack proj2.csproj -p Config=Release",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -3004,7 +3048,8 @@ namespace Proj2
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj2Directory,
-                    "pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release");
+                    "pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -3063,7 +3108,8 @@ namespace Proj2
                 var r = CommandRunner.Run(
                     nugetexe,
                     projDirectory,
-                    "pack package.nuspec");
+                    "pack package.nuspec",
+                    testOutputHelper: _testOutputHelper);
 
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
@@ -3152,7 +3198,8 @@ namespace Proj1
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    "pack proj1.csproj -build");
+                    "pack proj1.csproj -build",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -3238,7 +3285,8 @@ namespace Proj1
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    "pack proj1.csproj -build");
+                    "pack proj1.csproj -build",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -3356,7 +3404,8 @@ namespace Proj1
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    "pack proj1.csproj -build -IncludeReferencedProjects");
+                    "pack proj1.csproj -build -IncludeReferencedProjects",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -3470,7 +3519,8 @@ namespace Proj1
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    "pack proj1.csproj -build -IncludeReferencedProjects");
+                    "pack proj1.csproj -build -IncludeReferencedProjects",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -3576,13 +3626,15 @@ namespace Proj1
                 var r = CommandRunner.Run(
                     msbuild,
                     proj1Directory,
-                    "proj1.csproj /p:Config=Release");
+                    "proj1.csproj /p:Config=Release",
+                    testOutputHelper: _testOutputHelper);
 
                 // Act
                 r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    "pack proj1.nuspec");
+                    "pack proj1.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -3691,7 +3743,8 @@ namespace Proj2
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj2Directory,
-                    $@"pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release -msbuildversion 14");
+                    $@"pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release -msbuildversion 14",
+                    testOutputHelper: _testOutputHelper);
 
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
@@ -3815,7 +3868,8 @@ namespace Proj2
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj2Directory,
-                    $@"pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release -msbuildversion 15.0");
+                    $@"pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release -msbuildversion 15.0",
+                    testOutputHelper: _testOutputHelper);
 
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
@@ -3939,7 +3993,8 @@ namespace Proj2
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj2Directory,
-                    @"pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release -MSBuildVersion 15.1");
+                    @"pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release -MSBuildVersion 15.1",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -4066,7 +4121,8 @@ namespace Proj2
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj2Directory,
-                    $@"pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release -MSBuildPath ""{msbuildPath}"" ");
+                    $@"pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release -MSBuildPath ""{msbuildPath}"" ",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -4194,7 +4250,8 @@ namespace Proj2
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj2Directory,
-                    $@"pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release -MSBuildPath ""{msbuildPath}"" -MSBuildVersion 12 ");
+                    $@"pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release -MSBuildPath ""{msbuildPath}"" -MSBuildVersion 12 ",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -4319,7 +4376,8 @@ namespace Proj2
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj2Directory,
-                    $@"pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release -MSBuildPath ""{msbuildPath}"" ");
+                    $@"pack proj2.csproj -build -IncludeReferencedProjects -p Config=Release -MSBuildPath ""{msbuildPath}"" ",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -4342,7 +4400,8 @@ namespace Proj2
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    "pack proj1.csproj -Build -Suffix alpha");
+                    "pack proj1.csproj -Build -Suffix alpha",
+                    testOutputHelper: _testOutputHelper);
 
                 // Assert
                 Assert.True(r.Success, r.AllOutput);
@@ -4453,7 +4512,8 @@ stuff \n &lt;&lt;
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec -verbosity detailed");
+                    "pack packageA.nuspec -verbosity detailed",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -4542,7 +4602,8 @@ stuff \n <<".Replace("\r\n", "\n");
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    "pack proj1.csproj -build");
+                    "pack proj1.csproj -build",
+                    testOutputHelper: _testOutputHelper);
                 Assert.Equal(1, r.ExitCode);
 
                 // Assert
@@ -4587,7 +4648,8 @@ stuff \n <<".Replace("\r\n", "\n");
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -4662,7 +4724,8 @@ namespace Proj1
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1ProjectDirectory,
-                    @"pack proj1.csproj -build -IncludeReferencedProjects -Properties Configuration=Release");
+                    @"pack proj1.csproj -build -IncludeReferencedProjects -Properties Configuration=Release",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -4733,7 +4796,8 @@ namespace Proj1
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    $"pack proj1.csproj -build -version 1.0.0-rtm+asdassd");
+                    $"pack proj1.csproj -build -version 1.0.0-rtm+asdassd",
+                    testOutputHelper: _testOutputHelper);
                 r.Success.Should().BeTrue(because: r.AllOutput);
                 var expectedMessage = "WARNING: " + NuGetLogCode.NU5115.ToString();
                 if (expectToWarn)
@@ -4801,7 +4865,8 @@ namespace Proj1
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    $"pack proj1.csproj -build -version 1.0.0-rtm+asdassd");
+                    $"pack proj1.csproj -build -version 1.0.0-rtm+asdassd",
+                    testOutputHelper: _testOutputHelper);
 
                 var nupkgPath = Path.Combine(workingDirectory, "proj1", "proj1.1.0.0-rtm.nupkg");
 
@@ -4874,7 +4939,8 @@ namespace Proj1
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    $"pack proj1.csproj -build -version 1.0.0-rtm+asdassd");
+                    $"pack proj1.csproj -build -version 1.0.0-rtm+asdassd",
+                    testOutputHelper: _testOutputHelper);
 
                 var nupkgPath = Path.Combine(workingDirectory, "proj1", "proj1.1.0.0-rtm.nupkg");
 
@@ -4921,7 +4987,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -4984,7 +5051,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -5048,7 +5116,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 // This should fail.
                 Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
 
@@ -5095,7 +5164,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 // This should fail.
                 Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
 
@@ -5142,7 +5212,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 // This should fail.
                 Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
 
@@ -5195,7 +5266,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -5262,7 +5334,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 // This should fail.
                 Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
 
@@ -5312,7 +5385,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 // This should fail.
                 Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
 
@@ -5363,7 +5437,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 // This should fail.
                 Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
 
@@ -5411,7 +5486,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 // This should fail.
                 Assert.True(1 == r.ExitCode, r.Output + " " + r.Errors);
 
@@ -5456,7 +5532,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 Assert.Contains("NU5125", r.Output);
@@ -5521,7 +5598,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -5624,7 +5702,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    $"pack {packageName}.csproj -build -symbols -SymbolPackageFormat {extension}");
+                    $"pack {packageName}.csproj -build -symbols -SymbolPackageFormat {extension}",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -5726,7 +5805,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -5793,7 +5873,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack packageA.nuspec");
+                    "pack packageA.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -5943,7 +6024,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     Util.GetNuGetExePath(),
                     testDirBuilder.BaseDir,
-                    $"pack {testDirBuilder.NuspecPath}");
+                    $"pack {testDirBuilder.NuspecPath}",
+                    testOutputHelper: _testOutputHelper);
 
                 Util.VerifyResultSuccess(r, expectedOutputMessage: NuGetLogCode.NU5048.ToString());
                 Assert.Contains(AnalysisResources.IconUrlDeprecationWarning, r.Output);
@@ -6092,7 +6174,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     Util.GetNuGetExePath(),
                     testDirBuilder.BaseDir,
-                    $"pack A.csproj -Build -Symbols -SymbolPackageFormat {symbolExtension}");
+                    $"pack A.csproj -Build -Symbols -SymbolPackageFormat {symbolExtension}",
+                    testOutputHelper: _testOutputHelper);
 
                 // Verify
                 Util.VerifyResultSuccess(r);
@@ -6160,7 +6243,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     Util.GetNuGetExePath(),
                     testDirBuilder.BaseDir,
-                    $"pack A.csproj -Build");
+                    $"pack A.csproj -Build",
+                    testOutputHelper: _testOutputHelper);
 
                 Util.VerifyResultSuccess(r, expectedOutputMessage: NuGetLogCode.NU5048.ToString());
                 Assert.Contains(AnalysisResources.IconUrlDeprecationWarning, r.Output);
@@ -6201,7 +6285,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     Util.GetNuGetExePath(),
                     testDirBuilder.BaseDir,
-                    $"pack {testDirBuilder.NuspecPath}");
+                    $"pack {testDirBuilder.NuspecPath}",
+                    testOutputHelper: _testOutputHelper);
 
                 // Assert
                 Util.VerifyResultSuccess(r, message);
@@ -6232,7 +6317,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     Util.GetNuGetExePath(),
                     testDirBuilder.BaseDir,
-                    $"pack {testDirBuilder.NuspecPath}");
+                    $"pack {testDirBuilder.NuspecPath}",
+                    testOutputHelper: _testOutputHelper);
 
                 // Assert
                 Util.VerifyResultFailure(r, message);
@@ -6595,7 +6681,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     Util.GetNuGetExePath(),
                     testDirBuilder.BaseDir,
-                    $"pack {testDirBuilder.NuspecPath}");
+                    $"pack {testDirBuilder.NuspecPath}",
+                    testOutputHelper: _testOutputHelper);
 
                 // Assert
                 Util.VerifyResultSuccess(r, message);
@@ -6667,7 +6754,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     var r = CommandRunner.Run(
                         nugetexe,
                         workingDirectory,
-                        string.Format(command, path));
+                        string.Format(command, path),
+                        testOutputHelper: _testOutputHelper);
                     Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
 
@@ -6746,7 +6834,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    "pack proj1.csproj -build -solutionDir ../solution");
+                    "pack proj1.csproj -build -solutionDir ../solution",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(r.Success, r.AllOutput);
             }
         }
@@ -6795,7 +6884,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    "pack proj1.csproj -build -packagesDir ../pkgs");
+                    "pack proj1.csproj -build -packagesDir ../pkgs",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(r.Success, r.AllOutput);
             }
         }
@@ -6920,7 +7010,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    $"pack proj1.csproj -build -packagesDir {packagesFolder} -solutionDir {solDirectory}");
+                    $"pack proj1.csproj -build -packagesDir {packagesFolder} -solutionDir {solDirectory}",
+                    testOutputHelper: _testOutputHelper);
                 Util.VerifyResultSuccess(r);
                 Assert.True(File.Exists(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg")));
 
@@ -6928,7 +7019,8 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                 var r2 = CommandRunner.Run(
                     nugetexe,
                     proj3Directory,
-                    $"pack proj3.csproj -build -packagesDir {packagesFolder2} -solutionDir {solDirectory} -configFile {Path.Combine(solDirectory, "AlternateNuget.config")}");
+                    $"pack proj3.csproj -build -packagesDir {packagesFolder2} -solutionDir {solDirectory} -configFile {Path.Combine(solDirectory, "AlternateNuget.config")}",
+                    testOutputHelper: _testOutputHelper);
                 Util.VerifyResultSuccess(r2);
                 Assert.True(File.Exists(Path.Combine(proj3Directory, "proj3.0.0.0.nupkg")));
             }
@@ -6985,7 +7077,8 @@ namespace Proj1
                 var r = CommandRunner.Run(
                     nugetexe,
                     proj1Directory,
-                    $"pack proj1.csproj -build -version 1.0.0-rtm+asdassd");
+                    $"pack proj1.csproj -build -version 1.0.0-rtm+asdassd",
+                    testOutputHelper: _testOutputHelper);
                 r.Success.Should().BeTrue(because: r.AllOutput);
                 r.AllOutput.Should().NotContain(NuGetLogCode.NU5105.ToString());
             }
@@ -7085,7 +7178,8 @@ using System.Runtime.InteropServices;
                 var r = CommandRunner.Run(
                     nugetexe,
                     projectDirectory,
-                    "pack -build");
+                    "pack -build",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -7204,7 +7298,8 @@ using System.Runtime.InteropServices;
                 var r = CommandRunner.Run(
                     renamedNuGetExe,
                     projectDirectory,
-                    "pack -build");
+                    "pack -build",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
@@ -7249,7 +7344,8 @@ using System.Runtime.InteropServices;
                 var result = CommandRunner.Run(
                     nugetexe,
                     projDirectory,
-                    "pack A.csproj -build");
+                    "pack A.csproj -build",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(result.ExitCode == 0, result.Output + " " + result.Errors);
 
                 // Assert
@@ -7295,11 +7391,13 @@ using System.Runtime.InteropServices;
                 CommandRunnerResult specResult = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "spec");
+                    "spec",
+                    testOutputHelper: _testOutputHelper);
                 CommandRunnerResult packResult = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "pack Package.nuspec");
+                    "pack Package.nuspec",
+                    testOutputHelper: _testOutputHelper);
                 Assert.True(0 == specResult.ExitCode, specResult.AllOutput);
                 Assert.True(0 == packResult.ExitCode, packResult.AllOutput);
 
@@ -7373,14 +7471,16 @@ namespace proj1
                 CommandRunnerResult specResult = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    "spec");
+                    "spec",
+                    testOutputHelper: _testOutputHelper);
 
                 Assert.True(0 == specResult.ExitCode, specResult.AllOutput);
 
                 CommandRunnerResult packResult = CommandRunner.Run(
                     nugetexe,
                     workingDirectory,
-                    " pack -properties tagVar=CustomTag;author=microsoft.com;Description=aaaaaaa -build");
+                    " pack -properties tagVar=CustomTag;author=microsoft.com;Description=aaaaaaa -build",
+                    testOutputHelper: _testOutputHelper);
 
                 // Assert
                 Assert.True(0 == packResult.ExitCode, packResult.AllOutput);
@@ -7442,7 +7542,8 @@ namespace Proj1
             var r = CommandRunner.Run(
                 Util.GetNuGetExePath(),
                 proj1Directory,
-                "pack proj1.csproj -build");
+                "pack proj1.csproj -build",
+                testOutputHelper: _testOutputHelper);
             r.Success.Should().BeFalse();
             r.AllOutput.Should().Contain("NU5049");
             r.AllOutput.Should().Contain("dotnet pack");
@@ -7492,7 +7593,8 @@ namespace Proj1
                 environmentVariables: new Dictionary<string, string>()
                 {
                     { "NUGET_ENABLE_LEGACY_CSPROJ_PACK", "true" }
-                });
+                },
+                testOutputHelper: _testOutputHelper);
             r.Success.Should().BeTrue();
             r.AllOutput.Should().NotContain("NU5049");
             r.AllOutput.Should().NotContain("dotnet pack");

--- a/test/NuGet.Clients.Tests/NuGet.Indexing.Test/NuGet.Indexing.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.Indexing.Test/NuGet.Indexing.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Indexing.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
     <NETCoreWPFProject>true</NETCoreWPFProject>
     <Description>Unit and integration tests for NuGet.PackageManagement.UI.</Description>
-    <UseParallelXunit>true</UseParallelXunit>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
@@ -33,9 +33,4 @@
     <PackageReference Include="Microsoft.Build.Framework" />
     <PackageReference Include="Microsoft.NET.StringTools" />
   </ItemGroup>
-
-  <ItemGroup>
-    <None Include="xunit.runner.json"
-          CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
 </Project>

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/NuGet.SolutionRestoreManager.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/NuGet.SolutionRestoreManager.Test.csproj
@@ -5,11 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="xunit.runner.json"
-          CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.PackageManagement.VisualStudio\NuGet.PackageManagement.VisualStudio.csproj" />
     <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.SolutionRestoreManager\NuGet.SolutionRestoreManager.csproj" />
     <ProjectReference Include="..\..\TestUtilities\Test.Utility\Test.Utility.csproj" />

--- a/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGet.Tools.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGet.Tools.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Tools.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/NuGet.VisualStudio.Common.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/NuGet.VisualStudio.Common.Test.csproj
@@ -5,11 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="xunit.runner.json"
-      CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\NuGet.Core.Tests\NuGet.PackageManagement.Test\NuGet.PackageManagement.Test.csproj" />
     <ProjectReference Include="..\..\TestUtilities\Test.Utility\Test.Utility.csproj" />
   </ItemGroup>

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Test/NuGet.VisualStudio.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Test/NuGet.VisualStudio.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit and integration tests for NuGet.VisualStudio.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Clients.Tests/NuGetConsole.Host.PowerShell.Test/NuGetConsole.Host.PowerShell.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGetConsole.Host.PowerShell.Test/NuGetConsole.Host.PowerShell.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit and integration tests for NuGet.PackageManagement.PowerShellCmdlets.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/Msbuild.Integration.Test.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(NETFXTargetFramework)</TargetFrameworks>
     <Description>Integration tests for NuGet powered msbuild functionalities (restore/pack).</Description>
-    <UseParallelXunit>true</UseParallelXunit>
     <TestProjectType Condition="'$(IsXPlat)' == 'true'">None</TestProjectType>
   </PropertyGroup>
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/NuGet.Commands.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/NuGet.Commands.FuncTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
     <Description>Integration tests for the more involved NuGet.Commands, such as restore.</Description>
-    <UseParallelXunit>true</UseParallelXunit>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/NuGet.Packaging.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/NuGet.Packaging.FuncTest.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Integration tests for the more involved NuGet.Packaging functionality, such as signing.</Description>
   </PropertyGroup>
 
@@ -19,8 +18,6 @@
   <ItemGroup>
     <None Remove="compiler\resources\UntrustedTimestampPackage.nupkg" />
     <None Remove="compiler\resources\TimestampInvalidGenTimePackage.nupkg" />
-    <None Include="xunit.runner.json"
-          CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/NuGet.Protocol.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/NuGet.Protocol.FuncTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
     <Description>Integration tests for the more involved NuGet.Protocol functionality, such as plugins.</Description>
-    <UseParallelXunit>true</UseParallelXunit>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.FuncTests/NuGet.Signing.CrossFramework.Test/NuGet.Signing.CrossFramework.Test.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Signing.CrossFramework.Test/NuGet.Signing.CrossFramework.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>NuGet package signing cross framework test.</Description>
     <TestProjectType Condition="'$(IsXPlat)' == 'true'">None</TestProjectType>
   </PropertyGroup>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
     <Description>Functional tests for nuget in dotnet CLI scenarios, using the NuGet.CommandLine.XPlat assembly.</Description>
-    <UseParallelXunit>true</UseParallelXunit>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/Microsoft.Build.NuGetSdkResolver.Test.csproj
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/Microsoft.Build.NuGetSdkResolver.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for Microsoft.Build.NuGetSdkResolver.</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/NuGet.Build.Tasks.Console.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/NuGet.Build.Tasks.Console.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Build.Tasks.Console.</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/NuGet.Build.Tasks.Pack.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/NuGet.Build.Tasks.Pack.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Build.Tasks.Pack.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/NuGet.Build.Tasks.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/NuGet.Build.Tasks.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Build.Tasks.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NuGet.CommandLine.Xplat.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NuGet.CommandLine.Xplat.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.CommandLine.XPlat.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/NuGet.Commands.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/NuGet.Commands.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Commands.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/NuGet.Common.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/NuGet.Common.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Common.</Description>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/NuGet.Configuration.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/NuGet.Configuration.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Configuration.</Description>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/NuGet.Core.Tests/NuGet.Credentials.Test/NuGet.Credentials.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Credentials.Test/NuGet.Credentials.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Credentials.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/NuGet.DependencyResolver.Core.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/NuGet.DependencyResolver.Core.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.DependencyResolver.Core.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGet.Frameworks.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGet.Frameworks.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Frameworks.</Description>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/NuGet.LibraryModel.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/NuGet.LibraryModel.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.LibraryModel.</Description>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGet.PackageManagement.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGet.PackageManagement.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.PackageManagement.</Description>
     <TestProjectType Condition="'$(IsXPlat)' != 'true'">Functional</TestProjectType>
     <TestProjectType Condition="'$(IsXPlat)' == 'true'">None</TestProjectType>
@@ -16,9 +15,5 @@
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
     <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.VisualStudio.Common\NuGet.VisualStudio.Common.csproj" />
     <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.PackageManagement.VisualStudio\NuGet.PackageManagement.VisualStudio.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Packaging.</Description>
     <!-- remove warnings for obsolete types and methods: SYSLIB0023: RNGCryptoServiceProvider, SYSLIB0026: X509Certificate2() blank constructor -->
     <NoWarn>$(NoWarn);SYSLIB0023;SYSLIB0026</NoWarn>

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/NuGet.ProjectModel.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/NuGet.ProjectModel.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.ProjectModel.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGet.Protocol.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGet.Protocol.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Protocol.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/TaskLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/TaskLogMessageTests.cs
@@ -23,7 +23,8 @@ namespace NuGet.Protocol.Plugins.Tests
 
             var message = VerifyOuterMessageAndReturnInnerMessage(logMessage, now, "task");
 
-            Assert.Equal(5, message.Count);
+            // The message will not have a current task ID if the current task is null meaning only a single thread is running.
+            Assert.Equal(Task.CurrentId.HasValue ? 5 : 4, message.Count);
 
             var actualRequestId = message.Value<string>("request ID");
             var actualMethod = Enum.Parse(typeof(MessageMethod), message.Value<string>("method"));
@@ -35,7 +36,10 @@ namespace NuGet.Protocol.Plugins.Tests
             Assert.Equal(method, actualMethod);
             Assert.Equal(type, actualType);
             Assert.Equal(state, actualState);
-            Assert.Equal(Task.CurrentId, actualCurrentTaskId);
+            if (Task.CurrentId.HasValue)
+            {
+                Assert.Equal(Task.CurrentId, actualCurrentTaskId);
+            }
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Resolver.Test/NuGet.Resolver.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Resolver.Test/NuGet.Resolver.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Resolver.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Shared.Tests/NuGet.Shared.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Shared.Tests/NuGet.Shared.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for the utilities included using shared compilation.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGet.Versioning.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGet.Versioning.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
-    <UseParallelXunit>true</UseParallelXunit>
     <Description>Unit tests for NuGet.Versioning.</Description>
     <nullable>enable</nullable>
   </PropertyGroup>

--- a/test/TestUtilities/Test.Utility/CommandRunner.cs
+++ b/test/TestUtilities/Test.Utility/CommandRunner.cs
@@ -55,7 +55,7 @@ namespace NuGet.Test.Utility
                     process.StartInfo.Environment["UseSharedCompilation"] = bool.FalseString;
                     process.StartInfo.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = bool.TrueString;
                     process.StartInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = bool.TrueString;
-                    process.StartInfo.Environment["SuppressNETCoreSdkPreviewMessage"] = bool.FalseString;
+                    process.StartInfo.Environment["SuppressNETCoreSdkPreviewMessage"] = bool.TrueString;
 
                     if (environmentVariables != null)
                     {

--- a/test/TestUtilities/Test.Utility/CommandRunner.cs
+++ b/test/TestUtilities/Test.Utility/CommandRunner.cs
@@ -53,6 +53,9 @@ namespace NuGet.Test.Utility
                     process.StartInfo.Environment["NUGET_SHOW_STACK"] = bool.TrueString;
                     process.StartInfo.Environment["NuGetTestModeEnabled"] = bool.TrueString;
                     process.StartInfo.Environment["UseSharedCompilation"] = bool.FalseString;
+                    process.StartInfo.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = bool.TrueString;
+                    process.StartInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = bool.TrueString;
+                    process.StartInfo.Environment["SuppressNETCoreSdkPreviewMessage"] = bool.FalseString;
 
                     if (environmentVariables != null)
                     {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2501
Fixes: https://github.com/NuGet/Client.Engineering/issues/2866

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
The Functional tests seem to very unreliable with a few symptoms that this pull request hopefully addresses:
1. Test host process crashing
2. A particular command times out
3. A particular test or set of tests hang, causing ADO to cancel the test run

To attempt to address the issues, I've tweaked the parallelism in the test runner.  There are three settings in the `.runsettings` for parallelism:

| Setting | Purprose | Old value | New Value |
|---|---|---|---|
| `MaxCpuCount` | The number or processes that `vstest.console.exe` spawns to run tests in | 0 | 4 |
| `MaxParallelThreads` | The number of threads that the xunit runner can use at a time | 0 | 4 |
| `ParallelizeAssembly` | Whether or not the xunit test runner should run tests in assemblies in parallel | `true` | `false` |

Since we are currently using the default values for `MaxCpuCount` and `MaxParallelThreads`, as well as enabling `ParallelizeAssembly`, I suspect that `vstest.console.exe` is launching 12 process, each one then runs the tests for each assembly with 12 threads, and if one process is running multiple assemblies, they're happening in parallel.  My suspicion is that we're over parallelizing tests, leading to crashes.  By changing the values to lower, I do not see any increase in test run time and in fact, sometimes the runs are faster.  However, in my testing, I rarely see a test host process crashing anymore.

I also deleted `build\TestShared\xunit.runner.json` and moved the settings to `build\xunit.runsettings` so that everything is defined in one place.  Some projects were opting into test parallelization with the `UseParallelXunit` property which would copy the `xunit.runner.json` to the output directory, while other projects were copying it themselves.  I found it confusing to determine why some projects were allowed to run in parallel and others weren't so I changed how we run tests in parallel and made it uniform across the repo.

Finally, I've disabled the crash dump helper when running tests since all of the memory dumps it provided were always for the main `vstest.console.exe` which wasn't helpful since the tests themselves are running in a different process.  Instead, I've added the `--diag` switch to the call to `dotnet test` and now there's a diagnostic log for the main process and all of the child processes with valuable information.  These logs go to the binlog location and get uploaded when a test run fails or if you enable diagnostics on a particular pipeline run.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
