### PR TITLE
Install all packages during dependency walk in new resolver

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -517,6 +517,13 @@ namespace NuGet.Commands
                             libraryRangeInterningTable);
 
                         findLibraryEntryCache.Add(libraryRangeOfCurrentRef, refItemResult);
+
+                        // If the package came from a remote library provider, it needs to be installed locally.
+                        var isRemote = context.RemoteLibraryProviders.Contains(refItem.Data.Match.Provider);
+                        if (isRemote)
+                        {
+                            newRTG.Install.Add(refItem.Data.Match);
+                        }
                     }
 
                     HashSet<LibraryDependencyIndex>? suppressions = default;
@@ -715,13 +722,6 @@ namespace NuGet.Commands
                     if (findLibraryEntryCache.TryGetValue(chosenRefRangeIndex, out var node))
                     {
                         newFlattened.Add(node.Item);
-
-                        // If the package came from a remote library provider, it needs to be installed locally.
-                        var isRemote = context.RemoteLibraryProviders.Contains(node.Item.Data.Match.Provider);
-                        if (isRemote)
-                        {
-                            newRTG.Install.Add(node.Item.Data.Match);
-                        }
 
                         for (int i = 0; i < node.Item.Data.Dependencies.Count; i++)
                         {


### PR DESCRIPTION
## Description
The legacy dependency resolution algorithm installs all packages in the graph walk while the new one only installs packages that ended up in the resolved graph.  However, this means that for subsequent restores, more I/O is needed since NuGet will ask the feed for the package again, download it, and read the nuspec.  Especially in Visual Studio this can cause more allocations.

This change adds to the list of packages to install during the walk instead of at the end based on the resolved graph.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
