### PR TITLE
Upload binary logs in CI for cancellations

### DIFF
--- a/eng/pipelines/pr.job.yml
+++ b/eng/pipelines/pr.job.yml
@@ -81,9 +81,16 @@ jobs:
       arguments: --no-restore --restore:false --no-build --framework $(TestTargetFramework) --binarylogger:"$(BinlogDirectory)02-RunTests.binlog"
       testRunTitle: ${{ parameters.osName }} $(TestType) Tests ($(TestTargetFramework))
 
+  - ${{ if eq(parameters.osName, 'Windows') }}:
+    - script: taskkill /im dotnet.exe /f
+      displayName: Terminate dotnet.exe processes on cancellation or failure
+      continueOnError: true
+      condition: or(failed(), canceled(), eq(variables['System.Debug'], 'true'))
+
   - task: PublishPipelineArtifact@1
     displayName: Publish MSBuild Binary Logs
-    condition: or(failed(), eq(variables['System.Debug'], 'true'))
+    condition: or(failed(), canceled(), eq(variables['System.Debug'], 'true'))
     inputs:
       targetPath: $(BinlogDirectory)
       artifact: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
+


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
This change includes publishing of logs when a CI job is cancelled, particularly for when a test run times out.  The binary logs might be incomplete but the VS Test diagnostic logs shows all of the output from xunit including long running tests, communication errors, etc.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
