### PR TITLE
Telemetry for navigating to: License, ReportAbuse, Readme, ProjectUrl

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -5,6 +5,7 @@
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   xmlns:nuget="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns:nugettel="clr-namespace:NuGet.PackageManagement.Telemetry;assembly=NuGet.PackageManagement.VisualStudio"
   xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
   xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
   xmlns:glob="clr-namespace:System.Globalization;assembly=mscorlib"
@@ -24,6 +25,7 @@
                 <Hyperlink
                     Style="{StaticResource HyperlinkStyle}"
                     Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
+                    CommandParameter="{x:Static nugettel:HyperlinkType.License}"
                     ToolTip="{Binding Link}"
                     NavigateUri="{Binding Link}"
                     AutomationProperties.Name="{x:Static nuget:Resources.Label_License}">
@@ -252,6 +254,7 @@
           NavigateUri="{Binding Path=ReadmeUrl}"
           Style="{StaticResource HyperlinkStyle}"
           Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
+          CommandParameter="{x:Static nugettel:HyperlinkType.Readme}"
           ToolTip="{Binding RelativeSource={RelativeSource Self}, Path=NavigateUri}"
           AutomationProperties.Name="{x:Static nuget:Resources.Hyperlink_Readme}">
           <Run Text="{x:Static nuget:Resources.Text_ViewReadme}" />
@@ -318,6 +321,7 @@
           NavigateUri="{Binding Path=ProjectUrl}"
           Style="{StaticResource HyperlinkStyle}"
           Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
+          CommandParameter="{x:Static nugettel:HyperlinkType.ProjectUri}"
           AutomationProperties.Name="{x:Static nuget:Resources.Hyperlink_ProjectUrl}">
           <Run Text="{Binding Path=ProjectUrl}" />
         </Hyperlink>
@@ -343,6 +347,7 @@
           NavigateUri="{Binding Path=ReportAbuseUrl}"
           Style="{StaticResource HyperlinkStyle}"
           Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
+          CommandParameter="{x:Static nugettel:HyperlinkType.ReportAbuse}"
           AutomationProperties.Name="{x:Static nuget:Resources.Hyperlink_ReportAbuse}">
           <Run Text="{Binding Path=ReportAbuseUrl}" />
         </Hyperlink>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/HyperlinkType.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/HyperlinkType.cs
@@ -9,7 +9,6 @@ namespace NuGet.PackageManagement.Telemetry
         License,
         ProjectUri,
         ReportAbuse,
-        FeedHome,
         Readme,
         DeprecationMoreInfo,
         DeprecationAlternativeDetails,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13749

## Description

Hooks up the `navigated` telemetry event for existing hyperlinks: License, ReportAbuse, Readme, ProjectUrl.

The standard `navigated` event is reused here which is the event I migrated other hyperlink events onto previously.
Since the event is standardized and already doesn't include PII, no assessment was done to attach another event.

Removed FeedHome as I don't know what this is and couldn't find any reference using it.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests - N/A manually tested by monitoring emitted telemetry
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
