### PR TITLE
Fix hang in Solution Explorer search through transitive package items of dependencies tree

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/AssetsFileTopLevelDependenciesCollectionSourceProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/AssetsFileTopLevelDependenciesCollectionSourceProvider.cs
@@ -92,11 +92,21 @@ namespace NuGet.VisualStudio.SolutionExplorer
 
             var collectionSource = new AggregateRelationCollectionSource(hierarchyItem);
             AggregateContainsRelationCollection? collection = null;
+            AssetsFileDependenciesSnapshot? lastSnapshot = null;
 
             var actionBlock = new ActionBlock<IProjectVersionedValue<AssetsFileDependenciesSnapshot>>(
                 async versionedValue =>
                 {
                     AssetsFileDependenciesSnapshot snapshot = versionedValue.Value;
+
+                    if (ReferenceEquals(snapshot, lastSnapshot))
+                    {
+                        // Skip version-only updates.
+                        return;
+                    }
+
+                    lastSnapshot = snapshot;
+
                     if (snapshot.TryGetTarget(target, out AssetsFileTarget? targetData))
                     {
                         if (TryGetLibrary(targetData, libraryName, out AssetsFileTargetLibrary? library))


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

Fixes: https://github.com/NuGet/Home/issues/13619
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2079818

## Description

#5508 reduced the number of dataflow updates through code that led to redundant tree updates. It did that by inhibiting updates in cases where nothing changed.

`AssetsFileDependenciesTreeSearchProvider` uses `GetLatestVersionAsync` to obtain the latest snapshot value, relative to the current data versions of the project. However suppression of updates meant that the latest version might not be present, and the call would hang indefinitely. This would break Solution Explorer search for customers who enabled "Search External Items", have SDK-style .NET projects in the solution, and make certain project changes that lead to so-called "version-only" updates.

This PR reverts #5508 and adds a downstream check for unchanged data, skipping tree updates in such cases. This means that the latest data is always available for the search component to consume, meaning there's no hang.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
