### PR TITLE
Downgrade MSBuild to .NET SDK's supported version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Default MSBuild version -->
+    <!-- Code we insert into the .NET SDK must comply with their minimum Visual Studio version documented at
+        https://learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs#targeting-and-support-rules
+        Therefore do not update THIS MSBuild version unless the version of the .NET SDK that the current branch
+        of NuGet is inserting into allows the higher MSBuld version
+     -->
+    <MicrosoftBuildVersion Condition="'$(MicrosoftBuildVersion)' == '' And '$(UseMSBuildVersionForDotnetSdk)' == 'true'">17.8.3</MicrosoftBuildVersion>
+    <!-- The rest of NuGet can use a MSBuild version up to the version of VS that the current branch inserts into -->
     <MicrosoftBuildVersion Condition="'$(MicrosoftBuildVersion)' == ''">17.10.4</MicrosoftBuildVersion>
     <!-- The last package version of MSBuild that works with netcoreapp3.1 or netstandard2.0 is 16.8.0.  Our assemblies are still compiled against MSBuild assembly version 15.1.0.0 which will work with all versions -->
     <MicrosoftBuildVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'netstandard2.0'">16.8.0</MicrosoftBuildVersion>

--- a/src/NuGet.Core/Directory.Build.props
+++ b/src/NuGet.Core/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <SignWithMicrosoftKey Condition="'$(SignWithMicrosoftKey)' == ''">true</SignWithMicrosoftKey>
+    <UseMSBuildVersionForDotnetSdk>true</UseMSBuildVersionForDotnetSdk>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

this is for release-6.11.x, which maps to .NET 8.0.4xx SDK

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13775

## Description

The .NET SDK has documented the minimum VS that the SDK supports. NuGet cannot use versions of MSBuild higher than that, otherwise it will unintentionally break the .NET SDK on older versions of VS
https://learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs#targeting-and-support-rules

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~  manually tested, will think about some kind of validation in the dev branch to try to enforce it.
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
