### PR TITLE
Simplify user-agent OS string

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -5,9 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-#if IS_CORECLR
-using System.Runtime.InteropServices;
-#endif
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
@@ -31,7 +28,6 @@ using NuGet.ProjectManagement;
 using NuGet.Shared;
 using static NuGet.Shared.XmlUtility;
 using System.Globalization;
-using System.Collections;
 #endif
 
 namespace NuGet.Build.Tasks
@@ -169,8 +165,7 @@ namespace NuGet.Build.Tasks
 
                 // Set user agent string used for network calls
 #if IS_CORECLR
-                UserAgent.SetUserAgentString(new UserAgentStringBuilder("NuGet .NET Core MSBuild Task")
-                    .WithOSDescription(RuntimeInformation.OSDescription));
+                UserAgent.SetUserAgentString(new UserAgentStringBuilder("NuGet .NET Core MSBuild Task"));
 #else
                 // OS description is set by default on Desktop
                 UserAgent.SetUserAgentString(new UserAgentStringBuilder("NuGet Desktop MSBuild Task"));

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs
@@ -67,8 +67,7 @@ namespace NuGet.CommandLine.XPlat
         public static void SetUserAgent()
         {
 #if IS_CORECLR
-            UserAgent.SetUserAgentString(new UserAgentStringBuilder("NuGet xplat")
-                .WithOSDescription(RuntimeInformation.OSDescription));
+            UserAgent.SetUserAgentString(new UserAgentStringBuilder("NuGet xplat"));
 #else
             UserAgent.SetUserAgentString(new UserAgentStringBuilder("NuGet xplat"));
 #endif

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs
@@ -6,12 +6,6 @@
 using System.Globalization;
 using System;
 using System.IO;
-using System.Linq;
-
-#if IS_CORECLR
-using System.Runtime.InteropServices;
-#endif
-
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
@@ -66,11 +60,7 @@ namespace NuGet.CommandLine.XPlat
 
         public static void SetUserAgent()
         {
-#if IS_CORECLR
             UserAgent.SetUserAgentString(new UserAgentStringBuilder("NuGet xplat"));
-#else
-            UserAgent.SetUserAgentString(new UserAgentStringBuilder("NuGet xplat"));
-#endif
         }
 
         internal static ISettings ProcessConfigFile(string configFile)

--- a/src/NuGet.Core/NuGet.Protocol/UserAgentStringBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol/UserAgentStringBuilder.cs
@@ -106,6 +106,10 @@ namespace NuGet.Protocol.Core.Types
                 return OSPlatform.OSX.ToString();
             }
 #if NETCOREAPP
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+            {
+                return OSPlatform.FreeBSD.ToString();
+            }
             else if (OperatingSystem.IsBrowser())
             {
                 return "BROWSER";

--- a/src/NuGet.Core/NuGet.Protocol/UserAgentStringBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol/UserAgentStringBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using NuGet.Packaging;
 
 namespace NuGet.Protocol.Core.Types
@@ -30,18 +31,15 @@ namespace NuGet.Protocol.Core.Types
 
             // Read the client version from the assembly metadata and normalize it.
             NuGetClientVersion = MinClientVersionUtility.GetNuGetClientVersion().ToNormalizedString();
+
+            _osInfo = GetOS();
         }
 
         public string NuGetClientVersion { get; }
 
+        [Obsolete("This value is now ignored")]
         public UserAgentStringBuilder WithOSDescription(string osInfo)
         {
-#if NETCOREAPP2_0_OR_GREATER
-            _osInfo = osInfo.Replace("(", @"\(", StringComparison.Ordinal).Replace(")", @"\)", StringComparison.Ordinal);
-#else
-            _osInfo = osInfo.Replace("(", @"\(").Replace(")", @"\)");
-#endif
-
             return this;
         }
 
@@ -53,8 +51,6 @@ namespace NuGet.Protocol.Core.Types
 
         public string Build()
         {
-            var osDescription = _osInfo ?? GetOSVersion();
-
             var clientInfo = _clientName;
             if (NuGetTestMode.Enabled)
             {
@@ -65,7 +61,7 @@ namespace NuGet.Protocol.Core.Types
                 clientInfo = DefaultNuGetClientName;
             }
 
-            if (string.IsNullOrEmpty(osDescription))
+            if (string.IsNullOrEmpty(_osInfo))
             {
                 return string.Format(
                     CultureInfo.InvariantCulture,
@@ -81,7 +77,7 @@ namespace NuGet.Protocol.Core.Types
                     UserAgentWithOSDescriptionTemplate,
                     clientInfo,
                     NuGetClientVersion,
-                    osDescription);
+                    _osInfo);
             }
             else
             {
@@ -90,26 +86,35 @@ namespace NuGet.Protocol.Core.Types
                     UserAgentWithOSDescriptionAndVisualStudioSKUTemplate,
                     _clientName,
                     NuGetClientVersion, /* NuGet version */
-                    osDescription, /* OS version */
+                    _osInfo, /* OS version */
                     _vsInfo);  /* VS SKU + version */
             }
         }
 
-        private string GetOSVersion()
+        internal static string GetOS()
         {
-            if (_osInfo == null)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-#if !IS_CORECLR
-                // When not on CoreClr and no OSDescription was provided,
-                // we will set it ourselves.
-                _osInfo = Environment.OSVersion.ToString();
-#else
-                // When on CoreClr, one should use the .WithOSDescription() method to set it.
-                _osInfo = string.Empty;
-#endif
+                return OSPlatform.Windows.ToString();
             }
-
-            return _osInfo;
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return OSPlatform.Linux.ToString();
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return OSPlatform.OSX.ToString();
+            }
+#if NETCOREAPP
+            else if (OperatingSystem.IsBrowser())
+            {
+                return "BROWSER";
+            }
+#endif
+            else
+            {
+                return "UnknownOS";
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13531

Regression? no

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

This PR will change NuGet so that outgoing HTTP requests will no longer provide detailed operating system information in the User-Agent HTTP header. Going forward, it will only provide "Windows", "Linux", "OSX", and maybe "Browser". This will be invisible to customers running NuGet (except it will stop breaking for customers affected by the current bug). It is a kind of "breaking change" from the NuGet server's point of view. However, I checked with the nuget.org team, and they don't use it. Any other server that tries to parse the User-Agent header for telemetry or statistics reasons is going to be affected.

Unfortunately, I couldn't find an API that returns an `OSPlatform` or `OperatingSystem` object. So instead, we call APIs to check a bunch of platforms and return a value based on the first one to return true.

Use `RuntimeInformation.IsOSPlatform(..)` with the most common platforms (Windows, Linux, OSX) and just use the OSPlatform string in the User-Agent header. This avoids any future issues with different Linux distros using other characters that are not valid in the User-Agent HTTP header.

On .NET (Core), also test `OperatingSystem.IsBrowser()`, as I wouldn't be surprised if someone tries to use NuGet.Protocol in a Blazor app (although NuGet.Protocol writes to the filesystem, so not sure it world work). There are a bunch of other methods on `OperatingSystem`, like `IsAndroid`, `IsIOS`, `IsWatchOS`. But I don't think it's likely that developers will use NuGet.Protocol with apps on those platforms. We could add them all anyway, but then I feel like we're committing to updating the list each time .NET adds a new OS.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
