### PR TITLE
Remove CI triggers excluding markdown files

### DIFF
--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -42,17 +42,11 @@ trigger:
   branches:
     include:
     - dev
-  paths:
-    exclude:
-    - '*.md'
 
 pr:
   branches:
     include:
     - '*'
-  paths:
-    exclude:
-    - '*.md'
 
 stages:
 - ${{ if eq(parameters.RunUnitTestsOnWindows, true) }}:

--- a/eng/pipelines/vs-tests.yml
+++ b/eng/pipelines/vs-tests.yml
@@ -5,9 +5,6 @@ trigger:
   branches:
     include:
     - dev-*
-  paths:
-    exclude:
-    - '*.md'
 
 parameters:
 # build parameters


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: N/A - engineering

## Description

Remove the CI trigger exclusion of markdown files, because we can't configure GitHub branch policies to allow PRs with only markdown file changes to skip required checks policies.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
