### PR TITLE
NuGet should normalize file paths when extracting

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -5111,6 +5111,8 @@ namespace NuGet.Packaging.Test
             }
         }
 
+        // This test is likely to only catch bugs on Linux/Mac, but there's little harm in running the test
+        // on Windows as well.
         [Fact]
         public async Task InstallFromSourceAsync_NupkgWithNonNormalizedPaths_FixesPathsToExtract()
         {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -5129,8 +5129,8 @@ namespace NuGet.Packaging.Test
                    identity.Id,
                    identity.Version.ToString(),
                    entryModifiedTime: DateTimeOffset.Now,
-                   "path\\1",
-                   "path/2");
+                   "path\\one\\1",
+                   "path/two/2");
 
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                 {
@@ -5146,21 +5146,21 @@ namespace NuGet.Packaging.Test
                         identity,
                         NullLogger.Instance))
                     {
+                        // Act
                         var installed = await PackageExtractor.InstallFromSourceAsync(
                             identity,
                             packageDownloader,
                             resolver,
                             packageExtractionContext,
                             CancellationToken.None);
-
                     }
                 }
 
                 // Assert
                 var packagePath = resolver.GetInstallPath(identity.Id, identity.Version);
                 Directory.Exists(packagePath).Should().BeTrue();
-                File.Exists(Path.Combine(packagePath, "path", "1")).Should().BeTrue();
-                File.Exists(Path.Combine(packagePath, "path", "2")).Should().BeTrue();
+                File.Exists(Path.Combine(packagePath, "path", "one", "1")).Should().BeTrue();
+                File.Exists(Path.Combine(packagePath, "path", "two", "2")).Should().BeTrue();
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -390,11 +390,16 @@ namespace NuGet.Packaging.Test
                         clientPolicyContext: null,
                         logger: NullLogger.Instance),
                     CancellationToken.None);
+                var normalizedFiles = new List<string>();
+                foreach (var file in files)
+                {
+                    normalizedFiles.Add(Path.GetFullPath(file));
+                }
 
                 // Assert
                 var packagePath = resolver.GetInstallPath(identity);
-                Assert.DoesNotContain(Path.Combine(packagePath, "[Content_Types].xml"), files);
-                Assert.Contains(Path.Combine(packagePath, "content", "[Content_Types].xml"), files);
+                Assert.DoesNotContain(Path.Combine(packagePath, "[Content_Types].xml"), normalizedFiles);
+                Assert.Contains(Path.Combine(packagePath, "content", "[Content_Types].xml"), normalizedFiles);
             }
         }
 
@@ -1479,6 +1484,11 @@ namespace NuGet.Packaging.Test
                     test.Resolver,
                     test.Context,
                     CancellationToken.None);
+                var normalizedFiles = new List<string>(files.Count());
+                foreach (var file in files)
+                {
+                    normalizedFiles.Add(Path.GetFullPath(file));
+                }
 
                 var packageId = test.PackageIdentity.Id;
                 var packageVersion = test.PackageIdentity.Version.ToNormalizedString();
@@ -1493,9 +1503,9 @@ namespace NuGet.Packaging.Test
 
                 var comparer = PathUtility.GetStringComparerBasedOnOS();
 
-                Assert.DoesNotContain(nupkgFilePath, files, comparer);
-                Assert.DoesNotContain(nuspecFilePath, files, comparer);
-                Assert.Contains(libFilePath, files, comparer);
+                Assert.DoesNotContain(nupkgFilePath, normalizedFiles, comparer);
+                Assert.DoesNotContain(nuspecFilePath, normalizedFiles, comparer);
+                Assert.Contains(libFilePath, normalizedFiles, comparer);
                 Assert.False(File.Exists(nupkgFilePath));
                 Assert.False(File.Exists(nuspecFilePath));
                 Assert.True(File.Exists(libFilePath));
@@ -1593,6 +1603,11 @@ namespace NuGet.Packaging.Test
                     test.Resolver,
                     test.Context,
                     CancellationToken.None);
+                var normalizedFiles = new List<string>(files.Count());
+                foreach (var file in files)
+                {
+                    normalizedFiles.Add(Path.GetFullPath(file));
+                }
 
                 var packageId = test.PackageIdentity.Id;
                 var packageVersion = test.PackageIdentity.Version.ToNormalizedString();
@@ -1607,9 +1622,9 @@ namespace NuGet.Packaging.Test
 
                 var comparer = PathUtility.GetStringComparerBasedOnOS();
 
-                Assert.Contains(nupkgFilePath, files, comparer);
-                Assert.DoesNotContain(nuspecFilePath, files, comparer);
-                Assert.Contains(libFilePath, files, comparer);
+                Assert.Contains(nupkgFilePath, normalizedFiles, comparer);
+                Assert.DoesNotContain(nuspecFilePath, normalizedFiles, comparer);
+                Assert.Contains(libFilePath, normalizedFiles, comparer);
                 Assert.True(File.Exists(nupkgFilePath));
                 Assert.False(File.Exists(nuspecFilePath));
                 Assert.True(File.Exists(libFilePath));
@@ -1631,6 +1646,11 @@ namespace NuGet.Packaging.Test
                     test.Resolver,
                     test.Context,
                     CancellationToken.None);
+                var normalizedPath = new List<string>(files.Count());
+                foreach (var file in files)
+                {
+                    normalizedPath.Add(Path.GetFullPath(file));
+                }
 
                 var packageId = test.PackageIdentity.Id;
                 var packageVersion = test.PackageIdentity.Version.ToNormalizedString();
@@ -1645,9 +1665,9 @@ namespace NuGet.Packaging.Test
 
                 var comparer = PathUtility.GetStringComparerBasedOnOS();
 
-                Assert.Contains(nupkgFilePath, files, comparer);
-                Assert.Contains(nuspecFilePath, files, comparer);
-                Assert.Contains(libFilePath, files, comparer);
+                Assert.Contains(nupkgFilePath, normalizedPath, comparer);
+                Assert.Contains(nuspecFilePath, normalizedPath, comparer);
+                Assert.Contains(libFilePath, normalizedPath, comparer);
                 Assert.True(File.Exists(nupkgFilePath));
                 Assert.True(File.Exists(nuspecFilePath));
                 Assert.True(File.Exists(libFilePath));
@@ -1680,7 +1700,7 @@ namespace NuGet.Packaging.Test
 
                 var comparer = PathUtility.GetStringComparerBasedOnOS();
 
-                Assert.Contains(xmlFilePath, files, comparer);
+                Assert.Contains(xmlFilePath, files.Select(Path.GetFullPath), comparer);
                 Assert.True(File.Exists(xmlFilePath));
             }
         }
@@ -1742,7 +1762,7 @@ namespace NuGet.Packaging.Test
 
                 var comparer = PathUtility.GetStringComparerBasedOnOS();
 
-                Assert.Contains(xmlZipFilePath, files, comparer);
+                Assert.Contains(xmlZipFilePath, files.Select(Path.GetFullPath), comparer);
                 Assert.True(File.Exists(xmlZipFilePath));
             }
         }
@@ -4915,7 +4935,7 @@ namespace NuGet.Packaging.Test
                     CancellationToken.None)).ToArray();
 
                 Assert.Equal(1, files.Length);
-                Assert.Equal(Path.Combine(testDirectory.Path, "lib", "net45", "fr", "A.resources.dll"), files[0]);
+                Assert.Equal(Path.Combine(testDirectory.Path, "lib", "net45", "fr", "A.resources.dll"), Path.GetFullPath(files[0]));
             }
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13732

## Description

There are other known issue in NuGet/Home about forward slashes vs back slashes, particularly around file globbing. This PR does not try to address any of those.  This PR only addresses when a nupkg's zip central directory contains files whose paths use `\` instead of `/`, and the package is being extracted on Linux or Mac which only use `/` as a path separator (Windows uses both).

This makes NuGet more resilient to package authors who create (or modify) their package without using official tools.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ PR makes NuGet resilient to "poorly authored" packages. I don't believe it's something we want to document, certainly not encourage.
