### PR TITLE
Update _WalkEachTargetPerFramework to walk TFMs in parallel

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -350,11 +350,16 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="_WalkEachTargetPerFramework">
+    <ItemGroup>
+        <_ProjectsWithTFM Include="$(MSBuildProjectFullPath)" AdditionalProperties="TargetFramework=%(_TargetFrameworks.Identity)" />
+        <_ProjectsWithTFMNoBuild Include="$(MSBuildProjectFullPath)" AdditionalProperties="TargetFramework=%(_TargetFrameworks.Identity);BuildProjectReferences=false" />
+
+    </ItemGroup>
     <MSBuild
       Condition="'$(IncludeBuildOutput)' == 'true'"
-      Projects="$(MSBuildProjectFullPath)"
+      Projects="@(_ProjectsWithTFM)"
       Targets="_GetBuildOutputFilesWithTfm"
-      Properties="TargetFramework=%(_TargetFrameworks.Identity);">
+      BuildInParallel="$(BuildInParallel)">
 
       <Output
           TaskParameter="TargetOutputs"
@@ -363,9 +368,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <MSBuild
       Condition="'$(TargetsForTfmSpecificContentInPackage)' != ''"
-      Projects="$(MSBuildProjectFullPath)"
+      Projects="@(_ProjectsWithTFM)"
       Targets="_GetTfmSpecificContentForPackage"
-      Properties="TargetFramework=%(_TargetFrameworks.Identity);">
+      BuildInParallel="$(BuildInParallel)">
 
       <Output
           TaskParameter="TargetOutputs"
@@ -374,9 +379,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <MSBuild
       Condition="'$(IncludeBuildOutput)' == 'true'"
-      Projects="$(MSBuildProjectFullPath)"
+      Projects="@(_ProjectsWithTFM)"
       Targets="_GetDebugSymbolsWithTfm"
-      Properties="TargetFramework=%(_TargetFrameworks.Identity);">
+      BuildInParallel="$(BuildInParallel)">
 
       <Output
           TaskParameter="TargetOutputs"
@@ -385,10 +390,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <MSBuild
       Condition="'$(IncludeSource)' == 'true'"
-      Projects="$(MSBuildProjectFullPath)"
+      Projects="@(_ProjectsWithTFMNoBuild)"
       Targets="SourceFilesProjectOutputGroup"
-      Properties="TargetFramework=%(_TargetFrameworks.Identity);
-                  BuildProjectReferences=false;">
+      BuildInParallel="$(BuildInParallel)">
 
       <Output
           TaskParameter="TargetOutputs"
@@ -396,10 +400,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     </MSBuild>
 
     <MSBuild
-      Projects="$(MSBuildProjectFullPath)"
+      Projects="@(_ProjectsWithTFMNoBuild)"
       Targets="_GetFrameworkAssemblyReferences"
-      Properties="TargetFramework=%(_TargetFrameworks.Identity);
-                  BuildProjectReferences=false;">
+      BuildInParallel="$(BuildInParallel)">
 
       <Output
           TaskParameter="TargetOutputs"
@@ -407,10 +410,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     </MSBuild>
 
     <MSBuild
-      Projects="$(MSBuildProjectFullPath)"
+      Projects="@(_ProjectsWithTFMNoBuild)"
       Targets="_GetFrameworksWithSuppressedDependencies"
-      Properties="TargetFramework=%(_TargetFrameworks.Identity);
-                  BuildProjectReferences=false;">
+      BuildInParallel="$(BuildInParallel)">
 
       <Output
           TaskParameter="TargetOutputs"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13776

## Description

This PR changes the `MSBuild` invocations in this Target to issue parallel build requests for each target where possible. This results in less overhead and more parallelism by default in the build, and in my testing results in a 50% reduction in time taken for this target. This reduction remains consistent as the number of TFMs grows and should be more pronounced as the work done in this 
target (i.e. custom user targets) takes more time.

I've included the use of the conventional `BuildInParallel` property to control this parallelism - if specified the performance is essentially the same as the old version of this target.

Before:
![image](https://github.com/user-attachments/assets/a0f3d80b-4171-4cb2-a899-121f6c9312d6)

After:
![image](https://github.com/user-attachments/assets/19082553-9f2d-4e4b-b506-b0b41524c458)


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests (no need, no user facing change)
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. (no need, doesn't require new docs).
