### PR TITLE
Improve build.sh and fixes for building on arm64 macOS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 
+CONFIGURATION=
+CI=0
+BUILD_NUMBER=
+RELEASE_LABEL=zlocal
+
 while true ; do
 	case "$1" in
-		-c|--clear-cache) CLEAR_CACHE=1 ; shift ;;
+		-c) CONFIGURATION=$2 ; shift ;;
+		--ci) CI=1 ; shift ;;
+		--clear-cache) CLEAR_CACHE=1 ; shift ;;
+		-n) BUILD_NUMBER=$2 ; shift ;;
+		-l) RELEASE_LABEL=$2 ; shift ;;
 		--) shift ; break ;;
 		*) shift ; break ;;
 	esac
@@ -28,9 +37,26 @@ if [ "$CLEAR_CACHE" == "1" ]; then
 	rm -r -f ~/.nuget/packages/*
 fi
 
+if [ "$BUILD_NUMBER" != "" ]; then
+	build_number_arg="/p:BuildNumber=$BUILD_NUMBER"
+fi
+
+if [ "$RELEASE_LABEL" != "" ]; then
+	release_label_arg="/p:ReleaseLabel=$RELEASE_LABEL"
+fi
+
+# CI build is Release by default, local builds are Debug by default
+if [ "$CONFIGURATION" == "" ]; then
+	if [ "$CI" == "1" ]; then
+		CONFIGURATION=Release
+	else
+		CONFIGURATION=Debug
+	fi
+fi
+
 # restore packages
-echo "dotnet msbuild build/build.proj /t:Restore /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta"
-dotnet msbuild build/build.proj /t:Restore /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta
+echo "dotnet msbuild build/build.proj /t:Restore /p:Configuration=$CONFIGURATION $build_number_arg $release_label_arg"
+dotnet msbuild build/build.proj /t:Restore /p:Configuration=$CONFIGURATION $build_number_arg $release_label_arg
 
 if [ $? -ne 0 ]; then
 	echo "Restore failed!!"
@@ -38,8 +64,8 @@ if [ $? -ne 0 ]; then
 fi
 
 # run tests
-echo "dotnet msbuild build/build.proj /t:CoreUnitTests /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta"
-dotnet msbuild build/build.proj /t:CoreUnitTests /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta
+echo "dotnet msbuild build/build.proj /t:CoreUnitTests /p:Configuration=$CONFIGURATION $build_number_arg $release_label_arg"
+dotnet msbuild build/build.proj /t:CoreUnitTests /p:Configuration=$CONFIGURATION $build_number_arg $release_label_arg
 
 if [ $? -ne 0 ]; then
 	echo "Tests failed!!"

--- a/build/DotNetSdkVersions.txt
+++ b/build/DotNetSdkVersions.txt
@@ -1,3 +1,3 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Channel 8.0.3xx
 -Channel 3.1 -Runtime dotnet
+-Channel 8.0.3xx


### PR DESCRIPTION
Some changes to make build.sh closer to the Windows equivalent and also fix downloading the right dotnet host on arm64 macOS.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
