### PR TITLE
return counts from RestoreTask for PackageReference projects

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -138,7 +138,8 @@ namespace NuGet.Build.Tasks.Console
 
             try
             {
-                bool result = await BuildTasksUtility.RestoreAsync(
+                // todo: need to return Restore task output properties, like in NuGet.targets
+                List<RestoreSummary> restoreSummaries = await BuildTasksUtility.RestoreAsync(
                     dependencyGraphSpec: dependencyGraphSpec,
                     interactive,
                     recursive: IsOptionTrue(nameof(RestoreTaskEx.Recursive), options),
@@ -152,6 +153,7 @@ namespace NuGet.Build.Tasks.Console
                     cleanupAssetsForUnsupportedProjects: IsOptionTrue(nameof(RestoreTaskEx.CleanupAssetsForUnsupportedProjects), options),
                     log: MSBuildLogger,
                 cancellationToken: CancellationToken.None);
+                bool result = restoreSummaries.All(rs => rs.Success);
 
                 LogFilesToEmbedInBinlog(dependencyGraphSpec, options);
 

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -139,6 +139,7 @@ namespace NuGet.Build.Tasks.Console
             try
             {
                 // todo: need to return Restore task output properties, like in NuGet.targets
+                // https://github.com/NuGet/Home/issues/13828
                 List<RestoreSummary> restoreSummaries = await BuildTasksUtility.RestoreAsync(
                     dependencyGraphSpec: dependencyGraphSpec,
                     interactive,

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -114,7 +114,7 @@ namespace NuGet.Build.Tasks
             ProjectStyle.ProjectJson
         };
 
-        public static Task<bool> RestoreAsync(
+        public static Task<List<RestoreSummary>> RestoreAsync(
             DependencyGraphSpec dependencyGraphSpec,
             bool interactive,
             bool recursive,
@@ -131,7 +131,7 @@ namespace NuGet.Build.Tasks
             return RestoreAsync(dependencyGraphSpec, interactive, recursive, noCache, ignoreFailedSources, disableParallel, force, forceEvaluate, hideWarningsAndErrors, restorePC, cleanupAssetsForUnsupportedProjects: false, log, cancellationToken);
         }
 
-        public static async Task<bool> RestoreAsync(
+        public static async Task<List<RestoreSummary>> RestoreAsync(
             DependencyGraphSpec dependencyGraphSpec,
             bool interactive,
             bool recursive,
@@ -289,7 +289,7 @@ namespace NuGet.Build.Tasks
                 {
                     RestoreSummary.Log(log, restoreSummaries);
                 }
-                return restoreSummaries.All(x => x.Success);
+                return restoreSummaries;
             }
             finally
             {

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -191,6 +191,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       RestorePackagesConfig="$(RestorePackagesConfig)"
       EmbedFilesInBinlog="$(RestoreEmbedFilesInBinlog)">
       <Output TaskParameter="EmbedInBinlog" ItemName="EmbedInBinlog" />
+      <Output TaskParameter="ProjectsRestored" PropertyName="RestoreProjectCount" />
+      <Output TaskParameter="ProjectsAlreadyUpToDate" PropertyName="RestoreSkippedCount" />
+      <Output TaskParameter="ProjectsAudited" PropertyName="RestoreProjectsAuditedCount" />
     </RestoreTask>
   </Target>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -89,6 +89,30 @@ namespace NuGet.Build.Tasks
         public ITaskItem[] EmbedInBinlog { get; set; }
 
         /// <summary>
+        /// Gets or sets the number of projects that were considered for this restore operation.
+        /// </summary>
+        /// <remarks>
+        /// Projects that no-op (were already up to date) are included.
+        /// </remarks>
+        [Output]
+        public int ProjectsRestored { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of projects that were already up to date.
+        /// </summary>
+        [Output]
+        public int ProjectsAlreadyUpToDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of projects that NuGetAudit scanned.
+        /// </summary>
+        /// <remarks>
+        /// NuGetAudit does not run on no-op restores, or when no vulnerability database can be downloaded.
+        /// </remarks>
+        [Output]
+        public int ProjectsAudited { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to embed files produced by restore in the MSBuild binary logger.
         /// 0 = Nothing
         /// 1 = Assets file, g.props, and g.targets
@@ -148,7 +172,7 @@ namespace NuGet.Build.Tasks
                 log.LogInformation(Strings.Log_RestoreNoCacheInformation);
             }
 
-            return await BuildTasksUtility.RestoreAsync(
+            var restoreSummaries = await BuildTasksUtility.RestoreAsync(
                 dependencyGraphSpec: dgFile,
                 interactive: Interactive,
                 recursive: RestoreRecursive,
@@ -161,6 +185,20 @@ namespace NuGet.Build.Tasks
                 restorePC: RestorePackagesConfig,
                 log: log,
                 cancellationToken: _cts.Token);
+
+            int upToDate = 0;
+            int audited = 0;
+            foreach (var summary in restoreSummaries)
+            {
+                if (summary.NoOpRestore) { upToDate++; }
+                if (summary.AuditRan) { audited++; }
+            }
+
+            ProjectsRestored = restoreSummaries.Count;
+            ProjectsAlreadyUpToDate = upToDate;
+            ProjectsAudited = audited;
+
+            return restoreSummaries.All(s => s.Success);
         }
 
         public void Cancel()

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+NuGet.Commands.RestoreSummary.AuditRan.get -> bool

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+NuGet.Commands.RestoreSummary.AuditRan.get -> bool

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+NuGet.Commands.RestoreSummary.AuditRan.get -> bool

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -533,7 +533,7 @@ namespace NuGet.Commands
                 graphs,
                 _request.DependencyProviders.VulnerabilityInfoProviders,
                 _logger);
-            await audit.CheckPackageVulnerabilitiesAsync(token);
+            bool auditRan = await audit.CheckPackageVulnerabilitiesAsync(token);
 
             telemetry.TelemetryEvent[AuditLevel] = (int)audit.MinSeverity;
             telemetry.TelemetryEvent[AuditMode] = AuditUtility.GetString(audit.AuditMode);
@@ -563,7 +563,7 @@ namespace NuGet.Commands
             if (audit.GenerateOutputDurationSeconds.HasValue) { telemetry.TelemetryEvent[AuditDurationOutput] = audit.GenerateOutputDurationSeconds.Value; }
             telemetry.EndIntervalMeasure(AuditDurationTotal);
 
-            return audit.AuditRan;
+            return auditRan;
 
             void AddPackagesList(TelemetryActivity telemetry, string eventName, List<string> packages)
             {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -82,6 +82,9 @@ namespace NuGet.Commands
         /// </summary>
         internal PackagesLockFile _newPackagesLockFile { get; }
 
+        /// <inheritdoc cref="RestoreSummary.AuditRan"/>
+        internal bool AuditRan { get; init; }
+
 
         private readonly string _dependencyGraphSpecFilePath;
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
@@ -29,8 +29,13 @@ namespace NuGet.Commands
         /// <summary>
         /// A boolean that specifies if NuGetAudit verified packages for known vulnerabilities
         /// </summary>
-        /// <remarks>This could be false either is NuGetAudit is disabled, but also if
-        /// no sources provided NuGetAudit with a vulnerability database.</remarks>
+        /// <remarks>This could be false if NuGetAudit is disabled, if
+        /// <list type="bullet">
+        /// <item>NuGetAudit is disabled</item>
+        /// <item>Project is already up to date (no-op restore)</item>
+        /// <item>No sources provided a vulnerability database</item>
+        /// </list>
+        /// </remarks>
         public bool AuditRan { get; }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
@@ -27,6 +27,13 @@ namespace NuGet.Commands
         public int InstallCount { get; }
 
         /// <summary>
+        /// A boolean that specifies if NuGetAudit verified packages for known vulnerabilities
+        /// </summary>
+        /// <remarks>This could be false either is NuGetAudit is disabled, but also if
+        /// no sources provided NuGetAudit with a vulnerability database.</remarks>
+        public bool AuditRan { get; }
+
+        /// <summary>
         /// All the warnings and errors that were produced as a result of the restore.
         /// </summary>
         public IReadOnlyList<IRestoreLogMessage> Errors { get; }
@@ -59,6 +66,7 @@ namespace NuGet.Commands
                 .AsReadOnly();
             InstallCount = result.GetAllInstalled().Count;
             Errors = errors.ToArray();
+            AuditRan = result.AuditRan;
         }
 
         public RestoreSummary(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
@@ -51,9 +51,6 @@ namespace NuGet.Commands.Restore.Utility
         internal int DistinctAdvisoriesSuppressedCount { get; private set; }
         internal int TotalWarningsSuppressedCount { get; private set; }
 
-        /// <inheritdoc cref="RestoreSummary.AuditRan"/>
-        internal bool AuditRan { get; private set; }
-
         public AuditUtility(
             ProjectModel.RestoreAuditProperties? restoreAuditProperties,
             string projectFullPath,
@@ -81,14 +78,13 @@ namespace NuGet.Commands.Restore.Utility
             }
         }
 
-        public async Task CheckPackageVulnerabilitiesAsync(CancellationToken cancellationToken)
+        public async Task<bool> CheckPackageVulnerabilitiesAsync(CancellationToken cancellationToken)
         {
             // Performance: Early exit if restore graph does not contain any packages.
             if (!HasPackages())
             {
                 // No packages means we've validated there are none with known vulnerabilities.
-                AuditRan = true;
-                return;
+                return true;
             }
 
             Stopwatch stopwatch = Stopwatch.StartNew();
@@ -99,13 +95,11 @@ namespace NuGet.Commands.Restore.Utility
             // Performance: Early exit if there's no vulnerability data to check packages against.
             if (allVulnerabilityData is null || !AnyVulnerabilityDataFound(allVulnerabilityData))
             {
-                AuditRan = false;
-                return;
+                return false;
             }
 
             CheckPackageVulnerabilities(allVulnerabilityData);
-            AuditRan = true;
-            return;
+            return true;
 
             bool HasPackages()
             {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/AuditUtility.cs
@@ -51,6 +51,9 @@ namespace NuGet.Commands.Restore.Utility
         internal int DistinctAdvisoriesSuppressedCount { get; private set; }
         internal int TotalWarningsSuppressedCount { get; private set; }
 
+        /// <inheritdoc cref="RestoreSummary.AuditRan"/>
+        internal bool AuditRan { get; private set; }
+
         public AuditUtility(
             ProjectModel.RestoreAuditProperties? restoreAuditProperties,
             string projectFullPath,
@@ -83,6 +86,8 @@ namespace NuGet.Commands.Restore.Utility
             // Performance: Early exit if restore graph does not contain any packages.
             if (!HasPackages())
             {
+                // No packages means we've validated there are none with known vulnerabilities.
+                AuditRan = true;
                 return;
             }
 
@@ -94,10 +99,13 @@ namespace NuGet.Commands.Restore.Utility
             // Performance: Early exit if there's no vulnerability data to check packages against.
             if (allVulnerabilityData is null || !AnyVulnerabilityDataFound(allVulnerabilityData))
             {
+                AuditRan = false;
                 return;
             }
 
             CheckPackageVulnerabilities(allVulnerabilityData);
+            AuditRan = true;
+            return;
 
             bool HasPackages()
             {

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -2696,7 +2696,8 @@ EndGlobal";
             allTargets.Should().Contain(condition);
         }
 
-        [Fact]
+        // https://github.com/NuGet/Home/issues/13829
+        [PlatformFact(SkipPlatform = Platform.Linux)]
         public async Task DotnetRestore_WithServerProvidingAuditData_RestoreTaskReturnsCountProperties()
         {
             // Arrange

--- a/test/TestUtilities/Test.Utility/FileSystemBackedV3MockServer.cs
+++ b/test/TestUtilities/Test.Utility/FileSystemBackedV3MockServer.cs
@@ -158,7 +158,7 @@ namespace Test.Utility
                         return new Action<HttpListenerResponse>(response =>
                         {
                             response.ContentType = "application/json";
-                            var vulnerabilityJson = FeedUtilities.CreateVulnerabilitiesJson(Uri + "/vulnerability/vulnerability.json");
+                            var vulnerabilityJson = FeedUtilities.CreateVulnerabilitiesJson(Uri + "vulnerability/vulnerability.json");
                             SetResponseContent(response, vulnerabilityJson.ToString());
                         });
                     }

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -112,11 +112,13 @@ namespace NuGet.Test.Utility
 
             var config = GetOrAddSection(doc, "config");
             var packageSources = GetOrAddSection(doc, "packageSources");
+            var auditSources = GetOrAddSection(doc, "auditSources");
             var disabledSources = GetOrAddSection(doc, "disabledPackageSources");
             var fallbackFolders = GetOrAddSection(doc, "fallbackPackageFolders");
             var packageSourceMapping = GetOrAddSection(doc, "packageSourceMapping");
 
             packageSources.Add(new XElement(XName.Get("clear")));
+            auditSources.Add(new XElement(XName.Get("clear")));
             disabledSources.Add(new XElement(XName.Get("clear")));
             packageSourceMapping.Add(new XElement(XName.Get("clear")));
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13778

## Description

Add properties output properties `RestoreProjectCount`, `RestoreSkippedCount`, and `RestoreProjectsAuditedCount` to RestoreTask (non-static graph version). Static graph version will be implemented later, and including packages.config projects is waiting for customer feedback.

The tests demonstrate how to to fail a restore if NuGetAudit was not enabled for at least 1 project.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.: https://github.com/NuGet/Home/issues/13802
