### PR TITLE
LibraryRange.ToLockFileDependencyGroupString handles scenarios without a specified version gracefully

### DIFF
--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
@@ -73,42 +73,40 @@ namespace NuGet.LibraryModel
             return output;
         }
 
-        public string? ToLockFileDependencyGroupString()
+        public string ToLockFileDependencyGroupString()
         {
-            if (VersionRange is null)
-            {
-                return null;
-            }
-
             StringBuilder sb = StringBuilderPool.Shared.Rent(256);
 
             sb.Append(Name);
 
-            if (VersionRange.HasLowerBound)
+            if (VersionRange != null)
             {
-                if (VersionRange.IsMinInclusive)
+                if (VersionRange.HasLowerBound)
                 {
-                    sb.Append(" >= ");
-                }
-                else
-                {
-                    sb.Append(" > ");
+                    if (VersionRange.IsMinInclusive)
+                    {
+                        sb.Append(" >= ");
+                    }
+                    else
+                    {
+                        sb.Append(" > ");
+                    }
+
+                    if (VersionRange.IsFloating)
+                    {
+                        VersionRange.Float.ToString(sb);
+                    }
+                    else
+                    {
+                        sb.Append(VersionRange.MinVersion.ToNormalizedString());
+                    }
                 }
 
-                if (VersionRange.IsFloating)
+                if (VersionRange.HasUpperBound)
                 {
-                    VersionRange.Float.ToString(sb);
+                    sb.Append(VersionRange.IsMaxInclusive ? " <= " : " < ");
+                    sb.Append(VersionRange.MaxVersion.ToNormalizedString());
                 }
-                else
-                {
-                    sb.Append(VersionRange.MinVersion.ToNormalizedString());
-                }
-            }
-
-            if (VersionRange.HasUpperBound)
-            {
-                sb.Append(VersionRange.IsMaxInclusive ? " <= " : " < ");
-                sb.Append(VersionRange.MaxVersion.ToNormalizedString());
             }
 
             return StringBuilderPool.Shared.ToStringAndReturn(sb);

--- a/src/NuGet.Core/NuGet.LibraryModel/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.LibraryModel/PublicAPI.Shipped.txt
@@ -121,7 +121,7 @@ NuGet.LibraryModel.LibraryRange.LibraryRange(string! name, NuGet.LibraryModel.Li
 NuGet.LibraryModel.LibraryRange.LibraryRange(string! name, NuGet.Versioning.VersionRange? versionRange, NuGet.LibraryModel.LibraryDependencyTarget typeConstraint) -> void
 NuGet.LibraryModel.LibraryRange.Name.get -> string!
 NuGet.LibraryModel.LibraryRange.Name.set -> void
-NuGet.LibraryModel.LibraryRange.ToLockFileDependencyGroupString() -> string?
+NuGet.LibraryModel.LibraryRange.ToLockFileDependencyGroupString() -> string!
 NuGet.LibraryModel.LibraryRange.TypeConstraint.get -> NuGet.LibraryModel.LibraryDependencyTarget
 NuGet.LibraryModel.LibraryRange.TypeConstraint.set -> void
 NuGet.LibraryModel.LibraryRange.TypeConstraintAllows(NuGet.LibraryModel.LibraryDependencyTarget flag) -> bool

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/LibraryRangeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/LibraryRangeTests.cs
@@ -17,13 +17,14 @@ namespace NuGet.LibraryModel.Tests
         [InlineData("[1.0.0 , 2.0.0]", "packageA >= 1.0.0 <= 2.0.0")]
         [InlineData("(1.0.0 , 2.0.0)", "packageA > 1.0.0 < 2.0.0")]
         [InlineData("(1.0.0 , 2.0.0]", "packageA > 1.0.0 <= 2.0.0")]
+        [InlineData(null, "")]
         public void LibraryRange_ToLockFileDependencyGroupString(string versionRange, string expected)
         {
             // Arrange
             LibraryRange range = new LibraryRange()
             {
                 Name = "packageA",
-                VersionRange = VersionRange.Parse(versionRange),
+                VersionRange = versionRange != null ? VersionRange.Parse(versionRange) : null,
                 TypeConstraint = LibraryDependencyTarget.Project
             };
 

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/LibraryRangeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/LibraryRangeTests.cs
@@ -17,7 +17,7 @@ namespace NuGet.LibraryModel.Tests
         [InlineData("[1.0.0 , 2.0.0]", "packageA >= 1.0.0 <= 2.0.0")]
         [InlineData("(1.0.0 , 2.0.0)", "packageA > 1.0.0 < 2.0.0")]
         [InlineData("(1.0.0 , 2.0.0]", "packageA > 1.0.0 <= 2.0.0")]
-        [InlineData(null, "")]
+        [InlineData(null, "packageA")]
         public void LibraryRange_ToLockFileDependencyGroupString(string versionRange, string expected)
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13563

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

https://github.com/NuGet/NuGet.Client/commit/2be8680071ba845a08d51df71e4c5f089765918a accidentally regressed the writing for ToLockFileDependencyGroupString, where a package is missing a version. 
It used to just write the name, but it was accidentally changed to write null, which led to https://github.com/NuGet/Home/issues/13563, and a null reference on the .NET SDK side. 

There's probably still some improvements to do on the SDK side, but the NuGet side itself is a regression.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
