### PR TITLE
More dependency graph resolver fixes

### DIFF
--- a/build/Shared/TaskResultCache.cs
+++ b/build/Shared/TaskResultCache.cs
@@ -59,6 +59,11 @@ namespace NuGet
         }
 
         /// <summary>
+        /// Gets a collection containing the keys in the cache.
+        /// </summary>
+        public ICollection<TKey> Keys => _cache.Keys;
+
+        /// <summary>
         /// Gets the cached async operation associated with the specified key, or runs the operation asynchronously and returns <see cref="Task{TValue}" /> that the caller can await.
         /// </summary>
         /// <param name="key">The key for the async operation to get or store in the cache.</param>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -19,6 +19,7 @@ using NuGet.Packaging;
 using NuGet.ProjectModel;
 using NuGet.Repositories;
 using NuGet.RuntimeModel;
+using NuGet.Shared;
 using NuGet.Versioning;
 using LibraryDependencyIndex = NuGet.Commands.DependencyGraphResolver.LibraryDependencyInterningTable.LibraryDependencyIndex;
 using LibraryRangeIndex = NuGet.Commands.DependencyGraphResolver.LibraryRangeInterningTable.LibraryRangeIndex;
@@ -1419,7 +1420,7 @@ namespace NuGet.Commands
         internal sealed class LibraryRangeInterningTable
         {
             private readonly object _lockObject = new();
-            private readonly ConcurrentDictionary<string, LibraryRangeIndex> _table = new ConcurrentDictionary<string, LibraryRangeIndex>(StringComparer.OrdinalIgnoreCase);
+            private readonly ConcurrentDictionary<LibraryRange, LibraryRangeIndex> _table = new(LibraryRangeComparer.Instance);
             private int _nextIndex = 0;
 
             public enum LibraryRangeIndex : int
@@ -1431,11 +1432,10 @@ namespace NuGet.Commands
             {
                 lock (_lockObject)
                 {
-                    string key = libraryRange.ToString();
-                    if (!_table.TryGetValue(key, out LibraryRangeIndex index))
+                    if (!_table.TryGetValue(libraryRange, out LibraryRangeIndex index))
                     {
                         index = (LibraryRangeIndex)_nextIndex++;
-                        _table.TryAdd(key, index);
+                        _table.TryAdd(libraryRange, index);
                     }
 
                     return index;
@@ -1541,6 +1541,98 @@ namespace NuGet.Commands
                     rangeIndex,
                     libraryDependencyInterningTable,
                     libraryRangeInterningTable);
+            }
+        }
+
+        internal sealed class LibraryRangeComparer : IEqualityComparer<LibraryRange>
+        {
+            public static LibraryRangeComparer Instance { get; } = new LibraryRangeComparer();
+
+            private LibraryRangeComparer()
+            {
+            }
+
+            public bool Equals(LibraryRange? x, LibraryRange? y)
+            {
+                if (x == null || y == null || x.VersionRange == null || y.VersionRange == null)
+                {
+                    return false;
+                }
+
+                if (ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+
+                LibraryDependencyTarget typeConstraint1 = LibraryDependencyTarget.None;
+                LibraryDependencyTarget typeConstraint2 = LibraryDependencyTarget.None;
+
+                switch (x.TypeConstraint)
+                {
+                    case LibraryDependencyTarget.Reference:
+                        typeConstraint1 = LibraryDependencyTarget.Reference;
+                        break;
+
+                    case LibraryDependencyTarget.ExternalProject:
+                        typeConstraint1 = LibraryDependencyTarget.ExternalProject;
+                        break;
+
+                    case LibraryDependencyTarget.Project:
+                    case LibraryDependencyTarget.Project | LibraryDependencyTarget.ExternalProject:
+                        typeConstraint1 = LibraryDependencyTarget.Project;
+                        break;
+                }
+
+                switch (y.TypeConstraint)
+                {
+                    case LibraryDependencyTarget.Reference:
+                        typeConstraint2 = LibraryDependencyTarget.Reference;
+                        break;
+
+                    case LibraryDependencyTarget.ExternalProject:
+                        typeConstraint2 = LibraryDependencyTarget.ExternalProject;
+                        break;
+
+                    case LibraryDependencyTarget.Project:
+                    case LibraryDependencyTarget.Project | LibraryDependencyTarget.ExternalProject:
+                        typeConstraint2 = LibraryDependencyTarget.Project;
+                        break;
+                }
+
+                return typeConstraint1 == typeConstraint2 &&
+                       VersionRangeComparer.Default.Equals(x.VersionRange, y.VersionRange) &&
+                       x.Name.Equals(y.Name, StringComparison.OrdinalIgnoreCase);
+            }
+
+            public int GetHashCode(LibraryRange obj)
+            {
+                LibraryDependencyTarget typeConstraint = LibraryDependencyTarget.None;
+
+                switch (obj.TypeConstraint)
+                {
+                    case LibraryDependencyTarget.Reference:
+                        typeConstraint = LibraryDependencyTarget.Reference;
+                        break;
+
+                    case LibraryDependencyTarget.ExternalProject:
+                        typeConstraint = LibraryDependencyTarget.ExternalProject;
+                        break;
+
+                    case LibraryDependencyTarget.Project:
+                    case LibraryDependencyTarget.Project | LibraryDependencyTarget.ExternalProject:
+                        typeConstraint = LibraryDependencyTarget.Project;
+                        break;
+                }
+
+                VersionRange versionRange = obj.VersionRange ?? VersionRange.None;
+
+                var combiner = new HashCodeCombiner();
+
+                combiner.AddObject((int)typeConstraint);
+                combiner.AddStringIgnoreCase(obj.Name);
+                combiner.AddObject(versionRange);
+
+                return combiner.CombinedHash;
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -145,6 +145,7 @@ namespace NuGet.Commands
 
             _success = !request.AdditionalMessages?.Any(m => m.Level == LogLevel.Error) ?? true;
 
+            if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("DEBUGIT"))) System.Diagnostics.Debugger.Launch();
             _enableNewDependencyResolver = _request.Project.RuntimeGraph.Supports.Count == 0 && !_request.Project.RestoreMetadata.UseLegacyDependencyResolver;
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -145,7 +145,6 @@ namespace NuGet.Commands
 
             _success = !request.AdditionalMessages?.Any(m => m.Level == LogLevel.Error) ?? true;
 
-            if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("DEBUGIT"))) System.Diagnostics.Debugger.Launch();
             _enableNewDependencyResolver = _request.Project.RuntimeGraph.Supports.Count == 0 && !_request.Project.RestoreMetadata.UseLegacyDependencyResolver;
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -1280,7 +1280,7 @@ namespace NuGet.Commands.FuncTest
 
             // Assert
             // There will be compatibility errors, but we don't care
-            Assert.Equal(25, installed.Count);
+            Assert.Equal(26, installed.Count);
             Assert.Equal(0, unresolved.Count);
             Assert.Equal(24, result.LockFile.Targets[0].Libraries.Count);
             Assert.Equal("7.0.1", jsonNetPackage.Version.ToNormalizedString());


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
These changes address issues found around transitive pinning and slowness when downloading packages.

When a package is transitively pinned, NuGet does not honor PrivateAssets=All and instead just adds those packages.

To make package downloads happen in parallel, the algorithm now queues a background thread which fetches the package.  Later on, the item is taken off the top of the queue and the task is awaited.  This makes all packages download in parallel for any given level like the legacy algorithm.

I also fixed an issue where the new algorithm was merging runtimes more than was necessary.  It now uses a HashSet<T> to keep track of which frameworks we have already processed runtime graphs for.

I've tested this with an experimental VS insertion and there is only one regression that we're going to get an exception for.


## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
