### PR TITLE
Fix invalid target framework error for Solution restore

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -525,6 +525,11 @@ namespace NuGet.Build.Tasks.Console
             if (string.IsNullOrEmpty(targetFrameworks))
             {
                 targetFrameworks = project.GetProperty("TargetFramework");
+                if (targetFrameworks.Contains(';'))
+                {
+                    var error = RestoreLogMessage.CreateError(NuGetLogCode.NU1001, string.Format(CultureInfo.CurrentCulture, Strings.Error_TargetFrameworkWithSemicolon, targetFrameworks));
+                    throw new RestoreCommandException(error);
+                }
             }
             var projectFrameworkStrings = MSBuildStringUtility.Split(targetFrameworks);
             return projectFrameworkStrings;

--- a/src/NuGet.Core/NuGet.Build.Tasks/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Strings.Designer.cs
@@ -207,6 +207,15 @@ namespace NuGet.Build.Tasks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The TargetFramework value &apos;{0}&apos; is not valid. To multi-target, use the &apos;TargetFrameworks&apos; property instead..
+        /// </summary>
+        public static string Error_TargetFrameworkWithSemicolon {
+            get {
+                return ResourceManager.GetString("Error_TargetFrameworkWithSemicolon", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ProjectReference &apos;{0}&apos; was resolved using &apos;{1}&apos; instead of the project target framework &apos;{2}&apos;. This project may not be fully compatible with your project..
         /// </summary>
         public static string ImportsFallbackWarning {

--- a/src/NuGet.Core/NuGet.Build.Tasks/Strings.resx
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Strings.resx
@@ -229,4 +229,8 @@
     <value>An error occurred starting static graph-based restore. {0}. Please file an issue at https://github.com/NuGet/Home</value>
     <comment>0 - The exception message</comment>
   </data>
+  <data name="Error_TargetFrameworkWithSemicolon" xml:space="preserve">
+    <value>The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</value>
+    <comment>0 - Is a string with a list of target frameworks separated by a semi colon</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -458,6 +458,12 @@ namespace NuGet.Commands
             foreach (var item in GetItemByType(items, "TargetFrameworkInformation"))
             {
                 var frameworkString = item.GetProperty("TargetFramework");
+                if (frameworkString.Contains(';'))
+                {
+                    var error = RestoreLogMessage.CreateError(NuGetLogCode.NU1001, string.Format(CultureInfo.CurrentCulture, Strings.Error_TargetFrameworkWithSemicolon, frameworkString));
+                    throw new RestoreCommandException(error);
+                }
+
                 var targetFrameworkMoniker = item.GetProperty("TargetFrameworkMoniker");
                 var targetPlatforMoniker = item.GetProperty("TargetPlatformMoniker");
                 var targetPlatformMinVersion = item.GetProperty("TargetPlatformMinVersion");

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -808,6 +808,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The TargetFramework value &apos;{0}&apos; is not valid. To multi-target, use the &apos;TargetFrameworks&apos; property instead..
+        /// </summary>
+        internal static string Error_TargetFrameworkWithSemicolon {
+            get {
+                return ResourceManager.GetString("Error_TargetFrameworkWithSemicolon", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid tools package {0} {1}. Tools packages cannot contain more than one PackageType..
         /// </summary>
         internal static string Error_ToolsPackageWithExtraPackageTypes {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1127,4 +1127,8 @@ NuGet requires HTTPS sources. Refer to https://aka.ms/nuget-https-everywhere for
     <value>Audit source '{0}' did not provide any vulnerability data.</value>
     <comment>{0} is the source name</comment>
   </data>
+  <data name="Error_TargetFrameworkWithSemicolon" xml:space="preserve">
+    <value>The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</value>
+    <comment>0 - Is a string with a list of target frameworks separated by a semi colon</comment>
+  </data>
 </root>

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
@@ -101,6 +101,19 @@ namespace NuGet.Build.Tasks.Console.Test
             actual.Should().BeEquivalentTo(expected);
         }
 
+        [Theory]
+        [InlineData("net40;net45")]
+        [InlineData("net40;net45 ; netstandard2.0 ")]
+        public void GetOriginalTargetFramework_WhenTargetFramworkSpecified_HasCorrectTargetFramework(string targetFrameworks)
+        {
+            var project = new MockMSBuildProject(new Dictionary<string, string>
+            {
+                ["TargetFramework"] = targetFrameworks
+            });
+
+            Assert.Throws<RestoreCommandException>(() => MSBuildStaticGraphRestore.GetTargetFrameworkStrings(project));
+        }
+
         [Fact]
         public void GetPackageDownloads_WhenDuplicatesExist_DuplicatesIgnored()
         {

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -3400,6 +3400,36 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
+        public void MSBuildRestoreUtility_GetPackageSpec_InvalidTargetFramework()
+        {
+            // Arrange
+            var targetFramework = "netstandard2.0;net7.0";
+            var items = new[] {
+                 CreateItems(new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "ProjectName", "a" },
+                    { "ProjectStyle", "PackageReference" },
+                    { "ProjectUniqueName", "a" },
+                }),
+            CreateItems(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "AssetTargetFallback", "" },
+                    { "PackageTargetFallback", "" },
+                    { "ProjectUniqueName", "a" },
+                    { "TargetFramework", targetFramework },
+                    { "TargetPlatformIdentifier", "" },
+                    { "TargetPlatformMoniker", "" },
+                    { "TargetPlatformVersion", "" },
+                })
+            };
+
+            // Act & Assert
+            var exception = Assert.Throws<RestoreCommandException>(() => MSBuildRestoreUtility.GetPackageSpec(items));
+        }
+
+        [Fact]
         public void MSBuildRestoreUtility_AddPackageDownloads_NoVersion_ThrowsException()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13772

## Description
There is a difference in behavior when doing a restore in Solution vs Project with an invalid target framework in the `<TargetFramework>` tag.  When doing it in the project Level, sdk will run a validation before doing restore in https://github.com/dotnet/sdk/blob/5ab26633bdf4676efa25140a31a3d6182efb02f9/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets#L92.

The problem is that Solution level does not this validation (since it doesn't run a restore for each project) and will fail with 
```
...\Current\bin\NuGet.targets(169,5): error : Sequence contains no matching element [<repo>\dirs.proj]
```

This PR adds a validation and return the same error message as the project level. Currently, I decided to error with a NuGet error but we could also add `NETSDK1046` in the error message.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
