### PR TITLE
raise warning if insecure sha-1 certificate fingerprint is passed to nuget.exe sign command

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -1520,7 +1520,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SHA-1 fingerprint of the certificate used to search a local certificate store for the certificate.
+        ///   Looks up a localized string similar to SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate.
         ///The certificate store can be specified by -CertificateStoreName and -CertificateStoreLocation options..
         /// </summary>
         internal static string SignCommandCertificateFingerprintDescription {
@@ -1605,6 +1605,15 @@ namespace NuGet.CommandLine {
         internal static string SignCommandHashAlgorithmDescription {
             get {
                 return ResourceManager.GetString("SignCommandHashAlgorithmDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid value for &apos;CertificateFingerprint&apos; option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal)..
+        /// </summary>
+        internal static string SignCommandInvalidCertificateFingerprint {
+            get {
+                return ResourceManager.GetString("SignCommandInvalidCertificateFingerprint", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -678,7 +678,7 @@ This option can be used to specify the password for the certificate. If no passw
     <value>File path to the certificate to be used while signing the package.</value>
   </data>
   <data name="SignCommandCertificateFingerprintDescription" xml:space="preserve">
-    <value>SHA-1 fingerprint of the certificate used to search a local certificate store for the certificate.
+    <value>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate.
 The certificate store can be specified by -CertificateStoreName and -CertificateStoreLocation options.</value>
   </data>
   <data name="SignCommandCertificateSubjectNameDescription" xml:space="preserve">
@@ -936,5 +936,8 @@ nuget client-certs List</value>
   </data>
   <data name="SourcesCommandAllowInsecureConnectionsDescription" xml:space="preserve">
     <value>Allows HTTP connections for adding or updating packages. Note: This method is not secure. For secure options, see https://aka.ms/nuget-https-everywhere for more information.</value>
+  </data>
+  <data name="SignCommandInvalidCertificateFingerprint" xml:space="preserve">
+    <value>Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</value>
   </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
-using EnvDTE80;
 using FluentAssertions;
 using NuGet.Common;
 using NuGet.Packaging.Signing;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2931

## Description

Deprecate the usage of SHA-1 fingerprints in NuGet.exe sign command especially for `CertificateFingerprint` option. Instead, allow `nuget.exe sign` command to accept SHA-2 (SHA-256, SHA-384 and SHA-512) family fingerprints for searching a local certificate store for the certificate.

Here is how the nuget.exe sign command works after this PR has been merged:

- Validates the certificate fingerprint to ensure it is either SHA-1, SHA-256, SHA-384, or SHA-512 algorithm. Throws an error otherwise.
- Raises a warning if a SHA-1 certificate fingerprint is provided. This warning will be promoted to an error in the future.
- While searching for a certificate from the local store, if a SHA-1 hash is provided, finds the certificate using the existing API i.e. `store.Certificates.Find(X509FindType.FindByThumbprint, options.Fingerprint, validOnly);`
- If a SHA-256, SHA-384, or SHA-512 certificate fingerprint is provided, loops through the certificates in the store to find the certificate with the matching hash.

I made similar changes to the dotnet sign command in https://github.com/NuGet/NuGet.Client/pull/5895.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Client.Engineering/issues/2876
