### PR TITLE
Map SourceBranchName from sourcelink to RepositoryBranch for NuGet pack

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -289,10 +289,10 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="InitializeSourceControlInformation"
           Condition="'$(SourceControlInformationFeatureSupported)' == 'true'">
     <PropertyGroup>
-      <!-- The project must specify PublishRepositoryUrl=true in order to publish the URL, in order to prevent inadvertent leak of internal URL. -->
+      <!-- The project must specify PublishRepositoryUrl=true in order to publish the URL or branch, in order to prevent inadvertent leak of internal data. -->
       <RepositoryUrl Condition="'$(RepositoryUrl)' == '' and '$(PublishRepositoryUrl)' == 'true'">$(PrivateRepositoryUrl)</RepositoryUrl>
       <RepositoryCommit Condition="'$(RepositoryCommit)' == ''">$(SourceRevisionId)</RepositoryCommit>
-      <RepositoryBranch Condition="'$(RepositoryBranch)' == '' and '$(SourceBranchName)' != ''">$(SourceBranchName)</RepositoryBranch>
+      <RepositoryBranch Condition="'$(RepositoryBranch)' == '' and '$(PublishRepositoryUrl)' == 'true' and '$(SourceBranchName)' != ''">$(SourceBranchName)</RepositoryBranch>
     </PropertyGroup>
   </Target>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -292,6 +292,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- The project must specify PublishRepositoryUrl=true in order to publish the URL, in order to prevent inadvertent leak of internal URL. -->
       <RepositoryUrl Condition="'$(RepositoryUrl)' == '' and '$(PublishRepositoryUrl)' == 'true'">$(PrivateRepositoryUrl)</RepositoryUrl>
       <RepositoryCommit Condition="'$(RepositoryCommit)' == ''">$(SourceRevisionId)</RepositoryCommit>
+      <RepositoryBranch Condition="'$(RepositoryBranch)' == '' and '$(SourceBranchName)' != ''">$(SourceBranchName)</RepositoryBranch>
     </PropertyGroup>
   </Target>
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -3667,6 +3667,7 @@ namespace ClassLibrary
         <PropertyGroup>
             <SourceRevisionId>e1c65e4524cd70ee6e22abe33e6cb6ec73938cb1</SourceRevisionId>
             <PrivateRepositoryUrl>https://github.com/NuGet/NuGet.Client.git</PrivateRepositoryUrl>
+            <SourceBranchName>refs/heads/main</SourceBranchName>
         </PropertyGroup>
     </Target>
 </Project>");
@@ -3787,6 +3788,7 @@ namespace ClassLibrary
     <PropertyGroup>
       <SourceRevisionId>e1c65e4524cd70ee6e22abe33e6cb6ec73938cb1</SourceRevisionId>
       <PrivateRepositoryUrl>https://github.com/NuGet/NuGet.Client.git</PrivateRepositoryUrl>
+      <SourceBranchName>refs/heads/main</SourceBranchName>
     </PropertyGroup>
 </Target>
 </Project>";
@@ -3809,7 +3811,7 @@ namespace ClassLibrary
                     var repositoryMetadata = nuspecReader.GetRepositoryMetadata();
                     repositoryMetadata.Type.Should().Be("git");
                     repositoryMetadata.Url.Should().Be("https://github.com/NuGet/NuGet.Client.git");
-                    repositoryMetadata.Branch.Should().Be("");
+                    repositoryMetadata.Branch.Should().Be("refs/heads/main");
                     repositoryMetadata.Commit.Should().Be("e1c65e4524cd70ee6e22abe33e6cb6ec73938cb1");
                 }
             }
@@ -3836,6 +3838,7 @@ namespace ClassLibrary
                     ProjectFileUtils.AddProperty(xml, "PublishRepositoryUrl", "true");
                     ProjectFileUtils.AddProperty(xml, "RepositoryCommit", "1111111111111111111111111111111111111111");
                     ProjectFileUtils.AddProperty(xml, "RepositoryUrl", "https://github.com/Overridden");
+                    ProjectFileUtils.AddProperty(xml, "RepositoryBranch", "refs/heads/overwritten");
 
                     // mock implementation of InitializeSourceControlInformation common targets:
                     xml.Root.Add(
@@ -3843,7 +3846,8 @@ namespace ClassLibrary
                             new XAttribute("Name", "InitializeSourceControlInformation"),
                             new XElement(ns + "PropertyGroup",
                                 new XElement("SourceRevisionId", "e1c65e4524cd70ee6e22abe33e6cb6ec73938cb1"),
-                                new XElement("PrivateRepositoryUrl", "https://github.com/NuGet/NuGet.Client"))));
+                                new XElement("PrivateRepositoryUrl", "https://github.com/NuGet/NuGet.Client"),
+                                new XElement("SourceBranchName", "refs/heads/main"))));
 
                     xml.Root.Add(
                         new XElement(ns + "PropertyGroup",
@@ -3868,7 +3872,7 @@ namespace ClassLibrary
                     var repositoryMetadata = nuspecReader.GetRepositoryMetadata();
                     repositoryMetadata.Type.Should().Be("git");
                     repositoryMetadata.Url.Should().Be("https://github.com/Overridden");
-                    repositoryMetadata.Branch.Should().Be("");
+                    repositoryMetadata.Branch.Should().Be("refs/heads/overwritten");
                     repositoryMetadata.Commit.Should().Be("1111111111111111111111111111111111111111");
                 }
             }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -3694,8 +3694,10 @@ namespace ClassLibrary
             }
         }
 
-        [PlatformFact(Platform.Windows)]
-        public void PackCommand_PackWithSourceControlInformation_PrivateUrl_VerifyNuspec()
+        [PlatformTheory(Platform.Windows)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void PackCommand_PackWithSourceControlInformation_PrivateUrl_VerifyNuspec(bool shouldEmitPublishProperty)
         {
             using (var testDirectory = _dotnetFixture.CreateTestDirectory())
             {
@@ -3712,6 +3714,10 @@ namespace ClassLibrary
                     var ns = xml.Root.Name.Namespace;
 
                     ProjectFileUtils.AddProperty(xml, "RepositoryType", "git");
+                    if (shouldEmitPublishProperty)
+                    {
+                        ProjectFileUtils.AddProperty(xml, "PublishRepositoryUrl", "false");
+                    }
 
                     xml.Root.Add(
                         new XElement(ns + "PropertyGroup",
@@ -3726,6 +3732,7 @@ namespace ClassLibrary
     <PropertyGroup>
       <SourceRevisionId>e1c65e4524cd70ee6e22abe33e6cb6ec73938cb1</SourceRevisionId>
       <PrivateRepositoryUrl>https://github.com/NuGet/NuGet.Client.git</PrivateRepositoryUrl>
+      <SourceBranchName>refs/heads/abc</SourceBranchName>
     </PropertyGroup>
 </Target>
 </Project>";


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13625

## Description

This is a companion PR for https://github.com/dotnet/sourcelink/pull/1248. Once that change lands and sourcelink is emitting the source branch name, this PR consumes that value and sets it to `RepositoryBranch` as part of NuGet pack.

## PR Checklist

- [X] Meaningful title, helpful description and a linked NuGet/Home issue
- [X] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
