### PR TITLE
Use concurrent dictionary in related extensions calculation

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemCollection.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemCollection.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -14,8 +15,7 @@ namespace NuGet.ContentModel
         private static readonly ReadOnlyMemory<char> Winmd = ".winmd".AsMemory();
 
         private List<Asset> _assets;
-        private Dictionary<ReadOnlyMemory<char>, string> _assemblyRelatedExtensions;
-
+        private ConcurrentDictionary<ReadOnlyMemory<char>, string> _assemblyRelatedExtensions;
         /// <summary>
         /// True if lib/contract exists
         /// </summary>
@@ -309,14 +309,14 @@ namespace NuGet.ContentModel
             // If no related files found.
             if (relatedFileExtensionList is null || relatedFileExtensionList.Count == 0)
             {
-                _assemblyRelatedExtensions[assemblyPrefix] = null;
+                _assemblyRelatedExtensions.TryAdd(assemblyPrefix, null);
                 return null;
             }
             else
             {
                 relatedFileExtensionList.Sort();
                 string relatedFileExtensionsProperty = string.Join(";", relatedFileExtensionList);
-                _assemblyRelatedExtensions[assemblyPrefix] = relatedFileExtensionsProperty;
+                _assemblyRelatedExtensions.TryAdd(assemblyPrefix, relatedFileExtensionsProperty);
                 return relatedFileExtensionsProperty;
             }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Related: https://github.com/NuGet/Home/issues/12728 

## Description

It's failing the insertion: https://github.com/dotnet/sdk/pull/42458. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~ Functional tests exist. The SDK side that caught this test out graph build scenarios, which are more challenging to replicate. Since this is blocking an insertion, I have created a follow issue. https://github.com/NuGet/Home/issues/13678
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
