### PR TITLE
[Transitive's in Solution PM UI] Update vulnerability warning tooltips

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -167,7 +167,7 @@ namespace NuGet.PackageManagement.UI
                         project.PackageLevel = null;
                     }
 
-                    if (_searchResultPackage.VulnerableVersions.TryGetValue(project.InstalledVersion, out int vulnerable))
+                    if (project?.InstalledVersion is not null && _searchResultPackage.VulnerableVersions.TryGetValue(project.InstalledVersion, out int vulnerable))
                     {
                         project.InstalledVersionMaxVulnerability = vulnerable;
                         vulnerabilitiesSet.Add(project.InstalledVersion);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1159,7 +1159,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} vulnerable versions installed.
+        ///   Looks up a localized string similar to {0} vulnerable versions installed..
         /// </summary>
         public static string Label_InstalledVulnerabilitiesCount {
             get {
@@ -1168,7 +1168,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} vulnerable version installed.
+        ///   Looks up a localized string similar to {0} vulnerable version installed..
         /// </summary>
         public static string Label_InstalledVulnerabilitiesCountSingle {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1186,6 +1186,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This package installed versions: {0} contain vulnerabilities..
+        /// </summary>
+        public static string Label_MultiplePackageVulnerableVersionToolTip {
+            get {
+                return ResourceManager.GetString("Label_MultiplePackageVulnerableVersionToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An error occurred while fetching additional information about the package. Refresh to try again..
         /// </summary>
         public static string Label_NetworkError {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1159,24 +1159,6 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} vulnerable versions installed..
-        /// </summary>
-        public static string Label_InstalledVulnerabilitiesCount {
-            get {
-                return ResourceManager.GetString("Label_InstalledVulnerabilitiesCount", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} vulnerable version installed..
-        /// </summary>
-        public static string Label_InstalledVulnerabilitiesCountSingle {
-            get {
-                return ResourceManager.GetString("Label_InstalledVulnerabilitiesCountSingle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to License:.
         /// </summary>
         public static string Label_License {
@@ -1186,7 +1168,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This package installed versions: {0} contain vulnerabilities..
+        ///   Looks up a localized string similar to These installed package versions contain vulnerabilities: {0}.
         /// </summary>
         public static string Label_MultiplePackageVulnerableVersionToolTip {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1061,11 +1061,11 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <value>Owner</value>
   </data>
   <data name="Label_InstalledVulnerabilitiesCount" xml:space="preserve">
-    <value>{0} vulnerable versions installed</value>
+    <value>{0} vulnerable versions installed.</value>
     <comment>{0} is the number of installed vulnerable versions</comment>
   </data>
   <data name="Label_InstalledVulnerabilitiesCountSingle" xml:space="preserve">
-    <value>{0} vulnerable version installed</value>
+    <value>{0} vulnerable version installed.</value>
     <comment>{0} is the number of installed vulnerable versions</comment>
   </data>
   <data name="Text_PackageLevelTransitive" xml:space="preserve">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1074,4 +1074,8 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Text_PackageLevelTopLevel" xml:space="preserve">
     <value>Top-level</value>
   </data>
+  <data name="Label_MultiplePackageVulnerableVersionToolTip" xml:space="preserve">
+    <value>This package installed versions: {0} contain vulnerabilities.</value>
+    <comment>{0} are package versions</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1060,14 +1060,6 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Hyperlink_Owner" xml:space="preserve">
     <value>Owner</value>
   </data>
-  <data name="Label_InstalledVulnerabilitiesCount" xml:space="preserve">
-    <value>{0} vulnerable versions installed.</value>
-    <comment>{0} is the number of installed vulnerable versions</comment>
-  </data>
-  <data name="Label_InstalledVulnerabilitiesCountSingle" xml:space="preserve">
-    <value>{0} vulnerable version installed.</value>
-    <comment>{0} is the number of installed vulnerable versions</comment>
-  </data>
   <data name="Text_PackageLevelTransitive" xml:space="preserve">
     <value>Transitive</value>
   </data>
@@ -1075,7 +1067,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <value>Top-level</value>
   </data>
   <data name="Label_MultiplePackageVulnerableVersionToolTip" xml:space="preserve">
-    <value>This package installed versions: {0} contain vulnerabilities.</value>
+    <value>These installed package versions contain vulnerabilities: {0}</value>
     <comment>{0} are package versions</comment>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -138,6 +138,14 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
+        public string VulnerableVersionsString
+        {
+            get
+            {
+                return string.Join(", ", VulnerableVersions.Keys);
+            }
+        }
+
         private Dictionary<NuGetVersion, int> _vulnerableVersions = [];
         public Dictionary<NuGetVersion, int> VulnerableVersions
         {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -26,6 +26,30 @@
       <nuget:NullToBooleanConverter
         x:Key="NullToBooleanConverter" />
 
+      <!--Style for warning tooltip text-->
+      <Style TargetType="TextBlock" x:Key="VulnerabilitiesCountText">
+        <Setter Property="Text">
+          <Setter.Value>
+            <MultiBinding Converter="{StaticResource StringFormatConverter}">
+              <Binding Source="{x:Static nuget:Resources.Label_MultiplePackageVulnerableVersionToolTip}" />
+              <Binding Path="VulnerableVersionsString" />
+            </MultiBinding>
+          </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+          <DataTrigger Binding="{Binding VulnerableVersions.Count}" Value="1">
+            <Setter Property="Text">
+              <Setter.Value>
+                <MultiBinding Converter="{StaticResource StringFormatConverter}">
+                  <Binding Source="{x:Static nuget:Resources.Label_PackageVulnerableToolTip}" />
+                  <Binding Path="VulnerabilityMaxSeverity" Converter="{StaticResource IntToVulnerabilitySeverityConverter}" />
+                </MultiBinding>
+              </Setter.Value>
+            </Setter>
+          </DataTrigger>
+        </Style.Triggers>
+      </Style>
+      
       <!-- style for install, uninstall and update buttons -->
       <Style x:Key="buttonStyle" TargetType="{x:Type Button}">
         <Setter Property="Template">
@@ -286,14 +310,9 @@
             <imaging:CrispImage.ToolTip>
               <StackPanel>
                 <TextBlock
-                Margin="0, 0, 0, 8"
-                Visibility="{Binding IsPackageVulnerable,Converter={StaticResource BooleanToVisibilityConverter}}">
-                  <TextBlock.Text>
-                    <MultiBinding Converter="{StaticResource StringFormatConverter}">
-                      <Binding Source="{x:Static nuget:Resources.Label_PackageVulnerableToolTip}" />
-                      <Binding Path="VulnerabilityMaxSeverity" Converter="{StaticResource IntToVulnerabilitySeverityConverter}" />
-                    </MultiBinding>
-                  </TextBlock.Text>
+                  Margin="0, 0, 0, 8"
+                  Style="{StaticResource VulnerabilitiesCountText}"
+                  Visibility="{Binding IsPackageVulnerable,Converter={StaticResource BooleanToVisibilityConverter}}">
                 </TextBlock>
                 <TextBlock
                 Text="{x:Static nuget:Resources.Label_PackageDeprecatedToolTip}"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
@@ -96,30 +96,6 @@
         </Setter>
       </Style>
 
-      <!--style of the installed header vulnerable icon-->
-      <Style TargetType="TextBlock" x:Key="VulnerabilitiesCountText">
-        <Setter Property="Text">
-          <Setter.Value>
-            <MultiBinding Converter="{StaticResource StringFormatConverter}">
-              <Binding Source="{x:Static local:Resources.Label_InstalledVulnerabilitiesCount}" />
-              <Binding Path="InstalledVulnerabilitiesCount" />
-            </MultiBinding>
-          </Setter.Value>
-        </Setter>
-        <Style.Triggers>
-          <DataTrigger Binding="{Binding InstalledVulnerabilitiesCount}" Value="1">
-            <Setter Property="Text">
-              <Setter.Value>
-                <MultiBinding Converter="{StaticResource StringFormatConverter}">
-                  <Binding Source="{x:Static local:Resources.Label_InstalledVulnerabilitiesCountSingle}" />
-                  <Binding Path="InstalledVulnerabilitiesCount" />
-                </MultiBinding>
-              </Setter.Value>
-            </Setter>
-          </DataTrigger>
-        </Style.Triggers>
-      </Style>
-      
       <!-- the style of the list view items -->
       <Style x:Key="ListViewItemFocusVisual" TargetType="{x:Type Control}" BasedOn="{StaticResource ControlsFocusVisualStyle}">
         <Setter Property="Margin" Value="2"/>
@@ -364,8 +340,14 @@
                     Visibility="{Binding InstalledVulnerabilitiesCount, Converter={StaticResource IsGreaterThanToVisibilityConverter}, ConverterParameter=0}"
                     Moniker="{x:Static catalog:KnownMonikers.StatusWarning}">
                     <imaging:CrispImage.ToolTip>
-                      <TextBlock
-                        Style="{StaticResource VulnerabilitiesCountText}" />
+                      <TextBlock>
+                        <TextBlock.Text>
+                          <MultiBinding Converter="{StaticResource StringFormatConverter}">
+                            <Binding Source="{x:Static local:Resources.Label_Installed_VulnerableWarning}" />
+                            <Binding Path="InstalledVulnerabilitiesCount" />
+                          </MultiBinding>
+                        </TextBlock.Text>
+                      </TextBlock>
                     </imaging:CrispImage.ToolTip>
                   </imaging:CrispImage>
                 </StackPanel>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
@@ -96,6 +96,30 @@
         </Setter>
       </Style>
 
+      <!--style of the installed header vulnerable icon-->
+      <Style TargetType="TextBlock" x:Key="VulnerabilitiesCountText">
+        <Setter Property="Text">
+          <Setter.Value>
+            <MultiBinding Converter="{StaticResource StringFormatConverter}">
+              <Binding Source="{x:Static local:Resources.Label_InstalledVulnerabilitiesCount}" />
+              <Binding Path="InstalledVulnerabilitiesCount" />
+            </MultiBinding>
+          </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+          <DataTrigger Binding="{Binding InstalledVulnerabilitiesCount}" Value="1">
+            <Setter Property="Text">
+              <Setter.Value>
+                <MultiBinding Converter="{StaticResource StringFormatConverter}">
+                  <Binding Source="{x:Static local:Resources.Label_InstalledVulnerabilitiesCountSingle}" />
+                  <Binding Path="InstalledVulnerabilitiesCount" />
+                </MultiBinding>
+              </Setter.Value>
+            </Setter>
+          </DataTrigger>
+        </Style.Triggers>
+      </Style>
+      
       <!-- the style of the list view items -->
       <Style x:Key="ListViewItemFocusVisual" TargetType="{x:Type Control}" BasedOn="{StaticResource ControlsFocusVisualStyle}">
         <Setter Property="Margin" Value="2"/>
@@ -340,14 +364,8 @@
                     Visibility="{Binding InstalledVulnerabilitiesCount, Converter={StaticResource IsGreaterThanToVisibilityConverter}, ConverterParameter=0}"
                     Moniker="{x:Static catalog:KnownMonikers.StatusWarning}">
                     <imaging:CrispImage.ToolTip>
-                      <TextBlock>
-                        <TextBlock.Text>
-                          <MultiBinding Converter="{StaticResource StringFormatConverter}">
-                            <Binding Source="{x:Static local:Resources.Label_PackageVulnerableToolTip}" />
-                            <Binding Path="InstalledVersionMaxVulnerability" Converter="{StaticResource IntToVulnerabilitySeverityConverter}" />
-                          </MultiBinding>
-                        </TextBlock.Text>
-                      </TextBlock>
+                      <TextBlock
+                        Style="{StaticResource VulnerabilitiesCountText}" />
                     </imaging:CrispImage.ToolTip>
                   </imaging:CrispImage>
                 </StackPanel>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13762

## Description
Updated texts for vulnerability tooltips. 

Packages list tooltip has a new text with specific vulnerable versions installed. If there is just 1 version installed it will display the same text as before.

![image](https://github.com/user-attachments/assets/3b891d53-4c99-4a92-80ab-f9d5ceab1556)
![image](https://github.com/user-attachments/assets/d7ac797e-91c2-4c6c-983b-31cc7e9acbf4)

Solution Details pane table has two new warnings. One in the header that tells the user how many installed versions are vulnerable and another in the rows that tells the user the vulnerability severity.

![image](https://github.com/user-attachments/assets/c727eef5-c7cd-4067-bf00-d63873ca46fc)
![image](https://github.com/user-attachments/assets/08b2bf76-0dc9-4407-87a6-fe74f65560cd)


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- ~[ ] Added tests~ UI texts
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
