### PR TITLE
Test:  remove SHA-1 verification from test OCSP responder

### DIFF
--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/CertificateUtilities.cs
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/CertificateUtilities.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Internal.NuGet.Testing.SignedPackages
                     rng.GetBytes(bytes);
 
                     // Treat the byte array as a little-endian integer.
-                    // Ensure the number is non-negative by setting the highest bit of the first byte to 0.
+                    // Ensure the number is non-negative by setting the highest bit of the first byte (little-endian) to 0.
                     bytes[bytes.Length - 1] &= 0x7F;
 
                     BigInteger serialNumber = new(bytes);

--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/CertificateUtilities.cs
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/CertificateUtilities.cs
@@ -1,9 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Generic;
+using System.Numerics;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
@@ -46,6 +50,39 @@ namespace Microsoft.Internal.NuGet.Testing.SignedPackages
                 return new X509Certificate2(certificateWithPrivateKey.Export(X509ContentType.Pfx));
             }
 #endif
+        }
+
+        internal static byte[] GenerateSerialNumber(HashSet<BigInteger>? uniqueSerialNumbers = null)
+        {
+            // See https://www.rfc-editor.org/rfc/rfc5280#section-4.1.2.2
+            // A serial number MUST be:
+            //    * a non-negative integer
+            //    * unique for that CA
+            //    * <= 20 bytes
+            //    * big-endian encoded
+            byte[] bytes = new byte[20];
+
+            using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
+            {
+                while (true)
+                {
+                    rng.GetBytes(bytes);
+
+                    // Treat the byte array as a little-endian integer.
+                    // Ensure the number is non-negative by setting the highest bit of the first byte to 0.
+                    bytes[bytes.Length - 1] &= 0x7F;
+
+                    BigInteger serialNumber = new(bytes);
+
+                    if (uniqueSerialNumbers is null || uniqueSerialNumbers.Add(serialNumber))
+                    {
+                        // Convert to big-endian.
+                        Array.Reverse(bytes);
+
+                        return bytes;
+                    }
+                }
+            }
         }
     }
 }

--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/CertificateUtilities.cs
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/CertificateUtilities.cs
@@ -55,11 +55,20 @@ namespace Microsoft.Internal.NuGet.Testing.SignedPackages
         internal static byte[] GenerateSerialNumber(HashSet<BigInteger>? uniqueSerialNumbers = null)
         {
             // See https://www.rfc-editor.org/rfc/rfc5280#section-4.1.2.2
+            //
             // A serial number MUST be:
+            //
             //    * a non-negative integer
             //    * unique for that CA
             //    * <= 20 bytes
             //    * big-endian encoded
+            //
+            // To enforce uniqueness, we'll use BigInteger.
+            //
+            // Endianness here is dictated by .NET API's not the CPU architecture running this code.
+            //
+            //    * BigInteger's constructor requires an array of bytes interpreted as an integer in little-endian order.
+            //    * CertificateRequest.Create(...) requires an array of bytes interpreted as an unsigned integer in big-endian order.
             byte[] bytes = new byte[20];
 
             using (RandomNumberGenerator rng = RandomNumberGenerator.Create())

--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/SigningTestUtility.cs
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/SigningTestUtility.cs
@@ -412,10 +412,8 @@ namespace Microsoft.Internal.NuGet.Testing.SignedPackages
             certGen.NotAfter = notAfter ?? DateTime.UtcNow.Add(TimeSpan.FromMinutes(30));
             certGen.NotBefore = DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(30));
 
-            var random = new Random();
-            var serial = random.Next();
-            var serialNumber = BitConverter.GetBytes(serial);
-            Array.Reverse(serialNumber);
+            byte[] serialNumber = CertificateUtilities.GenerateSerialNumber();
+
             certGen.SetSerialNumber(serialNumber);
 
             certGen.Extensions.Add(


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Client.Engineering/issues/2996
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2221932

## Description

`CertificateAuthority` is test infrastructure that enables us to test a variety of scenarios without external dependencies.  For example, we can test revocation checking (via OCSP) using `CertificateAuthority` because it sufficiently implements an OCSP responder.  This is important for package signing test coverage and robustness.

The OCSP standard [requires](https://www.rfc-editor.org/rfc/rfc6960#section-4.1.1) that an OCSP request includes a `CertID` structure:

```
   CertID          ::=     SEQUENCE {
       hashAlgorithm       AlgorithmIdentifier,
       issuerNameHash      OCTET STRING, -- Hash of issuer's DN
       issuerKeyHash       OCTET STRING, -- Hash of issuer's public key
       serialNumber        CertificateSerialNumber }
```

`CertID` specifies a hash algorithm (e.g.:  SHA-1, SHA-256, etc.) and hashes of the issuer distinguished name and public key for the certificate for which revocation status is being checked.  These hashes are used to verify that the to-be-verified certificate is one that the responding certificate authority actually issued.  Per the OCSP specification, if a CA receives an OCSP request for a certificate which it did not issue, the OCSP responder should respond with an `Unknown` status.

Ideally, a modern timestamp authority (TSA) would support all SHA-2 algorithms, and a modern OCSP client would use SHA-2 algorithms.

We can ban SHA-1 in our test TSA; however, we can't ban SHA-1 in OCSP clients.  We don't control that.  We have tests that chain build and check revocation status and it's _the operating system_ --- in this case, Windows --- that chooses SHA-1 to identify a certificate in the OCSP request.

From https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-ocsp/22de9ccd-4347-460d-a4cc-3ea1aefa1284:

> The CertId field always uses the SHA-1 hash algorithm.

Windows follows [RFC 5019, section 2.1.1](https://www.rfc-editor.org/rfc/rfc5019.html#section-2.1.1), which says:

>    Clients MUST use SHA1 as the hashing algorithm for the
   CertID.issuerNameHash and the CertID.issuerKeyHash values.

This change:

* Gives SHA-1 `CertID`'s a pass.  Don't verify hashes; just assume they're correct.  Only verify certificate serial number.
* Improves the randomness of serial numbers.
* Implements support for SHA-2 algorithms.
* Returns an `Unknown` status for any other hash algorithm.

In product code, we have done something similar to the first point above.  See [Remove SHA-1 from cryptography use (#3596) · NuGet/NuGet.Client@3501dde (github.com)](https://github.com/NuGet/NuGet.Client/commit/3501ddedc274ac10d4b135856b7593a6bb8a72f1#diff-cdc41aa3367ec3539fb21298d72068190e4cbb92d560b53da47d5bfbc90543c3L584-R584)

## PR Checklist

- [X] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~~Added tests~~ N/A
- [ ] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~ N/A

CC @kartheekp-ms