### PR TITLE
Throw an exception with a message when unable to read corrupted .nupkg.metadata

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
@@ -53,11 +53,11 @@ namespace NuGet.Packaging
             }
             catch (Exception ex)
             {
-                log.LogWarning(string.Format(CultureInfo.CurrentCulture,
+                var message = string.Format(CultureInfo.CurrentCulture,
                     Strings.Error_LoadingHashFile,
-                    path, ex.Message));
+                    path, ex.Message);
 
-                throw;
+                throw new Exception(message);
             }
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using Newtonsoft.Json;
@@ -39,25 +40,35 @@ namespace NuGet.Packaging
 
         public static NupkgMetadataFile Read(TextReader reader, ILogger log, string path)
         {
-            try
-            {
-                using (var jsonReader = new JsonTextReader(reader))
-                {
-                    var nupkgMetadata = JsonSerializer.Deserialize<NupkgMetadataFile>(jsonReader);
-                    if (nupkgMetadata == null)
-                    {
-                        throw new InvalidDataException();
-                    }
-                    return nupkgMetadata;
-                }
-            }
-            catch (Exception ex)
-            {
-                var message = string.Format(CultureInfo.CurrentCulture,
-                    Strings.Error_LoadingHashFile,
-                    path, ex.Message);
+            List<string> errors = new List<string>();
 
-                throw new Exception(message);
+            var serializerSettings = new JsonSerializerSettings
+            {
+                Error = delegate (object sender, Newtonsoft.Json.Serialization.ErrorEventArgs args)
+                {
+                    // Log the error
+                    log.LogWarning(string.Format(CultureInfo.CurrentCulture,
+                        Strings.Error_LoadingHashFile,
+                        path, args.ErrorContext.Error.Message));
+
+                    // Add the error message to the list
+                    errors.Add(args.ErrorContext.Error.Message);
+                    args.ErrorContext.Handled = true;
+                }
+            };
+
+            using (var jsonReader = new JsonTextReader(reader))
+            {
+                var serializer = JsonSerializer.Create(serializerSettings);
+                var nupkgMetadata = serializer.Deserialize<NupkgMetadataFile>(jsonReader);
+
+                if (nupkgMetadata == null || errors.Count > 0)
+                {
+                    string errorMessage = $"Error: {string.Join("; ", errors)}";
+                    throw new InvalidDataException(errorMessage);
+                }
+
+                return nupkgMetadata;
             }
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
@@ -62,10 +62,17 @@ namespace NuGet.Packaging
                 var serializer = JsonSerializer.Create(serializerSettings);
                 var nupkgMetadata = serializer.Deserialize<NupkgMetadataFile>(jsonReader);
 
-                if (nupkgMetadata == null || errors.Count > 0)
+                if (errors.Count > 0)
                 {
                     string errorMessage = $"Error: {string.Join("; ", errors)}";
                     throw new InvalidDataException(errorMessage);
+                }
+                else if (errors.Count == 0 && nupkgMetadata == null)
+                {
+                    var error = string.Format(CultureInfo.CurrentCulture,
+                        Strings.Error_UnableToLoadNupkgMetadata,
+                        path);
+                    throw new InvalidDataException($"Error: {error}");
                 }
 
                 return nupkgMetadata;

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -367,6 +367,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to load nupkg metadata `{0}`..
+        /// </summary>
+        internal static string Error_UnableToLoadNupkgMetadata {
+            get {
+                return ResourceManager.GetString("Error_UnableToLoadNupkgMetadata", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot target author signatures that are countersignatures..
         /// </summary>
         internal static string ErrorAuthorTargetCannotBeACountersignature {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -887,4 +887,8 @@ Valid from:</comment>
 {2}</value>
     <comment>0 is a certificate subject, 1 is a certificate fingerprint, and 2 is a PEM-encoded certificate.</comment>
   </data>
+  <data name="Error_UnableToLoadNupkgMetadata" xml:space="preserve">
+    <value>Unable to load nupkg metadata `{0}`.</value>
+    <comment>0 - nupkg metadata file.</comment>
+  </data>
 </root>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NupkgMetadataFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NupkgMetadataFileFormatTests.cs
@@ -94,13 +94,10 @@ namespace NuGet.Packaging.Test
             // Arrange
             var logger = new TestLogger();
 
-            // Act
             using (var stringReader = new StringReader(contents))
             {
-                var ex = Assert.Throws<Exception>(() => NupkgMetadataFileFormat.Read(stringReader, logger, "from memory"));
-
-                // Assert
-                Assert.Contains("Error parsing nupkg metadata file", ex.Message);
+                // Act & Assert
+                var ex = Assert.Throws<InvalidDataException>(() => NupkgMetadataFileFormat.Read(stringReader, logger, "from memory"));
             }
         }
 
@@ -110,13 +107,10 @@ namespace NuGet.Packaging.Test
             // Arrange
             var logger = new TestLogger();
 
-            // Act
             using (var stringReader = new StringReader(@"{""version"":"))
             {
-                var ex = Assert.Throws<Exception>(() => NupkgMetadataFileFormat.Read(stringReader, logger, "from memory"));
-
-                // Assert
-                Assert.Contains("Error parsing nupkg metadata file", ex.Message);
+                // Act & Assert
+                var ex = Assert.Throws<InvalidDataException>(() => NupkgMetadataFileFormat.Read(stringReader, logger, "from memory"));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NupkgMetadataFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NupkgMetadataFileFormatTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.IO;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NupkgMetadataFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NupkgMetadataFileFormatTests.cs
@@ -1,8 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.Test.Utility;
@@ -97,11 +97,11 @@ namespace NuGet.Packaging.Test
             // Act
             using (var stringReader = new StringReader(contents))
             {
-                Assert.Throws<InvalidDataException>(() => NupkgMetadataFileFormat.Read(stringReader, logger, "from memory"));
-            }
+                var ex = Assert.Throws<Exception>(() => NupkgMetadataFileFormat.Read(stringReader, logger, "from memory"));
 
-            // Assert
-            Assert.Equal(1, logger.Messages.Count);
+                // Assert
+                Assert.Contains("Error parsing nupkg metadata file", ex.Message);
+            }
         }
 
         [Fact]
@@ -113,11 +113,11 @@ namespace NuGet.Packaging.Test
             // Act
             using (var stringReader = new StringReader(@"{""version"":"))
             {
-                Assert.Throws<JsonReaderException>(() => NupkgMetadataFileFormat.Read(stringReader, logger, "from memory"));
-            }
+                var ex = Assert.Throws<Exception>(() => NupkgMetadataFileFormat.Read(stringReader, logger, "from memory"));
 
-            // Assert
-            Assert.Equal(1, logger.Messages.Count);
+                // Assert
+                Assert.Contains("Error parsing nupkg metadata file", ex.Message);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13763

## Description

Previously when nuget comes across a nupkg.metadata that is corrupt, it logs a warning and rethrows an exception. The exception that is rethrown does not have a message that specifies the path of the corrupt metadata. This PR does the following
* Remove the warning being logged. We do not need to log and then throw the exception. It will result in double logging
* Adds a specific message to the exception that clarifies which file is causing the problem

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
