### PR TITLE
Refactor calls to EnsureVisualStudioHost() to a base [TestInitialize] method

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NetCoreProjectTestCase.cs
@@ -20,8 +20,6 @@ namespace NuGet.Tests.Apex.Daily
         [Timeout(DefaultTimeout)]
         public async Task InstallPackageToSDKBasedProjectFromUI(ProjectTemplate projectTemplate)
         {
-            EnsureVisualStudioHost();
-
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, addNetStandardFeeds: true))
             {
                 // Arrange
@@ -52,8 +50,6 @@ namespace NuGet.Tests.Apex.Daily
         [Timeout(DefaultTimeout)]
         public async Task UpdatePackageToSDKBasedProjectFromUI(ProjectTemplate projectTemplate)
         {
-            EnsureVisualStudioHost();
-
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, addNetStandardFeeds: true))
             {
                 // Arrange
@@ -93,8 +89,6 @@ namespace NuGet.Tests.Apex.Daily
         [Timeout(DefaultTimeout)]
         public async Task UninstallPackageFromSDKBasedProjectFromUI(ProjectTemplate projectTemplate)
         {
-            EnsureVisualStudioHost();
-
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, addNetStandardFeeds: true))
             {
                 // Arrange

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetConsoleTestCase.cs
@@ -24,7 +24,6 @@ namespace NuGet.Tests.Apex.Daily
         public async Task VerifyCacheFileInsideObjFolder(ProjectTemplate projectTemplate)
         {
             // Arrange
-            EnsureVisualStudioHost();
             using (var simpleTestPathContext = new SimpleTestPathContext())
             {
                 simpleTestPathContext.Settings.SetPackageFormatToPackageReference();
@@ -60,7 +59,6 @@ namespace NuGet.Tests.Apex.Daily
         [Timeout(DefaultTimeout)]
         public async Task UpdateAllPackagesInPMC(ProjectTemplate projectTemplate, string packageName1, string packageVersion1, string packageVersion2, string packageName2, string packageVersion3, string packageVersion4)
         {
-            EnsureVisualStudioHost();
             using (var simpleTestPathContext = new SimpleTestPathContext())
             {
                 // Arrange
@@ -106,7 +104,6 @@ namespace NuGet.Tests.Apex.Daily
         [Timeout(DefaultTimeout)]
         public async Task InstallPackageForPRInPMC(ProjectTemplate projectTemplate)
         {
-            EnsureVisualStudioHost();
             using (var simpleTestPathContext = new SimpleTestPathContext())
             {
                 // Arrange
@@ -141,7 +138,6 @@ namespace NuGet.Tests.Apex.Daily
         [Timeout(DefaultTimeout)]
         public async Task UpdatePackageForPRInPMC(ProjectTemplate projectTemplate)
         {
-            EnsureVisualStudioHost();
             using (var simpleTestPathContext = new SimpleTestPathContext())
             {
                 // Arrange
@@ -183,7 +179,6 @@ namespace NuGet.Tests.Apex.Daily
         [Timeout(DefaultTimeout)]
         public async Task UninstallPackageForPRInPMC(ProjectTemplate projectTemplate)
         {
-            EnsureVisualStudioHost();
             using (var simpleTestPathContext = new SimpleTestPathContext())
             {
                 // Arrange
@@ -224,7 +219,6 @@ namespace NuGet.Tests.Apex.Daily
         [Timeout(DefaultTimeout)]
         public async Task InstallPackageForPCInPMC(ProjectTemplate projectTemplate)
         {
-            EnsureVisualStudioHost();
             using (var simpleTestPathContext = new SimpleTestPathContext())
             {
                 // Arrange
@@ -257,7 +251,6 @@ namespace NuGet.Tests.Apex.Daily
         [Timeout(DefaultTimeout)]
         public async Task UpdatePackageForPCInPMC(ProjectTemplate projectTemplate)
         {
-            EnsureVisualStudioHost();
             using (var simpleTestPathContext = new SimpleTestPathContext())
             {
                 // Arrange
@@ -296,7 +289,6 @@ namespace NuGet.Tests.Apex.Daily
         [Timeout(DefaultTimeout)]
         public async Task UninstallPackageForPCInPMC(ProjectTemplate projectTemplate)
         {
-            EnsureVisualStudioHost();
             using (var simpleTestPathContext = new SimpleTestPathContext())
             {
                 // Arrange
@@ -333,7 +325,6 @@ namespace NuGet.Tests.Apex.Daily
         [Timeout(DefaultTimeout)]
         public async Task InstallLatestPackageInPMC(ProjectTemplate projectTemplate)
         {
-            EnsureVisualStudioHost();
             using (var simpleTestPathContext = new SimpleTestPathContext())
             {
                 // Arrange
@@ -373,7 +364,6 @@ namespace NuGet.Tests.Apex.Daily
         [Timeout(DefaultTimeout)]
         public void VerifyInitScriptsExecution(ProjectTemplate projectTemplate)
         {
-            EnsureVisualStudioHost();
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))
             {
                 // Arrange
@@ -409,7 +399,6 @@ namespace NuGet.Tests.Apex.Daily
         [Timeout(DefaultTimeout)]
         public async Task VerifyCmdFindPackageExactMatchInPMC()
         {
-            EnsureVisualStudioHost();
             using (var simpleTestPathContext = new SimpleTestPathContext())
             {
                 // Arrange
@@ -437,7 +426,6 @@ namespace NuGet.Tests.Apex.Daily
         [Timeout(DefaultTimeout)]
         public async Task VerifyCmdGetPackageUpdateInPMC()
         {
-            EnsureVisualStudioHost();
             using (var simpleTestPathContext = new SimpleTestPathContext())
             {
                 // Arrange
@@ -472,7 +460,6 @@ namespace NuGet.Tests.Apex.Daily
         [Timeout(DefaultTimeout)]
         public void VerifyCmdGetProjectInPMC()
         {
-            EnsureVisualStudioHost();
             using (var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.ClassLibrary, Logger))
             {
                 // Arrange

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
@@ -31,7 +31,6 @@ namespace NuGet.Tests.Apex.Daily
         public void InstallPackageToWebSiteProjectFromUI()
         {
             // Arrange
-            EnsureVisualStudioHost();
             var dte = VisualStudio.Dte;
             var solutionService = VisualStudio.Get<SolutionService>();
             solutionService.CreateEmptySolution();
@@ -55,7 +54,6 @@ namespace NuGet.Tests.Apex.Daily
         public void UpdateWebSitePackageFromUI()
         {
             // Arrange
-            EnsureVisualStudioHost();
             var dte = VisualStudio.Dte;
             var solutionService = VisualStudio.Get<SolutionService>();
             solutionService.CreateEmptySolution();
@@ -80,7 +78,6 @@ namespace NuGet.Tests.Apex.Daily
         public void UninstallWebSitePackageFromUI()
         {
             // Arrange
-            EnsureVisualStudioHost();
             var dte = VisualStudio.Dte;
             var solutionService = VisualStudio.Get<SolutionService>();
             solutionService.CreateEmptySolution();
@@ -197,7 +194,6 @@ namespace NuGet.Tests.Apex.Daily
         public void InstallVulnerablePackageFromUI(ProjectTemplate projectTemplate, string packageName, string packageVersion)
         {
             // Arrange
-            EnsureVisualStudioHost();
             var solutionService = VisualStudio.Get<SolutionService>();
             solutionService.CreateEmptySolution();
             var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, "TestProject");
@@ -223,7 +219,6 @@ namespace NuGet.Tests.Apex.Daily
         public void UpdateVulnerablePackageFromUI(ProjectTemplate projectTemplate, string packageName, string packageVersion1, string packageVersion2)
         {
             // Arrange
-            EnsureVisualStudioHost();
             var solutionService = VisualStudio.Get<SolutionService>();
             solutionService.CreateEmptySolution();
             var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, "TestProject");
@@ -256,7 +251,6 @@ namespace NuGet.Tests.Apex.Daily
         public void UninstallVulnerablePackageFromUI(ProjectTemplate projectTemplate, string packageName, string packageVersion)
         {
             // Arrange
-            EnsureVisualStudioHost();
             var solutionService = VisualStudio.Get<SolutionService>();
             solutionService.CreateEmptySolution();
             var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, "Testproject");
@@ -289,7 +283,6 @@ namespace NuGet.Tests.Apex.Daily
         public void InstallDeprecatedPackageFromUI(ProjectTemplate projectTemplate, string packageName, string packageVersion)
         {
             // Arrange
-            EnsureVisualStudioHost();
             var solutionService = VisualStudio.Get<SolutionService>();
             solutionService.CreateEmptySolution();
             var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, "TestProject");
@@ -315,7 +308,6 @@ namespace NuGet.Tests.Apex.Daily
         public void UpdateDeprecatedPackageFromUI(ProjectTemplate projectTemplate, string packageName, string packageVersion1, string packageVersion2)
         {
             // Arrange
-            EnsureVisualStudioHost();
             var solutionService = VisualStudio.Get<SolutionService>();
             solutionService.CreateEmptySolution();
             var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, "TestProject");
@@ -348,7 +340,6 @@ namespace NuGet.Tests.Apex.Daily
         public void UninstallDeprecatedPackageFromUI(ProjectTemplate projectTemplate, string packageName, string packageVersion)
         {
             // Arrange
-            EnsureVisualStudioHost();
             var solutionService = VisualStudio.Get<SolutionService>();
             solutionService.CreateEmptySolution();
             var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, "Testproject");
@@ -584,8 +575,6 @@ namespace NuGet.Tests.Apex.Daily
         public void VerifyPackageNotRestoredAfterDisablingPackageRestore()
         {
             // Arrange
-            EnsureVisualStudioHost();
-
             SolutionService solutionService = VisualStudio.Get<SolutionService>();
             solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
             solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.MauiClassLibrary, "TestProject");

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/SharedVisualStudioHostTestClass.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/SharedVisualStudioHostTestClass.cs
@@ -91,5 +91,13 @@ namespace NuGet.Tests.Apex
         {
             return string.Join(Environment.NewLine, VisualStudio.GetOutputWindowsLines());
         }
+
+        [TestInitialize]
+        public override void TestInitialize()
+        {
+            base.TestInitialize();
+
+            EnsureVisualStudioHost();
+        }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -15,9 +15,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public void CreateNetCoreProject_RestoresNewProject(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, addNetStandardFeeds: true))
             {
                 VisualStudio.AssertNoErrors();
@@ -30,9 +27,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public void CreateNetCoreProject_AddProjectReference(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, addNetStandardFeeds: true))
             {
                 var project2 = testContext.SolutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject2");
@@ -55,8 +49,6 @@ namespace NuGet.Tests.Apex
         public async Task WithSourceMappingEnabled_InstallPackageFromPMUIFromExpectedSource_Succeeds(ProjectTemplate projectTemplate)
         {
             // Arrange
-            EnsureVisualStudioHost();
-
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, addNetStandardFeeds: true))
             {
                 var privateRepositoryPath = Path.Combine(testContext.SolutionRoot, "PrivateRepository");
@@ -121,8 +113,6 @@ namespace NuGet.Tests.Apex
         public async Task WithSourceMappingEnabled_InstallAndUpdatePackageFromPMUIFromExpectedSource_Succeeds(ProjectTemplate projectTemplate)
         {
             // Arrange
-            EnsureVisualStudioHost();
-
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, addNetStandardFeeds: true))
             {
                 var privateRepositoryPath = Path.Combine(testContext.SolutionRoot, "PrivateRepository");
@@ -191,8 +181,6 @@ namespace NuGet.Tests.Apex
         public async Task WithSourceMappingEnabled_InstallPackageFromPMUIAndNoSourcesFound_Fails(ProjectTemplate projectTemplate)
         {
             // Arrange
-            EnsureVisualStudioHost();
-
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, addNetStandardFeeds: true))
             {
                 var privateRepositoryPath = Path.Combine(testContext.SolutionRoot, "PrivateRepository");

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetAuditTests.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetAuditTests.cs
@@ -57,8 +57,6 @@ namespace NuGet.Tests.Apex.NuGetEndToEndTests
 
             testPathContext.Settings.AddSource("auditSource", mockServer.ServiceIndexUri, allowInsecureConnectionsValue: "true");
 
-            EnsureVisualStudioHost();
-
             using var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.ConsoleApplication, Logger, addNetStandardFeeds: true, simpleTestPathContext: testPathContext);
 
             var errorListService = VisualStudio.Get<ErrorListService>();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -19,9 +19,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task InstallPackageFromPMCWithNoAutoRestoreVerifyAssetsFileAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, noAutoRestore: true, addNetStandardFeeds: true))
             {
                 var packageName = "TestPackage";
@@ -41,9 +38,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task InstallPackageFromPMCVerifyInstallForPCAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))
             {
                 var packageName = "TestPackage";
@@ -63,9 +57,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task UninstallPackageFromPMCForPCAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))
             {
                 var packageName = "TestPackage";
@@ -86,9 +77,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task UpdatePackageFromPMCForPCAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))
             {
                 var packageName = "TestPackage";
@@ -111,9 +99,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task InstallMultiplePackagesFromPMCForPCAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))
             {
                 var packageName1 = "TestPackage1";
@@ -139,8 +124,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task UninstallMultiplePackagesFromPMCForPCAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
             var packageName1 = "TestPackage1";
             var packageVersion1 = "1.0.0";
             var packageName2 = "TestPackage2";
@@ -179,8 +162,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task DowngradePackageFromPMCForPCAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
             var packageName = "TestPackage";
             var packageVersion1 = "1.0.0";
             var packageVersion2 = "2.0.0";
@@ -204,9 +185,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task NetCoreTransitivePackageReferenceLimitAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, addNetStandardFeeds: true))
             {
                 var project2 = testContext.SolutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject2");
@@ -250,7 +228,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task InstallAndUpdatePackageWithSourceParameterWarnsAsync(ProjectTemplate projectTemplate, bool warns)
         {
-            EnsureVisualStudioHost();
             var packageName = "TestPackage";
             var packageVersion1 = "1.0.0";
             var packageVersion2 = "2.0.0";
@@ -301,8 +278,6 @@ namespace NuGet.Tests.Apex
         public async Task InstallPackageForPC_PackageSourceMapping_WithSingleFeed(ProjectTemplate projectTemplate)
         {
             // Arrange
-            EnsureVisualStudioHost();
-
             using var simpleTestPathContext = new SimpleTestPathContext();
             string solutionDirectory = simpleTestPathContext.SolutionRoot;
             var privateRepositoryPath = Path.Combine(solutionDirectory, "PrivateRepository");
@@ -347,8 +322,6 @@ namespace NuGet.Tests.Apex
         public async Task UpdatePackageForPC_PackageSourceMapping_WithSingleFeed(ProjectTemplate projectTemplate)
         {
             // Arrange
-            EnsureVisualStudioHost();
-
             using var simpleTestPathContext = new SimpleTestPathContext();
             string solutionDirectory = simpleTestPathContext.SolutionRoot;
             var privateRepositoryPath = Path.Combine(solutionDirectory, "PrivateRepository");
@@ -396,8 +369,6 @@ namespace NuGet.Tests.Apex
         public async Task InstallPackageForPC_PackageSourceMapping_WithMultipleFeedsWithIdenticalPackages_InstallsCorrectPackage(ProjectTemplate projectTemplate)
         {
             // Arrange
-            EnsureVisualStudioHost();
-
             using var simpleTestPathContext = new SimpleTestPathContext();
             string solutionDirectory = simpleTestPathContext.SolutionRoot;
             var packageName = "Contoso.A";
@@ -460,8 +431,6 @@ namespace NuGet.Tests.Apex
         public async Task UpdatePackageForPC_PackageSourceMapping_WithMultipleFeedsWithIdenticalPackages_UpdatesCorrectPackage(ProjectTemplate projectTemplate)
         {
             // Arrange
-            EnsureVisualStudioHost();
-
             using var simpleTestPathContext = new SimpleTestPathContext();
             string solutionDirectory = simpleTestPathContext.SolutionRoot;
             var packageName = "Contoso.A";
@@ -526,7 +495,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task UpdateAllReinstall_WithPackageReferenceProject_WarnsAsync(ProjectTemplate projectTemplate, bool warns)
         {
-            EnsureVisualStudioHost();
             var packageName = "TestPackage";
             var packageVersion1 = "1.0.0";
 
@@ -566,8 +534,6 @@ namespace NuGet.Tests.Apex
         public async Task InstallPackageForPR_PackageNamespace_WithMultipleFeedsWithIdenticalPackages_InstallsCorrectPackage(ProjectTemplate projectTemplate)
         {
             // Arrange
-            EnsureVisualStudioHost();
-
             using var simpleTestPathContext = new SimpleTestPathContext();
             string solutionDirectory = simpleTestPathContext.SolutionRoot;
             var packageName = "Contoso.A";
@@ -625,8 +591,6 @@ namespace NuGet.Tests.Apex
         public async Task UpdatePackageForPR_PackageNamespace_WithMultipleFeedsWithIdenticalPackages_InstallsCorrectPackage(ProjectTemplate projectTemplate)
         {
             // Arrange
-            EnsureVisualStudioHost();
-
             using var simpleTestPathContext = new SimpleTestPathContext();
             string solutionDirectory = simpleTestPathContext.SolutionRoot;
             var packageName = "Contoso.A";
@@ -697,8 +661,6 @@ namespace NuGet.Tests.Apex
         public async Task UpdatePackageForPR_PackageIdWithDifferentCase_UpdatesSuccessfully()
         {
             // Arrange
-            EnsureVisualStudioHost();
-
             using var simpleTestPathContext = new SimpleTestPathContext();
             string solutionDirectory = simpleTestPathContext.SolutionRoot;
             var packageName = "Contoso.A";

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetPackageSigningTests/AuthorSignedPackageTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetPackageSigningTests/AuthorSignedPackageTestCase.cs
@@ -28,9 +28,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task InstallFromPMCForPC_SucceedAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             var signedPackage = Fixture.AuthorSignedTestPackage;
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))
@@ -50,9 +47,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task UninstallFromPMCForPC_SucceedAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             var signedPackage = Fixture.AuthorSignedTestPackage;
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))
@@ -73,9 +67,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task UpdateUnsignedToSignedVersionFromPMCForPC_SucceedAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             var packageVersion09 = "0.9.0";
             var signedPackage = Fixture.AuthorSignedTestPackage;
 
@@ -98,9 +89,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task DowngradeSignedToUnsignedVersionFromPMCForPC_SucceedAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             // This test is not considered an ideal behavior of the product but states the current behavior.
             // A package that is already installed as signed should be specailly treated and a user should not be
             // able to downgrade to an unsigned version. This test needs to be updated once this behavior gets
@@ -127,9 +115,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task WithExpiredCertificate_InstallFromPMCForPC_WarnAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))
             using (var trustedExpiringTestCert = SigningUtility.GenerateTrustedTestCertificateThatWillExpireSoon())
             {
@@ -159,9 +144,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task Tampered_InstallFromPMCForPC_FailAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             var signedPackage = Fixture.AuthorSignedTestPackage;
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetPackageSigningTests/RepositoryCountersignedPackageTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetPackageSigningTests/RepositoryCountersignedPackageTestCase.cs
@@ -30,9 +30,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task InstallFromPMCForPC_SucceedAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             var signedPackage = Fixture.RepositoryCountersignedTestPackage;
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))
@@ -52,9 +49,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task UninstallFromPMCForPC_SucceedAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             var signedPackage = Fixture.RepositoryCountersignedTestPackage;
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))
@@ -75,9 +69,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task UpdateUnsignedToSignedVersionFromPMCForPC_SucceedAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             var packageVersion09 = "0.9.0";
             var signedPackage = Fixture.RepositoryCountersignedTestPackage;
 
@@ -100,9 +91,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task WithExpiredAuthorCertificateAtCountersigning_InstallFromPMCForPC_WarnAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             var timestampService = await Fixture.GetDefaultTrustedTimestampServiceAsync();
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))
@@ -145,9 +133,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task Tampered_InstallFromPMCForPC_FailAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             var signedPackage = Fixture.RepositoryCountersignedTestPackage;
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetPackageSigningTests/RepositorySignedPackageTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetPackageSigningTests/RepositorySignedPackageTestCase.cs
@@ -29,9 +29,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task InstallFromPMCForPC_SucceedAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             var signedPackage = Fixture.RepositorySignedTestPackage;
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))
@@ -51,9 +48,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task UninstallFromPMCForPC_SucceedAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             var signedPackage = Fixture.RepositorySignedTestPackage;
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))
@@ -74,9 +68,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task UpdateUnsignedToSignedVersionFromPMCForPC_SucceedAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             var packageVersion09 = "0.9.0";
             var signedPackage = Fixture.RepositorySignedTestPackage;
 
@@ -99,9 +90,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task WithExpiredCertificate_InstallFromPMCForPC_WarnAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))
             using (var trustedExpiringTestCert = SigningUtility.GenerateTrustedTestCertificateThatWillExpireSoon())
             {
@@ -130,9 +118,6 @@ namespace NuGet.Tests.Apex
         [Timeout(DefaultTimeout)]
         public async Task Tampered_InstallFromPMCForPC_FailAsync(ProjectTemplate projectTemplate)
         {
-            // Arrange
-            EnsureVisualStudioHost();
-
             var signedPackage = Fixture.RepositorySignedTestPackage;
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger))


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes https://github.com/NuGet/Home/issues/13786

## Description
Adds a TestInitialize method on the SharedVisualStudioHostTestClass (base class used by all Apex tests) to make this call.  This ensures it is consistently applied for all tests.  Removed all individual calls to the method.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
