### PR TITLE
Attempt Loading package Icon from local folders to avoid accessing remote feeds for metadata

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.100",
-    "rollForward": "latestMajor",
+    "version": "8.0.400",
+    "rollForward": "disable",
     "allowPrerelease": true
   },
   "msbuild-sdks": {

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.400",
-    "rollForward": "disable",
+    "version": "8.0.100",
+    "rollForward": "latestMajor",
     "allowPrerelease": true
   },
   "msbuild-sdks": {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageFileService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageFileService.cs
@@ -114,7 +114,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 return null;
             }
 
-            Stream? stream;
+            Stream? stream = null;
             if (IsEmbeddedUri(uri))
             {
                 stream = await GetEmbeddedFileAsync(uri, cancellationToken);
@@ -126,7 +126,8 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     stream = await GetEmbeddedFileAsync(localUri, cancellationToken);
                 }
-                else
+
+                if (stream == null)
                 {
                     stream = await GetStream(uri);
                 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageFileService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageFileService.cs
@@ -179,7 +179,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 // use GetFullPath to normalize "..", so that zip slip attack cannot allow a user to walk up the file directory
                 if (Path.GetFullPath(extractedIconPath).StartsWith(dirPath, StringComparison.OrdinalIgnoreCase) && File.Exists(extractedIconPath))
                 {
-                    Stream fileStream = new FileStream(extractedIconPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                    Stream fileStream = File.OpenRead(extractedIconPath);
                     return fileStream;
                 }
                 else
@@ -213,7 +213,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 if (File.Exists(uri.LocalPath))
                 {
-                    return new FileStream(uri.LocalPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                    return File.OpenRead(uri.LocalPath);
                 }
                 else
                 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageFileService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageFileService.cs
@@ -26,6 +26,7 @@ namespace NuGet.PackageManagement.VisualStudio
     public sealed class NuGetPackageFileService : INuGetPackageFileService, IDisposable
     {
         public static readonly string IconPrefix = "icon:";
+        public static readonly string LocalIconPrefix = "localIcon:";
         public static readonly string LicensePrefix = "license:";
 
         private ServiceActivationOptions? _options;
@@ -52,6 +53,15 @@ namespace NuGet.PackageManagement.VisualStudio
         public static void AddIconToCache(PackageIdentity packageIdentity, Uri iconUri)
         {
             string key = NuGetPackageFileService.IconPrefix + packageIdentity.ToString();
+            if (iconUri != null)
+            {
+                IdentityToUriCache.Set(key, iconUri, CacheItemPolicy);
+            }
+        }
+
+        public static void AddLocalIconToCache(PackageIdentity packageIdentity, Uri iconUri)
+        {
+            string key = NuGetPackageFileService.LocalIconPrefix + packageIdentity.ToString();
             if (iconUri != null)
             {
                 IdentityToUriCache.Set(key, iconUri, CacheItemPolicy);
@@ -92,7 +102,9 @@ namespace NuGet.PackageManagement.VisualStudio
         public async ValueTask<Stream?> GetPackageIconAsync(PackageIdentity packageIdentity, CancellationToken cancellationToken)
         {
             Assumes.NotNull(packageIdentity);
-            string key = NuGetPackageFileService.IconPrefix + packageIdentity.ToString();
+            string packageId = packageIdentity.ToString();
+            string key = NuGetPackageFileService.IconPrefix + packageId;
+
             Uri? uri = IdentityToUriCache.Get(key) as Uri;
 
             if (uri == null)
@@ -109,10 +121,30 @@ namespace NuGet.PackageManagement.VisualStudio
             }
             else
             {
-                stream = await GetStream(uri);
+                Uri? localUri = GetLocalEmbeddedIconUri(packageId);
+                if (localUri is not null)
+                {
+                    stream = await GetEmbeddedFileAsync(localUri, cancellationToken);
+                }
+                else
+                {
+                    stream = await GetStream(uri);
+                }
             }
 
             return stream;
+        }
+
+        private static Uri? GetLocalEmbeddedIconUri(string packageId)
+        {
+            string localIconKey = NuGetPackageFileService.LocalIconPrefix + packageId;
+            Uri? localUri = IdentityToUriCache.Get(localIconKey) as Uri;
+            if (localUri is not null && IsEmbeddedUri(localUri))
+            {
+                return localUri;
+            }
+
+            return null;
         }
 
         public async ValueTask<Stream?> GetEmbeddedLicenseAsync(PackageIdentity packageIdentity, CancellationToken cancellationToken)
@@ -180,7 +212,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 if (File.Exists(uri.LocalPath))
                 {
-                    return new FileStream(uri.LocalPath, FileMode.Open);
+                    return new FileStream(uri.LocalPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                 }
                 else
                 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/SearchObject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/SearchObject.cs
@@ -111,7 +111,12 @@ namespace NuGet.PackageManagement.VisualStudio
             var packageSearchMetadataContextInfoCollection = new List<PackageSearchMetadataContextInfo>(mainFeedResult.Items.Count);
             foreach (IPackageSearchMetadata packageSearchMetadata in mainFeedResult.Items)
             {
-                CacheBackgroundData(packageSearchMetadata, filter.IncludePrerelease);
+                IPackageSearchMetadata? localPackageSearchMetadata = null;
+
+                // Attach local metadata in case we do not have an icon remotely, can try local metadata.
+                localPackageSearchMetadata = await _packageMetadataProvider.GetOnlyLocalPackageMetadataAsync(packageSearchMetadata.Identity, cancellationToken);
+
+                CacheBackgroundData(packageSearchMetadata, localPackageSearchMetadata, filter.IncludePrerelease);
                 var knownOwners = CreateKnownOwners(packageSearchMetadata);
                 packageSearchMetadataContextInfoCollection.Add(PackageSearchMetadataContextInfo.Create(packageSearchMetadata, knownOwners));
             }
@@ -227,6 +232,11 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private void CacheBackgroundData(IPackageSearchMetadata packageSearchMetadata, bool includesPrerelease)
         {
+            CacheBackgroundData(packageSearchMetadata, localPackageSearchMetadata: null, includesPrerelease);
+        }
+
+        private void CacheBackgroundData(IPackageSearchMetadata packageSearchMetadata, IPackageSearchMetadata? localPackageSearchMetadata, bool includesPrerelease)
+        {
             if (_inMemoryObjectCache == null)
             {
                 return;
@@ -247,6 +257,10 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             NuGetPackageFileService.AddIconToCache(packageSearchMetadata.Identity, packageSearchMetadata.IconUrl);
+            if (localPackageSearchMetadata?.IconUrl != null)
+            {
+                NuGetPackageFileService.AddLocalIconToCache(packageSearchMetadata.Identity, localPackageSearchMetadata.IconUrl);
+            }
 
             string? packagePath = (packageSearchMetadata as LocalPackageSearchMetadata)?.PackagePath ??
                     (packageSearchMetadata as ClonedPackageSearchMetadata)?.PackagePath;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageFileServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageFileServiceTests.cs
@@ -274,28 +274,34 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 FileInfo fileInfo = new FileInfo(pathAndFileReadOnly);
                 fileInfo.IsReadOnly = true;
 
-                var packageFileService = new NuGetPackageFileService(
-                        default(ServiceActivationOptions),
-                        Mock.Of<IServiceBroker>(),
-                        new AuthorizationServiceClient(Mock.Of<IAuthorizationService>()),
-                        _telemetryProvider.Object);
-                var packageIdentity = new PackageIdentity(nameof(GetPackageIconAsync_EmbeddedFromFallbackFolder_CanOpenReadOnlyFile), NuGetVersion.Parse("1.0.0"));
+                try
+                {
+                    var packageFileService = new NuGetPackageFileService(
+                            default(ServiceActivationOptions),
+                            Mock.Of<IServiceBroker>(),
+                            new AuthorizationServiceClient(Mock.Of<IAuthorizationService>()),
+                            _telemetryProvider.Object);
+                    var packageIdentity = new PackageIdentity(nameof(GetPackageIconAsync_EmbeddedFromFallbackFolder_CanOpenReadOnlyFile), NuGetVersion.Parse("1.0.0"));
 
-                // Add a fragment to consider this an embedded icon.
-                // Note: file:// is required for Uri to parse the Fragment.
-                var uri = new Uri("file://" + pathAndFileReadOnly + "#testFile.txt");
+                    // Add a fragment to consider this an embedded icon.
+                    // Note: file:// is required for Uri to parse the Fragment.
+                    var uri = new Uri("file://" + pathAndFileReadOnly + "#testFile.txt");
 
-                NuGetPackageFileService.AddIconToCache(packageIdentity, uri);
+                    NuGetPackageFileService.AddIconToCache(packageIdentity, uri);
 
-                // Act
-                // System.UnauthorizedAccessException would occur in the Act if we're requiring Write access on the Read-Only file.
-                using Stream iconStream = await packageFileService.GetPackageIconAsync(packageIdentity, CancellationToken.None);
-                // Assert
-                Assert.NotNull(iconStream);
-                Assert.True(iconStream.CanRead);
-                Assert.False(iconStream.CanWrite);
-                Assert.Equal(fileContents.Length, iconStream.Length);
-                iconStream.Dispose();
+                    // Act
+                    // System.UnauthorizedAccessException would occur in the Act if we're requiring Write access on the Read-Only file.
+                    using Stream iconStream = await packageFileService.GetPackageIconAsync(packageIdentity, CancellationToken.None);
+                    // Assert
+                    Assert.NotNull(iconStream);
+                    Assert.True(iconStream.CanRead);
+                    Assert.False(iconStream.CanWrite);
+                    Assert.Equal(fileContents.Length, iconStream.Length);
+                }
+                finally
+                {
+                    fileInfo.IsReadOnly = false;
+                }
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageFileServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageFileServiceTests.cs
@@ -94,7 +94,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var packageIdentity = new PackageIdentity(nameof(GetPackageIconAsync_EmbeddedFromFallbackFolder_HasOnlyReadAccess), NuGetVersion.Parse("1.0.0"));
 
                 // Add a fragment to consider this an embedded icon.
-                // Note: file:// is required for Uri to parse the Fragment (possibly a Uri bug).
+                // Note: file:// is required for Uri to parse the Fragment.
                 var uri = new Uri("file://" + filePath + "#testFile.txt");
 
                 NuGetPackageFileService.AddIconToCache(packageIdentity, uri);
@@ -129,10 +129,10 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         _telemetryProvider.Object);
 
                 var packageIdentity = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
-                var remoteInaccessibleUri = new Uri("http://api.source/index.json");
+                var remoteInaccessibleUri = new Uri("http://source.test/index.json");
 
                 // Add a fragment to consider this an embedded icon.
-                // Note: file:// is required for Uri to parse the Fragment (possibly a Uri bug).
+                // Note: file:// is required for Uri to parse the Fragment.
                 var localUri = new Uri("file://" + filePath + "#testFile.txt");
 
                 NuGetPackageFileService.AddIconToCache(packageIdentity, remoteInaccessibleUri);
@@ -171,7 +171,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var packageIdentity = new PackageIdentity(nameof(GetPackageIconAsync_EmbeddedFromFallbackFolder_DoesNotLockFile), NuGetVersion.Parse("1.0.0"));
 
                 // Add a fragment to consider this an embedded icon.
-                // Note: file:// is required for Uri to parse the Fragment (possibly a Uri bug).
+                // Note: file:// is required for Uri to parse the Fragment.
                 var uri = new Uri("file://" + filePath + "#testFile.txt");
 
                 NuGetPackageFileService.AddIconToCache(packageIdentity, uri);
@@ -212,7 +212,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var packageIdentity = new PackageIdentity(nameof(GetPackageIconAsync_NonEmbedded_GetStream_DoesNotLockFile), NuGetVersion.Parse("1.0.0"));
 
                 // Do not add a fragment which is typically required for the embedded icon.
-                // Note: file:// is required for Uri to parse the Fragment (possibly a Uri bug).
+                // Note: file:// is required for Uri to parse the Fragment.
                 var uri = new Uri("file://" + filePath);
                 NuGetPackageFileService.AddIconToCache(packageIdentity, uri);
                 FileStream fileNotLocked = File.Open(uri.LocalPath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read);
@@ -254,7 +254,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var packageIdentity = new PackageIdentity(nameof(GetPackageIconAsync_EmbeddedFromFallbackFolder_CanOpenReadOnlyFile), NuGetVersion.Parse("1.0.0"));
 
                 // Add a fragment to consider this an embedded icon.
-                // Note: file:// is required for Uri to parse the Fragment (possibly a Uri bug).
+                // Note: file:// is required for Uri to parse the Fragment.
                 var uri = new Uri("file://" + pathAndFileReadOnly + "#testFile.txt");
 
                 NuGetPackageFileService.AddIconToCache(packageIdentity, uri);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13766
Fixes: https://github.com/NuGet/Home/issues/13768

## Description

If a package icon exists in a local metadata source (global packages folder and packages folders), load it from disk rather than requesting it from the remote feed.
Remote feeds may not be able to provide icon metadata if they are, for example, an upstream Azure DevOps feed which requires authentication. Additionally, upstream sources apparently do not copy down icon (and other) metadata to the main feed.

The goal is to sometimes avoid a lookup in the remote feed, which is:
  1. More efficient (disk vs network)
  1. Reduces the occurrence of the problem where an AzDo feed doesn't have the iconUri for a package, or that Uri is inaccessible (eg, missing authentication). The default package icon was shown for nearly all packages in search results for AzDo feeds. 

### Synopsis of algorithm
- During PM UI loading of Search results, lookup and store any local icon paths in the Icon cache (using a `localIcon:` prefix as the key) when the package is found locally and its `iconUri` is non-null. 
- When icons begin loading in the PM UI, first look for the local icon path in the cache
- If there's a cache miss or the file in the cached path doesn't exist (or can't be read), only then attempt to go to the remote feed for the icon. This can result in the default package icon being shown if the icon is both not locally available and not retrievable from the remote feed.

Example (before on the left; after on the right) of how this PR impacts PM UI:

_Highlighted squares on the right are icons which do not appear prior to this PR_
![image](https://github.com/user-attachments/assets/878c054b-f652-4f8b-8b15-ede254322d7c)


### Secondary refactoring
- Unrelated to this change is a refactoring in this area: Stop opening files with Write permissions in `GetStream`. I'm not aware of any case where search metadata would need Write permission to a local file path using the PM UI. Similar change was made for embedded files in https://github.com/NuGet/NuGet.Client/pull/3969

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. N/A since this is enabling more icons to show when they currently fail to show in PM UI.
