### PR TITLE
Catch all RestoreCommand exceptions and log them as an error

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
 ~static NuGet.Commands.MSBuildRestoreUtility.GetRestoreAuditProperties(NuGet.Commands.IMSBuildItem specItem, System.Collections.Generic.HashSet<string> suppressionItems) -> NuGet.ProjectModel.RestoreAuditProperties
+~NuGet.Commands.RestoreSummary.RestoreSummary(bool success, System.Collections.Generic.IEnumerable<NuGet.Common.RestoreLogMessage> errors) -> void

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
 ~static NuGet.Commands.MSBuildRestoreUtility.GetRestoreAuditProperties(NuGet.Commands.IMSBuildItem specItem, System.Collections.Generic.HashSet<string> suppressionItems) -> NuGet.ProjectModel.RestoreAuditProperties
+~NuGet.Commands.RestoreSummary.RestoreSummary(bool success, System.Collections.Generic.IEnumerable<NuGet.Common.RestoreLogMessage> errors) -> void

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
 ~static NuGet.Commands.MSBuildRestoreUtility.GetRestoreAuditProperties(NuGet.Commands.IMSBuildItem specItem, System.Collections.Generic.HashSet<string> suppressionItems) -> NuGet.ProjectModel.RestoreAuditProperties
+~NuGet.Commands.RestoreSummary.RestoreSummary(bool success, System.Collections.Generic.IEnumerable<NuGet.Common.RestoreLogMessage> errors) -> void

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -86,6 +86,8 @@ namespace NuGet.Commands
                     {
                         RestoreLogMessage restoreLogMessage = new RestoreLogMessage(LogLevel.Error, ex.Message);
                         RestoreSummary restoreSummary = new RestoreSummary(success: false, errors: new List<RestoreLogMessage>() { restoreLogMessage });
+                        log.LogError(ex.Message);
+                        restoreSummaries.Add(restoreSummary);
                     }
 #pragma warning restore CA1031 // Do not catch general exception types
                 }
@@ -109,6 +111,8 @@ namespace NuGet.Commands
                 {
                     RestoreLogMessage restoreLogMessage = new RestoreLogMessage(LogLevel.Error, ex.Message);
                     RestoreSummary restoreSummary = new RestoreSummary(success: false, errors: new List<RestoreLogMessage>() { restoreLogMessage });
+                    log.LogError(ex.Message);
+                    restoreSummaries.Add(restoreSummary);
                 }
 #pragma warning restore CA1031 // Do not catch general exception types
             }
@@ -265,7 +269,7 @@ namespace NuGet.Commands
 
             // Run the restore
             var request = summaryRequest.Request;
-
+            if (request.Project.FilePath == "N:\\trash\\multiprojectWithOneErrors\\bad\\bad.csproj") { throw new Exception("Test error"); }
             var command = new RestoreCommand(request);
             if (NuGetEventSource.IsEnabled) TraceEvents.RestoreProjectStart(request.Project.FilePath);
             var result = await command.ExecuteAsync(token);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -269,7 +269,6 @@ namespace NuGet.Commands
 
             // Run the restore
             var request = summaryRequest.Request;
-            if (request.Project.FilePath == "N:\\trash\\multiprojectWithOneErrors\\bad\\bad.csproj") { throw new Exception("Test error"); }
             var command = new RestoreCommand(request);
             if (NuGetEventSource.IsEnabled) TraceEvents.RestoreProjectStart(request.Project.FilePath);
             var result = await command.ExecuteAsync(token);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -269,6 +269,7 @@ namespace NuGet.Commands
 
             // Run the restore
             var request = summaryRequest.Request;
+
             var command = new RestoreCommand(request);
             if (NuGetEventSource.IsEnabled) TraceEvents.RestoreProjectStart(request.Project.FilePath);
             var result = await command.ExecuteAsync(token);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -84,9 +84,9 @@ namespace NuGet.Commands
                     }
                     catch (Exception ex)
                     {
-                        RestoreLogMessage restoreLogMessage = new RestoreLogMessage(LogLevel.Error, ex.Message);
-                        RestoreSummary restoreSummary = new RestoreSummary(success: false, errors: new List<RestoreLogMessage>() { restoreLogMessage });
-                        log.LogError(ex.Message);
+                        var unWrapped = ExceptionUtilities.Unwrap(ex) as ILogMessageException;
+                        RestoreSummary restoreSummary = new RestoreSummary(success: false, errors: new List<RestoreLogMessage>() { unWrapped.AsLogMessage() as RestoreLogMessage });
+                        ExceptionUtilities.LogException(ex, log);
                         restoreSummaries.Add(restoreSummary);
                     }
 #pragma warning restore CA1031 // Do not catch general exception types
@@ -109,9 +109,9 @@ namespace NuGet.Commands
                 }
                 catch (Exception ex)
                 {
-                    RestoreLogMessage restoreLogMessage = new RestoreLogMessage(LogLevel.Error, ex.Message);
-                    RestoreSummary restoreSummary = new RestoreSummary(success: false, errors: new List<RestoreLogMessage>() { restoreLogMessage });
-                    log.LogError(ex.Message);
+                    var unWrapped = ExceptionUtilities.Unwrap(ex) as ILogMessageException;
+                    RestoreSummary restoreSummary = new RestoreSummary(success: false, errors: new List<RestoreLogMessage>() { unWrapped.AsLogMessage() as RestoreLogMessage });
+                    ExceptionUtilities.LogException(ex, log);
                     restoreSummaries.Add(restoreSummary);
                 }
 #pragma warning restore CA1031 // Do not catch general exception types

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -76,8 +76,18 @@ namespace NuGet.Commands
                 // Throttle and wait for a task to finish if we have hit the limit
                 if (restoreTasks.Count == maxTasks)
                 {
-                    var restoreSummary = await CompleteTaskAsync(restoreTasks);
-                    restoreSummaries.Add(restoreSummary);
+#pragma warning disable CA1031 // Do not catch general exception types
+                    try
+                    {
+                        var restoreSummary = await CompleteTaskAsync(restoreTasks);
+                        restoreSummaries.Add(restoreSummary);
+                    }
+                    catch (Exception ex)
+                    {
+                        RestoreLogMessage restoreLogMessage = new RestoreLogMessage(LogLevel.Error, ex.Message);
+                        RestoreSummary restoreSummary = new RestoreSummary(success: false, errors: new List<RestoreLogMessage>() { restoreLogMessage });
+                    }
+#pragma warning restore CA1031 // Do not catch general exception types
                 }
 
                 var request = requests.Dequeue();
@@ -89,8 +99,18 @@ namespace NuGet.Commands
             // Wait for all restores to finish
             while (restoreTasks.Count > 0)
             {
-                var restoreSummary = await CompleteTaskAsync(restoreTasks);
-                restoreSummaries.Add(restoreSummary);
+#pragma warning disable CA1031 // Do not catch general exception types
+                try
+                {
+                    var restoreSummary = await CompleteTaskAsync(restoreTasks);
+                    restoreSummaries.Add(restoreSummary);
+                }
+                catch (Exception ex)
+                {
+                    RestoreLogMessage restoreLogMessage = new RestoreLogMessage(LogLevel.Error, ex.Message);
+                    RestoreSummary restoreSummary = new RestoreSummary(success: false, errors: new List<RestoreLogMessage>() { restoreLogMessage });
+                }
+#pragma warning restore CA1031 // Do not catch general exception types
             }
 
             // Summary

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -84,10 +84,7 @@ namespace NuGet.Commands
                     }
                     catch (Exception ex)
                     {
-                        var unWrapped = ExceptionUtilities.Unwrap(ex) as ILogMessageException;
-                        RestoreSummary restoreSummary = new RestoreSummary(success: false, errors: new List<RestoreLogMessage>() { unWrapped.AsLogMessage() as RestoreLogMessage });
-                        ExceptionUtilities.LogException(ex, log);
-                        restoreSummaries.Add(restoreSummary);
+                        HandleRestoreException(ex, restoreSummaries, log);
                     }
 #pragma warning restore CA1031 // Do not catch general exception types
                 }
@@ -109,16 +106,21 @@ namespace NuGet.Commands
                 }
                 catch (Exception ex)
                 {
-                    var unWrapped = ExceptionUtilities.Unwrap(ex) as ILogMessageException;
-                    RestoreSummary restoreSummary = new RestoreSummary(success: false, errors: new List<RestoreLogMessage>() { unWrapped.AsLogMessage() as RestoreLogMessage });
-                    ExceptionUtilities.LogException(ex, log);
-                    restoreSummaries.Add(restoreSummary);
+                    HandleRestoreException(ex, restoreSummaries, log);
                 }
 #pragma warning restore CA1031 // Do not catch general exception types
             }
 
             // Summary
             return restoreSummaries;
+        }
+
+        private static void HandleRestoreException(Exception ex, List<RestoreSummary> restoreSummaries, ILogger log)
+        {
+            var unWrapped = ExceptionUtilities.Unwrap(ex) as ILogMessageException;
+            RestoreSummary restoreSummary = new RestoreSummary(success: false, errors: new List<RestoreLogMessage>() { unWrapped.AsLogMessage() as RestoreLogMessage });
+            ExceptionUtilities.LogException(ex, log);
+            restoreSummaries.Add(restoreSummary);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -118,6 +118,10 @@ namespace NuGet.Commands
         private static void HandleRestoreException(Exception ex, List<RestoreSummary> restoreSummaries, ILogger log)
         {
             var unWrapped = ExceptionUtilities.Unwrap(ex) as ILogMessageException;
+            if (unWrapped is null)
+            {
+                unWrapped = new RestoreCommandException(new RestoreLogMessage(LogLevel.Error, ex.Message));
+            }
             RestoreSummary restoreSummary = new RestoreSummary(success: false, errors: new List<RestoreLogMessage>() { unWrapped.AsLogMessage() as RestoreLogMessage });
             ExceptionUtilities.LogException(ex, log);
             restoreSummaries.Add(restoreSummary);
@@ -271,7 +275,7 @@ namespace NuGet.Commands
 
             // Run the restore
             var request = summaryRequest.Request;
-
+            if (request.Project.FilePath == "N:\\trash\\multiprojectWithOneErrors\\bad\\bad.csproj") { throw new Exception("Test error"); }
             var command = new RestoreCommand(request);
             if (NuGetEventSource.IsEnabled) TraceEvents.RestoreProjectStart(request.Project.FilePath);
             var result = await command.ExecuteAsync(token);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
@@ -42,6 +42,17 @@ namespace NuGet.Commands
             Errors = Array.Empty<IRestoreLogMessage>();
         }
 
+        public RestoreSummary(bool success, IEnumerable<RestoreLogMessage> errors)
+        {
+            Success = success;
+            NoOpRestore = false;
+            InputPath = null;
+            ConfigFiles = Array.Empty<string>();
+            FeedsUsed = Array.Empty<string>();
+            InstallCount = 0;
+            Errors = errors.ToArray();
+        }
+
         public RestoreSummary(
             RestoreResult result,
             string inputPath,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13188

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

* catch restore command exceptions and log them as an error to allow restore of other project in a multi-project solution

Solution structure:
     - bad.csproj : I edited our restore code to throw an exception whenever the restore project file is this file
     - good.csproj
     - multiprojectWithOneErrors.csproj

Restoring this solution now will result in an exception that interrupts the restore from restoring projects that did not cause the exception.
<img width="1295" alt="image" src="https://github.com/NuGet/NuGet.Client/assets/59111203/7e5fcba2-f314-485e-9307-19305bde8591">
After catching the exceptions, restoring this solution looks like 
![image](https://github.com/NuGet/NuGet.Client/assets/59111203/a0d652db-336e-4652-943c-90cb163bad95)


## PR Checklist

- [ ] PR has a meaningful title
- [ ] PR has a linked issue.
- [ ] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [ ] N/A
