### PR TITLE
Migrate .nupkg.metadata read/write to System.Text.Json

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
@@ -53,7 +53,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Memory" Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)'" />
-    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="System.Text.Json" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != '$(NETFXTargetFramework)'">

--- a/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Memory" Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)'" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != '$(NETFXTargetFramework)'">

--- a/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Text.Json;
 using Newtonsoft.Json;
 using NuGet.Common;
 
@@ -17,7 +18,16 @@ namespace NuGet.Packaging
         private const string HashProperty = "contentHash";
         private const string SourceProperty = "source";
 
-        private static readonly JsonSerializer JsonSerializer = JsonSerializer.Create(GetSerializerSettings());
+        private static readonly Newtonsoft.Json.JsonSerializer JsonSerializer = Newtonsoft.Json.JsonSerializer.Create(GetSerializerSettings());
+        private static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions()
+        {
+            WriteIndented = true,
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            // This file is not intended to be parsed in javascript, and the contentHash property contains a Base64 encoded string that
+            // can contain characters such as + that has not been encoded in the past.
+            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        };
 
         public static NupkgMetadataFile Read(string filePath)
         {
@@ -31,12 +41,35 @@ namespace NuGet.Packaging
 
         public static NupkgMetadataFile Read(Stream stream, ILogger log, string path)
         {
-            using (var textReader = new StreamReader(stream))
+            if (stream is null) { throw new ArgumentNullException(nameof(stream)); }
+
+            try
             {
-                return Read(textReader, log, path);
+                try
+                {
+                    NupkgMetadataFile nupkgMetadata = System.Text.Json.JsonSerializer.Deserialize<NupkgMetadataFile>(stream, JsonSerializerOptions);
+                    if (nupkgMetadata == null)
+                    {
+                        throw new InvalidDataException();
+                    }
+                    return nupkgMetadata;
+                }
+                catch (System.Text.Json.JsonException jsonException)
+                {
+                    throw new InvalidDataException(jsonException.Message, jsonException);
+                }
+            }
+            catch (Exception ex)
+            {
+                log.LogWarning(string.Format(CultureInfo.CurrentCulture,
+                    Strings.Error_LoadingHashFile,
+                    path, ex.Message));
+
+                throw;
             }
         }
 
+        [Obsolete("Use a different overload for better performance. This overload will get deleted in the future.")]
         public static NupkgMetadataFile Read(TextReader reader, ILogger log, string path)
         {
             try
@@ -75,12 +108,12 @@ namespace NuGet.Packaging
 
         public static void Write(Stream stream, NupkgMetadataFile hashFile)
         {
-            using (var textWriter = new StreamWriter(stream))
-            {
-                Write(textWriter, hashFile);
-            }
+            if (stream is null) { throw new ArgumentNullException(nameof(stream)); }
+
+            System.Text.Json.JsonSerializer.Serialize(stream, hashFile, JsonSerializerOptions);
         }
 
+        [Obsolete("Use a different overload for better performance. This overload will get deleted in the future.")]
         public static void Write(TextWriter textWriter, NupkgMetadataFile hashFile)
         {
             using (var jsonWriter = new JsonTextWriter(textWriter))
@@ -111,7 +144,7 @@ namespace NuGet.Packaging
                 return objectType == TargetType;
             }
 
-            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
                 NupkgMetadataFile nupkgMetadataFile = existingValue as NupkgMetadataFile;
                 if (nupkgMetadataFile == null)
@@ -161,7 +194,7 @@ namespace NuGet.Packaging
                 throw new JsonReaderException();
             }
 
-            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            public override void WriteJson(JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)
             {
                 if (!(value is NupkgMetadataFile nupkgMetadataFile))
                 {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13835

## Description

Port `NupkgMetadataFileFormat` to System.Text.Json

<details>
<summary>benchmark code</summary>
<div>

```cs
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using NuGet.Common;
using NuGet.Packaging;

namespace Benchmark
{
    [MemoryDiagnoser]
    public class Program
    {
        static void Main(string[] args)
        {
            BenchmarkRunner.Run<Program>();
        }

#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
        // These properties are set by the global setup
        private string _readPath;
        private string _writePath;
        private NupkgMetadataFile _instance;
#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.

        [GlobalSetup]
        public void GlobalSetup()
        {
            var gpf = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
            foreach (var file in Directory.EnumerateFiles(gpf, ".nupkg.metadata", SearchOption.AllDirectories))
            {
                _readPath = file;
                break;
            }

            _writePath = Path.GetTempFileName();

            _instance = new NupkgMetadataFile()
            {
                Version = 2,
                ContentHash = "1234567890ABCDEFGHIJLMNOPQRSTUVWXYZ",
                Source = "https://contoso.test/v3/index.json",
            };
        }

        [Benchmark]
        [Obsolete]
        public NupkgMetadataFile NJRead()
        {
            using (var reader = new StreamReader(_readPath))
            {
                NupkgMetadataFile metadata = NupkgMetadataFileFormat.Read(reader, NullLogger.Instance, _readPath);
                return metadata;
            }
        }

        [Benchmark]
        public NupkgMetadataFile STJRead()
        {
            NupkgMetadataFile metadata = NupkgMetadataFileFormat.Read(_readPath);
            return metadata;
        }

        [Benchmark]
        [Obsolete]
        public void NJWrite()
        {
            using (var writer = new StreamWriter(_writePath))
            {
                NupkgMetadataFileFormat.Write(writer, _instance);
            }
        }

        [Benchmark]
        public void STJWrite()
        {
            NupkgMetadataFileFormat.Write(_writePath, _instance);
        }
    }
}

```

</div>
</details>

| Method   | Mean     | Error   | StdDev  | Gen0   | Allocated |
|--------- |---------:|--------:|--------:|-------:|----------:|
| NJRead   | 106.4 us | 1.70 us | 1.59 us | 0.6104 |   10680 B |
| STJRead  | 105.2 us | 1.32 us | 1.17 us |      - |     664 B |
| NJWrite  | 201.4 us | 2.30 us | 1.92 us | 0.2441 |    7416 B |
| STJWrite | 180.2 us | 2.14 us | 1.89 us | 0.2441 |    4632 B |

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ existing tests were updated
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ no functional changes to product
