### PR TITLE
Fix runtime dependency resolution and downgrades for VersionRange.All

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -877,11 +877,15 @@ namespace NuGet.Commands
                                         continue;
                                     }
 
-
-                                    var resolvedVersion = node.Item.Data.Match?.Library?.Version;
-                                    if (resolvedVersion != null && dep.LibraryRange.VersionRange.Satisfies(resolvedVersion))
+                                    if (findLibraryEntryCache.TryGetValue(chosenItemRangeIndex, out Task<FindLibraryEntryResult>? chosenResolvedItemTask))
                                     {
-                                        continue;
+                                        FindLibraryEntryResult chosenResolvedItem = await chosenResolvedItemTask;
+
+                                        var resolvedVersion = chosenResolvedItem.Item.Data.Match?.Library?.Version;
+                                        if (resolvedVersion != null && dep.LibraryRange.VersionRange.Satisfies(resolvedVersion))
+                                        {
+                                            continue;
+                                        }
                                     }
 
                                     // Downgrade

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -684,12 +684,13 @@ namespace NuGet.Commands
                                     state.dependencyIndex,
                                     state.rangeIndex,
                                     state.Framework,
+                                    state.RuntimeIdentifier,
                                     state.context,
                                     state.libraryDependencyInterningTable,
                                     state.libraryRangeInterningTable,
                                     state.token);
                             },
-                            (libraryDependency: actualLibraryDependency, dependencyIndex: depIndex, rangeIndex, pair.Framework, context, libraryDependencyInterningTable, libraryRangeInterningTable, token),
+                            (libraryDependency: actualLibraryDependency, dependencyIndex: depIndex, rangeIndex, pair.Framework, refItemResult.RuntimeIdentifier, context, libraryDependencyInterningTable, libraryRangeInterningTable, token),
                             token);
                     }
 
@@ -720,12 +721,13 @@ namespace NuGet.Commands
                                 return Task.FromResult(new FindLibraryEntryResult(
                                     state.currentRef,
                                     state.rootNode.Item,
+                                    state.RuntimeIdentifier,
                                     state.currentRefDependencyIndex,
                                     state.currentRefRangeIndex,
                                     state.libraryDependencyInterningTable,
                                     state.libraryRangeInterningTable));
                             },
-                            (currentRef, rootNode, currentRefDependencyIndex, currentRefRangeIndex, libraryDependencyInterningTable, libraryRangeInterningTable),
+                            (currentRef, rootNode, refItemResult.RuntimeIdentifier, currentRefDependencyIndex, currentRefRangeIndex, libraryDependencyInterningTable, libraryRangeInterningTable),
                             token);
 
                         // Enqueue each of the runtime dependencies, but only if they weren't already present in refItemResult before merging the runtime dependencies above.
@@ -1378,6 +1380,7 @@ namespace NuGet.Commands
             public FindLibraryEntryResult(
                 LibraryDependency libraryDependency,
                 GraphItem<RemoteResolveResult> resolvedItem,
+                string? runtimeIdentifier,
                 LibraryDependencyIndex itemDependencyIndex,
                 LibraryRangeIndex itemRangeIndex,
                 LibraryDependencyInterningTable libraryDependencyInterningTable,
@@ -1386,6 +1389,7 @@ namespace NuGet.Commands
                 Item = resolvedItem;
                 DependencyIndex = itemDependencyIndex;
                 RangeIndex = itemRangeIndex;
+                RuntimeIdentifier = runtimeIdentifier;
                 int dependencyCount = resolvedItem.Data.Dependencies.Count;
 
                 if (dependencyCount == 0)
@@ -1412,6 +1416,8 @@ namespace NuGet.Commands
             public GraphItem<RemoteResolveResult> Item { get; }
 
             public LibraryRangeIndex RangeIndex { get; }
+
+            public string? RuntimeIdentifier { get; set; }
 
             public LibraryDependencyIndex GetDependencyIndexForDependency(int dependencyIndex)
             {
@@ -1440,6 +1446,7 @@ namespace NuGet.Commands
                 return new FindLibraryEntryResult(
                     libraryDependency,
                     refItem,
+                    runtimeIdentifier,
                     dependencyIndex,
                     rangeIndex,
                     libraryDependencyInterningTable,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -209,7 +209,7 @@ namespace NuGet.Commands
                         (LibraryRangeIndex[] evictedPath, LibraryDependencyIndex evictedDepIndex, LibraryDependencyTarget evictedTypeConstraint) = eviction;
 
                         // If we evicted this same version previously, but the type constraint of currentRef is more stringent (package), then do not skip the current item - this is the one we want.
-                        // This is tricky. I don't really know what this means. Normally we'd key off of versions instead.
+                        // TODO: This is tricky. I don't really know what this means. Normally we'd key off of versions instead.
                         if (!((evictedTypeConstraint == LibraryDependencyTarget.PackageProjectExternal || evictedTypeConstraint == LibraryDependencyTarget.ExternalProject) &&
                             currentRef.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package))
                         {
@@ -288,6 +288,7 @@ namespace NuGet.Commands
 
                         if (evictOnTypeConstraint || !RemoteDependencyWalker.IsGreaterThanOrEqualTo(ovr, nvr))
                         {
+                            // TODO: I don't really get this whole thing.
                             if (chosenRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package) && currentRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
                             {
                                 bool isParentCentrallyPinned = false;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -165,22 +165,17 @@ namespace NuGet.Commands
                     rootProjectRefItem.LibraryRangeIndex,
                     async static (state) =>
                     {
-                        GraphItem<RemoteResolveResult> refItem = await ResolverUtility.FindLibraryEntryAsync(
-                            state.rootProjectRefItem.LibraryDependency!.LibraryRange,
+                        return await FindLibraryEntryResult.CreateAsync(
+                            state.libraryDependency,
+                            state.dependencyIndex,
+                            state.rangeIndex,
                             state.Framework,
-                            runtimeIdentifier: null,
                             state.context,
+                            state.libraryDependencyInterningTable,
+                            state.libraryRangeInterningTable,
                             state.token);
-
-                        return new FindLibraryEntryResult(
-                            state.rootProjectRefItem.LibraryDependency!,
-                                refItem,
-                                state.rootProjectRefItem.LibraryDependencyIndex,
-                                state.rootProjectRefItem.LibraryRangeIndex,
-                                state.libraryDependencyInterningTable,
-                                state.libraryRangeInterningTable);
                     },
-                    (rootProjectRefItem, pair.Framework, context, libraryDependencyInterningTable, libraryRangeInterningTable, token),
+                    (libraryDependency: initialProject, dependencyIndex: rootProjectRefItem.LibraryDependencyIndex, rangeIndex: rootProjectRefItem.LibraryRangeIndex, pair.Framework, context, libraryDependencyInterningTable, libraryRangeInterningTable, token),
                     token);
 
             ProcessDeepEviction:
@@ -759,12 +754,13 @@ namespace NuGet.Commands
                                             state.dependencyIndex,
                                             state.rangeIndex,
                                             state.Framework,
+                                            state.RuntimeIdentifier,
                                             state.context,
                                             state.libraryDependencyInterningTable,
                                             state.libraryRangeInterningTable,
                                             state.token);
                                     },
-                                    (libraryDependency: dep, dependencyIndex: runtimeDependencyGraphItem.LibraryDependencyIndex, rangeIndex: runtimeDependencyGraphItem.LibraryRangeIndex, pair.Framework, context, libraryDependencyInterningTable, libraryRangeInterningTable, token),
+                                    (libraryDependency: dep, dependencyIndex: runtimeDependencyGraphItem.LibraryDependencyIndex, rangeIndex: runtimeDependencyGraphItem.LibraryRangeIndex, pair.Framework, pair.RuntimeIdentifier, context, libraryDependencyInterningTable, libraryRangeInterningTable, token),
                                     token);
 
                                 runtimeDependencyIndex++;
@@ -877,6 +873,13 @@ namespace NuGet.Commands
                                     }
 
                                     if (chosenSuppressions.Count > 0 && chosenSuppressions[0].Contains(depIndex))
+                                    {
+                                        continue;
+                                    }
+
+
+                                    var resolvedVersion = node.Item.Data.Match?.Library?.Version;
+                                    if (resolvedVersion != null && dep.LibraryRange.VersionRange.Satisfies(resolvedVersion))
                                     {
                                         continue;
                                     }
@@ -1416,12 +1419,17 @@ namespace NuGet.Commands
                 return _rangeIndices[dependencyIndex];
             }
 
-            public async static Task<FindLibraryEntryResult> CreateAsync(LibraryDependency libraryDependency, LibraryDependencyIndex dependencyIndex, LibraryRangeIndex rangeIndex, NuGetFramework framework, RemoteWalkContext context, LibraryDependencyInterningTable libraryDependencyInterningTable, LibraryRangeInterningTable libraryRangeInterningTable, CancellationToken cancellationToken)
+            public static Task<FindLibraryEntryResult> CreateAsync(LibraryDependency libraryDependency, LibraryDependencyIndex dependencyIndex, LibraryRangeIndex rangeIndex, NuGetFramework framework, RemoteWalkContext context, LibraryDependencyInterningTable libraryDependencyInterningTable, LibraryRangeInterningTable libraryRangeInterningTable, CancellationToken cancellationToken)
+            {
+                return CreateAsync(libraryDependency, dependencyIndex, rangeIndex, framework, runtimeIdentifier: null, context, libraryDependencyInterningTable, libraryRangeInterningTable, cancellationToken);
+            }
+
+            public async static Task<FindLibraryEntryResult> CreateAsync(LibraryDependency libraryDependency, LibraryDependencyIndex dependencyIndex, LibraryRangeIndex rangeIndex, NuGetFramework framework, string? runtimeIdentifier, RemoteWalkContext context, LibraryDependencyInterningTable libraryDependencyInterningTable, LibraryRangeInterningTable libraryRangeInterningTable, CancellationToken cancellationToken)
             {
                 GraphItem<RemoteResolveResult> refItem = await ResolverUtility.FindLibraryEntryAsync(
                     libraryDependency.LibraryRange,
                     framework,
-                    runtimeIdentifier: null,
+                    runtimeIdentifier,
                     context,
                     cancellationToken);
 

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -253,6 +253,8 @@ namespace NuGet.DependencyResolver
 
         public static bool EvaluateRuntimeDependencies(ref LibraryRange libraryRange, string runtimeName, RuntimeGraph runtimeGraph, ref HashSet<LibraryDependency> runtimeDependencies)
         {
+            bool changedLibraryRange = false;
+
             // HACK(davidfowl): This is making runtime.json support package redirects
 
             // Look up any additional dependencies for this package
@@ -276,7 +278,7 @@ namespace NuGet.DependencyResolver
                     {
                         libraryRange = libraryDependency.LibraryRange;
 
-                        return true;
+                        changedLibraryRange = true;
                     }
                 }
                 else
@@ -287,7 +289,7 @@ namespace NuGet.DependencyResolver
                 }
             }
 
-            return false;
+            return changedLibraryRange;
         }
 
         public static void MergeRuntimeDependencies(HashSet<LibraryDependency> runtimeDependencies, GraphNode<RemoteResolveResult> node)

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -1289,7 +1289,7 @@ namespace NuGet.Commands.FuncTest
             // Act & Assert
             (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1);
             result.Success.Should().BeTrue();
-            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets.Should().HaveCount(2);
             result.LockFile.Targets[0].Libraries.Should().HaveCount(2);
             result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
             result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NuGet.Commands.Test;
@@ -61,7 +63,7 @@ namespace NuGet.Commands.FuncTest
         [Fact]
         // Project 1 -> a 1.0.0 -> b 1.0.0
         //                      -> c 1.0.0 -> -> d 1.0.0 -> b 2.0.0
-        public async Task RestoreCommand_WithPackageDrivenDowngrade_RespectsDowngrade_AndRaisesWarningAgain()
+        public async Task RestoreCommand_WithPackageDrivenDowngradeAndDepthDifferenceMoreThanOne_RespectsDowngrade_AndRaisesWarning()
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
@@ -349,13 +351,11 @@ namespace NuGet.Commands.FuncTest
                                     ""version"": ""[1.0.0,)"",
                                     ""target"": ""Package"",
                                     ""versionOverride"": ""[1.0.0, )"",
-                                    ""versionCentrallyManaged"": true
                                 },
                                 ""b"": {
                                     ""version"": ""[1.0.0,)"",
                                     ""target"": ""Package"",
                                     ""versionOverride"": ""[1.0.0, )"",
-                                    ""versionCentrallyManaged"": true,
                                 }
                         },
                         ""centralPackageVersions"": {
@@ -451,13 +451,11 @@ namespace NuGet.Commands.FuncTest
                                     ""version"": ""[1.0.0,)"",
                                     ""target"": ""Package"",
                                     ""versionOverride"": ""[1.0.0, )"",
-                                    ""versionCentrallyManaged"": true
                                 },
                                 ""b"": {
                                     ""version"": ""[1.0.0,)"",
                                     ""target"": ""Package"",
                                     ""versionOverride"": ""[1.0.0, )"",
-                                    ""versionCentrallyManaged"": true,
                                     ""suppressParent"": ""All""
                                 }
                         },
@@ -1131,6 +1129,173 @@ namespace NuGet.Commands.FuncTest
             }
         }
 
+        [Fact]
+        public async Task RestoreCommand_WithRuntimeSpecificPackage_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                new SimpleTestPackageContext("a", "1.0.0")
+                {
+                    Dependencies = [new SimpleTestPackageContext("b", "1.0.0")],
+                    RuntimeJson = @"{
+                  ""runtimes"": {
+                    ""win"": {
+                            ""a"": {
+                                ""runtime.a"": ""1.0.0""
+                            }
+                          }
+                        }
+                  }"
+                },
+                new SimpleTestPackageContext("runtime.a", "1.0.0"));
+
+            var spec1 = @"
+                {
+                  ""runtimes"": {
+                        ""win"": {}
+                  },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                            ""a"": {
+                                ""version"": ""[1.0.0,)"",
+                                ""target"": ""Package"",
+                            }
+                        }
+                    }
+                  }
+                }";
+
+            // Setup project
+            var project1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, spec1);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1);
+            result.Success.Should().BeTrue();
+            result.LockFile.Targets.Should().HaveCount(2);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+            result.LockFile.Targets[1].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[1].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[1].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[1].Libraries[2].Name.Should().Be("runtime.a");
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithRuntimeSpecificPackageAndALockFile_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                new SimpleTestPackageContext("a", "1.0.0")
+                {
+                    Dependencies = [new SimpleTestPackageContext("b", "1.0.0")],
+                    RuntimeJson = @"{
+                  ""runtimes"": {
+                    ""win"": {
+                            ""a"": {
+                                ""runtime.a"": ""1.0.0""
+                            }
+                          }
+                        }
+                  }"
+                },
+                new SimpleTestPackageContext("runtime.a", "1.0.0"));
+
+            var spec1 = @"
+                {
+                  ""runtimes"": {
+                        ""win"": {}
+                  },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                            ""a"": {
+                                ""version"": ""[1.0.0,)"",
+                                ""target"": ""Package"",
+                            }
+                        }
+                    }
+                  }
+                }";
+
+            // Setup project
+            var project1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, spec1);
+            project1.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties("true", null, false);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1);
+            result.Success.Should().BeTrue();
+            result.LockFile.Targets.Should().HaveCount(2);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+            result.LockFile.Targets[1].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[1].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[1].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[1].Libraries[2].Name.Should().Be("runtime.a");
+
+            await result.CommitAsync(NullLogger.Instance, CancellationToken.None);
+            File.Delete(result.LockFilePath); // Ensure restore happens again.
+
+            // Act & Assert
+            (var resultWithLockFile, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1);
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithPackageWithAMissingDependencyVersion_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            await SimpleTestPackageUtility.CreatePackagesWithoutDependenciesAsync(
+                pathContext.PackageSource,
+                new SimpleTestPackageContext("a", "1.0.0")
+                {
+                    Dependencies = [new SimpleTestPackageContext("b", null)],
+                },
+                new SimpleTestPackageContext("b", "2.0.0")
+                );
+
+            // Setup project
+            var spec1 = @"
+                {
+                  ""runtimes"": {
+                        ""win"": {}
+                  },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                            ""a"": {
+                                ""version"": ""[1.0.0,)"",
+                                ""target"": ""Package"",
+                            },
+                            ""b"": {
+                                ""version"": ""[2.0.0,)"",
+                                ""target"": ""Package"",
+                            }
+                        }
+                    }
+                  }
+                }";
+
+            // Setup project
+            var project1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, spec1);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1);
+            result.Success.Should().BeTrue();
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+        }
+
+        // TODO NK - This needs removed.
         // Here's why package driven dependencies should flow.
         // Say we have P1 -> P2 -> P3 -> A 1.0.0 -> B 2.0.0
         //                            -> B 1.5.0


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13794

## Description
When resolving runtime dependencies via a `packages.lock.json`, the runtime must be passed along.  The original implementation of the new resolver was not doing this and we have no tests for it.  The resolver now passes the runtime identifier for runtime dependencies.

This change also fixes a bug where the resolver considers a downgrade for a package dependency when no version is specified and instead it defaults to `VersionRange.All`.  This results in a downgrade warning and instead the code should verify if the version is satisfied by the chosen version.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
