### PR TITLE
Update ProjectSystemCache to be case insensitive for _primaryCache

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/ProjectSystemCache.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/ProjectSystemCache.cs
@@ -22,7 +22,7 @@ namespace NuGet.PackageManagement.VisualStudio
         // 0 - Cache is clean
         // 1 - Cache is dirty
         private int _isCacheDirty = 0;
-        private readonly Dictionary<string, CacheEntry> _primaryCache = new Dictionary<string, CacheEntry>();
+        private readonly Dictionary<string, CacheEntry> _primaryCache = new Dictionary<string, CacheEntry>(StringComparer.OrdinalIgnoreCase);
         private readonly ReaderWriterLockSlim _readerWriterLock = new ReaderWriterLockSlim();
 
         // Secondary index. Mapping from all names to a project name structure

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
@@ -25,7 +25,6 @@ namespace NuGet.Tests.Apex.Daily
         {
         }
 
-        [Ignore("https://github.com/NuGet/Client.Engineering/issues/2829")]
         [TestMethod]
         [Timeout(DefaultTimeout)]
         public void InstallPackageToWebSiteProjectFromUI()
@@ -48,7 +47,6 @@ namespace NuGet.Tests.Apex.Daily
             CommonUtility.AssertPackageInPackagesConfig(VisualStudio, project, "log4net", "2.0.12", Logger);
         }
 
-        [Ignore("https://github.com/NuGet/Client.Engineering/issues/2829")]
         [TestMethod]
         [Timeout(DefaultTimeout)]
         public void UpdateWebSitePackageFromUI()


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2829

## Description
Projects information was being added/updated with different cases, causes our apex tests to fail. The primary key for the _primaryCache is projectNames.FullName which is the full path and filename of the project. Switching the dictionary to ignore case allows the project to be added to the single entry instead of creating a new one. 

When we load an empty solution, there are no projects, and [VsSolutionManager.EnsureNuGetAndVsProjectAdapterCacheAsync](https://github.com/NuGet/NuGet.Client/blob/0bf00d2496ec6de66fe67b1c8f571090ac2eef87/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs#L746) does not initialize the cache. 

When we create a new project we call [VsSolutionManager.OnEnvDTEProjectAdded](https://github.com/NuGet/NuGet.Client/blob/0bf00d2496ec6de66fe67b1c8f571090ac2eef87/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs#L693C22-L693C42) which attempts to initialize the cache again then add the project. 

EnsureNuGetAndVsProjectAdapterCacheAsync gets the project name from
https://github.com/NuGet/NuGet.Client/blob/0bf00d2496ec6de66fe67b1c8f571090ac2eef87/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs#L37-L43

Then later in OnEnVDTEProjectedAdded we get the full name from the EnvDTE.Project full name
https://github.com/NuGet/NuGet.Client/blob/0bf00d2496ec6de66fe67b1c8f571090ac2eef87/src/NuGet.Clients/NuGet.VisualStudio.Common/ProjectSystems/ProjectNames.cs#L92

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~
