### PR TITLE
Fix new resolver reporting downgrades for pinned packages that have PrivateAssets=All

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -820,7 +820,8 @@ namespace NuGet.Commands
                                 newGraphNode.OuterNode = currentGraphNode;
                                 currentGraphNode.InnerNodes.Add(newGraphNode);
                             }
-                            if (isCentralPackageTransitivePinningEnabled && !downgrades.ContainsKey(chosenItemRangeIndex) && !RemoteDependencyWalker.IsGreaterThanOrEqualTo(chosenItem.LibraryDependency.LibraryRange.VersionRange, dep.LibraryRange.VersionRange))
+
+                            if (dep.SuppressParent != LibraryIncludeFlags.All && isCentralPackageTransitivePinningEnabled && !downgrades.ContainsKey(chosenItemRangeIndex) && !RemoteDependencyWalker.IsGreaterThanOrEqualTo(chosenItem.LibraryDependency.LibraryRange.VersionRange, dep.LibraryRange.VersionRange))
                             {
                                 downgrades.Add(chosenItem.LibraryRangeIndex, (currentGraphNode, dep));
                             }


### PR DESCRIPTION
## Description
This fixes a problem with https://github.com/NuGet/NuGet.Client/pull/5965 where a transitively pinned package is erroneously being reported as a downgrade even if the package has PrivateAssets=All.

I'll need to add a unit test to cover this since it wasn't found with our current setup.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
