### PR TITLE
Workflow improvements - simplify the PR template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,12 +5,12 @@
 <!-- If this is an engineering change or test change only, you do not need an issue. -->
 <!-- Find or create an issue in NuGet/Home and paste the full url. -->
 <!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
-Fixes:
+Fixes: 
 
 ## Description
 
 ## PR Checklist
 
-- [ ] Meaningful title, helpful description and a linked issue
-- [ ] Automated tests, a test exception request or does not apply
-- [ ] Create and link to an issue to update docs if this PR changes settings, environment variables, new feature, etc.
+- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
+- [ ] Added tests
+- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,5 +12,5 @@ Fixes:
 ## PR Checklist
 
 - [ ] Meaningful title, helpful description and a linked issue
-- [ ] PR has automated tests added, I have described why I need an exception or test changes do not apply to this PR.
-- [ ] Link to a documentation issue or PR or these changes do not require documentation changes.
+- [ ] Automated tests, a test exception request or does not apply
+- [ ] Link to a documentation issue or PR or does not apply

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,4 +13,4 @@ Fixes:
 
 - [ ] Meaningful title, helpful description and a linked issue
 - [ ] Automated tests, a test exception request or does not apply
-- [ ] Link to a documentation issue or PR or does not apply
+- [ ] Create and link to an issue to update docs if this PR changes settings, environment variables, new feature, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 <!-- If this is an engineering change or test change only, you do not need an issue. -->
 <!-- Find or create an issue in NuGet/Home and paste the full url. -->
-<!-- Multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
+<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
 Fixes:
 
 ## Description

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,31 +1,16 @@
 <!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
-## Bug
 
-<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
-<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
+# Bug
+
+<!-- If this is an engineering change or test change only, you do not need an issue. -->
+<!-- Find or create an issue in NuGet/Home and paste the full url. -->
+<!-- Multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
 Fixes:
 
-Regression? Last working version:
-
 ## Description
-<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
 
 ## PR Checklist
 
-- [ ] PR has a meaningful title
-- [ ] PR has a linked issue.
-- [ ] Described changes
-
-- **Tests**
-  - [ ] Automated tests added
-  - **OR**
-  <!-- Describe why you haven't added automation. -->
-  - [ ] Test exception
-  - **OR**
-  - [ ] N/A <!-- Infrastructure, documentation etc. -->
-
-- **Documentation**
-  <!-- Please link the PR/issue if appropriate -->
-  - [ ] Documentation PR or issue filled
-  - **OR**
-  - [ ] N/A
+- [ ] Meaningful title, helpful description and a linked issue
+- [ ] PR has automated tests added, I have described why I need an exception or test changes do not apply to this PR.
+- [ ] Link to a documentation issue or PR or these changes do not require documentation changes.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -8,12 +8,13 @@ In here we describe the general workflow guidelines the NuGet developer/contribu
 
 To help ensure that only the highest quality code makes its way into the project, all code changes need to be submitted to GitHub as PRs.
 
-In general a PR should be approved by the Subject Matter Expert (SME) of that code. For example, a change to the Banana project should be signed off by `@Monkey`, and not by `@Giraffe`. If you don't know the SME, someone on the team will help you identify them. Of course, sometimes it's the SME who is making a change, in which case a secondary person will have to sign off on the change (e.g. `@JuniorMonkey`).
+In general a PR should be approved by a Subject Matter Expert (SME) of that code. For example, a change to the Banana project should be signed off by `@Monkey`, and not by `@Giraffe`. If you don't know the SME, someone on the team will help you identify them. Of course, sometimes it's the SME who is making a change, in which case a secondary person will have to sign off on the change (e.g. `@JuniorMonkey`).
 
 To commit the PR to the repo use the GitHub `Squash and Merge` button. We can't stress this enough. Always use `Squash and Merge` unless an exception is explicitly stated in this document.
 
 This repo has bots that manage all stale PRs. Stale PRs will be autoclosed.
 
+- *Do* follow the pull request template, as it helps the maintainers drive quality across the product.
 - *Do* favor having more than 1 reviewer.
 - *Do not* merge too quickly. Wait for at least 24h after the last significant changes before merging unless the change is urgent.
 - *Do* address all feedback. Not necessarily by accepting it, but by reaching a resolution with the reviewer. All comments need to be marked as resolved before merging.


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes:

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

In this PR, I attempt to simplify the PR template. Some reasoning behind these changes.
Before I get into the reason, the question probably is "why even have a template". The reason is release automation.

- Allow us to automatically generate release notes. Not following the template creates busy work each release. A few minutes each change is well worth the hours it'd take to generate the release notes otherwise.
- Release readiness automation (such as for the docs, catching issues that weren't closed, changes that were reverted etc.


Here's some of the logic behind the changes: 

- Current there are 8 checkboxes, but a complete PR only requires 5 of them to be selected. The motivation is require all the checklists to be checked.
- The 8 checkboxes often don't end up filled out. This reduces that.
- The regression part is really something that should be included in the issue, not in the PR. 
- Merged the naming, description and linking an issue into 1. This is just basics around prepping a PR.
- Merged the test section into 1. During the PR review it'll be obvious if there are tests missing. If  there's a test exception request (infrequent), it is the burden of the PR author to add that information.
- Merged the docs section. This is the most missed section. There's many changes that needed docs updates, but never gotten them because this section wasn't honored. Similar to the other ones, it is the responsibility of PR author to get this right.
- I have further remove the need for 1 issue 1 PR. The idea is that we can make simple engineering changes without an issue and simple test changes without an issue. It is also acceptable that a single issue may have a few tiny PRs (think, memory improvements during restore). This shouldn't be something that's abused and it should be at the discretion of the maintainers to enforce it as they see it. 

Open to feedback. Hoping we can come up with something simpler :) 
## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A

---------------------
The below is an example of how the new template would look like for this PR
---------------------

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- Multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: Developer docs

## Description


In this PR, I attempt to simplify the PR template. Some reasoning behind these changes.
Before I get into the reason, the question probably is "why even have a template". The reason is release automation.

- Allow us to automatically generate release notes. Not following the template creates busy work each release. A few minutes each change is well worth the hours it'd take to generate the release notes otherwise.
- Release readiness automation (such as for the docs, catching issues that weren't closed, changes that were reverted etc.


Here's some of the logic behind the changes: 

- Current there are 8 checkboxes, but a complete PR only requires 5 of them to be selected. The motivation is require all the checklists to be checked.
- The 8 checkboxes often don't end up filled out. This reduces that.
- The regression part is really something that should be included in the issue, not in the PR. 
- Merged the naming, description and linking an issue into 1. This is just basics around prepping a PR.
- Merged the test section into 1. During the PR review it'll be obvious if there are tests missing. If  there's a test exception request (infrequent), it is the burden of the PR author to add that information.
- Merged the docs section. This is the most missed section. There's many changes that needed docs updates, but never gotten them because this section wasn't honored. Similar to the other ones, it is the responsibility of PR author to get this right.
- I have further remove the need for 1 issue 1 PR. The idea is that we can make simple engineering changes without an issue and simple test changes without an issue. It is also acceptable that a single issue may have a few tiny PRs (think, memory improvements during restore). This shouldn't be something that's abused and it should be at the discretion of the maintainers to enforce it as they see it. 

Open to feedback. Hoping we can come up with something simpler :) 

## PR Checklist

- [x] Meaningful title, helpful description and a linked issue
- [x] Automated tests, a test exception request or does not apply
- [x] Link to a documentation issue or PR or does not apply

