### PR TITLE
Disable GetPackageSpec_WithInvalidUsingMicrosoftNetSdk_ThrowsAnException as it's flaky.

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -4106,7 +4106,7 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(isSdk, packageSpec.RestoreMetadata.UsingMicrosoftNETSdk);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/13849")]
         public void GetPackageSpec_WithInvalidUsingMicrosoftNetSdk_ThrowsAnException()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

Tracking issue: https://github.com/NuGet/Home/issues/13849

There's a few failures across different PRs;
https://dev.azure.com/dnceng-public/public/_build/results?buildId=838927&view=ms.vss-test-web.build-test-results-tab&runId=21730028&resultId=106737&paneView=debug - affected @nkolev92

https://dev.azure.com/dnceng-public/public/_build/results?buildId=836878&view=ms.vss-test-web.build-test-results-tab&runId=21686622&resultId=105444m - affected @Nigusu-Allehu 

There's certainly more, but due to the parallelization and multiple platforms we have this is a test that runs like ~10 within one build, so the history gets filled up quickly.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
