### PR TITLE
Reduce console output when running tests and update more tests to use ITestOutputHelper

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/ListPackage/ListPackageJsonRenderer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/ListPackage/ListPackageJsonRenderer.cs
@@ -54,7 +54,7 @@ namespace NuGet.CommandLine.XPlat.ListPackage
 
         public ListPackageJsonRenderer(TextWriter textWriter = null)
         {
-            _writer = textWriter != null ? textWriter : Console.Out;
+            _writer = textWriter ?? Console.Out;
         }
 
         public void AddProblem(ProblemType problemType, string text)

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTLSCertificateValidationTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTLSCertificateValidationTests.cs
@@ -37,7 +37,7 @@ namespace Dotnet.Integration.Test
                     packageA100);
             var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, packageA100, "net472");
             var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectA.ProjectName);
-            SelfSignedCertificateMockServer tcpListenerServer = new SelfSignedCertificateMockServer(packageSourceDirectory);
+            SelfSignedCertificateMockServer tcpListenerServer = new SelfSignedCertificateMockServer(packageSourceDirectory, _testOutputHelper);
             var serverTask = tcpListenerServer.StartServerAsync();
             pathContext.Settings.AddSource("https-feed", $"{tcpListenerServer.URI}v3/index.json", "disableTLSCertificateValidation", "true");
 
@@ -59,7 +59,7 @@ namespace Dotnet.Integration.Test
                     packageB100);
             var projectB = XPlatTestUtils.CreateProject("ProjectB", pathContext, packageB100, "net472");
             var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectB.ProjectName);
-            SelfSignedCertificateMockServer tcpListenerServer = new SelfSignedCertificateMockServer(packageSourceDirectory);
+            SelfSignedCertificateMockServer tcpListenerServer = new SelfSignedCertificateMockServer(packageSourceDirectory, _testOutputHelper);
             var serverTask = tcpListenerServer.StartServerAsync();
             pathContext.Settings.AddSource("https-feed", $"{tcpListenerServer.URI}v3/index.json");
 
@@ -81,8 +81,8 @@ namespace Dotnet.Integration.Test
                     packageB100);
             var projectB = XPlatTestUtils.CreateProject("ProjectB", pathContext, packageB100, "net472");
             var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectB.ProjectName);
-            SelfSignedCertificateMockServer tcpListenerServer1 = new SelfSignedCertificateMockServer(packageSourceDirectory);
-            SelfSignedCertificateMockServer tcpListenerServer2 = new SelfSignedCertificateMockServer(packageSourceDirectory);
+            SelfSignedCertificateMockServer tcpListenerServer1 = new SelfSignedCertificateMockServer(packageSourceDirectory, _testOutputHelper);
+            SelfSignedCertificateMockServer tcpListenerServer2 = new SelfSignedCertificateMockServer(packageSourceDirectory, _testOutputHelper);
             var serverTask = tcpListenerServer1.StartServerAsync();
             var serverTask2 = tcpListenerServer2.StartServerAsync();
             pathContext.Settings.AddSource("https-feed1", $"{tcpListenerServer1.URI}v3/index.json");
@@ -107,8 +107,8 @@ namespace Dotnet.Integration.Test
                     packageB100);
             var projectB = XPlatTestUtils.CreateProject("ProjectB", pathContext, packageB100, "net472");
             var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectB.ProjectName);
-            SelfSignedCertificateMockServer tcpListenerServer1 = new SelfSignedCertificateMockServer(packageSourceDirectory);
-            SelfSignedCertificateMockServer tcpListenerServer2 = new SelfSignedCertificateMockServer(packageSourceDirectory);
+            SelfSignedCertificateMockServer tcpListenerServer1 = new SelfSignedCertificateMockServer(packageSourceDirectory, _testOutputHelper);
+            SelfSignedCertificateMockServer tcpListenerServer2 = new SelfSignedCertificateMockServer(packageSourceDirectory, _testOutputHelper);
             var serverTask = tcpListenerServer1.StartServerAsync();
             var serverTask2 = tcpListenerServer2.StartServerAsync();
             pathContext.Settings.AddSource("https-feed1", $"{tcpListenerServer1.URI}v3/index.json");

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/BasicLoggingTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/BasicLoggingTests.cs
@@ -2,16 +2,24 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.XPlat.FuncTest
 {
     public class BasicLoggingTests
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public BasicLoggingTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
         [Fact]
         public void BasicLogging_NoParams_ExitCode()
         {
             // Arrange
-            var log = new TestCommandOutputLogger();
+            var log = new TestCommandOutputLogger(_testOutputHelper);
 
             var args = new string[]
             {

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
@@ -211,6 +212,10 @@ namespace NuGet.XPlat.FuncTest
             await RestoreProjectsAsync(pathContext, projectA, projectB, _testOutputHelper);
 
             // Act
+            var output = new StringBuilder();
+            var error = new StringBuilder();
+            using TextWriter consoleOut = new StringWriter(output);
+            using TextWriter consoleError = new StringWriter(error);
             var logger = new TestLogger(_testOutputHelper);
             ListPackageCommandRunner listPackageCommandRunner = new();
             var packageRefArgs = new ListPackageArgs(
@@ -218,7 +223,7 @@ namespace NuGet.XPlat.FuncTest
                                         packageSources: [new(mockServer.ServiceIndexUri)],
                                         frameworks: ["net6.0"],
                                         reportType: ReportType.Vulnerable,
-                                        renderer: new ListPackageConsoleRenderer(),
+                                        renderer: new ListPackageConsoleRenderer(consoleOut, consoleError),
                                         includeTransitive: false,
                                         prerelease: false,
                                         highestPatch: false,

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -294,7 +294,7 @@ namespace NuGet.XPlat.FuncTest
                 File.WriteAllText(projectPath, string.Empty);
 
                 var logLevel = LogLevel.Information;
-                var logger = new TestCommandOutputLogger();
+                var logger = new TestCommandOutputLogger(_testOutputHelper);
                 var testApp = new CommandLineApplication();
                 var mockCommandRunner = new Mock<IListPackageCommandRunner>();
                 mockCommandRunner

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/TestCommandOutputLogger.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/TestCommandOutputLogger.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using NuGet.CommandLine.XPlat;
 using NuGet.Common;
 using NuGet.Test.Utility;
+using Xunit.Abstractions;
 
 namespace NuGet.XPlat.FuncTest
 {
@@ -13,12 +14,14 @@ namespace NuGet.XPlat.FuncTest
     {
         private readonly bool _observeLogLevel;
 
-        public TestLogger Logger { get; set; } = new TestLogger();
+        public TestLogger Logger { get; set; }
 
-        public TestCommandOutputLogger(bool observeLogLevel = false)
+        public TestCommandOutputLogger(ITestOutputHelper testOutputHelper, bool observeLogLevel = false)
             : base(LogLevel.Debug)
         {
             _observeLogLevel = observeLogLevel;
+
+            Logger = new TestLogger(testOutputHelper);
         }
 
         protected override void LogInternal(LogLevel logLevel, string message)

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -322,7 +322,6 @@ namespace NuGet.XPlat.FuncTest
             {
                     new object[] { new string[] { "1.0.0-preview.1", "1.0.0-preview.2", "1.0.0-preview.3" }, false },
             };
-        
 
         [Theory]
         [MemberData(nameof(AddPkg_PackageVersionsLatestPrereleasNoStableAvailableData))]
@@ -596,7 +595,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger)  );
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
                 // Assert
@@ -920,7 +919,9 @@ namespace NuGet.XPlat.FuncTest
 
                 var logger = new TestCommandOutputLogger(_testOutputHelper);
 
-                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger,packageX_V3.Id, packageX_V3.Version.ToString(),
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger,
+                    packageX_V3.Id,
+                    packageX_V3.Version.ToString(),
                     projectA,
                     sources: customSourcePath);
 
@@ -969,7 +970,9 @@ namespace NuGet.XPlat.FuncTest
                 var logger = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Since user is not inputing a version, it is converted to a "*" in the command
-                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger,packageX.Id, "*",
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger,
+                    packageX.Id,
+                    "*",
                     projectA,
                     frameworks: userInputFrameworks,
                     noVersion: true);

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatClientCertTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatClientCertTests.cs
@@ -12,12 +12,20 @@ using NuGet.CommandLine.XPlat;
 using NuGet.Configuration;
 using NuGet.Test.Utility;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.XPlat.FuncTest
 {
     [Collection("NuGet XPlat Test Collection")]
     public class XPlatClientCertTests
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public XPlatClientCertTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
         [Fact]
         public void ClientCertAddCommand_Fail_CertificateSourceCombinationSpecified()
         {
@@ -38,7 +46,7 @@ namespace NuGet.XPlat.FuncTest
                     testInfo.CertificateStoreLocation.ToString()
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -65,7 +73,7 @@ namespace NuGet.XPlat.FuncTest
                     testInfo.PackageSourceName
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -95,7 +103,7 @@ namespace NuGet.XPlat.FuncTest
                     @".\MyCertificate.pfx"
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -113,7 +121,7 @@ namespace NuGet.XPlat.FuncTest
             // Arrange
             var args = new[] { "add", "client-cert" };
 
-            var log = new TestCommandOutputLogger();
+            var log = new TestCommandOutputLogger(_testOutputHelper);
 
             // Act
             var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -143,7 +151,7 @@ namespace NuGet.XPlat.FuncTest
                     "SOME"
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -178,7 +186,7 @@ namespace NuGet.XPlat.FuncTest
                     testInfo.CertificatePassword
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 //Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -218,7 +226,7 @@ namespace NuGet.XPlat.FuncTest
                     "--force"
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -259,7 +267,7 @@ namespace NuGet.XPlat.FuncTest
                     password
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -300,7 +308,7 @@ namespace NuGet.XPlat.FuncTest
                     testInfo.CertificateFindValue.ToString()
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -343,7 +351,7 @@ namespace NuGet.XPlat.FuncTest
                     "--force"
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -375,7 +383,7 @@ namespace NuGet.XPlat.FuncTest
                     testInfo.ConfigFile
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -413,7 +421,7 @@ namespace NuGet.XPlat.FuncTest
                     testInfo.ConfigFile
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -443,7 +451,7 @@ namespace NuGet.XPlat.FuncTest
                     testInfo.PackageSourceName
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -479,7 +487,7 @@ namespace NuGet.XPlat.FuncTest
                     testInfo.PackageSourceName
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -513,7 +521,7 @@ namespace NuGet.XPlat.FuncTest
                     testInfo.CertificateStoreLocation.ToString()
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -545,7 +553,7 @@ namespace NuGet.XPlat.FuncTest
                     testInfo.CertificatePassword
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -573,7 +581,7 @@ namespace NuGet.XPlat.FuncTest
                     testInfo.PackageSourceName
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -615,7 +623,7 @@ namespace NuGet.XPlat.FuncTest
                     "--force"
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -668,7 +676,7 @@ namespace NuGet.XPlat.FuncTest
                     "--force"
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -716,7 +724,7 @@ namespace NuGet.XPlat.FuncTest
                     updatedPassword
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -751,7 +759,7 @@ namespace NuGet.XPlat.FuncTest
                     updatedPassword
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -799,7 +807,7 @@ namespace NuGet.XPlat.FuncTest
                     updatedFindValue
                 };
 
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Act
                 var exitCode = Program.MainInternal(args.ToArray(), log);

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatHelpOutputTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatHelpOutputTests.cs
@@ -7,11 +7,19 @@ using System.IO;
 using System.Linq;
 using NuGet.CommandLine.XPlat;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.XPlat.FuncTest
 {
     public class XPlatHelpOutputTests
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public XPlatHelpOutputTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
         public static IEnumerable<object[]> ParseSuccessfully
         {
             get
@@ -43,7 +51,7 @@ namespace NuGet.XPlat.FuncTest
             var originalConsoleOut = Console.Out;
             using var consoleOutput = new StringWriter();
             Console.SetOut(consoleOutput);
-            var log = new TestCommandOutputLogger();
+            var log = new TestCommandOutputLogger(_testOutputHelper);
 
             // Act
             var exitCode = Program.MainInternal(args.ToArray(), log);
@@ -63,7 +71,7 @@ namespace NuGet.XPlat.FuncTest
             var originalConsoleOut = Console.Out;
             using var consoleOutput = new StringWriter();
             Console.SetOut(consoleOutput);
-            var log = new TestCommandOutputLogger();
+            var log = new TestCommandOutputLogger(_testOutputHelper);
 
             // Act
             var exitCode = Program.MainInternal(args.ToArray(), log);

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatPushTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatPushTests.cs
@@ -1,20 +1,25 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.Test.Utility;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.XPlat.FuncTest
 {
     public class XPlatPushTests
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public XPlatPushTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
         [PackageSourceTheory]
         [PackageSourceData(TestSources.MyGet)]
         [PackageSourceData(TestSources.ProGet, Skip = "No such host is known")]
@@ -30,7 +35,7 @@ namespace NuGet.XPlat.FuncTest
                 var packageVersion = "1.0.0";
                 var packageFile = await TestPackagesCore.GetRuntimePackageAsync(packageDir, packageId, packageVersion);
                 var configFile = XPlatTestUtils.CopyFuncTestConfig(packageDir);
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 var apiKey = XPlatTestUtils.ReadApiKey(packageSource.Name);
                 Assert.False(string.IsNullOrEmpty(apiKey));
@@ -72,8 +77,8 @@ namespace NuGet.XPlat.FuncTest
                 var packageVersion = "1.0.0";
                 var packageFile = await TestPackagesCore.GetRuntimePackageAsync(packageDir, packageId, packageVersion);
                 var configFile = XPlatTestUtils.CopyFuncTestConfig(packageDir);
-                var logFirstPush = new TestCommandOutputLogger();
-                var logSecondPush = new TestCommandOutputLogger();
+                var logFirstPush = new TestCommandOutputLogger(_testOutputHelper);
+                var logSecondPush = new TestCommandOutputLogger(_testOutputHelper);
 
                 var apiKey = XPlatTestUtils.ReadApiKey(packageSource.Name);
                 Assert.False(string.IsNullOrEmpty(apiKey));
@@ -121,12 +126,12 @@ namespace NuGet.XPlat.FuncTest
                 var packageVersion = "1.0.0";
                 var packageFile = await TestPackagesCore.GetRuntimePackageAsync(packageDir, packageId, packageVersion);
                 var configFile = XPlatTestUtils.CopyFuncTestConfig(packageDir);
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
 
                 var apiKey = XPlatTestUtils.ReadApiKey(packageSource.Name);
                 Assert.False(string.IsNullOrEmpty(apiKey));
 
-                DeletePackageBeforePush(packageId, packageVersion, packageSource.Source, apiKey);
+                DeletePackageBeforePush(packageId, packageVersion, packageSource.Source, apiKey, _testOutputHelper);
 
                 var pushArgs = new List<string>
                 {
@@ -157,7 +162,7 @@ namespace NuGet.XPlat.FuncTest
             using (var source = TestDirectory.Create())
             {
                 // Arrange
-                var log = new TestCommandOutputLogger();
+                var log = new TestCommandOutputLogger(_testOutputHelper);
                 var packageInfoCollection = new[]
                 {
                     await TestPackagesCore.GetRuntimePackageAsync(packageDirectory, "testPackageA", "1.1.0"),
@@ -192,10 +197,10 @@ namespace NuGet.XPlat.FuncTest
         /// This is called when the package must be deleted before being pushed. It's ok if this
         /// fails, maybe the package was never pushed.
         /// </summary>
-        private static void DeletePackageBeforePush(string packageId, string packageVersion, string sourceUri, string apiKey)
+        private static void DeletePackageBeforePush(string packageId, string packageVersion, string sourceUri, string apiKey, ITestOutputHelper testOutputHelper)
         {
             var packageUri = $"{sourceUri.TrimEnd('/')}/{packageId}/{packageVersion}";
-            var log = new TestCommandOutputLogger();
+            var log = new TestCommandOutputLogger(testOutputHelper);
             var args = new List<string>
             {
                 "delete",

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -11,13 +11,11 @@ using System.Xml.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.CommandLine.XPlat;
-using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
-using NuGet.Versioning;
 
 namespace NuGet.XPlat.FuncTest
 {
@@ -209,19 +207,16 @@ namespace NuGet.XPlat.FuncTest
             return package;
         }
 
-        internal static PackageReferenceArgs GetPackageReferenceArgs(string packageId, SimpleTestProjectContext project)
+        internal static PackageReferenceArgs GetPackageReferenceArgs(TestCommandOutputLogger logger, string packageId, SimpleTestProjectContext project)
         {
-            var logger = new TestCommandOutputLogger();
             return new PackageReferenceArgs(project.ProjectPath, logger)
             {
                 PackageId = packageId
             };
         }
 
-        internal static PackageReferenceArgs GetPackageReferenceArgs(string packageId, string packageVersion, SimpleTestProjectContext project,
-            string frameworks = "", string packageDirectory = "", string sources = "", bool noRestore = false, bool noVersion = false, bool prerelease = false)
+        internal static PackageReferenceArgs GetPackageReferenceArgs(TestCommandOutputLogger logger, string packageId, string packageVersion, SimpleTestProjectContext project, string frameworks = "", string packageDirectory = "", string sources = "", bool noRestore = false, bool noVersion = false, bool prerelease = false)
         {
-            var logger = new TestCommandOutputLogger();
             var dgFilePath = string.Empty;
             if (!noRestore)
             {

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTrustTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTrustTests.cs
@@ -130,7 +130,7 @@ namespace NuGet.XPlat.FuncTest
         {
             // Arrange
             var logLevel = LogLevel.Information;
-            var logger = new TestCommandOutputLogger();
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
             var testApp = new CommandLineApplication();
 
             testApp.Name = "dotnet nuget_test";

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatVerifyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatVerifyTests.cs
@@ -10,12 +10,20 @@ using NuGet.CommandLine.XPlat;
 using NuGet.Commands;
 using NuGet.Common;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.XPlat.FuncTest
 {
     [Collection("NuGet XPlat Test Collection")]
     public class XPlatVerifyTests
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public XPlatVerifyTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
         [Fact]
         public void VerifyCommandArgsParsing_MissingPackagePath_Throws()
         {
@@ -85,7 +93,7 @@ namespace NuGet.XPlat.FuncTest
         {
             // Arrange
             var logLevel = LogLevel.Information;
-            var logger = new TestCommandOutputLogger();
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
             var testApp = new CommandLineApplication();
             var mockCommandRunner = new Mock<IVerifyCommandRunner>();
             mockCommandRunner

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatWhyTests.cs
@@ -5,6 +5,7 @@ using NuGet.CommandLine.XPlat;
 using NuGet.Packaging;
 using NuGet.Test.Utility;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.XPlat.FuncTest
 {
@@ -12,14 +13,18 @@ namespace NuGet.XPlat.FuncTest
     public class XPlatWhyTests
     {
         private static readonly string ProjectName = "Test.Project.DotnetNugetWhy";
-        private static MSBuildAPIUtility MsBuild => new MSBuildAPIUtility(new TestCommandOutputLogger());
+
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public XPlatWhyTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
 
         [Fact]
         public async void WhyCommand_ProjectHasTransitiveDependency_DependencyPathExists()
         {
             // Arrange
-            var logger = new TestCommandOutputLogger();
-
             var pathContext = new SimpleTestPathContext();
             var projectFramework = "net472";
             var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, projectFramework);
@@ -37,9 +42,10 @@ namespace NuGet.XPlat.FuncTest
                 packageX,
                 packageY);
 
-            var addPackageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, packageX.Version, project);
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var addPackageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, project);
             var addPackageCommandRunner = new AddPackageReferenceCommandRunner();
-            var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageArgs, MsBuild);
+            var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageArgs, new MSBuildAPIUtility(logger));
 
             var whyCommandArgs = new WhyCommandArgs(
                     project.ProjectPath,
@@ -63,8 +69,6 @@ namespace NuGet.XPlat.FuncTest
         public async void WhyCommand_ProjectHasNoDependencyOnTargetPackage_PathDoesNotExist()
         {
             // Arrange
-            var logger = new TestCommandOutputLogger();
-
             var pathContext = new SimpleTestPathContext();
             var projectFramework = "net472";
             var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, projectFramework);
@@ -80,9 +84,10 @@ namespace NuGet.XPlat.FuncTest
                 packageX,
                 packageZ);
 
-            var addPackageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, packageX.Version, project);
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var addPackageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, project);
             var addPackageCommandRunner = new AddPackageReferenceCommandRunner();
-            var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageArgs, MsBuild);
+            var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageArgs, new MSBuildAPIUtility(logger));
 
             var whyCommandArgs = new WhyCommandArgs(
                     project.ProjectPath,
@@ -104,7 +109,7 @@ namespace NuGet.XPlat.FuncTest
         public void WhyCommand_ProjectDidNotRunRestore_Fails()
         {
             // Arrange
-            var logger = new TestCommandOutputLogger();
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
 
             var pathContext = new SimpleTestPathContext();
             var projectFramework = "net472";
@@ -137,7 +142,7 @@ namespace NuGet.XPlat.FuncTest
         public void WhyCommand_EmptyProjectArgument_Fails()
         {
             // Arrange
-            var logger = new TestCommandOutputLogger();
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
 
             var whyCommandArgs = new WhyCommandArgs(
                     "",
@@ -159,7 +164,7 @@ namespace NuGet.XPlat.FuncTest
         public void WhyCommand_EmptyPackageArgument_Fails()
         {
             // Arrange
-            var logger = new TestCommandOutputLogger();
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
 
             var pathContext = new SimpleTestPathContext();
             var projectFramework = "net472";
@@ -185,7 +190,7 @@ namespace NuGet.XPlat.FuncTest
         public void WhyCommand_InvalidProject_Fails()
         {
             // Arrange
-            var logger = new TestCommandOutputLogger();
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
 
             string fakeProjectPath = "FakeProjectPath.csproj";
 
@@ -209,8 +214,6 @@ namespace NuGet.XPlat.FuncTest
         public async void WhyCommand_InvalidFrameworksOption_WarnsCorrectly()
         {
             // Arrange
-            var logger = new TestCommandOutputLogger();
-
             var pathContext = new SimpleTestPathContext();
             var projectFramework = "net472";
             var inputFrameworksOption = "invalidFrameworkAlias";
@@ -229,9 +232,10 @@ namespace NuGet.XPlat.FuncTest
                 packageX,
                 packageY);
 
-            var addPackageCommandArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, packageX.Version, project);
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var addPackageCommandArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, project);
             var addPackageCommandRunner = new AddPackageReferenceCommandRunner();
-            var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageCommandArgs, MsBuild);
+            var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageCommandArgs, new MSBuildAPIUtility(logger));
 
             var whyCommandArgs = new WhyCommandArgs(
                     project.ProjectPath,

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatRemovePkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatRemovePkgTests.cs
@@ -122,7 +122,7 @@ namespace NuGet.XPlat.FuncTest
                 var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
                 var logger = new TestCommandOutputLogger(_testOutputHelper);
 
-                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger,unknownPackageId, projectA);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, unknownPackageId, projectA);
                 var commandRunner = new RemovePackageReferenceCommandRunner();
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatRemovePkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatRemovePkgTests.cs
@@ -10,6 +10,7 @@ using NuGet.CommandLine.XPlat;
 using NuGet.Packaging;
 using NuGet.Test.Utility;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.XPlat.FuncTest
 {
@@ -17,8 +18,12 @@ namespace NuGet.XPlat.FuncTest
     public class XPlatRemovePkgTests
     {
         private static readonly string ProjectName = "test_project_removepkg";
+        private readonly ITestOutputHelper _testOutputHelper;
 
-        private static MSBuildAPIUtility MsBuild => new MSBuildAPIUtility(new TestCommandOutputLogger());
+        public XPlatRemovePkgTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
 
         // Argument parsing related tests
 
@@ -40,7 +45,7 @@ namespace NuGet.XPlat.FuncTest
                     projectOption,
                     projectPath};
 
-                var logger = new TestCommandOutputLogger();
+                var logger = new TestCommandOutputLogger(_testOutputHelper);
                 var testApp = new CommandLineApplication();
                 var mockCommandRunner = new Mock<IPackageReferenceCommandRunner>();
                 mockCommandRunner
@@ -84,6 +89,7 @@ namespace NuGet.XPlat.FuncTest
                     packageX);
 
                 var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, packageX, "net46");
+                var logger = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Verify that the package reference exists before removing.
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
@@ -92,11 +98,11 @@ namespace NuGet.XPlat.FuncTest
                 Assert.NotNull(itemGroup);
                 Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, "1.0.0"));
 
-                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, projectA);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, projectA);
                 var commandRunner = new RemovePackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, MsBuild);
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
                 projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
                 // Assert
@@ -114,16 +120,16 @@ namespace NuGet.XPlat.FuncTest
             using (var pathContext = new SimpleTestPathContext())
             {
                 var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
+                var logger = new TestCommandOutputLogger(_testOutputHelper);
 
-                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(unknownPackageId, projectA);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger,unknownPackageId, projectA);
                 var commandRunner = new RemovePackageReferenceCommandRunner();
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
                 Assert.True(XPlatTestUtils.ValidateNoReference(projectXmlRoot, unknownPackageId));
-                var msBuild = MsBuild;
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
                 projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
                 // Assert
@@ -149,6 +155,8 @@ namespace NuGet.XPlat.FuncTest
 
                 var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, packageX, "net46; netcoreapp1.0", packageframework);
 
+                var logger = new TestCommandOutputLogger(_testOutputHelper);
+
                 // Verify that the package reference exists before removing.
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
                 var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, packageframework);
@@ -156,11 +164,11 @@ namespace NuGet.XPlat.FuncTest
                 Assert.NotNull(itemGroup);
                 Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, "1.0.0"));
 
-                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, projectA);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, projectA);
                 var commandRunner = new RemovePackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, MsBuild);
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
                 projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
                 // Assert

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatSignTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatSignTests.cs
@@ -13,6 +13,7 @@ using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Packaging.Signing;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.XPlat.FuncTest
 {
@@ -20,6 +21,12 @@ namespace NuGet.XPlat.FuncTest
     public class XplatSignTests
     {
         private const string _invalidArgException = "Invalid value provided for '{0}'. The accepted values are {1}.";
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public XplatSignTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
 
         [Fact]
         public void SignCommandArgsParsing_MissingPackagePath_Throws()
@@ -430,7 +437,7 @@ namespace NuGet.XPlat.FuncTest
         {
             // Arrange
             var logLevel = LogLevel.Information;
-            var logger = new TestCommandOutputLogger();
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
             var testApp = new CommandLineApplication();
             var mockCommandRunner = new Mock<ISignCommandRunner>();
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/ListPackageCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/ListPackageCommandRunnerTests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
@@ -134,13 +136,18 @@ namespace NuGet.CommandLine.Xplat.Tests
                         resolvedPackageVersionString: "2.0.0", latestPackageVersionString: "3.0.0"));
                 }
 
+                var output = new StringBuilder();
+                var error = new StringBuilder();
+                using TextWriter consoleOut = new StringWriter(output);
+                using TextWriter consoleError = new StringWriter(error);
+
                 packages.TopLevelPackages = topLevelPackages;
                 packages.TransitivePackages = transitivePackages;
                 var allPackages = new List<FrameworkPackages> { packages };
                 var listPackageArgs = new ListPackageArgs(path: "", packageSources: new List<PackageSource>(),
                     frameworks: new List<string>(),
                     ReportType.Outdated,
-                    new ListPackageConsoleRenderer(),
+                    new ListPackageConsoleRenderer(consoleOut, consoleError),
                     includeTransitive: true, prerelease: false, highestPatch: false, highestMinor: false,
                     logger: new Mock<ILogger>().Object,
                     CancellationToken.None);
@@ -176,13 +183,18 @@ namespace NuGet.CommandLine.Xplat.Tests
                             latestPackageVersionString: "3.0.0")
                     };
 
+                var output = new StringBuilder();
+                var error = new StringBuilder();
+                using TextWriter consoleOut = new StringWriter(output);
+                using TextWriter consoleError = new StringWriter(error);
+
                 packages.TopLevelPackages = topLevelPackages;
                 packages.TransitivePackages = transitivePackages;
                 List<FrameworkPackages> allPackages = new List<FrameworkPackages> { packages };
                 ListPackageArgs listPackageArgs = new ListPackageArgs(path: "", packageSources: new List<PackageSource>(),
                     frameworks: new List<string>(),
                     ReportType.Outdated,
-                    new ListPackageConsoleRenderer(),
+                    new ListPackageConsoleRenderer(consoleOut, consoleError),
                     includeTransitive: true, prerelease: false, highestPatch: true, highestMinor: true,
                     logger: new Mock<ILogger>().Object,
                     CancellationToken.None);
@@ -250,13 +262,18 @@ namespace NuGet.CommandLine.Xplat.Tests
                     transitivePackages.Add(ListPackageTestHelper.CreateInstalledPackageReference(isDeprecated: true));
                 }
 
+                var output = new StringBuilder();
+                var error = new StringBuilder();
+                using TextWriter consoleOut = new StringWriter(output);
+                using TextWriter consoleError = new StringWriter(error);
+
                 packages.TopLevelPackages = topLevelPackages;
                 packages.TransitivePackages = transitivePackages;
                 var allPackages = new List<FrameworkPackages> { packages };
                 var listPackageArgs = new ListPackageArgs(path: "", packageSources: new List<PackageSource>(),
                     frameworks: new List<string>(),
                     ReportType.Deprecated,
-                    new ListPackageConsoleRenderer(),
+                    new ListPackageConsoleRenderer(consoleOut, consoleError),
                     includeTransitive: true, prerelease: false, highestPatch: false, highestMinor: false, logger: new Mock<ILogger>().Object,
                     CancellationToken.None);
 
@@ -324,13 +341,18 @@ namespace NuGet.CommandLine.Xplat.Tests
                     transitivePackages.Add(ListPackageTestHelper.CreateInstalledPackageReference(vulnerabilityCount: 1));
                 }
 
+                var output = new StringBuilder();
+                var error = new StringBuilder();
+                using TextWriter consoleOut = new StringWriter(output);
+                using TextWriter consoleError = new StringWriter(error);
+
                 packages.TopLevelPackages = topLevelPackages;
                 packages.TransitivePackages = transitivePackages;
                 var allPackages = new List<FrameworkPackages> { packages };
                 var listPackageArgs = new ListPackageArgs(path: "", packageSources: new List<PackageSource>(),
                     frameworks: new List<string>(),
                     ReportType.Vulnerable,
-                    new ListPackageConsoleRenderer(),
+                    new ListPackageConsoleRenderer(consoleOut, consoleError),
                     includeTransitive: true, prerelease: false, highestPatch: false, highestMinor: false, logger: new Mock<ILogger>().Object,
                     CancellationToken.None);
 

--- a/test/TestUtilities/Test.Utility/SelfSignedCertificateMockServer.cs
+++ b/test/TestUtilities/Test.Utility/SelfSignedCertificateMockServer.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NuGet.Test.Server;
+using Xunit.Abstractions;
 
 namespace Test.Utility
 {
@@ -21,13 +22,15 @@ namespace Test.Utility
     {
         private readonly X509Certificate2 _certificate;
         private readonly string _packageDirectory;
+        private readonly ITestOutputHelper _testOutputHelper;
         private TcpListener _tcpListener;
         private bool _runServer = true;
         public string URI;
 
-        public SelfSignedCertificateMockServer(string packageDirectory)
+        public SelfSignedCertificateMockServer(string packageDirectory, ITestOutputHelper testOutputHelper)
         {
             _packageDirectory = packageDirectory;
+            _testOutputHelper = testOutputHelper;
             _certificate = GenerateSelfSignedCertificate();
         }
 
@@ -103,7 +106,7 @@ namespace Test.Utility
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine("Error processing request: " + ex.Message);
+                        _testOutputHelper.WriteLine($"[SelfSignedCertificateMockServer] Error processing request: {ex}");
                     }
                 }
             }
@@ -124,7 +127,7 @@ namespace Test.Utility
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error processing request: {ex.Message}");
+                _testOutputHelper.WriteLine($"[SelfSignedCertificateMockServer] Error processing request: {ex}");
             }
         }
 


### PR DESCRIPTION
## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
A couple of .NET test runs execute code paths that end up calling `Console.WriteLine()` which I find confusing when looking at a test run's output:

```
  The given project `ProjectA` has no vulnerable packages given the current sources.
  The given project `ProjectB` has no vulnerable packages given the current sources.
  Specify --help for a list of available options and commands.
  Specify --help for a list of available options and commands.
  Specify --help for a list of available options and commands.
  Specify --help for a list of available options and commands.
  Error processing request: The decryption operation failed, see inner exception.
  Error processing request: The decryption operation failed, see inner exception.
  Error processing request: The decryption operation failed, see inner exception.
  Error processing request: The decryption operation failed, see inner exception.
  Error processing request: The decryption operation failed, see inner exception.
  Error processing request: The decryption operation failed, see inner exception.
```

The "Error processing request" is coming from `SelfSignedCertificateMockServer` so I updated it to use `ITestOutputHelper`.  I also updated more tests that weren't logging command output to `ITestOutputHelper` that @donnie-msft had reported.  

Another change is to `ListPackageConsoleRenderer` to allow tests to capture its output instead of it writing to `Console.Out`.

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue. N/A
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
