### PR TITLE
Fix problem in new resolver with pinned package and version override

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -542,7 +542,22 @@ namespace NuGet.Commands
                             }
                             suppressions.Add(depIndex);
                         }
-                        if (dep.VersionOverride != null)
+
+                        if (isCentralPackageTransitivePinningEnabled)
+                        {
+                            bool isTransitive = currentRefRangeIndex != rootProjectRefItem.LibraryRangeIndex && dep.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package;
+                            bool isPinned = pinnedPackageVersions != null && pinnedPackageVersions.ContainsKey(depIndex);
+
+                            if (dep.VersionOverride != null && (!isTransitive || !isPinned))
+                            {
+                                if (newOverrides == null)
+                                {
+                                    newOverrides = new Dictionary<LibraryDependencyIndex, VersionRange>(OverridesDictionarySize);
+                                }
+                                newOverrides[depIndex] = dep.VersionOverride;
+                            }
+                        }
+                        else if (dep.VersionOverride != null)
                         {
                             if (newOverrides == null)
                             {
@@ -607,7 +622,7 @@ namespace NuGet.Commands
 
                             isCentrallyPinnedTransitiveDependency = true;
 
-                            rangeIndex = libraryRangeInterningTable.Intern(dep.LibraryRange);
+                            rangeIndex = libraryRangeInterningTable.Intern(actualLibraryDependency.LibraryRange);
                         }
                         else
                         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
If a project has a direct package reference with `VersionOverride`, that should take precedence over everything else.  If that project references another project with `VersionOverride` on a different package, that `VersionOverride` should take precedence.

However, if transitive pinning is enabled, the pinned version should override the `VersionOverride` of a transitive PackageReference.  This change corrects the behavior in the new dependency resolution algorithm.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
