### PR TITLE
E2E Test: Fix solution folder name comparison

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsProjectBuildProperties.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using EnvDTE;
 using Microsoft;
@@ -64,7 +63,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 // This project system does not implement IVsBuildPropertyStorage, meaning
                 // this call will never return a value, even when the project file specifies
                 // a value for the property.
-                Debug.Fail("The project system does not implement IVsBuildPropertyStorage");
                 return null;
             }
 

--- a/test/TestExtensions/API.Test/VSSolutionHelper.cs
+++ b/test/TestExtensions/API.Test/VSSolutionHelper.cs
@@ -380,7 +380,7 @@ namespace API.Test
 
                 if (project != null)
                 {
-                    if (project.UniqueName.StartsWith(solutionFolderName, StringComparison.OrdinalIgnoreCase))
+                    if (project.Name.StartsWith(solutionFolderName, StringComparison.OrdinalIgnoreCase))
                     {
                         if (solutionFolderParts.Length == level + 1)
                         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

This fixes a good chunk of the E2E tests. 
Creating folders/subfolders and retrieving them was broken. 
This brings the failing down from 64 to 50

Run Group #1 - 41 to 37 failures
Run Group #2 - 23 to 13 failures

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
