### PR TITLE
Allow passing assets file directly to dotnet nuget why

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/WhyCommand/WhyCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/WhyCommand/WhyCommandRunner.cs
@@ -118,23 +118,13 @@ namespace NuGet.CommandLine.XPlat
                         }
 
                         string? assetsFilePath = project.GetPropertyValue(ProjectAssetsFile);
-                        if (string.IsNullOrEmpty(assetsFilePath))
-                        {
-                            logger.LogError(
-                                string.Format(
-                                    CultureInfo.CurrentCulture,
-                                    Strings.Error_ProjectAssetsFilePropertyNotFound,
-                                    project.FullPath));
-                            continue;
-                        }
-
-                        if (!File.Exists(assetsFilePath))
+                        if (string.IsNullOrEmpty(assetsFilePath) || !File.Exists(assetsFilePath))
                         {
                             logger.LogError(
                                 string.Format(
                                     CultureInfo.CurrentCulture,
                                     Strings.Error_AssetsFileNotFound,
-                                    assetsFilePath));
+                                    project.FullPath));
                             continue;
                         }
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/WhyCommand/WhyCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/WhyCommand/WhyCommandRunner.cs
@@ -91,7 +91,7 @@ namespace NuGet.CommandLine.XPlat
         private static IEnumerable<(string assetsFilepath, string? projectPath)> FindAssetsFiles(string path, ILoggerWithColor logger)
         {
             var extension = Path.GetExtension(path);
-            if (string.Equals(".json", extension, StringComparison.OrdinalIgnoreCase))
+            if (XPlatUtility.IsJsonFile(extension))
             {
                 yield return (path, null);
                 yield break;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/WhyCommand/WhyCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/WhyCommand/WhyCommandRunner.cs
@@ -88,10 +88,9 @@ namespace NuGet.CommandLine.XPlat
             return anyErrors ? ExitCodes.Error : ExitCodes.Success;
         }
 
-        private static IEnumerable<(string assetsFilepath, string? projectPath)> FindAssetsFiles(string path, ILoggerWithColor logger)
+        private static IEnumerable<(string assetsFilePath, string? projectPath)> FindAssetsFiles(string path, ILoggerWithColor logger)
         {
-            var extension = Path.GetExtension(path);
-            if (XPlatUtility.IsJsonFile(extension))
+            if (XPlatUtility.IsJsonFile(path))
             {
                 yield return (path, null);
                 yield break;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/WhyCommand/WhyCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/WhyCommand/WhyCommandRunner.cs
@@ -30,10 +30,10 @@ namespace NuGet.CommandLine.XPlat
             }
 
             string targetPackage = whyCommandArgs.Package;
-            IEnumerable<string> projectPaths;
+            IEnumerable<(string assetsFilePath, string? projectPath)> assetsFiles;
             try
             {
-                projectPaths = MSBuildAPIUtility.GetListOfProjectsFromPathArgument(whyCommandArgs.Path);
+                assetsFiles = GetAssetsFiles(whyCommandArgs.Path, whyCommandArgs.Logger);
             }
             catch (ArgumentException ex)
             {
@@ -46,57 +46,110 @@ namespace NuGet.CommandLine.XPlat
                 return ExitCodes.InvalidArguments;
             }
 
-            foreach (var projectPath in projectPaths)
+            bool anyErrors = false;
+            foreach ((string assetsFilePath, string? projectPath) in assetsFiles)
             {
-                Project project = MSBuildAPIUtility.GetProject(projectPath);
+                LockFile? assetsFile = GetProjectAssetsFile(assetsFilePath, projectPath, whyCommandArgs.Logger);
 
-                string usingNetSdk = project.GetPropertyValue("UsingMicrosoftNETSdk");
-
-                if (!string.IsNullOrEmpty(usingNetSdk))
+                if (assetsFile != null)
                 {
-                    LockFile? assetsFile = GetProjectAssetsFile(project, whyCommandArgs.Logger);
+                    ValidateFrameworksOptionsExistInAssetsFile(assetsFile, whyCommandArgs.Frameworks, whyCommandArgs.Logger);
 
-                    if (assetsFile != null)
+                    Dictionary<string, List<DependencyNode>?>? dependencyGraphPerFramework = DependencyGraphFinder.GetAllDependencyGraphsForTarget(
+                        assetsFile,
+                        whyCommandArgs.Package,
+                        whyCommandArgs.Frameworks);
+
+                    if (dependencyGraphPerFramework != null)
                     {
-                        ValidateFrameworksOptionsExistInAssetsFile(assetsFile, whyCommandArgs.Frameworks, whyCommandArgs.Logger);
+                        whyCommandArgs.Logger.LogMinimal(
+                            string.Format(
+                                Strings.WhyCommand_Message_DependencyGraphsFoundInProject,
+                                assetsFile.PackageSpec.Name,
+                                targetPackage));
 
-                        Dictionary<string, List<DependencyNode>?>? dependencyGraphPerFramework = DependencyGraphFinder.GetAllDependencyGraphsForTarget(
-                            assetsFile,
-                            whyCommandArgs.Package,
-                            whyCommandArgs.Frameworks);
-
-                        if (dependencyGraphPerFramework != null)
-                        {
-                            whyCommandArgs.Logger.LogMinimal(
-                                string.Format(
-                                    Strings.WhyCommand_Message_DependencyGraphsFoundInProject,
-                                    assetsFile.PackageSpec.Name,
-                                    targetPackage));
-
-                            DependencyGraphPrinter.PrintAllDependencyGraphs(dependencyGraphPerFramework, targetPackage, whyCommandArgs.Logger);
-                        }
-                        else
-                        {
-                            whyCommandArgs.Logger.LogMinimal(
-                                string.Format(
-                                    Strings.WhyCommand_Message_NoDependencyGraphsFoundInProject,
-                                    assetsFile.PackageSpec.Name,
-                                    targetPackage));
-                        }
+                        DependencyGraphPrinter.PrintAllDependencyGraphs(dependencyGraphPerFramework, targetPackage, whyCommandArgs.Logger);
+                    }
+                    else
+                    {
+                        whyCommandArgs.Logger.LogMinimal(
+                            string.Format(
+                                Strings.WhyCommand_Message_NoDependencyGraphsFoundInProject,
+                                assetsFile.PackageSpec.Name,
+                                targetPackage));
                     }
                 }
                 else
                 {
-                    whyCommandArgs.Logger.LogMinimal(
-                            string.Format(
-                                Strings.WhyCommand_Message_NonSDKStyleProjectsAreNotSupported,
-                                project.GetPropertyValue("MSBuildProjectName")));
+                    anyErrors = true;
                 }
-
-                ProjectCollection.GlobalProjectCollection.UnloadProject(project);
             }
 
-            return ExitCodes.Success;
+            return anyErrors ? ExitCodes.Error : ExitCodes.Success;
+        }
+
+        private static IEnumerable<(string assetsFilepath, string? projectPath)> GetAssetsFiles(string path, ILoggerWithColor logger)
+        {
+            var extension = Path.GetExtension(path);
+            if (string.Equals(".json", extension, StringComparison.OrdinalIgnoreCase))
+            {
+                yield return (path, null);
+                yield break;
+            }
+
+            var projectPaths = MSBuildAPIUtility.GetListOfProjectsFromPathArgument(path);
+            foreach (string projectPath in projectPaths.NoAllocEnumerate())
+            {
+                Project project = MSBuildAPIUtility.GetProject(projectPath);
+                try
+                {
+                    string usingNetSdk = project.GetPropertyValue("UsingMicrosoftNETSdk");
+                    if (bool.TryParse(usingNetSdk, out bool b) && b)
+                    {
+                        if (!MSBuildAPIUtility.IsPackageReferenceProject(project))
+                        {
+                            logger.LogError(
+                                string.Format(
+                                    CultureInfo.CurrentCulture,
+                                    Strings.Error_NotPRProject,
+                                    project.FullPath));
+
+                            continue;
+                        }
+
+                        string assetsFilePath = project.GetPropertyValue(ProjectAssetsFile);
+                        if (string.IsNullOrEmpty(assetsFilePath))
+                        {
+                            // TODO: show error message
+                            continue;
+                        }
+
+                        if (!File.Exists(assetsFilePath))
+                        {
+                            logger.LogError(
+                                string.Format(
+                                    CultureInfo.CurrentCulture,
+                                    Strings.Error_AssetsFileNotFound,
+                                    assetsFilePath));
+                            continue;
+                        }
+
+                        yield return (assetsFilePath, projectPath);
+                    }
+                    else
+                    {
+                        logger.LogMinimal(
+                                string.Format(
+                                    CultureInfo.CurrentCulture,
+                                    Strings.WhyCommand_Message_NonSDKStyleProjectsAreNotSupported,
+                                    project.GetPropertyValue("MSBuildProjectName")));
+                    }
+                }
+                finally
+                {
+                    ProjectCollection.GlobalProjectCollection.UnloadProject(project);
+                }
+            }
         }
 
         /// <summary>
@@ -126,14 +179,14 @@ namespace NuGet.CommandLine.XPlat
                     string.Format(
                         CultureInfo.CurrentCulture,
                         Strings.WhyCommand_Error_ArgumentExceptionThrown,
-                        string.Format(CultureInfo.CurrentCulture, Strings.Error_PathIsMissingOrInvalid, path)));
+                        string.Format(CultureInfo.CurrentCulture, Strings.Error_PathIsMissingOrInvalid_AllowAssetsFile, path)));
                 return false;
             }
 
             // Check that the path is a directory, solution file or project file
             if (Directory.Exists(fullPath)
                 || (File.Exists(fullPath)
-                    && (XPlatUtility.IsSolutionFile(fullPath) || XPlatUtility.IsProjectFile(fullPath))))
+                    && (XPlatUtility.IsSolutionFile(fullPath) || XPlatUtility.IsProjectFile(fullPath) || XPlatUtility.IsJsonFile(fullPath))))
             {
                 return true;
             }
@@ -143,7 +196,7 @@ namespace NuGet.CommandLine.XPlat
                     string.Format(
                         CultureInfo.CurrentCulture,
                         Strings.WhyCommand_Error_ArgumentExceptionThrown,
-                        string.Format(CultureInfo.CurrentCulture, Strings.Error_PathIsMissingOrInvalid, path)));
+                        string.Format(CultureInfo.CurrentCulture, Strings.Error_PathIsMissingOrInvalid_AllowAssetsFile, path)));
                 return false;
             }
         }
@@ -184,51 +237,49 @@ namespace NuGet.CommandLine.XPlat
         }
 
         /// <summary>
-        /// Validates and returns the assets file for the given project.
+        /// Returns the path to an assets file for the given project.
         /// </summary>
         /// <param name="project">Evaluated MSBuild project</param>
         /// <param name="logger">Logger for the 'why' command</param>
         /// <returns>Assets file for the given project. Returns null if there was any issue finding or parsing the assets file.</returns>
-        private static LockFile? GetProjectAssetsFile(Project project, ILoggerWithColor logger)
+        private static LockFile? GetProjectAssetsFile(string assetsFilePath, string? projectPath, ILoggerWithColor logger)
         {
-            if (!MSBuildAPIUtility.IsPackageReferenceProject(project))
-            {
-                logger.LogError(
-                    string.Format(
-                        CultureInfo.CurrentCulture,
-                        Strings.Error_NotPRProject,
-                        project.FullPath));
-
-                return null;
-            }
-
-            string assetsPath = project.GetPropertyValue(ProjectAssetsFile);
-
-            if (!File.Exists(assetsPath))
+            if (!File.Exists(assetsFilePath))
             {
                 logger.LogError(
                     string.Format(
                         CultureInfo.CurrentCulture,
                         Strings.Error_AssetsFileNotFound,
-                        project.FullPath));
+                        assetsFilePath));
 
                 return null;
             }
 
             var lockFileFormat = new LockFileFormat();
-            LockFile assetsFile = lockFileFormat.Read(assetsPath);
+            LockFile assetsFile = lockFileFormat.Read(assetsFilePath);
 
             // assets file validation
             if (assetsFile.PackageSpec == null
                 || assetsFile.Targets == null
                 || assetsFile.Targets.Count == 0)
             {
-                logger.LogError(
-                    string.Format(
-                        CultureInfo.CurrentCulture,
-                        Strings.WhyCommand_Error_InvalidAssetsFile,
-                        assetsFile.Path,
-                        project.FullPath));
+                if (string.IsNullOrEmpty(projectPath))
+                {
+                    logger.LogError(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.WhyCommand_Error_InvalidAssetsFile_WithoutProject,
+                            assetsFilePath));
+                }
+                else
+                {
+                    logger.LogError(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.WhyCommand_Error_InvalidAssetsFile_WithProject,
+                            assetsFilePath,
+                            projectPath));
+                }
 
                 return null;
             }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -673,6 +673,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Missing or invalid path &apos;{0}&apos;. Please provide a path to a project, solution, or NuGet assets file, or directory..
+        /// </summary>
+        internal static string Error_PathIsMissingOrInvalid_AllowAssetsFile {
+            get {
+                return ResourceManager.GetString("Error_PathIsMissingOrInvalid_AllowAssetsFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The specified path &apos;{0}&apos; does not exist..
         /// </summary>
         internal static string Error_PathNotFound {
@@ -2269,11 +2278,20 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The assets file &apos;{0}&apos; is invalid. Please run restore for project &apos;{1}&apos; before running this command..
+        ///   Looks up a localized string similar to The file &apos;{0}&apos; does not appear to be a NuGet assets file. For more information, see https://aka.ms/dotnet-nuget-why.
         /// </summary>
-        internal static string WhyCommand_Error_InvalidAssetsFile {
+        internal static string WhyCommand_Error_InvalidAssetsFile_WithoutProject {
             get {
-                return ResourceManager.GetString("WhyCommand_Error_InvalidAssetsFile", resourceCulture);
+                return ResourceManager.GetString("WhyCommand_Error_InvalidAssetsFile_WithoutProject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The file &apos;{0}&apos; does not appear to be a NuGet assets file. Please run restore for project &apos;{1}&apos; before running this command..
+        /// </summary>
+        internal static string WhyCommand_Error_InvalidAssetsFile_WithProject {
+            get {
+                return ResourceManager.GetString("WhyCommand_Error_InvalidAssetsFile_WithProject", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -673,15 +673,6 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Missing or invalid path &apos;{0}&apos;. Please provide a path to a project, solution, or NuGet assets file, or directory..
-        /// </summary>
-        internal static string Error_PathIsMissingOrInvalid_AllowAssetsFile {
-            get {
-                return ResourceManager.GetString("Error_PathIsMissingOrInvalid_AllowAssetsFile", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The specified path &apos;{0}&apos; does not exist..
         /// </summary>
         internal static string Error_PathNotFound {
@@ -714,6 +705,15 @@ namespace NuGet.CommandLine.XPlat {
         internal static string Error_PrereleaseWhenVersionSpecified {
             get {
                 return ResourceManager.GetString("Error_PrereleaseWhenVersionSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Project &apos;{0}&apos; does not have MSBuild property ProjectAssetsFile defined. This may indicate that this project does not support NuGet PackageReference, or that project customization has prevented the .NET SDK setting default values..
+        /// </summary>
+        internal static string Error_ProjectAssetsFilePropertyNotFound {
+            get {
+                return ResourceManager.GetString("Error_ProjectAssetsFilePropertyNotFound", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -2278,7 +2278,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The file &apos;{0}&apos; does not appear to be a NuGet assets file. For more information, see https://aka.ms/dotnet-nuget-why.
+        ///   Looks up a localized string similar to The file &apos;{0}&apos; does not appear to be a NuGet assets file. For more information, see https://aka.ms/dotnet/nuget/why#older-project-format.
         /// </summary>
         internal static string WhyCommand_Error_InvalidAssetsFile_WithoutProject {
             get {
@@ -2332,7 +2332,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to run &apos;dotnet nuget why&apos; for project &apos;{0}&apos;. This command only works on SDK-style projects..
+        ///   Looks up a localized string similar to Unable to run &apos;dotnet nuget why&apos; for project &apos;{0}&apos;. See https://aka.ms/dotnet/nuget/why#older-project-format.
         /// </summary>
         internal static string WhyCommand_Message_NonSDKStyleProjectsAreNotSupported {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -937,6 +937,10 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
     <value>Missing or invalid path '{0}'. Please provide a path to a project, solution file, or directory.</value>
     <comment>{0} - Input path argument</comment>
   </data>
+  <data name="Error_PathIsMissingOrInvalid_AllowAssetsFile" xml:space="preserve">
+    <value>Missing or invalid path '{0}'. Please provide a path to a project, solution, or NuGet assets file, or directory.</value>
+    <comment>{0} - Input path argument</comment>
+  </data>
   <data name="WhyCommand_Error_ArgumentExceptionThrown" xml:space="preserve">
     <value>Unable to run 'dotnet nuget why'. {0}</value>
     <comment>{0} - Exception mssage</comment>
@@ -944,8 +948,12 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
   <data name="WhyCommand_Message_NonSDKStyleProjectsAreNotSupported" xml:space="preserve">
     <value>Unable to run 'dotnet nuget why' for project '{0}'. This command only works on SDK-style projects.</value>
   </data>
-  <data name="WhyCommand_Error_InvalidAssetsFile" xml:space="preserve">
-    <value>The assets file '{0}' is invalid. Please run restore for project '{1}' before running this command.</value>
+  <data name="WhyCommand_Error_InvalidAssetsFile_WithoutProject" xml:space="preserve">
+    <value>The file '{0}' does not appear to be a NuGet assets file. For more information, see https://aka.ms/dotnet-nuget-why</value>
+    <comment>{0} - Assets file path</comment>
+  </data>
+  <data name="WhyCommand_Error_InvalidAssetsFile_WithProject" xml:space="preserve">
+    <value>The file '{0}' does not appear to be a NuGet assets file. Please run restore for project '{1}' before running this command.</value>
     <comment>{0} - Assets file path, {1} - Project name</comment>
   </data>
   <data name="WhyCommand_Warning_AssetsFileDoesNotContainSpecifiedTarget" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -937,10 +937,6 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
     <value>Missing or invalid path '{0}'. Please provide a path to a project, solution file, or directory.</value>
     <comment>{0} - Input path argument</comment>
   </data>
-  <data name="Error_PathIsMissingOrInvalid_AllowAssetsFile" xml:space="preserve">
-    <value>Missing or invalid path '{0}'. Please provide a path to a project, solution, or NuGet assets file, or directory.</value>
-    <comment>{0} - Input path argument</comment>
-  </data>
   <data name="WhyCommand_Error_ArgumentExceptionThrown" xml:space="preserve">
     <value>Unable to run 'dotnet nuget why'. {0}</value>
     <comment>{0} - Exception mssage</comment>
@@ -976,5 +972,9 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
   </data>
   <data name="SignCommandInvalidCertificateFingerprint" xml:space="preserve">
     <value>Invalid value for '--certificate-fingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</value>
+  </data>
+  <data name="Error_ProjectAssetsFilePropertyNotFound" xml:space="preserve">
+    <value>Project '{0}' does not have MSBuild property ProjectAssetsFile defined. This may indicate that this project does not support NuGet PackageReference, or that project customization has prevented the .NET SDK setting default values.</value>
+    <comment>{0} - Path to the project with the error</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -942,10 +942,10 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
     <comment>{0} - Exception mssage</comment>
   </data>
   <data name="WhyCommand_Message_NonSDKStyleProjectsAreNotSupported" xml:space="preserve">
-    <value>Unable to run 'dotnet nuget why' for project '{0}'. This command only works on SDK-style projects.</value>
+    <value>Unable to run 'dotnet nuget why' for project '{0}'. See https://aka.ms/dotnet/nuget/why#older-project-format</value>
   </data>
   <data name="WhyCommand_Error_InvalidAssetsFile_WithoutProject" xml:space="preserve">
-    <value>The file '{0}' does not appear to be a NuGet assets file. For more information, see https://aka.ms/dotnet-nuget-why</value>
+    <value>The file '{0}' does not appear to be a NuGet assets file. For more information, see https://aka.ms/dotnet/nuget/why#older-project-format</value>
     <comment>{0} - Assets file path</comment>
   </data>
   <data name="WhyCommand_Error_InvalidAssetsFile_WithProject" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs
@@ -158,5 +158,11 @@ namespace NuGet.CommandLine.XPlat
 
             return false;
         }
+
+        internal static bool IsJsonFile(string filename)
+        {
+            var extension = Path.GetExtension(filename);
+            return string.Equals(".json", extension, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
@@ -292,9 +292,9 @@ namespace Dotnet.Integration.Test
                 }
                 else
                 {
-                    result.ExitCode.Should().Be(
-                        1,
-                        "{0} {1} should have failed with exit code 1 but returned exit code {2} after {3:N1}s with the following output:{4}{5}",
+                    result.ExitCode.Should().NotBe(
+                        0,
+                        "{0} {1} should have failed with a non-zero exit code but returned exit code {2} after {3:N1}s with the following output:{4}{5}",
                         TestDotnetCli,
                         args,
                         result.ExitCode,

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
@@ -302,7 +302,7 @@ namespace Dotnet.Integration.Test
             CommandRunnerResult result = _testFixture.RunDotnetExpectFailure(testDirectory, whyCommandArgs);
 
             // Assert
-            result.AllOutput.Should().Contain("https://aka.ms/dotnet-nuget-why");
+            result.AllOutput.Should().Contain("https://aka.ms/dotnet/nuget/why");
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13576

## Description

Refactored WhyCommandRunner so the "main loop" will read the assets file, without evaluating the project via MSBuild. Then modified the code that finds all projects in a solution to handle a json file like a single project solution.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc: https://github.com/NuGet/Home/issues/13623
