### PR TITLE
Add telemetry for HTTP resources that have an HTTPS source

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Providers/DownloadResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/DownloadResourceV3Provider.cs
@@ -36,7 +36,8 @@ namespace NuGet.Protocol
                 var uri = serviceIndex.GetServiceEntryUri(ServiceTypes.PackageBaseAddress);
                 var packageBaseAddress = uri?.AbsoluteUri;
 
-                if (source.PackageSource.IsHttps &&
+                if (uri != null &&
+                    source.PackageSource.IsHttps &&
                     uri?.Scheme == Uri.UriSchemeHttp &&
                     uri?.Scheme != Uri.UriSchemeHttps)
                 {

--- a/src/NuGet.Core/NuGet.Protocol/Providers/DownloadResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/DownloadResourceV3Provider.cs
@@ -36,13 +36,14 @@ namespace NuGet.Protocol
                 var uri = serviceIndex.GetServiceEntryUri(ServiceTypes.PackageBaseAddress);
                 var packageBaseAddress = uri?.AbsoluteUri;
 
-                // Telemetry for HTTPS sources that have an HTTP resource
-                var telemetry = new ServiceIndexEntryTelemetry(
-                    source.PackageSource.IsHttps &&
+                if (source.PackageSource.IsHttps &&
                     uri?.Scheme == Uri.UriSchemeHttp &&
-                    uri?.Scheme != Uri.UriSchemeHttps ? 1 : 0,
-                    "RestorePackageSourceSummary");
-                TelemetryActivity.EmitTelemetryEvent(telemetry);
+                    uri?.Scheme != Uri.UriSchemeHttps)
+                {
+                    // Telemetry for HTTPS sources that have an HTTP resource
+                    var telemetry = new ServiceIndexEntryTelemetry(1, "RestorePackageSourceSummary");
+                    TelemetryActivity.EmitTelemetryEvent(telemetry);
+                }
 
                 if (packageBaseAddress != null)
                 {

--- a/src/NuGet.Core/NuGet.Protocol/Providers/OwnerDetailsUriResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/OwnerDetailsUriResourceV3Provider.cs
@@ -32,13 +32,14 @@ namespace NuGet.Protocol.Providers
             {
                 Uri? uriTemplate = serviceIndex.GetServiceEntryUri(ServiceTypes.OwnerDetailsUriTemplate);
 
-                // Telemetry for HTTPS sources that have an HTTP resource
-                var telemetry = new ServiceIndexEntryTelemetry(
-                    source.PackageSource.IsHttps &&
+                if (source.PackageSource.IsHttps &&
                     uriTemplate?.Scheme == Uri.UriSchemeHttp &&
-                    uriTemplate?.Scheme != Uri.UriSchemeHttps ? 1 : 0,
-                    "RestorePackageSourceSummary");
-                TelemetryActivity.EmitTelemetryEvent(telemetry);
+                    uriTemplate?.Scheme != Uri.UriSchemeHttps)
+                {
+                    // Telemetry for HTTPS sources that have an HTTP resource
+                    var telemetry = new ServiceIndexEntryTelemetry(1, "RestorePackageSourceSummary");
+                    TelemetryActivity.EmitTelemetryEvent(telemetry);
+                }
 
                 if (uriTemplate != null)
                 {

--- a/src/NuGet.Core/NuGet.Protocol/Providers/OwnerDetailsUriResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/OwnerDetailsUriResourceV3Provider.cs
@@ -32,7 +32,8 @@ namespace NuGet.Protocol.Providers
             {
                 Uri? uriTemplate = serviceIndex.GetServiceEntryUri(ServiceTypes.OwnerDetailsUriTemplate);
 
-                if (source.PackageSource.IsHttps &&
+                if (uriTemplate != null &&
+                    source.PackageSource.IsHttps &&
                     uriTemplate?.Scheme == Uri.UriSchemeHttp &&
                     uriTemplate?.Scheme != Uri.UriSchemeHttps)
                 {

--- a/src/NuGet.Core/NuGet.Protocol/Providers/PackageDetailsUriResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/PackageDetailsUriResourceV3Provider.cs
@@ -26,7 +26,8 @@ namespace NuGet.Protocol
             {
                 var uri = serviceIndex.GetServiceEntryUri(ServiceTypes.PackageDetailsUriTemplate);
 
-                if (source.PackageSource.IsHttps &&
+                if (uri != null &&
+                    source.PackageSource.IsHttps &&
                     uri?.Scheme == Uri.UriSchemeHttp &&
                     uri?.Scheme != Uri.UriSchemeHttps)
                 {

--- a/src/NuGet.Core/NuGet.Protocol/Providers/PackageDetailsUriResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/PackageDetailsUriResourceV3Provider.cs
@@ -26,13 +26,14 @@ namespace NuGet.Protocol
             {
                 var uri = serviceIndex.GetServiceEntryUri(ServiceTypes.PackageDetailsUriTemplate);
 
-                // Telemetry for HTTPS sources that have an HTTP resource
-                var telemetry = new ServiceIndexEntryTelemetry(
-                    source.PackageSource.IsHttps &&
+                if (source.PackageSource.IsHttps &&
                     uri?.Scheme == Uri.UriSchemeHttp &&
-                    uri?.Scheme != Uri.UriSchemeHttps ? 1 : 0,
-                    "RestorePackageSourceSummary");
-                TelemetryActivity.EmitTelemetryEvent(telemetry);
+                    uri?.Scheme != Uri.UriSchemeHttps)
+                {
+                    // Telemetry for HTTPS sources that have an HTTP resource
+                    var telemetry = new ServiceIndexEntryTelemetry(1, "RestorePackageSourceSummary");
+                    TelemetryActivity.EmitTelemetryEvent(telemetry);
+                }
 
                 resource = PackageDetailsUriResourceV3.CreateOrNull(uri?.OriginalString);
             }

--- a/src/NuGet.Core/NuGet.Protocol/Providers/PackageUpdateResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/PackageUpdateResourceV3Provider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Security.Policy;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -31,13 +32,14 @@ namespace NuGet.Protocol
             {
                 var baseUrl = serviceIndex.GetServiceEntryUri(ServiceTypes.PackagePublish);
 
-                // Telemetry for HTTPS sources that have an HTTP resource
-                var telemetry = new ServiceIndexEntryTelemetry(
-                    source.PackageSource.IsHttps &&
-                    baseUrl?.Scheme == Uri.UriSchemeHttp &&
-                    baseUrl?.Scheme != Uri.UriSchemeHttps ? 1 : 0,
-                    "RestorePackageSourceSummary");
-                TelemetryActivity.EmitTelemetryEvent(telemetry);
+                if (source.PackageSource.IsHttps &&
+                    uri?.Scheme == Uri.UriSchemeHttp &&
+                    uri?.Scheme != Uri.UriSchemeHttps)
+                {
+                    // Telemetry for HTTPS sources that have an HTTP resource
+                    var telemetry = new ServiceIndexEntryTelemetry(1, "RestorePackageSourceSummary");
+                    TelemetryActivity.EmitTelemetryEvent(telemetry);
+                }
 
                 HttpSource httpSource = null;
                 var sourceUri = baseUrl?.AbsoluteUri;

--- a/src/NuGet.Core/NuGet.Protocol/Providers/PackageUpdateResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/PackageUpdateResourceV3Provider.cs
@@ -31,7 +31,8 @@ namespace NuGet.Protocol
             {
                 var baseUrl = serviceIndex.GetServiceEntryUri(ServiceTypes.PackagePublish);
 
-                if (source.PackageSource.IsHttps &&
+                if (baseUrl != null &&
+                    source.PackageSource.IsHttps &&
                     baseUrl?.Scheme == Uri.UriSchemeHttp &&
                     baseUrl?.Scheme != Uri.UriSchemeHttps)
                 {

--- a/src/NuGet.Core/NuGet.Protocol/Providers/PackageUpdateResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/PackageUpdateResourceV3Provider.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Globalization;
-using System.Security.Policy;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -33,8 +32,8 @@ namespace NuGet.Protocol
                 var baseUrl = serviceIndex.GetServiceEntryUri(ServiceTypes.PackagePublish);
 
                 if (source.PackageSource.IsHttps &&
-                    uri?.Scheme == Uri.UriSchemeHttp &&
-                    uri?.Scheme != Uri.UriSchemeHttps)
+                    baseUrl?.Scheme == Uri.UriSchemeHttp &&
+                    baseUrl?.Scheme != Uri.UriSchemeHttps)
                 {
                     // Telemetry for HTTPS sources that have an HTTP resource
                     var telemetry = new ServiceIndexEntryTelemetry(1, "RestorePackageSourceSummary");

--- a/src/NuGet.Core/NuGet.Protocol/Providers/RegistrationResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/RegistrationResourceV3Provider.cs
@@ -28,7 +28,8 @@ namespace NuGet.Protocol
                 //This will come back as null if there are no matching RegistrationsBaseUrl types
                 var baseUrl = serviceIndex.GetServiceEntryUri(ServiceTypes.RegistrationsBaseUrl);
 
-                if (source.PackageSource.IsHttps &&
+                if (baseUrl != null &&
+                    source.PackageSource.IsHttps &&
                     baseUrl?.Scheme == Uri.UriSchemeHttp &&
                     baseUrl?.Scheme != Uri.UriSchemeHttps)
                 {

--- a/src/NuGet.Core/NuGet.Protocol/Providers/RegistrationResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/RegistrationResourceV3Provider.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Security.Policy;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -30,8 +29,8 @@ namespace NuGet.Protocol
                 var baseUrl = serviceIndex.GetServiceEntryUri(ServiceTypes.RegistrationsBaseUrl);
 
                 if (source.PackageSource.IsHttps &&
-                    uri?.Scheme == Uri.UriSchemeHttp &&
-                    uri?.Scheme != Uri.UriSchemeHttps)
+                    baseUrl?.Scheme == Uri.UriSchemeHttp &&
+                    baseUrl?.Scheme != Uri.UriSchemeHttps)
                 {
                     // Telemetry for HTTPS sources that have an HTTP resource
                     var telemetry = new ServiceIndexEntryTelemetry(1, "RestorePackageSourceSummary");

--- a/src/NuGet.Core/NuGet.Protocol/Providers/RegistrationResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/RegistrationResourceV3Provider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Security.Policy;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -28,13 +29,14 @@ namespace NuGet.Protocol
                 //This will come back as null if there are no matching RegistrationsBaseUrl types
                 var baseUrl = serviceIndex.GetServiceEntryUri(ServiceTypes.RegistrationsBaseUrl);
 
-                // Telemetry for HTTPS sources that have an HTTP resource
-                var telemetry = new ServiceIndexEntryTelemetry(
-                    source.PackageSource.IsHttps &&
-                    baseUrl?.Scheme == Uri.UriSchemeHttp &&
-                    baseUrl?.Scheme != Uri.UriSchemeHttps ? 1 : 0,
-                    "RestorePackageSourceSummary");
-                TelemetryActivity.EmitTelemetryEvent(telemetry);
+                if (source.PackageSource.IsHttps &&
+                    uri?.Scheme == Uri.UriSchemeHttp &&
+                    uri?.Scheme != Uri.UriSchemeHttps)
+                {
+                    // Telemetry for HTTPS sources that have an HTTP resource
+                    var telemetry = new ServiceIndexEntryTelemetry(1, "RestorePackageSourceSummary");
+                    TelemetryActivity.EmitTelemetryEvent(telemetry);
+                }
 
                 if (baseUrl != null)
                 {

--- a/src/NuGet.Core/NuGet.Protocol/Providers/RegistrationResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/RegistrationResourceV3Provider.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Security.Policy;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;

--- a/src/NuGet.Core/NuGet.Protocol/Providers/ReportAbuseResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/ReportAbuseResourceV3Provider.cs
@@ -27,7 +27,8 @@ namespace NuGet.Protocol
                 var uri = serviceIndex.GetServiceEntryUri(ServiceTypes.ReportAbuse);
                 var uriTemplate = uri?.AbsoluteUri;
 
-                if (source.PackageSource.IsHttps &&
+                if (uri != null &&
+                    source.PackageSource.IsHttps &&
                     uri?.Scheme == Uri.UriSchemeHttp &&
                     uri?.Scheme != Uri.UriSchemeHttps)
                 {

--- a/src/NuGet.Core/NuGet.Protocol/Providers/ReportAbuseResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/ReportAbuseResourceV3Provider.cs
@@ -27,13 +27,14 @@ namespace NuGet.Protocol
                 var uri = serviceIndex.GetServiceEntryUri(ServiceTypes.ReportAbuse);
                 var uriTemplate = uri?.AbsoluteUri;
 
-                // Telemetry for HTTPS sources that have an HTTP resource
-                var telemetry = new ServiceIndexEntryTelemetry(
-                    source.PackageSource.IsHttps &&
+                if (source.PackageSource.IsHttps &&
                     uri?.Scheme == Uri.UriSchemeHttp &&
-                    uri?.Scheme != Uri.UriSchemeHttps ? 1 : 0,
-                    "RestorePackageSourceSummary");
-                TelemetryActivity.EmitTelemetryEvent(telemetry);
+                    uri?.Scheme != Uri.UriSchemeHttps)
+                {
+                    // Telemetry for HTTPS sources that have an HTTP resource
+                    var telemetry = new ServiceIndexEntryTelemetry(1, "RestorePackageSourceSummary");
+                    TelemetryActivity.EmitTelemetryEvent(telemetry);
+                }
 
                 // construct a new resource
                 resource = new ReportAbuseResourceV3(uriTemplate);

--- a/src/NuGet.Core/NuGet.Protocol/Providers/SymbolPackageUpdateResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/SymbolPackageUpdateResourceV3Provider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Security.Policy;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -28,13 +29,14 @@ namespace NuGet.Protocol
             {
                 var baseUrl = serviceIndex.GetServiceEntryUri(ServiceTypes.SymbolPackagePublish);
 
-                // Telemetry for HTTPS sources that have an HTTP resource
-                var telemetry = new ServiceIndexEntryTelemetry(
-                    source.PackageSource.IsHttps &&
-                    baseUrl?.Scheme == Uri.UriSchemeHttp &&
-                    baseUrl?.Scheme != Uri.UriSchemeHttps ? 1 : 0,
-                    "RestorePackageSourceSummary");
-                TelemetryActivity.EmitTelemetryEvent(telemetry);
+                if (source.PackageSource.IsHttps &&
+                    uri?.Scheme == Uri.UriSchemeHttp &&
+                    uri?.Scheme != Uri.UriSchemeHttps)
+                {
+                    // Telemetry for HTTPS sources that have an HTTP resource
+                    var telemetry = new ServiceIndexEntryTelemetry(1, "RestorePackageSourceSummary");
+                    TelemetryActivity.EmitTelemetryEvent(telemetry);
+                }
 
                 HttpSource httpSource = null;
                 var sourceUri = baseUrl?.AbsoluteUri;

--- a/src/NuGet.Core/NuGet.Protocol/Providers/SymbolPackageUpdateResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/SymbolPackageUpdateResourceV3Provider.cs
@@ -28,7 +28,8 @@ namespace NuGet.Protocol
             {
                 var baseUrl = serviceIndex.GetServiceEntryUri(ServiceTypes.SymbolPackagePublish);
 
-                if (source.PackageSource.IsHttps &&
+                if (baseUrl != null &&
+                    source.PackageSource.IsHttps &&
                     baseUrl?.Scheme == Uri.UriSchemeHttp &&
                     baseUrl?.Scheme != Uri.UriSchemeHttps)
                 {

--- a/src/NuGet.Core/NuGet.Protocol/Providers/SymbolPackageUpdateResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/SymbolPackageUpdateResourceV3Provider.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Security.Policy;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -30,8 +29,8 @@ namespace NuGet.Protocol
                 var baseUrl = serviceIndex.GetServiceEntryUri(ServiceTypes.SymbolPackagePublish);
 
                 if (source.PackageSource.IsHttps &&
-                    uri?.Scheme == Uri.UriSchemeHttp &&
-                    uri?.Scheme != Uri.UriSchemeHttps)
+                    baseUrl?.Scheme == Uri.UriSchemeHttp &&
+                    baseUrl?.Scheme != Uri.UriSchemeHttps)
                 {
                     // Telemetry for HTTPS sources that have an HTTP resource
                     var telemetry = new ServiceIndexEntryTelemetry(1, "RestorePackageSourceSummary");

--- a/src/NuGet.Core/NuGet.Protocol/Providers/SymbolPackageUpdateResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/SymbolPackageUpdateResourceV3Provider.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Security.Policy;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;

--- a/src/NuGet.Core/NuGet.Protocol/Providers/V3FeedListResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/V3FeedListResourceProvider.cs
@@ -31,7 +31,8 @@ namespace NuGet.Protocol
             {
                 var baseUrl = serviceIndex.GetServiceEntryUri(ServiceTypes.LegacyGallery);
 
-                if (source.PackageSource.IsHttps &&
+                if (baseUrl != null &&
+                    source.PackageSource.IsHttps &&
                     baseUrl?.Scheme == Uri.UriSchemeHttp &&
                     baseUrl?.Scheme != Uri.UriSchemeHttps)
                 {

--- a/src/NuGet.Core/NuGet.Protocol/Providers/V3FeedListResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/V3FeedListResourceProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Security.Policy;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -31,13 +32,14 @@ namespace NuGet.Protocol
             {
                 var baseUrl = serviceIndex.GetServiceEntryUri(ServiceTypes.LegacyGallery);
 
-                // Telemetry for HTTPS sources that have an HTTP resource
-                var telemetry = new ServiceIndexEntryTelemetry(
-                    source.PackageSource.IsHttps &&
-                    baseUrl?.Scheme == Uri.UriSchemeHttp &&
-                    baseUrl?.Scheme != Uri.UriSchemeHttps ? 1 : 0,
-                    "RestorePackageSourceSummary");
-                TelemetryActivity.EmitTelemetryEvent(telemetry);
+                if (source.PackageSource.IsHttps &&
+                    uri?.Scheme == Uri.UriSchemeHttp &&
+                    uri?.Scheme != Uri.UriSchemeHttps)
+                {
+                    // Telemetry for HTTPS sources that have an HTTP resource
+                    var telemetry = new ServiceIndexEntryTelemetry(1, "RestorePackageSourceSummary");
+                    TelemetryActivity.EmitTelemetryEvent(telemetry);
+                }
 
                 if (baseUrl != null)
                 {

--- a/src/NuGet.Core/NuGet.Protocol/Providers/V3FeedListResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/V3FeedListResourceProvider.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Security.Policy;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -33,8 +32,8 @@ namespace NuGet.Protocol
                 var baseUrl = serviceIndex.GetServiceEntryUri(ServiceTypes.LegacyGallery);
 
                 if (source.PackageSource.IsHttps &&
-                    uri?.Scheme == Uri.UriSchemeHttp &&
-                    uri?.Scheme != Uri.UriSchemeHttps)
+                    baseUrl?.Scheme == Uri.UriSchemeHttp &&
+                    baseUrl?.Scheme != Uri.UriSchemeHttps)
                 {
                     // Telemetry for HTTPS sources that have an HTTP resource
                     var telemetry = new ServiceIndexEntryTelemetry(1, "RestorePackageSourceSummary");

--- a/src/NuGet.Core/NuGet.Protocol/Providers/VulnerabilityInfoResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/VulnerabilityInfoResourceV3Provider.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Resources;
 
@@ -26,6 +27,15 @@ namespace NuGet.Protocol.Providers
         {
             var serviceIndexResource = await source.GetResourceAsync<ServiceIndexResourceV3>(token);
             Uri? baseUri = serviceIndexResource?.GetServiceEntryUri(ServiceTypes.VulnerabilityInfo);
+
+            // Telemetry for HTTPS sources that have an HTTP resource
+            var telemetry = new ServiceIndexEntryTelemetry(
+                source.PackageSource.IsHttps &&
+                baseUri?.Scheme == Uri.UriSchemeHttp &&
+                baseUri?.Scheme != Uri.UriSchemeHttps ? 1 : 0,
+                "RestorePackageSourceSummary");
+            TelemetryActivity.EmitTelemetryEvent(telemetry);
+
             if (baseUri != null)
             {
                 var resource = new VulnerabilityInfoResourceV3(source);
@@ -33,6 +43,14 @@ namespace NuGet.Protocol.Providers
             }
 
             return new Tuple<bool, INuGetResource?>(false, null);
+        }
+
+        private class ServiceIndexEntryTelemetry : TelemetryEvent
+        {
+            public ServiceIndexEntryTelemetry(int NumSourceWithHttpResource, string eventName) : base(eventName)
+            {
+                this["NumHTTPVulnerabilityInfoResourceWithHTTPSSource"] = NumSourceWithHttpResource;
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Providers/VulnerabilityInfoResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/VulnerabilityInfoResourceV3Provider.cs
@@ -28,9 +28,10 @@ namespace NuGet.Protocol.Providers
             var serviceIndexResource = await source.GetResourceAsync<ServiceIndexResourceV3>(token);
             Uri? baseUri = serviceIndexResource?.GetServiceEntryUri(ServiceTypes.VulnerabilityInfo);
 
-            if (source.PackageSource.IsHttps &&
-                    baseUri?.Scheme == Uri.UriSchemeHttp &&
-                    baseUri?.Scheme != Uri.UriSchemeHttps)
+            if (baseUri != null &&
+                source.PackageSource.IsHttps &&
+                baseUri?.Scheme == Uri.UriSchemeHttp &&
+                baseUri?.Scheme != Uri.UriSchemeHttps)
             {
                 // Telemetry for HTTPS sources that have an HTTP resource
                 var telemetry = new ServiceIndexEntryTelemetry(1, "RestorePackageSourceSummary");

--- a/src/NuGet.Core/NuGet.Protocol/Providers/VulnerabilityInfoResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/VulnerabilityInfoResourceV3Provider.cs
@@ -4,7 +4,6 @@
 #nullable enable
 
 using System;
-using System.Security.Policy;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -30,8 +29,8 @@ namespace NuGet.Protocol.Providers
             Uri? baseUri = serviceIndexResource?.GetServiceEntryUri(ServiceTypes.VulnerabilityInfo);
 
             if (source.PackageSource.IsHttps &&
-                    uri?.Scheme == Uri.UriSchemeHttp &&
-                    uri?.Scheme != Uri.UriSchemeHttps)
+                    baseUri?.Scheme == Uri.UriSchemeHttp &&
+                    baseUri?.Scheme != Uri.UriSchemeHttps)
             {
                 // Telemetry for HTTPS sources that have an HTTP resource
                 var telemetry = new ServiceIndexEntryTelemetry(1, "RestorePackageSourceSummary");

--- a/src/NuGet.Core/NuGet.Protocol/Providers/VulnerabilityInfoResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/VulnerabilityInfoResourceV3Provider.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System;
+using System.Security.Policy;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -28,13 +29,14 @@ namespace NuGet.Protocol.Providers
             var serviceIndexResource = await source.GetResourceAsync<ServiceIndexResourceV3>(token);
             Uri? baseUri = serviceIndexResource?.GetServiceEntryUri(ServiceTypes.VulnerabilityInfo);
 
-            // Telemetry for HTTPS sources that have an HTTP resource
-            var telemetry = new ServiceIndexEntryTelemetry(
-                source.PackageSource.IsHttps &&
-                baseUri?.Scheme == Uri.UriSchemeHttp &&
-                baseUri?.Scheme != Uri.UriSchemeHttps ? 1 : 0,
-                "RestorePackageSourceSummary");
-            TelemetryActivity.EmitTelemetryEvent(telemetry);
+            if (source.PackageSource.IsHttps &&
+                    uri?.Scheme == Uri.UriSchemeHttp &&
+                    uri?.Scheme != Uri.UriSchemeHttps)
+            {
+                // Telemetry for HTTPS sources that have an HTTP resource
+                var telemetry = new ServiceIndexEntryTelemetry(1, "RestorePackageSourceSummary");
+                TelemetryActivity.EmitTelemetryEvent(telemetry);
+            }
 
             if (baseUri != null)
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/13744

## Description

This PR adds telemetry for service index resources that are HTTP, but the sources is HTTPS.
for example a v3 source with the following index would end up using a non https service endpoint.
```json
{
    "version": "3.0.0",
    "resources": [
        {
            "@id": "http://source",
            "@type": "SearchQueryService",
            "comment": "Query endpoint of NuGet Search service (primary)"
        }]
}
```
This telemetry will allow us to count how many resources are HTTP (just like the search resource above) but have an HTTPS source.

|Key|Purpose|
|----|----|
|NumHTTPDownloadResourceWithHTTPSSource| Counts download resources that are HTTP but have an HTTPS source|
|NumHTTPOwnerDetailsUriResourceWithHTTPSSource|Counts Owner details Uri resources ...|
|NumHTTPPackageDetailsUriResourceWithHTTPSSource|Counts Package Details Uri resources..|

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
