### PR TITLE
Add support for package type queries in both local and remote sources

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/SearchFilterFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/SearchFilterFormatter.cs
@@ -12,7 +12,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
     {
         private const string IncludePrereleasePropertyName = "includeprerelease";
         private const string IncludeDelistedPropertyName = "includedelisted";
-        private const string PackageTypesPropertyName = "packagetypes";
+        private const string PackageTypePropertyName = "packagetype";
         private const string FilterPropertyName = "filter";
         private const string OrderByPropertyName = "orderby";
         private const string SupportedFrameworksPropertyName = "supportedframeworks";
@@ -30,7 +30,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             SearchFilterType? filterType = null;
             SearchOrderBy? searchOrderBy = null;
             IEnumerable<string>? supportedFrameworks = null;
-            IEnumerable<string>? packageTypes = null;
+            string? packageType = null;
 
             int propertyCount = reader.ReadMapHeader();
             for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
@@ -43,8 +43,8 @@ namespace NuGet.VisualStudio.Internal.Contracts
                     case IncludeDelistedPropertyName:
                         includeDelisted = reader.ReadBoolean();
                         break;
-                    case PackageTypesPropertyName:
-                        packageTypes = options.Resolver.GetFormatter<IEnumerable<string>>()!.Deserialize(ref reader, options);
+                    case PackageTypePropertyName:
+                        packageType = reader.ReadString();
                         break;
                     case FilterPropertyName:
                         filterType = options.Resolver.GetFormatter<SearchFilterType?>()!.Deserialize(ref reader, options);
@@ -65,7 +65,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             {
                 SupportedFrameworks = supportedFrameworks,
                 OrderBy = searchOrderBy,
-                PackageTypes = packageTypes,
+                PackageType = packageType,
                 IncludeDelisted = includeDelisted,
             };
         }
@@ -77,8 +77,8 @@ namespace NuGet.VisualStudio.Internal.Contracts
             writer.Write(value.IncludePrerelease);
             writer.Write(IncludeDelistedPropertyName);
             writer.Write(value.IncludeDelisted);
-            writer.Write(PackageTypesPropertyName);
-            options.Resolver.GetFormatter<IEnumerable<string>>()!.Serialize(ref writer, value.PackageTypes, options);
+            writer.Write(PackageTypePropertyName);
+            writer.Write(value.PackageType);
             writer.Write(FilterPropertyName);
             options.Resolver.GetFormatter<SearchFilterType?>()!.Serialize(ref writer, value.Filter, options);
             writer.Write(OrderByPropertyName);

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageSearchResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageSearchResource.cs
@@ -59,6 +59,21 @@ namespace NuGet.Protocol
                     query = query.Where(package => ContainsAnyTerm(terms, package));
                 }
 
+                // Filter on package types
+                if (filters?.PackageTypes != null
+                    && filters.PackageTypes.Any())
+                {
+                    foreach (var packageTypeName in filters.PackageTypes)
+                    {
+                        query = query
+                            .Where(package => package.Nuspec
+                                .GetPackageTypes()
+                                .Any(packageType => StringComparer.OrdinalIgnoreCase.Equals(
+                                    packageType.Name,
+                                    packageTypeName)));
+                    }
+                }
+
                 // Collapse to the highest version per id, if necessary
                 var collapsedQuery = filters?.Filter == SearchFilterType.IsLatestVersion ||
                                      filters?.Filter == SearchFilterType.IsAbsoluteLatestVersion

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageSearchResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageSearchResource.cs
@@ -60,18 +60,14 @@ namespace NuGet.Protocol
                 }
 
                 // Filter on package types
-                if (filters?.PackageTypes != null
-                    && filters.PackageTypes.Any())
+                if (!string.IsNullOrEmpty(filters.PackageType))
                 {
-                    foreach (var packageTypeName in filters.PackageTypes)
-                    {
-                        query = query
-                            .Where(package => package.Nuspec
-                                .GetPackageTypes()
-                                .Any(packageType => StringComparer.OrdinalIgnoreCase.Equals(
-                                    packageType.Name,
-                                    packageTypeName)));
-                    }
+                    query = query
+                        .Where(package => package.Nuspec
+                            .GetPackageTypes()
+                            .Any(packageType => StringComparer.OrdinalIgnoreCase.Equals(
+                                packageType.Name,
+                                filters.PackageType)));
                 }
 
                 // Collapse to the highest version per id, if necessary

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -267,8 +267,6 @@ NuGet.Protocol.Core.Types.SearchFilter.IncludeDelisted.set -> void
 NuGet.Protocol.Core.Types.SearchFilter.IncludePrerelease.get -> bool
 NuGet.Protocol.Core.Types.SearchFilter.OrderBy.get -> NuGet.Protocol.Core.Types.SearchOrderBy?
 NuGet.Protocol.Core.Types.SearchFilter.OrderBy.set -> void
-~NuGet.Protocol.Core.Types.SearchFilter.PackageTypes.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Protocol.Core.Types.SearchFilter.PackageTypes.set -> void
 NuGet.Protocol.Core.Types.SearchFilter.SearchFilter(bool includePrerelease) -> void
 NuGet.Protocol.Core.Types.SearchFilter.SearchFilter(bool includePrerelease, NuGet.Protocol.Core.Types.SearchFilterType? filter) -> void
 ~NuGet.Protocol.Core.Types.SearchFilter.SupportedFrameworks.get -> System.Collections.Generic.IEnumerable<string>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 NuGet.Protocol.Plugins.PluginDiscoverer.PluginDiscoverer() -> void
 virtual NuGet.Protocol.Plugins.PluginFactory.Dispose() -> void
+~NuGet.Protocol.Core.Types.SearchFilter.PackageType.get -> string
+~NuGet.Protocol.Core.Types.SearchFilter.PackageType.set -> void
 ~NuGet.Protocol.Plugins.PluginFile.PluginFile(string filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState> state, bool requiresDotnetHost) -> void
 ~NuGet.Protocol.Plugins.PluginManager.PluginManager(NuGet.Common.IEnvironmentVariableReader reader, System.Lazy<NuGet.Protocol.Plugins.IPluginDiscoverer> pluginDiscoverer, System.Func<System.TimeSpan, NuGet.Protocol.Plugins.PluginFactory> pluginFactoryCreator, System.Lazy<string> pluginsCacheDirectoryPath) -> void
 ~virtual NuGet.Protocol.Plugins.PluginFactory.GetOrCreateAsync(NuGet.Protocol.Plugins.PluginFile pluginFile, System.Collections.Generic.IEnumerable<string> arguments, NuGet.Protocol.Plugins.IRequestHandlers requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@ virtual NuGet.Protocol.Plugins.PluginFactory.Dispose() -> void
 ~NuGet.Protocol.Core.Types.SearchFilter.PackageType.set -> void
 ~NuGet.Protocol.Plugins.PluginFile.PluginFile(string filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState> state, bool requiresDotnetHost) -> void
 ~NuGet.Protocol.Plugins.PluginManager.PluginManager(NuGet.Common.IEnvironmentVariableReader reader, System.Lazy<NuGet.Protocol.Plugins.IPluginDiscoverer> pluginDiscoverer, System.Func<System.TimeSpan, NuGet.Protocol.Plugins.PluginFactory> pluginFactoryCreator, System.Lazy<string> pluginsCacheDirectoryPath) -> void
+~static readonly NuGet.Protocol.ServiceTypes.Version350 -> string
 ~virtual NuGet.Protocol.Plugins.PluginFactory.GetOrCreateAsync(NuGet.Protocol.Plugins.PluginFile pluginFile, System.Collections.Generic.IEnumerable<string> arguments, NuGet.Protocol.Plugins.IRequestHandlers requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin>
 NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticServiceIndexEntryEventHandler
 NuGet.Protocol.Events.ProtocolDiagnosticServiceIndexEntryEvent

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -267,8 +267,6 @@ NuGet.Protocol.Core.Types.SearchFilter.IncludeDelisted.set -> void
 NuGet.Protocol.Core.Types.SearchFilter.IncludePrerelease.get -> bool
 NuGet.Protocol.Core.Types.SearchFilter.OrderBy.get -> NuGet.Protocol.Core.Types.SearchOrderBy?
 NuGet.Protocol.Core.Types.SearchFilter.OrderBy.set -> void
-~NuGet.Protocol.Core.Types.SearchFilter.PackageTypes.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Protocol.Core.Types.SearchFilter.PackageTypes.set -> void
 NuGet.Protocol.Core.Types.SearchFilter.SearchFilter(bool includePrerelease) -> void
 NuGet.Protocol.Core.Types.SearchFilter.SearchFilter(bool includePrerelease, NuGet.Protocol.Core.Types.SearchFilterType? filter) -> void
 ~NuGet.Protocol.Core.Types.SearchFilter.SupportedFrameworks.get -> System.Collections.Generic.IEnumerable<string>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 NuGet.Protocol.Plugins.PluginDiscoverer.PluginDiscoverer() -> void
 virtual NuGet.Protocol.Plugins.PluginFactory.Dispose() -> void
+~NuGet.Protocol.Core.Types.SearchFilter.PackageType.get -> string
+~NuGet.Protocol.Core.Types.SearchFilter.PackageType.set -> void
 ~NuGet.Protocol.Plugins.PluginFile.PluginFile(string filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState> state, bool requiresDotnetHost) -> void
 ~NuGet.Protocol.Plugins.PluginManager.PluginManager(NuGet.Common.IEnvironmentVariableReader reader, System.Lazy<NuGet.Protocol.Plugins.IPluginDiscoverer> pluginDiscoverer, System.Func<System.TimeSpan, NuGet.Protocol.Plugins.PluginFactory> pluginFactoryCreator, System.Lazy<string> pluginsCacheDirectoryPath) -> void
 ~virtual NuGet.Protocol.Plugins.PluginFactory.GetOrCreateAsync(NuGet.Protocol.Plugins.PluginFile pluginFile, System.Collections.Generic.IEnumerable<string> arguments, NuGet.Protocol.Plugins.IRequestHandlers requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@ virtual NuGet.Protocol.Plugins.PluginFactory.Dispose() -> void
 ~NuGet.Protocol.Core.Types.SearchFilter.PackageType.set -> void
 ~NuGet.Protocol.Plugins.PluginFile.PluginFile(string filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState> state, bool requiresDotnetHost) -> void
 ~NuGet.Protocol.Plugins.PluginManager.PluginManager(NuGet.Common.IEnvironmentVariableReader reader, System.Lazy<NuGet.Protocol.Plugins.IPluginDiscoverer> pluginDiscoverer, System.Func<System.TimeSpan, NuGet.Protocol.Plugins.PluginFactory> pluginFactoryCreator, System.Lazy<string> pluginsCacheDirectoryPath) -> void
+~static readonly NuGet.Protocol.ServiceTypes.Version350 -> string
 ~virtual NuGet.Protocol.Plugins.PluginFactory.GetOrCreateAsync(NuGet.Protocol.Plugins.PluginFile pluginFile, System.Collections.Generic.IEnumerable<string> arguments, NuGet.Protocol.Plugins.IRequestHandlers requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin>
 NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticServiceIndexEntryEventHandler
 NuGet.Protocol.Events.ProtocolDiagnosticServiceIndexEntryEvent

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -267,8 +267,6 @@ NuGet.Protocol.Core.Types.SearchFilter.IncludeDelisted.set -> void
 NuGet.Protocol.Core.Types.SearchFilter.IncludePrerelease.get -> bool
 NuGet.Protocol.Core.Types.SearchFilter.OrderBy.get -> NuGet.Protocol.Core.Types.SearchOrderBy?
 NuGet.Protocol.Core.Types.SearchFilter.OrderBy.set -> void
-~NuGet.Protocol.Core.Types.SearchFilter.PackageTypes.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Protocol.Core.Types.SearchFilter.PackageTypes.set -> void
 NuGet.Protocol.Core.Types.SearchFilter.SearchFilter(bool includePrerelease) -> void
 NuGet.Protocol.Core.Types.SearchFilter.SearchFilter(bool includePrerelease, NuGet.Protocol.Core.Types.SearchFilterType? filter) -> void
 ~NuGet.Protocol.Core.Types.SearchFilter.SupportedFrameworks.get -> System.Collections.Generic.IEnumerable<string>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 NuGet.Protocol.Plugins.PluginDiscoverer.PluginDiscoverer() -> void
 virtual NuGet.Protocol.Plugins.PluginFactory.Dispose() -> void
+~NuGet.Protocol.Core.Types.SearchFilter.PackageType.get -> string
+~NuGet.Protocol.Core.Types.SearchFilter.PackageType.set -> void
 ~NuGet.Protocol.Plugins.PluginFile.PluginFile(string filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState> state, bool requiresDotnetHost) -> void
 ~NuGet.Protocol.Plugins.PluginManager.PluginManager(NuGet.Common.IEnvironmentVariableReader reader, System.Lazy<NuGet.Protocol.Plugins.IPluginDiscoverer> pluginDiscoverer, System.Func<System.TimeSpan, NuGet.Protocol.Plugins.PluginFactory> pluginFactoryCreator, System.Lazy<string> pluginsCacheDirectoryPath) -> void
 ~virtual NuGet.Protocol.Plugins.PluginFactory.GetOrCreateAsync(NuGet.Protocol.Plugins.PluginFile pluginFile, System.Collections.Generic.IEnumerable<string> arguments, NuGet.Protocol.Plugins.IRequestHandlers requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@ virtual NuGet.Protocol.Plugins.PluginFactory.Dispose() -> void
 ~NuGet.Protocol.Core.Types.SearchFilter.PackageType.set -> void
 ~NuGet.Protocol.Plugins.PluginFile.PluginFile(string filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState> state, bool requiresDotnetHost) -> void
 ~NuGet.Protocol.Plugins.PluginManager.PluginManager(NuGet.Common.IEnvironmentVariableReader reader, System.Lazy<NuGet.Protocol.Plugins.IPluginDiscoverer> pluginDiscoverer, System.Func<System.TimeSpan, NuGet.Protocol.Plugins.PluginFactory> pluginFactoryCreator, System.Lazy<string> pluginsCacheDirectoryPath) -> void
+~static readonly NuGet.Protocol.ServiceTypes.Version350 -> string
 ~virtual NuGet.Protocol.Plugins.PluginFactory.GetOrCreateAsync(NuGet.Protocol.Plugins.PluginFile pluginFile, System.Collections.Generic.IEnumerable<string> arguments, NuGet.Protocol.Plugins.IRequestHandlers requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin>
 NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticServiceIndexEntryEventHandler
 NuGet.Protocol.Events.ProtocolDiagnosticServiceIndexEntryEvent

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
@@ -142,7 +142,7 @@ namespace NuGet.Protocol
                 {
                     var types = string.Join("&",
                         filters.PackageTypes.Select(
-                            s => "packageTypeFilter=" + s));
+                            s => "packageType=" + s));
                     queryString += "&" + types;
                 }
 

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
@@ -137,13 +137,9 @@ namespace NuGet.Protocol
                     queryString += "&" + frameworks;
                 }
 
-                if (filters.PackageTypes != null
-                    && filters.PackageTypes.Any())
+                if (!string.IsNullOrEmpty(filters.PackageType))
                 {
-                    var types = string.Join("&",
-                        filters.PackageTypes.Select(
-                            s => "packageType=" + s));
-                    queryString += "&" + types;
+                    queryString += "&packageType=" + filters.PackageType;
                 }
 
                 queryString += "&semVerLevel=2.0.0";

--- a/src/NuGet.Core/NuGet.Protocol/Resources/RawSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/RawSearchResourceV3.cs
@@ -67,13 +67,9 @@ namespace NuGet.Protocol
                     queryString += "&" + frameworks;
                 }
 
-                if (filters.PackageTypes != null
-                    && filters.PackageTypes.Any())
+                if (!string.IsNullOrEmpty(filters.PackageType))
                 {
-                    var types = string.Join("&",
-                        filters.PackageTypes.Select(
-                            s => "packageTypeFilter=" + s));
-                    queryString += "&" + types;
+                    queryString += "&packageType=" + filters.PackageType;
                 }
 
                 queryString += "&semVerLevel=2.0.0";

--- a/src/NuGet.Core/NuGet.Protocol/SearchFilter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SearchFilter.cs
@@ -55,9 +55,9 @@ namespace NuGet.Protocol.Core.Types
         public bool IncludeDelisted { get; set; } = false;
 
         /// <summary>
-        /// Restrict the search to certain package types.
+        /// Restrict the search to a specific package type.
         /// </summary>
-        public IEnumerable<string> PackageTypes { get; set; } = Enumerable.Empty<string>();
+        public string PackageType { get; set; } = null;
 
         /// <summary>
         /// The optional filter type. Absense of this value indicates that all versions should be returned.

--- a/src/NuGet.Core/NuGet.Protocol/ServiceTypes.cs
+++ b/src/NuGet.Core/NuGet.Protocol/ServiceTypes.cs
@@ -10,6 +10,7 @@ namespace NuGet.Protocol
         public static readonly string Version300rc = "/3.0.0-rc";
         public static readonly string Version300 = "/3.0.0";
         public static readonly string Version340 = "/3.4.0";
+        public static readonly string Version350 = "/3.5.0";
         public static readonly string Version360 = "/3.6.0";
         public static readonly string Versioned = "/Versioned";
         public static readonly string Version470 = "/4.7.0";
@@ -20,7 +21,7 @@ namespace NuGet.Protocol
         internal const string Version6110 = "/6.11.0";
         internal const string Version6130 = "/6.13.0";
 
-        public static readonly string[] SearchQueryService = { "SearchQueryService" + Versioned, "SearchQueryService" + Version340, "SearchQueryService" + Version300beta };
+        public static readonly string[] SearchQueryService = { "SearchQueryService" + Versioned, "SearchQueryService" + Version350, "SearchQueryService" + Version300beta };
         public static readonly string[] RegistrationsBaseUrl = { $"RegistrationsBaseUrl{Versioned}", $"RegistrationsBaseUrl{Version360}", $"RegistrationsBaseUrl{Version340}", $"RegistrationsBaseUrl{Version300rc}", $"RegistrationsBaseUrl{Version300beta}", "RegistrationsBaseUrl" };
         public static readonly string[] SearchAutocompleteService = { "SearchAutocompleteService" + Versioned, "SearchAutocompleteService" + Version300beta };
         public static readonly string[] ReportAbuse = { "ReportAbuseUriTemplate" + Versioned, "ReportAbuseUriTemplate" + Version300 };

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/SearchFilterFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/SearchFilterFormatterTests.cs
@@ -20,7 +20,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
             Assert.Equal(expectedResult.IncludeDelisted, actualResult.IncludeDelisted);
             Assert.Equal(expectedResult.IncludePrerelease, actualResult.IncludePrerelease);
             Assert.Equal(expectedResult.OrderBy, actualResult.OrderBy);
-            Assert.Equal(expectedResult.PackageTypes, actualResult.PackageTypes);
+            Assert.Equal(expectedResult.PackageType, actualResult.PackageType);
             Assert.Equal(expectedResult.SupportedFrameworks, actualResult.SupportedFrameworks);
         }
 
@@ -31,7 +31,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
                     {
                         IncludeDelisted = true,
                         OrderBy = SearchOrderBy.Id,
-                        PackageTypes = new List<string>() { "packageType1", "packageType2" },
+                        PackageType = "packageType",
                         SupportedFrameworks = new List<string>() { ".Net451", ".Net452" }
                     }
                 },

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalPackageSearchResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalPackageSearchResourceTests.cs
@@ -196,6 +196,87 @@ namespace NuGet.Protocol.Tests
         }
 
         [Fact]
+        public async Task LocalPackageSearchResource_MatchOnPackageTypeAsync()
+        {
+            using (var root = TestDirectory.Create())
+            {
+                // Arrange
+                var testLogger = new TestLogger();
+
+                var nuspec = XDocument.Parse($@"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <package>
+                        <metadata>
+                            <id>myPackage</id>
+                            <version>1.0.0-alpha.1.2+5</version>
+                            <description>package description</description>
+                            <tags>apple orange</tags>
+                            <packageTypes>
+                              <packageType name=""test"" />
+                            </packageTypes>
+                        </metadata>
+                        </package>");
+
+                var packageA = new SimpleTestPackageContext()
+                {
+                    Id = "myPackage",
+                    Version = "1.0.0-alpha.1.2+5",
+                    Nuspec = nuspec
+                };
+
+                var nuspec2 = XDocument.Parse($@"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <package>
+                        <metadata>
+                            <id>myOtherPackage</id>
+                            <version>1.0.0-alpha.1.3+5</version>
+                            <description>package description</description>
+                            <tags>grape</tags>
+                        </metadata>
+                        </package>");
+
+                var packageA2 = new SimpleTestPackageContext()
+                {
+                    Id = "myOtherPackage",
+                    Version = "1.0.0-alpha.1.3+5",
+                    Nuspec = nuspec2
+                };
+
+                var packageContexts = new SimpleTestPackageContext[]
+                {
+                    packageA,
+                    packageA2
+                };
+
+                await SimpleTestPackageUtility.CreatePackagesAsync(root, packageContexts);
+
+                var localResource = new FindLocalPackagesResourceV2(root);
+                var resource = new LocalPackageSearchResource(localResource);
+
+                var filter = new SearchFilter(includePrerelease: true)
+                {
+                    PackageTypes = new[] { "test" }
+                };
+
+                // Act
+                var packages = (await resource.SearchAsync(
+                        "",
+                        filter,
+                        skip: 0,
+                        take: 30,
+                        log: testLogger,
+                        token: CancellationToken.None))
+                        .OrderBy(p => p.Identity.Id)
+                        .ToList();
+
+                var package = packages.First();
+
+                // Assert
+                Assert.Equal(1, packages.Count);
+                Assert.Equal("myPackage", package.Identity.Id);
+                Assert.Equal("1.0.0-alpha.1.2+5", package.Identity.Version.ToFullString());
+            }
+        }
+
+        [Fact]
         public async Task LocalPackageSearchResource_MatchOnDescriptionAsync()
         {
             using (var root = TestDirectory.Create())

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalPackageSearchResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalPackageSearchResourceTests.cs
@@ -253,7 +253,7 @@ namespace NuGet.Protocol.Tests
 
                 var filter = new SearchFilter(includePrerelease: true)
                 {
-                    PackageTypes = new[] { "test" }
+                    PackageType = "test"
                 };
 
                 // Act

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV3Tests.cs
@@ -111,6 +111,44 @@ namespace NuGet.Protocol.Tests
             package.Vulnerabilities.Should().BeEmpty();
         }
 
+
+        [Fact]
+        public async Task PackageSearchResourceV3_SearchPackageType()
+        {
+            // Arrange
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
+
+            var responses = new Dictionary<string, string>();
+            responses.Add(
+                serviceAddress + "?q=package&skip=0&take=1&prerelease=false&packageType=test&semVerLevel=2.0.0",
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.V3Search.json", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
+
+            var packageSearchResourceV3 = new PackageSearchResourceV3(httpSource, new Uri[] { new Uri(serviceAddress) });
+
+            var searchFilter = new SearchFilter(includePrerelease: false)
+            {
+                PackageTypes = new[] { "test" }
+            };
+
+            // Act
+            var packages = await packageSearchResourceV3.Search(
+                        "package",
+                        searchFilter,
+                        skip: 0,
+                        take: 1,
+                        NullLogger.Instance,
+                        CancellationToken.None);
+
+            var packagesArray = packages.ToArray();
+
+            // Assert
+            // Verify that the url matches the one in the response dictionary
+            Assert.True(packagesArray.Length > 0);
+        }
+
         [Fact]
         public async Task PackageSearchResourceV3_UsesReferenceCache()
         {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV3Tests.cs
@@ -130,7 +130,7 @@ namespace NuGet.Protocol.Tests
 
             var searchFilter = new SearchFilter(includePrerelease: false)
             {
-                PackageTypes = new[] { "test" }
+                PackageType = "test"
             };
 
             // Act


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/8915

## Description

nuget.org allows filtering by package type using the `packageType` query parameter since [`SearchQueryService/3.5.0`](https://learn.microsoft.com/en-us/nuget/api/search-query-service-resource#searchqueryservice350). This parameter has not been officially surfaced by the client API, although relevant infrastructure has already been introduced in the `SearchFilter` class:

https://github.com/NuGet/NuGet.Client/blob/c8d14f3c28e3af3bdc3dcd38b23a212a91d13234/src/NuGet.Core/NuGet.Protocol/SearchFilter.cs#L60

Upon inspection of relevant source code, it looks like the relevant bits had already been introduced in `PackageSearchResourceV3` but using the old query parameter name `packageTypeFilter`. The fix is simply replacing the below query parameter with `packageType`:

https://github.com/NuGet/NuGet.Client/blob/c8d14f3c28e3af3bdc3dcd38b23a212a91d13234/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs#L140-L147

For completeness, we also add package type filtering functionality to `LocalPackageSearchResource` by filtering over the package types available through `package.Nuspec.GetPackageTypes()`.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
