### PR TITLE
CentralPackageVersion dictionary should be ignore case

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -141,7 +141,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return packageVersions
                 .Select(item => ToCentralPackageVersion(item.PackageId, item.Version))
                 .Distinct(CentralPackageVersionNameComparer.Default)
-                .ToDictionary(cpv => cpv.Name);
+                .ToDictionary(cpv => cpv.Name, StringComparer.OrdinalIgnoreCase);
         }
 
         private CentralPackageVersion ToCentralPackageVersion(string packageId, string version)

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -120,7 +120,7 @@ namespace NuGet.SolutionRestoreManager
                     centralPackageVersions = packageVersions
                         .Select(ToCentralPackageVersion)
                         .Distinct(CentralPackageVersionNameComparer.Default)
-                        .ToDictionary(cpv => cpv.Name);
+                        .ToDictionary(cpv => cpv.Name, StringComparer.OrdinalIgnoreCase);
                 }
 
                 if (targetFrameworkInfo.Items.TryGetValue(ProjectItems.PackageReference, out var packageReferences))

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -279,7 +279,7 @@ namespace NuGet.Build.Tasks.Console
         /// <returns>An <see cref="IEnumerable{CentralPackageVersion}" /> containing the package versions for the specified project.</returns>
         internal static Dictionary<string, CentralPackageVersion> GetCentralPackageVersions(IMSBuildProject project)
         {
-            var result = new Dictionary<string, CentralPackageVersion>();
+            var result = new Dictionary<string, CentralPackageVersion>(StringComparer.OrdinalIgnoreCase);
             IEnumerable<IMSBuildItem> packageVersionItems = GetDistinctItemsOrEmpty(project, "PackageVersion");
 
             foreach (var projectItemInstance in packageVersionItems)

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -2695,7 +2695,7 @@ namespace NuGet.SolutionRestoreManager.Test
         }
 
         [Fact]
-        public void ToPackageSpec_WithCPMAndPackageReferenceWithDifferentCasing_CombinesDataCorrect()
+        public void ToPackageSpec_WithCPMAndPackageReferenceWithDifferentCasing_CombinesCorrectly()
         {
             // Arrange
             ProjectNames projectName = new ProjectNames(@"f:\project\project.csproj", "project", "project.csproj", "projectC", Guid.NewGuid().ToString());

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -1950,7 +1950,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             result.Success.Should().BeTrue(because: result.AllOutput);
             projectA.AssetsFile.LogMessages.Should().HaveCount(0);
             projectA.AssetsFile.Targets[0].Libraries.Should().HaveCount(1);
-            projectA.AssetsFile.Targets[0].Libraries.Should().HaveCount(1);
             projectA.AssetsFile.Targets[0].Libraries[0].Name.Should().Be(packageX.Id);
         }
     }

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -1867,7 +1867,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task MsbuildRestore_WithMissingCPMVersions_RaisesNU1008(bool useStaticGraphRestore)
+        public async Task MsbuildRestore_WithPackageReferenceAndPackageVersion_RaisesNU1008(bool useStaticGraphRestore)
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
@@ -1878,7 +1878,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 
             SimpleTestProjectContext projectA = SimpleTestProjectContext.CreateNETCoreWithSDK("a", pathContext.SolutionRoot, FrameworkConstants.CommonFrameworks.Net472.GetShortFolderName());
 
-            // Since we're using CPM, add a PackageReference without a Version.
             projectA.AddPackageToAllFrameworks(new SimpleTestPackageContext()
             {
                 Id = packageX.Id,
@@ -1907,6 +1906,52 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             result.Success.Should().BeFalse(because: result.AllOutput);
             projectA.AssetsFile.LogMessages.Should().HaveCount(1);
             projectA.AssetsFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1008);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task MsbuildRestore_WithDifferentCasingInPackageReferenceAndPackageVersion_RestoresCorrectly(bool useStaticGraphRestore)
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            var packageX = new SimpleTestPackageContext("x", "1.0.0");
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageX);
+
+            SimpleTestProjectContext projectA = SimpleTestProjectContext.CreateNETCoreWithSDK("a", pathContext.SolutionRoot, FrameworkConstants.CommonFrameworks.Net472.GetShortFolderName());
+
+            projectA.AddPackageToAllFrameworks(new SimpleTestPackageContext()
+            {
+                Id = packageX.Id,
+                Version = null
+            });
+
+            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+            solution.Projects.Add(projectA);
+            solution.Create(pathContext.SolutionRoot);
+
+            var directoryPackagesProps = $@"<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include=""{packageX.Id.ToUpperInvariant()}"" Version=""{packageX.Version}"" />
+    </ItemGroup>
+</Project>";
+            var directoryPackagesPropsPath = Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props");
+            File.WriteAllText(directoryPackagesPropsPath, directoryPackagesProps);
+
+            // Act
+            CommandRunnerResult result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore /p:RestoreUseStaticGraphEvaluation={useStaticGraphRestore} {projectA.ProjectPath}", ignoreExitCode: true, testOutputHelper: _testOutputHelper);
+
+            // Assert
+            result.Success.Should().BeTrue(because: result.AllOutput);
+            projectA.AssetsFile.LogMessages.Should().HaveCount(0);
+            projectA.AssetsFile.Targets[0].Libraries.Should().HaveCount(1);
+            projectA.AssetsFile.Targets[0].Libraries.Should().HaveCount(1);
+            projectA.AssetsFile.Targets[0].Libraries[0].Name.Should().Be(packageX.Id);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/13871

## Description

https://github.com/NuGet/NuGet.Client/commit/15691b7351cf0aa2c0e7f613648fe46a3ccb18da regressed the merging of Central Package Version and PackageReference and unfortunately we didn't have proper testing.

This is blocking the current dev insertion

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
