### PR TITLE
[Pack] Handle empty Version tag in nuspec error

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
@@ -146,7 +146,7 @@ namespace NuGet.Packaging
             var manifest = ManifestReader.ReadManifest(document);
 
             // Update manifest metadata version if version was provided by the CLI command
-            if (propertyProvider is not null)
+            if (propertyProvider is not null && propertyProvider.Target.GetType().Name.Equals("PackArgs"))
             {
                 var version = propertyProvider("version");
                 if (version is not null)

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
@@ -12,6 +12,8 @@ using NuGet.Packaging.Core;
 using NuGet.Packaging.PackageCreation.Resources;
 using NuGet.Packaging.Xml;
 using static NuGet.Shared.XmlUtility;
+using NuGet.Versioning;
+
 
 #if !IS_CORECLR
 using System.Xml.Schema;
@@ -142,6 +144,16 @@ namespace NuGet.Packaging
 
             // Deserialize it
             var manifest = ManifestReader.ReadManifest(document);
+
+            // Update manifest metadata version if version was provided by the CLI command
+            if (propertyProvider is not null)
+            {
+                var version = propertyProvider("version");
+                if (version is not null)
+                {
+                    manifest.Metadata.Version = NuGetVersion.Parse(version);
+                }
+            }
 
             // Validate before returning
             Validate(manifest);

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
@@ -88,7 +88,7 @@ namespace NuGet.Packaging
                     case "version":
                         NuGetVersion version;
                         NuGetVersion.TryParse(value, out version);
-                        manifestMetadata.Version = version ?? new NuGetVersion(0, 0, 0);
+                        manifestMetadata.Version = version;
                         break;
                     case "authors":
                         manifestMetadata.Authors = value?.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
@@ -87,8 +87,10 @@ namespace NuGet.Packaging
                         break;
                     case "version":
                         NuGetVersion version;
-                        NuGetVersion.TryParse(value, out version);
-                        manifestMetadata.Version = version;
+                        if (NuGetVersion.TryParse(value, out version))
+                        {
+                            manifestMetadata.Version = version;
+                        }
                         break;
                     case "authors":
                         manifestMetadata.Authors = value?.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
@@ -86,7 +86,9 @@ namespace NuGet.Packaging
                         manifestMetadata.Id = value;
                         break;
                     case "version":
-                        manifestMetadata.Version = NuGetVersion.Parse(value);
+                        NuGetVersion version;
+                        NuGetVersion.TryParse(value, out version);
+                        manifestMetadata.Version = version ?? new NuGetVersion(0, 0, 0);
                         break;
                     case "authors":
                         manifestMetadata.Authors = value?.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
@@ -86,8 +86,7 @@ namespace NuGet.Packaging
                         manifestMetadata.Id = value;
                         break;
                     case "version":
-                        NuGetVersion version;
-                        if (NuGetVersion.TryParse(value, out version))
+                        if (NuGetVersion.TryParse(value, out NuGetVersion version))
                         {
                             manifestMetadata.Version = version;
                         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/PackCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/PackCommandRunnerTests.cs
@@ -62,14 +62,7 @@ namespace NuGet.Commands.Test
                 };
                 var runner = new PackCommandRunner(args, createProjectFactory: null);
 
-                try
-                {
-                    var result = runner.RunPackageBuild();
-                }
-                catch (Exception e)
-                {
-                    Assert.Equal(e.Message, "Version is required.");
-                }
+                Assert.Throws<Exception>(() => runner.RunPackageBuild());
 
                 var nupkgPath = Path.Combine(test.CurrentDirectory.FullName, $"DefaultExclusions.1.0.0.nupkg");
                 Assert.False(File.Exists(nupkgPath), "The output .nupkg should not exist when pack fails.");
@@ -77,7 +70,7 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
-        public void RunPackageBuild_WithValidNuspec_WithVersionAsArgumentSucceds()
+        public void RunPackageBuild_WithValidNuspec_WithVersionAsArgument_PackSucceeds()
         {
             using (var test = DefaultExclusionsTest.Create(validNuspec: true))
             {
@@ -91,22 +84,16 @@ namespace NuGet.Commands.Test
                 };
                 var runner = new PackCommandRunner(args, createProjectFactory: null);
 
-                try
-                {
-                    var result = runner.RunPackageBuild();
-                }
-                catch (Exception e)
-                {
-                    Assert.Equal(e.Message, "Version is required.");
-                }
+                var result = runner.RunPackageBuild();
+                Assert.True(result);
 
-                var nupkgPath = Path.Combine(test.CurrentDirectory.FullName, $"DefaultExclusions.1.0.0.nupkg");
-                Assert.False(File.Exists(nupkgPath), "The output .nupkg should not exist when pack fails.");
+                var nupkgPath = Path.Combine(test.CurrentDirectory.FullName, $"DefaultExclusions.3.1.2.nupkg");
+                Assert.True(File.Exists(nupkgPath), "nuspec file does not exist");
             }
         }
 
         [Fact]
-        public void RunPackageBuild_WithInvalidNuspec_WithVersionAsArgumentSucceds()
+        public void RunPackageBuild_WithInvalidNuspec_WithVersionAsArgument_PackSucceeds()
         {
             using (var test = DefaultExclusionsTest.Create(validNuspec: false))
             {
@@ -122,7 +109,7 @@ namespace NuGet.Commands.Test
                 var result = runner.RunPackageBuild();
 
                 var nupkgPath = Path.Combine(test.CurrentDirectory.FullName, $"DefaultExclusions.3.1.2.nupkg");
-                Assert.True(File.Exists(nupkgPath), "The output .nupkg should not exist when pack fails.");
+                Assert.True(File.Exists(nupkgPath), "nuspec file does not exist");
             }
         }
 
@@ -223,9 +210,7 @@ namespace NuGet.Commands.Test
                 else
                 {
                     InvaidNuspecNoVersion(nuspecFile.FullName, packageId, pattern);
-
                 }
-
 
                 var nupkgFile = new FileInfo(Path.Combine(currentDirectory.FullName, $"{packageId}.{packageVersion}.nupkg"));
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/PackCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/PackCommandRunnerTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using FluentAssertions;
 using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.Test.Utility;
@@ -51,7 +52,7 @@ namespace NuGet.Commands.Test
         [Fact]
         public void RunPackageBuild_WithInvalidNuspec_Throws()
         {
-            using (var test = DefaultExclusionsTest.Create(validNuspec: false))
+            using (var test = DefaultExclusionsTest.Create(packageVersion: string.Empty))
             {
                 var args = new PackArgs()
                 {
@@ -65,14 +66,14 @@ namespace NuGet.Commands.Test
                 Assert.Throws<Exception>(() => runner.RunPackageBuild());
 
                 var nupkgPath = Path.Combine(test.CurrentDirectory.FullName, $"DefaultExclusions.1.0.0.nupkg");
-                Assert.False(File.Exists(nupkgPath), "The output .nupkg should not exist when pack fails.");
+                File.Exists(nupkgPath).Should().BeFalse();
             }
         }
 
         [Fact]
-        public void RunPackageBuild_WithValidNuspec_WithVersionAsArgument_PackSucceeds()
+        public void RunPackageBuild_WithVersionAsArgument_NuspecVersionOverriddenByVersionArgument()
         {
-            using (var test = DefaultExclusionsTest.Create(validNuspec: true))
+            using (var test = DefaultExclusionsTest.Create())
             {
                 var args = new PackArgs()
                 {
@@ -88,14 +89,14 @@ namespace NuGet.Commands.Test
                 Assert.True(result);
 
                 var nupkgPath = Path.Combine(test.CurrentDirectory.FullName, $"DefaultExclusions.3.1.2.nupkg");
-                Assert.True(File.Exists(nupkgPath), "nuspec file does not exist");
+                File.Exists(nupkgPath).Should().BeTrue();
             }
         }
 
         [Fact]
-        public void RunPackageBuild_WithInvalidNuspec_WithVersionAsArgument_PackSucceeds()
+        public void RunPackageBuild_NuspecWithEmptyVersion_WithVersionAsArgument_PackSucceeds()
         {
-            using (var test = DefaultExclusionsTest.Create(validNuspec: false))
+            using (var test = DefaultExclusionsTest.Create(packageVersion: string.Empty))
             {
                 var args = new PackArgs()
                 {
@@ -109,7 +110,7 @@ namespace NuGet.Commands.Test
                 var result = runner.RunPackageBuild();
 
                 var nupkgPath = Path.Combine(test.CurrentDirectory.FullName, $"DefaultExclusions.3.1.2.nupkg");
-                Assert.True(File.Exists(nupkgPath), "nuspec file does not exist");
+                File.Exists(nupkgPath).Should().BeTrue();
             }
         }
 
@@ -177,7 +178,7 @@ namespace NuGet.Commands.Test
                 UnexpectedEntryNames = unexpectedEntryNames;
             }
 
-            internal static DefaultExclusionsTest Create(bool validNuspec = true)
+            internal static DefaultExclusionsTest Create(string packageVersion = "1.0.0")
             {
                 TestDirectory testDirectory = TestDirectory.Create();
 
@@ -200,17 +201,22 @@ namespace NuGet.Commands.Test
                 string pattern = $"..{Path.DirectorySeparatorChar}{packRootDirectory.Name}{Path.DirectorySeparatorChar}**{Path.DirectorySeparatorChar}*.*";
 
                 const string packageId = "DefaultExclusions";
-                const string packageVersion = "1.0.0";
 
-                if (validNuspec)
-                {
-                    ValidNuspec(nuspecFile.FullName, packageId, packageVersion, pattern);
-
-                }
-                else
-                {
-                    InvaidNuspecNoVersion(nuspecFile.FullName, packageId, pattern);
-                }
+                File.WriteAllText(nuspecFile.FullName, $@"<?xml version=""1.0""?>
+<package>
+    <metadata>
+        <id>{packageId}</id>
+        <version>{packageVersion}</version>
+        <title>title</title>
+        <description>description</description>
+        <authors>author</authors>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <dependencies />
+    </metadata>
+    <files>
+        <file src=""{pattern}"" target="""" />
+    </files>   
+</package>");
 
                 var nupkgFile = new FileInfo(Path.Combine(currentDirectory.FullName, $"{packageId}.{packageVersion}.nupkg"));
 
@@ -249,7 +255,7 @@ namespace NuGet.Commands.Test
                     </package>");
             }
 
-            internal static void InvaidNuspecNoVersion(string nuspecPath, string packageId, string pattern)
+            internal static void InvalidNuspecNoVersion(string nuspecPath, string packageId, string pattern)
             {
                 File.WriteAllText(nuspecPath,
                     $@"<?xml version=""1.0""?>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/7987

## Context of the bug
When running nuget pack with a .nuspec file that contains an empty version and passing -Version on the command line, nuget will fail with the error:

```
An error occured while trying to parse the value '' of property 'version' in the manifest file.
Value cannot be null or an empty string.
Parameter name: value
``` 

However, you put in a bogus version identifier in the nuspec file, the same command will run happily, with the version number passed on the command line.

## Description
After having conversations, right now the solution is to override the nuspec version with the CLI version that the customer specified.

~This PR makes that when the Version tag is empty it creates an `0.0.0` version which will be used to pack the package.~

Currently how it works is that we read the .nuspec and validate that Version is not null, this validation is used by the `nuget spec` and `nuget pack` commands. ~Removing an error is a breaking change, so I'm not sure if this is the best solution but for me the scenario for an empty `Version` tag is not common and setting the `0.0.0` version sounds less disruptive. Also, I tried to lag a warning but looks like the logger is not close to the validation close.~

Since we run this validation when reading the file, I cannot check if we are using the `-Version` property easily, the other option for to fix this is to move that validation to another place where we can check it against pack args. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests **Waiting for team feedback before adding tests**
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
