### PR TITLE
Fix floating version functionality for FloatingBehavior.AbsoluteLatest in new dependency graph resolver

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -491,19 +491,19 @@ namespace NuGet.DependencyResolver
 
         private static NuGetVersion GetReleaseLabelFreeVersion(VersionRange versionRange)
         {
-            if (versionRange.Float.FloatBehavior == NuGetVersionFloatBehavior.Major)
+            if (versionRange.Float.FloatBehavior == NuGetVersionFloatBehavior.Major || versionRange.Float.FloatBehavior == NuGetVersionFloatBehavior.PrereleaseMajor)
             {
                 return new NuGetVersion(int.MaxValue, int.MaxValue, int.MaxValue);
             }
-            else if (versionRange.Float.FloatBehavior == NuGetVersionFloatBehavior.Minor)
+            else if (versionRange.Float.FloatBehavior == NuGetVersionFloatBehavior.Minor || versionRange.Float.FloatBehavior == NuGetVersionFloatBehavior.PrereleaseMinor)
             {
                 return new NuGetVersion(versionRange.MinVersion.Major, int.MaxValue, int.MaxValue, int.MaxValue);
             }
-            else if (versionRange.Float.FloatBehavior == NuGetVersionFloatBehavior.Patch)
+            else if (versionRange.Float.FloatBehavior == NuGetVersionFloatBehavior.Patch || versionRange.Float.FloatBehavior == NuGetVersionFloatBehavior.PrereleasePatch)
             {
                 return new NuGetVersion(versionRange.MinVersion.Major, versionRange.MinVersion.Minor, int.MaxValue, int.MaxValue);
             }
-            else if (versionRange.Float.FloatBehavior == NuGetVersionFloatBehavior.Revision)
+            else if (versionRange.Float.FloatBehavior == NuGetVersionFloatBehavior.Revision || versionRange.Float.FloatBehavior == NuGetVersionFloatBehavior.PrereleaseRevision)
             {
                 return new NuGetVersion(
                     versionRange.MinVersion.Major,

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -511,6 +511,10 @@ namespace NuGet.DependencyResolver
                     versionRange.MinVersion.Patch,
                     int.MaxValue);
             }
+            else if (versionRange.Float.FloatBehavior == NuGetVersionFloatBehavior.AbsoluteLatest)
+            {
+                return new NuGetVersion(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue);
+            }
             else
             {
                 return new NuGetVersion(

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -1342,12 +1342,19 @@ namespace NuGet.Commands.FuncTest
 
         // P1 -> P2 -> B *
         // P1 -> A -> B 1.0.0
-        // TODO: *-*
-        [Fact]
-        public async Task RestoreCommand_WithTransitiveFloatingVersion_VerifiesEquivalency()
+        [Theory]
+        [InlineData("*")]
+        [InlineData("*-*")]
+        [InlineData("2.*")]
+        [InlineData("2.*-*")]
+        [InlineData("2.0.*")]
+        [InlineData("2.0.*-*")]
+        public async Task RestoreCommand_WithTransitiveFloatingVersion_VerifiesEquivalency(string floatingVersion)
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
+
+            var versionRange = VersionRange.Parse(floatingVersion);
 
             await SimpleTestPackageUtility.CreatePackagesAsync(
                 pathContext.PackageSource,
@@ -1379,7 +1386,7 @@ namespace NuGet.Commands.FuncTest
                     ""net472"": {
                         ""dependencies"": {
                             ""b"": {
-                                ""version"": ""[*,)"",
+                                ""version"": """ + versionRange.ToString() + @""",
                                 ""target"": ""Package"",
                             },
                         }

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
@@ -815,7 +815,7 @@ namespace NuGet.DependencyResolver.Tests
         [InlineData("3.1.0-beta-234", "3.2.0-*")]
         [InlineData("3.0.0-*", "3.1.0-beta-234")]
         [InlineData("6.8.0", "*-*")]
-        [InlineData("3.0.0-preview.1", "3.0.0-preview.*")] // TODO: This is probably broken, but maybe don't fix it now?
+        //[InlineData("3.0.0-preview.1", "3.0.0-preview.*")] // TODO: https://github.com/NuGet/Home/issues/13833
         [InlineData("3.0.1", "3.0.*")]
         [InlineData("3.0.1", "*-preview.*")]
         [InlineData("3.0.1", "3.*-preview.*")]

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
@@ -778,6 +778,13 @@ namespace NuGet.DependencyResolver.Tests
         [InlineData("2.8.1-*", "1.8.3-*")]
         [InlineData("3.2.0-*", "3.1.0-beta-234")]
         [InlineData("3.*", "3.1.*")]
+        [InlineData("*", "*-*")]
+        [InlineData("3.0.0-preview.*", "3.0.0-preview.1")]
+        [InlineData("3.0.*", "3.0.1")]
+        [InlineData("*-preview.*", "3.0.1")]
+        [InlineData("3.*-preview.*", "3.0.1")]
+        [InlineData("3.0.*-preview.*", "3.0.1")]
+        [InlineData("3.0.1.*-preview.*", "3.0.1")]
         public void IsGreaterThanEqualTo_ReturnsTrue_IfRightVersionIsSmallerThanLeft(string leftVersionString, string rightVersionString)
         {
             // Arrange
@@ -807,6 +814,14 @@ namespace NuGet.DependencyResolver.Tests
         [InlineData("3.4.6-beta*", "3.4.6-betb*")]
         [InlineData("3.1.0-beta-234", "3.2.0-*")]
         [InlineData("3.0.0-*", "3.1.0-beta-234")]
+        [InlineData("6.8.0", "*-*")]
+        [InlineData("3.0.0-preview.1", "3.0.0-preview.*")] // TODO: This is probably broken, but maybe don't fix it now?
+        [InlineData("3.0.1", "3.0.*")]
+        [InlineData("3.0.1", "*-preview.*")]
+        [InlineData("3.0.1", "3.*-preview.*")]
+        [InlineData("3.0.1", "3.0.*-preview.*")]
+        [InlineData("3.0.1", "3.0.1.*-preview.*")]
+
         public void IsGreaterThanEqualTo_ReturnsFalse_IfRightVersionIsLargerThanLeft(string leftVersionString, string rightVersionString)
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13830

## Description
`RemoteDependencyWalker.IsEqualToOrGreaterThan()` is calculating whether or not a VersionRange is equal to or greater than another VersionRange incorrectly in the case of `*` or `*-*`.  For ranges like `1.*` or `1.0.*`, it treats the star as "highest possible" by converting the version range to use `Int.MaxValue` for the parts of the version that are floating.  However, for something like `*` or `*-*`, it falls back to just using the specified values and it uses `0.0.0.0` instead which is always treated as lower.  This makes the new dependency resolver pick the wrong versions or improperly detect downgrades.

The change is to treat `*` or `*-*` as `Int.MaxValue.Int.MaxValue.Int.MaxValue.Int.MaxValue`, essentially the highest possible version range.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
