### PR TITLE
Represent all transitive origins for all installed package versions in tooltip

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -258,6 +258,20 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
+        private ObservableCollection<PackageIdentity> _transitiveOrigins;
+        public ObservableCollection<PackageIdentity> TransitiveOrigins
+        {
+            get
+            {
+                return _transitiveOrigins;
+            }
+            set
+            {
+                _transitiveOrigins = value;
+                OnPropertyChanged(nameof(TransitiveOrigins));
+            }
+        }
+
         private string _installedVersionToolTip;
 
         public string InstalledVersionToolTip


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13696

## Description
The PackageItemViewModel will accumulate the list of transitive origins across all transitively installed package versions and will update the tooltip to show the list of installed versions and all of the transitive origins.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ Will add tests and share arrange code with https://github.com/NuGet/NuGet.Client/pull/5998 in upcoming PR into feature branch.
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
