### PR TITLE
Fix restore when a package is installed with a version specified in CPM

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -134,7 +134,6 @@ namespace NuGet.CommandLine.XPlat
             {
                 if (originalPackageSpec.RestoreMetadata.CentralPackageVersionsEnabled)
                 {
-                    Thread.Sleep(TimeSpan.FromSeconds(10));
                     var centralVersion = originalPackageSpec
                         .TargetFrameworks
                         .Where(tf => tf.CentralPackageVersions.ContainsKey(packageReferenceArgs.PackageId))

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -142,9 +142,7 @@ namespace NuGet.CommandLine.XPlat
                         .Max();
                     if (centralVersion != null)
                     {
-                        // Clone VersionRange to set `OriginalString` to null
-                        var centralVersionRange = new VersionRange(centralVersion.VersionRange, centralVersion.VersionRange.Float);
-                        packageDependency = new PackageDependency(packageReferenceArgs.PackageId, centralVersionRange);
+                        packageDependency = new PackageDependency(packageReferenceArgs.PackageId, centralVersion.VersionRange);
                     }
                 }
                 if (packageDependency == null)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -132,22 +132,37 @@ namespace NuGet.CommandLine.XPlat
             PackageDependency packageDependency = default;
             if (packageReferenceArgs.NoVersion)
             {
-                var latestVersion = await GetLatestVersionAsync(originalPackageSpec, packageReferenceArgs.PackageId, packageReferenceArgs.Logger, packageReferenceArgs.Prerelease);
-
-                if (latestVersion == null)
+                if (originalPackageSpec.RestoreMetadata.CentralPackageVersionsEnabled)
                 {
-                    if (!packageReferenceArgs.Prerelease)
+                    var centralVersion = originalPackageSpec
+                        .TargetFrameworks
+                        .Select(tf => tf.CentralPackageVersions[packageReferenceArgs.PackageId])
+                        .Where(cpv => cpv != null)
+                        .Max();
+                    if (centralVersion != null)
                     {
-                        latestVersion = await GetLatestVersionAsync(originalPackageSpec, packageReferenceArgs.PackageId, packageReferenceArgs.Logger, !packageReferenceArgs.Prerelease);
-                        if (latestVersion != null)
-                        {
-                            throw new CommandException(string.Format(CultureInfo.CurrentCulture, Strings.PrereleaseVersionsAvailable, latestVersion));
-                        }
+                        packageDependency = new PackageDependency(packageReferenceArgs.PackageId, centralVersion.VersionRange);
                     }
-                    throw new CommandException(string.Format(CultureInfo.CurrentCulture, Strings.Error_NoVersionsAvailable, packageReferenceArgs.PackageId));
                 }
+                if (packageDependency == null)
+                {
+                    var latestVersion = await GetLatestVersionAsync(originalPackageSpec, packageReferenceArgs.PackageId, packageReferenceArgs.Logger, packageReferenceArgs.Prerelease);
 
-                packageDependency = new PackageDependency(packageReferenceArgs.PackageId, new VersionRange(minVersion: latestVersion, includeMinVersion: true));
+                    if (latestVersion == null)
+                    {
+                        if (!packageReferenceArgs.Prerelease)
+                        {
+                            latestVersion = await GetLatestVersionAsync(originalPackageSpec, packageReferenceArgs.PackageId, packageReferenceArgs.Logger, !packageReferenceArgs.Prerelease);
+                            if (latestVersion != null)
+                            {
+                                throw new CommandException(string.Format(CultureInfo.CurrentCulture, Strings.PrereleaseVersionsAvailable, latestVersion));
+                            }
+                        }
+                        throw new CommandException(string.Format(CultureInfo.CurrentCulture, Strings.Error_NoVersionsAvailable, packageReferenceArgs.PackageId));
+                    }
+
+                    packageDependency = new PackageDependency(packageReferenceArgs.PackageId, new VersionRange(minVersion: latestVersion, includeMinVersion: true));
+                }
             }
             else
             {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -134,14 +134,15 @@ namespace NuGet.CommandLine.XPlat
             {
                 if (originalPackageSpec.RestoreMetadata.CentralPackageVersionsEnabled)
                 {
+                    Thread.Sleep(TimeSpan.FromSeconds(10));
                     var centralVersion = originalPackageSpec
                         .TargetFrameworks
+                        .Where(tf => tf.CentralPackageVersions.ContainsKey(packageReferenceArgs.PackageId))
                         .Select(tf => tf.CentralPackageVersions[packageReferenceArgs.PackageId])
-                        .Where(cpv => cpv != null)
                         .Max();
                     if (centralVersion != null)
                     {
-                        // Clone the VersionRange to set `OriginalString` to null
+                        // Clone VersionRange to set `OriginalString` to null
                         var centralVersionRange = new VersionRange(centralVersion.VersionRange, centralVersion.VersionRange.Float);
                         packageDependency = new PackageDependency(packageReferenceArgs.PackageId, centralVersionRange);
                     }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -138,7 +138,7 @@ namespace NuGet.CommandLine.XPlat
                         .TargetFrameworks
                         .Where(tf => tf.CentralPackageVersions.ContainsKey(packageReferenceArgs.PackageId))
                         .Select(tf => tf.CentralPackageVersions[packageReferenceArgs.PackageId])
-                        .Max();
+                        .FirstOrDefault();
                     if (centralVersion != null)
                     {
                         packageDependency = new PackageDependency(packageReferenceArgs.PackageId, centralVersion.VersionRange);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -141,7 +141,9 @@ namespace NuGet.CommandLine.XPlat
                         .Max();
                     if (centralVersion != null)
                     {
-                        packageDependency = new PackageDependency(packageReferenceArgs.PackageId, centralVersion.VersionRange);
+                        // Clone the VersionRange to set `OriginalString` to null
+                        var centralVersionRange = new VersionRange(centralVersion.VersionRange, centralVersion.VersionRange.Float);
+                        packageDependency = new PackageDependency(packageReferenceArgs.PackageId, centralVersionRange);
                     }
                 }
                 if (packageDependency == null)

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -966,7 +966,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>
+<PropertyGroup>                   
 	<TargetFramework>{packageFrameworks}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -1028,7 +1028,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>
+<PropertyGroup>                   
 	<TargetFramework>{packageFrameworks}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -1160,7 +1160,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>
+<PropertyGroup>                   
 	<TargetFramework>{packageFrameworks}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -1225,7 +1225,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-    <PropertyGroup>
+    <PropertyGroup>                   
 	    <TargetFramework>{packageFrameworks}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -1283,7 +1283,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>
+<PropertyGroup>                   
 	<TargetFramework>{packageFrameworks}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -1345,7 +1345,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>
+<PropertyGroup>                   
 	<TargetFramework>{packageFrameworks}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -1409,7 +1409,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>
+<PropertyGroup>                   
 	<TargetFramework>{packageFrameworks}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -1474,7 +1474,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>
+<PropertyGroup>                   
 	<TargetFramework>{packageFrameworks}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -1538,7 +1538,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>
+<PropertyGroup>                   
 	<TargetFramework>{packageFrameworks}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -1603,7 +1603,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
     @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-    <PropertyGroup>
+    <PropertyGroup>                   
 	    <TargetFramework>{packageFrameworks}</TargetFramework>
 	    </PropertyGroup>
     </Project>";
@@ -1660,7 +1660,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
     @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-    <PropertyGroup>
+    <PropertyGroup>                   
 	    <TargetFramework>{packageFrameworks}</TargetFramework>
 	    </PropertyGroup>
         <ItemGroup>
@@ -1722,7 +1722,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
     @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-    <PropertyGroup>
+    <PropertyGroup>                   
 	    <TargetFramework>{packageFrameworks}</TargetFramework>
         <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
 	    </PropertyGroup>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -1051,6 +1051,72 @@ namespace Dotnet.Integration.Test
         }
 
         [Fact]
+        public async Task AddPkg_WithCPM_NoPackageReference_NoVersionOverride_WithPackageVersion_NoVersionCLI_Success()
+        {
+            // Arrange
+
+            using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();
+            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+            var projectA = XPlatTestUtils.CreateProject("projectA", pathContext, "net7.0");
+
+            const string version1 = "1.0.0";
+            const string version2 = "2.0.0";
+            const string packageX = "X";
+
+            var packageFrameworks = "net7.0";
+            var packageX100 = XPlatTestUtils.CreatePackage(packageX, version1, frameworkString: packageFrameworks);
+            var packageX200 = XPlatTestUtils.CreatePackage(packageX, version2, frameworkString: packageFrameworks);
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX100,
+                    packageX200);
+
+            var propsFile =
+@$"<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include=""X"" Version=""1.0.0"" />
+    </ItemGroup>
+</Project>";
+
+            solution.Projects.Add(projectA);
+            solution.Create(pathContext.SolutionRoot);
+
+            File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props"), propsFile);
+            var projectADirectory = Path.Combine(pathContext.SolutionRoot, projectA.ProjectName);
+
+            string projectContent =
+@$"<Project Sdk=""Microsoft.NET.Sdk"">
+    <PropertyGroup>
+        <TargetFramework>{packageFrameworks}</TargetFramework>
+    </PropertyGroup>
+</Project>";
+            File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "projectA", "projectA.csproj"), projectContent);
+
+            //Act
+
+            var result = _fixture.RunDotnetExpectSuccess(
+                projectADirectory,
+                $"add {projectA.ProjectPath} package {packageX}",
+                testOutputHelper: _testOutputHelper
+            );
+
+            // Assert
+
+            // Check the csproj has reference to X without version
+            var csprojFromDisk = File.ReadAllText(Path.Combine(projectADirectory, "projectA.csproj"));
+            Assert.Contains(@"<PackageReference Include=""X"" />", csprojFromDisk);
+
+            // Check package X is restored at version 1.0.0
+            var assetsFromDisk = File.ReadAllText(Path.Combine(projectADirectory, "obj", "project.assets.json"));
+            Assert.Contains(@"""X/1.0.0"": {", assetsFromDisk);
+        }
+
+        [Fact]
         public async Task AddPkg_WithCPM_WithPackageReference_NoVersionOverride_WithPackageVersion_NoVersionCLI_NoOps()
         {
             using SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext();

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -966,7 +966,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>                   
+<PropertyGroup>
 	<TargetFramework>{packageFrameworks}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -1028,7 +1028,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>                   
+<PropertyGroup>
 	<TargetFramework>{packageFrameworks}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -1087,7 +1087,6 @@ namespace Dotnet.Integration.Test
             solution.Create(pathContext.SolutionRoot);
 
             File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props"), propsFile);
-            var projectADirectory = Path.Combine(pathContext.SolutionRoot, projectA.ProjectName);
 
             string projectContent =
 @$"<Project Sdk=""Microsoft.NET.Sdk"">
@@ -1096,6 +1095,8 @@ namespace Dotnet.Integration.Test
     </PropertyGroup>
 </Project>";
             File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "projectA", "projectA.csproj"), projectContent);
+
+            var projectADirectory = Path.Combine(pathContext.SolutionRoot, projectA.ProjectName);
 
             //Act
 
@@ -1159,7 +1160,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>                   
+<PropertyGroup>
 	<TargetFramework>{packageFrameworks}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -1224,7 +1225,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-    <PropertyGroup>                   
+    <PropertyGroup>
 	    <TargetFramework>{packageFrameworks}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -1282,7 +1283,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>                   
+<PropertyGroup>
 	<TargetFramework>{packageFrameworks}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -1344,7 +1345,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>                   
+<PropertyGroup>
 	<TargetFramework>{packageFrameworks}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -1408,7 +1409,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>                   
+<PropertyGroup>
 	<TargetFramework>{packageFrameworks}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -1418,7 +1419,7 @@ namespace Dotnet.Integration.Test
             File.WriteAllText(Path.Combine(pathContext.SolutionRoot, "projectA", "projectA.csproj"), projectContent);
 
             //Act
-            var result = _fixture.RunDotnetExpectFailure(projectADirectory, $"add {projectA.ProjectPath} package {packageX}", testOutputHelper: _testOutputHelper);
+            var result = _fixture.RunDotnetExpectSuccess(projectADirectory, $"add {projectA.ProjectPath} package {packageX}", testOutputHelper: _testOutputHelper);
 
             // Assert
             Assert.DoesNotContain("error: Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion items: X", result.Output);
@@ -1426,7 +1427,7 @@ namespace Dotnet.Integration.Test
                                 <PackageVersion Include=""X"" Version=""1.0.0"" />
                                 </ItemGroup>", File.ReadAllText(Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props")));
             Assert.Contains(@$"<ItemGroup>
-        <PackageReference Include=""X"" VersionOverride=""1.0.0""/>
+        <PackageReference Include=""X"" VersionOverride=""1.0.0"" />
     </ItemGroup>", File.ReadAllText(Path.Combine(projectADirectory, "projectA.csproj")));
         }
 
@@ -1473,7 +1474,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>                   
+<PropertyGroup>
 	<TargetFramework>{packageFrameworks}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -1537,7 +1538,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>                   
+<PropertyGroup>
 	<TargetFramework>{packageFrameworks}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -1602,7 +1603,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
     @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-    <PropertyGroup>                   
+    <PropertyGroup>
 	    <TargetFramework>{packageFrameworks}</TargetFramework>
 	    </PropertyGroup>
     </Project>";
@@ -1659,7 +1660,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
     @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-    <PropertyGroup>                   
+    <PropertyGroup>
 	    <TargetFramework>{packageFrameworks}</TargetFramework>
 	    </PropertyGroup>
         <ItemGroup>
@@ -1721,7 +1722,7 @@ namespace Dotnet.Integration.Test
             // Arrange project file
             string projectContent =
     @$"<Project  Sdk=""Microsoft.NET.Sdk"">
-    <PropertyGroup>                   
+    <PropertyGroup>
 	    <TargetFramework>{packageFrameworks}</TargetFramework>
         <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
 	    </PropertyGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13657

## Description

When `dotnet add package` with version specified in `Directory.Packages.props`, the restored dependency is the last version and no the version specified in `Directory.Packages.props`.

The modification :
If a CPM version is available for the installed package then uses it.
Else old behavior (last package version)

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
