### PR TITLE
Add telemetry for https sources

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -336,7 +336,7 @@ namespace NuGet.SolutionRestoreManager
             var packageSources = _sourceRepositoryProvider.PackageSourceProvider.LoadPackageSources().ToList();
 
             int NumHTTPFeeds = 0;
-            int NumNonHttpsFeeds = 0;
+            int NumHttpsFeeds = 0;
             int NumLocalFeeds = 0;
             bool hasVSOfflineFeed = false;
             bool hasNuGetOrg = false;
@@ -349,9 +349,9 @@ namespace NuGet.SolutionRestoreManager
                     {
                         NumHTTPFeeds++;
 
-                        if (!packageSource.IsHttps)
+                        if (packageSource.IsHttps)
                         {
-                            NumNonHttpsFeeds++;
+                            NumHttpsFeeds++;
                         }
                         hasNuGetOrg |= UriUtility.IsNuGetOrg(packageSource.Source);
                     }
@@ -386,7 +386,7 @@ namespace NuGet.SolutionRestoreManager
                 intervalTimingTracker,
                 isPackageSourceMappingEnabled,
                 NumHTTPFeeds,
-                NumNonHttpsFeeds,
+                NumHttpsFeeds,
                 NumLocalFeeds,
                 hasNuGetOrg,
                 hasVSOfflineFeed);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -336,6 +336,7 @@ namespace NuGet.SolutionRestoreManager
             var packageSources = _sourceRepositoryProvider.PackageSourceProvider.LoadPackageSources().ToList();
 
             int NumHTTPFeeds = 0;
+            int NumNonHttpsFeeds = 0;
             int NumLocalFeeds = 0;
             bool hasVSOfflineFeed = false;
             bool hasNuGetOrg = false;
@@ -347,6 +348,11 @@ namespace NuGet.SolutionRestoreManager
                     if (packageSource.IsHttp)
                     {
                         NumHTTPFeeds++;
+
+                        if (!packageSource.IsHttps)
+                        {
+                            NumNonHttpsFeeds++;
+                        }
                         hasNuGetOrg |= UriUtility.IsNuGetOrg(packageSource.Source);
                     }
                     else
@@ -380,6 +386,7 @@ namespace NuGet.SolutionRestoreManager
                 intervalTimingTracker,
                 isPackageSourceMappingEnabled,
                 NumHTTPFeeds,
+                NumNonHttpsFeeds,
                 NumLocalFeeds,
                 hasNuGetOrg,
                 hasVSOfflineFeed);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
@@ -28,6 +28,7 @@ namespace NuGet.VisualStudio
         public const string TimeSinceLastRestoreCompleted = nameof(TimeSinceLastRestoreCompleted);
         public const string LastRestoreOperationSource = nameof(LastRestoreOperationSource);
         public const string NumHTTPFeeds = nameof(NumHTTPFeeds);
+        public const string NumNonHttpsFeeds = nameof(NumNonHttpsFeeds);
         public const string NumLocalFeeds = nameof(NumLocalFeeds);
         public const string NuGetOrg = nameof(NuGetOrg);
         public const string VsOfflinePackages = nameof(VsOfflinePackages);
@@ -56,6 +57,7 @@ namespace NuGet.VisualStudio
             IntervalTracker intervalTimingTracker,
             bool isPackageSourceMappingEnabled,
             int httpFeedsCount,
+            int nonHttpsFeedsCount,
             int localFeedsCount,
             bool hasNuGetOrg,
             bool hasVSOfflineFeed
@@ -74,6 +76,7 @@ namespace NuGet.VisualStudio
             base[nameof(ForceRestore)] = forceRestore;
             base[PackageSourceMappingIsMappingEnabled] = isPackageSourceMappingEnabled;
             base[NumHTTPFeeds] = httpFeedsCount;
+            base[NumNonHttpsFeeds] = nonHttpsFeedsCount;
             base[NumLocalFeeds] = localFeedsCount;
             base[NuGetOrg] = hasNuGetOrg;
             base[VsOfflinePackages] = hasVSOfflineFeed;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
@@ -28,7 +28,7 @@ namespace NuGet.VisualStudio
         public const string TimeSinceLastRestoreCompleted = nameof(TimeSinceLastRestoreCompleted);
         public const string LastRestoreOperationSource = nameof(LastRestoreOperationSource);
         public const string NumHTTPFeeds = nameof(NumHTTPFeeds);
-        public const string NumNonHttpsFeeds = nameof(NumNonHttpsFeeds);
+        public const string NumHttpsFeeds = nameof(NumHttpsFeeds);
         public const string NumLocalFeeds = nameof(NumLocalFeeds);
         public const string NuGetOrg = nameof(NuGetOrg);
         public const string VsOfflinePackages = nameof(VsOfflinePackages);
@@ -57,7 +57,7 @@ namespace NuGet.VisualStudio
             IntervalTracker intervalTimingTracker,
             bool isPackageSourceMappingEnabled,
             int httpFeedsCount,
-            int nonHttpsFeedsCount,
+            int httpsFeedsCount,
             int localFeedsCount,
             bool hasNuGetOrg,
             bool hasVSOfflineFeed
@@ -76,7 +76,7 @@ namespace NuGet.VisualStudio
             base[nameof(ForceRestore)] = forceRestore;
             base[PackageSourceMappingIsMappingEnabled] = isPackageSourceMappingEnabled;
             base[NumHTTPFeeds] = httpFeedsCount;
-            base[NumNonHttpsFeeds] = nonHttpsFeedsCount;
+            base[NumHttpsFeeds] = httpsFeedsCount;
             base[NumLocalFeeds] = localFeedsCount;
             base[NuGetOrg] = hasNuGetOrg;
             base[VsOfflinePackages] = hasVSOfflineFeed;

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+NuGet.Commands.SourceRepositoryDependencyProvider.IsHttps.get -> bool

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+NuGet.Commands.SourceRepositoryDependencyProvider.IsHttps.get -> bool

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+NuGet.Commands.SourceRepositoryDependencyProvider.IsHttps.get -> bool

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -54,6 +54,7 @@ namespace NuGet.Commands
         private const string NewPackagesInstalledCount = nameof(NewPackagesInstalledCount);
         private const string SourcesCount = nameof(SourcesCount);
         private const string HttpSourcesCount = nameof(HttpSourcesCount);
+        private const string NonHttpsSourcesCount = nameof(NonHttpsSourcesCount);
         private const string LocalSourcesCount = nameof(LocalSourcesCount);
         private const string FallbackFoldersCount = nameof(FallbackFoldersCount);
 
@@ -157,7 +158,9 @@ namespace NuGet.Commands
                 telemetry.TelemetryEvent[PackageSourceMappingIsMappingEnabled] = isPackageSourceMappingEnabled;
                 telemetry.TelemetryEvent[SourcesCount] = _request.DependencyProviders.RemoteProviders.Count;
                 int httpSourcesCount = _request.DependencyProviders.RemoteProviders.Where(e => e.IsHttp).Count();
+                int nonHttpsSourcesCount = _request.DependencyProviders.RemoteProviders.Where(e => !e.IsHttps).Count();
                 telemetry.TelemetryEvent[HttpSourcesCount] = httpSourcesCount;
+                telemetry.TelemetryEvent[NonHttpsSourcesCount] = nonHttpsSourcesCount;
                 telemetry.TelemetryEvent[LocalSourcesCount] = _request.DependencyProviders.RemoteProviders.Count - httpSourcesCount;
                 telemetry.TelemetryEvent[FallbackFoldersCount] = _request.DependencyProviders.FallbackPackageFolders.Count;
                 bool isLockFileEnabled = PackagesLockFileUtilities.IsNuGetLockFileEnabled(_request.Project);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -54,7 +54,7 @@ namespace NuGet.Commands
         private const string NewPackagesInstalledCount = nameof(NewPackagesInstalledCount);
         private const string SourcesCount = nameof(SourcesCount);
         private const string HttpSourcesCount = nameof(HttpSourcesCount);
-        private const string NonHttpsSourcesCount = nameof(NonHttpsSourcesCount);
+        private const string HttpsSourcesCount = nameof(HttpsSourcesCount);
         private const string LocalSourcesCount = nameof(LocalSourcesCount);
         private const string FallbackFoldersCount = nameof(FallbackFoldersCount);
 
@@ -158,9 +158,9 @@ namespace NuGet.Commands
                 telemetry.TelemetryEvent[PackageSourceMappingIsMappingEnabled] = isPackageSourceMappingEnabled;
                 telemetry.TelemetryEvent[SourcesCount] = _request.DependencyProviders.RemoteProviders.Count;
                 int httpSourcesCount = _request.DependencyProviders.RemoteProviders.Where(e => e.IsHttp).Count();
-                int nonHttpsSourcesCount = _request.DependencyProviders.RemoteProviders.Where(e => !e.IsHttps).Count();
+                int httpsSourcesCount = _request.DependencyProviders.RemoteProviders.Where(e => e.IsHttps).Count();
                 telemetry.TelemetryEvent[HttpSourcesCount] = httpSourcesCount;
-                telemetry.TelemetryEvent[NonHttpsSourcesCount] = nonHttpsSourcesCount;
+                telemetry.TelemetryEvent[HttpsSourcesCount] = httpsSourcesCount;
                 telemetry.TelemetryEvent[LocalSourcesCount] = _request.DependencyProviders.RemoteProviders.Count - httpSourcesCount;
                 telemetry.TelemetryEvent[FallbackFoldersCount] = _request.DependencyProviders.FallbackPackageFolders.Count;
                 bool isLockFileEnabled = PackagesLockFileUtilities.IsNuGetLockFileEnabled(_request.Project);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -144,6 +144,11 @@ namespace NuGet.Commands
         public bool IsHttp => _sourceRepository.PackageSource.IsHttp;
 
         /// <summary>
+        /// Gets a flag indicating whether or not the provider source is HTTPS.
+        /// </summary>
+        public bool IsHttps => _sourceRepository.PackageSource.IsHttps;
+
+        /// <summary>
         /// Gets the package source.
         /// </summary>
         /// <remarks>Optional. This will be <see langword="null" /> for project providers.</remarks>

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/IRemoteDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/IRemoteDependencyProvider.cs
@@ -26,6 +26,11 @@ namespace NuGet.DependencyResolver
         bool IsHttp { get; }
 
         /// <summary>
+        /// Gets a flag indicating whether or not the provider source is HTTPS.
+        /// </summary>
+        bool IsHttps { get; }
+
+        /// <summary>
         /// Gets the package source.
         /// </summary>
         /// <remarks>Optional. This will be <see langword="null" /> for project providers.</remarks>

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
@@ -45,6 +45,11 @@ namespace NuGet.DependencyResolver
         public bool IsHttp { get; private set; }
 
         /// <summary>
+        /// Gets a flag indicating whether or not the provider source is HTTPS.
+        /// </summary>
+        public bool IsHttps { get; private set; }
+
+        /// <summary>
         /// Gets the package source.
         /// </summary>
         /// <remarks>Optional. This will be <see langword="null" /> for project providers.</remarks>

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+NuGet.DependencyResolver.IRemoteDependencyProvider.IsHttps.get -> bool
+NuGet.DependencyResolver.LocalDependencyProvider.IsHttps.get -> bool

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/RestoreTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/RestoreTelemetryServiceTests.cs
@@ -72,7 +72,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 new IntervalTracker("Activity"),
                 isPackageSourceMappingEnabled: false,
                 httpFeedsCount: 1,
-                nonHttpsFeedsCount: 1,
+                httpsFeedsCount: 1,
                 localFeedsCount: 2,
                 hasNuGetOrg: true,
                 hasVSOfflineFeed: false);
@@ -139,7 +139,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 tracker,
                 isPackageSourceMappingEnabled: isPackageSourceMappingEnabled,
                 httpFeedsCount: 1,
-                nonHttpsFeedsCount: 1,
+                httpsFeedsCount: 1,
                 localFeedsCount: 2,
                 hasNuGetOrg: true,
                 hasVSOfflineFeed: false);
@@ -185,7 +185,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.Equal(expected[RestoreTelemetryEvent.NuGetOrg], (bool)actual["NuGetOrg"]);
             Assert.Equal(expected[RestoreTelemetryEvent.VsOfflinePackages], (bool)actual["VsOfflinePackages"]);
             Assert.Equal(1, (int)actual["NumHTTPFeeds"]);
-            Assert.Equal(1, (int)actual["NumNonHttpsFeeds"]);
+            Assert.Equal(1, (int)actual["NumHttpsFeeds"]);
             Assert.Equal(2, (int)actual["NumLocalFeeds"]);
             Assert.True((bool)actual["NuGetOrg"]);
             Assert.False((bool)actual["VsOfflinePackages"]);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/RestoreTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/RestoreTelemetryServiceTests.cs
@@ -72,6 +72,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 new IntervalTracker("Activity"),
                 isPackageSourceMappingEnabled: false,
                 httpFeedsCount: 1,
+                nonHttpsFeedsCount: 1,
                 localFeedsCount: 2,
                 hasNuGetOrg: true,
                 hasVSOfflineFeed: false);
@@ -138,6 +139,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 tracker,
                 isPackageSourceMappingEnabled: isPackageSourceMappingEnabled,
                 httpFeedsCount: 1,
+                nonHttpsFeedsCount: 1,
                 localFeedsCount: 2,
                 hasNuGetOrg: true,
                 hasVSOfflineFeed: false);
@@ -150,7 +152,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             Assert.NotNull(lastTelemetryEvent);
             Assert.Equal(RestoreTelemetryEvent.RestoreActionEventName, lastTelemetryEvent.Name);
-            Assert.Equal(27, lastTelemetryEvent.Count);
+            Assert.Equal(28, lastTelemetryEvent.Count);
 
             Assert.Equal(restoreTelemetryData.OperationSource.ToString(), lastTelemetryEvent["OperationSource"].ToString());
 
@@ -163,7 +165,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             Assert.NotNull(actual);
             Assert.Equal(RestoreTelemetryEvent.RestoreActionEventName, actual.Name);
-            Assert.Equal(26, actual.Count);
+            Assert.Equal(27, actual.Count);
 
             Assert.Equal(expected.OperationSource.ToString(), actual["OperationSource"].ToString());
 
@@ -183,6 +185,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.Equal(expected[RestoreTelemetryEvent.NuGetOrg], (bool)actual["NuGetOrg"]);
             Assert.Equal(expected[RestoreTelemetryEvent.VsOfflinePackages], (bool)actual["VsOfflinePackages"]);
             Assert.Equal(1, (int)actual["NumHTTPFeeds"]);
+            Assert.Equal(1, (int)actual["NumNonHttpsFeeds"]);
             Assert.Equal(2, (int)actual["NumLocalFeeds"]);
             Assert.True((bool)actual["NuGetOrg"]);
             Assert.False((bool)actual["VsOfflinePackages"]);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -2869,6 +2869,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 ["PackageSourceMapping.IsMappingEnabled"] = value => value.Should().Be(false),
                 ["SourcesCount"] = value => value.Should().Be(1),
                 ["HttpSourcesCount"] = value => value.Should().Be(0),
+                ["NonHttpsSourcesCount"] = value => value.Should().Be(0),
                 ["LocalSourcesCount"] = value => value.Should().Be(1),
                 ["FallbackFoldersCount"] = value => value.Should().Be(0),
                 ["Audit.Enabled"] = value => value.Should().Be("enabled"),
@@ -2982,6 +2983,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
             projectInformationEvent["PackageSourceMapping.IsMappingEnabled"].Should().Be(false);
             projectInformationEvent["SourcesCount"].Should().Be(1);
             projectInformationEvent["HttpSourcesCount"].Should().Be(0);
+            projectInformationEvent["NonHttpsSourcesCount"].Should().Be(0);
             projectInformationEvent["LocalSourcesCount"].Should().Be(1);
             projectInformationEvent["FallbackFoldersCount"].Should().Be(0);
             projectInformationEvent["IsLockFileEnabled"].Should().Be(false);
@@ -3043,7 +3045,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
             var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
 
-            projectInformationEvent.Count.Should().Be(29);
+            projectInformationEvent.Count.Should().Be(30);
             projectInformationEvent["RestoreSuccess"].Should().Be(true);
             projectInformationEvent["NoOpResult"].Should().Be(false);
             projectInformationEvent["TotalUniquePackagesCount"].Should().Be(2);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -2869,7 +2869,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 ["PackageSourceMapping.IsMappingEnabled"] = value => value.Should().Be(false),
                 ["SourcesCount"] = value => value.Should().Be(1),
                 ["HttpSourcesCount"] = value => value.Should().Be(0),
-                ["NonHttpsSourcesCount"] = value => value.Should().Be(0),
+                ["HttpsSourcesCount"] = value => value.Should().Be(0),
                 ["LocalSourcesCount"] = value => value.Should().Be(1),
                 ["FallbackFoldersCount"] = value => value.Should().Be(0),
                 ["Audit.Enabled"] = value => value.Should().Be("enabled"),
@@ -2983,7 +2983,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
             projectInformationEvent["PackageSourceMapping.IsMappingEnabled"].Should().Be(false);
             projectInformationEvent["SourcesCount"].Should().Be(1);
             projectInformationEvent["HttpSourcesCount"].Should().Be(0);
-            projectInformationEvent["NonHttpsSourcesCount"].Should().Be(0);
+            projectInformationEvent["HttpsSourcesCount"].Should().Be(0);
             projectInformationEvent["LocalSourcesCount"].Should().Be(1);
             projectInformationEvent["FallbackFoldersCount"].Should().Be(0);
             projectInformationEvent["IsLockFileEnabled"].Should().Be(false);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -2964,7 +2964,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
             var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
 
-            projectInformationEvent.Count.Should().Be(22);
+            projectInformationEvent.Count.Should().Be(23);
             projectInformationEvent["RestoreSuccess"].Should().Be(true);
             projectInformationEvent["NoOpResult"].Should().Be(true);
             projectInformationEvent["IsCentralVersionManagementEnabled"].Should().Be(false);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
@@ -79,6 +79,7 @@ namespace NuGet.Commands.Test
             using (var test = SourceRepositoryDependencyProviderTest.Create())
             {
                 Assert.Equal(test.PackageSource.IsHttp, test.Provider.IsHttp);
+                Assert.Equal(test.PackageSource.IsHttps, test.Provider.IsHttps);
                 Assert.Same(test.PackageSource, test.Provider.Source);
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/ResolverFacts.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/ResolverFacts.cs
@@ -122,6 +122,8 @@ namespace NuGet.DependencyResolver.Core.Tests
 
             public bool IsHttp => true;
 
+            public bool IsHttps => false;
+
             public PackageSource Source => new PackageSource("Test");
 
             public SourceRepository SourceRepository => throw new NotImplementedException();

--- a/test/TestUtilities/Test.Utility/DependencyResolver/DependencyProvider.cs
+++ b/test/TestUtilities/Test.Utility/DependencyResolver/DependencyProvider.cs
@@ -24,6 +24,8 @@ namespace Test.Utility
 
         public bool IsHttp => false;
 
+        public bool IsHttps => false;
+
         public PackageSource Source => new PackageSource("Test");
 
         public SourceRepository SourceRepository => throw new NotImplementedException();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: https://github.com/NuGet/Home/issues/13606

Regression? Last working version:

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->
This PR adds a property, `https` to the remote dependency provider. This property is utilized to track telemetry data regarding the usage of non-HTTPS sources. Since we already have telemetry for http sources adding https will allow use to have a bigger picture on the ratio of secure to insecure sources. "non https sources = http - https"
* NumNonHttpsFeeds in SolutionRestoreJob
* NonHttpsSourcesCount in RestoreCommand

**We would like to merge this PR for 17.11. It will establish a baseline for comparisons with version 17.12, which is planned to include Non-HTTPS source errors.**

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [x] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
