### PR TITLE
Add extension point to import msbuild logic after Directory.Packages.props is imported

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.props
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.props
@@ -38,4 +38,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CentralPackageVersionsFileImported>true</CentralPackageVersionsFileImported>
   </PropertyGroup>
 
+  <!-- Extension point after Directory.Packages.props is imported. -->
+  <Import Project="$(CustomAfterDirectoryPackagesProps)" Condition="'$(CentralPackageVersionsFileImported)' == 'true' and '$(CustomAfterDirectoryPackagesProps)' != ''" />
+
 </Project>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13743
Contributes to https://github.com/dotnet/dotnet/issues/1047

## Description
Define an msbuild extension point to be able to import msbuild logic directly after the Directory.Packages.props file gets imported.

This mimics the extension point that already exists for Directory.Packages.props: https://github.com/dotnet/msbuild/blob/07a6d0d9cd3515987587b34dd8171c5c7372dcd9/src/Tasks/Microsoft.Common.props#L36

This is useful as source-build updates the Version metadata on the PackageVersion items to lift dependencies to a live built version.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
