### PR TITLE
Fixing a typo in the XAML binding for VulnerableVersions count

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -37,7 +37,7 @@
           </Setter.Value>
         </Setter>
         <Style.Triggers>
-          <DataTrigger Binding="{Binding VulnerableVersionsCount}" Value="1">
+          <DataTrigger Binding="{Binding VulnerableVersions.Count}" Value="1">
             <Setter Property="Text">
               <Setter.Value>
                 <MultiBinding Converter="{StaticResource StringFormatConverter}">


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13216

## Description
Fixing a typo in the XAML binding on vulnerable packages count. The period was accidentally removed and is being restored in this PR.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ XAML binding / UI change
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
