### PR TITLE
Simplify assets selection for projects

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -688,9 +688,9 @@ namespace NuGet.Commands
         /// </summary>
         /// <remarks>Enumerate this once after calling.</remarks>
         private static IList<LockFileItem> GetLockFileItems(
-           List<SelectionCriteria> criteria,
-           ContentItemCollection items,
-           params PatternSet[] patterns)
+            List<SelectionCriteria> criteria,
+            ContentItemCollection items,
+            params PatternSet[] patterns)
         {
             return GetLockFileItems(criteria, items, additionalAction: null, patterns);
         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -559,6 +559,8 @@ namespace NuGet.Commands
 
             if (rootProjectStyle == ProjectStyle.PackageReference)
             {
+                bool def = true;
+
                 // Add files under asset groups
                 object msbuildPath;
                 if (localMatch.LocalLibrary.Items.TryGetValue(KnownLibraryProperties.MSBuildProjectPath, out msbuildPath))
@@ -569,32 +571,102 @@ namespace NuGet.Commands
                     // Ensure a trailing slash for the relative path helper.
                     var projectDir = PathUtility.EnsureTrailingSlash(msbuildFilePathInfo.Directory.FullName);
 
-                    var targetFrameworkShortName = targetGraph.Framework.GetShortFolderName();
-                    string packagePath = $"lib/{targetFrameworkShortName}/any.dll";
-                    string absolutePath = Path.Combine(projectDir, "bin", "placeholder", $"{localMatch.Library.Name}.dll");
-
-                    var contentItems = new ContentItemCollection();
-                    contentItems.Load([packagePath]);
-
-                    // Create an ordered list of selection criteria. Each will be applied, if the result is empty
-                    // fallback frameworks from "imports" will be tried.
-                    // These are only used for framework/RID combinations where content model handles everything.
-                    var orderedCriteria = CreateCriteria(targetGraph.Conventions, targetGraph.Framework, targetGraph.RuntimeIdentifier);
-
-                    var compileGroup = GetLockFileItems(
-                        orderedCriteria,
-                        contentItems,
-                        targetGraph.Conventions.Patterns.CompileLibAssemblies);
-
-                    var assemblies = new List<LockFileItem> { ConvertToProjectPaths(projectDir, absolutePath, compileGroup[0]) };
-
-                    if (compileGroup.Count > 0)
+                    if (def)
                     {
-                        projectLib.CompileTimeAssemblies = assemblies;
-                        projectLib.RuntimeAssemblies = assemblies;
+                        var targetFrameworkShortName = targetGraph.Framework.GetShortFolderName();
+                        string packagePath = $"lib/{targetFrameworkShortName}/any.dll";
+                        string absolutePath = Path.Combine(projectDir, "bin", "placeholder", $"{localMatch.Library.Name}.dll");
+
+                        var contentItems = new ContentItemCollection();
+                        contentItems.Load([packagePath]);
+
+                        // Create an ordered list of selection criteria. Each will be applied, if the result is empty
+                        // fallback frameworks from "imports" will be tried.
+                        // These are only used for framework/RID combinations where content model handles everything.
+                        var orderedCriteria = CreateCriteria(targetGraph.Conventions, targetGraph.Framework, targetGraph.RuntimeIdentifier);
+
+                        var compileGroup = GetLockFileItems(
+                            orderedCriteria,
+                            contentItems,
+                            targetGraph.Conventions.Patterns.CompileLibAssemblies);
+
+                        var assemblies = new List<LockFileItem> { ConvertToProjectPaths(projectDir, absolutePath, compileGroup[0]) };
+
+                        if (compileGroup.Count > 0)
+                        {
+                            projectLib.CompileTimeAssemblies = assemblies;
+                            projectLib.RuntimeAssemblies = assemblies;
+                        }
+                    }
+                    else
+                    {
+                        var files = new List<ProjectRestoreMetadataFile>();
+
+                        // Read files from the project if they were provided.
+                        if (localMatch.LocalLibrary.Items.TryGetValue(KnownLibraryProperties.ProjectRestoreMetadataFiles, out object filesObject))
+                        {
+                            files.AddRange((List<ProjectRestoreMetadataFile>)filesObject);
+                        }
+
+                        var libAnyPath = $"lib/{targetGraph.Framework.GetShortFolderName()}/any.dll";
+
+                        if (files.Count == 0)
+                        {
+                            // If the project did not provide a list of assets, add in default ones.
+                            // These are used to detect transitive vs non-transitive project references.
+                            var absolutePath = Path.Combine(projectDir, "bin", "placeholder", $"{localMatch.Library.Name}.dll");
+
+                            files.Add(new ProjectRestoreMetadataFile(libAnyPath, absolutePath));
+                        }
+
+                        var fileLookup = new Dictionary<string, ProjectRestoreMetadataFile>(StringComparer.OrdinalIgnoreCase);
+
+                        // Process and de-dupe files
+                        for (var i = 0; i < files.Count; i++)
+                        {
+                            var path = files[i].PackagePath;
+
+                            // LIBANY avoid compatibility checks and will always be used.
+                            if (LIBANY.Equals(path, StringComparison.Ordinal))
+                            {
+                                path = libAnyPath;
+                            }
+
+                            if (!fileLookup.ContainsKey(path))
+                            {
+                                fileLookup.Add(path, files[i]);
+                            }
+                        }
+
+                        var contentItems = new ContentItemCollection();
+                        contentItems.Load(fileLookup.Keys);
+
+                        // Create an ordered list of selection criteria. Each will be applied, if the result is empty
+                        // fallback frameworks from "imports" will be tried.
+                        // These are only used for framework/RID combinations where content model handles everything.
+                        var orderedCriteria = CreateCriteria(targetGraph.Conventions, targetGraph.Framework, targetGraph.RuntimeIdentifier);
+
+                        // Compile
+                        // ref takes precedence over lib
+                        var compileGroup = GetLockFileItems(
+                            orderedCriteria,
+                            contentItems,
+                            targetGraph.Conventions.Patterns.CompileRefAssemblies,
+                            targetGraph.Conventions.Patterns.CompileLibAssemblies);
+
+                        projectLib.CompileTimeAssemblies = ConvertToProjectPaths(fileLookup, projectDir, compileGroup);
+
+                        // Runtime
+                        var runtimeGroup = GetLockFileItems(
+                            orderedCriteria,
+                            contentItems,
+                            targetGraph.Conventions.Patterns.RuntimeAssemblies);
+
+                        projectLib.RuntimeAssemblies = ConvertToProjectPaths(fileLookup, projectDir, runtimeGroup);
                     }
                 }
             }
+
 
             // Add frameworkAssemblies for projects
             object frameworkAssembliesObject;
@@ -637,6 +709,23 @@ namespace NuGet.Commands
             PathUtility.GetRelativePath(projectDir, diskPath));
 
             return new LockFileItem(fixedPath);
+        }
+
+        private static List<LockFileItem> ConvertToProjectPaths(
+            Dictionary<string, ProjectRestoreMetadataFile> fileLookup,
+            string projectDir,
+            IList<LockFileItem> items)
+        {
+            var results = new List<LockFileItem>(items.Count);
+            foreach (var item in items.NoAllocEnumerate())
+            {
+                var diskPath = fileLookup[item.Path].AbsolutePath;
+                var fixedPath = PathUtility.GetPathWithForwardSlashes(
+                    PathUtility.GetRelativePath(projectDir, diskPath));
+
+                results.Add(new LockFileItem(fixedPath));
+            }
+            return results;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -643,7 +643,7 @@ namespace NuGet.Commands
         /// Create lock file items for the best matching group.
         /// </summary>
         /// <remarks>Enumerate this once after calling.</remarks>
-        private static List<LockFileItem> GetLockFileItems(
+        private static IList<LockFileItem> GetLockFileItems(
             List<SelectionCriteria> criteria,
             ContentItemCollection items,
             Action<LockFileItem> additionalAction,
@@ -666,7 +666,7 @@ namespace NuGet.Commands
                         object locale;
                         if (item.Properties.TryGetValue(ManagedCodeConventions.PropertyNames.Locale, out locale))
                         {
-                            newItem.Properties[ManagedCodeConventions.PropertyNames.Locale] = (string)locale;
+                            newItem.Properties["locale"] = (string)locale;
                         }
                         object related;
                         if (item.Properties.TryGetValue("related", out related))
@@ -687,10 +687,10 @@ namespace NuGet.Commands
         /// Create lock file items for the best matching group.
         /// </summary>
         /// <remarks>Enumerate this once after calling.</remarks>
-        private static List<LockFileItem> GetLockFileItems(
-            List<SelectionCriteria> criteria,
-            ContentItemCollection items,
-            params PatternSet[] patterns)
+        private static IList<LockFileItem> GetLockFileItems(
+           List<SelectionCriteria> criteria,
+           ContentItemCollection items,
+           params PatternSet[] patterns)
         {
             return GetLockFileItems(criteria, items, additionalAction: null, patterns);
         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -672,6 +672,9 @@ namespace NuGet.Commands
             return projectLib;
         }
 
+        /// <summary>
+        /// Convert from the expected nupkg path to the on disk path.
+        /// </summary>
         private static List<LockFileItem> ConvertToProjectPaths(
             Dictionary<string, ProjectRestoreMetadataFile> fileLookup,
             string projectDir,
@@ -716,7 +719,7 @@ namespace NuGet.Commands
                         object locale;
                         if (item.Properties.TryGetValue(ManagedCodeConventions.PropertyNames.Locale, out locale))
                         {
-                            newItem.Properties["locale"] = (string)locale;
+                            newItem.Properties[ManagedCodeConventions.PropertyNames.Locale] = (string)locale;
                         }
                         object related;
                         if (item.Properties.TryGetValue("related", out related))

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -575,8 +575,6 @@ namespace NuGet.Commands
                     string libAnyPath = $"lib/{targetGraph.Framework.GetShortFolderName()}/any.dll";
                     var contentItems = new ContentItemCollection();
 
-                    // Read files from the project if they were provided.
-
                     if (localMatch.LocalLibrary.Items.TryGetValue(KnownLibraryProperties.ProjectRestoreMetadataFiles, out object filesObject))
                     {
                         List<ProjectRestoreMetadataFile> files = (List<ProjectRestoreMetadataFile>)filesObject;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -634,9 +634,9 @@ namespace NuGet.Commands
                             if (compileGroup.Count > 0)
                             {
                                 string relativePath = PathUtility.GetPathWithForwardSlashes(Path.Combine("bin", "placeholder", $"{localMatch.Library.Name}.dll"));
-                                List<LockFileItem> assemblies = [new LockFileItem(relativePath)];
-                                projectLib.CompileTimeAssemblies = assemblies;
-                                projectLib.RuntimeAssemblies = assemblies;
+                                var lockFileItem = new LockFileItem(relativePath);
+                                projectLib.CompileTimeAssemblies = new List<LockFileItem>() { lockFileItem };
+                                projectLib.RuntimeAssemblies = new List<LockFileItem>() { lockFileItem };
                             }
                         }
                     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13712

## Description

CreateLockFileTargetProject allocates a lot due to the fact that it assumes that projects can provide their own assets.
While that may be true with project.json iterations, that's not really possible with PackageReference. 
Either way, this change is a backwards compatible way of allocating a lot less when the defaults are used, apply knowledge that say we don't need separate selections for compile/runtime when we know we only have 1 lib asset. 
The rest pretty much follows from that.

This saves about ~100MB in OrchardCore scenario

Before:
```
Name                                                                 	Inc %	           Inc
 nuget.commands!LockFileUtils.CreateLockFileTargetProject            	  2.3	   214,153,216
+ nuget.commands!LockFileUtils.ConvertToProjectPaths                 	  0.7	    64,684,240
+ nuget.commands!LockFileUtils.GetLockFileItems                      	  0.6	    57,482,360
+ nuget.packaging!ContentItemCollection.Load                         	  0.3	    23,740,184
+ mscorlib.ni!?                                                      	  0.2	    21,049,920
+ nuget.commands!LockFileUtils.ExcludeItems                          	  0.1	     8,489,328
+ system.core.ni!?                                                   	  0.1	     7,961,784
+ nuget.commands!LockFileUtils.CreateCriteria                        	  0.1	     7,808,504
+ clr!?                                                              	  0.1	     6,376,864
+ nuget.projectmodel!LockFileTargetLibrary.get_FrameworkAssemblies   	  0.1	     4,729,264
+ nuget.frameworks!NuGetFramework.GetShortFolderName                 	  0.0	     3,687,712
+ nuget.projectmodel!LockFileTargetLibrary.set_Dependencies          	  0.0	     3,237,216
+ nuget.common!PathUtility.EnsureTrailingSlash                       	  0.0	     2,332,672
+ nuget.projectmodel!LockFileTargetLibrary.get_FrameworkReferences   	  0.0	       821,560
+ nuget.projectmodel!NuGet.ProjectModel.LockFileTargetLibrary..ctor()	  0.0	       811,056
+ nuget.packaging!CollectionExtensions.AddRange                      	  0.0	       719,432
+ nuget.frameworks!NuGetFramework.get_DotNetFrameworkName            	  0.0	       221,184
```

After:

```
Name                                                                 	Inc %	           Inc
 nuget.commands!LockFileUtils.CreateLockFileTargetProject            	  1.3	   114,307,392
+ nuget.commands!LockFileUtils.GetLockFileItems                      	  0.3	    28,160,632
+ nuget.packaging!ContentItemCollection.Load                         	  0.3	    22,813,184
+ mscorlib.ni!?                                                      	  0.2	    13,635,064
+ system.core.ni!?                                                   	  0.1	     9,219,496
+ nuget.commands!LockFileUtils.CreateCriteria                        	  0.1	     8,881,448
+ nuget.commands!LockFileUtils.ExcludeItems                          	  0.1	     7,848,024
+ clr!?                                                              	  0.1	     6,061,472
+ nuget.projectmodel!LockFileTargetLibrary.get_FrameworkAssemblies   	  0.1	     4,860,792
+ nuget.common!PathUtility.GetPathWithForwardSlashes                 	  0.0	     3,151,440
+ nuget.common!PathUtility.EnsureTrailingSlash                       	  0.0	     2,556,800
+ nuget.frameworks!NuGetFramework.GetShortFolderName                 	  0.0	     2,548,160
+ nuget.projectmodel!LockFileTargetLibrary.set_Dependencies          	  0.0	     1,814,600
+ nuget.packaging!CollectionExtensions.AddRange                      	  0.0	     1,357,096
+ nuget.projectmodel!NuGet.ProjectModel.LockFileTargetLibrary..ctor()	  0.0	       876,808
+ nuget.projectmodel!LockFileTargetLibrary.get_FrameworkReferences   	  0.0	       417,976
+ nuget.frameworks!NuGetFramework.get_DotNetFrameworkName            	  0.0	       104,400

```

If you focus is on the difference, you'll see that ConvertToProjectPaths and its 64K are gone. 
LockFileUtils.GetLockFileItems is reduced about ~30K , and a bunch of reductions in the rest of the methods. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
