### PR TITLE
Enable SYSTEM_DEBUG envvar in CI for FuncTests

### DIFF
--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -33,6 +33,7 @@ variables:
   NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY: 3,1000
   SkipSigning: true
   CI: true
+  SYSTEM_DEBUG: true
 
 trigger:
   branches:


### PR DESCRIPTION
Enable [SYSTEM_DEBUG ](https://github.com/NuGet/NuGet.Client/blob/cc433c10be76a0759d359c72193e77795f15a0fc/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs#L28) to help diagnose functional test flakiness.

### Before this change:

**Example**: https://dev.azure.com/dnceng-public/public/_build/results?buildId=718472&view=logs&j=a6c3b38a-283e-5056-683e-4f48d8d79b4c&t=073c0aa9-8d8f-5250-fdd8-cbb62be7de3f

> Build FAILED.
> 
> /Users/runner/work/1/s/Directory.Solution.targets(207,5): error : Functional test run failed for framework 'net8.0'. [/Users/runner/work/1/s/NuGet.sln]
>     0 Warning(s)
>     1 Error(s)


### After this change:

**Example**: https://dev.azure.com/dnceng-public/public/_build/results?buildId=724750&view=logs&j=a6c3b38a-283e-5056-683e-4f48d8d79b4c&t=073c0aa9-8d8f-5250-fdd8-cbb62be7de3f&l=2856

**Suspected root cause:** The NU1101 errors. 

>   │  error: NU1101: Unable to find package Microsoft.AspNetCore.App.Ref. No packages exist with this id in source(s): source, template
>    │  error: NU1101: Unable to find package Microsoft.NETCore.App.Ref. No packages exist with this id in source(s): source, template
>    │  info : Package 'X' is compatible with all the specified frameworks in project '/Users/runner/work/1/s/.test/work/5fcea2e5/92eb4eca/solution/projectA/projectA.csproj'.
>    │  info : Generating MSBuild file /Users/runner/work/1/s/.test/work/5fcea2e5/92eb4eca/solution/projectA/obj/projectA.csproj.nuget.g.props.
>    │  info : Generating MSBuild file /Users/runner/work/1/s/.test/work/5fcea2e5/92eb4eca/solution/projectA/obj/projectA.csproj.nuget.g.targets.
>    │  info : Writing assets file to disk. Path: /Users/runner/work/1/s/.test/work/5fcea2e5/92eb4eca/solution/projectA/obj/project.assets.json
>    │  log  : Failed to restore /Users/runner/work/1/s/.test/work/5fcea2e5/92eb4eca/solution/projectA/projectA.csproj (in 333 ms).
>    └ Completed in 2.32s
> 