### PR TITLE
Only publish nuget.exe test for mono if mono tests are enabled

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -139,7 +139,7 @@ steps:
     solution: "test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\NuGet.CommandLine.Test.csproj"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/restore:false /target:CopyFinalNuGetExeToOutputPath /binarylogger:$(Build.StagingDirectory)\\binlog\\06.CopyFinalNuGetExeToOutputPath.binlog"
-  condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
+  condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'), ne(variables['RunMonoTestsOnMac'], 'false')))"
 
 - ${{ if eq(parameters.RunUnitTests, true) }}:
   - task: MSBuild@1

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -139,7 +139,7 @@ steps:
     solution: "test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\NuGet.CommandLine.Test.csproj"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/restore:false /target:CopyFinalNuGetExeToOutputPath /binarylogger:$(Build.StagingDirectory)\\binlog\\06.CopyFinalNuGetExeToOutputPath.binlog"
-  condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'), ne(variables['RunMonoTestsOnMac'], 'false')))"
+  condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'), ne(variables['RunMonoTestsOnMac'], 'false'))"
 
 - ${{ if eq(parameters.RunUnitTests, true) }}:
   - task: MSBuild@1

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -104,7 +104,6 @@ stages:
       isOfficialBuild: ${{ parameters.isOfficialBuild }}
       BuildRTM: "false"
       SemanticVersion: $[stageDependencies.Initialize.GetSemanticVersion.outputs['setsemanticversion.SemanticVersion']]
-      RunMonoTestsOnMac: ${{ variables['RunMonoTestsOnMac'] }}
     pool:
       name: VSEngSS-MicroBuild2022-1ES
     templateContext:

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -104,6 +104,7 @@ stages:
       isOfficialBuild: ${{ parameters.isOfficialBuild }}
       BuildRTM: "false"
       SemanticVersion: $[stageDependencies.Initialize.GetSemanticVersion.outputs['setsemanticversion.SemanticVersion']]
+      RunMonoTestsOnMac: ${{ variables['RunMonoTestsOnMac'] }}
     pool:
       name: VSEngSS-MicroBuild2022-1ES
     templateContext:
@@ -130,7 +131,7 @@ stages:
 
       - output: pipelineArtifact
         displayName: 'Publish NuGet.CommandLine.Test as artifact'
-        condition: "succeeded()"
+        condition: "and(succeeded(),ne(variables['RunMonoTestsOnMac'], 'false'))"
         targetPath: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472"
         artifactName: "NuGet.CommandLine.Test"
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: engineering

## Description

NuGet.CommandLine.Tests is only needed when mono tests on Mac are enabled. Hence don't publish it when it's not needed.

## PR Checklist

- [x] ~Meaningful title, helpful description and a linked NuGet/Home issue~ engineering change
- [x] ~Added tests~ engineering change
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ engineering change
