### PR TITLE
Account for InvalidOperationException in XunitLogger

### DIFF
--- a/test/TestUtilities/Test.Utility/XunitLogger.cs
+++ b/test/TestUtilities/Test.Utility/XunitLogger.cs
@@ -29,7 +29,15 @@ namespace Test.Utility
             var level = message.Level.ToString().ToLowerInvariant();
             level = level.Substring(0, Math.Min(level.Length, 4));
 
-            Output.WriteLine($"[test] {level}: {message.Message}");
+            try
+            {
+                Output.WriteLine($"[test] {level}: {message.Message}");
+            }
+            catch (InvalidOperationException)
+            {
+                // Under some circumstances, the output helper may throw an System.InvalidOperationException : There is no currently active test so fall back to writing to the console instead of failing the test.
+                Console.WriteLine($"[test] {level}: {message.Message}");
+            }
         }
 
         public override Task LogAsync(ILogMessage message)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Description
Some functional tests have been failing with this error:
```
System.InvalidOperationException : There is no currently active test.

 at Test.Utility.XunitLogger.Log(ILogMessage message) in D:\a\_work\1\s\test\TestUtilities\Test.Utility\XunitLogger.cs:line 32
   at NuGet.Common.LoggerBase.Log(LogLevel level, String data) in D:\a\_work\1\s\src\NuGet.Core\NuGet.Common\Logging\LoggerBase.cs:line 29
   at NuGet.Common.LoggerBase.LogInformation(String data) in D:\a\_work\1\s\src\NuGet.Core\NuGet.Common\Logging\LoggerBase.cs:line 55
   at NuGet.Test.NuGetPackageManagerTests.TestNuGetVSTelemetryService.EmitTelemetryEvent(TelemetryEvent telemetryData) in D:\a\_work\1\s\test\NuGet.Core.Tests\NuGet.PackageManagement.Test\NuGetPackageManagerTests.cs:line 8024
```

I guess under certain circumstances, the xunit APIs think a test isn't running and so writing to the `ITestOutputHelper` causes an exception.  This change catches the exception and writes to `Console.Out` instead.

https://dev.azure.com/dnceng-public/public/_build/results?buildId=759945&view=ms.vss-test-web.build-test-results-tab&runId=19293168&resultId=102473&paneView=debug

## PR Checklist

- [x] Meaningful title, helpful description
- [ ] ~~Added tests~~
- [ ] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~
