### PR TITLE
Add why and config commands to dotnet nuget help

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigCommand.cs
@@ -7,6 +7,7 @@ using System.CommandLine.Help;
 using System.CommandLine.Parsing;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.CommandLineUtils;
 using NuGet.Common;
 
 namespace NuGet.CommandLine.XPlat
@@ -82,6 +83,14 @@ namespace NuGet.CommandLine.XPlat
             var tokenList = parseResult.Tokens.TakeWhile(token => token.Type == CliTokenType.Argument || token.Type == CliTokenType.Command || token.Type == CliTokenType.Directive).Select(t => t.Value).ToList();
             tokenList.Add("-h");
             cmd.Parse(tokenList).Invoke();
+        }
+
+        internal static void Register(CommandLineApplication app)
+        {
+            app.Command("config", configCmd =>
+            {
+                configCmd.Description = Strings.Config_Description;
+            });
         }
 
         internal static CliCommand Register(CliCommand app, Func<ILogger> getLogger)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/WhyCommand/WhyCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/WhyCommand/WhyCommand.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Help;
+using Microsoft.Extensions.CommandLineUtils;
 
 namespace NuGet.CommandLine.XPlat
 {
@@ -32,6 +33,14 @@ namespace NuGet.CommandLine.XPlat
         {
             Arity = ArgumentArity.Zero
         };
+
+        internal static void Register(CommandLineApplication app)
+        {
+            app.Command("why", whyCmd =>
+            {
+                whyCmd.Description = Strings.WhyCommand_Description;
+            });
+        }
 
         internal static void Register(CliCommand rootCommand, Func<ILoggerWithColor> getLogger)
         {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using Microsoft.Extensions.CommandLineUtils;
 using NuGet.Commands;
 using NuGet.Common;
@@ -276,6 +275,8 @@ namespace NuGet.CommandLine.XPlat
                 VerifyCommand.Register(app, getHidePrefixLogger, setLogLevel, () => new VerifyCommandRunner());
                 TrustedSignersCommand.Register(app, getHidePrefixLogger, setLogLevel);
                 SignCommand.Register(app, getHidePrefixLogger, setLogLevel, () => new SignCommandRunner());
+                ConfigCommand.Register(app);
+                WhyCommand.Register(app);
             }
 
             app.FullName = Strings.App_FullName;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -275,6 +275,7 @@ namespace NuGet.CommandLine.XPlat
                 VerifyCommand.Register(app, getHidePrefixLogger, setLogLevel, () => new VerifyCommandRunner());
                 TrustedSignersCommand.Register(app, getHidePrefixLogger, setLogLevel);
                 SignCommand.Register(app, getHidePrefixLogger, setLogLevel, () => new SignCommandRunner());
+                // The commands below are implemented with System.CommandLine, and are here only for `dotnet nuget --help`
                 ConfigCommand.Register(app);
                 WhyCommand.Register(app);
             }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatHelpOutputTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatHelpOutputTests.cs
@@ -12,7 +12,6 @@ using System.Text.RegularExpressions;
 
 namespace NuGet.XPlat.FuncTest
 {
-    [Collection("NuGet XPlat dotnet help test collection")]
     public class XPlatHelpOutputTests
     {
         private readonly ITestOutputHelper _testOutputHelper;

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatHelpOutputTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatHelpOutputTests.cs
@@ -12,6 +12,7 @@ using System.Text.RegularExpressions;
 
 namespace NuGet.XPlat.FuncTest
 {
+    [Collection("NuGet XPlat dotnet help test collection")]
     public class XPlatHelpOutputTests
     {
         private readonly ITestOutputHelper _testOutputHelper;
@@ -121,11 +122,7 @@ namespace NuGet.XPlat.FuncTest
             var commandPattern = @"^\s{2}(\w+)\s{2,}"; // Matches lines starting with two spaces, a word (command), followed by at least two spaces
             IEnumerable<string> matches = Regex.Matches(output, commandPattern, RegexOptions.Multiline).Select(m => m.ToString().Trim());
 
-            foreach (var command in HelpCommands)
-            {
-                Assert.Contains(command, matches);
-            }
-
+            Assert.Equal(HelpCommands, matches);
             Assert.Equal(0, exitCode);
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13517

## Description
Added missing commands to `dotnet nuget` help commands, since the migration of the commands is still a work in progress we need to add them to the old help option. 

This PR only register so we can display their description but the functionality is implemented in `System.Commandline.CliCommand`
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
