### PR TITLE
Make NuGet.CommandLine.XPlat easier to debug

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -7,6 +7,7 @@
     <Shipping>true</Shipping>
     <PackProject>true</PackProject>
     <XPLATProject>true</XPLATProject>
+    <UseMSBuildLocator Condition=" '$(UseMSBuildLocator)' == '' And '$(Configuration)' == 'Debug' and '$(CI)' != 'true' ">true</UseMSBuildLocator>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,11 +20,17 @@
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 
-<!-- Microsoft.Build.Locator is only used when debugging, and the compiler will skip copying this dependency from Release assemblies we insert because we only refer to it conditionally with the DEBUG configuration.
-  Uncomment the following when debugging. Also uncomment the MSBuildLocator code from Program.cs -->
-  <!-- <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Locator" PrivateAssets="All" />
-  </ItemGroup> -->
+  <!-- Microsoft.Build.Locator is needed when debugging, but should not be used in the assemblies we insert. -->
+  <Choose>
+    <When Condition=" '$(UseMSBuildLocator)' == 'true' ">
+      <PropertyGroup>
+        <DefineConstants>$(DefineConstants);USEMSBUILDLOCATOR</DefineConstants>
+      </PropertyGroup>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Build.Locator" PrivateAssets="All" />
+      </ItemGroup>
+    </When>
+  </Choose>
 
   <ItemGroup>
     <Compile Remove="external\*" />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -36,7 +36,6 @@ namespace NuGet.CommandLine.XPlat
         public static int MainInternal(string[] args, CommandOutputLogger log)
         {
 #if USEMSBUILDLOCATOR
-            // Uncomment the following when debugging. Also uncomment the PackageReference for Microsoft.Build.Locator.
             try
             {
                 // .NET JIT compiles one method at a time. If this method calls `MSBuildLocator` directly, the

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Parsing;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -36,9 +35,9 @@ namespace NuGet.CommandLine.XPlat
         /// </summary>
         public static int MainInternal(string[] args, CommandOutputLogger log)
         {
-#if DEBUG
+#if USEMSBUILDLOCATOR
             // Uncomment the following when debugging. Also uncomment the PackageReference for Microsoft.Build.Locator.
-            /*try
+            try
             {
                 // .NET JIT compiles one method at a time. If this method calls `MSBuildLocator` directly, the
                 // try block is never entered if Microsoft.Build.Locator.dll can't be found. So, run it in a
@@ -49,14 +48,16 @@ namespace NuGet.CommandLine.XPlat
             {
                 // MSBuildLocator is used only to enable Visual Studio debugging.
                 // It's not needed when using a patched dotnet sdk, so it doesn't matter if it fails.
-            }*/
+            }
+#endif
 
+#if DEBUG
             var debugNuGetXPlat = Environment.GetEnvironmentVariable("DEBUG_NUGET_XPLAT");
 
             if (args.Contains(DebugOption) || string.Equals(bool.TrueString, debugNuGetXPlat, StringComparison.OrdinalIgnoreCase))
             {
                 args = args.Where(arg => !StringComparer.OrdinalIgnoreCase.Equals(arg, DebugOption)).ToArray();
-                Debugger.Launch();
+                System.Diagnostics.Debugger.Launch();
             }
 #endif
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  engineering/tech debt

## Description

Working on NuGet.CommandLine.XPlat is difficult, because you need to uncomment a PackageReference in the project file, and a few lines in Program.cs, in order to debug and run locally (without patching a .NET SDK). While that's not difficult, it's frustrating to have to remember to not commit those changes every time you commit anything (and I'm used to committing all unstaged changes), which leads to frequent errors and then more commits to put back the comments.

This PR bring back what we had 2+ years ago, where by default, in debug builds, the MSBuild Locator is used to make F5 debug work "out of the box".  If there is anyone who doesn't like this behaviour for some reason, they can set a `UseMSBuildLocator` environment variable to `false` and it won't happen, and I also set it up to not use the MSBuild locator in CI builds. Hopefully that satisfies whoever didn't like the choose-when debug setup we had before.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~ Tests not applicable for this engineering change
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ docs n/a
