### PR TITLE
Telemetry for navigating to an Owner Profile link

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/AuthorAndDownloadCount.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/AuthorAndDownloadCount.xaml
@@ -4,6 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:nuget="clr-namespace:NuGet.PackageManagement.UI"
+             xmlns:nugettel="clr-namespace:NuGet.PackageManagement.Telemetry;assembly=NuGet.PackageManagement.VisualStudio"
              mc:Ignorable="d"
              x:Name="_self"
              d:DesignHeight="300" d:DesignWidth="300">
@@ -40,7 +41,8 @@
               NavigateUri="{Binding Link, Mode=OneWay}"
               ToolTip="{Binding Link, Mode=OneWay}"
               Style="{StaticResource HyperlinkSelectorAware}"
-              Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}">
+              Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
+              CommandParameter="{x:Static nugettel:HyperlinkType.OwnerProfile}">
               <Run Text="{Binding Name, Mode=OneTime}" />
             </Hyperlink><TextBlock Margin="0,0,2,0" Text=",">
               <TextBlock.Visibility>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -5,6 +5,7 @@
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   xmlns:nuget="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns:nugettel="clr-namespace:NuGet.PackageManagement.Telemetry;assembly=NuGet.PackageManagement.VisualStudio"
   xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
   xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
   xmlns:glob="clr-namespace:System.Globalization;assembly=mscorlib"
@@ -177,7 +178,8 @@
                 ToolTip="{Binding Link, Mode=OneWay}"
                 Style="{StaticResource HyperlinkStyle}"
                 AutomationProperties.Name="{x:Static nuget:Resources.Hyperlink_Owner}"
-                Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}">
+                Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
+                CommandParameter="{x:Static nugettel:HyperlinkType.OwnerProfileDetailsPane}">
                 <Run Text="{Binding Name, Mode=OneTime}" />
               </Hyperlink><TextBlock Margin="0,0,2,0" Text=",">
                 <TextBlock.Visibility>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/HyperlinkType.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/HyperlinkType.cs
@@ -15,6 +15,8 @@ namespace NuGet.PackageManagement.Telemetry
         DeprecationAlternativeDetails,
         DeprecationAlternativePackageItem,
         VulnerabilityAdvisory,
-        OptionsBlocked
+        OptionsBlocked,
+        OwnerProfile,
+        OwnerProfileDetailsPane
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/13738

## Description

Creates 2 distinct types for Owner Profile links: One for Packages List and one for Details Pane.
I wanted to separate these so we can tell whether customers use one links from location more than the other.

The standard `navigated` event is reused here which is the event I migrated other hyperlink events onto previously.
Since the event is standardized and already doesn't include PII, no assessment was done to attach another event.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests - N/A manually tested by monitoring emitted telemetry
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
