### PR TITLE
Show transitive package details for packages that are top-level and transitive in the solution

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -4,14 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft;
 using Microsoft.ServiceHub.Framework;
-using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using NuGet.Common;
@@ -271,14 +269,13 @@ namespace NuGet.PackageManagement.UI
             {
                 var packageId = metadataContextInfo.Identity.Id;
                 var packageVersion = metadataContextInfo.Identity.Version;
+                var packageLevel = metadataContextInfo.TransitiveOrigins != null ? PackageLevel.Transitive : PackageLevel.TopLevel;
 
                 if (listItemViewModels.TryGetValue(packageId, out PackageItemViewModel existingListItem))
                 {
-                    existingListItem.InstalledVersions.Add(packageVersion);
-                    if (metadataContextInfo.TransitiveOrigins != null)
+                    if (packageLevel == PackageLevel.Transitive)
                     {
-                        existingListItem.TransitiveOrigins.AddRange(metadataContextInfo.TransitiveOrigins);
-                        existingListItem.TransitiveToolTipMessage = string.Format(CultureInfo.CurrentCulture, Resources.PackageVersionWithTransitiveOrigins, string.Join(", ", existingListItem.InstalledVersions), string.Join(", ", existingListItem.TransitiveOrigins));
+                        UpdateTransitiveInfo(existingListItem, metadataContextInfo);
                     }
 
                     existingListItem.UpdateInstalledPackagesVulnerabilities(new PackageIdentity(packageId, packageVersion));
@@ -311,15 +308,6 @@ namespace NuGet.PackageManagement.UI
                         versionOverride = versionOverrides.FirstOrDefault();
                     }
 
-                    var packageLevel = metadataContextInfo.TransitiveOrigins != null ? PackageLevel.Transitive : PackageLevel.TopLevel;
-                    var transitiveToolTipMessage = string.Empty;
-                    var transitiveOrigins = Enumerable.Empty<PackageIdentity>();
-                    if (packageLevel == PackageLevel.Transitive)
-                    {
-                        transitiveToolTipMessage = string.Format(CultureInfo.CurrentCulture, Resources.PackageVersionWithTransitiveOrigins, metadataContextInfo.Identity.Version, string.Join(", ", metadataContextInfo.TransitiveOrigins));
-                        transitiveOrigins = metadataContextInfo.TransitiveOrigins;
-                    }
-
                     ImmutableList<KnownOwnerViewModel> knownOwnerViewModels = null;
 
                     // Only load KnownOwners for the Browse tab and not for any Recommended packages.
@@ -350,9 +338,6 @@ namespace NuGet.PackageManagement.UI
                         PackageFileService = _packageFileService,
                         IncludePrerelease = _includePrerelease,
                         PackageLevel = packageLevel,
-                        TransitiveToolTipMessage = transitiveToolTipMessage,
-                        InstalledVersions = new ObservableCollection<NuGetVersion> { metadataContextInfo.Identity.Version },
-                        TransitiveOrigins = new ObservableCollection<PackageIdentity>(transitiveOrigins),
                     };
 
                     if (listItem.PackageLevel == PackageLevel.TopLevel)
@@ -361,6 +346,7 @@ namespace NuGet.PackageManagement.UI
                     }
                     else
                     {
+                        UpdateTransitiveInfo(listItem, metadataContextInfo);
                         listItem.UpdateTransitivePackageStatus(metadataContextInfo.Identity.Version);
                     }
 
@@ -369,6 +355,13 @@ namespace NuGet.PackageManagement.UI
             }
 
             return listItemViewModels.Values.ToArray();
+        }
+
+        private static void UpdateTransitiveInfo(PackageItemViewModel listItem, PackageSearchMetadataContextInfo metadataContextInfo)
+        {
+            listItem.TransitiveInstalledVersions.Add(metadataContextInfo.Identity.Version);
+            listItem.TransitiveOrigins.AddRange(metadataContextInfo.TransitiveOrigins);
+            listItem.TransitiveToolTipMessage = string.Format(CultureInfo.CurrentCulture, Resources.PackageVersionWithTransitiveOrigins, string.Join(", ", listItem.TransitiveInstalledVersions), string.Join(", ", listItem.TransitiveOrigins));
         }
 
         private static ImmutableList<KnownOwnerViewModel> LoadKnownOwnerViewModels(PackageSearchMetadataContextInfo metadataContextInfo)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -275,11 +275,12 @@ namespace NuGet.PackageManagement.UI
                 if (listItemViewModels.TryGetValue(packageId, out PackageItemViewModel existingListItem))
                 {
                     existingListItem.InstalledVersions.Add(packageVersion);
-                    if (existingListItem.PackageLevel == PackageLevel.Transitive)
+                    if (metadataContextInfo.TransitiveOrigins != null)
                     {
                         existingListItem.TransitiveOrigins.AddRange(metadataContextInfo.TransitiveOrigins);
                         existingListItem.TransitiveToolTipMessage = string.Format(CultureInfo.CurrentCulture, Resources.PackageVersionWithTransitiveOrigins, string.Join(", ", existingListItem.InstalledVersions), string.Join(", ", existingListItem.TransitiveOrigins));
                     }
+
                     existingListItem.UpdateInstalledPackagesVulnerabilities(new PackageIdentity(packageId, packageVersion));
                 }
                 else

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -138,20 +138,6 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private ObservableCollection<NuGetVersion> _installedVersions;
-        public ObservableCollection<NuGetVersion> InstalledVersions
-        {
-            get
-            {
-                return _installedVersions;
-            }
-            set
-            {
-                _installedVersions = value;
-                OnPropertyChanged(nameof(InstalledVersions));
-            }
-        }
-
         private Dictionary<NuGetVersion, int> _vulnerableVersions = [];
         public Dictionary<NuGetVersion, int> VulnerableVersions
         {
@@ -258,17 +244,31 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private ObservableCollection<PackageIdentity> _transitiveOrigins;
-        public ObservableCollection<PackageIdentity> TransitiveOrigins
+        private List<NuGetVersion> _transitiveInstalledVersions;
+        public List<NuGetVersion> TransitiveInstalledVersions
         {
             get
             {
-                return _transitiveOrigins;
+                if (_transitiveInstalledVersions == null)
+                {
+                    _transitiveInstalledVersions = new();
+                }
+
+                return _transitiveInstalledVersions;
             }
-            set
+        }
+
+        private List<PackageIdentity> _transitiveOrigins;
+        public List<PackageIdentity> TransitiveOrigins
+        {
+            get
             {
-                _transitiveOrigins = value;
-                OnPropertyChanged(nameof(TransitiveOrigins));
+                if (_transitiveOrigins == null)
+                {
+                    _transitiveOrigins = new();
+                }
+
+                return _transitiveOrigins;
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -77,7 +77,7 @@
       <Style x:Key="TransitiveInfoToolTipStyle" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource TooltipStyle}">
         <Setter Property="Visibility" Value="Visible" />
         <Style.Triggers>
-          <DataTrigger Binding="{Binding Path=TransitiveToolTipMessage}" Value="">
+          <DataTrigger Binding="{Binding Path=TransitiveToolTipMessage, Converter={StaticResource NullToBooleanConverter}}" Value="True">
             <Setter Property="Visibility" Value="Collapsed" />
           </DataTrigger>
         </Style.Triggers>
@@ -240,8 +240,8 @@
             </TextBlock>
             <TextBlock Style="{StaticResource TransitiveInfoToolTipStyle}">
               <Run
-                FontWeight="Bold"
-                Text="{x:Static nuget:Resources.ToolTip_TransitiveDependency}" />
+                Text="{x:Static nuget:Resources.ToolTip_TransitiveDependency}"
+                FontWeight="Bold" />
               <Run Text="{Binding TransitiveToolTipMessage}" />
             </TextBlock>
           </StackPanel>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -64,6 +64,24 @@
           </Trigger>
         </Style.Triggers>
       </Style>
+
+      <Style x:Key="PackageDescriptionToolTipStyle" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource TooltipStyle}">
+        <Setter Property="Visibility" Value="Collapsed" />
+        <Style.Triggers>
+          <DataTrigger Binding="{Binding Path=PackageLevel}" Value="TopLevel">
+            <Setter Property="Visibility" Value="Visible" />
+          </DataTrigger>
+        </Style.Triggers>
+      </Style>
+
+      <Style x:Key="TransitiveInfoToolTipStyle" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource TooltipStyle}">
+        <Setter Property="Visibility" Value="Visible" />
+        <Style.Triggers>
+          <DataTrigger Binding="{Binding Path=TransitiveToolTipMessage}" Value="">
+            <Setter Property="Visibility" Value="Collapsed" />
+          </DataTrigger>
+        </Style.Triggers>
+      </Style>
     </ResourceDictionary>
   </UserControl.Resources>
 
@@ -210,37 +228,23 @@
         </Grid>
 
         <Grid.ToolTip>
-          <TextBlock
-                        Style="{StaticResource TooltipStyle}">
-                        <Run
-                          Text="{Binding Id}"
-                          FontWeight="Bold" /> <Run Text="{Binding ByOwnerOrAuthor, Mode=OneTime}"/>
-                        <LineBreak />
-                        <Run FontWeight="Bold">
-                          <Run.Style>
-                            <Style TargetType="Run">
-                              <Setter Property="Text" Value="{x:Static nuget:Resources.ToolTip_TransitiveDependency}"/>
-                              <Style.Triggers>
-                                <DataTrigger Binding="{Binding Path=PackageLevel}" Value="TopLevel">
-                                    <Setter Property="Text" Value=""/>
-                                </DataTrigger>
-                              </Style.Triggers>
-                            </Style>
-                          </Run.Style>
-                        </Run>
-                        <Run>
-                          <Run.Style>
-                            <Style TargetType="Run">
-                              <Setter Property="Text" Value="{Binding TransitiveToolTipMessage}"/>
-                              <Style.Triggers>
-                                <DataTrigger Binding="{Binding Path=PackageLevel}" Value="TopLevel">
-                                  <Setter Property="Text" Value="{Binding Summary}"/>
-                                </DataTrigger>
-                              </Style.Triggers>
-                            </Style>
-                          </Run.Style>
-                        </Run>
-          </TextBlock>
+          <StackPanel>
+            <TextBlock
+              Style="{StaticResource TooltipStyle}">
+              <Run
+                Text="{Binding Id}"
+                FontWeight="Bold" /> <Run Text="{Binding ByOwnerOrAuthor, Mode=OneTime}"/>
+            </TextBlock>
+            <TextBlock Style="{StaticResource PackageDescriptionToolTipStyle}">
+              <Run Text="{Binding Summary}" />
+            </TextBlock>
+            <TextBlock Style="{StaticResource TransitiveInfoToolTipStyle}">
+              <Run
+                FontWeight="Bold"
+                Text="{x:Static nuget:Resources.ToolTip_TransitiveDependency}" />
+              <Run Text="{Binding TransitiveToolTipMessage}" />
+            </TextBlock>
+          </StackPanel>
         </Grid.ToolTip>
       </Grid>
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13798

## Description
To support the Solution PM UI, we are tracking information about all the package versions from each project when building the PackageItemViewModel. If a package is top-level but also has transitive origins, it means the package is top-level in at least one project, and transitive in at least one more. In that case, we want to show the transitive origins information to the user. To do that, we check if any of the package versions have transitive origins, and if so, we update the transitive info tool tip message.

Changes in the XAML include restructuring the package item tooltip code so it doesn't rely on data triggers for deciding the binding for each Run. Now, we define the section for the package description and a section for the transitive package info and we trigger visibility based on the package level and whether the transitive origins message is set. This simplifies and adds better structure to the tooltip code while preserving the same look and allows for more flexibility in the future.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~ Will add test(s) in follow-up to feature branch
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
