### PR TITLE
Refactoring the method that fetches the project context in the Solution PM UI

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "8.0.100",
-    "rollForward": "latestFeature",
+    "rollForward": "latestMajor",
     "allowPrerelease": true
   },
   "msbuild-sdks": {

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "8.0.100",
-    "rollForward": "latestMajor",
+    "rollForward": "latestFeature",
     "allowPrerelease": true
   },
   "msbuild-sdks": {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -122,6 +122,7 @@ namespace NuGet.PackageManagement.UI
         {
             project.InstalledVersion = installedVersion.Identity.Version;
             installedVersionsSet.Add(installedVersion.Identity.Version);
+            project.PackageLevel = installedVersion is ITransitivePackageReferenceContextInfo ? PackageLevel.Transitive : PackageLevel.TopLevel;
 
             if (project.PackageLevel == PackageLevel.TopLevel)
             {
@@ -156,11 +157,10 @@ namespace NuGet.PackageManagement.UI
                     }
                     else
                     {
-                        project.PackageLevel = packageContext is ITransitivePackageReferenceContextInfo ? PackageLevel.Transitive : PackageLevel.TopLevel;
                         UpdateProjectInstallationInfo(project, packageContext, installedVersionsSet);
                     }
 
-                    if (project?.InstalledVersion is not null && _searchResultPackage.VulnerableVersions.TryGetValue(project.InstalledVersion, out int vulnerable))
+                    if (project.InstalledVersion is not null && _searchResultPackage.VulnerableVersions.TryGetValue(project.InstalledVersion, out int vulnerable))
                     {
                         project.InstalledVersionMaxVulnerability = vulnerable;
                         vulnerabilitiesSet.Add(project.InstalledVersion);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -143,28 +143,21 @@ namespace NuGet.PackageManagement.UI
             {
                 try
                 {
-                    (IPackageReferenceContextInfo TopLevelPackage, IPackageReferenceContextInfo TransitivePackage) installedPackage = await GetInstalledAndTransitivePackagesAsync(project.NuGetProject, Id, cancellationToken);
-                    var topLevelPackageVersion = installedPackage.TopLevelPackage;
-                    var transitivePackageVersion = installedPackage.TransitivePackage;
+                    IPackageReferenceContextInfo packageContext = await GetPackageContextAsync(project.NuGetProject, Id, cancellationToken);
 
                     project.InstalledVersionMaxVulnerability = -1;
                     project.RequestedVersion = null;
                     project.AutoReferenced = false;
 
-                    if (transitivePackageVersion != null)
-                    {
-                        project.PackageLevel = PackageLevel.Transitive;
-                        UpdateProjectInstallationInfo(project, transitivePackageVersion, installedVersionsSet);
-                    }
-                    else if (topLevelPackageVersion != null)
-                    {
-                        project.PackageLevel = PackageLevel.TopLevel;
-                        UpdateProjectInstallationInfo(project, topLevelPackageVersion, installedVersionsSet);
-                    }
-                    else
+                    if (packageContext == null)
                     {
                         project.InstalledVersion = null;
                         project.PackageLevel = null;
+                    }
+                    else
+                    {
+                        project.PackageLevel = packageContext is ITransitivePackageReferenceContextInfo ? PackageLevel.Transitive : PackageLevel.TopLevel;
+                        UpdateProjectInstallationInfo(project, packageContext, installedVersionsSet);
                     }
 
                     if (project?.InstalledVersion is not null && _searchResultPackage.VulnerableVersions.TryGetValue(project.InstalledVersion, out int vulnerable))
@@ -207,24 +200,20 @@ namespace NuGet.PackageManagement.UI
             AutoSelectProjects();
         }
 
-        /// <summary>
-        /// This method is called from several methods that are called from properties and LINQ queries
-        /// It is likely not called more than once in an action.
-        /// </summary>
-        private async Task<(IPackageReferenceContextInfo TopLevelPackage, IPackageReferenceContextInfo TransitivePackage)> GetInstalledAndTransitivePackagesAsync(
+        private async Task<IPackageReferenceContextInfo> GetPackageContextAsync(
             IProjectContextInfo project,
             string packageId,
             CancellationToken cancellationToken)
         {
             IInstalledAndTransitivePackages installedAndTransitivePackages = await project.GetInstalledAndTransitivePackagesAsync(ServiceBroker, cancellationToken);
-            IPackageReferenceContextInfo installedPackages = installedAndTransitivePackages.InstalledPackages
+            IPackageReferenceContextInfo installedPackage = installedAndTransitivePackages.InstalledPackages
                 .Where(p => StringComparer.OrdinalIgnoreCase.Equals(p.Identity.Id, packageId))
                 .FirstOrDefault();
 
-            ITransitivePackageReferenceContextInfo transitivePackages = installedAndTransitivePackages.TransitivePackages
+            ITransitivePackageReferenceContextInfo transitivePackage = installedAndTransitivePackages.TransitivePackages
                 .Where(p => StringComparer.OrdinalIgnoreCase.Equals(p.Identity.Id, packageId))
                 .FirstOrDefault();
-            return (installedPackages, transitivePackages);
+            return installedPackage ?? transitivePackage;
         }
 
         protected override async Task CreateVersionsAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Refactoring the method that fetches the project context in the Solution PM UI to return only a single package and simplify the caller logic

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13216

## Description
Addressing feedback from the original pull request for the Transitive Packages in Solution PM UI feature: https://github.com/NuGet/NuGet.Client/pull/6044#discussion_r1774288377. This is a better design to only return one package context object and simplifies the caller logic in determining if the package is top-level or transitive. Removed an outdated comment on the method, and renamed the method to more accurately reflect its purpose.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ - Refactoring existing method. No new functionality to test.
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
