### PR TITLE
Properly handle missing package versions in new dependency resolver

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -205,12 +205,6 @@ namespace NuGet.Commands
                     IReadOnlyDictionary<LibraryDependencyIndex, VersionRange> currentOverrides = importRefItem.VersionOverrides!;
                     bool directPackageReferenceFromRootProject = importRefItem.IsDirectPackageReferenceFromRootProject;
 
-                    // Packages with missing versions should not be added to the graph
-                    if (currentRef.LibraryRange.VersionRange == null)
-                    {
-                        continue;
-                    }
-
                     if (!findLibraryEntryCache.TryGetValue(currentRefRangeIndex, out Task<FindLibraryEntryResult>? refItemTask))
                     {
                         Debug.Fail("This should not happen");
@@ -656,6 +650,12 @@ namespace NuGet.Commands
                     for (int i = 0; i < refItemResult.Item.Data.Dependencies.Count; i++)
                     {
                         var dep = refItemResult.Item.Data.Dependencies[i];
+                        // Packages with missing versions should not be added to the graph
+                        if (dep.LibraryRange.VersionRange == null)
+                        {
+                            continue;
+                        }
+
                         LibraryDependencyIndex depIndex = refItemResult.GetDependencyIndexForDependency(i);
                         if ((dep.SuppressParent == LibraryIncludeFlags.All) && (importRefItem.LibraryDependencyIndex != rootProjectRefItem.LibraryDependencyIndex))
                         {
@@ -724,8 +724,8 @@ namespace NuGet.Commands
                         LibraryDependency dep = refItemResult.Item.Data.Dependencies[i];
                         LibraryDependencyIndex depIndex = refItemResult.GetDependencyIndexForDependency(i);
 
-                        //Suppress this node
-                        if (!importRefItem.IsCentrallyPinnedTransitivePackage && suppressions!.Contains(depIndex))
+                        // Skip this node if the VersionRange is null or if its not transitively pinned and PrivateAssets=All
+                        if (dep.LibraryRange.VersionRange == null || (!importRefItem.IsCentrallyPinnedTransitivePackage && suppressions!.Contains(depIndex)))
                         {
                             continue;
                         }
@@ -918,6 +918,12 @@ namespace NuGet.Commands
                         for (int i = 0; i < node.Item.Data.Dependencies.Count; i++)
                         {
                             var dep = node.Item.Data.Dependencies[i];
+
+                            if (dep.LibraryRange.VersionRange == null)
+                            {
+                                continue;
+                            }
+
                             if (StringComparer.OrdinalIgnoreCase.Equals(dep.Name, node.Item.Key.Name) || StringComparer.OrdinalIgnoreCase.Equals(dep.Name, rootGraphNode.Key.Name))
                             {
                                 // Cycle

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -205,6 +205,12 @@ namespace NuGet.Commands
                     IReadOnlyDictionary<LibraryDependencyIndex, VersionRange> currentOverrides = importRefItem.VersionOverrides!;
                     bool directPackageReferenceFromRootProject = importRefItem.IsDirectPackageReferenceFromRootProject;
 
+                    // Packages with missing versions should not be added to the graph
+                    if (currentRef.LibraryRange.VersionRange == null)
+                    {
+                        continue;
+                    }
+
                     if (!findLibraryEntryCache.TryGetValue(currentRefRangeIndex, out Task<FindLibraryEntryResult>? refItemTask))
                     {
                         Debug.Fail("This should not happen");


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13788

## Description
During restore, NuGet verifies that CPM requirements are met by verifying all packages have versions.  However, when one project references another and the referenced project has a missing package, NuGet logs an error for the referenced project but restores the other.  It restores this project by skipping the dependency. 

This change updates the new dependency resolver to ignore packages with missing versions.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
