### PR TITLE
Fix threading issue in OutputConsoleLogger

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/OutputConsoleLoggerTests.Start.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/OutputConsoleLoggerTests.Start.cs
@@ -1,10 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.Sdk.TestFramework;
 using Moq;
-using NuGet.CommandLine;
 using Xunit;
 
 namespace NuGet.VisualStudio.Common.Test


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2528

## Description
The `OutputConsoleLoggerTests+Dispose.Disposes_error_list` test fails occasionally with the following exception:
```
System.ObjectDisposedException : Cannot access a disposed object.
Object name: 'Microsoft.VisualStudio.Threading.AsyncSemaphore'.
```

This change also adds synchronization to the `Dispose()` method by using an `int` and `Interlocked.CompareExchange()` to ensure that only one thread disposes of the underlying semaphore.

Before this change, I was not able to run the `OutputConsoleLoggerTests` over and over again with 100% success rate.  Now I can run them 100 times in a row and they pass every time.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~~Added tests~~ Existing tests provide sufficient coverage
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
