### PR TITLE
First step to fetch transitive packages in Solution PM UI package list and installed tab vulnerability warning

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1026,24 +1026,16 @@ namespace NuGet.PackageManagement.UI
             int deprecatedPackagesCount = 0;
             PackageCollection installedPackageCollection = null;
 
-            // Transitive dependencies are only displayed in Project-level PM UI.
-            if (Model.IsSolution)
-            {
-                installedPackageCollection = await loadContext.GetInstalledPackagesAsync();
-            }
-            else
-            {
-                IInstalledAndTransitivePackages installedAndTransitivePackages = await PackageCollection.GetInstalledAndTransitivePackagesAsync(loadContext.ServiceBroker, loadContext.Projects, includeTransitiveOrigins: true, token);
-                installedPackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.InstalledPackages);
-                PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.TransitivePackages.Where(p => p.TransitiveOrigins.Any()));
-                IEnumerable<PackageVulnerabilityMetadataContextInfo>[] transitivePackageVulnerabilities = await Task.WhenAll(transitivePackageCollection.Select(p => _packageVulnerabilityService.GetVulnerabilityInfoAsync(p, token)));
+            IInstalledAndTransitivePackages installedAndTransitivePackages = await PackageCollection.GetInstalledAndTransitivePackagesAsync(loadContext.ServiceBroker, loadContext.Projects, includeTransitiveOrigins: true, token);
+            installedPackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.InstalledPackages);
+            PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.TransitivePackages.Where(p => p.TransitiveOrigins.Any()));
+            IEnumerable<PackageVulnerabilityMetadataContextInfo>[] transitivePackageVulnerabilities = await Task.WhenAll(transitivePackageCollection.Select(p => _packageVulnerabilityService.GetVulnerabilityInfoAsync(p, token)));
 
-                foreach (IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfo in transitivePackageVulnerabilities)
+            foreach (IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfo in transitivePackageVulnerabilities)
+            {
+                if (vulnerabilityInfo != null && vulnerabilityInfo.Any())
                 {
-                    if (vulnerabilityInfo != null && vulnerabilityInfo.Any())
-                    {
-                        vulnerablePackagesCount++;
-                    }
+                    vulnerablePackagesCount++;
                 }
             }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
@@ -440,22 +440,12 @@ namespace NuGet.PackageManagement.VisualStudio
 
             if (itemFilter == ItemFilter.Installed)
             {
-                if (isSolution)
-                {
-                    // Installed Tab, Solution View: only needs installed packages.
-                    IReadOnlyCollection<IPackageReferenceContextInfo> installedSolutionTabPackages = await GetAllInstalledPackagesAsync(projectContextInfos, cancellationToken);
-                    PackageCollection installedPackageCollection = PackageCollection.FromPackageReferences(installedSolutionTabPackages);
-                    packageFeeds.mainFeed = new InstalledPackageFeed(installedPackageCollection, metadataProvider);
-                }
-                else // is Project
-                {
-                    // Installed Tab, Project View, Experiment On: needs installed, transitive packages and transitive origins data
-                    IInstalledAndTransitivePackages installedTabWithTransitiveOrigins = await PackageCollection.GetInstalledAndTransitivePackagesAsync(_serviceBroker, projectContextInfos, includeTransitiveOrigins: true, cancellationToken);
-                    PackageCollection installedPackageCollection = PackageCollection.FromPackageReferences(installedTabWithTransitiveOrigins.InstalledPackages);
-                    PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedTabWithTransitiveOrigins.TransitivePackages);
+                // Installed Tab: needs installed, transitive packages and transitive origins data
+                IInstalledAndTransitivePackages installedTabWithTransitiveOrigins = await PackageCollection.GetInstalledAndTransitivePackagesAsync(_serviceBroker, projectContextInfos, includeTransitiveOrigins: true, cancellationToken);
+                PackageCollection installedPackageCollection = PackageCollection.FromPackageReferences(installedTabWithTransitiveOrigins.InstalledPackages);
+                PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedTabWithTransitiveOrigins.TransitivePackages);
 
-                    packageFeeds.mainFeed = new InstalledAndTransitivePackageFeed(installedPackageCollection, transitivePackageCollection, metadataProvider);
-                }
+                packageFeeds.mainFeed = new InstalledAndTransitivePackageFeed(installedPackageCollection, transitivePackageCollection, metadataProvider);
 
                 return packageFeeds;
             }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
@@ -379,7 +379,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         [Theory]
         [InlineData(ItemFilter.All, true, typeof(MultiSourcePackageFeed))]
         [InlineData(ItemFilter.All, false, typeof(MultiSourcePackageFeed))]
-        [InlineData(ItemFilter.Installed, true, typeof(InstalledPackageFeed))]
+        [InlineData(ItemFilter.Installed, true, typeof(InstalledAndTransitivePackageFeed))]
         [InlineData(ItemFilter.Installed, false, typeof(InstalledAndTransitivePackageFeed))]
         [InlineData(ItemFilter.UpdatesAvailable, true, typeof(UpdatePackageFeed))]
         [InlineData(ItemFilter.UpdatesAvailable, false, typeof(UpdatePackageFeed))]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13695

## Description
This change enables the Solution-level PM UI to fetch transitive packages for showing in the packages list, and for determining if there are vulnerable packages in the Installed tab indicator. The Solution PM UI will no longer behave differently than the Project-level PM UI in that regard. There is still more work to be done to represent the package items and show vulnerability indicators in the package list which will come in related PRs for the feature.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests - Updated existing test to reflect changes
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
