### PR TITLE
Add ReadmeFileUrl field to IPackageSearchMetadata

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/TransitivePackageSearchMetadata.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/TransitivePackageSearchMetadata.cs
@@ -61,7 +61,6 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         public IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities => _packageSearchMetadata.Vulnerabilities;
 
-
         private readonly IPackageSearchMetadata _packageSearchMetadata;
 
         public TransitivePackageSearchMetadata(IPackageSearchMetadata package, IReadOnlyCollection<PackageIdentity> transitiveOrigins)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/TransitivePackageSearchMetadata.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/TransitivePackageSearchMetadata.cs
@@ -33,6 +33,8 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         public Uri ReadmeUrl => _packageSearchMetadata.ReadmeUrl;
 
+        public Uri ReadmeFileUrl => _packageSearchMetadata.ReadmeFileUrl;
+
         public Uri ReportAbuseUrl => _packageSearchMetadata.ReportAbuseUrl;
 
         public Uri PackageDetailsUrl => _packageSearchMetadata.PackageDetailsUrl;
@@ -58,6 +60,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         public LicenseMetadata LicenseMetadata => _packageSearchMetadata.LicenseMetadata;
 
         public IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities => _packageSearchMetadata.Vulnerabilities;
+
 
         private readonly IPackageSearchMetadata _packageSearchMetadata;
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/TransitivePackageSearchMetadata.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/TransitivePackageSearchMetadata.cs
@@ -33,7 +33,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         public Uri ReadmeUrl => _packageSearchMetadata.ReadmeUrl;
 
-        public Uri ReadmeFileUrl => _packageSearchMetadata.ReadmeFileUrl;
+        public string ReadmeFileUrl => _packageSearchMetadata.ReadmeFileUrl;
 
         public Uri ReportAbuseUrl => _packageSearchMetadata.ReportAbuseUrl;
 

--- a/src/NuGet.Core/NuGet.Protocol/Converters/ParserConstants.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/ParserConstants.cs
@@ -37,6 +37,7 @@ namespace NuGet.Protocol
         public const string LicenseExpressionVersion = "licenseExpressionVersion";
         public const string ProjectUrl = "projectUrl";
         public const string ReadmeUrl = "readmeUrl";
+        public const string ReadmeFileUrl = "readmeFileUrl";
         public const string Tags = "tags";
         public const string DownloadCount = "totalDownloads";
         public const string Created = "created";

--- a/src/NuGet.Core/NuGet.Protocol/Model/IPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/IPackageSearchMetadata.cs
@@ -24,6 +24,7 @@ namespace NuGet.Protocol.Core.Types
         Uri LicenseUrl { get; }
         Uri ProjectUrl { get; }
         Uri ReadmeUrl { get; }
+        Uri ReadmeFileUrl { get; }
         Uri ReportAbuseUrl { get; }
         Uri PackageDetailsUrl { get; }
         DateTimeOffset? Published { get; }

--- a/src/NuGet.Core/NuGet.Protocol/Model/IPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/IPackageSearchMetadata.cs
@@ -24,7 +24,7 @@ namespace NuGet.Protocol.Core.Types
         Uri LicenseUrl { get; }
         Uri ProjectUrl { get; }
         Uri ReadmeUrl { get; }
-        Uri ReadmeFileUrl { get; }
+        string ReadmeFileUrl { get; }
         Uri ReportAbuseUrl { get; }
         Uri PackageDetailsUrl { get; }
         DateTimeOffset? Published { get; }

--- a/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
@@ -225,7 +225,7 @@ namespace NuGet.Protocol
                 Fragment = embeddedReadme
             };
 
-            // get the special icon url
+            // get the readme url
             return builder.Uri;
         }
     }

--- a/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
@@ -226,7 +226,7 @@ namespace NuGet.Protocol
             };
 
             // get the readme url
-            return builder.Uri.AbsolutePath;
+            return builder.Uri.AbsoluteUri;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
@@ -38,6 +38,8 @@ namespace NuGet.Protocol
 
         public Uri IconUrl => GetIconUri();
 
+        public Uri ReadmeFileUrl => GetReadmeUri();
+
         public PackageIdentity Identity => _nuspec.GetIdentity();
 
         public Uri LicenseUrl => Convert(_nuspec.GetLicenseUrl());
@@ -201,6 +203,26 @@ namespace NuGet.Protocol
             UriBuilder builder = new UriBuilder(baseUri)
             {
                 Fragment = embeddedIcon
+            };
+
+            // get the special icon url
+            return builder.Uri;
+        }
+
+        private Uri GetReadmeUri()
+        {
+            string embeddedReadme = _nuspec.GetReadme();
+
+            if (embeddedReadme == null)
+            {
+                return null;
+            }
+
+            var baseUri = Convert(_package.Path);
+
+            UriBuilder builder = new UriBuilder(baseUri)
+            {
+                Fragment = embeddedReadme
             };
 
             // get the special icon url

--- a/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
@@ -38,7 +38,7 @@ namespace NuGet.Protocol
 
         public Uri IconUrl => GetIconUri();
 
-        public Uri ReadmeFileUrl => GetReadmeUri();
+        public string ReadmeFileUrl => GetReadmeUri();
 
         public PackageIdentity Identity => _nuspec.GetIdentity();
 
@@ -209,7 +209,7 @@ namespace NuGet.Protocol
             return builder.Uri;
         }
 
-        private Uri GetReadmeUri()
+        private string GetReadmeUri()
         {
             string embeddedReadme = _nuspec.GetReadme();
 
@@ -226,7 +226,7 @@ namespace NuGet.Protocol
             };
 
             // get the readme url
-            return builder.Uri;
+            return builder.Uri.AbsolutePath;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
@@ -106,7 +106,7 @@ namespace NuGet.Protocol
         [JsonConverter(typeof(SafeUriConverter))]
         public Uri ReadmeUrl { get; private set; }
 
-        [JsonIgnore]
+        [JsonProperty(PropertyName = JsonProperties.ReadmeFileUrl)]
         public string ReadmeFileUrl { get; private set; }
 
         [JsonIgnore]

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
@@ -107,7 +107,7 @@ namespace NuGet.Protocol
         public Uri ReadmeUrl { get; private set; }
 
         [JsonIgnore]
-        public Uri ReadmeFileUrl { get; private set; }
+        public string ReadmeFileUrl { get; private set; }
 
         [JsonIgnore]
         public Uri ReportAbuseUrl { get; set; }

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
@@ -107,6 +107,9 @@ namespace NuGet.Protocol
         public Uri ReadmeUrl { get; private set; }
 
         [JsonIgnore]
+        public Uri ReadmeFileUrl { get; private set; }
+
+        [JsonIgnore]
         public Uri ReportAbuseUrl { get; set; }
 
         [JsonIgnore]

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataBuilder.cs
@@ -40,6 +40,7 @@ namespace NuGet.Protocol.Core.Types
             public Uri ProjectUrl { get; set; }
             public DateTimeOffset? Published { get; set; }
             public Uri ReadmeUrl { get; set; }
+            public Uri ReadmeFileUrl { get; set; }
             public Uri ReportAbuseUrl { get; set; }
             public Uri PackageDetailsUrl { get; set; }
             public bool RequireLicenseAcceptance { get; set; }
@@ -98,6 +99,7 @@ namespace NuGet.Protocol.Core.Types
                 ProjectUrl = _metadata.ProjectUrl,
                 Published = _metadata.Published,
                 ReadmeUrl = _metadata.ReadmeUrl,
+                ReadmeFileUrl = _metadata.ReadmeFileUrl,
                 ReportAbuseUrl = _metadata.ReportAbuseUrl,
                 PackageDetailsUrl = _metadata.PackageDetailsUrl,
                 RequireLicenseAcceptance = _metadata.RequireLicenseAcceptance,

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataBuilder.cs
@@ -40,7 +40,7 @@ namespace NuGet.Protocol.Core.Types
             public Uri ProjectUrl { get; set; }
             public DateTimeOffset? Published { get; set; }
             public Uri ReadmeUrl { get; set; }
-            public Uri ReadmeFileUrl { get; set; }
+            public string ReadmeFileUrl { get; set; }
             public Uri ReportAbuseUrl { get; set; }
             public Uri PackageDetailsUrl { get; set; }
             public bool RequireLicenseAcceptance { get; set; }

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
@@ -105,6 +105,8 @@ namespace NuGet.Protocol
 
         public Uri ReadmeUrl { get; } = null; // The ReadmeUrl has not been added to the V2 feed.
 
+        public Uri ReadmeFileUrl { get; } = null; // The ReadmeFileUrl has not been added to the V2 feed.
+
         public Uri ReportAbuseUrl { get; private set; }
 
         public Uri PackageDetailsUrl { get; private set; }

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
@@ -105,7 +105,7 @@ namespace NuGet.Protocol
 
         public Uri ReadmeUrl { get; } = null; // The ReadmeUrl has not been added to the V2 feed.
 
-        public Uri ReadmeFileUrl { get; } = null; // The ReadmeFileUrl has not been added to the V2 feed.
+        public string ReadmeFileUrl { get; } = null; // The ReadmeFileUrl has not been added to the V2 feed.
 
         public Uri ReportAbuseUrl { get; private set; }
 

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
+~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
+~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.set -> void
+~NuGet.Protocol.LocalPackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
+~NuGet.Protocol.PackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
+~NuGet.Protocol.PackageSearchMetadataV2Feed.ReadmeFileUrl.get -> System.Uri

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+~const NuGet.Protocol.JsonProperties.ReadmeFileUrl = "readmeFileUrl" -> string
 ~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeFileUrl.get -> string
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.get -> string
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.set -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
+~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeFileUrl.get -> string
+~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.get -> string
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.set -> void
-~NuGet.Protocol.LocalPackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadataV2Feed.ReadmeFileUrl.get -> System.Uri
+~NuGet.Protocol.LocalPackageSearchMetadata.ReadmeFileUrl.get -> string
+~NuGet.Protocol.PackageSearchMetadata.ReadmeFileUrl.get -> string
+~NuGet.Protocol.PackageSearchMetadataV2Feed.ReadmeFileUrl.get -> string

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
+~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
+~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.set -> void
+~NuGet.Protocol.LocalPackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
+~NuGet.Protocol.PackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
+~NuGet.Protocol.PackageSearchMetadataV2Feed.ReadmeFileUrl.get -> System.Uri

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+~const NuGet.Protocol.JsonProperties.ReadmeFileUrl = "readmeFileUrl" -> string
 ~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeFileUrl.get -> string
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.get -> string
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.set -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
+~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeFileUrl.get -> string
+~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.get -> string
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.set -> void
-~NuGet.Protocol.LocalPackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadataV2Feed.ReadmeFileUrl.get -> System.Uri
+~NuGet.Protocol.LocalPackageSearchMetadata.ReadmeFileUrl.get -> string
+~NuGet.Protocol.PackageSearchMetadata.ReadmeFileUrl.get -> string
+~NuGet.Protocol.PackageSearchMetadataV2Feed.ReadmeFileUrl.get -> string

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
+~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
+~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.set -> void
+~NuGet.Protocol.LocalPackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
+~NuGet.Protocol.PackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
+~NuGet.Protocol.PackageSearchMetadataV2Feed.ReadmeFileUrl.get -> System.Uri

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+~const NuGet.Protocol.JsonProperties.ReadmeFileUrl = "readmeFileUrl" -> string
 ~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeFileUrl.get -> string
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.get -> string
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.set -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
+~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeFileUrl.get -> string
+~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.get -> string
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.set -> void
-~NuGet.Protocol.LocalPackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadata.ReadmeFileUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadataV2Feed.ReadmeFileUrl.get -> System.Uri
+~NuGet.Protocol.LocalPackageSearchMetadata.ReadmeFileUrl.get -> string
+~NuGet.Protocol.PackageSearchMetadata.ReadmeFileUrl.get -> string
+~NuGet.Protocol.PackageSearchMetadataV2Feed.ReadmeFileUrl.get -> string

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalPackageSearchMetadataTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalPackageSearchMetadataTests.cs
@@ -66,5 +66,14 @@ namespace NuGet.Protocol.Tests
             Assert.True(_testData.TestData.IconUrl.IsAbsoluteUri);
             Assert.NotNull(_testData.TestData.IconUrl.Fragment);
         }
+
+        [Fact]
+        public void ReadmeFileUrl_ReturnsEmbeddedReadmeUri()
+        {
+            Assert.NotNull(_testData.TestData.ReadmeFileUrl);
+            Assert.True(_testData.TestData.ReadmeFileUrl.IsFile);
+            Assert.True(_testData.TestData.ReadmeFileUrl.IsAbsoluteUri);
+            Assert.NotNull(_testData.TestData.ReadmeFileUrl.Fragment);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalPackageSearchMetadataTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalPackageSearchMetadataTests.cs
@@ -71,9 +71,11 @@ namespace NuGet.Protocol.Tests
         public void ReadmeFileUrl_ReturnsEmbeddedReadmeUri()
         {
             Assert.NotNull(_testData.TestData.ReadmeFileUrl);
-            Assert.True(_testData.TestData.ReadmeFileUrl.IsFile);
-            Assert.True(_testData.TestData.ReadmeFileUrl.IsAbsoluteUri);
-            Assert.NotNull(_testData.TestData.ReadmeFileUrl.Fragment);
+
+            var readmeFileUri = new Uri(_testData.TestData.ReadmeFileUrl);
+            Assert.True(readmeFileUri.IsFile);
+            Assert.True(readmeFileUri.IsAbsoluteUri);
+            Assert.NotNull(readmeFileUri.Fragment);
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/Protocol/LocalPackageSearchMetadataFixture.cs
+++ b/test/TestUtilities/Test.Utility/Protocol/LocalPackageSearchMetadataFixture.cs
@@ -25,6 +25,7 @@ namespace NuGet.Test.Utility
                 .WithPackageId(pkgId.Id)
                 .WithPackageVersion(pkgId.Version.ToNormalizedString())
                 .WithIcon("icon.png")
+                .WithReadme("readme.md")
                 .Build();
             pkg.Nuspec = XDocument.Parse(nuspec.ToString());
 

--- a/test/TestUtilities/Test.Utility/Protocol/V3PackageSearchMetadataFixture.cs
+++ b/test/TestUtilities/Test.Utility/Protocol/V3PackageSearchMetadataFixture.cs
@@ -74,6 +74,8 @@ namespace NuGet.Test.Utility
 
             public Uri ReadmeUrl => null;
 
+            public Uri ReadmeFileUrl => null;
+
             public Uri LicenseUrl => null;
 
             public Uri ProjectUrl => null;

--- a/test/TestUtilities/Test.Utility/Protocol/V3PackageSearchMetadataFixture.cs
+++ b/test/TestUtilities/Test.Utility/Protocol/V3PackageSearchMetadataFixture.cs
@@ -74,7 +74,7 @@ namespace NuGet.Test.Utility
 
             public Uri ReadmeUrl => null;
 
-            public Uri ReadmeFileUrl => null;
+            public string ReadmeFileUrl => null;
 
             public Uri LicenseUrl => null;
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Part of: https://github.com/NuGet/Home/issues/12583

## Description
Adds the ReadmeFileUrl field to IPackageSearchMetadata and implements the ability to get the URL for local packages. Future PRs will include implementations for getting the URL for remote READMEs and downloading them.  

## PR Checklist

- [X] Meaningful title, helpful description and a linked NuGet/Home issue
- [X] ~~Added tests~~
- [X] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~
