### PR TITLE
Fix null reference in PM UI for project references without framework

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -220,7 +220,9 @@ namespace NuGet.PackageManagement.VisualStudio
                         }
 
                         // If the project has project references, we need to compute transitive origins for their packages
-                        List<LockFileTargetLibrary> projectReferences = targetsList.SelectMany(t => t.Libraries).Where(l => l.Type == LibraryType.Project).ToList();
+                        List<LockFileTargetLibrary> projectReferences = targetsList
+                            .SelectMany(t => t.Libraries)
+                            .Where(l => l.Type == LibraryType.Project && l.Framework is not null).ToList();
                         List<PackageReference> calculatedLibraryReferences = new List<PackageReference>(projectReferences.Count + calculatedInstalledPackages.Count);
                         if (projectReferences.Count > 0)
                         {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -4126,6 +4126,31 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
+        public async Task GetInstalledAndTransitivePackagesAsync_ProjectReferenceWithNullFramework_EmptyInstalledAndTransitivePackagesAsync()
+        {
+            // Project2 -> Project1 ->  PackageA (1.0.0) -> PackageB (1.0.0)
+
+            // Arrange
+            using var rootDir = new SimpleTestPathContext();
+
+            await CreatePackagesAsync(rootDir, packageAVersion: "1.0.0");
+
+            PackageSpec prj1Spec = ProjectTestHelpers.GetPackageSpec("Project1", rootDir.SolutionRoot, framework: "netstandard2.0", dependencyName: "PackageA");
+            PackageSpec prj2Spec = ProjectTestHelpers.GetPackageSpec("Project2", rootDir.SolutionRoot, framework: "netstandard2.0").WithTestProjectReference(prj1Spec, null);
+
+            await RestorePackageSpecsAsync(rootDir, output: null, prj1Spec, prj2Spec);
+
+            CpsPackageReferenceProject project2 = PrepareCpsRestoredProject(prj2Spec);
+
+            // Act
+            ProjectPackages result = await project2.GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins: true, CancellationToken.None);
+
+            // Assert
+            Assert.Empty(result.InstalledPackages); // No installed packages
+            Assert.Empty(result.TransitivePackages); // No transitive packages
+        }
+
+        [Fact]
         public async Task GetInstalledAndTransitivePackagesAsync_SimulatePackageInstallation_UpdatesDataAsync()
         {
             using var rootDir = new SimpleTestPathContext();

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -4126,17 +4126,19 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async Task GetInstalledAndTransitivePackagesAsync_ProjectReferenceWithNullFramework_EmptyInstalledAndTransitivePackagesAsync()
+        public async Task GetInstalledAndTransitivePackagesAsync_WithPackagesConfigProjectReference_EmptyInstalledAndTransitivePackagesAsync()
         {
-            // Project2 -> Project1 ->  PackageA (1.0.0) -> PackageB (1.0.0)
+            // Project2 (PR) -> Project1 (PC)
 
             // Arrange
             using var rootDir = new SimpleTestPathContext();
 
             await CreatePackagesAsync(rootDir, packageAVersion: "1.0.0");
 
-            PackageSpec prj1Spec = ProjectTestHelpers.GetPackageSpec("Project1", rootDir.SolutionRoot, framework: "netstandard2.0", dependencyName: "PackageA");
-            PackageSpec prj2Spec = ProjectTestHelpers.GetPackageSpec("Project2", rootDir.SolutionRoot, framework: "netstandard2.0").WithTestProjectReference(prj1Spec, null);
+            PackageSpec prj1Spec = ProjectTestHelpers.GetPackagesConfigPackageSpec("Project1", rootDir.SolutionRoot, framework: "netstandard2.0");
+            PackageSpec prj2Spec = ProjectTestHelpers.GetPackageSpec("Project2", rootDir.SolutionRoot, framework: "netstandard2.0").WithTestProjectReference(prj1Spec);
+
+            prj1Spec.Dependencies.Add(target);
 
             await RestorePackageSpecsAsync(rootDir, output: null, prj1Spec, prj2Spec);
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -4126,7 +4126,32 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async Task GetInstalledAndTransitivePackagesAsync_WithPackagesConfigProjectReference_EmptyInstalledAndTransitivePackagesAsync()
+        public async Task GetInstalledAndTransitivePackagesAsync_WithProjectReference_MultipleTransitivePackagesAsync()
+        {
+            // Project2 -> Project1 -> PackageA (1.0.0) -> PackageB (1.0.0)
+
+            // Arrange
+            using var rootDir = new SimpleTestPathContext();
+
+            await CreatePackagesAsync(rootDir, packageAVersion: "1.0.0");
+
+            PackageSpec prj1Spec = ProjectTestHelpers.GetPackageSpec("Project1", rootDir.SolutionRoot, framework: "netstandard2.0", dependencyName: "PackageA");
+            PackageSpec prj2Spec = ProjectTestHelpers.GetPackageSpec("Project2", rootDir.SolutionRoot, framework: "netstandard2.0").WithTestProjectReference(prj1Spec);
+
+            await RestorePackageSpecsAsync(rootDir, output: null, prj1Spec, prj2Spec);
+
+            CpsPackageReferenceProject project2 = PrepareCpsRestoredProject(prj2Spec);
+
+            // Act
+            ProjectPackages result = await project2.GetInstalledAndTransitivePackagesAsync(includeTransitiveOrigins: true, CancellationToken.None);
+
+            // Assert
+            Assert.Empty(result.InstalledPackages); // No installed packages
+            Assert.Equal(2, result.TransitivePackages.Count); // A and B are transitive
+        }
+
+        [Fact]
+        public async Task GetInstalledAndTransitivePackagesAsync_WithPackagesConfigProjectReferenceAsync()
         {
             // Project2 (PR) -> Project1 (PC)
 
@@ -4137,8 +4162,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             PackageSpec prj1Spec = ProjectTestHelpers.GetPackagesConfigPackageSpec("Project1", rootDir.SolutionRoot, framework: "netstandard2.0");
             PackageSpec prj2Spec = ProjectTestHelpers.GetPackageSpec("Project2", rootDir.SolutionRoot, framework: "netstandard2.0").WithTestProjectReference(prj1Spec);
-
-            prj1Spec.Dependencies.Add(target);
 
             await RestorePackageSpecsAsync(rootDir, output: null, prj1Spec, prj2Spec);
 

--- a/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
@@ -92,11 +92,7 @@ namespace NuGet.Commands.Test
         {
             var spec = parent.Clone();
 
-            if (frameworks is null)
-            {
-                frameworks = Array.Empty<NuGetFramework>();
-            }
-            else if (frameworks.Length == 0)
+            if (frameworks.Length == 0)
             {
                 // Use all frameworks if none were given
                 frameworks = spec.TargetFrameworks.Select(e => e.FrameworkName).ToArray();

--- a/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
@@ -92,7 +92,11 @@ namespace NuGet.Commands.Test
         {
             var spec = parent.Clone();
 
-            if (frameworks.Length == 0)
+            if (frameworks is null)
+            {
+                frameworks = Array.Empty<NuGetFramework>();
+            }
+            else if (frameworks.Length == 0)
             {
                 // Use all frameworks if none were given
                 frameworks = spec.TargetFrameworks.Select(e => e.FrameworkName).ToArray();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13737

## Description
Project References are now considered when getting the projects transitive packages, in some scenarios there is no framework in the project reference on the assets file, this caused a null reference in the PM UI when trying to get the framework.

This PR will ignore those project references (in the PM UI for showing transitive's) that don't have a null reference.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
