### PR TITLE
CI: ShouldSkipOptimize is not a compile time variable

### DIFF
--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -93,7 +93,6 @@ stages:
       VsTargetChannelForTests: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannelForTests']]
       VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
       isOfficialBuild: ${{ parameters.isOfficialBuild }}
-      ShouldSkipOptimize: ${{ variables['ShouldSkipOptimize'] }}
       BuildRTM: "false"
       SemanticVersion: $[stageDependencies.Initialize.GetSemanticVersion.outputs['setsemanticversion.SemanticVersion']]
     pool:
@@ -111,7 +110,7 @@ stages:
           enabled: ${{ variables['isOfficialBuild'] }}
           OptimizationInputsLookupMethod: DropPrefix
           DropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
-          ShouldSkipOptimize: ${{ variables['ShouldSkipOptimize'] }}
+          ShouldSkipOptimize: $(ShouldSkipOptimize)
           AccessToken: $(System.AccessToken)
       outputs:
       - output: pipelineArtifact


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: release branch

Regression? yes, broken in migration to 1ES templates

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

`${{` is Azure Pipelines syntax for compile time logic. However, variables (as opposed to parameters) are illogically imported AFTER the template is compiled. Hence, trying to evaluate the variable at compile time results in an empty string.  Therefore, we need to use "normal" variable syntax, not compile time templating syntax.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
