### PR TITLE
Post E2E and Apex test results to GitHub Checks

### DIFF
--- a/eng/pipelines/dailytests.yml
+++ b/eng/pipelines/dailytests.yml
@@ -4,7 +4,7 @@ pr: none
 trigger:
   branches:
     include:
-    - dev-*
+    - dev
 
 parameters:
 # build parameters
@@ -76,8 +76,6 @@ stages:
       value: $[stageDependencies.Build.Build.outputs['dartlab_variables.QBuildSessionId']]
     - name: RunSettingsDrop
       value: $[stageDependencies.Build.Build.outputs['dartlab_variables.RunSettingsDrop']]
-    - name: GitHubStatusName
-      value: Apex Tests On Windows
     baseBuildDrop: $(VsBaseBuildDrop)
     bootstrapperUrl: $(VsBootstrapperUrl)
     dartLabEnvironment: ${{parameters.DartLabEnvironment}}

--- a/eng/pipelines/vs-test/apex.yml
+++ b/eng/pipelines/vs-test/apex.yml
@@ -150,6 +150,12 @@ stages:
 ## postDeployAndRunTestsStepList
 ##############################
       postDeployAndRunTestsStepList:
+        - task: PowerShell@1
+          displayName: "Test"
+          inputs:
+            scriptType: "inlineScript"
+            inlineScript: |
+              "This is a test"
         - ${{ if ne(parameters.GitHubStatusName, '') }}:
           - task: PowerShell@1
             displayName: "Set result status on GitHub Checks"

--- a/eng/pipelines/vs-test/apex.yml
+++ b/eng/pipelines/vs-test/apex.yml
@@ -150,7 +150,7 @@ stages:
 ## postDeployAndRunTestsStepList
 ##############################
       postDeployAndRunTestsStepList:
-        ${{ if ne(parameters.GitHubStatusName, '') }}
+        ${{ if ne(parameters.GitHubStatusName, '') }}:
           - task: PowerShell@1
             displayName: "Set result status on GitHub Checks"
             inputs:

--- a/eng/pipelines/vs-test/apex.yml
+++ b/eng/pipelines/vs-test/apex.yml
@@ -163,6 +163,6 @@ stages:
             inputs:
               scriptType: "inlineScript"
               inlineScript: |
-            . $(Build.StagingDirectory)\\scripts\\utils\\PostGitCommitStatus.ps1
+                . $(Build.StagingDirectory)\\scripts\\utils\\PostGitCommitStatus.ps1
                 SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(System.AccessToken) -CommitSha $(Build.SourceVersion) -TestName "${{ parameters.GitHubStatusName }}"
             condition: "not(eq(variables['ManualGitHubChecks'], 'false'))"

--- a/eng/pipelines/vs-test/apex.yml
+++ b/eng/pipelines/vs-test/apex.yml
@@ -26,6 +26,8 @@ parameters:
     default: false
   - name: QBuildSessionId
     type: string
+  - name: GitHubStatusName
+    type: string
 
 stages:
   - template: stages\visual-studio\build-to-build-upgrade\single-runsettings.yml@DartLabTemplates
@@ -143,3 +145,17 @@ stages:
           displayName: "SetupFunctionalTests.ps1"
           inputs:
             scriptName: "$(Build.StagingDirectory)/scripts/e2etests/SetupFunctionalTests.ps1"
+
+##############################
+## postDeployAndRunTestsStepList
+##############################
+      postDeployAndRunTestsStepList:
+        ${{ if ne(parameters.GitHubStatusName, '') }}
+          - task: PowerShell@1
+            displayName: "Set result status on GitHub Checks"
+            inputs:
+              scriptType: "inlineScript"
+              inlineScript: |
+                . $(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\PostGitCommitStatus.ps1
+                SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(System.AccessToken) -CommitSha $(Build.SourceVersion) -TestName "${{ parameters.GitHubStatusName }}"
+            condition: "not(eq(variables['ManualGitHubChecks'], 'false'))"

--- a/eng/pipelines/vs-test/apex.yml
+++ b/eng/pipelines/vs-test/apex.yml
@@ -150,7 +150,7 @@ stages:
 ## postDeployAndRunTestsStepList
 ##############################
       postDeployAndRunTestsStepList:
-        ${{ if ne(parameters.GitHubStatusName, '') }}:
+        - ${{ if ne(parameters.GitHubStatusName, '') }}:
           - task: PowerShell@1
             displayName: "Set result status on GitHub Checks"
             inputs:

--- a/eng/pipelines/vs-test/apex.yml
+++ b/eng/pipelines/vs-test/apex.yml
@@ -163,6 +163,6 @@ stages:
             inputs:
               scriptType: "inlineScript"
               inlineScript: |
-                . $(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\PostGitCommitStatus.ps1
+            . $(Build.StagingDirectory)\\scripts\\utils\\PostGitCommitStatus.ps1
                 SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(System.AccessToken) -CommitSha $(Build.SourceVersion) -TestName "${{ parameters.GitHubStatusName }}"
             condition: "not(eq(variables['ManualGitHubChecks'], 'false'))"

--- a/eng/pipelines/vs-test/apex.yml
+++ b/eng/pipelines/vs-test/apex.yml
@@ -28,6 +28,7 @@ parameters:
     type: string
   - name: GitHubStatusName
     type: string
+    default: ''
 
 stages:
   - template: stages\visual-studio\build-to-build-upgrade\single-runsettings.yml@DartLabTemplates

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -9,7 +9,7 @@ steps:
 - ${{ each check in parameters.GitHubChecksToInitialize }}:
   - task: PowerShell@1
     displayName: "Set GitHub Check ${{ check.Name }} to pending"
-    condition: ${{ checks.Enabled }}
+    condition: ${{ check.Enabled }}
     inputs:
       scriptType: "inlineScript"
       inlineScript: |

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -1,8 +1,20 @@
 parameters:
 - name: NuGetLocalizationType
   type: string
+- name: GitHubChecksToInitialize
+  type: object
 
 steps:
+- ${{ each check in parameters.GitHubChecksToInitialize }}
+  - task: PowerShell@1
+    displayName: "Set GitHub Check ${{ check.Name }} to pending"
+    condition: ${{ checks.Enabled }}
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        . $(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\PostGitCommitStatus.ps1
+        Update-GitCommitStatus -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "${{ check.Name }}" -Status "pending" -TargetUrl $env:BUILDURL -Description "in progress"
+
 - task: MicroBuildLocalizationPlugin@4
   displayName: "Install Localization Plugin"
 

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -3,6 +3,7 @@ parameters:
   type: string
 - name: GitHubChecksToInitialize
   type: object
+  default: []
 
 steps:
 - ${{ each check in parameters.GitHubChecksToInitialize }}

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -6,7 +6,7 @@ parameters:
   default: []
 
 steps:
-- ${{ each check in parameters.GitHubChecksToInitialize }}
+- ${{ each check in parameters.GitHubChecksToInitialize }}:
   - task: PowerShell@1
     displayName: "Set GitHub Check ${{ check.Name }} to pending"
     condition: ${{ checks.Enabled }}

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -13,7 +13,7 @@ steps:
     inputs:
       scriptType: "inlineScript"
       inlineScript: |
-        . $(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\PostGitCommitStatus.ps1
+        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
         Update-GitCommitStatus -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "${{ check.Name }}" -Status "pending" -TargetUrl $env:BUILDURL -Description "in progress"
 
 - task: MicroBuildLocalizationPlugin@4

--- a/eng/pipelines/vs-test/end_to_end.yml
+++ b/eng/pipelines/vs-test/end_to_end.yml
@@ -200,22 +200,12 @@ stages:
         testRunTitle: "NuGet.Client EndToEnd Tests On Windows"
       condition: "succeededOrFailed()"
 
-##############################
-## postDeployAndRunTestsStepList
-##############################
-      postDeployAndRunTestsStepList:
-        - task: PowerShell@1
-          displayName: "Test"
-          inputs:
-            scriptType: "inlineScript"
-            inlineScript: |
-              "This is a test"
-        - ${{ if ne(parameters.GitHubStatusName, '') }}:
-          - task: PowerShell@1
-            displayName: "Set result status on GitHub Checks"
-            inputs:
-              scriptType: "inlineScript"
-              inlineScript: |
-                . $(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\PostGitCommitStatus.ps1
-                SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(System.AccessToken) -CommitSha $(Build.SourceVersion) -TestName "${{ parameters.GitHubStatusName }}"
-            condition: "not(eq(variables['ManualGitHubChecks'], 'false'))"
+    - ${{ if ne(parameters.GitHubStatusName, '') }}:
+      - task: PowerShell@1
+        displayName: "Set result status on GitHub Checks"
+        inputs:
+          scriptType: "inlineScript"
+          inlineScript: |
+            . $(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\PostGitCommitStatus.ps1
+            SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(System.AccessToken) -CommitSha $(Build.SourceVersion) -TestName "${{ parameters.GitHubStatusName }}"
+        condition: "not(eq(variables['ManualGitHubChecks'], 'false'))"

--- a/eng/pipelines/vs-test/end_to_end.yml
+++ b/eng/pipelines/vs-test/end_to_end.yml
@@ -204,6 +204,12 @@ stages:
 ## postDeployAndRunTestsStepList
 ##############################
       postDeployAndRunTestsStepList:
+        - task: PowerShell@1
+          displayName: "Test"
+          inputs:
+            scriptType: "inlineScript"
+            inlineScript: |
+              "This is a test"
         - ${{ if ne(parameters.GitHubStatusName, '') }}:
           - task: PowerShell@1
             displayName: "Set result status on GitHub Checks"

--- a/eng/pipelines/vs-test/end_to_end.yml
+++ b/eng/pipelines/vs-test/end_to_end.yml
@@ -207,6 +207,6 @@ stages:
         inputs:
           scriptType: "inlineScript"
           inlineScript: |
-            . $(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\PostGitCommitStatus.ps1
+            . $(Build.StagingDirectory)\\scripts\\utils\\PostGitCommitStatus.ps1
             SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(System.AccessToken) -CommitSha $(Build.SourceVersion) -TestName "${{ parameters.GitHubStatusName }}"
         condition: "not(eq(variables['ManualGitHubChecks'], 'false'))"

--- a/eng/pipelines/vs-test/end_to_end.yml
+++ b/eng/pipelines/vs-test/end_to_end.yml
@@ -204,7 +204,7 @@ stages:
 ## postDeployAndRunTestsStepList
 ##############################
       postDeployAndRunTestsStepList:
-        ${{ if ne(parameters.GitHubStatusName, '') }}
+        ${{ if ne(parameters.GitHubStatusName, '') }}:
           - task: PowerShell@1
             displayName: "Set result status on GitHub Checks"
             inputs:

--- a/eng/pipelines/vs-test/end_to_end.yml
+++ b/eng/pipelines/vs-test/end_to_end.yml
@@ -31,6 +31,7 @@ parameters:
   type: string
 - name: GitHubStatusName
   type: string
+  default: ''
 
 stages:
 - template: stages\visual-studio\build-to-build-upgrade\agent.yml@DartLabTemplates

--- a/eng/pipelines/vs-test/end_to_end.yml
+++ b/eng/pipelines/vs-test/end_to_end.yml
@@ -29,6 +29,8 @@ parameters:
   - stop
 - name: QBuildSessionId
   type: string
+- name: GitHubStatusName
+  type: string
 
 stages:
 - template: stages\visual-studio\build-to-build-upgrade\agent.yml@DartLabTemplates
@@ -197,3 +199,17 @@ stages:
         mergeTestResults: "true"
         testRunTitle: "NuGet.Client EndToEnd Tests On Windows"
       condition: "succeededOrFailed()"
+
+##############################
+## postDeployAndRunTestsStepList
+##############################
+      postDeployAndRunTestsStepList:
+        ${{ if ne(parameters.GitHubStatusName, '') }}
+          - task: PowerShell@1
+            displayName: "Set result status on GitHub Checks"
+            inputs:
+              scriptType: "inlineScript"
+              inlineScript: |
+                . $(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\PostGitCommitStatus.ps1
+                SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(System.AccessToken) -CommitSha $(Build.SourceVersion) -TestName "${{ parameters.GitHubStatusName }}"
+            condition: "not(eq(variables['ManualGitHubChecks'], 'false'))"

--- a/eng/pipelines/vs-test/end_to_end.yml
+++ b/eng/pipelines/vs-test/end_to_end.yml
@@ -204,7 +204,7 @@ stages:
 ## postDeployAndRunTestsStepList
 ##############################
       postDeployAndRunTestsStepList:
-        ${{ if ne(parameters.GitHubStatusName, '') }}:
+        - ${{ if ne(parameters.GitHubStatusName, '') }}:
           - task: PowerShell@1
             displayName: "Set result status on GitHub Checks"
             inputs:

--- a/eng/pipelines/vs-tests.yml
+++ b/eng/pipelines/vs-tests.yml
@@ -85,11 +85,11 @@ stages:
       parameters:
         NuGetLocalizationType: ${{ parameters.NuGetLocalizationType }}
         GitHubChecksToInitialize:
-        - name:     GitHubStatusName: "VS tests - E2E part 1"
+        - name: "VS tests - E2E part 1"
           enabled: "ne(variables['RunEndToEndTests'], 'false')"
-        - name:     GitHubStatusName: "VS tests - E2E part 2"
+        - name: "VS tests - E2E part 2"
           enabled: "ne(variables['RunEndToEndTests'], 'false')"
-        - name:     GitHubStatusName: "VS tests - Apex"
+        - name: "VS tests - Apex"
           enabled: "ne(variables['RunApexTests'], 'false')"
 
 # Dartlab's template defines this in its own stage

--- a/eng/pipelines/vs-tests.yml
+++ b/eng/pipelines/vs-tests.yml
@@ -84,6 +84,13 @@ stages:
     - template: vs-test/build.yml
       parameters:
         NuGetLocalizationType: ${{ parameters.NuGetLocalizationType }}
+        GitHubChecksToInitialize:
+        - name:     GitHubStatusName: "VS tests - E2E part 1"
+          enabled: "ne(variables['RunEndToEndTests'], 'false')"
+        - name:     GitHubStatusName: "VS tests - E2E part 2"
+          enabled: "ne(variables['RunEndToEndTests'], 'false')"
+        - name:     GitHubStatusName: "VS tests - Apex"
+          enabled: "ne(variables['RunApexTests'], 'false')"
 
 # Dartlab's template defines this in its own stage
 - template: vs-test/end_to_end.yml

--- a/eng/pipelines/vs-tests.yml
+++ b/eng/pipelines/vs-tests.yml
@@ -112,6 +112,7 @@ stages:
     runSettingsURI: https://vsdrop.corp.microsoft.com/file/v1/$(RunSettingsDrop);NuGet.Tests.Apex.runsettings
     testExecutionJobTimeoutInMinutes: 100
     testMachineCleanUpStrategy: ${{parameters.E2EPart1AgentCleanup}}
+    GitHubStatusName: "VS tests - E2E part 1"
 
 # Dartlab's template defines this in its own stage
 - template: vs-test/end_to_end.yml
@@ -140,6 +141,7 @@ stages:
     runSettingsURI: https://vsdrop.corp.microsoft.com/file/v1/$(RunSettingsDrop);NuGet.Tests.Apex.runsettings
     testExecutionJobTimeoutInMinutes: 100
     testMachineCleanUpStrategy: ${{parameters.E2EPart2AgentCleanup}}
+    GitHubStatusName: "VS tests - E2E part 2"
 
 # Dartlab's template defines this in its own stage
 - template: vs-test/apex.yml
@@ -166,3 +168,4 @@ stages:
     runSettingsURI: https://vsdrop.corp.microsoft.com/file/v1/$(RunSettingsDrop);NuGet.Tests.Apex.runsettings
     testExecutionJobTimeoutInMinutes: 150
     testMachineCleanUpStrategy: ${{parameters.ApexAgentCleanup}}
+    GitHubStatusName: "VS tests - Apex"

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -14,7 +14,6 @@ Function Update-GitCommitStatus {
         [Parameter(Mandatory = $True)]
         [string]$PersonalAccessToken,
         [Parameter(Mandatory = $True)]
-        [ValidateSet( "Build_and_UnitTest_NonRTM", "Build_and_UnitTest_RTM", "Unit Tests On Mac", "Functional Tests On Mac", "Mono Tests On Mac", "Unit Tests On Linux", "Functional Tests On Linux", "Windows FunctionalTests IsDesktop", "Windows FunctionalTests IsCore", "Windows CrossFrameworkTests", "End_To_End_Tests_On_Windows Part1", "End_To_End_Tests_On_Windows Part2", "Apex Tests On Windows", "Static Analysis", "Source Build")]
         [string]$TestName,
         [Parameter(Mandatory = $True)]
         [ValidateSet( "pending", "success", "error", "failure")]
@@ -74,7 +73,7 @@ Function InitializeAllTestsToPending {
 
     Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Build_and_UnitTest_NonRTM" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
     Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Build_and_UnitTest_RTM" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
-    
+
     if($env:RunStaticAnalysis -eq "true")
     {
         Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Static Analysis" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"

--- a/test/TestUtilities/CreateEndToEndTestPackage/CreateEndToEndTestPackage.proj
+++ b/test/TestUtilities/CreateEndToEndTestPackage/CreateEndToEndTestPackage.proj
@@ -18,7 +18,6 @@
   <Target Name="CreateEndToEndTestPackage"
           AfterTargets="PrepareForRun">
     <PropertyGroup>
-      <ScriptsDirectory>$([MSBuild]::NormalizeDirectory($(WorkingDirectory), 'scripts'))</ScriptsDirectory>
       <EndToEndPackageFullPath>$([MSBuild]::NormalizePath($(EndToEndPackageOutputPath), 'EndToEnd.zip'))</EndToEndPackageFullPath>
     </PropertyGroup>
 
@@ -27,16 +26,16 @@
 
     <ItemGroup>
       <Artifact Remove="@(Artifact)" />
-      
+
       <Artifact Include="$([MSBuild]::NormalizeDirectory($(EnlistmentRoot), 'test', 'EndToEnd'))"
                 FileMatch="*"
                 DirExclude="Packages"
                 DestinationFolder="$(WorkingDirectory)" />
-      
+
       <Artifact Include="$([MSBuild]::NormalizeDirectory($(PkgNuGet_Client_EndToEnd_TestData), 'content', 'Packages'))"
                 FileMatch="*"
                 DestinationFolder="$([MSBuild]::NormalizeDirectory($(WorkingDirectory), 'Packages'))" />
-      
+
       <Artifact Include="$([MSBuild]::NormalizeDirectory(%(APITestOutput.RootDir), %(APITestOutput.Directory)))"
                 FileMatch="API.Test.*"
                 DestinationFolder="$(WorkingDirectory)" />
@@ -44,14 +43,6 @@
       <Artifact Include="$([MSBuild]::NormalizeDirectory(%(GenerateTestPackagesOutput.RootDir), %(GenerateTestPackagesOutput.Directory)))"
                 FileMatch="*.exe;*.dll;*.pdb;*.config"
                 DestinationFolder="$(WorkingDirectory)" />
-
-      <Artifact Include="$([MSBuild]::NormalizeDirectory($(EnlistmentRoot), 'scripts', 'e2etests'))"
-                FileMatch="*.ps1"
-                DestinationFolder="$(ScriptsDirectory)" />
-      
-      <Artifact Include="$([MSBuild]::NormalizeDirectory($(EnlistmentRoot), 'scripts', 'utils'))"
-                FileMatch="PostGitCommitStatus.ps1"
-                DestinationFolder="$(ScriptsDirectory)" />
     </ItemGroup>
 
     <Message Text="Copying files '%(Artifact.FileMatch)' from '%(Artifact.Identity)' to '%(Artifact.DestinationFolder)'" Importance="High" />
@@ -59,12 +50,12 @@
     <Robocopy Sources="@(Artifact)"
               RetryCount="$(CopyRetryCount)"
               RetryWait="$(CopyRetryDelayMilliseconds)" />
-    
+
     <Message Text="Creating test package '$(EndToEndPackageFullPath)'" Importance="High" />
-    
+
     <ZipDirectory SourceDirectory="$(WorkingDirectory)"
                   DestinationFile="$(EndToEndPackageFullPath)"
                   Overwrite="true" />
   </Target>
-  
+
 </Project>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2949

## Description

* Fix daily pipeline's trigger, and also remove the github checks name, since it doesn't need to report to github checks
* Make apex and e2e templates take an optional github checks name, and when it's non-empty, report the test status
* Make the build template take a list of checks, and for each one, set the github check to pending
* Since NuGet.Client no longer has a single pipeline, there isn't a single list of check names that we'll want to report. It's easier to remove the validation set from the powershell script, than to keep maintaining it.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
