### PR TITLE
Signing:  dispose `RSA` instance

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateUtility.cs
@@ -155,11 +155,12 @@ namespace NuGet.Packaging.Signing
         public static bool IsCertificatePublicKeyValid(X509Certificate2 certificate)
         {
             // Check if the public key is RSA with a valid keysize
-            System.Security.Cryptography.RSA RSAPublicKey = RSACertificateExtensions.GetRSAPublicKey(certificate);
-
-            if (RSAPublicKey != null)
+            using (System.Security.Cryptography.RSA publicKey = RSACertificateExtensions.GetRSAPublicKey(certificate))
             {
-                return RSAPublicKey.KeySize >= SigningSpecifications.V1.RSAPublicKeyMinLength;
+                if (publicKey != null)
+                {
+                    return publicKey.KeySize >= SigningSpecifications.V1.RSAPublicKeyMinLength;
+                }
             }
 
             return false;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:   https://github.com/NuGet/Home/issues/13823

## Description

This change disposes of a newly created `System.Security.Cryptography.RSA` object.

## PR Checklist

- [X] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~~Added tests~~ N/A
- [ ] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~ N/A
