### PR TITLE
Enable GenerateDocumentationFile

### DIFF
--- a/build/Shared/TaskResultCache.cs
+++ b/build/Shared/TaskResultCache.cs
@@ -29,7 +29,7 @@ namespace NuGet
         private readonly ConcurrentDictionary<TKey, object> _perTaskLock;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ResultCache{TKey, TValue}" /> class with the specified key comparer.
+        /// Initializes a new instance of the <see cref="TaskResultCache{TKey, TValue}" /> class with the specified key comparer.
         /// </summary>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}" /> to use when comparing keys.</param>
         public TaskResultCache(IEqualityComparer<TKey> comparer)
@@ -39,7 +39,7 @@ namespace NuGet
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ResultCache{TKey, TValue}" /> class.
+        /// Initializes a new instance of the <see cref="TaskResultCache{TKey, TValue}" /> class.
         /// </summary>
         public TaskResultCache()
         {

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -135,6 +135,12 @@
     <VsixPublishDestination>$(ArtifactRoot)$(VsixOutputDirName)\</VsixPublishDestination>
   </PropertyGroup>
 
+  <!-- Write out .XML files for projects that will be packed. -->
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <DocumentationFile Condition=" '$(DocumentationFile)' == '' AND '$(IsNetCoreProject)' != 'true' ">$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
+  </PropertyGroup>
+
   <!-- Set the output location for all non-test projects -->
   <!-- Test projects currently fail when the output dir is moved -->
   <PropertyGroup Condition=" '$(TestProject)' != 'true' OR '$(Shipping)' == 'true'">

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -135,7 +135,7 @@
     <VsixPublishDestination>$(ArtifactRoot)$(VsixOutputDirName)\</VsixPublishDestination>
   </PropertyGroup>
 
-  <!-- Write out .XML files for projects that will be packed. -->
+  <!-- Write out .XML files for projects all projects, required to enforce IDE0005 on build. -->
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile Condition=" '$(DocumentationFile)' == '' AND '$(IsNetCoreProject)' != 'true' ">$(OutputPath)\$(AssemblyName).xml</DocumentationFile>

--- a/build/common.targets
+++ b/build/common.targets
@@ -29,13 +29,7 @@
     <SymbolTargetsToGetPdbs Condition="'$(SymbolTargetsToGetPdbs)' == ''">GetDebugSymbolsProjectOutput</SymbolTargetsToGetPdbs>
     <LocTargets>GetBuildOutputWithLocMetadata</LocTargets>
   </PropertyGroup>
-
-  <!-- Write out .XML files for projects that will be packed. -->
-  <PropertyGroup Condition=" '$(PackProject)' == 'true' ">
-    <GenerateDocumentationFile Condition=" '$(GenerateDocumentationFile)' == '' ">true</GenerateDocumentationFile>
-    <DocumentationFile Condition=" '$(DocumentationFile)' == '' AND '$(GenerateDocumentationFile)' == 'true' AND '$(IsNetCoreProject)' != 'true' ">$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
-  </PropertyGroup>
-
+  
   <ImportGroup Condition=" '$(PackProject)' == 'true' AND '$(NuGetBuildTasksPackTargets)' != '' ">
       <Import Project="$(NuGetBuildTasksPackTargets)" />
   </ImportGroup>
@@ -43,6 +37,10 @@
   <!-- Readme file in shipping packages -->
   <PropertyGroup Condition=" '$(PackProject)' == 'true' ">
     <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(PackProject)' != 'true' ">
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CS0419;CS1570;CS1572;CS1573;CS1574;CS1584;CS1587;CS1591</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(PackProject)' == 'true' ">

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetProjectManagerService.cs
@@ -18,7 +18,6 @@ using NuGet.Frameworks;
 using NuGet.PackageManagement.Telemetry;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
-using NuGet.Packaging.Signing;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.Protocol.Core.Types;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Experimentation/ExperimentationConstants.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Experimentation/ExperimentationConstants.cs
@@ -20,7 +20,7 @@ namespace NuGet.VisualStudio
 
         /// <summary>
         /// The environment variable means of enabled this feature.
-        /// Might be <see cref="null"/>.
+        /// Might be <c>null</c>.
         /// </summary>
         internal string FlightEnvironmentVariable { get; }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
@@ -98,7 +98,7 @@ namespace NuGet.PackageManagement.VisualStudio
         IReadOnlyList<object> GetAllProjectRestoreInfoSources();
 
         /// <summary>
-        /// Gets the current open solution directory. <see cref="null"/> if the there's no open solution.
+        /// Gets the current open solution directory. <c>null</c> if the there's no open solution.
         /// </summary>
         Task<string> GetSolutionDirectoryAsync();
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs
@@ -190,7 +190,7 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// Gets all the hierarchies of all the NuGet compatible projects
         /// </summary>
-        /// <param name="vsSolution">The VS Solution instance. Must not be <see cref="null"/>. </param>
+        /// <param name="vsSolution">The VS Solution instance. Must not be <c>null</c>. </param>
         /// <returns>Hierarchies of the NuGet compatible projects</returns>
         /// <remarks>This method assumes the solution is open.</remarks>
         public static List<IVsHierarchy> GetAllLoadedProjects(IVsSolution vsSolution)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
@@ -70,7 +70,7 @@ namespace NuGet.VisualStudio
         /// </summary>
         /// <param name="itemName">The item name.</param>
         /// <param name="metadataNames">The metadata names to read.</param>
-        /// <returns>An <see cref="IEnumerable{(string ItemId, string[] ItemMetadata)}"/> containing the itemId and the metadata values.</returns>
+        /// <returns>An <see cref="IEnumerable{T}"/> containing the itemId and the metadata values.</returns>
         IEnumerable<(string ItemId, string[] ItemMetadata)> GetBuildItemInformation(string itemName, params string[] metadataNames);
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagConstants.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/NuGetFeatureFlagConstants.cs
@@ -21,7 +21,7 @@ namespace NuGet.VisualStudio
 
         /// <summary>
         /// The environment variable used to override the enabled or disabled state of this feature.
-        /// Might be <see cref="null"/>.
+        /// Might be <c>null</c>.
         /// </summary>
         internal string EnvironmentVariable { get; }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio/SolutionRestoreManager/IVsSolutionRestoreService5.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/SolutionRestoreManager/IVsSolutionRestoreService5.cs
@@ -3,12 +3,15 @@
 
 #nullable enable
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace NuGet.SolutionRestoreManager
 {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public interface IVsSolutionRestoreService5 : IVsSolutionRestoreService4
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     {
         /// <summary>
         /// An entry point used by CPS to indicate given project needs to be restored.

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
@@ -2,12 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using Microsoft.Build.Framework;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Packaging;
 using ILogger = NuGet.Common.ILogger;
+
+#if DEBUG
+using System.Diagnostics;
+#endif
 
 namespace NuGet.Build.Tasks.Pack
 {

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -738,7 +738,7 @@ namespace NuGet.Build.Tasks
         /// <summary>
         /// Gets the path to a packages.config for the specified project if one exists.
         /// </summary>
-        /// <param name="projectFullPath">The full path to the project directory.</param>
+        /// <param name="projectDirectory">The full path to the project directory.</param>
         /// <param name="projectName">The name of the project file.</param>
         /// <returns>The path to the packages.config file if one exists, otherwise <see langword="null" />.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="projectDirectory" /> -or- <paramref name="projectName" /> is <see langword="null" />.</exception>

--- a/src/NuGet.Core/NuGet.Build.Tasks/ConsoleOutLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/ConsoleOutLogMessage.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Build.Framework;
 using Newtonsoft.Json;
 
 namespace NuGet.Build.Tasks

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
@@ -4,11 +4,14 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NuGet.Common;
 using NuGet.Frameworks;
+
+#if NETFRAMEWORK || NETSTANDARD
+using System.Linq;
+#endif
 
 namespace NuGet.Build.Tasks
 {

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -13,6 +12,10 @@ using Microsoft.Build.Utilities;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.ProjectModel;
+
+#if DEBUG
+using System.Diagnostics;
+#endif
 
 namespace NuGet.Build.Tasks
 {

--- a/src/NuGet.Core/NuGet.Build.Tasks/WriteRestoreGraphTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/WriteRestoreGraphTask.cs
@@ -1,13 +1,16 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Newtonsoft.Json;
 using NuGet.Commands;
+
+#if DEBUG
+using System;
+using System.Diagnostics;
+#endif
 
 namespace NuGet.Build.Tasks
 {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -514,8 +514,7 @@ namespace NuGet.CommandLine.XPlat
         /// </summary>
         /// <param name="package">The package to get the latest version for</param>
         /// <param name="listPackageArgs">List args for the token and source provider></param>
-        /// <param name="packagesVersionsDict">A reference to the unique packages in the project
-        /// to be able to handle different sources having different latest versions</param>
+        /// <param name="cancellationToken"></param>
         /// <returns>A list of tasks for all latest versions for packages from all sources</returns>
         private async Task<KeyValuePair<string, List<IPackageSearchMetadata>>> GetPackageVersionsAsync(
             string package,
@@ -573,8 +572,7 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="packageSource">The source to look for packages at</param>
         /// <param name="listPackageArgs">The list args for the cancellation token</param>
         /// <param name="package">Package to look for updates for</param>
-        /// <param name="packagesVersionsDict">A reference to the unique packages in the project
-        /// to be able to handle different sources having different latest versions</param>
+        /// <param name="cancellationToken"></param>
         /// <returns>An updated package with the highest version at a single source</returns>
         private async Task<IEnumerable<IPackageSearchMetadata>> GetLatestVersionPerSourceAsync(
             PackageSource packageSource,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/IPackageSearchResultRenderer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/IPackageSearchResultRenderer.cs
@@ -26,7 +26,7 @@ namespace NuGet.CommandLine.XPlat
         /// Adds a message for a source, if search is unsuccessful.
         /// </summary>
         /// <param name="source">The source</param>
-        /// <param name="error">The error message to be rendered</param>
+        /// <param name="packageSearchProblem"></param>
         /// <returns></returns>
         void Add(PackageSource source, PackageSearchProblem packageSearchProblem);
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultTableRenderer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultTableRenderer.cs
@@ -68,6 +68,7 @@ namespace NuGet.CommandLine.XPlat
         /// </summary>
         /// <param name="results">An enumerable of package search metadata to be processed and added to the table.</param>
         /// <param name="table">The table where the results will be added as rows.</param>
+        /// <param name="verbosity">The verbosity level for the search results.</param>
         private static async void PopulateTableWithResultsAsync(IEnumerable<IPackageSearchMetadata> results, Table table, PackageSearchVerbosity verbosity)
         {
             CultureInfo culture = CultureInfo.CurrentCulture;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchRunner.cs
@@ -22,6 +22,7 @@ namespace NuGet.CommandLine.XPlat
         /// </summary>
         /// <param name="sourceProvider">The provider for package sources.</param>
         /// <param name="packageSearchArgs">Package search arguments</param>
+        /// <param name="cancellationToken"></param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         public static async Task<int> RunAsync(
             IPackageSourceProvider sourceProvider,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/DependencyGraphPrinter.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/DependencyGraphPrinter.cs
@@ -26,6 +26,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         /// </summary>
         /// <param name="dependencyGraphPerFramework">A dictionary mapping target frameworks to their dependency graphs.</param>
         /// <param name="targetPackage">The package we want the dependency paths for.</param>
+        /// <param name="logger"></param>
         public static void PrintAllDependencyGraphs(Dictionary<string, List<DependencyNode>?> dependencyGraphPerFramework, string targetPackage, ILoggerWithColor logger)
         {
             // print empty line
@@ -49,6 +50,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         /// <param name="frameworks">The list of frameworks that share this dependency graph.</param>
         /// <param name="topLevelNodes">The top-level package nodes of the dependency graph.</param>
         /// <param name="targetPackage">The package we want the dependency paths for.</param>
+        /// <param name="logger"></param>
         private static void PrintDependencyGraphPerFramework(List<string> frameworks, List<DependencyNode>? topLevelNodes, string targetPackage, ILoggerWithColor logger)
         {
             // print framework header

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommandRunner.cs
@@ -232,7 +232,8 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         /// <summary>
         /// Returns the path to an assets file for the given project.
         /// </summary>
-        /// <param name="project">Evaluated MSBuild project</param>
+        /// <param name="assetsFilePath"></param>
+        /// <param name="projectPath"></param>
         /// <param name="logger">Logger for the 'why' command</param>
         /// <returns>Assets file for the given project. Returns null if there was any issue finding or parsing the assets file.</returns>
         private static LockFile? GetProjectAssetsFile(string assetsFilePath, string? projectPath, ILoggerWithColor logger)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/AddPackageCommandUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/AddPackageCommandUtility.cs
@@ -23,6 +23,7 @@ namespace NuGet.CommandLine.XPlat.Utility
         /// <param name="logger">Logger</param>
         /// <param name="packageId">Package to look for</param>
         /// <param name="prerelease">Whether to include prerelease versions</param>
+        /// <param name="cancellationToken"></param>
         /// <returns>Return the latest version available from multiple sources and if no version is found returns null.</returns>
 
         public static async Task<NuGetVersion> GetLatestVersionFromSourcesAsync(IList<PackageSource> sources, ILogger logger, string packageId, bool prerelease, CancellationToken cancellationToken)
@@ -63,6 +64,7 @@ namespace NuGet.CommandLine.XPlat.Utility
         /// <param name="logger">Logger</param>
         /// <param name="packageId">Package to look for</param>
         /// <param name="prerelease">Whether to include prerelease versions</param>
+        /// <param name="cancellationToken"></param>
         /// <returns>Returns the latest version available from a source or a null if non is found.</returns>
         public static async Task<NuGetVersion> GetLatestVersionFromSourceAsync(PackageSource source, ILogger logger, string packageId, bool prerelease, CancellationToken cancellationToken)
         {

--- a/src/NuGet.Core/NuGet.Commands/Internal/HashCodeCombiner.cs
+++ b/src/NuGet.Core/NuGet.Commands/Internal/HashCodeCombiner.cs
@@ -1,10 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+
+#if !NETFRAMEWORK && !NETSTANDARD
+using System;
+#endif
 
 namespace Microsoft.Extensions.Internal
 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -511,7 +511,6 @@ namespace NuGet.Commands
         /// </summary>
         /// <param name="targetGraph">The <see cref="RestoreTargetGraph" /> to get centrally defined transitive dependencies for.</param>
         /// <param name="targetFrameworkInformation">The <see cref="TargetFrameworkInformation" /> for the target framework to get centrally defined transitive dependencies for.</param>
-        /// <param name="centralPackageTransitivePinningEnabled">A value indicating whether or not central transitive dependency version pinning is enabled.</param>
         /// <returns>An <see cref="IEnumerable{LibraryDependency}" /> representing the centrally defined transitive dependencies for the specified <see cref="RestoreTargetGraph" />.</returns>
         private IEnumerable<LibraryDependency> GetLibraryDependenciesForCentralTransitiveDependencies(RestoreTargetGraph targetGraph, TargetFrameworkInformation targetFrameworkInformation)
         {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -1124,7 +1124,7 @@ namespace NuGet.Commands
         /// </summary>
         /// <param name="projectSpecItem">The <see cref="IMSBuildItem" /> to get the central package management settings from.</param>
         /// <param name="projectStyle">The <see cref="ProjectStyle?" /> of the specified project.  Specify <see langword="null" /> when the project does not define a restore style.</param>
-        /// <returns>A <see cref="Tuple{T1, T2, T3, T4}" /> containing values indicating whether or not central package management is enabled, if the ability to override a package version 
+        /// <returns>A <see cref="Tuple{T1, T2, T3, T4}" /> containing values indicating whether or not central package management is enabled, if the ability to override a package version </returns>
         public static (bool IsEnabled, bool IsVersionOverrideDisabled, bool IsCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled) GetCentralPackageManagementSettings(IMSBuildItem projectSpecItem, ProjectStyle projectStyle)
         {
             if (projectStyle == ProjectStyle.PackageReference)

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/IPasswordProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/IPasswordProvider.cs
@@ -1,9 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if IS_DESKTOP
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
+#endif
 
 namespace NuGet.Commands.SignCommand
 {

--- a/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/TrustedSignersCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/TrustedSignersCommandRunner.cs
@@ -10,10 +10,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Configuration;
-using NuGet.Packaging;
 using NuGet.Packaging.Signing;
-using NuGet.Protocol;
 using static NuGet.Commands.TrustedSignersArgs;
+
+#if IS_SIGNING_SUPPORTED
+using NuGet.Packaging;
+using NuGet.Protocol;
+#endif
 
 namespace NuGet.Commands
 {

--- a/src/NuGet.Core/NuGet.Common/CryptoHashUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/CryptoHashUtility.cs
@@ -4,8 +4,11 @@
 using System;
 using System.Globalization;
 using System.IO;
-using System.Reflection;
 using System.Security.Cryptography;
+
+#if !IS_CORECLR
+using System.Reflection;
+#endif
 
 namespace NuGet.Common
 {

--- a/src/NuGet.Core/NuGet.Common/NetworkProtocolUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/NetworkProtocolUtility.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if !IS_CORECLR
 using System.Net;
+#endif
 
 namespace NuGet.Common
 {

--- a/src/NuGet.Core/NuGet.Configuration/PackageSourceMapping/PackageSourceMappingProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSourceMapping/PackageSourceMappingProvider.cs
@@ -19,6 +19,7 @@ namespace NuGet.Configuration
         /// <summary>
         /// Supports the disabling of saving to disk for any <see cref="ISettings"/> changes.
         /// </summary>
+        /// <param name="settings">The settings to be used by the provider.</param>
         /// <param name="shouldSkipSave">True to avoid saving any changes to disk and only modify the <see cref="ISettings"/> in memory.
         /// Default is false.</param>
         public PackageSourceMappingProvider(ISettings settings, bool shouldSkipSave)

--- a/src/NuGet.Core/NuGet.Credentials/CredentialResponse.cs
+++ b/src/NuGet.Core/NuGet.Credentials/CredentialResponse.cs
@@ -5,7 +5,9 @@ using System.Net;
 
 namespace NuGet.Credentials
 {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public class CredentialResponse
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     {
         /// <summary>
         /// Creates a credential response object without giving credentials. This constructor is used only if the
@@ -39,7 +41,11 @@ namespace NuGet.Credentials
             Status = status;
         }
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public ICredentials Credentials { get; }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public CredentialStatus Status { get; }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     }
 }

--- a/src/NuGet.Core/NuGet.Credentials/CredentialService.cs
+++ b/src/NuGet.Core/NuGet.Credentials/CredentialService.cs
@@ -34,6 +34,9 @@ namespace NuGet.Credentials
         /// </summary>
         private static readonly Semaphore ProviderSemaphore = new Semaphore(1, 1);
 
+        /// <summary>
+        /// Gets a value indicating whether this credential service handles default credentials.
+        /// </summary>
         public bool HandlesDefaultCredentials { get; }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Credentials/CredentialStatus.cs
+++ b/src/NuGet.Core/NuGet.Credentials/CredentialStatus.cs
@@ -9,8 +9,19 @@ namespace NuGet.Credentials
     /// </summary>
     public enum CredentialStatus
     {
+        /// <summary>
+        /// Credentials were successfully acquired.
+        /// </summary>
         Success,
+
+        /// <summary>
+        /// The provider was not applicable for acquiring credentials.
+        /// </summary>
         ProviderNotApplicable,
+
+        /// <summary>
+        /// The user canceled the credential acquisition process.
+        /// </summary>
         UserCanceled
     }
 }

--- a/src/NuGet.Core/NuGet.Credentials/CredentialsConstants.cs
+++ b/src/NuGet.Core/NuGet.Credentials/CredentialsConstants.cs
@@ -3,12 +3,24 @@
 
 namespace NuGet.Credentials
 {
+    /// <summary>
+    /// Contains constants used for credential providers.
+    /// </summary>
     public static class CredentialsConstants
     {
+        /// <summary>
+        /// Default timeout in seconds for the credential provider.
+        /// </summary>
         public static readonly int ProviderTimeoutSecondsDefault = 300;
 
+        /// <summary>
+        /// Environment variable for the credential provider timeout in seconds.
+        /// </summary>
         public static readonly string ProviderTimeoutSecondsEnvar = "NUGET_CREDENTIAL_PROVIDER_TIMEOUT_SECONDS";
 
+        /// <summary>
+        /// Setting name for the credential provider timeout.
+        /// </summary>
         public static readonly string ProviderTimeoutSecondsSetting = "CredentialProvider.Timeout";
     }
 }

--- a/src/NuGet.Core/NuGet.Credentials/DefaultCredentialServiceUtility.cs
+++ b/src/NuGet.Core/NuGet.Credentials/DefaultCredentialServiceUtility.cs
@@ -12,7 +12,9 @@ using NuGet.Protocol.Plugins;
 
 namespace NuGet.Credentials
 {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public static class DefaultCredentialServiceUtility
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     {
         /// <summary>
         /// Sets-up the CredentialService and all of its providers.

--- a/src/NuGet.Core/NuGet.Credentials/ICredentialProvider.cs
+++ b/src/NuGet.Core/NuGet.Credentials/ICredentialProvider.cs
@@ -9,10 +9,27 @@ using NuGet.Configuration;
 
 namespace NuGet.Credentials
 {
+    /// <summary>
+    /// Interface for providing credentials.
+    /// </summary>
     public interface ICredentialProvider
     {
+        /// <summary>
+        /// Gets the identifier of the credential provider.
+        /// </summary>
         string Id { get; }
 
+        /// <summary>
+        /// Asynchronously gets the credentials.
+        /// </summary>
+        /// <param name="uri">The URI for which the credentials are requested.</param>
+        /// <param name="proxy">The proxy to use.</param>
+        /// <param name="type">The type of credential request.</param>
+        /// <param name="message">The message to display.</param>
+        /// <param name="isRetry">Indicates if this is a retry attempt.</param>
+        /// <param name="nonInteractive">Indicates if the request should be non-interactive.</param>
+        /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the credential response.</returns>
         Task<CredentialResponse> GetAsync(
             Uri uri,
             IWebProxy proxy,

--- a/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
@@ -244,7 +244,9 @@ namespace NuGet.Credentials
             }
         }
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public virtual int Execute(ProcessStartInfo startInfo, CancellationToken cancellationToken, out string stdOut)
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
         {
             var outBuffer = new StringBuilder();
 

--- a/src/NuGet.Core/NuGet.Credentials/PluginCredentialProviderBuilder.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PluginCredentialProviderBuilder.cs
@@ -20,6 +20,12 @@ namespace NuGet.Credentials
         private readonly IExtensionLocator _extensionLocator;
         private readonly Common.ILogger _logger;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PluginCredentialProviderBuilder"/> class.
+        /// </summary>
+        /// <param name="extensionLocator">The extension locator.</param>
+        /// <param name="settings">The settings.</param>
+        /// <param name="logger">The logger.</param>
         public PluginCredentialProviderBuilder(
             IExtensionLocator extensionLocator,
             Configuration.ISettings settings,
@@ -28,6 +34,13 @@ namespace NuGet.Credentials
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PluginCredentialProviderBuilder"/> class.
+        /// </summary>
+        /// <param name="extensionLocator">The extension locator.</param>
+        /// <param name="settings">The settings.</param>
+        /// <param name="logger">The logger.</param>
+        /// <param name="envarReader">The environment variable reader.</param>
         public PluginCredentialProviderBuilder(
             IExtensionLocator extensionLocator,
             Configuration.ISettings settings,

--- a/src/NuGet.Core/NuGet.Credentials/PluginCredentialRequest.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PluginCredentialRequest.cs
@@ -8,12 +8,24 @@ namespace NuGet.Credentials
     /// </summary>
     public class PluginCredentialRequest
     {
+        /// <summary>
+        /// Gets or sets the URI for the credential request.
+        /// </summary>
         public string Uri { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the request is non-interactive.
+        /// </summary>
         public bool NonInteractive { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the request is a retry.
+        /// </summary>
         public bool IsRetry { get; set; }
 
+        /// <summary>
+        /// Gets or sets the verbosity level for the request.
+        /// </summary>
         public string Verbosity { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Credentials/PluginCredentialRequest.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PluginCredentialRequest.cs
@@ -9,7 +9,7 @@ namespace NuGet.Credentials
     public class PluginCredentialRequest
     {
         /// <summary>
-        /// Gets or sets the URI for the credential request.
+        /// Gets or sets the package source URI for the credential request.
         /// </summary>
         public string Uri { get; set; }
 

--- a/src/NuGet.Core/NuGet.Credentials/PluginCredentialResponse.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PluginCredentialResponse.cs
@@ -12,10 +12,19 @@ namespace NuGet.Credentials
     /// </summary>
     public class PluginCredentialResponse
     {
+        /// <summary>
+        /// Gets or sets the username.
+        /// </summary>
         public string Username { get; set; }
 
+        /// <summary>
+        /// Gets or sets the password.
+        /// </summary>
         public string Password { get; set; }
 
+        /// <summary>
+        /// Gets or sets the message.
+        /// </summary>
         public string Message { get; set; }
 
         /// <summary>
@@ -35,10 +44,13 @@ namespace NuGet.Credentials
                                && (AuthTypes == null || AuthTypes.Any());
     }
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public enum PluginCredentialResponseExitCode
     {
         Success = 0,
         ProviderNotApplicable = 1,
         Failure = 2
     }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+
 }

--- a/src/NuGet.Core/NuGet.Credentials/PluginException.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PluginException.cs
@@ -7,51 +7,73 @@ using System.Globalization;
 namespace NuGet.Credentials
 {
     [Serializable]
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public class PluginException : Exception
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     {
         private const string RedactedPassword = "********";
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public PluginException() { }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public PluginException(string message) : base(message) { }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public PluginException(string message, Exception inner) : base(message, inner) { }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 #if IS_DESKTOP
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         protected PluginException(
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
           System.Runtime.Serialization.SerializationInfo info,
           System.Runtime.Serialization.StreamingContext context) : base(info, context)
         { }
 #endif
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public static PluginException Create(string path, Exception inner)
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
         {
             return new PluginException(
                 string.Format(CultureInfo.CurrentCulture, Resources.PluginException_Exception_Format, path, inner.GetType().Name),
                 inner);
         }
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public static PluginException CreateTimeoutMessage(string path, int timeoutMillis)
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
         {
             return new PluginException(
                 string.Format(CultureInfo.CurrentCulture, Resources.PluginException_Timeout_Format, path, timeoutMillis));
         }
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public static PluginException CreateNotStartedMessage(string path)
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
         {
             return new PluginException(string.Format(CultureInfo.CurrentCulture, Resources.PluginException_NotStarted_Format, path));
         }
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public static PluginException CreatePathNotFoundMessage(string path, string attempted)
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
         {
             return new PluginException(string.Format(CultureInfo.CurrentCulture, Resources.PluginException_PathNotFound_Format, path,
                 attempted));
         }
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public static PluginException CreateAbortMessage(string path, string message)
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
         {
             return new PluginException(string.Format(CultureInfo.CurrentCulture, Resources.PluginException_Abort_Format, path, message));
         }
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public static PluginException CreateUnreadableResponseExceptionMessage(
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
             string path,
             PluginCredentialResponseExitCode status)
         {
@@ -62,7 +84,9 @@ namespace NuGet.Credentials
                 status));
         }
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public static PluginException CreateInvalidResponseExceptionMessage(
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
             string path,
             PluginCredentialResponseExitCode status,
             PluginCredentialResponse response)

--- a/src/NuGet.Core/NuGet.Credentials/PluginUnexpectedStatusException.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PluginUnexpectedStatusException.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Globalization;
+
+#if IS_DESKTOP
 using System.Runtime.Serialization;
+#endif
 
 namespace NuGet.Credentials
 {
@@ -15,17 +18,42 @@ namespace NuGet.Credentials
     [Serializable]
     public class PluginUnexpectedStatusException : PluginException
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PluginUnexpectedStatusException"/> class.
+        /// </summary>
         public PluginUnexpectedStatusException() { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PluginUnexpectedStatusException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
         public PluginUnexpectedStatusException(string message) : base(message) { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PluginUnexpectedStatusException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="inner">The exception that is the cause of the current exception.</param>
         public PluginUnexpectedStatusException(string message, Exception inner) : base(message, inner) { }
+
 #if IS_DESKTOP
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PluginUnexpectedStatusException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected PluginUnexpectedStatusException(
           SerializationInfo info,
           StreamingContext context) : base(info, context)
         { }
 #endif
+
+        /// <summary>
+        /// Creates a new <see cref="PluginUnexpectedStatusException"/> with a formatted message indicating an unexpected status.
+        /// </summary>
+        /// <param name="path">The path of the plugin.</param>
+        /// <param name="status">The unexpected status returned by the plugin.</param>
+        /// <returns>A new instance of <see cref="PluginUnexpectedStatusException"/>.</returns>
         public static PluginException CreateUnexpectedStatusMessage(
             string path, PluginCredentialResponseExitCode status)
         {

--- a/src/NuGet.Core/NuGet.Credentials/PreviewFeatureSettings.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PreviewFeatureSettings.cs
@@ -10,7 +10,9 @@ namespace NuGet.Credentials
     /// </summary>
     public static class PreviewFeatureSettings
     {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public const string DefaultCredentialsAfterCredentialProvidersEnvironmentVariableName
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
             = "NUGET_CREDENTIAL_PROVIDER_OVERRIDE_DEFAULT";
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Credentials/ProviderException.cs
+++ b/src/NuGet.Core/NuGet.Credentials/ProviderException.cs
@@ -2,26 +2,39 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+
+#if IS_DESKTOP
 using System.Runtime.Serialization;
+#endif
 
 namespace NuGet.Credentials
 {
     [Serializable]
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public class ProviderException : Exception
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public ProviderException()
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
         {
         }
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public ProviderException(string message) : base(message)
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
         {
         }
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public ProviderException(string message, Exception inner) : base(message, inner)
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
         {
         }
 #if IS_DESKTOP
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         protected ProviderException(
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
             SerializationInfo info,
             StreamingContext context) : base(info, context)
         {

--- a/src/NuGet.Core/NuGet.Credentials/SecurePluginCredentialProvider.cs
+++ b/src/NuGet.Core/NuGet.Credentials/SecurePluginCredentialProvider.cs
@@ -13,7 +13,9 @@ using NuGet.Protocol.Plugins;
 
 namespace NuGet.Credentials
 {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public sealed class SecurePluginCredentialProvider : ICredentialProvider
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     {
         private const string _basicAuthenticationType = "Basic";
 

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
@@ -238,7 +238,6 @@ namespace NuGet.DependencyResolver
         /// <summary>
         /// Resolves the library from the given sources. Note that it does not download the package.
         /// </summary>
-        /// <param name="cache">Cache of requests per library</param>
         /// <param name="libraryRange">The library requested</param>
         /// <param name="remoteWalkContext">remote Providers (all sources, including file sources)</param>
         /// <param name="cancellationToken">cancellation token</param>

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
@@ -7,12 +7,15 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
-using System.Xml.Schema;
 using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.PackageCreation.Resources;
 using NuGet.Packaging.Xml;
 using static NuGet.Shared.XmlUtility;
+
+#if !IS_CORECLR
+using System.Xml.Schema;
+#endif
 
 namespace NuGet.Packaging
 {

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
@@ -2,10 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Buffers;
 using System.IO;
 using System.IO.MemoryMappedFiles;
 using NuGet.Common;
+
+#if NETFRAMEWORK || NETSTANDARD2_0
+using System.Buffers;
+#endif
 
 namespace NuGet.Packaging
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/X509SignatureProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/X509SignatureProvider.cs
@@ -2,15 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 
 #if IS_SIGNING_SUPPORTED
+using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
-using System.Security.Cryptography.X509Certificates;
+using System.Text;
 #endif
 
 namespace NuGet.Packaging.Signing

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Cms/CmsFactory.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Cms/CmsFactory.cs
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+
+#if IS_SIGNING_SUPPORTED && !IS_DESKTOP
 using System.Security.Cryptography.Pkcs;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Cms/ManagedCmsWrapper.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Cms/ManagedCmsWrapper.cs
@@ -1,11 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if IS_SIGNING_SUPPORTED && IS_CORECLR
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
 using NuGet.Common;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Cms/NativeCms.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Cms/NativeCms.cs
@@ -3,14 +3,15 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+using NuGet.Packaging.Signing.Utility;
+
 #if IS_SIGNING_SUPPORTED
+using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 #endif
-using System.Security.Cryptography.X509Certificates;
-using NuGet.Packaging.Signing.Utility;
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Cms/NativeCmsWrapper.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Cms/NativeCmsWrapper.cs
@@ -1,10 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if IS_SIGNING_SUPPORTED && IS_DESKTOP
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageWriter.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageWriter.cs
@@ -1,10 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if IS_SIGNING_SUPPORTED
 using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/AuthorPrimarySignature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/AuthorPrimarySignature.cs
@@ -1,15 +1,15 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if IS_SIGNING_SUPPORTED
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-#if IS_SIGNING_SUPPORTED
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
-#endif
 using NuGet.Common;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/IRepositorySignature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/IRepositorySignature.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if IS_SIGNING_SUPPORTED
 using System;
 using System.Collections.Generic;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/PrimarySignature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/PrimarySignature.cs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+
+#if IS_SIGNING_SUPPORTED
 using System.IO;
 using System.Security.Cryptography;
-#if IS_SIGNING_SUPPORTED
 using System.Security.Cryptography.Pkcs;
-#endif
 using NuGet.Common;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/PrimarySignatureFactory.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/PrimarySignatureFactory.cs
@@ -3,7 +3,6 @@
 
 #if IS_SIGNING_SUPPORTED
 using System.Security.Cryptography.Pkcs;
-using NuGet.Common;
 #endif
 
 namespace NuGet.Packaging.Signing

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/RepositoryCountersignature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/RepositoryCountersignature.cs
@@ -2,14 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+
+#if IS_SIGNING_SUPPORTED
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-#if IS_SIGNING_SUPPORTED
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
-#endif
 using NuGet.Common;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/RepositoryPrimarySignature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/RepositoryPrimarySignature.cs
@@ -1,15 +1,15 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if IS_SIGNING_SUPPORTED
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-#if IS_SIGNING_SUPPORTED
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
-#endif
 using NuGet.Common;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
@@ -1,17 +1,17 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if IS_SIGNING_SUPPORTED
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-#if IS_SIGNING_SUPPORTED
 using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
-#endif
 using NuGet.Common;
 using HashAlgorithmName = NuGet.Common.HashAlgorithmName;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
@@ -2,19 +2,18 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+
+#if IS_SIGNING_SUPPORTED
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;
-
-#if IS_SIGNING_SUPPORTED
 using System.Security.Cryptography.Pkcs;
-#endif
-
 using System.Security.Cryptography.X509Certificates;
-using System.Threading;
-using System.Threading.Tasks;
-using NuGet.Common;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampTokenInfo.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampTokenInfo.cs
@@ -2,14 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Security.Cryptography;
+#if IS_DESKTOP
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography;
-#if IS_DESKTOP
 using System.Security.Cryptography.Pkcs;
-#endif
 using System.Security.Cryptography.X509Certificates;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampTokenInfoFactory.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampTokenInfoFactory.cs
@@ -3,7 +3,6 @@
 
 #if IS_SIGNING_SUPPORTED
 using System;
-using System.Security.Cryptography;
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampUtils.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampUtils.cs
@@ -3,10 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
-using System.Reflection;
-using System.Runtime.InteropServices;
 
 #if IS_DESKTOP
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.Pkcs;
 #endif
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampVerificationUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampVerificationUtility.cs
@@ -1,14 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if IS_SIGNING_SUPPORTED
 using System;
 using System.IO;
-
-#if IS_SIGNING_SUPPORTED
 using System.Security.Cryptography.Pkcs;
-#endif
-
 using System.Security.Cryptography.X509Certificates;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Timestamp.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Timestamp.cs
@@ -1,14 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if IS_SIGNING_SUPPORTED
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using NuGet.Common;
-
-#if IS_SIGNING_SUPPORTED
 using System.Security.Cryptography.Pkcs;
 #endif
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/X509TrustStore.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/X509TrustStore.cs
@@ -2,9 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using System.IO;
 using NuGet.Common;
+
+#if NET5_0_OR_GREATER
+using System.Globalization;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/AttributeUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/AttributeUtility.cs
@@ -1,15 +1,15 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if IS_SIGNING_SUPPORTED
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;
-#if IS_SIGNING_SUPPORTED
 using System.Security.Cryptography.Pkcs;
-#endif
 using System.Security.Cryptography.X509Certificates;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SigningUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SigningUtility.cs
@@ -2,16 +2,17 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Security.Cryptography;
-#if IS_SIGNING_SUPPORTED
-using System.Security.Cryptography.Pkcs;
-#endif
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
+
+#if IS_SIGNING_SUPPORTED
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.X509Certificates;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/VerificationUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/VerificationUtility.cs
@@ -4,9 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using NuGet.Common;
+
+#if IS_SIGNING_SUPPORTED
+using System.Linq;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/AllowListVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/AllowListVerificationProvider.cs
@@ -3,10 +3,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
+#if IS_SIGNING_SUPPORTED
+using System.Linq;
 using NuGet.Common;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/IntegrityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/IntegrityVerificationProvider.cs
@@ -2,12 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+#if IS_SIGNING_SUPPORTED
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using NuGet.Common;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
@@ -3,12 +3,15 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
+
+#if IS_SIGNING_SUPPORTED
+using System.Diagnostics;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+#endif
 
 namespace NuGet.Packaging.Signing
 {

--- a/src/NuGet.Core/NuGet.ProjectModel/CacheFile.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/CacheFile.cs
@@ -23,10 +23,10 @@ namespace NuGet.ProjectModel
         /// </summary>
         public IList<string> ExpectedPackageFilePaths { get; set; }
 
-        [Obsolete("File existence checks are a function of time not the cache file content.")]
         /// <summary>
         /// Gets or sets a value indicating if one or more of the expected files are missing.
         /// </summary>
+        [Obsolete("File existence checks are a function of time not the cache file content.")]
         public bool HasAnyMissingPackageFiles
         {
             get => throw new NotImplementedException("This API is no longer support");

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamIAssetsLogMessageConverter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamIAssetsLogMessageConverter.cs
@@ -15,7 +15,7 @@ namespace NuGet.ProjectModel
     /// <example>
     /// {
     ///     "code": "<see cref="NuGetLogCode"/>",
-    ///     "level": "<see cref="LogLevel"/>",
+    ///     "level": "<see cref="Common.LogLevel"/>",
     ///     "message": "test log message",
     ///     "warningLevel": <see cref="WarningLevel"/>,
     ///     "filePath": "C:\a\file\path.txt",

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamLockFileConverter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamLockFileConverter.cs
@@ -21,7 +21,7 @@ namespace NuGet.ProjectModel
     ///     "libraries": { <see cref="Utf8JsonStreamLockFileLibraryConverter"/> },
     ///     "projectFileDependencyGroups": { <see cref="Utf8JsonStreamProjectFileDependencyGroupConverter"/> },
     ///     "packageFolders": { <see cref="Utf8JsonStreamLockFileItemConverter{T}"/> },
-    ///     "project": { <see cref="JsonPackageSpecReader.GetPackageSpec(ref Utf8JsonStreamReader, string, string, string)"/> },
+    ///     "project": { <see cref="JsonPackageSpecReader.GetPackageSpec(ref Utf8JsonStreamReader, string, string, IEnvironmentVariableReader, string)"/> },
     ///     "logs": [ <see cref="Utf8JsonStreamIAssetsLogMessageConverter"/> ]
     /// }
     /// </example>

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecOperations.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecOperations.cs
@@ -17,7 +17,7 @@ namespace NuGet.ProjectModel
         /// <summary>
         /// Add or Update the dependencies in the spec. If the package exists in any of the dependencies list, only those will be updated.
         /// If the package does not exist in any of dependencies lists,
-        /// if the <see cref="PackageSpec.RestoreMetadata.ProjectStyle" /> is <see cref="ProjectStyle.PackageReference"/>
+        /// if the <see cref="ProjectRestoreMetadata.ProjectStyle" /> is <see cref="ProjectStyle.PackageReference"/>
         /// then the <see cref="TargetFrameworkInformation"/> will be updated,
         /// otherwise, the generic dependencies will be updated.
         /// </summary>
@@ -62,7 +62,7 @@ namespace NuGet.ProjectModel
         /// <summary>
         /// Add or Update the dependencies in the spec. If the package exists in any of the dependencies list, only those will be updated.
         /// If the package does not exist in any of dependencies lists,
-        /// if the <see cref="PackageSpec.RestoreMetadata.ProjectStyle" /> is <see cref="ProjectStyle.PackageReference"/>
+        /// if the <see cref="ProjectRestoreMetadata.ProjectStyle" /> is <see cref="ProjectStyle.PackageReference"/>
         /// then the <see cref="TargetFrameworkInformation"/> will be updated,
         /// otherwise, the generic dependencies will be updated.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
@@ -6,12 +6,15 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Security;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
+
+#if NETSTANDARD2_0
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+#endif
 
 namespace NuGet.Protocol
 {

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRequestMessageExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRequestMessageExtensions.cs
@@ -2,11 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+
+#if  NET5_0_OR_GREATER
+using System.Collections.Generic;
+#endif
 
 namespace NuGet.Protocol
 {

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceResourceProvider.cs
@@ -4,11 +4,14 @@
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
+
+#if IS_DESKTOP
+using System.Net;
+#endif
 
 namespace NuGet.Protocol
 {

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageVulnerabilityInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageVulnerabilityInfo.cs
@@ -38,7 +38,7 @@ namespace NuGet.Protocol.Model
             Versions = versions ?? throw new ArgumentNullException(nameof(versions));
         }
 
-        /// <inheritdoc cref="IEquatable{T}.Equals(T?)"/>
+        /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
         public bool Equals(PackageVulnerabilityInfo? other)
         {
             if (other is null)

--- a/src/NuGet.Core/NuGet.Protocol/Resources/OwnerDetailsUriTemplateResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/OwnerDetailsUriTemplateResourceV3.cs
@@ -9,8 +9,9 @@ using NuGet.Protocol.Core.Types;
 namespace NuGet.Protocol.Resources
 {
     /// <summary>Owner Details Uri Template for NuGet V3 HTTP feeds.</summary>
-    /// <remarks>Not intended to be created directly. Use <see cref="SourceRepository.GetResourceAsync{T}(CancellationToken)"/>
+    /// <remarks>Not intended to be created directly. Use <see cref="SourceRepository.GetResourceAsync{T}(System.Threading.CancellationToken)"/>
     /// with <see cref="OwnerDetailsUriTemplateResourceV3"/> for T, and typecast to this class.
+    /// </remarks>
     public class OwnerDetailsUriTemplateResourceV3 : INuGetResource
     {
         private readonly string _template;

--- a/src/NuGet.Core/NuGet.Versioning/VersionComparer.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionComparer.cs
@@ -12,6 +12,11 @@ namespace NuGet.Versioning
     /// </summary>
     public sealed class VersionComparer : IVersionComparer
     {
+        /// <summary>
+        /// Gets an IVersionComparer based on the specified VersionComparison mode.
+        /// </summary>
+        /// <param name="versionComparison">The version comparison mode to use.</param>
+        /// <returns>An IVersionComparer instance.</returns>
         public static IVersionComparer Get(VersionComparison versionComparison)
         {
             return versionComparison switch

--- a/src/NuGet.Core/NuGet.Versioning/VersionRangeComparer.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRangeComparer.cs
@@ -56,6 +56,11 @@ namespace NuGet.Versioning
 
         internal static IVersionRangeComparer VersionReleaseMetadata { get; } = new VersionRangeComparer(VersionComparer.VersionReleaseMetadata);
 
+        /// <summary>
+        /// Gets the appropriate version range comparer based on the specified version comparison.
+        /// </summary>
+        /// <param name="versionComparison">The version comparison to use.</param>
+        /// <returns>An instance of <see cref="IVersionRangeComparer"/>.</returns>
         public static IVersionRangeComparer Get(VersionComparison versionComparison)
         {
             return versionComparison switch

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/X509StoreCertificate.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/X509StoreCertificate.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using NuGet.Common;
-using NuGet.Packaging.Signing;
 using Test.Utility.Signing;
 
 namespace Dotnet.Integration.Test

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningUtilityTests.cs
@@ -4,7 +4,6 @@
 #if IS_SIGNING_SUPPORTED
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/HttpRetryHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/HttpRetryHandlerTests.cs
@@ -9,12 +9,15 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using NuGet.Common;
 using NuGet.Protocol;
 using NuGet.Test.Server;
 using NuGet.Test.Utility;
 using Test.Utility;
 using Xunit;
+
+#if IS_CORECLR
+using NuGet.Common;
+#endif
 
 namespace NuGet.Core.FuncTest
 {

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/PluginTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/PluginTests.cs
@@ -4,20 +4,23 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Protocol.Plugins;
+using Xunit.Abstractions;
+
+#if IS_DESKTOP
+using System.Globalization;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 using NuGet.Packaging;
-using NuGet.Protocol.Plugins;
 using NuGet.Test.Utility;
 using Xunit;
-using Xunit.Abstractions;
 using PluginProtocolConstants = NuGet.Protocol.Plugins.ProtocolConstants;
+#endif
 
 namespace NuGet.Protocol.FuncTest
 {

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Why/DependencyGraphFinderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Why/DependencyGraphFinderTests.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using NuGet.CommandLine.XPlat;
 using NuGet.CommandLine.XPlat.Commands.Why;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Why/WhyCommandLineParsingTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Why/WhyCommandLineParsingTests.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.CommandLine;
-using System.CommandLine.Parsing;
 using FluentAssertions;
-using NuGet.CommandLine.XPlat;
 using NuGet.CommandLine.XPlat.Commands.Why;
 using Xunit;
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NullLoggerWithColor.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NullLoggerWithColor.cs
@@ -2,11 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading.Tasks;
-
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
 using NuGet.CommandLine.XPlat;
 using NuGet.Common;
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -27,8 +27,11 @@ using NuGet.Versioning;
 using Test.Utility;
 using Test.Utility.Commands;
 using Test.Utility.ProjectManagement;
-using Test.Utility.Signing;
 using Xunit;
+
+#if IS_SIGNING_SUPPORTED
+using Test.Utility.Signing;
+#endif
 
 namespace NuGet.Commands.Test.RestoreCommandTests
 {

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
@@ -5,9 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-#if IS_SIGNING_SUPPORTED
-using System.Security.Cryptography.Pkcs;
-#endif
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -15,13 +12,17 @@ using Moq;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Configuration.Test;
-using NuGet.Packaging;
 using NuGet.Packaging.Signing;
 using NuGet.Protocol.Core.Types;
-using NuGet.Test.Utility;
 using Test.Utility;
-using Test.Utility.Signing;
 using Xunit;
+
+#if IS_SIGNING_SUPPORTED
+using System.Security.Cryptography.Pkcs;
+using NuGet.Packaging;
+using NuGet.Test.Utility;
+using Test.Utility.Signing;
+#endif
 
 namespace NuGet.Commands.Test
 {

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/CryptoHashUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/CryptoHashUtilityTests.cs
@@ -2,10 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Reflection;
 using System.Security.Cryptography;
 using NuGet.Packaging.Signing;
 using Xunit;
+
+#if !IS_CORECLR
+using System.Reflection;
+#endif
 
 namespace NuGet.Common.Test
 {

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -3,15 +3,18 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Resources;
 using FluentAssertions;
 using Moq;
 using NuGet.Common;
 using NuGet.Test.Utility;
 using Xunit;
+
+#if IS_DESKTOP
+using System.Globalization;
+using System.Resources;
+#endif
 
 namespace NuGet.Configuration.Test
 {

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
@@ -4,9 +4,12 @@
 using System;
 using System.IO;
 using FluentAssertions;
-using NuGet.Common;
 using NuGet.Test.Utility;
 using Xunit;
+
+#if IS_CORECLR
+using NuGet.Common;
+#endif
 
 namespace NuGet.Configuration.Test
 {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -7,8 +7,11 @@ using System.Threading.Tasks;
 using Moq;
 using NuGet.Packaging.Signing;
 using Test.Utility;
-using Test.Utility.Signing;
 using Xunit;
+
+#if IS_SIGNING_SUPPORTED
+using Test.Utility.Signing;
+#endif
 
 namespace NuGet.Packaging.Test
 {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageArchiveUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageArchiveUtilityTests.cs
@@ -5,14 +5,17 @@ using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Packaging.Signing;
 using Test.Utility.Signing;
 using Xunit;
+
+#if IS_SIGNING_SUPPORTED
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+#endif
 
 namespace NuGet.Packaging.Test
 {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV3Tests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Utility/OfflineFeedUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Utility/OfflineFeedUtilityTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if !IS_CORECLR
 using System;
 using System.IO;
 using System.Threading;
@@ -14,6 +15,7 @@ using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Xunit;
+#endif
 
 namespace NuGet.Protocol.Tests
 {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/V2FeedPackageInfoTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/V2FeedPackageInfoTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Linq;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;

--- a/test/TestUtilities/Test.Utility/DebuggerUtils.cs
+++ b/test/TestUtilities/Test.Utility/DebuggerUtils.cs
@@ -1,8 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Diagnostics;
+
+#if IS_CORECLR
+using System;
+#endif
 
 namespace Test.Utility
 {

--- a/test/TestUtilities/Test.Utility/Signing/CodeSigningRootX509Store.cs
+++ b/test/TestUtilities/Test.Utility/Signing/CodeSigningRootX509Store.cs
@@ -1,8 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Security.Cryptography.X509Certificates;
+
+#if !NET5_0_OR_GREATER
+using System;
+#endif
 
 namespace Test.Utility.Signing
 {

--- a/test/TestUtilities/Test.Utility/Signing/IHttpResonder.cs
+++ b/test/TestUtilities/Test.Utility/Signing/IHttpResonder.cs
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+
+#if IS_SIGNING_SUPPORTED
 using System.Net;
+#endif
 
 namespace Test.Utility.Signing
 {

--- a/test/TestUtilities/Test.Utility/Signing/SignatureTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SignatureTestUtility.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if IS_SIGNING_SUPPORTED
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -11,6 +12,7 @@ using NuGet.Common;
 using NuGet.Packaging.Signing;
 using NuGet.Test.Utility;
 using Xunit;
+#endif
 
 namespace Test.Utility.Signing
 {

--- a/test/TestUtilities/Test.Utility/Signing/SignedArchiveTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SignedArchiveTestUtility.cs
@@ -2,13 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-#if IS_SIGNING_SUPPORTED
-using System.Security.Cryptography.Pkcs;
-#endif
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,6 +13,11 @@ using NuGet.Packaging;
 using NuGet.Packaging.Signing;
 using NuGet.Test.Utility;
 using Xunit;
+
+#if IS_SIGNING_SUPPORTED
+using System.Collections.Generic;
+using System.Security.Cryptography.Pkcs;
+#endif
 
 namespace Test.Utility.Signing
 {

--- a/test/TestUtilities/Test.Utility/Signing/TestFallbackCertificateBundleX509ChainFactories.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TestFallbackCertificateBundleX509ChainFactories.cs
@@ -1,8 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using NuGet.Common;
 using NuGet.Packaging.Signing;
+
+#if NET5_0_OR_GREATER
+using NuGet.Common;
+#endif
 
 namespace Test.Utility.Signing
 {

--- a/test/TestUtilities/Test.Utility/Signing/TestFallbackCertificateBundleX509ChainFactory.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TestFallbackCertificateBundleX509ChainFactory.cs
@@ -1,9 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if NET5_0_OR_GREATER
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using NuGet.Packaging.Signing;
+#endif
 
 namespace Test.Utility.Signing
 {

--- a/test/TestUtilities/Test.Utility/Signing/TimestampingRootX509Store.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TimestampingRootX509Store.cs
@@ -1,8 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Security.Cryptography.X509Certificates;
+
+#if !NET5_0_OR_GREATER
+using System;
+#endif
 
 namespace Test.Utility.Signing
 {

--- a/test/TestUtilities/Test.Utility/Signing/X509RevocationReason.cs
+++ b/test/TestUtilities/Test.Utility/Signing/X509RevocationReason.cs
@@ -3,9 +3,6 @@
 
 #if !NET7_0_OR_GREATER
 
-using System;
-using System.Diagnostics;
-
 namespace System.Security.Cryptography.X509Certificates
 {
     /// <summary>

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Runtime.Versioning;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,8 +17,12 @@ using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.PackageExtraction;
-using NuGet.Packaging.Signing;
 using NuGet.Versioning;
+
+#if IS_SIGNING_SUPPORTED
+using System.Security.Cryptography.X509Certificates;
+using NuGet.Packaging.Signing;
+#endif
 
 namespace NuGet.Test.Utility
 {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2845

## Description
In order to enforce certain style rules we need to enable GenerateDocumentationFile for all projects. This is a known issue, https://github.com/dotnet/roslyn/issues/41640. The code we had for enabling GenerateDocumentationFile was not working because the value was being set by C# template. This now enables GenerateDocumentationFile for all projects. It also sets "WarningsNotAsErrors" for XML style errors for projects which are not shipped. CoPilot was used to generate documentation for some classes.

This also fixes errors that come up from enabling GenerateDocumentationFile. For using statements that need to be behind a conditional compilation, I grouped them together and placed them after the other using statements. 


## PR Checklist

- [X] Meaningful title, helpful description and a linked NuGet/Home issue
- [X] ~Added tests~
- [X] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
