### PR TITLE
Log inner exception for caught FatalProtocolExcetions in SourceRepositoryDependencyProvider

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -682,13 +682,8 @@ namespace NuGet.Commands
                 else
                 {
                     await logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1301, e.Message, id));
-                    Exception exception = e as Exception;
 
-                    while (exception.InnerException != null)
-                    {
-                        await logger.LogAsync(level: LogLevel.Verbose, e.InnerException.Message);
-                        exception = exception.InnerException;
-                    }
+                    logger.Log(LogLevel.Verbose, ExceptionUtilities.DisplayMessage(e));
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -682,9 +682,11 @@ namespace NuGet.Commands
                 {
                     await logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1301, e.Message, id));
 
-                    if (e.InnerException != null)
+                    while (e.InnerException != null)
                     {
                         await logger.LogAsync(level: LogLevel.Error, e.InnerException.Message);
+
+                        e = e.InnerException;
                     }
                 }
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -672,6 +672,8 @@ namespace NuGet.Commands
         {
             if (!_ignoreWarning)
             {
+                // Sometimes, there's a better root cause for a source failures we log that instead of NU1301.
+                // We only do this for errors, and not warnings.
                 var unwrappedLogMessage = UnwrapToLogMessage(e);
                 if (unwrappedLogMessage != null)
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -681,9 +681,7 @@ namespace NuGet.Commands
                 }
                 else
                 {
-                    await logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1301, e.Message, id));
-
-                    logger.Log(LogLevel.Verbose, ExceptionUtilities.DisplayMessage(e));
+                    await logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1301, ExceptionUtilities.DisplayMessage(e), id));
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -672,29 +672,21 @@ namespace NuGet.Commands
         {
             if (!_ignoreWarning)
             {
-                // Sometimes, there's a better root cause for a source failures we log that instead of NU1301.
-                // We only do this for errors, and not warnings.
-                var unwrappedLogMessage = UnwrapToLogMessage(e);
-                if (unwrappedLogMessage != null)
+                var unWrapped = ExceptionUtilities.Unwrap(e) as ILogMessageException;
+
+                if (unWrapped != null)
                 {
-                    await logger.LogAsync(unwrappedLogMessage);
+                    ExceptionUtilities.LogException(e, logger);
                 }
                 else
                 {
                     await logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1301, e.Message, id));
-                }
-            }
 
-            static ILogMessage UnwrapToLogMessage(Exception e)
-            {
-                var currentException = ExceptionUtilities.Unwrap(e);
-                while ((currentException is FatalProtocolException || currentException is not ILogMessageException) && currentException != null)
-                {
-                    currentException = currentException.InnerException;
+                    if (e.InnerException != null)
+                    {
+                        await logger.LogAsync(level: LogLevel.Error, e.InnerException.Message);
+                    }
                 }
-                var logMessageException = currentException as ILogMessageException;
-
-                return logMessageException?.AsLogMessage();
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -681,12 +681,12 @@ namespace NuGet.Commands
                 else
                 {
                     await logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1301, e.Message, id));
+                    Exception exception = e as Exception;
 
-                    while (e.InnerException != null)
+                    while (exception.InnerException != null)
                     {
                         await logger.LogAsync(level: LogLevel.Error, e.InnerException.Message);
-
-                        e = e.InnerException;
+                        exception = exception.InnerException;
                     }
                 }
             }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/12530

## Description

Makes sure inner exception is logged whene we have a FatalProtocolException. 

If a source that does not respond is added, currently, here is what our logged error messages look like
> error NU1301: Unable to load the service index for source https://api.nuget.org/v3/indexss.json.

After this PR here is what the error would be

> NU1301: Unable to load the service index for source https://api.nuget.org/v3/indexss.json.
>Response status code does not indicate success: 404 (The specified resource does not exist.).

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
