### PR TITLE
Update source-build team references

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -13,7 +13,7 @@
       Repo owners or contributors:
       If you get an error in source-build leg pointing at new prebuilt package being detected,
       resolve the prebuilt issue before merging your PR.
-      If that is not possible, contact the source-build team: @dotnet/source-build-internal.
+      If that is not possible, contact the source-build team: @dotnet/source-build.
     -->
 
     <!--


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Related to dotnet/source-build#4645

## Description

The @dotnet/source-build-internal team is being deprecated. All references to it were updated.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
