### PR TITLE
Remove usages of VersionOverride in new dependency graph resolver

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -1351,7 +1351,7 @@ namespace NuGet.Commands
             context.ProjectLibraryProviders.Add(
                     new PackageSpecReferenceDependencyProvider(updatedExternalProjects, _logger));
 
-            DependencyGraphResolver dependencyGraphResolver = new(_logger, _request, telemetryActivity, _operationId);
+            DependencyGraphResolver dependencyGraphResolver = new(_logger, _request, telemetryActivity);
 
             List<RestoreTargetGraph> graphs = null;
             RuntimeGraph runtimes = null;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Tracked in: https://github.com/NuGet/Client.Engineering/issues/3008

## Description
The `VersionOverride` functionality in the new dependency resolver shouldn't be needed as the way its handled is on a per-project basis as the version for any particular package to use instead of the centrally defined version.  

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
