### PR TITLE
Revert "Enable central package management implicitly when Directory.Packages.props exists (#5572)"

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.props
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.props
@@ -9,32 +9,33 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
+
 <Project>
+
   <!--
-    Determine the path to the 'Directory.Packages.props' file, if the user did not:
-      1. Set $(ManagePackageVersionsCentrally) to false
-      2. Set $(ImportDirectoryPackagesProps) to false
-      3. Already specify the path to a 'Directory.Packages.props' file via $(DirectoryPackagesPropsPath)
+      Import 'Directory.Packages.props' which will contain centralized packages for all the projects and solutions under
+      the directory in which the file is present. This is similar to 'Directory.Build.props/targets' logic which is present
+      in the common props/targets which serve a similar purpose.
   -->
-  <PropertyGroup Condition="'$(ManagePackageVersionsCentrally)' != 'false' And '$(ImportDirectoryPackagesProps)' != 'false' And '$(DirectoryPackagesPropsPath)' == ''">
+
+  <PropertyGroup>
+    <ImportDirectoryPackagesProps Condition="'$(ImportDirectoryPackagesProps)' == ''">true</ImportDirectoryPackagesProps>
+  </PropertyGroup>
+
+  <!--
+      Determine the path to the 'Directory.Packages.props' file, if the user did not disable $(ImportDirectoryPackagesProps) and
+      they did not already specify an absolute path to use via $(DirectoryPackagesPropsPath)
+  -->
+  <PropertyGroup Condition="'$(ImportDirectoryPackagesProps)' == 'true' and '$(DirectoryPackagesPropsPath)' == ''">
     <_DirectoryPackagesPropsFile Condition="'$(_DirectoryPackagesPropsFile)' == ''">Directory.Packages.props</_DirectoryPackagesPropsFile>
     <_DirectoryPackagesPropsBasePath Condition="'$(_DirectoryPackagesPropsBasePath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(MSBuildProjectDirectory)', '$(_DirectoryPackagesPropsFile)'))</_DirectoryPackagesPropsBasePath>
     <DirectoryPackagesPropsPath Condition="'$(_DirectoryPackagesPropsBasePath)' != '' and '$(_DirectoryPackagesPropsFile)' != ''">$([MSBuild]::NormalizePath('$(_DirectoryPackagesPropsBasePath)', '$(_DirectoryPackagesPropsFile)'))</DirectoryPackagesPropsPath>
   </PropertyGroup>
 
-  <!--
-    Default $(ManagePackageVersionsCentrally) to true, import Directory.Packages.props, and set $(CentralPackageVersionsFileImported) to true if the user did not:
-      1. Set $(ManagePackageVersionsCentrally) to false
-      2. Set $(ImportDirectoryPackagesProps) to false
-      3. The path specified in $(DirectoryPackagesPropsPath) exists
-  -->
-  <PropertyGroup Condition="'$(ManagePackageVersionsCentrally)' != 'false' And '$(ImportDirectoryPackagesProps)' != 'false' And Exists('$(DirectoryPackagesPropsPath)')">
-    <ManagePackageVersionsCentrally Condition="'$(ManagePackageVersionsCentrally)' == ''">true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
+  <Import Project="$(DirectoryPackagesPropsPath)" Condition="'$(ImportDirectoryPackagesProps)' == 'true' and '$(DirectoryPackagesPropsPath)' != '' and Exists('$(DirectoryPackagesPropsPath)')"/>
 
-  <Import Project="$(DirectoryPackagesPropsPath)" Condition="'$(ManagePackageVersionsCentrally)' != 'false' And '$(ImportDirectoryPackagesProps)' != 'false' And Exists('$(DirectoryPackagesPropsPath)')" />
-
-  <PropertyGroup Condition="'$(ManagePackageVersionsCentrally)' != 'false' And '$(ImportDirectoryPackagesProps)' != 'false' And Exists('$(DirectoryPackagesPropsPath)')">
+  <PropertyGroup Condition="'$(ImportDirectoryPackagesProps)' == 'true' and '$(DirectoryPackagesPropsPath)' != '' and Exists('$(DirectoryPackagesPropsPath)')">
     <CentralPackageVersionsFileImported>true</CentralPackageVersionsFileImported>
   </PropertyGroup>
+
 </Project>

--- a/test/EndToEnd/Directory.Packages.props
+++ b/test/EndToEnd/Directory.Packages.props
@@ -1,5 +1,1 @@
-<Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-</Project>
+<Project />

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -9184,6 +9184,7 @@ namespace NuGet.CommandLine.Test
                    "a",
                    pathContext.SolutionRoot,
                    NuGetFramework.Parse("net46"));
+                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
 
@@ -9268,6 +9269,7 @@ namespace NuGet.CommandLine.Test
                    "a",
                    pathContext.SolutionRoot,
                    NuGetFramework.Parse("net46"));
+                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
 
@@ -9350,6 +9352,7 @@ namespace NuGet.CommandLine.Test
                    "a",
                    pathContext.SolutionRoot,
                    NuGetFramework.Parse("net46"));
+                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
 
@@ -9423,6 +9426,7 @@ namespace NuGet.CommandLine.Test
                    "a",
                    pathContext.SolutionRoot,
                    NuGetFramework.Parse("net46"));
+                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
 
@@ -9496,6 +9500,7 @@ namespace NuGet.CommandLine.Test
                    "a",
                    pathContext.SolutionRoot,
                    NuGetFramework.Parse("net46"));
+                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
 
@@ -9568,6 +9573,7 @@ namespace NuGet.CommandLine.Test
                    "a",
                    pathContext.SolutionRoot,
                    NuGetFramework.Parse("net46"));
+                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
 
@@ -9670,16 +9676,19 @@ namespace NuGet.CommandLine.Test
                     "a",
                     pathContext.SolutionRoot,
                     netcoreapp2);
+                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
 
                 var projectB = SimpleTestProjectContext.CreateNETCore(
                     "b",
                     pathContext.SolutionRoot,
                     netcoreapp2);
+                projectB.Properties.Add("ManagePackageVersionsCentrally", "true");
 
                 var projectC = SimpleTestProjectContext.CreateNETCore(
                     "c",
                     pathContext.SolutionRoot,
                     netcoreapp2);
+                projectC.Properties.Add("ManagePackageVersionsCentrally", "true");
 
                 var packageX100 = new SimpleTestPackageContext()
                 {
@@ -9812,7 +9821,8 @@ namespace NuGet.CommandLine.Test
                    "projectA",
                    pathContext.SolutionRoot,
                    NuGetFramework.Parse("netcoreapp2.0"));
-                projectA.Properties.Add(ProjectBuildProperties.CentralPackageTransitivePinningEnabled, bool.TrueString);
+                projectA.Properties.Add(ProjectBuildProperties.ManagePackageVersionsCentrally, "true");
+                projectA.Properties.Add(ProjectBuildProperties.CentralPackageTransitivePinningEnabled, "true");
 
                 // the package references defined in the project should not have version
                 var packageBNoVersion = createTestPackage("B", null, packagesForProject);
@@ -9938,13 +9948,13 @@ namespace NuGet.CommandLine.Test
                 var libraries = assetsFile.Libraries.Select(l => $"{l.Name}.{l.Version}").OrderBy(n => n).ToList();
                 Assert.Equal(expectedLibraries, libraries);
 
-                var centralFileDependencyGroups = assetsFile
+                var centralfileDependencyGroups = assetsFile
                     .CentralTransitiveDependencyGroups
                     .SelectMany(g => g.TransitiveDependencies.Select(t => $"{g.FrameworkName}_{t.LibraryRange.Name}.{t.LibraryRange.VersionRange.OriginalString}")).ToList();
 
-                var expectedCentralFileDependencyGroups = new List<string>() { $"{framework.DotNetFrameworkName}_P.[3.0.0, )", $"{framework.DotNetFrameworkName}_S.[3.0.0, )" };
+                var expectedCentralfileDependencyGroups = new List<string>() { $"{framework.DotNetFrameworkName}_P.[3.0.0, )", $"{framework.DotNetFrameworkName}_S.[3.0.0, )" };
 
-                Assert.Equal(expectedCentralFileDependencyGroups, centralFileDependencyGroups);
+                Assert.Equal(expectedCentralfileDependencyGroups, centralfileDependencyGroups);
             }
         }
 
@@ -10062,6 +10072,7 @@ namespace NuGet.CommandLine.Test
                    "projectA",
                    pathContext.SolutionRoot,
                    framework);
+                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
 
                 // the package references defined in the project should not have version
                 var packageBNoVersion = createTestPackage("B", null, packagesForProject);
@@ -10099,70 +10110,11 @@ namespace NuGet.CommandLine.Test
                 var libraries = assetsFile.Libraries.Select(l => $"{l.Name}.{l.Version}").OrderBy(n => n).ToList();
                 Assert.Equal(expectedLibraries, libraries);
 
-                var centralFileDependencyGroups = assetsFile
+                var centralfileDependencyGroups = assetsFile
                     .CentralTransitiveDependencyGroups
                     .SelectMany(g => g.TransitiveDependencies.Select(t => $"{g.FrameworkName}_{t.LibraryRange.Name}.{t.LibraryRange.VersionRange.OriginalString}")).ToList();
 
-                Assert.Equal(0, centralFileDependencyGroups.Count);
-            }
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        [InlineData(null)]
-        public async Task RestoreNetCore_CPVMProject_ManagePackageVersionsCentrally_CanBeDisabled(bool? managePackageVersionsCentrally)
-        {
-            // Arrange
-            using var pathContext = new SimpleTestPathContext();
-
-            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-
-            var packageA = new SimpleTestPackageContext("A", "1.0.0");
-
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageA);
-
-            var projectA = SimpleTestProjectContext.CreateNETCore("projectA", pathContext.SolutionRoot, "net472");
-
-            if (managePackageVersionsCentrally is null || managePackageVersionsCentrally == true)
-            {
-                packageA.Version = null;
-            }
-
-            projectA.AddPackageToAllFrameworks(packageA);
-
-            solution.CentralPackageVersionsManagementFile = CentralPackageVersionsManagementFile.Create(pathContext.SolutionRoot, managePackageVersionsCentrally)
-                .SetPackageVersion("A", "1.0.0");
-
-            solution.Projects.Add(projectA);
-            solution.Create(pathContext.SolutionRoot);
-
-            // Act
-            var result = Util.RestoreSolution(pathContext);
-
-            // Assert
-            result.Success.Should().BeTrue();
-
-            var assetFileReader = new LockFileFormat();
-            var assetsFile = assetFileReader.Read(projectA.AssetsFileOutputPath);
-
-            assetsFile.Libraries.Select(l => $"{l.Name}.{l.Version}").Should().BeEquivalentTo(new string[] { "A.1.0.0" });
-
-            var targetFramework = assetsFile.PackageSpec.TargetFrameworks.Should().ContainSingle();
-
-            if (managePackageVersionsCentrally is null || managePackageVersionsCentrally == true)
-            {
-                targetFramework.Subject.Dependencies.Should().ContainSingle()
-                    .Which.VersionCentrallyManaged.Should().BeTrue();
-
-                targetFramework.Subject.CentralPackageVersions.Should().ContainSingle()
-                    .Which.Value.Should().Be(new CentralPackageVersion("A", VersionRange.Parse("1.0.0")));
-            }
-            else
-            {
-                targetFramework.Subject.Dependencies.Should().ContainSingle()
-                    .Which.VersionCentrallyManaged.Should().BeFalse();
-                targetFramework.Subject.CentralPackageVersions.Should().BeEmpty();
+                Assert.Equal(0, centralfileDependencyGroups.Count);
             }
         }
 
@@ -10296,6 +10248,8 @@ namespace NuGet.CommandLine.Test
 
                 var projectA = SimpleTestProjectContext.CreateNETCore("projectA", pathContext.SolutionRoot, framework);
 
+                projectA.Properties.Add("ManagePackageVersionsCentrally", "true");
+
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(
                    pathContext.PackageSource,
                    new[]
@@ -10354,11 +10308,11 @@ namespace NuGet.CommandLine.Test
                 var libraries = assetsFile.Libraries.Select(l => $"{l.Name}.{l.Version}").OrderBy(n => n).ToList();
                 Assert.Equal(expectedLibraries, libraries);
 
-                var centralFileDependencyGroups = assetsFile
+                var centralfileDependencyGroups = assetsFile
                     .CentralTransitiveDependencyGroups
                     .SelectMany(g => g.TransitiveDependencies.Select(t => $"{g.FrameworkName}_{t.LibraryRange.Name}.{t.LibraryRange.VersionRange.OriginalString}")).ToList();
 
-                Assert.Equal(0, centralFileDependencyGroups.Count);
+                Assert.Equal(0, centralfileDependencyGroups.Count);
             }
         }
 
@@ -10375,6 +10329,7 @@ namespace NuGet.CommandLine.Test
 
                 var projectA = SimpleTestProjectContext.CreateNETCore("projectA", pathContext.SolutionRoot, framework);
 
+                projectA.Properties.Add(ProjectBuildProperties.ManagePackageVersionsCentrally, bool.TrueString);
                 projectA.Properties.Add(ProjectBuildProperties.CentralPackageVersionOverrideEnabled, bool.FalseString);
 
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(
@@ -11375,6 +11330,11 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 
                 var xml = projectA.GetXML();
 
+                ProjectFileUtils.AddProperty(
+                    xml,
+                    "ManagePackageVersionsCentrally",
+                    "true");
+
                 ProjectFileUtils.AddItem(
                                     xml,
                                     "PackageReference",
@@ -11585,6 +11545,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                     pathContext.SolutionRoot,
                     "net472");
 
+                projectContext.Properties.Add("ManagePackageVersionsCentrally", "true");
                 projectContext.Properties.Add("CentralPackageTransitivePinningEnabled", centralPackageTransitivePinningEnabled.ToString());
 
                 if (referencedProject != null)

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -693,7 +693,12 @@ namespace Dotnet.Integration.Test
                     packageX100,
                     packageX200);
 
-            var propsFile = @$"<Project />";
+            var propsFile = @$"<Project>
+                                <PropertyGroup>
+                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                </PropertyGroup>
+                            </Project>
+                            ";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -736,7 +741,12 @@ namespace Dotnet.Integration.Test
                     packageX100,
                     packageX200);
 
-            var propsFile = @$"<Project />";
+            var propsFile = @$"<Project>
+                                <PropertyGroup>
+                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                </PropertyGroup>
+                            </Project>
+                            ";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -777,10 +787,14 @@ namespace Dotnet.Integration.Test
                     packageX200);
 
             var propsFile = @$"<Project>
-  <ItemGroup>
-    <PackageVersion Include=""X"" Version=""1.0.0"" />
-  </ItemGroup>
-</Project>";
+                                <PropertyGroup>
+                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                </PropertyGroup>
+                                <ItemGroup>
+                                <PackageVersion Include=""X"" Version=""1.0.0"" />
+                                </ItemGroup>
+                            </Project>
+                            ";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -824,10 +838,14 @@ namespace Dotnet.Integration.Test
                     packageX200);
 
             var propsFile = @$"<Project>
-  <ItemGroup>
-    <PackageVersion Include=""X"" Version=""1.0.0"" />
-  </ItemGroup>
-</Project>";
+                                <PropertyGroup>
+                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                </PropertyGroup>
+                                <ItemGroup>
+                                <PackageVersion Include=""X"" Version=""1.0.0"" />
+                                </ItemGroup>
+                            </Project>
+                            ";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -870,6 +888,9 @@ namespace Dotnet.Integration.Test
                     packageX100);
 
             var propsFile = @$"<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
   <ItemGroup>
     <Content Include=""SomeFile"" />
   </ItemGroup>
@@ -924,7 +945,12 @@ namespace Dotnet.Integration.Test
                     packageX100,
                     packageX200);
 
-            var propsFile = @$"<Project />";
+            var propsFile = @$"<Project>
+                                <PropertyGroup>
+                                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                </PropertyGroup>
+                            </Project>
+                            ";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -981,7 +1007,12 @@ namespace Dotnet.Integration.Test
                     packageX100,
                     packageX200);
 
-            var propsFile = @$"<Project />";
+            var propsFile = @$"<Project>
+                                <PropertyGroup>
+                                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                </PropertyGroup>
+                            </Project>
+                            ";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1039,10 +1070,14 @@ namespace Dotnet.Integration.Test
                     packageX200);
 
             var propsFile = @$"<Project>
-    <ItemGroup>
-        <PackageVersion Include=""X"" Version=""1.0.0"" />
-    </ItemGroup>
-</Project>";
+                                <PropertyGroup>
+                                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                    <ItemGroup>
+                                        <PackageVersion Include=""X"" Version=""1.0.0"" />
+                                    </ItemGroup>
+                                </PropertyGroup>
+                            </Project>
+                            ";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1064,11 +1099,13 @@ namespace Dotnet.Integration.Test
             File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "projectA", "projectA.csproj"), projectContent);
 
             //Act
-            var result = _fixture.RunDotnetExpectSuccess(projectADirectory, $"add {projectA.ProjectPath} package {packageX} ");
+            var result = _fixture.RunDotnetExpectFailure(projectADirectory, $"add {projectA.ProjectPath} package {packageX} ");
 
             // Assert
             Assert.DoesNotContain("error: Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion items: X", result.Output);
-            Assert.Contains(@$"<PackageVersion Include=""{packageX}"" Version=""{version1}"" />", File.ReadAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props")));
+            Assert.Contains(@$"<ItemGroup>
+                                        <PackageVersion Include=""X"" Version=""1.0.0"" />
+                                    </ItemGroup>", File.ReadAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props")));
             Assert.Contains(@$"<ItemGroup>
         <PackageReference Include=""X"" />
     </ItemGroup>", File.ReadAllText(Path.Combine(projectADirectory, "projectA.csproj")));
@@ -1098,10 +1135,14 @@ namespace Dotnet.Integration.Test
                     packageX200);
 
             var propsFile = @$"<Project>
-  <ItemGroup>
-    <PackageVersion Include=""X"" Version=""1.0.0"" />
-  </ItemGroup>
-</Project>";
+                                <PropertyGroup>
+                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                </PropertyGroup>
+                                <ItemGroup>
+                                <PackageVersion Include=""X"" Version=""1.0.0"" />
+                                </ItemGroup>
+                            </Project>
+                            ";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1154,7 +1195,12 @@ namespace Dotnet.Integration.Test
                     packageX100,
                     packageX200);
 
-            var propsFile = @$"<Project />";
+            var propsFile = @$"<Project>
+                                <PropertyGroup>
+                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                </PropertyGroup>
+                            </Project>
+                            ";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1211,7 +1257,12 @@ namespace Dotnet.Integration.Test
                     packageX100,
                     packageX200);
 
-            var propsFile = @$"<Project />";
+            var propsFile = @$"<Project>
+                                <PropertyGroup>
+                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                </PropertyGroup>
+                            </Project>
+                            ";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1268,10 +1319,14 @@ namespace Dotnet.Integration.Test
                     packageX200);
 
             var propsFile = @$"<Project>
-  <ItemGroup>
-    <PackageVersion Include=""X"" Version=""1.0.0"" />
-  </ItemGroup>
-</Project>";
+                                <PropertyGroup>
+                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                </PropertyGroup>
+                                <ItemGroup>
+                                <PackageVersion Include=""X"" Version=""1.0.0"" />
+                                </ItemGroup>
+                            </Project>
+                            ";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1297,7 +1352,9 @@ namespace Dotnet.Integration.Test
 
             // Assert
             Assert.DoesNotContain("error: Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion items: X", result.Output);
-            Assert.Contains(@$"<PackageVersion Include=""X"" Version=""1.0.0"" />", File.ReadAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props")));
+            Assert.Contains(@$"<ItemGroup>
+                                <PackageVersion Include=""X"" Version=""1.0.0"" />
+                                </ItemGroup>", File.ReadAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props")));
             Assert.Contains(@$"<ItemGroup>
         <PackageReference Include=""X"" VersionOverride=""1.0.0""/>
     </ItemGroup>", File.ReadAllText(Path.Combine(projectADirectory, "projectA.csproj")));
@@ -1327,10 +1384,14 @@ namespace Dotnet.Integration.Test
                     packageX200);
 
             var propsFile = @$"<Project>
-  <ItemGroup>
-    <PackageVersion Include=""X"" Version=""1.0.0"" />
-  </ItemGroup>
-</Project>";
+                                <PropertyGroup>
+                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                </PropertyGroup>
+                                <ItemGroup>
+                                <PackageVersion Include=""X"" Version=""1.0.0"" />
+                                </ItemGroup>
+                            </Project>
+                            ";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1387,10 +1448,14 @@ namespace Dotnet.Integration.Test
                     packageX200);
 
             var propsFile = @$"<Project>
-  <ItemGroup>
-    <PackageVersion Include=""X"" Version=""1.0.0"" />
-  </ItemGroup>
-</Project>";
+                                <PropertyGroup>
+                                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                </PropertyGroup>
+                                <ItemGroup>
+                                <PackageVersion Include=""X"" Version=""1.0.0"" />
+                                </ItemGroup>
+                            </Project>
+                            ";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1447,11 +1512,15 @@ namespace Dotnet.Integration.Test
                     packageX200);
 
             var propsFile = @$"<Project>
-  <ItemGroup>
-    <PackageVersion Include=""X"" Version=""1.0.0"" />
-    <PackageReference Include=""X"" VersionOverride=""1.0.0""/>
-  </ItemGroup>
-</Project>";
+                                    <PropertyGroup>
+                                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                    </PropertyGroup>
+                                    <ItemGroup>
+                                    <PackageVersion Include=""X"" Version=""1.0.0"" />
+                                    <PackageReference Include=""X"" VersionOverride=""1.0.0""/>
+                                    </ItemGroup>
+                                </Project>
+                                ";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1503,7 +1572,12 @@ namespace Dotnet.Integration.Test
                     packageX100,
                     packageX200);
 
-            var propsFile = @$"<Project />";
+            var propsFile = @$"<Project>
+                                    <PropertyGroup>
+                                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                    </PropertyGroup>
+                                </Project>
+                                ";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);
@@ -1560,7 +1634,12 @@ namespace Dotnet.Integration.Test
                     packageX100,
                     packageX200);
 
-            var propsFile = @$"<Project />";
+            var propsFile = @$"<Project>
+                                    <PropertyGroup>
+                                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                    </PropertyGroup>
+                                </Project>
+                                ";
 
             solution.Projects.Add(projectA);
             solution.Create(pathContext.SolutionRoot);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -100,7 +100,10 @@ namespace Dotnet.Integration.Test
 
                 var propsFile =
 @$"<Project>
-   <ItemGroup>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
         <PackageVersion Include=""X"" Version=""[0.1.0,)"" />
     </ItemGroup>
 </Project>";
@@ -149,6 +152,9 @@ namespace Dotnet.Integration.Test
 
                 var propsFile =
 @$"<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include=""X"" Version=""2.0.0"" />
     </ItemGroup>
@@ -196,6 +202,9 @@ namespace Dotnet.Integration.Test
 
                 var propsFile =
 @$"<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
     <ItemGroup>
         <GlobalPackageReference Include=""X"" Version=""0.1.0"" />
     </ItemGroup>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -1758,6 +1758,10 @@ EndGlobal";
                 using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
                 {
                     var xml = XDocument.Load(stream);
+                    ProjectFileUtils.AddProperty(
+                        xml,
+                        "ManagePackageVersionsCentrally",
+                        "true");
 
                     ProjectFileUtils.AddItem(
                          xml,
@@ -2302,6 +2306,10 @@ EndGlobal";
                 using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
                 {
                     var xml = XDocument.Load(stream);
+                    ProjectFileUtils.AddProperty(
+                        xml,
+                        "ManagePackageVersionsCentrally",
+                        "true");
 
                     ProjectFileUtils.AddItem(
                          xml,
@@ -2484,6 +2492,7 @@ EndGlobal";
                 {
                     var xml = XDocument.Load(stream);
                     ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", Constants.DefaultTargetFramework.GetShortFolderName());
+                    ProjectFileUtils.AddProperty(xml, "ManagePackageVersionsCentrally", "true");
 
                     ProjectFileUtils.AddItem(
                         xml,

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -5202,10 +5202,10 @@ namespace ClassLibrary
         }
 
         [PlatformTheory(Platform.Windows)]
-        [InlineData(false)]
-        [InlineData(true)]
+        [InlineData("false")]
+        [InlineData("true")]
         [InlineData(null)]
-        public void PackCommand_PackProjectWithCentralTransitiveDependencies(bool? centralPackageTransitivePinningEnabled)
+        public void PackCommand_PackProjectWithCentralTransitiveDependencies(string CentralPackageTransitivePinningEnabled)
         {
             using (var testDirectory = msbuildFixture.CreateTestDirectory())
             {
@@ -5228,24 +5228,33 @@ namespace ClassLibrary
                         new Dictionary<string, string>(),
                         new Dictionary<string, string>());
 
-                    if (centralPackageTransitivePinningEnabled.HasValue)
+                    ProjectFileUtils.AddProperty(
+                        xml,
+                        ProjectBuildProperties.ManagePackageVersionsCentrally,
+                        "true");
+
+                    if (CentralPackageTransitivePinningEnabled != null)
                     {
                         ProjectFileUtils.AddProperty(
                             xml,
                             ProjectBuildProperties.CentralPackageTransitivePinningEnabled,
-                            centralPackageTransitivePinningEnabled.ToString());
+                            CentralPackageTransitivePinningEnabled);
                     }
 
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
 
                 // The test depends on the presence of these packages and their versions.
-                var directoryPackagesPropsName = Path.Combine(workingDirectory, "Directory.Packages.props");
+                // Change to Directory.Packages.props when new cli that supports NuGet.props will be downloaded
+                var directoryPackagesPropsName = Path.Combine(workingDirectory, $"Directory.Build.props");
                 var directoryPackagesPropsContent = @"<Project>
                         <ItemGroup>
-                            <PackageVersion Include=""Moq"" Version=""4.10.0""/>
-                            <PackageVersion Include=""Castle.Core"" Version=""4.4.0""/>
+                            <PackageVersion Include = ""Moq"" Version = ""4.10.0""/>
+                            <PackageVersion Include = ""Castle.Core"" Version = ""4.4.0""/>
                         </ItemGroup>
+                        <PropertyGroup>
+	                        <CentralPackageVersionsFileImported>true</CentralPackageVersionsFileImported>
+                        </PropertyGroup>
                     </Project>";
                 File.WriteAllText(directoryPackagesPropsName, directoryPackagesPropsContent);
 
@@ -5266,7 +5275,7 @@ namespace ClassLibrary
                     Assert.Equal(1, dependencyGroups.Count);
                     Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard20, dependencyGroups[0].TargetFramework);
                     var packages = dependencyGroups[0].Packages.ToList();
-                    if (centralPackageTransitivePinningEnabled == true)
+                    if (CentralPackageTransitivePinningEnabled == "true")
                     {
                         Assert.Equal(2, packages.Count);
                         var moqPackage = packages.Where(p => p.Id.Equals("Moq", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -99,13 +99,14 @@ namespace Msbuild.Integration.Test
         internal CommandRunnerResult RunMsBuild(string workingDirectory, string args, bool ignoreExitCode = false)
         {
             var restoreDllPath = Path.Combine(_testDir, "NuGet.Build.Tasks.dll");
+            var nugetRestorePropsPath = Path.Combine(_testDir, "NuGet.props");
             var nugetRestoreTargetsPath = Path.Combine(_testDir, "NuGet.targets");
             // Uncomment to debug the msbuild call
             // _processEnvVars.Add("DEBUG_RESTORE_TASK", "true");
             _processEnvVars["UNIT_TEST_RESTORE_TASK"] = bool.TrueString;
             var result = CommandRunner.Run(_msbuildPath.Value,
                 workingDirectory,
-                $"/p:NuGetRestoreTargets={nugetRestoreTargetsPath} /p:RestoreTaskAssemblyFile={restoreDllPath} /p:ImportNuGetBuildTasksPackTargetsFromSdk=true {args}",
+                $"/p:NuGetPropsFile={nugetRestorePropsPath} /p:NuGetRestoreTargets={nugetRestoreTargetsPath} /p:RestoreTaskAssemblyFile={restoreDllPath} /p:ImportNuGetBuildTasksPackTargetsFromSdk=true {args}",
                 environmentVariables: _processEnvVars);
 
             if (!ignoreExitCode)

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -1300,6 +1300,9 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             File.WriteAllText(
                 Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props"),
                 @$"<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
   <ItemGroup>
     <GlobalPackageReference Include=""PackageA"" Version=""1.2.3"" />
     <GlobalPackageReference Include=""PackageB"" Version=""4.5.6"" />

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
@@ -44,7 +44,13 @@ namespace NuGet.CommandLine.Xplat.Tests
                 ProjectCollection = projectCollection
             };
 
-            File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), @$"<Project />");
+            var propsFile =
+@$"<Project>
+    <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+</Project>";
+            File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);
 
             string projectContent =
 @$"<Project Sdk=""Microsoft.NET.Sdk"">    
@@ -198,7 +204,13 @@ namespace NuGet.CommandLine.Xplat.Tests
             };
 
             // Arrange Directory.Packages.props file
-            File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), "<Project />");
+            var propsFile =
+@$"<Project>
+    <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+</Project>";
+            File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);
 
             // Arrange project file
             string projectContent =
@@ -259,8 +271,11 @@ namespace NuGet.CommandLine.Xplat.Tests
             // Arrange Directory.Packages.props file
             var propsFile =
 @$"<Project>
+    <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
     <ItemGroup>
-        <PackageVersion Include=""X"" Version=""1.0.0"" />
+    <PackageVersion Include=""X"" Version=""1.0.0"" />
     </ItemGroup>
 </Project>";
             File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);
@@ -325,8 +340,11 @@ namespace NuGet.CommandLine.Xplat.Tests
             // Arrange Directory.Packages.props file
             var propsFile =
 @$"<Project>
+    <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
     <ItemGroup>
-        <PackageVersion Include=""X"" Version=""1.0.0"" />
+    <PackageVersion Include=""X"" Version=""1.0.0"" />
     </ItemGroup>
 </Project>";
             File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);
@@ -391,8 +409,11 @@ namespace NuGet.CommandLine.Xplat.Tests
             // Arrange Directory.Packages.props file
             var propsFile =
 @$"<Project>
+    <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
     <ItemGroup>
-        <PackageVersion Include=""X"" Version=""1.0.0"" />
+    <PackageVersion Include=""X"" Version=""1.0.0"" />
     </ItemGroup>
 </Project>";
             File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);

--- a/test/TestUtilities/Test.Utility/CentralPackageVersionsManagementFile.cs
+++ b/test/TestUtilities/Test.Utility/CentralPackageVersionsManagementFile.cs
@@ -17,7 +17,7 @@ namespace NuGet.Test.Utility
     {
         private const string DirectoryPackagesProps = "Directory.Packages.props";
 
-        private readonly bool? _managePackageVersionsCentrally;
+        private readonly bool _managePackageVersionsCentrally;
 
         private readonly Dictionary<string, string> _packageVersions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -25,7 +25,7 @@ namespace NuGet.Test.Utility
 
         private readonly FileInfo _path;
 
-        private CentralPackageVersionsManagementFile(string directoryPath, bool? managePackageVersionsCentrally)
+        private CentralPackageVersionsManagementFile(string directoryPath, bool managePackageVersionsCentrally)
         {
             _path = new FileInfo(Path.Combine(directoryPath, DirectoryPackagesProps));
             _managePackageVersionsCentrally = managePackageVersionsCentrally;
@@ -47,7 +47,7 @@ namespace NuGet.Test.Utility
         /// <param name="directoryPath">The path to a directory to create the central package management in.</param>
         /// <param name="managePackageVersionsCentrally"><see langword="true" /> to enable central package management (default), or <see langword="false" /> to disable it.</param>
         /// <returns></returns>
-        public static CentralPackageVersionsManagementFile Create(string directoryPath, bool? managePackageVersionsCentrally = null)
+        public static CentralPackageVersionsManagementFile Create(string directoryPath, bool managePackageVersionsCentrally = true)
         {
             return new CentralPackageVersionsManagementFile(directoryPath, managePackageVersionsCentrally);
         }
@@ -59,11 +59,6 @@ namespace NuGet.Test.Utility
         /// <returns>The current <see cref="CentralPackageVersionsManagementFile" />.</returns>
         public CentralPackageVersionsManagementFile RemovePackageVersion(string packageId)
         {
-            if (_managePackageVersionsCentrally == false)
-            {
-                return this;
-            }
-
             _packageVersions.Remove(packageId);
 
             IsDirty = true;
@@ -76,13 +71,10 @@ namespace NuGet.Test.Utility
         /// </summary>
         public void Save()
         {
-            XElement managePackageVersionsCentrallyProperty = _managePackageVersionsCentrally is null
-                ? null
-                : new XElement("PropertyGroup", new XElement(ProjectBuildProperties.ManagePackageVersionsCentrally, new XText(_managePackageVersionsCentrally.ToString())));
-
             XDocument directoryPackagesPropsXml = new XDocument(
                 new XElement("Project",
-                    managePackageVersionsCentrallyProperty,
+                    new XElement("PropertyGroup",
+                        new XElement(ProjectBuildProperties.ManagePackageVersionsCentrally, new XText(_managePackageVersionsCentrally.ToString()))),
                     new XElement("ItemGroup", _packageVersions.Select(i => new XElement("PackageVersion", new XAttribute("Include", i.Key), new XAttribute("Version", i.Value)))),
                     new XElement("ItemGroup", _globalPackageReferences.Select(i => new XElement("GlobalPackageReference", new XAttribute("Include", i.Key), new XAttribute("Version", i.Value))))));
 
@@ -99,11 +91,6 @@ namespace NuGet.Test.Utility
         /// <returns>The current <see cref="CentralPackageVersionsManagementFile" />.</returns>
         public CentralPackageVersionsManagementFile SetPackageVersion(string packageId, string packageVersion)
         {
-            if (_managePackageVersionsCentrally == false)
-            {
-                return this;
-            }
-
             _packageVersions[packageId] = packageVersion;
 
             IsDirty = true;
@@ -113,11 +100,6 @@ namespace NuGet.Test.Utility
 
         public CentralPackageVersionsManagementFile SetGlobalPackageReference(string packageId, string packageVersion)
         {
-            if (_managePackageVersionsCentrally == false)
-            {
-                return this;
-            }
-
             _globalPackageReferences[packageId] = packageVersion;
 
             IsDirty = true;

--- a/test/TestUtilities/Test.Utility/TestFileSystemUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestFileSystemUtility.cs
@@ -54,13 +54,7 @@ namespace NuGet.Test.Utility
                     File.WriteAllText(Path.Combine(testDirectory.FullName, "Directory.Build.props"), "<Project />");
                     File.WriteAllText(Path.Combine(testDirectory.FullName, "Directory.Build.targets"), "<Project />");
                     File.WriteAllText(Path.Combine(testDirectory.FullName, "Directory.Build.rsp"), string.Empty);
-                    File.WriteAllText(
-                        Path.Combine(testDirectory.FullName, "Directory.Packages.props"),
-                        @"<Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-</Project>");
+                    File.WriteAllText(Path.Combine(testDirectory.FullName, "Directory.Packages.props"), "<Project />");
                 }
                 catch (Exception)
                 {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Re-opens: https://github.com/NuGet/Home/issues/11834

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This reverts commit c9b81ab1265f18f4471c229ac2d6b13294d91655 in the `release-6.10.x` while https://github.com/NuGet/NuGet.Client/pull/5876 reverts it in the `dev` branch.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
