### PR TITLE
Update ProjectInstallationInfo ToString() on Details Pane table and improve localization of table headers

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageInstallationInfo.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageInstallationInfo.cs
@@ -161,7 +161,9 @@ namespace NuGet.PackageManagement.UI
             var vulnerabilityString = string.Empty;
             if (InstalledVersionMaxVulnerability != -1)
             {
-                vulnerabilityString = string.Format(CultureInfo.CurrentCulture, Resources.Label_PackageVulnerableToolTip, (PackageVulnerabilitySeverity)InstalledVersionMaxVulnerability);
+                var converter = new IntToVulnerabilitySeverityConverter();
+                var severityString = converter.Convert(InstalledVersionMaxVulnerability, typeof(PackageVulnerabilitySeverity), null, CultureInfo.CurrentCulture) as string;
+                vulnerabilityString = string.Format(CultureInfo.CurrentCulture, Resources.Label_PackageVulnerableToolTip, severityString);
             }
 
             return $"{ProjectName} {InstalledVersion?.Version.ToString() ?? Resources.Text_NotInstalled} {vulnerabilityString} {PackageLevel}";

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageInstallationInfo.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageInstallationInfo.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ServiceHub.Framework;
 using NuGet.PackageManagement.VisualStudio;
+using NuGet.Protocol;
 using NuGet.Versioning;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
@@ -156,7 +158,13 @@ namespace NuGet.PackageManagement.UI
 
         public override string ToString()
         {
-            return $"{ProjectName} {InstalledVersion?.Version.ToString() ?? Resources.Text_NotInstalled}";
+            var vulnerabilityString = string.Empty;
+            if (InstalledVersionMaxVulnerability != -1)
+            {
+                vulnerabilityString = string.Format(CultureInfo.CurrentCulture, Resources.Label_PackageVulnerableToolTip, (PackageVulnerabilitySeverity)InstalledVersionMaxVulnerability);
+            }
+
+            return $"{ProjectName} {InstalledVersion?.Version.ToString() ?? Resources.Text_NotInstalled} {vulnerabilityString} {PackageLevel}";
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -619,6 +619,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package Level.
+        /// </summary>
+        public static string ColumnHeader_PackageLevel {
+            get {
+                return ResourceManager.GetString("ColumnHeader_PackageLevel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Project.
         /// </summary>
         public static string ColumnHeader_Project {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1073,4 +1073,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <value>These installed package versions contain vulnerabilities: {0}</value>
     <comment>{0} are package versions</comment>
   </data>
+  <data name="ColumnHeader_PackageLevel" xml:space="preserve">
+    <value>Package Level</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
@@ -386,10 +386,10 @@
           <GridViewColumn>
             <GridViewColumn.Header>
               <GridViewColumnHeader
-                AutomationProperties.Name="{x:Static local:Resources.ColumnHeader_InstalledVersion}"
+                AutomationProperties.Name="{x:Static local:Resources.ColumnHeader_PackageLevel}"
                 x:Name="_packageLevelColumnHeader"
                 Click="ColumnHeader_Clicked"
-                Content="Package Level"
+                Content="{x:Static local:Resources.ColumnHeader_PackageLevel}"
                 local:SortableColumnHeaderAttachedProperties.SortPropertyName="PackageLevel"
                 HorizontalContentAlignment="Left"
                 SizeChanged="SortableColumnHeader_SizeChanged"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13805

## Description
Narrator wasn't reading the whole table, we use the property ToString() in PackageInstallationInfo for that, now Narrator reads the vulnerability and the package level

![image](https://github.com/user-attachments/assets/dcebf48f-f636-4aab-9fb1-d2dc42efbece)
![image](https://github.com/user-attachments/assets/1c6bfec5-29f1-4d25-885d-60eb03181afc)

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
~- [ ] Added tests~ Narrator tested
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
