### PR TITLE
VersionRangeConverter should treat empty string same as null

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Converters/VersionRangeConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/VersionRangeConverter.cs
@@ -29,7 +29,8 @@ namespace NuGet.Protocol
         /// <returns>A <see cref="VersionRange" /> object.</returns>
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            return reader.TokenType != JsonToken.Null ? VersionRange.Parse(serializer.Deserialize<string>(reader)) : null;
+            string value = serializer.Deserialize<string>(reader);
+            return !string.IsNullOrEmpty(value) ? VersionRange.Parse(value) : null;
         }
 
         /// <summary>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
@@ -315,7 +316,7 @@ namespace NuGet.Protocol.Tests
 
             var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
 
-            var package = new PackageIdentity("dependencyedgecases", NuGetVersion.Parse("0.0.0"));
+            var package = new PackageIdentity("dependencyedgecases", NuGetVersion.Parse("0.1.0"));
 
             // Act
             using (var sourceCacheContext = new SourceCacheContext())
@@ -323,7 +324,11 @@ namespace NuGet.Protocol.Tests
                 var result = await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
 
                 // Assert
-                Assert.NotNull(result);
+                result.Should().NotBeNull();
+                result.DependencySets.Should().HaveCount(1);
+                var dependencySets = result.DependencySets.ToList();
+                dependencySets[0].Packages.Should().HaveCount(3);
+                dependencySets[0].Packages.All(p => p.VersionRange == VersionRange.All).Should().BeTrue();
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
@@ -302,5 +302,29 @@ namespace NuGet.Protocol.Tests
                 Assert.Null(metadata);
             }
         }
+
+        [Fact]
+        public async Task PackageMetadataResourceV3_GetMetadataAsync_DependencyRangeNull()
+        {
+            // Arrange
+            var responses = new Dictionary<string, string>();
+            responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
+            responses.Add("https://api.nuget.org/v3/registration0/dependencyedgecases/index.json", JsonData.PackageDependencyWithNullAndEmptyRange);
+
+            var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
+
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
+
+            var package = new PackageIdentity("dependencyedgecases", NuGetVersion.Parse("0.0.0"));
+
+            // Act
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var result = await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
+
+                // Assert
+                Assert.NotNull(result);
+            }
+        }
     }
 }

--- a/test/TestUtilities/Test.Utility/JsonData.cs
+++ b/test/TestUtilities/Test.Utility/JsonData.cs
@@ -4879,7 +4879,7 @@ namespace Test.Utility
                             ""@type"": ""PackageDependency"",
                             ""id"": ""SampleDependency2"",
                             ""registration"": ""https://apidev.nugettest.org/v3-registration3-gz-semver2/sampledependency2/index.json""
-                        }
+                        },
                         {
                             ""@id"": ""https://api.nuget.org/v3/catalog0/data/2015.02.03.09.41.00/dependencyedgecases.0.1.0.json#dependencygroup/sampledependency"",
                             ""@type"": ""PackageDependency"",

--- a/test/TestUtilities/Test.Utility/JsonData.cs
+++ b/test/TestUtilities/Test.Utility/JsonData.cs
@@ -4833,5 +4833,136 @@ namespace Test.Utility
     ""version"": ""0.0.0""
 }";
         #endregion
+
+        #region Package with dependency with empty range
+        public const string PackageDependencyWithNullAndEmptyRange = @"{
+  ""@id"": ""https://api.nuget.org/v3/registration0/deepequal/index.json"",
+  ""@type"": [
+    ""catalog:CatalogRoot"",
+    ""PackageRegistration"",
+    ""catalog:Permalink""
+  ],
+  ""commitId"": ""9f98eb89-f078-4af9-bcaf-5e27b5f26b59"",
+  ""commitTimeStamp"": ""2015-03-27T00:11:46.2598338Z"",
+  ""count"": 1,
+  ""items"": [
+    {
+      ""@id"": ""https://api.nuget.org/v3/registration0/dependencyedgecases/index.json#page/0.1.0/1.4.0.1-rc"",
+      ""@type"": ""catalog:CatalogPage"",
+      ""commitId"": ""9f98eb89-f078-4af9-bcaf-5e27b5f26b59"",
+      ""commitTimeStamp"": ""2015-03-27T00:11:46.2598338Z"",
+      ""count"": 1,
+      ""items"": [
+        {
+          ""@id"": ""https://api.nuget.org/v3/registration0/dependencyedgecases/0.1.0.json"",
+          ""@type"": ""Package"",
+          ""commitId"": ""1361eaec-6572-4f85-8c5e-af3bb6be1b35"",
+          ""commitTimeStamp"": ""2015-02-03T19:51:09.2502454Z"",
+          ""catalogEntry"": {
+            ""@id"": ""https://api.nuget.org/v3/catalog0/data/2015.02.03.09.41.00/dependencyedgecases.0.1.0.json"",
+            ""@type"": ""PackageDetails"",
+            ""authors"": ""James Foster"",
+            ""dependencyGroups"": [
+                {
+                    ""@id"": ""https://api.nuget.org/v3/catalog0/data/2015.02.03.09.41.00/dependencyedgecases.0.1.0.json#dependencygroup"",
+                    ""@type"": ""PackageDependencyGroup"",
+                    ""dependencies"": [
+                        {
+                            ""@id"": ""https://api.nuget.org/v3/catalog0/data/2015.02.03.09.41.00/dependencyedgecases.0.1.0.json#dependencygroup/sampledependency"",
+                            ""@type"": ""PackageDependency"",
+                            ""id"": ""SampleDependency1"",
+                            ""range"": """",
+                            ""registration"": ""https://apidev.nugettest.org/v3-registration3-gz-semver2/sampledependency1/index.json""
+                        },
+                        {
+                            ""@id"": ""https://api.nuget.org/v3/catalog0/data/2015.02.03.09.41.00/dependencyedgecases.0.1.0.json#dependencygroup/sampledependency"",
+                            ""@type"": ""PackageDependency"",
+                            ""id"": ""SampleDependency2"",
+                            ""registration"": ""https://apidev.nugettest.org/v3-registration3-gz-semver2/sampledependency2/index.json""
+                        }
+                        {
+                            ""@id"": ""https://api.nuget.org/v3/catalog0/data/2015.02.03.09.41.00/dependencyedgecases.0.1.0.json#dependencygroup/sampledependency"",
+                            ""@type"": ""PackageDependency"",
+                            ""id"": ""SampleDependency3"",
+                            ""range"": null,
+                            ""registration"": ""https://apidev.nugettest.org/v3-registration3-gz-semver2/sampledependency3/index.json""
+                        }
+                    ]
+                }
+            ],
+            ""description"": ""A package that tests dependency range edge cases"",
+            ""iconUrl"": """",
+            ""id"": ""DependencyEdgeCases"",
+            ""language"": """",
+            ""licenseUrl"": """",
+            ""minClientVersion"": """",
+            ""projectUrl"": ""http://git.test/DependencyEdgeCases"",
+            ""published"": ""2013-05-20T09:03:13.56Z"",
+            ""requireLicenseAcceptance"": false,
+            ""summary"": """",
+            ""tags"": [
+            ],
+            ""title"": ""DependencyEdgeCases"",
+            ""version"": ""0.1.0""
+          },
+          ""packageContent"": ""https://api.nuget.org/packages/dependencyedgecases.0.1.0.nupkg"",
+          ""registration"": ""https://api.nuget.org/v3/registration0/dependencyedgecases/index.json""
+        }
+      ],
+      ""parent"": ""https://api.nuget.org/v3/registration0/dependencyedgecases/index.json"",
+      ""lower"": ""0.1.0"",
+      ""upper"": ""0.1.0""
+    }
+  ],
+  ""@context"": {
+    ""@vocab"": ""http://schema.nuget.org/schema#"",
+    ""catalog"": ""http://schema.nuget.org/catalog#"",
+    ""xsd"": ""http://www.w3.org/2001/XMLSchema#"",
+    ""items"": {
+      ""@id"": ""catalog:item"",
+      ""@container"": ""@set""
+    },
+    ""commitTimeStamp"": {
+      ""@id"": ""catalog:commitTimeStamp"",
+      ""@type"": ""xsd:dateTime""
+    },
+    ""commitId"": {
+      ""@id"": ""catalog:commitId""
+    },
+    ""count"": {
+      ""@id"": ""catalog:count""
+    },
+    ""parent"": {
+      ""@id"": ""catalog:parent"",
+      ""@type"": ""@id""
+    },
+    ""tags"": {
+      ""@container"": ""@set"",
+      ""@id"": ""tag""
+    },
+    ""packageTargetFrameworks"": {
+      ""@container"": ""@set"",
+      ""@id"": ""packageTargetFramework""
+    },
+    ""dependencyGroups"": {
+      ""@container"": ""@set"",
+      ""@id"": ""dependencyGroup""
+    },
+    ""dependencies"": {
+      ""@container"": ""@set"",
+      ""@id"": ""dependency""
+    },
+    ""packageContent"": {
+      ""@type"": ""@id""
+    },
+    ""published"": {
+      ""@type"": ""xsd:dateTime""
+    },
+    ""registration"": {
+      ""@type"": ""@id""
+    }
+  }
+}";
+        #endregion
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13869

## Description

As pointed out by https://github.com/NuGet/Home/issues/13869#issuecomment-2427966443, prior to https://github.com/NuGet/NuGet.Client/pull/5872, deserializating v3 protocol registration (package metadata) pages would check dependency version ranges for both null and empty strings. After the PR, it only handles null, but not empty strings. Therefore, this PR changes it to treat empty strings the same as null.

This PR modifies `VersionRangeConverter`, which affects all NuGet.Protocol payloads with a `VersionRange` property (that is deserialized with Newtonsoft.Json).

If the team prefers, we can create a new converter and put the appropriate attribute on the PackageDepdency VersionRange property, so that it only affects this one property, nothing else.

However, this converter is in NuGet.Protocol, and therefore is not intended to be a general use VersionRange converter, only a converter in the context of NuGet server-client communication.  In this context, it's sensible to always treat empty version range strings as nulls, because if a feed does it in one place, you might as well assume that it's going to do it in other places as well.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
