### PR TITLE
Always debug RestoreTask and RestoreEx when environment variable is set

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -98,13 +98,13 @@ namespace NuGet.Build.Tasks
 
         public override bool Execute()
         {
-#if DEBUG
             var debugRestoreTask = Environment.GetEnvironmentVariable("DEBUG_RESTORE_TASK");
-            if (!string.IsNullOrEmpty(debugRestoreTask) && debugRestoreTask.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrEmpty(debugRestoreTask) &&
+                (debugRestoreTask.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase) || debugRestoreTask == "1")
             {
                 Debugger.Launch();
             }
-#endif
+
             var log = new MSBuildLogger(Log);
 
             NuGet.Common.Migrations.MigrationRunner.Run();

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -100,7 +100,7 @@ namespace NuGet.Build.Tasks
         {
             var debugRestoreTask = Environment.GetEnvironmentVariable("DEBUG_RESTORE_TASK");
             if (!string.IsNullOrEmpty(debugRestoreTask) &&
-                (debugRestoreTask.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase) || debugRestoreTask == "1")
+                (debugRestoreTask.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase) || debugRestoreTask == "1"))
             {
                 Debugger.Launch();
             }

--- a/src/NuGet.Core/NuGet.Build.Tasks/StaticGraphRestoreTaskBase.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/StaticGraphRestoreTaskBase.cs
@@ -95,9 +95,9 @@ namespace NuGet.Build.Tasks
         {
             try
             {
-                string debugEnvironmentVariableName = Environment.GetEnvironmentVariable(DebugEnvironmentVariableName);
-                if (string.Equals(debugEnvironmentVariableName, bool.TrueString, StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(debugEnvironmentVariableName, "1", StringComparison.OrdinalIgnoreCase))
+                string debugEnvironmentVariable = Environment.GetEnvironmentVariable(DebugEnvironmentVariableName);
+                if (string.Equals(debugEnvironmentVariable, bool.TrueString, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(debugEnvironmentVariable, "1", StringComparison.OrdinalIgnoreCase))
                 {
                     Debugger.Launch();
                 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/StaticGraphRestoreTaskBase.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/StaticGraphRestoreTaskBase.cs
@@ -95,12 +95,13 @@ namespace NuGet.Build.Tasks
         {
             try
             {
-#if DEBUG
-                if (string.Equals(Environment.GetEnvironmentVariable(DebugEnvironmentVariableName), bool.TrueString, StringComparison.OrdinalIgnoreCase))
+                string debugEnvironmentVariableName = Environment.GetEnvironmentVariable(DebugEnvironmentVariableName);
+                if (string.Equals(debugEnvironmentVariableName, bool.TrueString, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(debugEnvironmentVariableName, "1", StringComparison.OrdinalIgnoreCase))
                 {
                     Debugger.Launch();
                 }
-#endif
+
                 MSBuildLogger logger = new MSBuildLogger(Log);
 
                 Dictionary<string, string> globalProperties = GetGlobalProperties();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/12897

## Description
Allows to debug RestoreEx task for production builds of NuGet

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
