### PR TITLE
fix invalid argument error in NuGet performance script

### DIFF
--- a/scripts/perftests/RunPerformanceTests.ps1
+++ b/scripts/perftests/RunPerformanceTests.ps1
@@ -310,7 +310,7 @@ Try
     {
         Log "Running $($iterationCount)x no-op restores"
 
-        $enabledSwitches = @("")
+        [string[]]$enabledSwitches = @()
         If ($staticGraphRestore)
         {
             $enabledSwitches += "staticGraphRestore"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: Engineering change

## Description

The testing team reported that executing a couple of NuGet performance scripts failed with the following error:

```
12/09/2024 10:22:17: Problem running the test case C:\\Users\\USERID\\Desktop\\NuGet.Client\\scripts\\perftests\\testCases\\
Test-OrchardCore.ps1 with error Cannot process argument because the value of argument "name" is not valid. Change the value of the “name” argument and run the operation again.
```
During debugging, I learned that PowerShell treats the `enabledSwitches` variable as a HashTable internally when declared as `$enabledSwitches = @("")`. I suggested the fix proposed in this pull request, and the testing team has confirmed that they are no longer seeing this error message.  

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~