### PR TITLE
Make PackageSpecDependencyProvider consider the version being requested

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -101,7 +101,15 @@ namespace NuGet.ProjectModel
             // This must exist in the external references
             if (_externalProjectsByUniqueName.TryGetValue(name, out ExternalProjectReference externalReference))
             {
-                packageSpec = externalReference.PackageSpec;
+                if (externalReference.PackageSpec == null ||
+                    libraryRange.VersionRange.FindBestMatch(new NuGetVersion[] { externalReference.PackageSpec.Version }) != null)
+                {
+                    packageSpec = externalReference.PackageSpec;
+                }
+                else
+                {
+                    externalReference = null;
+                }
             }
 
             if (externalReference == null && packageSpec == null)

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -101,7 +101,9 @@ namespace NuGet.ProjectModel
             // This must exist in the external references
             if (_externalProjectsByUniqueName.TryGetValue(name, out ExternalProjectReference externalReference))
             {
+                // A library with a null version range means that all versions should match.
                 if (externalReference.PackageSpec == null ||
+                    libraryRange.VersionRange == null ||
                     libraryRange.VersionRange.FindBestMatch(new NuGetVersion[] { externalReference.PackageSpec.Version }) != null)
                 {
                     packageSpec = externalReference.PackageSpec;

--- a/test/TestUtilities/Test.Utility/Commands/TestRestoreRequest.cs
+++ b/test/TestUtilities/Test.Utility/Commands/TestRestoreRequest.cs
@@ -203,6 +203,7 @@ namespace NuGet.Commands.Test
             DependencyGraphSpec.AddProject(project);
             DependencyGraphSpec.AddRestore(project.RestoreMetadata.ProjectUniqueName);
             AllowNoOp = true;
+            ProjectStyle = project.RestoreMetadata.ProjectStyle;
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/10368
Re-submission of https://github.com/NuGet/NuGet.Client/pull/5452

## Description
https://github.com/dotnet/runtime/pull/106329 is currently blocked because of this NuGet tooling bug.

NuGet gets confused with transitive project and package dependencies with the same identity (name) in a multi-targeting project. It incorrectly selects the wrong type (project instead of package).

Projects are expected to be preferred over packages, but only when the version matches. If the version doesn't match, projects shouldn't be selected in frameworks which don't declare a `ProjectReference` to those projects.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.

cc @nkolev92

I'm happy to do as much validation as necessary. Please understand that this defect currently blocks one of our planned infrastructure modernization items. We can't merge the runtime PR until this fix flows into both the .NET SDK and VS and we can depend on the newer toolchain as otherwise restore would fail.