### PR TITLE
Make use of a retry mechanism in the CommandRunner for retrying when an exception occurs

### DIFF
--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/CommandRunnerTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/CommandRunnerTest.cs
@@ -192,7 +192,7 @@ namespace NuGet.CommandLine.FuncTest
 
             Stopwatch stopwatch = Stopwatch.StartNew();
 
-            new Action(() => CommandRunner.Run(fileName, arguments: args, timeOutInMilliseconds: 1000, testOutputHelper: _testOutputHelper, retryCount: 0))
+            new Action(() => CommandRunner.Run(fileName, arguments: args, timeOutInMilliseconds: 1000, testOutputHelper: _testOutputHelper, timeoutRetryCount: 0))
                 .Should().Throw<TimeoutException>();
 
             stopwatch.Stop();

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/CommandRunnerTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/CommandRunnerTest.cs
@@ -192,7 +192,7 @@ namespace NuGet.CommandLine.FuncTest
 
             Stopwatch stopwatch = Stopwatch.StartNew();
 
-            new Action(() => CommandRunner.Run(fileName, arguments: args, timeOutInMilliseconds: 1000, testOutputHelper: _testOutputHelper))
+            new Action(() => CommandRunner.Run(fileName, arguments: args, timeOutInMilliseconds: 1000, testOutputHelper: _testOutputHelper, retryCount: 0))
                 .Should().Throw<TimeoutException>();
 
             stopwatch.Stop();

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/RetryRunnerTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/RetryRunnerTest.cs
@@ -102,5 +102,22 @@ namespace NuGet.CommandLine.FuncTest
             Assert.Throws<InvalidOperationException>(() => RetryRunner.RunWithRetries<int, Exception>(func, maxRetries, _output));
             runCount.Should().Be(1);
         }
+
+        [Fact]
+        public void RunWithRetries_NonSpecifiedException_ShouldThrow()
+        {
+            // Arrange
+            int runCount = 0;
+            Func<int> func = () =>
+            {
+                runCount++;
+                throw new ArgumentException("Simulated exception");
+            };
+
+            // Act & Assert
+            Action act = () => RetryRunner.RunWithRetries<int, InvalidOperationException>(func);
+            act.Should().Throw<ArgumentException>(); // Should not catch and retry ArgumentException
+            runCount.Should().Be(1);
+        }
     }
 }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/RetryRunnerTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/RetryRunnerTest.cs
@@ -1,0 +1,106 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+using Xunit.Abstractions;
+using FluentAssertions;
+using NuGet.Test.Utility;
+
+namespace NuGet.CommandLine.FuncTest
+{
+    public class RetryRunnerTest
+    {
+        private readonly ITestOutputHelper _output;
+
+        public RetryRunnerTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void RunWithRetries_WhenNoException_ShouldReturnResult()
+        {
+            // Arrange
+            int maxRetries = 3;
+            int runCount = 0;
+            Func<int> func = () =>
+            {
+                runCount++;
+                return 42;
+            };
+
+            // Act
+            int result = RetryRunner.RunWithRetries<int, Exception>(func, maxRetries, _output);
+
+            // Assert
+            result.Should().Be(42);
+            runCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void RunWithRetries_OnException_ShouldRetry()
+        {
+            // Arrange
+            int maxRetries = 1;
+            int runCount = 0;
+            Func<int> func = () =>
+            {
+                runCount++;
+                if (runCount < maxRetries + 1)
+                {
+                    throw new InvalidOperationException("Simulated exception");
+                }
+                return 42;
+            };
+
+            // Act
+            int result = RetryRunner.RunWithRetries<int, InvalidOperationException>(func, maxRetries, _output);
+
+            // Assert
+            result.Should().Be(42);
+            runCount.Should().Be(2); // Includes initial attempt
+        }
+
+        [Fact]
+        public void RunWithRetries_OnSuccess_ShouldNotRetry()
+        {
+            // Arrange
+            int maxRetries = 1;
+            int runCount = 0;
+            Func<int> func = () =>
+            {
+                runCount++;
+                if (runCount < maxRetries + 1)
+                {
+                    throw new InvalidOperationException("Simulated exception");
+                }
+                return 42;
+            };
+
+            // Act
+            int result = RetryRunner.RunWithRetries<int, InvalidOperationException>(func, maxRetries, _output);
+
+            // Assert
+            result.Should().Be(42);
+            runCount.Should().Be(2); // Only initial attempt
+        }
+
+        [Fact]
+        public void RunWithRetries_WhenMaxRetriesIsZero_ShouldNotRetry()
+        {
+            // Arrange
+            int maxRetries = 0;
+            int runCount = 0;
+            Func<int> func = () =>
+            {
+                runCount++;
+                throw new InvalidOperationException("Simulated exception");
+            };
+
+            // Act and Assert
+            Assert.Throws<InvalidOperationException>(() => RetryRunner.RunWithRetries<int, Exception>(func, maxRetries, _output));
+            runCount.Should().Be(1);
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/CommandRunner.cs
+++ b/test/TestUtilities/Test.Utility/CommandRunner.cs
@@ -26,105 +26,110 @@ namespace NuGet.Test.Utility
         /// <param name="environmentVariables">An optional <see cref="Dictionary{TKey, TValue}" /> containing environment variables to specify when running the executable.</param>
         /// <param name="testOutputHelper">An optional <see cref="ITestOutputHelper" /> to write output to.</param>
         /// <returns>A <see cref="CommandRunnerResult" /> containing details about the result of the running the executable including the exit code and console output.</returns>
-        public static CommandRunnerResult Run(string filename, string workingDirectory = null, string arguments = null, int timeOutInMilliseconds = 60000, Action<StreamWriter> inputAction = null, IDictionary<string, string> environmentVariables = null, ITestOutputHelper testOutputHelper = null)
+        public static CommandRunnerResult Run(string filename, string workingDirectory = null, string arguments = null, int timeOutInMilliseconds = 60000, Action<StreamWriter> inputAction = null, IDictionary<string, string> environmentVariables = null, ITestOutputHelper testOutputHelper = null, int retryCount = 1)
         {
-            StringBuilder output = new();
-            StringBuilder error = new();
-            int exitCode = 0;
-
-            using (Process process = new()
+            return RetryRunner.RunWithRetries<CommandRunnerResult, TimeoutException>(() =>
             {
-                EnableRaisingEvents = true,
-                StartInfo = new ProcessStartInfo(Path.GetFullPath(filename), arguments)
-                {
-                    WorkingDirectory = Path.GetFullPath(workingDirectory ?? Environment.CurrentDirectory),
-                    UseShellExecute = false,
-                    RedirectStandardError = true,
-                    RedirectStandardOutput = true,
-                    RedirectStandardInput = true,
-                    CreateNoWindow = true,
-                },
-            })
-            {
-                process.StartInfo.Environment["MSBUILDDISABLENODEREUSE"] = "1";
-                process.StartInfo.Environment["NUGET_SHOW_STACK"] = bool.TrueString;
-                process.StartInfo.Environment["NuGetTestModeEnabled"] = bool.TrueString;
-                process.StartInfo.Environment["UseSharedCompilation"] = bool.FalseString;
+                StringBuilder output = new();
+                StringBuilder error = new();
+                int exitCode = 0;
 
-                if (environmentVariables != null)
+                using (Process process = new()
                 {
-                    foreach (var pair in environmentVariables)
+                    EnableRaisingEvents = true,
+                    StartInfo = new ProcessStartInfo(Path.GetFullPath(filename), arguments)
                     {
-                        process.StartInfo.EnvironmentVariables[pair.Key] = pair.Value;
+                        WorkingDirectory = Path.GetFullPath(workingDirectory ?? Environment.CurrentDirectory),
+                        UseShellExecute = false,
+                        RedirectStandardError = true,
+                        RedirectStandardOutput = true,
+                        RedirectStandardInput = true,
+                        CreateNoWindow = true,
+                    },
+                })
+                {
+                    process.StartInfo.Environment["MSBUILDDISABLENODEREUSE"] = "1";
+                    process.StartInfo.Environment["NUGET_SHOW_STACK"] = bool.TrueString;
+                    process.StartInfo.Environment["NuGetTestModeEnabled"] = bool.TrueString;
+                    process.StartInfo.Environment["UseSharedCompilation"] = bool.FalseString;
+
+                    if (environmentVariables != null)
+                    {
+                        foreach (var pair in environmentVariables)
+                        {
+                            process.StartInfo.EnvironmentVariables[pair.Key] = pair.Value;
+                        }
+                    }
+
+                    process.OutputDataReceived += OnOutputDataReceived;
+                    process.ErrorDataReceived += OnErrorDataReceived;
+
+                    testOutputHelper?.WriteLine($"> {process.StartInfo.FileName} {process.StartInfo.Arguments}");
+
+                    Stopwatch stopwatch = Stopwatch.StartNew();
+
+                    process.Start();
+
+                    process.BeginOutputReadLine();
+                    process.BeginErrorReadLine();
+
+                    inputAction?.Invoke(process.StandardInput);
+
+                    process.StandardInput.Close();
+
+                    if (!process.WaitForExit(timeOutInMilliseconds))
+                    {
+                        if (!process.HasExited)
+                        {
+                            process.Kill();
+                        }
+
+                        throw new TimeoutException($"{process.StartInfo.FileName} {process.StartInfo.Arguments} timed out after {stopwatch.Elapsed.TotalSeconds:N2} seconds");
+                    }
+
+                    // The application that is processing the asynchronous output should call the WaitForExit method to ensure that the output buffer has been flushed.
+                    process.WaitForExit();
+
+                    stopwatch.Stop();
+                    testOutputHelper?.WriteLine($"└ Completed in {stopwatch.Elapsed.TotalSeconds:N2}s");
+
+                    process.OutputDataReceived -= OnOutputDataReceived;
+                    process.ErrorDataReceived -= OnErrorDataReceived;
+
+                    testOutputHelper?.WriteLine(string.Empty);
+                    exitCode = process.ExitCode;
+                }
+
+                return new CommandRunnerResult(exitCode, output.ToString(), error.ToString());
+
+                void OnOutputDataReceived(object sender, DataReceivedEventArgs args)
+                {
+                    if (args?.Data != null)
+                    {
+                        testOutputHelper?.WriteLine($"│  {args.Data}");
+
+                        lock (output)
+                        {
+                            output.AppendLine(args.Data);
+                        }
                     }
                 }
 
-                process.OutputDataReceived += OnOutputDataReceived;
-                process.ErrorDataReceived += OnErrorDataReceived;
-
-                testOutputHelper?.WriteLine($"> {process.StartInfo.FileName} {process.StartInfo.Arguments}");
-
-                Stopwatch stopwatch = Stopwatch.StartNew();
-
-                process.Start();
-
-                process.BeginOutputReadLine();
-                process.BeginErrorReadLine();
-
-                inputAction?.Invoke(process.StandardInput);
-
-                process.StandardInput.Close();
-
-                if (!process.WaitForExit(timeOutInMilliseconds))
+                void OnErrorDataReceived(object sender, DataReceivedEventArgs args)
                 {
-                    if (!process.HasExited)
+                    if (args?.Data != null)
                     {
-                        process.Kill();
-                    }
+                        testOutputHelper?.WriteLine($"│  {args.Data}");
 
-                    throw new TimeoutException($"{process.StartInfo.FileName} {process.StartInfo.Arguments} timed out after {stopwatch.Elapsed.TotalSeconds:N2} seconds");
-                }
-
-                // The application that is processing the asynchronous output should call the WaitForExit method to ensure that the output buffer has been flushed.
-                process.WaitForExit();
-
-                stopwatch.Stop();
-                testOutputHelper?.WriteLine($"└ Completed in {stopwatch.Elapsed.TotalSeconds:N2}s");
-
-                process.OutputDataReceived -= OnOutputDataReceived;
-                process.ErrorDataReceived -= OnErrorDataReceived;
-
-                testOutputHelper?.WriteLine(string.Empty);
-                exitCode = process.ExitCode;
-            }
-
-            return new CommandRunnerResult(exitCode, output.ToString(), error.ToString());
-
-            void OnOutputDataReceived(object sender, DataReceivedEventArgs args)
-            {
-                if (args?.Data != null)
-                {
-                    testOutputHelper?.WriteLine($"│  {args.Data}");
-
-                    lock (output)
-                    {
-                        output.AppendLine(args.Data);
+                        lock (error)
+                        {
+                            error.AppendLine(args.Data);
+                        }
                     }
                 }
-            }
-
-            void OnErrorDataReceived(object sender, DataReceivedEventArgs args)
-            {
-                if (args?.Data != null)
-                {
-                    testOutputHelper?.WriteLine($"│  {args.Data}");
-
-                    lock (error)
-                    {
-                        error.AppendLine(args.Data);
-                    }
-                }
-            }
+            },
+            retryCount,
+            testOutputHelper);
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/CommandRunner.cs
+++ b/test/TestUtilities/Test.Utility/CommandRunner.cs
@@ -25,8 +25,9 @@ namespace NuGet.Test.Utility
         /// <param name="inputAction">An optional <see cref="Action{T}" /> to invoke against the executables input stream.</param>
         /// <param name="environmentVariables">An optional <see cref="Dictionary{TKey, TValue}" /> containing environment variables to specify when running the executable.</param>
         /// <param name="testOutputHelper">An optional <see cref="ITestOutputHelper" /> to write output to.</param>
+        /// <param name="timeoutRetryCount">An optional number of times to retry running the command if it times out. Defaults to 1.</param>
         /// <returns>A <see cref="CommandRunnerResult" /> containing details about the result of the running the executable including the exit code and console output.</returns>
-        public static CommandRunnerResult Run(string filename, string workingDirectory = null, string arguments = null, int timeOutInMilliseconds = 60000, Action<StreamWriter> inputAction = null, IDictionary<string, string> environmentVariables = null, ITestOutputHelper testOutputHelper = null, int retryCount = 1)
+        public static CommandRunnerResult Run(string filename, string workingDirectory = null, string arguments = null, int timeOutInMilliseconds = 60000, Action<StreamWriter> inputAction = null, IDictionary<string, string> environmentVariables = null, ITestOutputHelper testOutputHelper = null, int timeoutRetryCount = 1)
         {
             return RetryRunner.RunWithRetries<CommandRunnerResult, TimeoutException>(() =>
             {
@@ -128,7 +129,7 @@ namespace NuGet.Test.Utility
                     }
                 }
             },
-            retryCount,
+            timeoutRetryCount,
             testOutputHelper);
         }
     }

--- a/test/TestUtilities/Test.Utility/RetryRunner.cs
+++ b/test/TestUtilities/Test.Utility/RetryRunner.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit.Abstractions;
+
+namespace NuGet.Test.Utility
+{
+    internal class RetryRunner
+    {
+        public static T RunWithRetries<T, E>(Func<T> func, int maxRetries = 1, ITestOutputHelper logger = null) where E : Exception
+        {
+            {
+                int retryCount = 0;
+
+                while (true)
+                {
+                    try
+                    {
+                        return func();
+                    }
+                    catch (E exception)
+                    {
+                        if (retryCount >= maxRetries)
+                        {
+                            throw exception;
+                        }
+
+                        retryCount++;
+                        logger?.WriteLine($"Encountered exception during run attempt #{retryCount}: {exception.Message}");
+                        logger?.WriteLine($"Retrying {retryCount} of {maxRetries}");
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2866

Regression? Last working version: N/A

## Description
Added a retry mechanism that can rerun a function a given number of times if the function throws a specific exception. To retry when any exception is thrown, the caller can simply use Exception as a generic parameter. Added tests for the retry runner.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
