### PR TITLE
Change NuGetAuditMode default to all for non-SDK style projects

### DIFF
--- a/docs/feature-guide.md
+++ b/docs/feature-guide.md
@@ -97,6 +97,33 @@ These considerations are also useful for smaller changes that might not require 
   * World readiness considerations
 * User documentation
 
+#### Warnings and defaults
+
+The .NET 9 SDK introduces a new [`SdkAnalysisLevel` property](https://github.com/dotnet/designs/blob/main/proposed/sdk-analysis-level.md), which is intended to allow customers to avoid breaking changes while still upgrading to new versions of the build tools.
+Going forward, any in-scope change to NuGet must compare `SdkAnalysisLevel` to the version of the .NET SDK that corresponds to NuGet's dev branch is going to be inserted into.
+For example, NuGet 6.12 will ship in the .NET 9.0.100 SDK.
+Therefore, any in-scope change to NuGet in NuGet 6.12 must retain existing/previous behavior when `SdkAnalysisVersion` is lower than this version, and the new behavior applies only when it's equal or higher.
+
+Since `SdkAnalysisLevel` will apply to many features, including features that are not part of NuGet, it is not a substitute for having a feature specific configuration.
+`SdkAnalysisLevel` should just be used to decide what the default is for that configuration value.
+
+A non-exhaustive list of examples of in-scope changes to NuGet include:
+
+* New restore warning
+* New pack validation
+* Change a warning to an error
+* Changes to feature opt-in/out, or other changes to configuration defaults
+
+Note that `SdkAnalysisLevel` is only set by the .NET SDK, and only starting from the .NET 9.0.100 SDK.
+Therefore the following logic should apply anywhere NuGet needs to make a decision based on the `SdkAnalysisLevel`:
+
+1. If `SdkAnalysisLevel` is set, regardless of project type, always use that value.
+1. Otherwise, if `UsingMicrosoftNETSdk` has the value `true`, then assume that the `SdkAnalysisLevel` is 8.0.400.
+1. Otherwise, assume `SdkAnalysisLevel` is equal to the highest version that the feature compares to, so always use the latest defaults.
+
+This means that `SdkAnalysisLevel` is used as intended for SDK style projects, but non-SDK style project always use the latest defaults.
+All project types use the same configuration, so that customers can set a single property in a *Directory.Build.props* file, or environment variable.
+
 #### Restore considerations
 
 * NuGet tool parity, ensure all products work as expected

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -70,14 +70,20 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <!-- Enable NuGetAudit by default -->
     <NuGetAudit Condition=" '$(NuGetAudit)' == '' ">true</NuGetAudit>
-    <!-- Report on low severity vulnerabilities, and higher. Allowed values are: low, moderate, high, critical -->
+    <!-- Report all severity vulnerabilities (low severity and higher). Allowed values are: low, moderate, high, critical -->
     <NuGetAuditLevel Condition=" '$(NuGetAuditLevel)' == '' ">low</NuGetAuditLevel>
-    <!-- Report known vulnerabilities on direct dependencies only. Allowed values are: direct, all -->
+    <!-- Report known vulnerabilities on direct and transitive dependencies, unless using .NET SDK with version lower than 9.0.100. Allowed values are: direct, all -->
     <NuGetAuditMode Condition="'$(NuGetAuditMode)' == ''
                     AND '$(NuGetExeSkipSdkAnalysisLevelCheck)' != 'true'
-                    AND $([MSBuild]::VersionGreaterThanOrEquals($([MSBuild]::ValueOrDefault('$(SdkAnalysisLevel)', '0.0')), '9.0.100'))"
-                    >all</NuGetAuditMode>
-    <NuGetAuditMode Condition=" '$(NuGetAuditMode)' == '' ">direct</NuGetAuditMode>
+                    AND '$(SdkAnalysisLevel)' != ''
+                    AND $([MSBuild]::VersionLessThan('$(SdkAnalysisLevel)', '9.0.100'))"
+                    >direct</NuGetAuditMode>
+    <NuGetAuditMode Condition="'$(NuGetAuditMode)' == ''
+                    AND '$(NuGetExeSkipSdkAnalysisLevelCheck)' != 'true'
+                    AND '$(UsingMicrosoftNETSdk)' == 'true'
+                    AND '$(SdkAnalysisLevel)' == ''"
+                    >direct</NuGetAuditMode>
+    <NuGetAuditMode Condition=" '$(NuGetAuditMode)' == '' ">all</NuGetAuditMode>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -72,7 +72,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NuGetAudit Condition=" '$(NuGetAudit)' == '' ">true</NuGetAudit>
     <!-- Report all severity vulnerabilities (low severity and higher). Allowed values are: low, moderate, high, critical -->
     <NuGetAuditLevel Condition=" '$(NuGetAuditLevel)' == '' ">low</NuGetAuditLevel>
-    <!-- Report known vulnerabilities on direct and transitive dependencies, unless using .NET SDK with version lower than 9.0.100. Allowed values are: direct, all -->
+    <!-- Report known vulnerabilities on direct and transitive dependencies, unless SdkAnalysisLevel (or equalivant) is lower than 9.0.100. Allowed values are: direct, all -->
     <NuGetAuditMode Condition="'$(NuGetAuditMode)' == ''
                     AND '$(NuGetExeSkipSdkAnalysisLevelCheck)' != 'true'
                     AND '$(SdkAnalysisLevel)' != ''

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/NuGetAuditDefaultsTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/NuGetAuditDefaultsTests.cs
@@ -53,7 +53,14 @@ namespace Msbuild.Integration.Test
         }
 
         [Fact]
-        public void NuGetAuditModeDefaults_NuGetExeEmulation()
+        // Some customers run the latest Nuget.exe with old versions of MSBuild. MSBuild only added intrinsic functions
+        // needed for SdkAnalysisVersion comparisons in dev16, so NuGet.exe detects the MSBuild version and adds a
+        // global property when invoking MSBuild, so that our MSBuild script can avoid calling intrinstic functions
+        // that don't exist. In order to test this with a "real" integration test, we'd need an old version of MSBuild
+        // installed, which is not worth the effort, assuming it's even feasible. Therefore, while this test can't
+        // validate that the intrinstic functions are not called, it can set the same global property and validate that
+        // the default values are what we expect.
+        public void NuGetAuditModeDefaults_NuGetExeWithOldMSBuildEmulation()
         {
             // Arrange
             using var testDirectory = TestDirectory.Create();

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/NuGetAuditDefaultsTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/NuGetAuditDefaultsTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using FluentAssertions;
+using NuGet.Test.Utility;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Msbuild.Integration.Test
+{
+    public class NuGetAuditDefaultsTests : IClassFixture<MsbuildIntegrationTestFixture>
+    {
+        private MsbuildIntegrationTestFixture _fixture;
+        private ITestOutputHelper _output;
+
+        public NuGetAuditDefaultsTests(MsbuildIntegrationTestFixture fixture, ITestOutputHelper output)
+        {
+            _fixture = fixture;
+            _output = output;
+        }
+
+        [Theory]
+        // .NET 9 SDK
+        [InlineData("9.0.100", "true", "all")]
+        // .NET 8 SDK
+        [InlineData(null, "true", "direct")]
+        // non-SDK style project
+        [InlineData(null, null, "all")]
+        // non-SDK style project explicit opt-out
+        [InlineData("8.0", null, "direct")]
+        public void NuGetAuditModeDefaults(string SdkAnalysisLevel, string UsingMicrosoftNETSdk, string expected)
+        {
+            // Arrange
+            using var testDirectory = TestDirectory.Create();
+
+            string projectText = @"<Project>
+    <Import Project=""$(NuGetRestoreTargets)"" />
+</Project>";
+            var projectFilePath = Path.Combine(testDirectory, "my.proj");
+            File.WriteAllText(projectFilePath, projectText);
+
+            string args = $"{projectFilePath} -getProperty:NuGetAuditMode";
+            if (!string.IsNullOrEmpty(SdkAnalysisLevel)) args += $" -p:SdkAnalysisLevel={SdkAnalysisLevel}";
+            if (!string.IsNullOrEmpty(UsingMicrosoftNETSdk)) args += $" -p:UsingMicrosoftNETSdk={UsingMicrosoftNETSdk}";
+
+            // Act
+            var result = _fixture.RunMsBuild(testDirectory, args);
+            var resultText = result.Output.Trim();
+
+            // Assert
+            resultText.Should().Be(expected);
+        }
+
+        [Fact]
+        public void NuGetAuditModeDefaults_NuGetExeEmulation()
+        {
+            // Arrange
+            using var testDirectory = TestDirectory.Create();
+
+            string projectText = @"<Project>
+    <Import Project=""$(NuGetRestoreTargets)"" />
+</Project>";
+            var projectFilePath = Path.Combine(testDirectory, "my.proj");
+            File.WriteAllText(projectFilePath, projectText);
+
+            string args = $"{projectFilePath} -getProperty:NuGetAuditMode -p:NuGetExeSkipSdkAnalysisLevelCheck=true";
+
+            // Act
+            var result = _fixture.RunMsBuild(testDirectory, args);
+            var resultText = result.Output.Trim();
+
+            // Assert
+            resultText.Should().Be("all");
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13584

Regression? No

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Change NuGet.targets' defaults for `NuGetAuditMode` to be roughly:

```
if (SdkAnalysisVersion != '')
    NuGetAuditMode = SdkAnalysisVersion >= '9.0.100' ? "all" : "direct"
else if (UsingMicrosoftNETSdk == 'true')
    // The .NET SDK only started setting SdkAnalysisVersion from 9.0.100, the same version we started changing defaults
    NugetAuditMode = "direct"
else
    NuGetAuditMode = "all"
```

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
