### PR TITLE
raise warning if insecure sha-1 certificate fingerprint is passed to mssign and reposign commands

### DIFF
--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignAbstract.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignAbstract.cs
@@ -88,7 +88,30 @@ namespace NuGet.MSSigning.Extensions
 
         protected X509Certificate2 GetCertificate(X509Certificate2Collection certCollection)
         {
-            var matchingCertCollection = certCollection.Find(X509FindType.FindByThumbprint, CertificateFingerprint, validOnly: false);
+            X509Certificate2Collection matchingCertCollection = [];
+
+            if (!string.IsNullOrEmpty(CertificateFingerprint) &&
+                CertificateUtility.TryDeduceHashAlgorithm(CertificateFingerprint, out Common.HashAlgorithmName hashAlgorithmName))
+            {
+                if (hashAlgorithmName == Common.HashAlgorithmName.SHA1)
+                {
+                    matchingCertCollection = certCollection.Find(X509FindType.FindByThumbprint, CertificateFingerprint, validOnly: false);
+                }
+                else if (hashAlgorithmName != Common.HashAlgorithmName.Unknown)
+                {
+                    foreach (var cert in certCollection)
+                    {
+                        string actualFingerprint = CertificateUtility.GetHashString(cert, hashAlgorithmName);
+
+                        if (string.Equals(actualFingerprint, CertificateFingerprint, StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            matchingCertCollection.Add(cert);
+                            break;
+                        }
+                    }
+
+                }
+            }
 
             if (matchingCertCollection == null || matchingCertCollection.Count == 0)
             {
@@ -132,7 +155,7 @@ namespace NuGet.MSSigning.Extensions
             }
         }
 
-        protected void ValidateCertificateInputs()
+        protected void ValidateCertificateInputs(ILogger logger)
         {
             if (string.IsNullOrEmpty(CertificateFile))
             {
@@ -157,8 +180,19 @@ namespace NuGet.MSSigning.Extensions
             if (string.IsNullOrEmpty(CertificateFingerprint))
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
-                        NuGetMSSignCommand.MSSignCommandInvalidArgumentException,
+                        NuGetMSSignCommand.MSSignCommandInvalidCertificateFingerprint,
                         nameof(CertificateFingerprint)));
+            }
+            else
+            {
+                if (!CertificateUtility.TryDeduceHashAlgorithm(CertificateFingerprint, out Common.HashAlgorithmName hashAlgorithmName))
+                {
+                    throw new ArgumentException(NuGetMSSignCommand.MSSignCommandInvalidCertificateFingerprint);
+                }
+                else if (hashAlgorithmName == Common.HashAlgorithmName.SHA1)
+                {
+                    logger.Log(LogMessage.CreateWarning(NuGetLogCode.NU3043, NuGetMSSignCommand.MSSignCommandInvalidCertificateFingerprint));
+                }
             }
         }
 

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignAbstract.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignAbstract.cs
@@ -90,8 +90,7 @@ namespace NuGet.MSSigning.Extensions
         {
             X509Certificate2Collection matchingCertCollection = [];
 
-            if (!string.IsNullOrEmpty(CertificateFingerprint) &&
-                CertificateUtility.TryDeduceHashAlgorithm(CertificateFingerprint, out Common.HashAlgorithmName hashAlgorithmName))
+            if (CertificateUtility.TryDeduceHashAlgorithm(CertificateFingerprint, out Common.HashAlgorithmName hashAlgorithmName))
             {
                 if (hashAlgorithmName == Common.HashAlgorithmName.SHA1)
                 {

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignCommand.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignCommand.cs
@@ -40,7 +40,7 @@ namespace NuGet.MSSigning.Extensions
         {
             ValidatePackagePath();
             WarnIfNoTimestamper(Console);
-            ValidateCertificateInputs();
+            ValidateCertificateInputs(Console);
             EnsureOutputDirectory();
 
             var signingSpec = SigningSpecifications.V1;

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.MSSigning.Extensions {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class NuGetMSSignCommand {
@@ -70,7 +70,7 @@ namespace NuGet.MSSigning.Extensions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SHA-1 fingerprint of the certificate used to search a p7b file for the certificate..
+        ///   Looks up a localized string similar to SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a p7b file for the certificate..
         /// </summary>
         internal static string MSSignCommandCertificateFingerprintDescription {
             get {
@@ -106,11 +106,20 @@ namespace NuGet.MSSigning.Extensions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid value provided for &apos;{0}&apos;. For a list of accepted values, please visit https://docs.nuget.org/docs/reference/command-line-reference.
+        ///   Looks up a localized string similar to Invalid value provided for &apos;{0}&apos;. For a list of accepted values, please visit https://learn.microsoft.com/nuget/reference/cli-reference/cli-ref-sign.
         /// </summary>
         internal static string MSSignCommandInvalidArgumentException {
             get {
                 return ResourceManager.GetString("MSSignCommandInvalidArgumentException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid value for &apos;CertificateFingerprint&apos; option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal)..
+        /// </summary>
+        internal static string MSSignCommandInvalidCertificateFingerprint {
+            get {
+                return ResourceManager.GetString("MSSignCommandInvalidCertificateFingerprint", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.resx
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.resx
@@ -121,7 +121,7 @@
     <value>File path to the p7b file to be used while signing the package.</value>
   </data>
   <data name="MSSignCommandCertificateFingerprintDescription" xml:space="preserve">
-    <value>SHA-1 fingerprint of the certificate used to search a p7b file for the certificate.</value>
+    <value>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a p7b file for the certificate.</value>
   </data>
   <data name="MSSignCommandCSPNameDescription" xml:space="preserve">
     <value>Name of the cryptographic service provider which contains the private key container.</value>
@@ -133,7 +133,7 @@
     <value>Hash algorithm to be used while generating the package manifest file. Defaults to SHA256.</value>
   </data>
   <data name="MSSignCommandInvalidArgumentException" xml:space="preserve">
-    <value>Invalid value provided for '{0}'. For a list of accepted values, please visit https://docs.nuget.org/docs/reference/command-line-reference</value>
+    <value>Invalid value provided for '{0}'. For a list of accepted values, please visit https://learn.microsoft.com/nuget/reference/cli-reference/cli-ref-sign</value>
     <comment>{0} - argument name</comment>
   </data>
   <data name="MSSignCommandInvalidCngKeyException" xml:space="preserve">
@@ -201,5 +201,8 @@ nuget reposign MyPackage.nupkg -Timestamper http://timestamper.test -Certificate
   </data>
   <data name="RepoSignCommandV3ServiceIndexUrlDescription" xml:space="preserve">
     <value>Repository V3 service index URL.</value>
+  </data>
+  <data name="MSSignCommandInvalidCertificateFingerprint" xml:space="preserve">
+    <value>Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/RepoSignCommand.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/RepoSignCommand.cs
@@ -53,7 +53,7 @@ namespace NuGet.MSSigning.Extensions
         {
             ValidatePackagePath();
             WarnIfNoTimestamper(Console);
-            ValidateCertificateInputs();
+            ValidateCertificateInputs(Console);
             EnsureOutputDirectory();
             ValidatePackageOwners();
 

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/MSSignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/MSSignCommandTests.cs
@@ -25,13 +25,14 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
     {
         private readonly string _noTimestamperWarningCode = NuGetLogCode.NU3002.ToString();
         private readonly string _invalidCertificateFingerprintCode = NuGetLogCode.NU3043.ToString();
-        private const string _sha1Hash = "89967D1DD995010B6C66AE24FF8E66885E6E03A8";
+        private const string Sha1Hash = "89967D1DD995010B6C66AE24FF8E66885E6E03A8";
+        private const string Sha256Hash = "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b55b046cbb7f506fb";
 
-        private TrustedTestCert<TestCertificate> _trustedTestCertWithPrivateKey;
-        private TrustedTestCert<TestCertificate> _trustedTestCertWithoutPrivateKey;
+        private readonly TrustedTestCert<TestCertificate> _trustedTestCertWithPrivateKey;
+        private readonly TrustedTestCert<TestCertificate> _trustedTestCertWithoutPrivateKey;
 
         private MSSignCommandTestFixture _testFixture;
-        private string _nugetExePath;
+        private readonly string _nugetExePath;
 
         public MSSignCommandTests(MSSignCommandTestFixture fixture)
         {
@@ -122,8 +123,10 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             }
         }
 
-        [CIOnlyFact]
-        public void GetAuthorSignRequest_InvalidFingerprint()
+        [CIOnlyTheory]
+        [InlineData(Sha1Hash)]
+        [InlineData(Sha256Hash)]
+        public void GetAuthorSignRequest_InvalidFingerprint(string certificateFingerPrint)
         {
             var mockConsole = new Mock<IConsole>();
             var timestampUri = "http://timestamp.test/url";
@@ -139,7 +142,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     CertificateFile = test.CertificatePath,
                     CSPName = test.CertificateCSPName,
                     KeyContainer = test.CertificateKeyContainer,
-                    CertificateFingerprint = _sha1Hash,
+                    CertificateFingerprint = certificateFingerPrint,
                 };
                 signCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
 

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/ReposignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/ReposignCommandTests.cs
@@ -25,13 +25,14 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
     {
         private readonly string _noTimestamperWarningCode = NuGetLogCode.NU3002.ToString();
         private readonly string _invalidCertificateFingerprintCode = NuGetLogCode.NU3043.ToString();
-        private const string _sha1Hash = "89967D1DD995010B6C66AE24FF8E66885E6E03A8";
+        private const string Sha1Hash = "89967D1DD995010B6C66AE24FF8E66885E6E03A8";
+        private const string Sha256Hash = "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b55b046cbb7f506fb";
 
-        private TrustedTestCert<TestCertificate> _trustedTestCertWithPrivateKey;
-        private TrustedTestCert<TestCertificate> _trustedTestCertWithoutPrivateKey;
+        private readonly TrustedTestCert<TestCertificate> _trustedTestCertWithPrivateKey;
+        private readonly TrustedTestCert<TestCertificate> _trustedTestCertWithoutPrivateKey;
 
         private MSSignCommandTestFixture _testFixture;
-        private string _nugetExePath;
+        private readonly string _nugetExePath;
 
         public ReposignCommandTests(MSSignCommandTestFixture fixture)
         {
@@ -128,8 +129,10 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             }
         }
 
-        [CIOnlyFact]
-        public void GetRepositorySignRequest_InvalidFingerprint()
+        [CIOnlyTheory]
+        [InlineData(Sha1Hash)]
+        [InlineData(Sha256Hash)]
+        public void GetRepositorySignRequest_InvalidFingerprint(string certificateFingerPrint)
         {
             var mockConsole = new Mock<IConsole>();
             var v3serviceIndex = "https://v3serviceindex.test/api/index.json";
@@ -146,7 +149,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     CertificateFile = test.CertificatePath,
                     CSPName = test.CertificateCSPName,
                     KeyContainer = test.CertificateKeyContainer,
-                    CertificateFingerprint = _sha1Hash,
+                    CertificateFingerprint = certificateFingerPrint,
                     V3ServiceIndexUrl = v3serviceIndex,
                 };
                 reposignCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/ReposignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/ReposignCommandTests.cs
@@ -41,7 +41,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             _nugetExePath = _testFixture.NuGetExePath;
         }
 
-        [Fact]
+        [CIOnlyFact]
         public void GetRepositorySignRequest_InvalidCertificateFile()
         {
             var mockConsole = new Mock<IConsole>();
@@ -70,7 +70,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public void GetRepositorySignRequest_InvalidCSPName()
         {
             var mockConsole = new Mock<IConsole>();
@@ -99,7 +99,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public void GetRepositorySignRequest_InvalidKeyContainer()
         {
             var mockConsole = new Mock<IConsole>();
@@ -128,7 +128,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public void GetRepositorySignRequest_InvalidFingerprint()
         {
             var mockConsole = new Mock<IConsole>();
@@ -157,7 +157,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public void GetRepositorySignRequest_Success()
         {
             var mockConsole = new Mock<IConsole>();
@@ -192,7 +192,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task ReposignCommand_PrimarySignPackage_WithNoTimestampAsync()
         {
             var package = new SimpleTestPackageContext();
@@ -213,7 +213,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task ReposignCommand_PrimarySignPackage_WithTimestampAsync()
         {
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
@@ -235,7 +235,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task ReposignCommand_Countersign_RepositorySignedPackage_FailAsync()
         {
             var package = new SimpleTestPackageContext();
@@ -265,7 +265,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task ReposignCommand_Countersign_AuthorSignedPackage_WithNoTimestampAsync()
         {
             var package = new SimpleTestPackageContext();
@@ -295,7 +295,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task ReposignCommand_Countersign_AuthorSignedPackage_WithTimestampAsync()
         {
             var package = new SimpleTestPackageContext();
@@ -326,7 +326,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task ReposignCommand_Countersign_RepositoryCountersignedPackage_FailAsync()
         {
             var package = new SimpleTestPackageContext();

--- a/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetMSSignCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetMSSignCommandTest.cs
@@ -10,11 +10,11 @@ namespace NuGet.MSSigning.Extensions.Test
 {
     public class NuGetMSSignCommandTest
     {
-        private const string _noPackageException = "No package was provided. For a list of accepted ways to provide a package, please visit https://docs.nuget.org/docs/reference/command-line-reference";
-        private const string _invalidArgException = "Invalid value provided for '{0}'. For a list of accepted values, please visit https://learn.microsoft.com/nuget/reference/cli-reference/cli-ref-sign";
-        private const string _noCertificateException = "No {0} provided or provided file is not a p7b file.";
-        private const string _invalidCertificateFingerprint = "Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).";
-        private const string _sha1Hash = "89967D1DD995010B6C66AE24FF8E66885E6E03A8";
+        private const string NoPackageException = "No package was provided. For a list of accepted ways to provide a package, please visit https://docs.nuget.org/docs/reference/command-line-reference";
+        private const string InvalidArgException = "Invalid value provided for '{0}'. For a list of accepted values, please visit https://learn.microsoft.com/nuget/reference/cli-reference/cli-ref-sign";
+        private const string NoCertificateException = "No {0} provided or provided file is not a p7b file.";
+        private const string InvalidCertificateFingerprint = "Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).";
+        private const string Sha256Hash = "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b55b046cbb7f506fb";
 
         [Fact]
         public void MSSignCommandArgParsing_NoPackagePath()
@@ -42,7 +42,7 @@ namespace NuGet.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
-                Assert.Equal(_noPackageException, ex.Message);
+                Assert.Equal(NoPackageException, ex.Message);
             }
         }
 
@@ -71,7 +71,7 @@ namespace NuGet.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
-                Assert.Equal(string.Format(_noCertificateException, nameof(signCommand.CertificateFile)), ex.Message);
+                Assert.Equal(string.Format(NoCertificateException, nameof(signCommand.CertificateFile)), ex.Message);
             }
         }
 
@@ -84,7 +84,7 @@ namespace NuGet.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = _sha1Hash;
+                var certificateFingerprint = Sha256Hash;
                 var keyContainer = new Guid().ToString();
 
                 var mockConsole = new Mock<IConsole>();
@@ -101,7 +101,7 @@ namespace NuGet.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
-                Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.CSPName)), ex.Message);
+                Assert.Equal(string.Format(InvalidArgException, nameof(signCommand.CSPName)), ex.Message);
             }
         }
 
@@ -114,7 +114,7 @@ namespace NuGet.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = _sha1Hash;
+                var certificateFingerprint = Sha256Hash;
                 var cspName = "cert provider";
 
                 var mockConsole = new Mock<IConsole>();
@@ -131,7 +131,7 @@ namespace NuGet.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
-                Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.KeyContainer)), ex.Message);
+                Assert.Equal(string.Format(InvalidArgException, nameof(signCommand.KeyContainer)), ex.Message);
             }
         }
 
@@ -161,7 +161,7 @@ namespace NuGet.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
-                Assert.Equal(_invalidCertificateFingerprint, ex.Message);
+                Assert.Equal(InvalidCertificateFingerprint, ex.Message);
             }
         }
 
@@ -194,7 +194,7 @@ namespace NuGet.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
-                Assert.Equal(_invalidCertificateFingerprint, ex.Message);
+                Assert.Equal(InvalidCertificateFingerprint, ex.Message);
             }
         }
 
@@ -214,7 +214,7 @@ namespace NuGet.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = _sha1Hash;
+                var certificateFingerprint = Sha256Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
                 var parsable = Enum.TryParse(hashAlgorithm, ignoreCase: true, result: out Common.HashAlgorithmName parsedHashAlgorithm);
@@ -235,7 +235,7 @@ namespace NuGet.MSSigning.Extensions.Test
                 // Act & Assert
                 Assert.True(parsable);
                 var ex = Assert.Throws<CryptographicException>(() => signCommand.GetAuthorSignRequest());
-                Assert.NotEqual(string.Format(_invalidArgException, nameof(signCommand.HashAlgorithm)), ex.Message);
+                Assert.NotEqual(string.Format(InvalidArgException, nameof(signCommand.HashAlgorithm)), ex.Message);
             }
         }
 
@@ -248,7 +248,7 @@ namespace NuGet.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = _sha1Hash;
+                var certificateFingerprint = Sha256Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
                 var hashAlgorithm = "MD5";
@@ -269,7 +269,7 @@ namespace NuGet.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
-                Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.HashAlgorithm)), ex.Message);
+                Assert.Equal(string.Format(InvalidArgException, nameof(signCommand.HashAlgorithm)), ex.Message);
             }
         }
 
@@ -289,7 +289,7 @@ namespace NuGet.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = _sha1Hash;
+                var certificateFingerprint = Sha256Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
                 var parsable = Enum.TryParse(timestampHashAlgorithm, ignoreCase: true, result: out Common.HashAlgorithmName parsedHashAlgorithm);
@@ -310,7 +310,7 @@ namespace NuGet.MSSigning.Extensions.Test
                 // Act & Assert
                 Assert.True(parsable);
                 var ex = Assert.Throws<CryptographicException>(() => signCommand.GetAuthorSignRequest());
-                Assert.NotEqual(string.Format(_invalidArgException, nameof(signCommand.TimestampHashAlgorithm)), ex.Message);
+                Assert.NotEqual(string.Format(InvalidArgException, nameof(signCommand.TimestampHashAlgorithm)), ex.Message);
             }
         }
 
@@ -323,7 +323,7 @@ namespace NuGet.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = _sha1Hash;
+                var certificateFingerprint = Sha256Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
                 var timestampHashAlgorithm = "MD5";
@@ -344,7 +344,7 @@ namespace NuGet.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
-                Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.TimestampHashAlgorithm)), ex.Message);
+                Assert.Equal(string.Format(InvalidArgException, nameof(signCommand.TimestampHashAlgorithm)), ex.Message);
             }
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetReposignCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetReposignCommandTest.cs
@@ -14,11 +14,11 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
 {
     public class NuGetReposignCommandTest
     {
-        private const string _noPackageException = "No package was provided. For a list of accepted ways to provide a package, please visit https://docs.nuget.org/docs/reference/command-line-reference";
-        private const string _invalidArgException = "Invalid value provided for '{0}'. For a list of accepted values, please visit https://learn.microsoft.com/nuget/reference/cli-reference/cli-ref-sign";
-        private const string _noCertificateException = "No {0} provided or provided file is not a p7b file.";
-        private const string _invalidCertificateFingerprint = "Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).";
-        private const string _sha1Hash = "89967D1DD995010B6C66AE24FF8E66885E6E03A8";
+        private const string NoPackageException = "No package was provided. For a list of accepted ways to provide a package, please visit https://docs.nuget.org/docs/reference/command-line-reference";
+        private const string InvalidArgException = "Invalid value provided for '{0}'. For a list of accepted values, please visit https://learn.microsoft.com/nuget/reference/cli-reference/cli-ref-sign";
+        private const string NoCertificateException = "No {0} provided or provided file is not a p7b file.";
+        private const string InvalidCertificateFingerprint = "Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).";
+        private const string Sha256Hash = "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b55b046cbb7f506fb";
 
         [Fact]
         public void ReposignCommandArgParsing_NoPackagePath()
@@ -47,7 +47,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-                Assert.Equal(_noPackageException, ex.Message);
+                Assert.Equal(NoPackageException, ex.Message);
             }
         }
 
@@ -78,7 +78,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-                Assert.Equal(string.Format(_noCertificateException, nameof(reposignCommand.CertificateFile)), ex.Message);
+                Assert.Equal(string.Format(NoCertificateException, nameof(reposignCommand.CertificateFile)), ex.Message);
             }
         }
 
@@ -91,7 +91,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = _sha1Hash;
+                var certificateFingerprint = Sha256Hash;
                 var keyContainer = new Guid().ToString();
                 var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
 
@@ -110,7 +110,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-                Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.CSPName)), ex.Message);
+                Assert.Equal(string.Format(InvalidArgException, nameof(reposignCommand.CSPName)), ex.Message);
             }
         }
 
@@ -123,7 +123,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = _sha1Hash;
+                var certificateFingerprint = Sha256Hash;
                 var cspName = "cert provider";
                 var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
 
@@ -142,7 +142,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-                Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.KeyContainer)), ex.Message);
+                Assert.Equal(string.Format(InvalidArgException, nameof(reposignCommand.KeyContainer)), ex.Message);
             }
         }
 
@@ -174,7 +174,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-                Assert.Equal(_invalidCertificateFingerprint, ex.Message);
+                Assert.Equal(InvalidCertificateFingerprint, ex.Message);
             }
         }
 
@@ -209,7 +209,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-                Assert.Equal(_invalidCertificateFingerprint, ex.Message);
+                Assert.Equal(InvalidCertificateFingerprint, ex.Message);
             }
         }
 
@@ -222,7 +222,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = _sha1Hash;
+                var certificateFingerprint = Sha256Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
 
@@ -241,7 +241,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-                Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.V3ServiceIndexUrl)), ex.Message);
+                Assert.Equal(string.Format(InvalidArgException, nameof(reposignCommand.V3ServiceIndexUrl)), ex.Message);
             }
         }
 
@@ -254,7 +254,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = _sha1Hash;
+                var certificateFingerprint = Sha256Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
                 var serviceIndex = "not-valid-uri";
@@ -275,7 +275,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-                Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.V3ServiceIndexUrl)), ex.Message);
+                Assert.Equal(string.Format(InvalidArgException, nameof(reposignCommand.V3ServiceIndexUrl)), ex.Message);
             }
         }
 
@@ -288,7 +288,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = _sha1Hash;
+                var certificateFingerprint = Sha256Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
                 var serviceIndex = "http://validv3NonhttpsUri.test/api/index.json";
@@ -309,7 +309,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-                Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.V3ServiceIndexUrl)), ex.Message);
+                Assert.Equal(string.Format(InvalidArgException, nameof(reposignCommand.V3ServiceIndexUrl)), ex.Message);
             }
         }
 
@@ -322,7 +322,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = _sha1Hash;
+                var certificateFingerprint = Sha256Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
                 var serviceIndex = "https://v3serviceindex.test/api/index.json";
@@ -345,7 +345,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-                Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.PackageOwners)), ex.Message);
+                Assert.Equal(string.Format(InvalidArgException, nameof(reposignCommand.PackageOwners)), ex.Message);
             }
         }
 
@@ -365,7 +365,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = _sha1Hash;
+                var certificateFingerprint = Sha256Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
                 var serviceIndex = "https://v3serviceindex.test/api/index.json";
@@ -388,7 +388,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 // Act & Assert
                 Assert.True(parsable);
                 var ex = Assert.Throws<CryptographicException>(() => reposignCommand.GetRepositorySignRequest());
-                Assert.NotEqual(string.Format(_invalidArgException, nameof(reposignCommand.HashAlgorithm)), ex.Message);
+                Assert.NotEqual(string.Format(InvalidArgException, nameof(reposignCommand.HashAlgorithm)), ex.Message);
             }
         }
 
@@ -401,7 +401,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = _sha1Hash;
+                var certificateFingerprint = Sha256Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
                 var serviceIndex = "https://v3serviceindex.test/api/index.json";
@@ -424,7 +424,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-                Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.HashAlgorithm)), ex.Message);
+                Assert.Equal(string.Format(InvalidArgException, nameof(reposignCommand.HashAlgorithm)), ex.Message);
             }
         }
 
@@ -444,7 +444,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = _sha1Hash;
+                var certificateFingerprint = Sha256Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
                 var serviceIndex = "https://v3serviceindex.test/api/index.json";
@@ -467,7 +467,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 // Act & Assert
                 Assert.True(parsable);
                 var ex = Assert.Throws<CryptographicException>(() => reposignCommand.GetRepositorySignRequest());
-                Assert.NotEqual(string.Format(_invalidArgException, nameof(reposignCommand.TimestampHashAlgorithm)), ex.Message);
+                Assert.NotEqual(string.Format(InvalidArgException, nameof(reposignCommand.TimestampHashAlgorithm)), ex.Message);
             }
         }
 
@@ -480,7 +480,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = _sha1Hash;
+                var certificateFingerprint = Sha256Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
                 var serviceIndex = "https://v3serviceindex.test/api/index.json";
@@ -503,7 +503,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-                Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.TimestampHashAlgorithm)), ex.Message);
+                Assert.Equal(string.Format(InvalidArgException, nameof(reposignCommand.TimestampHashAlgorithm)), ex.Message);
             }
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetReposignCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetReposignCommandTest.cs
@@ -15,8 +15,10 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
     public class NuGetReposignCommandTest
     {
         private const string _noPackageException = "No package was provided. For a list of accepted ways to provide a package, please visit https://docs.nuget.org/docs/reference/command-line-reference";
-        private const string _invalidArgException = "Invalid value provided for '{0}'. For a list of accepted values, please visit https://docs.nuget.org/docs/reference/command-line-reference";
+        private const string _invalidArgException = "Invalid value provided for '{0}'. For a list of accepted values, please visit https://learn.microsoft.com/nuget/reference/cli-reference/cli-ref-sign";
         private const string _noCertificateException = "No {0} provided or provided file is not a p7b file.";
+        private const string _invalidCertificateFingerprint = "Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).";
+        private const string _sha1Hash = "89967D1DD995010B6C66AE24FF8E66885E6E03A8";
 
         [Fact]
         public void ReposignCommandArgParsing_NoPackagePath()
@@ -89,7 +91,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = new Guid().ToString();
+                var certificateFingerprint = _sha1Hash;
                 var keyContainer = new Guid().ToString();
                 var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
 
@@ -121,7 +123,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = new Guid().ToString();
+                var certificateFingerprint = _sha1Hash;
                 var cspName = "cert provider";
                 var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
 
@@ -172,7 +174,42 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
 
                 // Act & Assert
                 var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-                Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.CertificateFingerprint)), ex.Message);
+                Assert.Equal(_invalidCertificateFingerprint, ex.Message);
+            }
+        }
+
+        [Theory]
+        [InlineData("89967D1DD995010B6C66AE24FF8E66885E6E03")] // 39 characters long not SHA-1
+        [InlineData("invalid-certificate-fingerprint")]
+        public void ReposignCommandArgParsing_InvalidCertificateFingerprint_Throws_Exception(string certificateFingerprint)
+        {
+            using (var dir = TestDirectory.Create())
+            {
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
+                var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
+
+                var mockConsole = new Mock<IConsole>();
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CertificateFingerprint = certificateFingerprint,
+                    CSPName = cspName,
+                    KeyContainer = keyContainer,
+                    V3ServiceIndexUrl = v3serviceIndexUrl,
+                };
+
+                reposignCommand.Arguments.Add(packagePath);
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+                Assert.Equal(_invalidCertificateFingerprint, ex.Message);
             }
         }
 
@@ -185,7 +222,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = new Guid().ToString();
+                var certificateFingerprint = _sha1Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
 
@@ -217,7 +254,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = new Guid().ToString();
+                var certificateFingerprint = _sha1Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
                 var serviceIndex = "not-valid-uri";
@@ -251,7 +288,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = new Guid().ToString();
+                var certificateFingerprint = _sha1Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
                 var serviceIndex = "http://validv3NonhttpsUri.test/api/index.json";
@@ -285,7 +322,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = new Guid().ToString();
+                var certificateFingerprint = _sha1Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
                 var serviceIndex = "https://v3serviceindex.test/api/index.json";
@@ -328,7 +365,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = new Guid().ToString();
+                var certificateFingerprint = _sha1Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
                 var serviceIndex = "https://v3serviceindex.test/api/index.json";
@@ -364,7 +401,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = new Guid().ToString();
+                var certificateFingerprint = _sha1Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
                 var serviceIndex = "https://v3serviceindex.test/api/index.json";
@@ -407,7 +444,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = new Guid().ToString();
+                var certificateFingerprint = _sha1Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
                 var serviceIndex = "https://v3serviceindex.test/api/index.json";
@@ -443,7 +480,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
                 var packagePath = Path.Combine(dir, "package.nupkg");
                 var timestamper = "https://timestamper.test";
                 var certFile = Path.Combine(dir, "cert.p7b");
-                var certificateFingerprint = new Guid().ToString();
+                var certificateFingerprint = _sha1Hash;
                 var keyContainer = new Guid().ToString();
                 var cspName = "cert provider";
                 var serviceIndex = "https://v3serviceindex.test/api/index.json";


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2939

## Description

Deprecate the usage of SHA-1 fingerprints in `mssign` and `reposign` commands especially for `CertificateFingerprint` option. Instead, allow `mssign` and `reposign` commands to accept SHA-2 (SHA-256, SHA-384 and SHA-512) family fingerprints for searching a local certificate store for the certificate.

Here is how the `mssign` and `reposign` commands after this PR has been merged:

- Validates the certificate fingerprint to ensure it is either SHA-1, SHA-256, SHA-384, or SHA-512 algorithm. Throws an error otherwise.
- Raises a warning if a SHA-1 certificate fingerprint is provided. This warning will be promoted to an error in the future.
- While searching for a certificate from the local store, if a SHA-1 hash is provided, finds the certificate using the existing API i.e. `certCollection.Find(X509FindType.FindByThumbprint, CertificateFingerprint, validOnly: false);`
- If a SHA-256, SHA-384, or SHA-512 certificate fingerprint is provided, loops through the certificates in the store to find the certificate with the matching hash.

I made similar changes to the dotnet sign command in https://github.com/NuGet/NuGet.Client/pull/5895 and nuget.exe sign command in https://github.com/NuGet/NuGet.Client/pull/5924.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Client.Engineering/issues/2876
