### PR TITLE
Add a note in the PR template reminding to follow NuGet guidelines 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,3 +14,10 @@ Fixes:
 - [ ] Meaningful title, helpful description and a linked NuGet/Home issue
 - [ ] Added tests
 - [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
+
+<!--
+Note please make sure you follow the following guidlines.
+https://github.com/NuGet/NuGet.Client/blob/dev/docs/feature-guide.md
+https://github.com/NuGet/NuGet.Client/blob/dev/docs/coding-guidelines.md
+https://github.com/NuGet/NuGet.Client/blob/dev/docs/localizability.md
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ Fixes:
 - [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
 
 <!--
-Note please make sure you follow the following guidelines.
+Note: please make sure you follow the following guidelines.
 https://github.com/NuGet/NuGet.Client/blob/dev/docs/feature-guide.md
 https://github.com/NuGet/NuGet.Client/blob/dev/docs/coding-guidelines.md
 https://github.com/NuGet/NuGet.Client/blob/dev/docs/localizability.md

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ Fixes:
 - [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
 
 <!--
-Note please make sure you follow the following guidlines.
+Note please make sure you follow the following guidelines.
 https://github.com/NuGet/NuGet.Client/blob/dev/docs/feature-guide.md
 https://github.com/NuGet/NuGet.Client/blob/dev/docs/coding-guidelines.md
 https://github.com/NuGet/NuGet.Client/blob/dev/docs/localizability.md


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
This PR tries to make sure our guidelines are more visible by adding them to the PR template. I added the guidelines as a note in a comment section of the template. However, we could also have them as checklists as proposed in my comment. This will make sure the owner of the PR at least is aware of the guidelines.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
