### PR TITLE
PackageManagementFormat only updates settings when it has a value

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/PackageManagementFormat.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/PackageManagementFormat.cs
@@ -102,10 +102,17 @@ namespace NuGet.VisualStudio
 
         public void ApplyChanges()
         {
-            _settings.AddOrUpdate(ConfigurationConstants.PackageManagementSection,
-                new AddItem(ConfigurationConstants.DefaultPackageManagementFormatKey, _selectedPackageFormat.ToString(CultureInfo.InvariantCulture)));
-            _settings.AddOrUpdate(ConfigurationConstants.PackageManagementSection,
-                new AddItem(ConfigurationConstants.DoNotShowPackageManagementSelectionKey, _showDialogValue.Value.ToString(CultureInfo.InvariantCulture)));
+            if (_selectedPackageFormat != -1)
+            {
+                _settings.AddOrUpdate(ConfigurationConstants.PackageManagementSection,
+                    new AddItem(ConfigurationConstants.DefaultPackageManagementFormatKey, _selectedPackageFormat.ToString(CultureInfo.InvariantCulture)));
+            }
+
+            if (_showDialogValue.HasValue)
+            {
+                _settings.AddOrUpdate(ConfigurationConstants.PackageManagementSection,
+                    new AddItem(ConfigurationConstants.DoNotShowPackageManagementSelectionKey, _showDialogValue.Value.ToString(CultureInfo.InvariantCulture)));
+            }
             _settings.SaveToDisk();
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/PackageManagementFormat.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/PackageManagementFormat.cs
@@ -18,7 +18,7 @@ namespace NuGet.VisualStudio
         // keep track of current value for selected package format
         private int _selectedPackageFormat = -1;
 
-        // keep track of current value for shwo dialog checkbox
+        // keep track of current value for show dialog checkbox
         private bool? _showDialogValue;
 
         public PackageManagementFormat(Configuration.ISettings settings)

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/PackageManagementFormatTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/PackageManagementFormatTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Globalization;
+using Moq;
+using NuGet.Configuration;
+using Xunit;
+
+namespace NuGet.VisualStudio.Common.Test
+{
+    public class PackageManagementFormatTests
+    {
+        private Mock<ISettings> _settings;
+        private PackageManagementFormat _packageManagementFormat;
+
+        public PackageManagementFormatTests()
+        {
+            _settings = new Mock<ISettings>();
+            _packageManagementFormat = new PackageManagementFormat(_settings.Object);
+        }
+
+        [Fact]
+        public void ApplyChanges_WhenPropertiesNotChanged_DoesNotThrowOrUpdateSettings()
+        {
+            // Act
+            _packageManagementFormat.ApplyChanges();
+
+            // Assert
+            // Ensure no settings change calls are made.
+            _settings.Verify(settings => settings.AddOrUpdate(It.IsAny<string>(), It.IsAny<SettingItem>()), Times.Never);
+
+            // Calling to save settings should always happen, regardless of values.
+            _settings.Verify(settings => settings.SaveToDisk(), Times.Once());
+        }
+
+        [Fact]
+        public void ApplyChanges_WhenEnabledIsSet_SavesAndDoesNotThrow()
+        {
+            // Arrange
+            _packageManagementFormat.Enabled = false;
+            string expectedBooleanAsString = false.ToString(CultureInfo.InvariantCulture);
+
+            // Act
+            _packageManagementFormat.ApplyChanges();
+
+            // Assert
+            _settings.Verify(settings => settings.AddOrUpdate(ConfigurationConstants.PackageManagementSection,
+                It.Is<AddItem>(addItem => addItem.Key == ConfigurationConstants.DoNotShowPackageManagementSelectionKey && addItem.Value == expectedBooleanAsString)),
+                Times.Once);
+
+            // Calling to save settings should always happen, regardless of values.
+            _settings.Verify(settings => settings.SaveToDisk(), Times.Once());
+
+            _settings.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void ApplyChanges_WhenSelectedPackageManagementFormatIsSet_SavesAndDoesNotThrow()
+        {
+            // Arrange
+            _packageManagementFormat.SelectedPackageManagementFormat = 0;
+            string expectedIntegerAsString = 0.ToString(CultureInfo.InvariantCulture);
+
+            // Act
+            _packageManagementFormat.ApplyChanges();
+
+            // Assert
+            _settings.Verify(settings => settings.AddOrUpdate(ConfigurationConstants.PackageManagementSection,
+                It.Is<AddItem>(addItem => addItem.Key == ConfigurationConstants.DefaultPackageManagementFormatKey && addItem.Value == expectedIntegerAsString)),
+                Times.Once);
+
+            // Calling to save settings should always happen, regardless of values.
+            _settings.Verify(settings => settings.SaveToDisk(), Times.Once());
+
+            _settings.VerifyNoOtherCalls();
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/13773

## Description

While testing VS Settings, I found that if I do not invoke getters on properties in this class, then call `ApplyChanges` two issues can occur:

- `Enabled` property: an exception was thrown due to a nullable property being unset
- `SelectedPackageManagementFormat` property: a "-1" was written to the nuget.config. This is never a valid value and should never be written to a nuget.config‼️ 

Check properties for valid values prior to updating settings.
Tests ensure that if no values are set, nothing is updated in settings, even though the call to Save still occurs. I didn't want to change any other workflow that may depend on this call to save to disk.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
