### PR TITLE
Enable new resolver algorithm for more scenarios and add more tests

### DIFF
--- a/build/Shared/TaskResultCache.cs
+++ b/build/Shared/TaskResultCache.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -36,6 +37,16 @@ namespace NuGet
         {
             _cache = new(comparer);
             _perTaskLock = new(comparer);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TaskResultCache{TKey, TValue}" /> class with the specified initial capacity.
+        /// </summary>
+        /// <param name="capacity">The default capacity for the cache.</param>
+        public TaskResultCache(int capacity)
+        {
+            _cache = new(concurrencyLevel: Environment.ProcessorCount, capacity);
+            _perTaskLock = new(concurrencyLevel: Environment.ProcessorCount, capacity);
         }
 
         /// <summary>
@@ -99,6 +110,39 @@ namespace NuGet
                         cancellationToken,
                         TaskContinuationOptions.RunContinuationsAsynchronously,
                         TaskScheduler.Default);
+            }
+        }
+
+        /// <summary>
+        /// Gets the async operation associated with the specified key if one exists, otherwise throws a <see cref="KeyNotFoundException" />.
+        /// </summary>
+        /// <param name="key">The key for the async operation to get the value of.</param>
+        /// <returns></returns>
+        /// <exception cref="KeyNotFoundException">The specified key does not exist in the cache.</exception>
+        public Task<TValue> GetValueAsync(TKey key)
+        {
+            if (TryGetValue(key, out Task<TValue>? value))
+            {
+                return value;
+            }
+
+            throw new KeyNotFoundException();
+        }
+
+        /// <inheritdoc cref="Dictionary{TKey, TValue}.TryGetValue(TKey, out TValue)" />
+        public bool TryGetValue(TKey key, [NotNullWhen(true)] out Task<TValue>? value)
+        {
+            return _cache.TryGetValue(key, out value);
+        }
+
+        /// <inheritdoc cref="ConcurrentDictionary{TKey, TValue}.TryRemove(TKey, out TValue)" />
+        public bool TryRemove(TKey key)
+        {
+            object lockObject = _perTaskLock.GetOrAdd(key, static (TKey _) => new object());
+
+            lock (lockObject)
+            {
+                return _cache.TryRemove(key, out _);
             }
         }
     }

--- a/build/Shared/TaskResultCache.cs
+++ b/build/Shared/TaskResultCache.cs
@@ -134,16 +134,5 @@ namespace NuGet
         {
             return _cache.TryGetValue(key, out value);
         }
-
-        /// <inheritdoc cref="ConcurrentDictionary{TKey, TValue}.TryRemove(TKey, out TValue)" />
-        public bool TryRemove(TKey key)
-        {
-            object lockObject = _perTaskLock.GetOrAdd(key, static (TKey _) => new object());
-
-            lock (lockObject)
-            {
-                return _cache.TryRemove(key, out _);
-            }
-        }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/NuGet.Commands.csproj
+++ b/src/NuGet.Core/NuGet.Commands/NuGet.Commands.csproj
@@ -47,8 +47,10 @@
     <Compile Include="$(SharedDirectory)\DeconstructionExtensions.cs" />
     <Compile Include="$(SharedDirectory)\EqualityUtility.cs" />
     <Compile Include="$(SharedDirectory)\HashCodeCombiner.cs" />
+    <Compile Include="$(SharedDirectory)\IsExternalInit.cs" />
     <Compile Include="$(SharedDirectory)\NoAllocEnumerateExtensions.cs" />
     <Compile Include="$(SharedDirectory)\NullableAttributes.cs" />
+    <Compile Include="$(SharedDirectory)\RequiredModifierAttributes.cs" />
     <Compile Include="$(SharedDirectory)\SharedExtensions.cs" />
     <Compile Include="$(SharedDirectory)\TaskResult.cs" />
     <Compile Include="$(SharedDirectory)\TaskResultCache.cs" />

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -993,6 +993,11 @@ namespace NuGet.Commands
                             continue;
                         }
 
+                        if (!findLibraryEntryCache.TryGetValue(downgrade.Key, out FindLibraryEntryResult? findLibraryEntryResult))
+                        {
+                            continue;
+                        }
+
                         analyzeResult.Downgrades.Add(new DowngradeResult<RemoteResolveResult>
                         {
                             DowngradedFrom = new GraphNode<RemoteResolveResult>(downgrade.Value.FromLibraryDependency.LibraryRange)
@@ -1002,7 +1007,7 @@ namespace NuGet.Commands
                             },
                             DowngradedTo = new GraphNode<RemoteResolveResult>(downgrade.Value.ToLibraryDependency.LibraryRange)
                             {
-                                Item = new GraphItem<RemoteResolveResult>(new LibraryIdentity(downgrade.Value.ToLibraryDependency.Name, downgrade.Value.ToLibraryDependency.LibraryRange.VersionRange?.MinVersion!, LibraryType.Package))
+                                Item = new GraphItem<RemoteResolveResult>(findLibraryEntryResult.Item.Key)
                                 {
                                     IsCentralTransitive = downgrade.Value.IsCentralTransitive
                                 },

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -340,7 +340,7 @@ namespace NuGet.Commands
                                 goto ProcessDeepEviction;
                             }
 
-                            bool isCentrallyPinnedTransitivePackage = chosenResolvedItem.IsCentrallyPinnedTransitivePackage;
+                            bool isCentrallyPinnedTransitivePackage = importRefItem.IsCentrallyPinnedTransitivePackage;
 
                             //Since this is a "new" choice, its gets a new import context list
                             chosenResolvedItems.Add(
@@ -632,7 +632,7 @@ namespace NuGet.Commands
                         LibraryDependencyIndex depIndex = refItemResult.GetDependencyIndexForDependency(i);
 
                         //Suppress this node
-                        if (suppressions!.Contains(depIndex))
+                        if (!importRefItem.IsCentrallyPinnedTransitivePackage && suppressions!.Contains(depIndex))
                         {
                             continue;
                         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -927,7 +927,7 @@ namespace NuGet.Commands
 
                             if (dep.SuppressParent != LibraryIncludeFlags.All && isCentralPackageTransitivePinningEnabled && !downgrades.ContainsKey(chosenItemRangeIndex) && !RemoteDependencyWalker.IsGreaterThanOrEqualTo(chosenItem.LibraryDependency.LibraryRange.VersionRange, dep.LibraryRange.VersionRange))
                             {
-                                downgrades.Add(chosenItem.LibraryRangeIndex, (currentLibraryRangeIndex, dep, currentLibraryRangeIndex, chosenItem.LibraryDependency, true));
+                                downgrades.Add(chosenItem.LibraryRangeIndex, (currentLibraryRangeIndex, dep, rootProjectRefItem.LibraryRangeIndex, chosenItem.LibraryDependency, true));
                             }
 
                             if (newGraphNode.Item.Key.Type != LibraryType.Project && newGraphNode.Item.Key.Type != LibraryType.ExternalProject && newGraphNode.Item.Key.Type != LibraryType.Unresolved && !versionConflicts.ContainsKey(chosenItemRangeIndex) && dep.SuppressParent != LibraryIncludeFlags.All && dep.LibraryRange.VersionRange != null && !dep.LibraryRange.VersionRange!.Satisfies(newGraphNode.Item.Key.Version) && !downgrades.ContainsKey(chosenItemRangeIndex))

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -215,13 +215,13 @@ namespace NuGet.Commands
                         bool packageReferenceFromRootProject = chosenResolvedItem.IsDirectPackageReferenceFromRootProject;
                         List<SuppressionsAndVersionOverrides> chosenSuppressions = chosenResolvedItem.SuppressionsAndVersionOverrides;
 
-                        if (packageReferenceFromRootProject)
+                        if (packageReferenceFromRootProject) // direct dependencies always win.
                         {
-                            continue; // This is literally Direct Dependency Wins....we could fix this probably
+                            continue;
                         }
 
                         // We should evict on type constraint if the type constraint of the current ref is more stringent than the chosen ref.
-                        // This happens when a previous type constraint is broader (e.g. PackageProjectExternal) than the current type constraint (e.g. Package). Prefer project over package
+                        // This happens when a previous type constraint is broader (e.g. PackageProjectExternal) than the current type constraint (e.g. Package).
                         bool evictOnTypeConstraint = false;
                         if ((chosenRefRangeIndex == currentRefRangeIndex) && EvictOnTypeConstraint(currentRef.LibraryRange.TypeConstraint, chosenRef.LibraryRange.TypeConstraint))
                         {
@@ -238,7 +238,6 @@ namespace NuGet.Commands
 
                         if (evictOnTypeConstraint || !RemoteDependencyWalker.IsGreaterThanOrEqualTo(ovr, nvr))
                         {
-                            // What is this supposed to be?
                             if (chosenRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package) && currentRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
                             {
                                 if (chosenResolvedItem.Parents != null)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -759,6 +759,9 @@ namespace NuGet.Commands
                 var versionConflicts = new Dictionary<LibraryRangeIndex, GraphNode<RemoteResolveResult>>();
 
                 itemsToFlatten.Enqueue((initialProjectIndex, cri.LibraryRangeIndex, rootGraphNode));
+
+                nodesById.Add(cri.LibraryRangeIndex, rootGraphNode);
+
                 while (itemsToFlatten.Count > 0)
                 {
                     (LibraryDependencyIndex currentDependencyIndex, LibraryRangeIndex currentLibraryRangeIndex, GraphNode<RemoteResolveResult> currentGraphNode) = itemsToFlatten.Dequeue();
@@ -1174,6 +1177,7 @@ namespace NuGet.Commands
             return true;
         }
 
+        [DebuggerDisplay("{LibraryDependency}, RangeIndex={LibraryRangeIndex}")]
         private class ResolvedDependencyGraphItem
         {
             public bool IsCentrallyPinnedTransitivePackage { get; set; }
@@ -1273,7 +1277,7 @@ namespace NuGet.Commands
             }
         }
 
-        [DebuggerDisplay("{LibraryDependency}")]
+        [DebuggerDisplay("{LibraryDependency}, DependencyIndex={LibraryDependencyIndex}, RangeIndex={LibraryRangeIndex}")]
         private class DependencyGraphItem
         {
             public bool IsCentrallyPinnedTransitivePackage { get; set; }
@@ -1284,6 +1288,7 @@ namespace NuGet.Commands
 
             public LibraryDependencyIndex LibraryDependencyIndex { get; set; } = LibraryDependencyIndex.Invalid;
 
+            [DebuggerDisplay("Hello")]
             public LibraryRangeIndex LibraryRangeIndex { get; set; } = LibraryRangeIndex.Invalid;
 
             public LibraryRangeIndex[] Path { get; set; } = Array.Empty<LibraryRangeIndex>();
@@ -1291,6 +1296,11 @@ namespace NuGet.Commands
             public HashSet<LibraryDependencyIndex>? Suppressions { get; set; }
 
             public IReadOnlyDictionary<LibraryDependencyIndex, VersionRange>? VersionOverrides { get; set; }
+
+            private string GetLibraryRange()
+            {
+                return LibraryDependency?.LibraryRange.ToString() ?? string.Empty;
+            }
         }
 
         private class FindLibraryEntryResult

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -263,7 +263,7 @@ namespace NuGet.Commands
 
                                     foreach (LibraryRangeIndex parentRangeIndex in chosenResolvedItem.Parents.NoAllocEnumerate())
                                     {
-                                        if (importRefItem.Path.Contains(parentRangeIndex))
+                                        if (importRefItem.Path.Length > 2 && importRefItem.Path[importRefItem.Path.Length - 2] == parentRangeIndex)
                                         {
                                             atLeastOneCommonAncestor = true;
                                             break;
@@ -276,7 +276,7 @@ namespace NuGet.Commands
                                     }
                                 }
 
-                                if (HasCommonAncestor(importRefItem.Path, chosenResolvedItem.Path))
+                                if (chosenResolvedItem.Path.Length > 1 && importRefItem.Path.Length > 2 && chosenResolvedItem.Path[chosenResolvedItem.Path.Length - 1] == importRefItem.Path[importRefItem.Path.Length - 2])
                                 {
                                     continue;
                                 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -361,7 +361,23 @@ namespace NuGet.Commands
                             // We must remove it, otherwise we won't call FindLibraryCachedAsync again to load the correct item and save it into allResolvedItems.
                             if (evictOnTypeConstraint)
                             {
-                                findLibraryEntryCache.TryRemove(evictedLR);
+                                refItemResult = await findLibraryEntryCache.GetOrAddAsync(
+                                    currentRefRangeIndex,
+                                    refresh: true,
+                                    async static state =>
+                                    {
+                                        return await FindLibraryEntryResult.CreateAsync(
+                                            state.libraryDependency,
+                                            state.dependencyIndex,
+                                            state.rangeIndex,
+                                            state.Framework,
+                                            state.context,
+                                            state.libraryDependencyInterningTable,
+                                            state.libraryRangeInterningTable,
+                                            state.token);
+                                    },
+                                    (libraryDependency: currentRef, dependencyIndex: currentRefDependencyIndex, rangeIndex: currentRefRangeIndex, pair.Framework, context, libraryDependencyInterningTable, libraryRangeInterningTable, token),
+                                    token);
                             }
 
                             int deepEvictions = 0;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -186,9 +186,6 @@ namespace NuGet.Commands
                     LibraryRangeIndex libraryRangeOfCurrentRef = importRefItem.LibraryRangeIndex;
 
                     LibraryDependencyTarget typeConstraint = currentRef.LibraryRange.TypeConstraint;
-
-                    bool isProject = (typeConstraint & (LibraryDependencyTarget.Project | LibraryDependencyTarget.ExternalProject)) != LibraryDependencyTarget.None; // TODO NK - This is incorrectly detecting project reference, check PackageSpecReferenceProvider
-
                     if (evictions.TryGetValue(libraryRangeOfCurrentRef, out var eviction))
                     {
                         (LibraryRangeIndex[] evictedPath, LibraryDependencyIndex evictedDepIndex, LibraryDependencyTarget evictedTypeConstraint) = eviction;
@@ -556,7 +553,7 @@ namespace NuGet.Commands
                     {
                         var dep = refItemResult.Item.Data.Dependencies[i];
                         LibraryDependencyIndex depIndex = refItemResult.GetDependencyIndexForDependency(i);
-                        if ((dep.SuppressParent == LibraryIncludeFlags.All) && (isProject == false)) // Why do we care whether this is a project? For suppressions, wouldn't it normally mean we suppress the package unless it's the current project.
+                        if ((dep.SuppressParent == LibraryIncludeFlags.All) && (importRefItem.LibraryDependencyIndex != rootProjectRefItem.LibraryDependencyIndex))
                         {
                             if (suppressions == null)
                             {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -145,10 +145,8 @@ namespace NuGet.Commands
 
             _success = !request.AdditionalMessages?.Any(m => m.Level == LogLevel.Error) ?? true;
 
-            // Enable the new dependency resolver if the project is using PackageReference, transitive pinning is disabled, and the user has not explicitly opted out of using it
-            _enableNewDependencyResolver = request.Project.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference
-                && !(_request.Project.RestoreMetadata?.CentralPackageVersionsEnabled == true && _request.Project.RestoreMetadata?.CentralPackageTransitivePinningEnabled == true)
-                && !_request.Project.RestoreMetadata.UseLegacyDependencyResolver;
+            // Use the new resolver unless transitive pinning is disabled or the user has not explicitly opted out of using it
+            _enableNewDependencyResolver = !_request.Project.RestoreMetadata.UseLegacyDependencyResolver;
         }
 
         public Task<RestoreResult> ExecuteAsync()

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -145,7 +145,6 @@ namespace NuGet.Commands
 
             _success = !request.AdditionalMessages?.Any(m => m.Level == LogLevel.Error) ?? true;
 
-            // Use the new resolver unless transitive pinning is disabled or the user has not explicitly opted out of using it
             _enableNewDependencyResolver = !_request.Project.RestoreMetadata.UseLegacyDependencyResolver;
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -145,7 +145,7 @@ namespace NuGet.Commands
 
             _success = !request.AdditionalMessages?.Any(m => m.Level == LogLevel.Error) ?? true;
 
-            _enableNewDependencyResolver = !_request.Project.RestoreMetadata.UseLegacyDependencyResolver;
+            _enableNewDependencyResolver = _request.Project.RuntimeGraph.Supports.Count == 0 && !_request.Project.RestoreMetadata.UseLegacyDependencyResolver;
         }
 
         public Task<RestoreResult> ExecuteAsync()

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/NuGet.DependencyResolver.Core.csproj
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/NuGet.DependencyResolver.Core.csproj
@@ -33,6 +33,7 @@
   <ItemGroup Label="NuGet Shared">
     <Compile Include="$(SharedDirectory)\HashCodeCombiner.cs" />
     <Compile Include="$(SharedDirectory)\NoAllocEnumerateExtensions.cs" />
+    <Compile Include="$(SharedDirectory)\NullableAttributes.cs" />
     <Compile Include="$(SharedDirectory)\SharedExtensions.cs" />
     <Compile Include="$(SharedDirectory)\TaskResult.cs" />
     <Compile Include="$(SharedDirectory)\TaskResultCache.cs" />

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
 #nullable enable
 ~NuGet.DependencyResolver.GraphNode<TItem>.GraphNode(NuGet.LibraryModel.LibraryRange key, bool hasInnerNodes, bool hasParentNodes) -> void
-~static NuGet.DependencyResolver.RemoteDependencyWalker.EvaluateRuntimeDependencies(ref NuGet.LibraryModel.LibraryRange libraryRange, string runtimeName, NuGet.RuntimeModel.RuntimeGraph runtimeGraph, ref System.Collections.Generic.HashSet<NuGet.LibraryModel.LibraryDependency> runtimeDependencies) -> void
+~static NuGet.DependencyResolver.RemoteDependencyWalker.EvaluateRuntimeDependencies(ref NuGet.LibraryModel.LibraryRange libraryRange, string runtimeName, NuGet.RuntimeModel.RuntimeGraph runtimeGraph, ref System.Collections.Generic.HashSet<NuGet.LibraryModel.LibraryDependency> runtimeDependencies) -> bool
 ~static NuGet.DependencyResolver.RemoteDependencyWalker.MergeRuntimeDependencies(System.Collections.Generic.HashSet<NuGet.LibraryModel.LibraryDependency> runtimeDependencies, NuGet.DependencyResolver.GraphNode<NuGet.DependencyResolver.RemoteResolveResult> node) -> void

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -251,7 +251,7 @@ namespace NuGet.DependencyResolver
             return rootNode;
         }
 
-        public static void EvaluateRuntimeDependencies(ref LibraryRange libraryRange, string runtimeName, RuntimeGraph runtimeGraph, ref HashSet<LibraryDependency> runtimeDependencies)
+        public static bool EvaluateRuntimeDependencies(ref LibraryRange libraryRange, string runtimeName, RuntimeGraph runtimeGraph, ref HashSet<LibraryDependency> runtimeDependencies)
         {
             // HACK(davidfowl): This is making runtime.json support package redirects
 
@@ -275,6 +275,8 @@ namespace NuGet.DependencyResolver
                         libraryRange.VersionRange.MinVersion < runtimeDependency.VersionRange.MinVersion)
                     {
                         libraryRange = libraryDependency.LibraryRange;
+
+                        return true;
                     }
                 }
                 else
@@ -284,6 +286,8 @@ namespace NuGet.DependencyResolver
                     runtimeDependencies.Add(libraryDependency);
                 }
             }
+
+            return false;
         }
 
         public static void MergeRuntimeDependencies(HashSet<LibraryDependency> runtimeDependencies, GraphNode<RemoteResolveResult> node)

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -1304,7 +1304,6 @@ namespace NuGet.Commands.FuncTest
                 Assert.Equal("7.0.1", jsonNetPackage.Version.ToNormalizedString());
                 Assert.Equal(24, runtimeAssemblies.Count);
                 Assert.NotNull(jsonNetReference);
-                // TODO NK - Add equivalency test?
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -1298,7 +1298,7 @@ namespace NuGet.Commands.FuncTest
 
                 // Assert
                 // There will be compatibility errors, but we don't care
-                Assert.Equal(useLegacyResolver ? 25 : 26, installed.Count);
+                Assert.Equal(25, installed.Count);
                 Assert.Equal(0, unresolved.Count);
                 Assert.Equal(24, result.LockFile.Targets[0].Libraries.Count);
                 Assert.Equal("7.0.1", jsonNetPackage.Version.ToNormalizedString());

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -119,7 +119,7 @@ namespace NuGet.Commands.FuncTest
         // Project 1 -> d 1.0.0 -> b 2.0.0
         // Project 1 -> a 1.0.0 -> b 1.0.0
         //                      -> c 1.0.0 -> b 3.0.0
-        public async Task RestoreCommand_WithPackageDrivenDowngradeWithMultipleAncestorsAndCousin_RespectsDowngrade_AndRaisesWarning()
+        public async Task RestoreCommand_WithPackageDrivenDowngradeWithMultipleAncestorsAndCousin_RespectsDowngrade_AndDoesNotRaiseWarning()
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
@@ -156,14 +156,14 @@ namespace NuGet.Commands.FuncTest
 
             // Assert
             result.Success.Should().BeTrue();
-            result.LogMessages.Select(e => e.Code).Should().BeEquivalentTo([NuGetLogCode.NU1605]);
+            result.LogMessages.Should().BeEmpty();
             result.LockFile.Targets.Should().HaveCount(1);
             result.LockFile.Targets[0].Libraries.Should().HaveCount(4);
             result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
             result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
 
             result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
-            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
 
             result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
             result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -15,8 +15,6 @@ using Xunit;
 
 namespace NuGet.Commands.FuncTest
 {
-    // Tests that validate the equivalency of the old/new algorithm.
-    // The rule of thumb is everything that's a theory (ie providing new/old algo switch) is a difference, but everything that's a fact, instead calling ValidateRestoreAlgorithmEquivalency is a equivalent
     public partial class RestoreCommandTests
     {
         [Fact]
@@ -435,7 +433,6 @@ namespace NuGet.Commands.FuncTest
             var project1 = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net5.0");
             var project2 = ProjectTestHelpers.GetPackageSpec("Project2", pathContext.SolutionRoot, framework: "net5.0");
             var project3 = ProjectTestHelpers.GetPackageSpec("Project3", pathContext.SolutionRoot, framework: "net5.0", dependencyName: "a");
-            // todo NK - Add a better method
 
             var projectA = ProjectTestHelpers.GetPackageSpec("a", pathContext.SolutionRoot, framework: "net5.0");
             projectA.Version = new NuGetVersion("2.0.0");

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -417,19 +417,21 @@ namespace NuGet.Commands.FuncTest
             // Act & Assert
             (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec, projectSpec2);
             result.LockFile.Targets.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
             result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
             result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0"));
-            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
-            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
 
             (var result2, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec2);
             result2.LockFile.Targets.Should().HaveCount(1);
             result2.LockFile.Targets[0].Libraries.Should().HaveCount(2);
             result2.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
             result2.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
-            result2.LockFile.Targets[0].Libraries[0].Name.Should().Be("b");
-            result2.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result2.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result2.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
         // P1 -> P2 -> A (VersionOverride) -> B
@@ -516,16 +518,18 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
             result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
             result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0"));
-            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
-            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
 
             (var result2, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec2);
             result2.LockFile.Targets.Should().HaveCount(1);
             result2.LockFile.Targets[0].Libraries.Should().HaveCount(2);
             result2.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
             result2.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
-            result2.LockFile.Targets[0].Libraries[0].Name.Should().Be("b");
-            result2.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result2.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result2.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
         // P1 -> P2 -> A 1.0.0 -> B 1.0.0

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -235,8 +235,11 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
-        // P1 -> P2 -> A -> B
+        // P1 -> P2 -> A (VersionOverride) -> B
         // P1 -> P2 -> B (PrivateAssets) VersionOverride
+        // Pinning is enabled for both P1 and P2, and P1s versions are higher than those of P2 (otherwise it'd be a downgrade error).
+        // TODO - There's a chance the new behavior might be more appropriate in this case, since P2 suppressed it,
+        // explicitly not wanting the assets. it's very likely that the old algorithm has a bug, or potentially it's a consequence of how the behavior was implemented to begin with.
         [Fact]
         public async Task RestoreCommand_WithVersionOverrideAndTransitivePinning_VerifiesEquivalency()
         {

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -313,6 +313,26 @@ namespace NuGet.Commands.FuncTest
             result3.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
+        [Fact]
+        public async Task RestoreCommand_WithProjectReferenceWithSuppressedDependencies_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net5.0");
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpec("Project2", pathContext.SolutionRoot, framework: "net5.0", dependencyName: "a");
+            projectSpec2.TargetFrameworks[0].Dependencies[0].SuppressParent = LibraryIncludeFlags.All;
+            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec, projectSpec2);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
         // VersionOverride vs transitive pinnning with project reference
         // PrivateAssets
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -182,7 +182,8 @@ namespace NuGet.Commands.FuncTest
             using var pathContext = new SimpleTestPathContext();
             var packageA = new SimpleTestPackageContext("a", "1.0.0")
             {
-                Dependencies = [new SimpleTestPackageContext("b", "2.0.0") {
+                Dependencies = [new SimpleTestPackageContext("b", "2.0.0")
+                {
                     Dependencies = [new SimpleTestPackageContext("e", "1.0")]
                 }]
             };

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -1,0 +1,409 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Commands.Test;
+using NuGet.Common;
+using NuGet.LibraryModel;
+using NuGet.Packaging;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Commands.FuncTest
+{
+    // Tests that validate the equivalency of the old/new algorithm.
+    // The rule of thumb is everything that's a theory (ie providing new/old algo switch) is a difference, but everything that's a fact, instead calling ValidateRestoreAlgorithmEquivalency is a equivalent
+    public partial class RestoreCommandTests
+    {
+        [Theory]
+        //[InlineData(true)]
+        [InlineData(false)]
+        // Project 1 -> a 1.0.0 -> b 1.0.0
+        //                      -> c 1.0.0 -> b 2.0.0
+        // Old algorithm: When project 1 is restored, b 1.0.0 should be chosen since b 2.0.0 was explicitly downgraded to b 1.0.0 by a 1.0.0
+        // New algorithm: When project 1 is restored, B 2.0.0 is chosen since only project downgrades are supported
+        public async Task RestoreCommand_WithPackageDrivenDowngrade_RespectsDowngrade_AndRaisesWarning(bool useLegacyDependencyResolver)
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            var packageA = new SimpleTestPackageContext("a", "1.0.0");
+            packageA.Dependencies.Add(new SimpleTestPackageContext("b", "1.0.0"));
+            packageA.Dependencies.Add(new SimpleTestPackageContext("c", "1.0.0")
+            {
+                Dependencies = new() { new SimpleTestPackageContext("b", "2.0.0") }
+            });
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA);
+
+            var project1spec = ProjectTestHelpers.GetPackageSpec("Project1",
+                pathContext.SolutionRoot,
+                framework: "net472",
+                dependencyName: "a");
+            project1spec.RestoreMetadata.UseLegacyDependencyResolver = useLegacyDependencyResolver;
+
+            var logger = new TestLogger();
+            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1spec));
+
+            // Act
+            RestoreResult result = await command.ExecuteAsync();
+
+            // Assert
+            result.Success.Should().BeTrue();
+            //if (useLegacyDependencyResolver)
+            //{
+            result.LogMessages.Select(e => e.Code).Should().BeEquivalentTo([NuGetLogCode.NU1605]);
+            //}
+            //else
+            //{
+            //    result.LogMessages.Should().BeEmpty();
+            //}
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            //if (useLegacyDependencyResolver)
+            //{
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            //}
+            //else
+            //{
+            //    result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
+            //}
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        // Project 1 -> d 1.0.0 -> b 1.0.0
+        // Project 1 -> a 1.0.0 -> b 1.0.0
+        //                      -> c 1.0.0 -> b 2.0.0
+        // Old algorithm: When project 1 is restored, b 1.0.0 should be chosen since b 2.0.0 was explicitly downgraded to b 1.0.0 by a 1.0.0
+        // New algorithm: When project 1 is restored, B 2.0.0 is chosen since only project downgrades are supported
+        public async Task RestoreCommand_WithPackageDrivenDowngradeWithMultipleAncestors_RespectsDowngrade_AndRaisesWarning(bool useLegacyDependencyResolver)
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            var packageA = new SimpleTestPackageContext("a", "1.0.0");
+            packageA.Dependencies.Add(new SimpleTestPackageContext("b", "1.0.0"));
+            packageA.Dependencies.Add(new SimpleTestPackageContext("c", "1.0.0")
+            {
+                Dependencies = new() { new SimpleTestPackageContext("b", "2.0.0") }
+            });
+            var packageD = new SimpleTestPackageContext("d", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("b", "1.0.0")]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA,
+                packageD);
+
+            var projectSpec = @"
+                {
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""d"": ""1.0.0"",
+                                ""a"":  ""1.0.0""
+                        }
+                    }
+                  }
+                }";
+
+            var project1spec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, projectSpec);
+            project1spec.RestoreMetadata.UseLegacyDependencyResolver = useLegacyDependencyResolver;
+
+            var logger = new TestLogger();
+            var command = new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1spec));
+
+            // Act
+            RestoreResult result = await command.ExecuteAsync();
+
+            // Assert
+            result.Success.Should().BeTrue();
+            //if (useLegacyDependencyResolver)
+            //{
+            result.LogMessages.Select(e => e.Code).Should().BeEquivalentTo([NuGetLogCode.NU1605]);
+            //}
+            //else
+            //{
+            //    result.LogMessages.Should().BeEmpty();
+            //}
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(4);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            //if (useLegacyDependencyResolver)
+            //{
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            //}
+            //else
+            //{
+            //    result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
+            //}
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("d");
+            result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        [Fact]
+        // Project 1 -> A 1.0 -> B 2.0 -> E 1.0
+        //           -> C 2.0 -> D 1.0 -> B 3.0
+        // Expected: A 1.0, B 3.0, C 2.0, D 1.0
+        public async Task RestoreCommand_WithNewPackageEvictedByVersionBump()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            var packageA = new SimpleTestPackageContext("a", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("b", "2.0.0") {
+                    Dependencies = [new SimpleTestPackageContext("e", "1.0")]
+                }]
+            };
+            var packageC = new SimpleTestPackageContext("c", "2.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("d", "1.0.0")
+                {
+                    Dependencies = [new SimpleTestPackageContext("b", "3.0.0")
+                    {
+                        Dependencies = [/*new SimpleTestPackageContext("e", "1.0.0")*/]
+                    }]
+                }]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA,
+                packageC);
+
+            var projectSpec = @"
+                {
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""a"":  ""1.0.0"",
+                                ""c"": ""2.0.0""
+                        }
+                    }
+                  }
+                }";
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, projectSpec));
+
+            // Assert
+            result.Success.Should().BeTrue();
+            result.LogMessages.Should().HaveCount(0);
+
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(4);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("3.0.0"));
+
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("2.0.0"));
+
+            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("d");
+            result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithVersionOverrideAndTransitivePinning_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("a", "1.0.0");
+            packageA.Dependencies.Add(new SimpleTestPackageContext("b", "1.0.0"));
+            var packageB150 = new SimpleTestPackageContext("b", "1.5.0");
+            var packageB200 = new SimpleTestPackageContext("b", "2.0.0");
+
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA,
+                packageB150,
+                packageB200);
+
+            var project1 = @"
+                {
+                    ""restore"": {
+                                    ""centralPackageVersionsManagementEnabled"": true,
+                                    ""CentralPackageTransitivePinningEnabled"": true,
+                    },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""a"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionCentrallyManaged"": true
+                                }
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""[1.0.0,)"",
+                            ""b"": ""[2.0.0,)""
+                        }
+                    }
+                  }
+                }";
+
+            var project2 = @"
+                {
+                    ""restore"": {
+                                    ""centralPackageVersionsManagementEnabled"": true,
+                                    ""CentralPackageTransitivePinningEnabled"": true,
+                    },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""b"": {
+                                    ""version"": ""[1.5.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionOverride"": ""[1.5.0, )"",
+                                    ""versionCentrallyManaged"": true
+                                }
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""[1.0.0,)"",
+                            ""b"": ""[2.0.0,)""
+                        }
+                    }
+                  }
+                }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, project2);
+            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec, projectSpec2);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            (var result2, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec2);
+            result2.LockFile.Targets.Should().HaveCount(1);
+            result2.LockFile.Targets[0].Libraries.Should().HaveCount(1);
+            result2.LockFile.Targets[0].Libraries[0].Name.Should().Be("b");
+            result2.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.5.0"));
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithSuppressedProjectReferences_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("a", "1.0.0");
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA);
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot);
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpec("Project2", pathContext.SolutionRoot);
+            var projectSpec3 = ProjectTestHelpers.GetPackageSpec("Project3", pathContext.SolutionRoot, "net5.0", dependencyName: "a");
+            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+            projectSpec2 = projectSpec2.WithTestProjectReference(projectSpec3, LibraryIncludeFlags.All); // With PrivateAssetsAll
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec, projectSpec2, projectSpec3);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            (var result2, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec2, projectSpec3);
+            result2.LockFile.Targets.Should().HaveCount(1);
+            result2.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+            result2.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result2.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result2.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project3");
+            result2.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            (var result3, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec3);
+            result3.LockFile.Targets.Should().HaveCount(1);
+            result3.LockFile.Targets[0].Libraries.Should().HaveCount(1);
+            result3.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result3.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        // VersionOverride vs transitive pinnning with project reference
+        // PrivateAssets
+
+        internal static async Task<(RestoreResult, RestoreResult)> ValidateRestoreAlgorithmEquivalency(SimpleTestPathContext pathContext, params PackageSpec[] projects)
+        {
+            var legacyResolverProjects = DuplicateAndEnableLegacyAlgorithm(projects);
+
+            RestoreResult result = await RunRestoreAsync(pathContext, projects);
+            RestoreResult legacyResult = await RunRestoreAsync(pathContext, legacyResolverProjects);
+
+            // Assert
+            ValidateRestoreResults(result, legacyResult);
+            return (result, legacyResult);
+        }
+
+        internal static Task<RestoreResult> RunRestoreAsync(SimpleTestPathContext pathContext, params PackageSpec[] projects)
+        {
+            return new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, new TestLogger(), projects)).ExecuteAsync();
+        }
+
+        internal static PackageSpec[] DuplicateAndEnableLegacyAlgorithm(PackageSpec[] projects)
+        {
+            var result = new PackageSpec[projects.Length];
+            for (int i = 0; i < projects.Length; i++)
+            {
+                var legacyResolverProject = projects[i].Clone();
+                legacyResolverProject.RestoreMetadata.UseLegacyDependencyResolver = true;
+                result[i] = legacyResolverProject;
+            }
+
+            return result;
+        }
+
+        internal static void ValidateRestoreResults(RestoreResult left, RestoreResult right)
+        {
+            var leftPackageSpec = left.LockFile.PackageSpec;
+            var rightPackageSpec = right.LockFile.PackageSpec;
+
+            left.Success.Should().Be(right.Success);
+            left.LockFile.PackageSpec = null;
+            right.LockFile.PackageSpec = null;
+            left.LockFile.Should().Be(right.LockFile);
+
+            //Reset package specs
+            left.LockFile.PackageSpec = leftPackageSpec;
+            right.LockFile.PackageSpec = rightPackageSpec;
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -27,11 +27,10 @@ using NuGet.Versioning;
 using Test.Utility;
 using Test.Utility.Commands;
 using Test.Utility.ProjectManagement;
-using Xunit;
-
 #if IS_SIGNING_SUPPORTED
 using Test.Utility.Signing;
 #endif
+using Xunit;
 
 namespace NuGet.Commands.Test.RestoreCommandTests
 {

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecReferenceDependencyProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecReferenceDependencyProviderTests.cs
@@ -44,7 +44,7 @@ namespace NuGet.ProjectModel.Test
             var centralVersionBar = new CentralPackageVersion("bar", VersionRange.Parse("2.0.0"));
 
             var tfi = CreateTargetFrameworkInformation(new List<LibraryDependency>() { dependencyFoo }, new List<CentralPackageVersion>() { centralVersionFoo, centralVersionBar }, cpvmEnabled);
-            var dependencyGraphSpec = CreateDependencyGraphSpecWithCentralDependencies(cpvmEnabled, CentralPackageTransitivePinningEnabled, tfi);
+            var dependencyGraphSpec = CreateDependencyGraphSpecWithCentralDependencies(cpvmEnabled, CentralPackageTransitivePinningEnabled, true, tfi);
             var packSpec = dependencyGraphSpec.Projects[0];
 
             var dependencyProvider = new PackageSpecReferenceDependencyProvider(new List<ExternalProjectReference>(), NullLogger.Instance, useLegacyDependencyGraphResolution);
@@ -79,6 +79,8 @@ namespace NuGet.ProjectModel.Test
                 Assert.Equal(LibraryDependencyReferenceType.Direct, fooDep.ReferenceType);
             }
         }
+
+        // TODO - Add a test verifying that the new algorithm *doesn't* require packages to be added as top level
 
         [Theory]
         [InlineData(null, 1)]
@@ -131,7 +133,7 @@ namespace NuGet.ProjectModel.Test
             return tfi;
         }
 
-        private static DependencyGraphSpec CreateDependencyGraphSpecWithCentralDependencies(bool cpvmEnabled, bool tdpEnabled, params TargetFrameworkInformation[] tfis)
+        private static DependencyGraphSpec CreateDependencyGraphSpecWithCentralDependencies(bool cpvmEnabled, bool tdpEnabled, bool legacyAlgorithmEnabled, params TargetFrameworkInformation[] tfis)
         {
             var packageSpec = new PackageSpec(tfis);
             packageSpec.RestoreMetadata = new ProjectRestoreMetadata
@@ -139,6 +141,7 @@ namespace NuGet.ProjectModel.Test
                 ProjectUniqueName = "a",
                 CentralPackageVersionsEnabled = cpvmEnabled,
                 CentralPackageTransitivePinningEnabled = tdpEnabled,
+                UseLegacyDependencyResolver = legacyAlgorithmEnabled,
             };
             var dgSpec = new DependencyGraphSpec();
             dgSpec.AddRestore("a");

--- a/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
@@ -71,7 +71,7 @@ namespace NuGet.Commands.Test
 
         /// <summary>
         /// Add restore metadata only if not already set.
-        /// Sets the project style to PackageReference.
+        /// Sets the project style to ProjectJson.
         /// </summary>
         public static PackageSpec EnsureProjectJsonRestoreMetadata(this PackageSpec spec)
         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Tracked in https://github.com/NuGet/Client.Engineering/issues/2959

## Description
This change fixes a few scenarios that didn't work with the new dependency resolution algorithm.  Specifically, `project.json` and central transitive pinning.

It is still disabled for projects that use runtime "supports" because that logic in the legacy algorithm is fairly complex where it installs packages, queries for other frameworks, restores again, and then restores a third time.  At this time we don't think its necessary for the new algorithm to support this as its not used much since DNXCore.

We also added more tests that cover scenarios that were found when restoring the Visual Studio repository and had missing coverage in our repo.

This also makes the download of packages happen in parallel by queuing a thread to call `FindLibraryEntryAsync()` and awaiting it when processing.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
