### PR TITLE
Make assets file reading more permissive, allow nulls in arrays to be ignored

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/Utf8JsonStreamReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/Utf8JsonStreamReader.cs
@@ -180,9 +180,12 @@ namespace NuGet.ProjectModel
                 {
                     string value = _reader.ReadTokenAsString();
 
-                    strings ??= new List<string>();
+                    if (value != null)
+                    {
+                        strings ??= new List<string>();
 
-                    strings.Add(value);
+                        strings.Add(value);
+                    }
                 }
             }
             return strings;
@@ -250,7 +253,7 @@ namespace NuGet.ProjectModel
 
             while (Read() && _reader.TokenType != JsonTokenType.EndArray)
             {
-                string value = _reader.ReadTokenAsString();
+                string value = _reader.ReadTokenAsString(); // TODO NK - why is this one null accepting?
 
                 strings ??= new List<string>();
 

--- a/src/NuGet.Core/NuGet.ProjectModel/Utf8JsonStreamReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/Utf8JsonStreamReader.cs
@@ -253,7 +253,7 @@ namespace NuGet.ProjectModel
 
             while (Read() && _reader.TokenType != JsonTokenType.EndArray)
             {
-                string value = _reader.ReadTokenAsString(); // TODO NK - why is this one null accepting?
+                string value = _reader.ReadTokenAsString();
 
                 strings ??= new List<string>();
 

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Utf8JsonStreamReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Utf8JsonStreamReaderTests.cs
@@ -569,8 +569,7 @@ namespace NuGet.ProjectModel.Test
                     actualValue => Assert.Equal("a", actualValue),
                     actualValue => Assert.Equal("-2", actualValue),
                     actualValue => Assert.Equal("3.14", actualValue),
-                    actualValue => Assert.Equal("True", actualValue),
-                    actualValue => Assert.Null(actualValue));
+                    actualValue => Assert.Equal("True", actualValue));
                 Assert.Equal(JsonTokenType.EndArray, reader.TokenType);
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13563

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

This is a 2nd fix after https://github.com/NuGet/NuGet.Client/commit/ae8c3e443cce585cfc973075a8d9c7a809c549fd.

There's a discrepancy in how the arrays are read in NJ and STJ reading.
Unfortunately it's not 100% consistent in the reading overall (not a NJ vs STJ thing, but within the same implementation), so it's hard to really tell what the correct thing.

In this case, I analyzed before and after of the code paths I'm changing and I summarized the results. 

Here's the table: 

| Element | Null Safe | Reasoning |
| ----------|----------|-------------|
| Authors | not null safe | Deprecated and unused waiting to be removed, so we don't care. |
| ContentFiles | not null safe | Deprecated and unused waiting to be removed, so we don't care. |
| ConfigFilePaths | not null safe | Unlikely to have nulls at write, even through bugs. |
| FallbackFolders| not null safe | Unlikely to have nulls at write, even through bugs. |
| OriginalTargetFrameworks | not null safe | Unlikely to have nulls at write, even through bugs. |
| Owners | not null safe | Deprecated and unused waiting to be removed, so we don't care. |
| Tags | not null safe | Deprecated and unused waiting to be removed, so we don't care. |
|  runtimedescription | not null safe | could theoretically be null, but unlikely |
| TargetGraph in log messages | null safe | This change aligns it. |
| Files list in lock file target library | null safe | This change aligns it. |
| framework assembly in lock file target library | null safe | This change aligns it. |
| framework reference in lock file target library | null safe | This change aligns it. |
| dependencies in project file dependency group (the original issue)  | null safe | This change aligns it. |

The primary risk of taking this PR is that we would be potentially hiding the original issue. One would argue that's bad, as we'd rather see an issue reproing consistently than sometimes. 
This way, we're "more reliable" at the potential risk of bugs. Note that the roslyn would've seen their bug through NU1008 that was raised.

Open to opinions. Not sold 100% on either approach.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
