### PR TITLE
Disable Static Analysis status check if its not being run

### DIFF
--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -74,8 +74,11 @@ Function InitializeAllTestsToPending {
 
     Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Build_and_UnitTest_NonRTM" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
     Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Build_and_UnitTest_RTM" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Static Analysis" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
     
+    if($env:RunStaticAnalysis -eq "true")
+    {
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Static Analysis" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+    }
     if($env:RunSourceBuild -eq "true")
     {
         Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Source Build" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

## Description
This is a follow-up to a missed change in https://github.com/NuGet/NuGet.Client/pull/5904 where the Static Analysis status check is being added even though it won't be run in the PrivateDev pipeline anymore.

Now it shows up but never runs unless you manually run that job
![image](https://github.com/user-attachments/assets/05469d6e-a75b-4830-9ad4-fc67e105bab2)

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
