### PR TITLE
Test:  fix ZIP entry LastWriteTime tests to support running locally (when system clock is not UTC)

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
@@ -20,7 +20,7 @@ namespace Commands.Test
 
     public class NugetPackageUtilsTests
     {
-        private readonly int DefaultTimeOut = (int)TimeSpan.FromMinutes(5).TotalMilliseconds;
+        private static readonly int DefaultTimeOut = (int)TimeSpan.FromMinutes(5).TotalMilliseconds;
 
         [Fact]
         public async Task PackageExpander_ExpandsPackage()
@@ -620,7 +620,9 @@ namespace Commands.Test
         {
             // Arrange
             var packageIdentity = new PackageIdentity("packageA", new NuGetVersion("2.0.3"));
-            var entryModifiedTime = new DateTimeOffset(1985, 11, 20, 12, 0, 0, TimeSpan.FromHours(-7.0)).DateTime;
+            var entryModifiedTime = new DateTimeOffset(1985, 11, 20, 12, 0, 0, TimeSpan.FromHours(-7.0));
+            DateTime expectedLastWriteTime = entryModifiedTime.DateTime.ToLocalTime();
+
             using (var packagesDirectory = TestDirectory.Create())
             {
                 var pathResolver = new VersionFolderPathResolver(packagesDirectory);
@@ -641,7 +643,7 @@ namespace Commands.Test
 
                 // Act
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
-                    null,
+                    source: null,
                     packageFileInfo.FullName,
                     packageIdentity,
                     NullLogger.Instance))
@@ -661,7 +663,7 @@ namespace Commands.Test
                 var dllPath = Path.Combine(packageVersionDirectory, "lib", "net45", "A.dll");
                 var dllFileInfo = new FileInfo(dllPath);
                 AssertFileExists(dllFileInfo.FullName);
-                Assert.Equal(entryModifiedTime, dllFileInfo.LastWriteTime);
+                Assert.Equal(expectedLastWriteTime, dllFileInfo.LastWriteTime);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -5,7 +5,9 @@ using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+#if IS_SIGNING_SUPPORTED
 using System.Text;
+#endif
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
@@ -15,7 +17,9 @@ using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
+#if IS_SIGNING_SUPPORTED
 using Test.Utility.Signing;
+#endif
 using Xunit;
 
 namespace NuGet.Packaging.Test
@@ -899,7 +903,7 @@ namespace NuGet.Packaging.Test
                    root,
                    identity.Id,
                    identity.Version.ToString(),
-                   DateTimeOffset.UtcNow.LocalDateTime,
+                   entryModifiedTime: DateTimeOffset.Now,
                    "../../A.dll",
                    "content/net40/B.nuspec");
 
@@ -931,7 +935,7 @@ namespace NuGet.Packaging.Test
                    root,
                    identity.Id,
                    identity.Version.ToString(),
-                   DateTimeOffset.UtcNow.LocalDateTime,
+                   entryModifiedTime: DateTimeOffset.Now,
                    $"{rootPath}/A.dll",
                    "content/net40/B.nuspec");
 
@@ -962,7 +966,7 @@ namespace NuGet.Packaging.Test
                    root,
                    identity.Id,
                    identity.Version.ToString(),
-                   DateTimeOffset.UtcNow.LocalDateTime,
+                   entryModifiedTime: DateTimeOffset.Now,
                    ".",
                    "content/net40/B.nuspec");
 
@@ -1016,7 +1020,7 @@ namespace NuGet.Packaging.Test
                        root,
                        identity.Id,
                        identity.Version.ToString(),
-                       DateTimeOffset.UtcNow.LocalDateTime,
+                       entryModifiedTime: DateTimeOffset.Now,
                        @"readme~.txt");
 
                     using (var packageStream = File.OpenRead(packageFileInfo.FullName))
@@ -1055,7 +1059,7 @@ namespace NuGet.Packaging.Test
                        root,
                        identity.Id,
                        identity.Version.ToString(),
-                       DateTimeOffset.UtcNow.LocalDateTime,
+                       entryModifiedTime: DateTimeOffset.Now,
                        @"readme~.txt");
 
                     using (var packageStream = File.OpenRead(packageFileInfo.FullName))
@@ -1701,7 +1705,7 @@ namespace NuGet.Packaging.Test
                    root,
                    identity.Id,
                    identity.Version.ToString(),
-                   DateTimeOffset.UtcNow.LocalDateTime,
+                   entryModifiedTime: DateTimeOffset.Now,
                    "../../A.dll",
                    "content/net40/B.nuspec");
 
@@ -1728,7 +1732,7 @@ namespace NuGet.Packaging.Test
                    root,
                    identity.Id,
                    identity.Version.ToString(),
-                   DateTimeOffset.UtcNow.LocalDateTime,
+                   entryModifiedTime: DateTimeOffset.Now,
                    $"{rootPath}/A.dll",
                    "content/net40/B.nuspec");
 
@@ -1755,7 +1759,7 @@ namespace NuGet.Packaging.Test
                    root,
                    identity.Id,
                    identity.Version.ToString(),
-                   DateTimeOffset.UtcNow.LocalDateTime,
+                   entryModifiedTime: DateTimeOffset.Now,
                    ".",
                    "content/net40/B.nuspec");
 
@@ -1780,7 +1784,7 @@ namespace NuGet.Packaging.Test
                    root,
                    identity.Id,
                    identity.Version.ToString(),
-                   DateTimeOffset.UtcNow.LocalDateTime,
+                   entryModifiedTime: DateTimeOffset.Now,
                    "C++.dll",
                    "content/net40/B&#A.txt",
                    "content/net40/B.nuspec");
@@ -1807,7 +1811,7 @@ namespace NuGet.Packaging.Test
                    root,
                    identity.Id,
                    identity.Version.ToString(),
-                   DateTimeOffset.UtcNow.LocalDateTime,
+                   entryModifiedTime: DateTimeOffset.Now,
                    "lib/net40/A.dll",
                    "content/net40/B.nuspec");
 

--- a/test/TestUtilities/Test.Utility/TestPackagesCore.cs
+++ b/test/TestUtilities/Test.Utility/TestPackagesCore.cs
@@ -800,7 +800,7 @@ namespace NuGet.Test.Utility
 
         public static async Task<FileInfo> GetPackageWithSHA512AtRoot(string path, string packageId, string packageVersion)
         {
-            return await GeneratePackageAsync(path, packageId, packageVersion, DateTimeOffset.UtcNow.LocalDateTime,
+            return await GeneratePackageAsync(path, packageId, packageVersion, entryModifiedTime: DateTimeOffset.Now,
                 "lib/net45/A.dll",
                 "lib/net45/B.sha512",
                 $"{packageId}.${packageVersion}.nupkg.sha512",
@@ -809,7 +809,7 @@ namespace NuGet.Test.Utility
 
         public static async Task<FileInfo> GetPackageWithNupkgAtRoot(string path, string packageId, string packageVersion)
         {
-            return await GeneratePackageAsync(path, packageId, packageVersion, DateTimeOffset.UtcNow.LocalDateTime,
+            return await GeneratePackageAsync(path, packageId, packageVersion, entryModifiedTime: DateTimeOffset.Now,
                 "lib/net45/A.dll",
                 "lib/net45/B.nupkg",
                 $"{packageId}.{packageVersion}.nupkg");
@@ -824,7 +824,7 @@ namespace NuGet.Test.Utility
                 path,
                 packageId,
                 packageVersion,
-                DateTimeOffset.UtcNow.LocalDateTime,
+                entryModifiedTime: DateTimeOffset.Now,
                 "lib/net45/A.dll");
         }
 
@@ -839,7 +839,7 @@ namespace NuGet.Test.Utility
                 runtimePackageId + "." + language,
                 packageVersion,
                 language,
-                DateTimeOffset.UtcNow.LocalDateTime,
+                entryModifiedTime: DateTimeOffset.Now,
                 $"lib/net45/{language}/{runtimePackageId}.resources.dll");
         }
 
@@ -847,7 +847,7 @@ namespace NuGet.Test.Utility
             string path,
             string packageId,
             string packageVersion,
-            DateTime entryModifiedTime,
+            DateTimeOffset entryModifiedTime,
             params string[] zipEntries)
         {
             return await GeneratePackageAsync(
@@ -864,7 +864,7 @@ namespace NuGet.Test.Utility
             string packageId,
             string packageVersion,
             string language,
-            DateTime entryModifiedTime,
+            DateTimeOffset entryModifiedTime,
             params string[] zipEntries)
         {
             return await GeneratePackageAsync(
@@ -882,7 +882,7 @@ namespace NuGet.Test.Utility
             string packageId,
             string packageVersion,
             string language,
-            DateTime entryModifiedTime,
+            DateTimeOffset entryModifiedTime,
             IEnumerable<string> zipEntries,
             IEnumerable<string> zipContents,
             bool frameworkAssemblies = false,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/11312

## Description

This change fixes some tests that only pass when the system clock is UTC (like on a CI build machine).

The way the `DateTimeOffset ZipArchiveEntry.LastWriteTime` property works is for any `DateTimeOffset` value you set it to, `ZipArchiveEntry` will use only the `DateTime` property of that `DateTimeOffset`.  [`DateTimeOffset.DateTime`](https://learn.microsoft.com/dotnet/api/system.datetimeoffset.datetime?view=net-8.0) effectively returns the `DateTime` component of a `DateTimeOffset`, after first discarding its time zone information.  To illustrate, the `DateTime` property of these different `DateTimeOffset` values all return the same `DateTime` value of `8/3/2024 11:50:51 AM` with an "unspecified" time zone.

```
8/3/2024 11:50:51 AM -07:00
8/3/2024 11:50:51 AM +00:00
8/3/2024 11:50:51 AM +05:30
```

That means any test that checks that NuGet sets a file's `LastWriteTime` value correctly must use `DateTimeOffset.DateTime` to check the file's last write time in UTC, or `DateTimeOffset.DateTime.ToLocalTime()` to check the file's last write time in local.

As part of this change, I changed the `entryModifiedTime` type from `DateTime` to `DateTimeOffset` to match the `ZipArchiveEntry.LastWriteTime` data type.

I also opportunistically fixed some code style issues in the area.

## PR Checklist

- [X] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~~Added tests~~ N/A
- [ ] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~ N/A

CC @aortiz-msft
