### PR TITLE
[Transitive's in Solution PM UI] Fix Install/Uninstall button for transitive packages

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
@@ -1621,6 +1621,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
             PackageInstallationInfo firstProject = _testInstance.Projects.First();
             firstProject.IsSelected = true;
             firstProject.InstalledVersion = version;
+            firstProject.PackageLevel = PackageLevel.TopLevel;
 
             // Explicitly trigger PropertyChanged event.
             _testInstance.SetInstalledOrUpdateButtonIsEnabled();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3016

## Description
The Install/Uninstall button wasn't aware of the package level, so there were some scenarios where the behavior wasn't as expected. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- ~[] Added tests~ UI changes
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
