### PR TITLE
Disable code sign validation for non-shipping artifacts

### DIFF
--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -145,6 +145,8 @@ stages:
         condition: "succeeded()"
         targetPath: $(MicroBuildOutputFolderOverride)\MicroBuild\Output
         artifactName: MicroBuildOutputs
+        # need to make daily Apex test pipeline build its own bootstrapper, and remove this from official pipeline
+        codeSignValidationEnabled: false
 
       - output: artifactsDrop
         displayName: 'Publish the .runsettings files to artifact services'
@@ -155,6 +157,8 @@ stages:
         toLowerCase: false
         usePat: true
         dropMetadataContainerName: 'DropMetadata-RunSettings'
+        # need to make daily Apex test pipeline build its own tests, and remove this from official pipeline
+        codeSignValidationEnabled: false
 
       - output: artifactsDrop
         displayName: 'OptProfV2:  publish profiling inputs to artifact services'
@@ -176,6 +180,7 @@ stages:
         condition: "or(eq(variables['OverridePublishLocalizationArtifact'], 'true'), and(succeededOrFailed(), eq(variables['IsOfficialBuild'], 'true')))"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\localizationArtifacts\\"
         artifactName: "localizationArtifacts"
+        codeSignValidationEnabled: false
 
       - output: pipelineArtifact
         displayName: 'Publish symbols as pipeline artifacts'


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: n/a. Engineering/compliance requirement

## Description

Disable code sign validation for non-shipping artifacts.

The bootstrapper and runsettings are only needed to run VS tests. The loc data can be modified to publish signed assemblies, but it'll be more than a one line effort, so putting it off until later.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~ (engineering change)
- [x] ~Added tests~ engineering change
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ non-functional change
