### PR TITLE
[CI] Re-enable Mac Mono Tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -61,6 +61,7 @@
     <PackageVersion Include="Microsoft.PowerShell.3.ReferenceAssemblies" Version="1.0.0" />
     <PackageVersion Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="16.153.0" />
     <PackageVersion Include="Microsoft.Test.Apex.VisualStudio" Version="17.11.35005.70" />
+    <PackageVersion Include="Microsoft.TestPlatform.Portable" Version="17.1.0" />
     <PackageVersion Include="Microsoft.VisualStudio.LanguageServices" Version="4.3.1" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem" Version="17.4.221-pre" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.Managed" Version="17.2.0-beta1-20502-01" />

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -41,7 +41,7 @@ parameters:
 - name: RunMonoTestsOnMac
   displayName: Run Mono tests on Mac
   type: boolean
-  default: false
+  default: true
 
 resources:
   pipelines:

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -26,7 +26,7 @@ parameters:
 - name: RunMonoTestsOnMac
   displayName: Run Mono tests on Mac
   type: boolean
-  default: true
+  default: false
 
 resources:
   repositories:

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -26,7 +26,7 @@ parameters:
 - name: RunMonoTestsOnMac
   displayName: Run Mono tests on Mac
   type: boolean
-  default: false
+  default: true
 
 resources:
   repositories:

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -37,7 +37,7 @@ parameters:
 - name: RunMonoTestsOnMac
   displayName: Run Mono tests on Mac
   type: boolean
-  default: false
+  default: true
 - name: RunStaticAnalysis
   displayName: Run static analysis
   type: boolean

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -470,7 +470,7 @@ stages:
       TestRunCommandLineArguments: "--mono-tests"
     pool:
       name: 'Azure Pipelines'
-      vmImage: macos-13
+      vmImage: macos-latest
       os: macOS
     templateContext:
       outputs:

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -77,7 +77,7 @@ if [ "$MONO_TESTS" == "1" ]; then
             Darwin)
                 echo "==================== Run mono tests started at `date -u +"%Y-%m-%dT%H:%M:%S"` ======================"
                 set -x
-                mono $VsTestConsole $TestDir/NuGet.CommandLine.Test.dll --logger:"console;verbosity=$VsTestVerbosity" --logger:trx --diag:$BUILD_STAGINGDIRECTORY/binlog/vstest.diag.log --ResultsDirectory:$TestResultsDir
+                mono $VsTestConsole $TestDir/NuGet.CommandLine.Test.dll --logger:"console;verbosity=$VsTestVerbosity" --logger:trx --diag:$BUILD_STAGINGDIRECTORY/binlog/vstest.diag.log --ResultsDirectory:$TestResultsDir --Settings:$DIR/build/xunit.runsettings
                 EXIT_CODE=$?
                 set +x
                 echo "================== mono tests finished at `date -u +"%Y-%m-%dT%H:%M:%S"` ==================="

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -68,21 +68,22 @@ if [ "$MONO_TESTS" == "1" ]; then
     rm -rf "$TestDir/System.*" "$TestDir/WindowsBase.dll" "$TestDir/Microsoft.CSharp.dll" "$TestDir/Microsoft.Build.Engine.dll"
 
     case "$(uname -s)" in
-		    Linux)
-			    # We are not testing Mono on linux currently, so comment it out.
-			    #echo "mono $VsTestConsole $TestDir/NuGet.CommandLine.Test.dll --TestCaseFilter:Platform!=Windows&Platform!=Darwin --logger:console;verbosity=$VsTestVerbosity --logger:"trx" --ResultsDirectory:$TestResultsDir"
-			    #mono $VsTestConsole "$TestDir/NuGet.CommandLine.Test.dll" --TestCaseFilter:"Platform!=Windows&Platform!=Darwin" --logger:"console;verbosity=$VsTestVerbosity" --logger:"trx" --ResultsDirectory:"$TestResultsDir"
-			    #EXIT_CODE=$?
-			    ;;
-		    Darwin)
+            Linux)
+                # We are not testing Mono on linux currently, so comment it out.
+                #echo "mono $VsTestConsole $TestDir/NuGet.CommandLine.Test.dll --TestCaseFilter:Platform!=Windows&Platform!=Darwin --logger:console;verbosity=$VsTestVerbosity --logger:"trx" --ResultsDirectory:$TestResultsDir"
+                #mono $VsTestConsole "$TestDir/NuGet.CommandLine.Test.dll" --TestCaseFilter:"Platform!=Windows&Platform!=Darwin" --logger:"console;verbosity=$VsTestVerbosity" --logger:"trx" --ResultsDirectory:"$TestResultsDir"
+                #EXIT_CODE=$?
+                ;;
+            Darwin)
                 echo "==================== Run mono tests started at `date -u +"%Y-%m-%dT%H:%M:%S"` ======================"
-			    echo "mono $VsTestConsole $TestDir/NuGet.CommandLine.Test.dll --TestCaseFilter:Platform!=Windows&Platform!=Linux --logger:console;verbosity=$VsTestVerbosity --logger:"trx" --ResultsDirectory:$TestResultsDir"
-			    mono $VsTestConsole "$TestDir/NuGet.CommandLine.Test.dll" --TestCaseFilter:"Platform!=Windows&Platform!=Linux" --logger:"console;verbosity=$VsTestVerbosity" --logger:"trx" --ResultsDirectory:"$TestResultsDir"
-			    EXIT_CODE=$?
+                set -x
+                mono $VsTestConsole $TestDir/NuGet.CommandLine.Test.dll --logger:"console;verbosity=$VsTestVerbosity" --logger:trx --diag:$BUILD_STAGINGDIRECTORY/binlog/vstest.diag.log --ResultsDirectory:$TestResultsDir
+                EXIT_CODE=$?
+                set +x
                 echo "================== mono tests finished at `date -u +"%Y-%m-%dT%H:%M:%S"` ==================="
                 echo ""
-			    ;;
-		    *) ;;
+                ;;
+            *) ;;
     esac
 fi
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.NET.StringTools" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.TestPlatform.Portable" IncludeAssets="None" />
   </ItemGroup>
 
   <ItemGroup>
@@ -35,6 +36,8 @@
              CopyToOutputDirectory="PreserveNewest"
              Visible="false"
              Condition="'$(PkgMicrosoft_TestPlatform_Portable)' != ''" />
+    <None Include="xunit.runner.json"
+          CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/xunit.runner.json
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/xunit.runner.json
@@ -1,0 +1,7 @@
+{
+  "diagnosticMessages": true,
+  "methodDisplay": "classAndMethod",
+  "parallelizeAssembly": true,
+  "parallelizeTestCollections": true,
+  "longRunningTestSeconds": 120
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2926

## Description
This re-enables the Mac Mono tests after they were disabled due to not working after a change.  I had to bring back the `xunit.runner.json` for some reason.  I spent a lot of time trying to use newer tooling but that seems to be broken.  So I really just brought them back the way there were before.  

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
