### PR TITLE
Suggest using dotnet nuget why in transitive package tooltip

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -2259,15 +2259,6 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to dotnet nuget why.
-        /// </summary>
-        public static string ToolTip_DotnetNuGetWhy {
-            get {
-                return ResourceManager.GetString("ToolTip_DotnetNuGetWhy", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Install {0} version {1}..
         /// </summary>
         public static string ToolTip_InstallButton {
@@ -2331,6 +2322,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to To learn more about transitive paths, see.
+        /// </summary>
+        public static string ToolTip_SeeDotnetNuGetWhy {
+            get {
+                return ResourceManager.GetString("ToolTip_SeeDotnetNuGetWhy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Settings.
         /// </summary>
         public static string ToolTip_Settings {
@@ -2381,15 +2381,6 @@ namespace NuGet.PackageManagement.UI {
         public static string ToolTip_UpdateButton {
             get {
                 return ResourceManager.GetString("ToolTip_UpdateButton", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to To know this package transitive origin path use command.
-        /// </summary>
-        public static string ToolTip_UseDotnetCommand {
-            get {
-                return ResourceManager.GetString("ToolTip_UseDotnetCommand", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -2322,15 +2322,6 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To learn more about transitive paths, see.
-        /// </summary>
-        public static string ToolTip_SeeDotnetNuGetWhy {
-            get {
-                return ResourceManager.GetString("ToolTip_SeeDotnetNuGetWhy", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Settings.
         /// </summary>
         public static string ToolTip_Settings {
@@ -2354,6 +2345,15 @@ namespace NuGet.PackageManagement.UI {
         public static string ToolTip_TransitiveDependencyVersion {
             get {
                 return ResourceManager.GetString("ToolTip_TransitiveDependencyVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To learn more about transitive paths, see.
+        /// </summary>
+        public static string ToolTip_TransitivePathHelp {
+            get {
+                return ResourceManager.GetString("ToolTip_TransitivePathHelp", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -2259,6 +2259,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to dotnet nuget why.
+        /// </summary>
+        public static string ToolTip_DotnetNuGetWhy {
+            get {
+                return ResourceManager.GetString("ToolTip_DotnetNuGetWhy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Install {0} version {1}..
         /// </summary>
         public static string ToolTip_InstallButton {
@@ -2372,6 +2381,15 @@ namespace NuGet.PackageManagement.UI {
         public static string ToolTip_UpdateButton {
             get {
                 return ResourceManager.GetString("ToolTip_UpdateButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To know this package transitive origin path use command.
+        /// </summary>
+        public static string ToolTip_UseDotnetCommand {
+            get {
+                return ResourceManager.GetString("ToolTip_UseDotnetCommand", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1060,7 +1060,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Hyperlink_Owner" xml:space="preserve">
     <value>Owner</value>
   </data>
-  <data name="ToolTip_SeeDotnetNuGetWhy" xml:space="preserve">
+  <data name="ToolTip_TransitivePathHelp" xml:space="preserve">
     <value>To learn more about transitive paths, see</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1060,10 +1060,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Hyperlink_Owner" xml:space="preserve">
     <value>Owner</value>
   </data>
-  <data name="ToolTip_UseDotnetCommand" xml:space="preserve">
-    <value>To know this package transitive origin path use command</value>
-  </data>
-  <data name="ToolTip_DotnetNuGetWhy" xml:space="preserve">
-    <value>dotnet nuget why</value>
+  <data name="ToolTip_SeeDotnetNuGetWhy" xml:space="preserve">
+    <value>To learn more about transitive paths, see</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1060,4 +1060,10 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Hyperlink_Owner" xml:space="preserve">
     <value>Owner</value>
   </data>
+  <data name="ToolTip_UseDotnetCommand" xml:space="preserve">
+    <value>To know this package transitive origin path use command</value>
+  </data>
+  <data name="ToolTip_DotnetNuGetWhy" xml:space="preserve">
+    <value>dotnet nuget why</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -215,7 +215,18 @@
                         <Run
                           Text="{Binding Id}"
                           FontWeight="Bold" /> <Run Text="{Binding ByOwnerOrAuthor, Mode=OneTime}"/>
-                        <LineBreak /><Run FontWeight="Bold">
+                        <LineBreak />
+                        <Run>
+                          <Run.Style>
+                            <Style TargetType="Run">
+                              <Style.Triggers>
+                                <DataTrigger Binding="{Binding Path=PackageLevel}" Value="TopLevel">
+                                  <Setter Property="Text" Value="{Binding Summary}"/>
+                                </DataTrigger>
+                              </Style.Triggers>
+                            </Style>
+                          </Run.Style>
+                        </Run><Run FontWeight="Bold">
                           <Run.Style>
                             <Style TargetType="Run">
                               <Style.Triggers>
@@ -225,13 +236,13 @@
                               </Style.Triggers>
                             </Style>
                           </Run.Style>
-                        </Run><Run>
+                        </Run>
+                        <Run>
                           <Run.Style>
                             <Style TargetType="Run">
-                              <Setter Property="Text" Value="{Binding TransitiveToolTipMessage}"/>
                               <Style.Triggers>
-                                <DataTrigger Binding="{Binding Path=PackageLevel}" Value="TopLevel">
-                                  <Setter Property="Text" Value="{Binding Summary}"/>
+                                <DataTrigger Binding="{Binding Path=PackageLevel}" Value="Transitive">
+                                  <Setter Property="Text" Value="{Binding TransitiveToolTipMessage}"/>
                                 </DataTrigger>
                               </Style.Triggers>
                             </Style>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -262,7 +262,7 @@
                             <Style TargetType="Run">
                               <Style.Triggers>
                                 <DataTrigger Binding="{Binding Path=PackageLevel}" Value="Transitive">
-                                  <Setter Property="Text" Value="{x:Static nuget:Resources.ToolTip_SeeDotnetNuGetWhy}" />
+                                  <Setter Property="Text" Value="{x:Static nuget:Resources.ToolTip_TransitivePathHelp}" />
                                 </DataTrigger>
                               </Style.Triggers>
                             </Style>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -215,26 +215,54 @@
                         <Run
                           Text="{Binding Id}"
                           FontWeight="Bold" /> <Run Text="{Binding ByOwnerOrAuthor, Mode=OneTime}"/>
-                        <LineBreak />
-                        <Run FontWeight="Bold">
+                        <LineBreak /><Run FontWeight="Bold">
                           <Run.Style>
                             <Style TargetType="Run">
-                              <Setter Property="Text" Value="{x:Static nuget:Resources.ToolTip_TransitiveDependency}"/>
                               <Style.Triggers>
-                                <DataTrigger Binding="{Binding Path=PackageLevel}" Value="TopLevel">
-                                    <Setter Property="Text" Value=""/>
+                                <DataTrigger Binding="{Binding Path=PackageLevel}" Value="Transitive">
+                                  <Setter Property="Text" Value="{x:Static nuget:Resources.ToolTip_TransitiveDependency}"/>
                                 </DataTrigger>
                               </Style.Triggers>
                             </Style>
                           </Run.Style>
-                        </Run>
-                        <Run>
+                        </Run><Run>
                           <Run.Style>
                             <Style TargetType="Run">
                               <Setter Property="Text" Value="{Binding TransitiveToolTipMessage}"/>
                               <Style.Triggers>
                                 <DataTrigger Binding="{Binding Path=PackageLevel}" Value="TopLevel">
                                   <Setter Property="Text" Value="{Binding Summary}"/>
+                                </DataTrigger>
+                              </Style.Triggers>
+                            </Style>
+                          </Run.Style>
+                        </Run><Run>
+                          <Run.Style>
+                            <Style TargetType="Run">
+                              <Style.Triggers>
+                                <DataTrigger Binding="{Binding Path=PackageLevel}" Value="Transitive">
+                                  <Setter Property="Text" Value="&#x0a;&#x0a;" />
+                                </DataTrigger>
+                              </Style.Triggers>
+                            </Style>
+                          </Run.Style>
+                        </Run><Run>
+                          <Run.Style>
+                            <Style TargetType="Run">
+                              <Style.Triggers>
+                                <DataTrigger Binding="{Binding Path=PackageLevel}" Value="Transitive">
+                                  <Setter Property="Text" Value="{x:Static nuget:Resources.ToolTip_UseDotnetCommand}" />
+                                </DataTrigger>
+                              </Style.Triggers>
+                            </Style>
+                          </Run.Style>
+                        </Run><Run>
+                          <Run.Style>
+                            <Style TargetType="Run">
+                              <Style.Triggers>
+                                <DataTrigger Binding="{Binding Path=PackageLevel}" Value="Transitive">
+                                  <Setter Property="Text" Value="{x:Static nuget:Resources.ToolTip_DotnetNuGetWhy}"/>
+                                  <Setter Property="FontWeight" Value="Bold"/>
                                 </DataTrigger>
                               </Style.Triggers>
                             </Style>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -251,7 +251,7 @@
                             <Style TargetType="Run">
                               <Style.Triggers>
                                 <DataTrigger Binding="{Binding Path=PackageLevel}" Value="Transitive">
-                                  <Setter Property="Text" Value="{x:Static nuget:Resources.ToolTip_UseDotnetCommand}" />
+                                  <Setter Property="Text" Value="{x:Static nuget:Resources.ToolTip_SeeDotnetNuGetWhy}" />
                                 </DataTrigger>
                               </Style.Triggers>
                             </Style>
@@ -262,7 +262,7 @@
                             <Style TargetType="Run">
                               <Style.Triggers>
                                 <DataTrigger Binding="{Binding Path=PackageLevel}" Value="Transitive">
-                                  <Setter Property="Text" Value="{x:Static nuget:Resources.ToolTip_DotnetNuGetWhy}"/>
+                                  <Setter Property="Text" Value="aka.ms/dotnet/nuget/why"/>
                                   <Setter Property="FontWeight" Value="Bold"/>
                                 </DataTrigger>
                               </Style.Triggers>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -256,7 +256,8 @@
                               </Style.Triggers>
                             </Style>
                           </Run.Style>
-                        </Run><Run>
+                        </Run>
+                        <Run>
                           <Run.Style>
                             <Style TargetType="Run">
                               <Style.Triggers>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/12105 Removing extra space in tooltip, `<Run>` should be in the same line otherwise it will add an extra space.

![image](https://github.com/user-attachments/assets/5b3d1e2e-401d-4e76-b0b9-b9366ae6e4d4)

Fixes: https://github.com/NuGet/Home/issues/13574
Fixes: https://github.com/NuGet/Home/pull/13680

## Description
Add a new text to the transitive level packages tooltip that suggests the user to use the command dotnet nuget why to know more about the package transitive path.
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests - It's an UI change
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
