### PR TITLE
enable IDE0055 analyzer for test code also

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -147,6 +147,8 @@ dotnet_naming_rule.private_field_rule.style = private_member_style
 dotnet_diagnostic.IDE0076.severity = warning
 dotnet_diagnostic.IDE0005.severity = warning
 
+dotnet_diagnostic.IDE0055.severity = warning
+
 dotnet_diagnostic.VSTHRD200.severity = none
 
 # NuGet Code Analysis Rules
@@ -266,7 +268,6 @@ dotnet_diagnostic.CA5397.severity = none
 dotnet_diagnostic.CA9999.severity = none
 dotnet_diagnostic.VSTHRD103.severity = silent
 dotnet_diagnostic.VSTHRD105.severity = silent
-dotnet_diagnostic.IDE0055.severity = warning
 
 # Code files under test/ folder
 [test/**/*.cs]

--- a/.editorconfig
+++ b/.editorconfig
@@ -147,8 +147,6 @@ dotnet_naming_rule.private_field_rule.style = private_member_style
 dotnet_diagnostic.IDE0076.severity = warning
 dotnet_diagnostic.IDE0005.severity = warning
 
-dotnet_diagnostic.IDE0055.severity = warning
-
 dotnet_diagnostic.VSTHRD200.severity = none
 
 # NuGet Code Analysis Rules
@@ -268,6 +266,7 @@ dotnet_diagnostic.CA5397.severity = none
 dotnet_diagnostic.CA9999.severity = none
 dotnet_diagnostic.VSTHRD103.severity = silent
 dotnet_diagnostic.VSTHRD105.severity = silent
+dotnet_diagnostic.IDE0055.severity = warning
 
 # Code files under test/ folder
 [test/**/*.cs]
@@ -284,3 +283,4 @@ dotnet_diagnostic.VSTHRD103.severity = none
 dotnet_diagnostic.VSTHRD104.severity = none
 dotnet_diagnostic.VSTHRD105.severity = none
 dotnet_diagnostic.VSTHRD106.severity = none
+dotnet_diagnostic.IDE0055.severity = warning


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Related: https://github.com/NuGet/Client.Engineering/issues/1190 

## Description
In https://github.com/NuGet/NuGet.Client/pull/5841, I removed the dependency on the FxCop analyzers package in the repository in favor of .NET Analyzers. During the process, I mistakenly enabled the [`IDE0055`](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) analyzer only for product code. In this PR, I enabled the analyzer for both test and product code so that any formatting issues in the code will cause the IDE to report an error, which is much better than pushing the change to the repository and subsequently causing a CI failure due to formatting issues.

## PR Checklist

- [X] Meaningful title, helpful description and a linked NuGet/Home issue
- [X] ~Added tests~N/A (Manually tested to ensure `IDE0055` analyzer reports an error if there is any formatting issue in test code also)
- [X] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
