### PR TITLE
Do not run tests in isolation

### DIFF
--- a/build/xunit.runsettings
+++ b/build/xunit.runsettings
@@ -14,11 +14,6 @@
 
     <!-- Specify a Boolean value, which defines the exit code when no tests are discovered. If the value is true and no tests are discovered, a nonzero exit code is returned. Otherwise, zero is returned. -->
     <TreatNoTestsAsError>true</TreatNoTestsAsError>
-
-    <EnvironmentVariables>
-      <!-- Changes the default timeout in VSTest for shutdown to 1000ms instead of 100ms which can cause intermittent failures in CI. -->
-      <VSTEST_TESTHOST_SHUTDOWN_TIMEOUT>1000</VSTEST_TESTHOST_SHUTDOWN_TIMEOUT>
-    </EnvironmentVariables>
   </RunConfiguration>
 
   <!-- https://xunit.net/docs/runsettings -->

--- a/eng/pipelines/pr.job.yml
+++ b/eng/pipelines/pr.job.yml
@@ -88,6 +88,8 @@ jobs:
     displayName: Run $(TestType) Tests 
     condition: succeeded()
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+    env:
+      VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: 1000
     inputs:
       command: test
       arguments: --no-restore --restore:false --no-build --framework $(TestTargetFramework) --binarylogger:"$(BinlogDirectory)02-RunTests.binlog"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
When you specify environment variables in a RunSettings file, I noticed this in the [docs](https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file?view=vs-2022#example):

> Because these environment variables should always be set when the test host is started, the tests should always run in a separate process. For this, the /InIsolation flag will be set when there are environment variables so that the test host is always invoked.

So this change sets the environment variable in the pipeline YAML instead which could improve our test run times.  Supposedly this can make tests run a little slower but I wonder if its also contributing to test runs hanging/timing out.  This mainly just removes a layer of complexity.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
