### PR TITLE
Add tests for DependencyGraphResolver.LibraryRangeComparer

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -1435,8 +1435,14 @@ namespace NuGet.Commands
             }
         }
 
+        /// <summary>
+        /// Represents an <see cref="IEqualityComparer{T}" /> of <see cref="LibraryRange" /> that considers them to be equal based on the same functionality of <see cref="LibraryRange.ToString" />.
+        /// </summary>
         internal sealed class LibraryRangeComparer : IEqualityComparer<LibraryRange>
         {
+            /// <summary>
+            /// Gets an instance of <see cref="LibraryRangeComparer" />.
+            /// </summary>
             public static LibraryRangeComparer Instance { get; } = new LibraryRangeComparer();
 
             private LibraryRangeComparer()
@@ -1455,6 +1461,8 @@ namespace NuGet.Commands
                     return true;
                 }
 
+
+                // All of this logic is copied from LibraryRange.ToString()
                 LibraryDependencyTarget typeConstraint1 = LibraryDependencyTarget.None;
                 LibraryDependencyTarget typeConstraint2 = LibraryDependencyTarget.None;
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/DependencyGraphResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/DependencyGraphResolverTests.cs
@@ -20,55 +20,15 @@ namespace NuGet.Commands.Test
             string libraryRange1String = libraryRange1.ToString();
             string libraryRange2String = libraryRange2.ToString();
 
-            var constraintString1 = string.Empty;
-
-            switch (libraryRange1.TypeConstraint)
-            {
-                case LibraryDependencyTarget.Reference:
-                    constraintString1 = LibraryType.Reference;
-                    break;
-
-                case LibraryDependencyTarget.ExternalProject:
-                    constraintString1 = LibraryType.ExternalProject;
-                    break;
-
-                case LibraryDependencyTarget.Project:
-                case LibraryDependencyTarget.Project | LibraryDependencyTarget.ExternalProject:
-                    constraintString1 = LibraryType.Project;
-                    break;
-            }
-
-            var constraintString2 = string.Empty;
-
-            switch (libraryRange2.TypeConstraint)
-            {
-                case LibraryDependencyTarget.Reference:
-                    constraintString2 = LibraryType.Reference;
-                    break;
-
-                case LibraryDependencyTarget.ExternalProject:
-                    constraintString2 = LibraryType.ExternalProject;
-                    break;
-
-                case LibraryDependencyTarget.Project:
-                case LibraryDependencyTarget.Project | LibraryDependencyTarget.ExternalProject:
-                    constraintString2 = LibraryType.Project;
-                    break;
-            }
-
             // If the LibraryRange.ToString() is the same, then we expect DependencyGraphResolver.LibraryRangeComparer to also consider them equal
-            if (string.Equals(constraintString1, constraintString2))
+            if (string.Equals(libraryRange1String, libraryRange2String))
             {
-                libraryRange1String.Should().Be(libraryRange2String);
-
                 comparer.Equals(libraryRange1, libraryRange2).Should().BeTrue();
 
                 comparer.GetHashCode(libraryRange1).Should().Be(comparer.GetHashCode(libraryRange2));
             }
             else
             {
-                libraryRange1String.Should().NotBe(libraryRange2String);
-
                 comparer.Equals(libraryRange1, libraryRange2).Should().BeFalse();
 
                 comparer.GetHashCode(libraryRange1).Should().NotBe(comparer.GetHashCode(libraryRange2));
@@ -87,23 +47,15 @@ namespace NuGet.Commands.Test
             string libraryRange1String = libraryRange1.ToString();
             string libraryRange2String = libraryRange2.ToString();
 
-            string versionString1 = libraryRange1.VersionRange!.ToNonSnapshotRange().PrettyPrint();
-
-            string versionString2 = libraryRange2.VersionRange!.ToNonSnapshotRange().PrettyPrint();
-
             // If the version strings are the same, then we expect DependencyGraphResolver.LibraryRangeComparer to also consider them equal
-            if (string.Equals(versionString1, versionString2))
+            if (string.Equals(libraryRange1String, libraryRange2String))
             {
-                libraryRange1String.Should().Be(libraryRange2String);
-
                 comparer.Equals(libraryRange1, libraryRange2).Should().BeTrue();
 
                 comparer.GetHashCode(libraryRange1).Should().Be(comparer.GetHashCode(libraryRange2));
             }
             else
             {
-                libraryRange1String.Should().NotBe(libraryRange2String);
-
                 comparer.Equals(libraryRange1, libraryRange2).Should().BeFalse();
 
                 comparer.GetHashCode(libraryRange1).Should().NotBe(comparer.GetHashCode(libraryRange2));

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/DependencyGraphResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/DependencyGraphResolverTests.cs
@@ -1,0 +1,183 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using NuGet.LibraryModel;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class DependencyGraphResolverTests
+    {
+        /// <summary>
+        /// Verifies that the <see cref="DependencyGraphResolver.LibraryRangeComparer" /> calculates the same equality and hash code as <see cref="LibraryRange.ToString()" />.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(TypeConstraintCombinations))]
+        public void LibraryRangeComparer_AllTypeConstraints(LibraryRange libraryRange1, LibraryRange libraryRange2)
+        {
+            DependencyGraphResolver.LibraryRangeComparer comparer = DependencyGraphResolver.LibraryRangeComparer.Instance;
+
+            string libraryRange1String = libraryRange1.ToString();
+            string libraryRange2String = libraryRange2.ToString();
+
+            var constraintString1 = string.Empty;
+
+            switch (libraryRange1.TypeConstraint)
+            {
+                case LibraryDependencyTarget.Reference:
+                    constraintString1 = LibraryType.Reference;
+                    break;
+
+                case LibraryDependencyTarget.ExternalProject:
+                    constraintString1 = LibraryType.ExternalProject;
+                    break;
+
+                case LibraryDependencyTarget.Project:
+                case LibraryDependencyTarget.Project | LibraryDependencyTarget.ExternalProject:
+                    constraintString1 = LibraryType.Project;
+                    break;
+            }
+
+            var constraintString2 = string.Empty;
+
+            switch (libraryRange2.TypeConstraint)
+            {
+                case LibraryDependencyTarget.Reference:
+                    constraintString2 = LibraryType.Reference;
+                    break;
+
+                case LibraryDependencyTarget.ExternalProject:
+                    constraintString2 = LibraryType.ExternalProject;
+                    break;
+
+                case LibraryDependencyTarget.Project:
+                case LibraryDependencyTarget.Project | LibraryDependencyTarget.ExternalProject:
+                    constraintString2 = LibraryType.Project;
+                    break;
+            }
+
+            // If the LibraryRange.ToString() is the same, then we expect DependencyGraphResolver.LibraryRangeComparer to also consider them equal
+            if (string.Equals(constraintString1, constraintString2))
+            {
+                libraryRange1String.Should().Be(libraryRange2String);
+
+                comparer.Equals(libraryRange1, libraryRange2).Should().BeTrue();
+
+                comparer.GetHashCode(libraryRange1).Should().Be(comparer.GetHashCode(libraryRange2));
+            }
+            else
+            {
+                libraryRange1String.Should().NotBe(libraryRange2String);
+
+                comparer.Equals(libraryRange1, libraryRange2).Should().BeFalse();
+
+                comparer.GetHashCode(libraryRange1).Should().NotBe(comparer.GetHashCode(libraryRange2));
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the <see cref="DependencyGraphResolver.LibraryRangeComparer" /> calculates the same equality and hash code as <see cref="VersionRange.ToNonSnapshotRange()" />.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(VersionRangeCombinations))]
+        public void LibraryRangeComparer_AllVersionRangeTypes(LibraryRange libraryRange1, LibraryRange libraryRange2)
+        {
+            DependencyGraphResolver.LibraryRangeComparer comparer = DependencyGraphResolver.LibraryRangeComparer.Instance;
+
+            string libraryRange1String = libraryRange1.ToString();
+            string libraryRange2String = libraryRange2.ToString();
+
+            string versionString1 = libraryRange1.VersionRange!.ToNonSnapshotRange().PrettyPrint();
+
+            string versionString2 = libraryRange2.VersionRange!.ToNonSnapshotRange().PrettyPrint();
+
+            // If the version strings are the same, then we expect DependencyGraphResolver.LibraryRangeComparer to also consider them equal
+            if (string.Equals(versionString1, versionString2))
+            {
+                libraryRange1String.Should().Be(libraryRange2String);
+
+                comparer.Equals(libraryRange1, libraryRange2).Should().BeTrue();
+
+                comparer.GetHashCode(libraryRange1).Should().Be(comparer.GetHashCode(libraryRange2));
+            }
+            else
+            {
+                libraryRange1String.Should().NotBe(libraryRange2String);
+
+                comparer.Equals(libraryRange1, libraryRange2).Should().BeFalse();
+
+                comparer.GetHashCode(libraryRange1).Should().NotBe(comparer.GetHashCode(libraryRange2));
+            }
+        }
+
+        public static IEnumerable<object[]> TypeConstraintCombinations()
+        {
+            LibraryDependencyTarget[] typeConstraints =
+            [
+                LibraryDependencyTarget.All,
+                LibraryDependencyTarget.ExternalProject,
+                LibraryDependencyTarget.Package,
+                LibraryDependencyTarget.Project,
+                LibraryDependencyTarget.Reference,
+                LibraryDependencyTarget.WinMD,
+                LibraryDependencyTarget.PackageProjectExternal,
+                LibraryDependencyTarget.None,
+                LibraryDependencyTarget.Project | LibraryDependencyTarget.ExternalProject,
+                LibraryDependencyTarget.Project | LibraryDependencyTarget.ExternalProject | LibraryDependencyTarget.Package
+            ];
+
+            string name = "PackageA";
+
+            VersionRange versionRange = new VersionRange(new NuGetVersion(1, 0, 0));
+
+            for (int i = 0; i < typeConstraints.Length; i++)
+            {
+                for (int x = 0; x < typeConstraints.Length; x++)
+                {
+                    LibraryDependencyTarget typeConstraint1 = typeConstraints[i];
+                    LibraryDependencyTarget typeConstraint2 = typeConstraints[x];
+
+                    yield return new object[]
+                    {
+                        new LibraryRange(name, versionRange, typeConstraint1),
+                        new LibraryRange(name, versionRange, typeConstraint2),
+                    };
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> VersionRangeCombinations()
+        {
+            LibraryDependencyTarget typeConstraint = LibraryDependencyTarget.Package;
+
+            string name = "PackageA";
+
+            VersionRange[] versionRanges =
+            [
+                new VersionRange(new NuGetVersion(1, 0, 0)), // Min version
+                new VersionRange(new NuGetVersion(1, 0, 0), true, new NuGetVersion(2, 0, 0), true), // Min and Max version
+                new VersionRange(null, true, new NuGetVersion(2, 0, 0), true), // Max version
+                VersionRange.Parse("10.1.*", allowFloating: true), // Floating version
+                new VersionRange(NuGetVersion.Parse("1.0.0-beta")), // Prerelease version
+                new VersionRange(NuGetVersion.Parse("1.0.0-beta"), true, NuGetVersion.Parse("2.0.0-beta"), true), // Prerelease min and max version
+                new VersionRange(NuGetVersion.Parse("1.0.0-beta"), true, null, true), // Prerelease min version
+                new VersionRange(null, true, NuGetVersion.Parse("2.0.0-beta"), true) // Prerelease max
+            ];
+
+            for (int i = 0; i < versionRanges.Length; i++)
+            {
+                for (int x = 0; x < versionRanges.Length; x++)
+                {
+                    VersionRange versionRange1 = versionRanges[i];
+                    VersionRange versionRange2 = versionRanges[x];
+
+                    yield return new object[]
+                    {
+                        new LibraryRange(name, versionRange1, typeConstraint),
+                        new LibraryRange(name, versionRange2, typeConstraint),
+                    };
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Tracked in https://github.com/NuGet/Client.Engineering/issues/3008

## Description
This change add tests for DependencyGraphResolver.LibraryRangeComparer as a follow-up to its implementation.

This comparer takes into account the same logic as LibraryRange.ToString() which has custom logic around what two LibraryRange objects are considered equal.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
