### PR TITLE
Fix issue with dependency resolver related to VersionOverride

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -227,14 +227,6 @@ namespace NuGet.Commands
                         }
                     }
 
-                    if (currentOverrides.TryGetValue(currentRefDependencyIndex, out var ov))
-                    {
-                        if (!ov.Equals(currentRef.LibraryRange.VersionRange))
-                        {
-                            continue;
-                        }
-                    }
-
                     HashSet<LibraryDependency>? runtimeDependencies = null;
 
                     if (runtimeGraph != null && !string.IsNullOrWhiteSpace(pair.RuntimeIdentifier))

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -494,6 +494,190 @@ namespace NuGet.Commands.FuncTest
             result2.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
+        // P1 -> P2 -> A (VersionOverride) 1.0.0
+        // P1 -> P2 -> B (VersionOverride) 1.0.0
+        // P1 and P2 centrally manages A to 2.0.0-preview.1, but not B.
+        [Fact]
+        public async Task RestoreCommand_WithVersionOverrideOfNotCentrallyManagedPackageAndTransitivePinning_VerifiesEquivalency()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("a", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("b", "1.0.0")]
+            };
+            var packageA200 = new SimpleTestPackageContext("a", "2.0.0-preview.1")
+            {
+                Dependencies = [new SimpleTestPackageContext("b", "2.0.0-preview.1")]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA,
+                packageA200);
+
+            var project1 = @"
+                {
+                    ""restore"": {
+                                    ""centralPackageVersionsManagementEnabled"": true,
+                                    ""CentralPackageTransitivePinningEnabled"": true,
+                    },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""2.0.0-preview.1"",
+                        }
+                    }
+                  }
+                }";
+
+            var project2 = @"
+                {
+                    ""restore"": {
+                                    ""centralPackageVersionsManagementEnabled"": true,
+                                    ""CentralPackageTransitivePinningEnabled"": true,
+                    },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""a"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionOverride"": ""[1.0.0, )"",
+                                },
+                                ""b"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionOverride"": ""[1.0.0, )"",
+                                }
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""2.0.0-preview.1"",
+                        }
+                    }
+                  }
+                }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, project2);
+            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec, projectSpec2);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0-preview.1"));
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0-preview.1"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            (var result2, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec2);
+            result2.LockFile.Targets.Should().HaveCount(1);
+            result2.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+            result2.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result2.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result2.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result2.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        // P1 -> P2 -> A (VersionOverride) 1.0.0
+        // P1 -> P2 -> B (VersionOverride) 1.0.0
+        // P1 and P2 centrally manages A to 2.0.0-preview.1, but not B. No pinning means, only the version override versions are used.
+        [Fact]
+        public async Task RestoreCommand_WithVersionOverrideOfNotCentrallyManagedPackage_VerifiesEquivalency()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("a", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("b", "1.0.0")]
+            };
+            var packageA200 = new SimpleTestPackageContext("a", "2.0.0-preview.1")
+            {
+                Dependencies = [new SimpleTestPackageContext("b", "2.0.0-preview.1")]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA,
+                packageA200);
+
+            var project1 = @"
+                {
+                    ""restore"": {
+                                    ""centralPackageVersionsManagementEnabled"": true,
+                    },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""2.0.0-preview.1"",
+                        }
+                    }
+                  }
+                }";
+
+            var project2 = @"
+                {
+                    ""restore"": {
+                                    ""centralPackageVersionsManagementEnabled"": true,
+                    },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""a"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionOverride"": ""[1.0.0, )"",
+                                },
+                                ""b"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionOverride"": ""[1.0.0, )"",
+                                }
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""2.0.0-preview.1"",
+                        }
+                    }
+                  }
+                }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, project2);
+            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec, projectSpec2);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            (var result2, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec2);
+            result2.LockFile.Targets.Should().HaveCount(1);
+            result2.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+            result2.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result2.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result2.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result2.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
         // P1 -> P2 -> A (VersionOverride) -> B
         // P1 -> P2 -> B (PrivateAssets) VersionOverride
         // P1 has 2.0.0 for both packages, P2 has 1.0.0 for both packages


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2959

## Description
The new dependency resolution algorithm is using VersionOverride in a way that appears to break some scenarios.  Disabling this functionality appears to fix the breakage seen:

https://dev.azure.com/dnceng-public/public/_build/results?buildId=810947&view=logs&j=bd984918-332a-5954-fad9-103f3254a889&t=b308b3ab-01af-58d5-d851-72051b2c582c



## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
