### PR TITLE
Split up functional test execution in CI

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -17,7 +17,9 @@
           Returns="@(TestProject)"
           Condition="'$(TestProject)' == 'true'">
     <ItemGroup>
-      <TestProject Include="$(MSBuildProjectFullPath)" TestType="$(TestProjectType)" />
+      <TestProject Include="$(MSBuildProjectFullPath)"
+                   TestType="$(TestProjectType)"
+                   ProjectName="$(MSBuildProjectName)" />
     </ItemGroup>
   </Target>
 
@@ -29,7 +31,9 @@
           DependsOnTargets="GetProjectTargetFrameworks"
           Returns="@(_SupportedProject)">
     <ItemGroup>
-      <_SupportedProject Include="%(ProjectTargetFramework.ProjectFile)" Condition="'%(Identity)' == '$(ProjectTargetFramework)'" />
+      <_SupportedProject Include="%(ProjectTargetFramework.ProjectFile)"
+                         ProjectName="$(MSBuildProjectName)"
+                         Condition="'%(Identity)' == '$(ProjectTargetFramework)'" />
     </ItemGroup>
   </Target>
   

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -56,11 +56,34 @@
               ItemName="_TestProject" />
     </MSBuild>
 
+    <MSBuild Projects="@(_TestProject)"
+         Targets="DoesProjectSupportTargetFramework"
+         Condition="'$(TargetFramework)' != ''"
+         BuildInParallel="$(BuildInParallel)"
+         RemoveProperties="TargetFramework"
+         Properties="ProjectTargetFramework=$(TargetFramework)">
+      <Output TaskParameter="TargetOutputs"
+              ItemName="_TestProjectForFramework" />
+    </MSBuild>
+
     <ItemGroup>
       <!--
         Add only the specified test type to the TestProject item group.
       -->
-      <TestProject Include="@(_TestProject->WithMetadataValue('TestType', '$(TestType)'))" />
+      <TestProject Include="@(_TestProject->WithMetadataValue('TestType', '$(TestType)'))" Condition="'$(TargetFramework)' == ''" />
+      <TestProject Include="@(_TestProjectForFramework->WithMetadataValue('TestType', '$(TestType)'))" Condition="'$(TargetFramework)' != ''" />
+    </ItemGroup>
+    
+    <ItemGroup Condition="'$(TestProjectName)' != ''">
+        <_FilteredTestProject Include="@(TestProject)" Condition="'%(TestProject.ProjectName)' == '$(TestProjectName)'" />
+    </ItemGroup>
+    
+    <Error Text="The specified test project '$(TestProjectName)' was not found.  Possible projects are &quot;@(TestProject->'%(ProjectName)', ', ')&quot;"
+           Condition="'$(TestProjectName)' != '' And @(_FilteredTestProject->Count()) == 0" />
+
+    <ItemGroup Condition="'$(TestProjectName)' != ''">
+      <TestProject Remove="@(TestProject)" />
+      <TestProject Include="@(_FilteredTestProject)" />
     </ItemGroup>
 
     <!--
@@ -185,11 +208,16 @@
               ItemName="TestAssembly" />
     </MSBuild>
 
+    <Message Text="Only running tests from a single test project: @(TestProject)"
+             Importance="High"
+             Condition="'$(TestProjectName)' != ''" />
+
     <ItemGroup>
       <!--
         Adds the console logger with verbosity and then adds any specified from the command-line.
       -->
       <VSTestLogger Include="console%3Bverbosity=$(VSTestVerbosity);$(VSTestLogger)" />
+      <TestAssembly Remove="@(TestAssembly)" Condition="'$(TestAssembly)' != '' And '%(TestAssembly.Identity)' != '$(TestAssembly)'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/eng/pipelines/pr.job.yml
+++ b/eng/pipelines/pr.job.yml
@@ -19,6 +19,10 @@ parameters:
   displayName: Optional name of an individual test project to run tests from.  The default is to run tests from all applicable projects.
   type: string
   default: ''
+- name: testVerbosity
+  displayName: Optional verbosity to use when running tests.
+  type: string
+  default: 'minimal'
 
 jobs:
 - job:
@@ -35,6 +39,8 @@ jobs:
         value: $(Agent.TempDirectory)\binlogs\
       ${{ else }}:
         value: $(Agent.TempDirectory)/binlogs/
+    - name: VSTestVerbosity
+      value: ${{ parameters.testVerbosity }}
 
   pool:
     name: ${{ parameters.agentPool }}

--- a/eng/pipelines/pr.job.yml
+++ b/eng/pipelines/pr.job.yml
@@ -15,16 +15,21 @@ parameters:
 - name: timeoutInMinutes
   type: number
   default: 15
+- name: testProjectName
+  displayName: Optional name of an individual test project to run tests from.  The default is to run tests from all applicable projects.
+  type: string
+  default: ''
 
 jobs:
 - job:
   displayName: ${{ parameters.displayName }}
-  timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
   variables:
     - name: TestType
       value: ${{ parameters.testType }}
     - name: TestTargetFramework
       value: ${{ parameters.testTargetFramework }}
+    - name: TestProjectName
+      value: ${{ parameters.testProjectName }}
     - name: BinlogDirectory
       ${{ if eq(parameters.osName, 'Windows') }}:
         value: $(Agent.TempDirectory)\binlogs\
@@ -76,10 +81,14 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: Run $(TestType) Tests 
     condition: succeeded()
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     inputs:
       command: test
       arguments: --no-restore --restore:false --no-build --framework $(TestTargetFramework) --binarylogger:"$(BinlogDirectory)02-RunTests.binlog"
-      testRunTitle: ${{ parameters.osName }} $(TestType) Tests ($(TestTargetFramework))
+      ${{ if ne(parameters.testProjectName, '') }}:
+        testRunTitle: ${{ parameters.osName }} $(TestType) Tests for $(TestProjectName) ($(TestTargetFramework))
+      ${{ else }}:
+        testRunTitle: ${{ parameters.osName }} $(TestType) Tests ($(TestTargetFramework))
 
   - ${{ if eq(parameters.osName, 'Windows') }}:
     - script: taskkill /im dotnet.exe /f

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -153,6 +153,7 @@ stages:
         testType: Functional
         testTargetFramework: net472
         testProjectName: NuGet.CommandLine.Test
+        testVerbosity: normal
         timeoutInMinutes: 45
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -102,7 +102,7 @@ stages:
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
-    displayName: 
+    displayName: Msbuild.Integration.Test on Windows (.NET Framework 4.7.2)
     dependsOn: []
     jobs:
     - template: pr.job.yml

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -102,12 +102,12 @@ stages:
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
-    displayName: Functional Tests on Windows (.NET Framework 4.7.2)
+    displayName: Functional Tests on Windows (.NET Framework 4.7.2) Msbuild.Integration.Test
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Functional Tests on Windows (.NET Framework 4.7.2)
+        displayName: Functional Tests on Windows (.NET Framework 4.7.2) Msbuild.Integration.Test
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
@@ -116,16 +116,71 @@ stages:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Functional
         testTargetFramework: net472
-        timeoutInMinutes: 60
+        testProjectName: Msbuild.Integration.Test
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
-    displayName: Functional Tests on Windows (.NET 8.0)
+    displayName: Functional Tests on Windows (.NET Framework 4.7.2) NuGet.CommandLine.FuncTest
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Functional Tests on Windows (.NET 8.0)
+        displayName: Functional Tests on Windows (.NET Framework 4.7.2) NuGet.CommandLine.FuncTest
+        osName: Windows
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          agentPool: NetCore-Public
+          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+        ${{ else }}:
+          agentPool: VSEngSS-MicroBuild2022-1ES
+        testType: Functional
+        testTargetFramework: net472
+        testProjectName: NuGet.CommandLine.FuncTest
+
+- ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
+  - stage:
+    displayName: Functional Tests on Windows (.NET Framework 4.7.2) NuGet.CommandLine.Test
+    dependsOn: []
+    jobs:
+    - template: pr.job.yml
+      parameters:
+        displayName: Functional Tests on Windows (.NET Framework 4.7.2) NuGet.CommandLine.Test
+        osName: Windows
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          agentPool: NetCore-Public
+          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+        ${{ else }}:
+          agentPool: VSEngSS-MicroBuild2022-1ES
+        testType: Functional
+        testTargetFramework: net472
+        testProjectName: NuGet.CommandLine.Test
+        timeoutInMinutes: 45
+
+- ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
+  - stage:
+    displayName: Functional Tests on Windows (.NET Framework 4.7.2) NuGet.Packaging.FuncTest
+    dependsOn: []
+    jobs:
+    - template: pr.job.yml
+      parameters:
+        displayName: Functional Tests on Windows (.NET Framework 4.7.2) NuGet.Packaging.FuncTest
+        osName: Windows
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          agentPool: NetCore-Public
+          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+        ${{ else }}:
+          agentPool: VSEngSS-MicroBuild2022-1ES
+        testType: Functional
+        testTargetFramework: net472
+        testProjectName: NuGet.Packaging.FuncTest
+
+- ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
+  - stage:
+    displayName: Functional Tests on Windows (.NET 8.0) Dotnet.Integration.Test
+    dependsOn: []
+    jobs:
+    - template: pr.job.yml
+      parameters:
+        displayName: Functional Tests on Windows (.NET 8.0) Dotnet.Integration.Test
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
@@ -134,16 +189,17 @@ stages:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Functional
         testTargetFramework: net8.0
-        timeoutInMinutes: 60
+        testProjectName: Dotnet.Integration.Test
+        timeoutInMinutes: 45
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
-    displayName: Functional Tests on Windows (.NET Core 3.1)
+    displayName: Functional Tests on Windows (.NET 8.0) NuGet.Packaging.FuncTest
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Functional Tests on Windows (.NET Core 3.1)
+        displayName: Functional Tests on Windows (.NET 8.0) NuGet.Packaging.FuncTest
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
@@ -151,8 +207,8 @@ stages:
         ${{ else }}:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Functional
-        testTargetFramework: netcoreapp3.1
-        timeoutInMinutes: 60
+        testTargetFramework: net8.0
+        testProjectName: NuGet.Packaging.FuncTest
 
 - ${{ if eq(parameters.RunUnitTestsOnLinux, true) }}:
   - stage:
@@ -192,20 +248,7 @@ stages:
         vmImage: ubuntu-latest
         testType: Functional
         testTargetFramework: net8.0
-        timeoutInMinutes: 60
-
-- ${{ if eq(parameters.RunFunctionalTestsOnLinux, true) }}:
-  - stage:
-    displayName: Functional Tests on Linux (.NET Core 3.1)
-    dependsOn: []
-    jobs:
-    - template: pr.job.yml
-      parameters:
-        displayName: Functional Tests on Linux (.NET Core 3.1)
-        osName: Linux
-        vmImage: ubuntu-latest
-        testType: Functional
-        testTargetFramework: netcoreapp3.1
+        timeoutInMinutes: 30
 
 - ${{ if eq(parameters.RunUnitTestsOnMacOS, true) }}:
   - stage:
@@ -245,20 +288,7 @@ stages:
         vmImage: macos-latest
         testType: Functional
         testTargetFramework: net8.0
-        timeoutInMinutes: 60
-
-- ${{ if eq(parameters.RunFunctionalTestsOnMacOS, true) }}:
-  - stage:
-    displayName: Functional Tests on MacOS (.NET Core 3.1)
-    dependsOn: []
-    jobs:
-    - template: pr.job.yml
-      parameters:
-        displayName: Functional Tests on MacOS (.NET Core 3.1)
-        osName: MacOS
-        vmImage: macos-latest
-        testType: Functional
-        testTargetFramework: netcoreapp3.1
+        timeoutInMinutes: 30
 
 - ${{ if or(eq(parameters.RunSourceBuild, true), eq(parameters.RunStaticAnalysis, true)) }}:
   - stage:

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -102,12 +102,12 @@ stages:
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
-    displayName: Functional Tests on Windows (.NET Framework 4.7.2) Msbuild.Integration.Test
+    displayName: 
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Functional Tests on Windows (.NET Framework 4.7.2) Msbuild.Integration.Test
+        displayName: Msbuild.Integration.Test on Windows (.NET Framework 4.7.2)
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
@@ -120,12 +120,12 @@ stages:
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
-    displayName: Functional Tests on Windows (.NET Framework 4.7.2) NuGet.CommandLine.FuncTest
+    displayName: NuGet.CommandLine.FuncTest on Windows (.NET Framework 4.7.2)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Functional Tests on Windows (.NET Framework 4.7.2) NuGet.CommandLine.FuncTest
+        displayName: NuGet.CommandLine.FuncTest on Windows (.NET Framework 4.7.2)
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
@@ -138,12 +138,12 @@ stages:
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
-    displayName: Functional Tests on Windows (.NET Framework 4.7.2) NuGet.CommandLine.Test
+    displayName: NuGet.CommandLine.Test on Windows (.NET Framework 4.7.2)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Functional Tests on Windows (.NET Framework 4.7.2) NuGet.CommandLine.Test
+        displayName: NuGet.CommandLine.Test on Windows (.NET Framework 4.7.2)
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
@@ -158,12 +158,12 @@ stages:
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
-    displayName: Functional Tests on Windows (.NET Framework 4.7.2) NuGet.Packaging.FuncTest
+    displayName: NuGet.Packaging.FuncTest on Windows (.NET Framework 4.7.2)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Functional Tests on Windows (.NET Framework 4.7.2) NuGet.Packaging.FuncTest
+        displayName: NuGet.Packaging.FuncTest on Windows (.NET Framework 4.7.2)
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
@@ -176,12 +176,12 @@ stages:
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
-    displayName: Functional Tests on Windows (.NET 8.0) Dotnet.Integration.Test
+    displayName: Dotnet.Integration.Test on Windows (.NET 8.0)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Functional Tests on Windows (.NET 8.0) Dotnet.Integration.Test
+        displayName: Dotnet.Integration.Test on Windows (.NET 8.0)
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
@@ -195,12 +195,12 @@ stages:
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
-    displayName: Functional Tests on Windows (.NET 8.0) NuGet.Packaging.FuncTest
+    displayName: NuGet.Packaging.FuncTest on Windows (.NET 8.0)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Functional Tests on Windows (.NET 8.0) NuGet.Packaging.FuncTest
+        displayName: NuGet.Packaging.FuncTest on Windows (.NET 8.0)
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/NuGet.CommandLine.FuncTest.csproj
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/NuGet.CommandLine.FuncTest.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
     <Description>A functional (end-to-end) test suite for NuGet.CommandLine. Contains tests for every nuget.exe command.</Description>
+    <TestProjectType Condition="'$(IsXPlat)' != 'true'">Functional</TestProjectType>
+    <TestProjectType Condition="'$(IsXPlat)' == 'true'">None</TestProjectType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/NuGet.MSSigning.Extensions.FuncTest.csproj
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/NuGet.MSSigning.Extensions.FuncTest.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
     <Description>A functional (end-to-end) test suite for NuGet.MSSigning.Extensions.</Description>
+    <TestProjectType Condition="'$(IsXPlat)' != 'true'">Unit</TestProjectType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -502,7 +502,7 @@ namespace NuGet.CommandLine.Test
                 server.Get.Add("/push", r => "OK");
                 server.Put.Add("/push", r =>
                 {
-                    System.Threading.Thread.Sleep(2000);
+                    System.Threading.Thread.Sleep(TimeSpan.FromSeconds(10));
                     return HttpStatusCode.Created;
                 });
                 pathContext.Settings.AddSource("http-feed", $"{server.Uri}push", allowInsecureConnectionsValue: "true");
@@ -512,7 +512,7 @@ namespace NuGet.CommandLine.Test
                 CommandRunnerResult result = CommandRunner.Run(
                     Util.GetNuGetExePath(),
                     pathContext.WorkingDirectory,
-                    $"push {packageFileName} -Source {server.Uri}push -Timeout 1");
+                    $"push {packageFileName} -Source {server.Uri}push -Timeout 3");
 
                 // Assert
                 Assert.Equal(1, result.ExitCode);

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/NuGet.Commands.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/NuGet.Commands.FuncTest.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
     <Description>Integration tests for the more involved NuGet.Commands, such as restore.</Description>
+    <TestProjectType>Unit</TestProjectType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/NuGet.Protocol.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/NuGet.Protocol.FuncTest.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
     <Description>Integration tests for the more involved NuGet.Protocol functionality, such as plugins.</Description>
+    <TestProjectType>Unit</TestProjectType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.FuncTests/NuGet.Signing.CrossFramework.Test/NuGet.Signing.CrossFramework.Test.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Signing.CrossFramework.Test/NuGet.Signing.CrossFramework.Test.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>NuGet package signing cross framework test.</Description>
+    <TestProjectType Condition="'$(IsXPlat)' != 'true'">Unit</TestProjectType>
     <TestProjectType Condition="'$(IsXPlat)' == 'true'">None</TestProjectType>
   </PropertyGroup>
   <ItemGroup>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
     <Description>Functional tests for nuget in dotnet CLI scenarios, using the NuGet.CommandLine.XPlat assembly.</Description>
+    <TestProjectType>Unit</TestProjectType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGet.PackageManagement.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGet.PackageManagement.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Unit tests for NuGet.PackageManagement.</Description>
-    <TestProjectType Condition="'$(IsXPlat)' != 'true'">Functional</TestProjectType>
+    <TestProjectType Condition="'$(IsXPlat)' != 'true'">Unit</TestProjectType>
     <TestProjectType Condition="'$(IsXPlat)' == 'true'">None</TestProjectType>
   </PropertyGroup>
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
This change splits the execution of functional tests into individual jobs per test assembly.  I also moved a few tests from "functional" to "unit" because they execute in under 2 minutes.  This should make the overall execution time go down a little.  Since I moved some tests to unit, there are no more non-Windows functional tests on .NET Core 3.1 so in the end our CI only uses one extra machine.

I audited the functional tests and made sure they were all represented:

|                                     | Functional net472 | Functional net8.0 | Unit net472 | Unit net8.0 |
| -| :--: | :--: | :--: | :--: |
| Dotnet.Integration.Test             |        | ✅      |        |        |
| Msbuild.Integration.Test            | ✅      |        |        |        |
| NuGet.CommandLine.FuncTest          | ✅      |        |        |        |
| NuGet.CommandLine.Test              | ✅      |        |        |        |
| NuGet.Commands.FuncTest             |        |        | ✅      | ✅      |
| NuGet.MSSigning.Extensions.FuncTest |        |        | ✅      |        |
| NuGet.Packaging.FuncTest            | ✅      | ✅      |        |        |
| NuGet.Protocol.FuncTest             |        |        | ✅      | ✅      |
| NuGet.Signing.CrossFramework.Test   |        |        | ✅      |        |
| NuGet.XPlat.FuncTest                |        |        |        | ✅      |

I also adjusted some timeout so that hung tests hopefully don't run longer than they need to.  
## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
