### PR TITLE
New dependency resolver: Handle preferring project over package correctly

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -293,8 +293,8 @@ namespace NuGet.Commands
                         {
 
                             //if (chosenRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package) && currentRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
-//                            if (chosenRef.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package && currentRef.LibraryRange.TypeConstraint == LibraryDependencyTarget.PackageProjectExternal)
-                            if(true)
+                            //                            if (chosenRef.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package && currentRef.LibraryRange.TypeConstraint == LibraryDependencyTarget.PackageProjectExternal)
+                            if (true)
                             {
                                 bool isParentCentrallyPinned = false;
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -292,8 +292,9 @@ namespace NuGet.Commands
                         if (evictOnTypeConstraint || !RemoteDependencyWalker.IsGreaterThanOrEqualTo(ovr, nvr))
                         {
 
-                            if (chosenRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package) && currentRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
+                            //if (chosenRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package) && currentRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
 //                            if (chosenRef.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package && currentRef.LibraryRange.TypeConstraint == LibraryDependencyTarget.PackageProjectExternal)
+                            if(true)
                             {
                                 bool isParentCentrallyPinned = false;
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -292,8 +292,8 @@ namespace NuGet.Commands
                         if (evictOnTypeConstraint || !RemoteDependencyWalker.IsGreaterThanOrEqualTo(ovr, nvr))
                         {
 
-                            //if (chosenRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package) && currentRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
-                            if (chosenRef.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package && currentRef.LibraryRange.TypeConstraint == LibraryDependencyTarget.PackageProjectExternal)
+                            if (chosenRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package) && currentRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
+//                            if (chosenRef.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package && currentRef.LibraryRange.TypeConstraint == LibraryDependencyTarget.PackageProjectExternal)
                             {
                                 bool isParentCentrallyPinned = false;
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -291,7 +291,9 @@ namespace NuGet.Commands
 
                         if (evictOnTypeConstraint || !RemoteDependencyWalker.IsGreaterThanOrEqualTo(ovr, nvr))
                         {
-                            if (chosenRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package) && currentRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
+
+                            //if (chosenRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package) && currentRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
+                            if (chosenRef.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package && currentRef.LibraryRange.TypeConstraint == LibraryDependencyTarget.PackageProjectExternal)
                             {
                                 bool isParentCentrallyPinned = false;
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -307,73 +307,76 @@ namespace NuGet.Commands
 
                         if (evictOnTypeConstraint || !RemoteDependencyWalker.IsGreaterThanOrEqualTo(ovr, nvr))
                         {
-                            bool isParentCentrallyPinned = false;
-
-                            if (isCentralPackageTransitivePinningEnabled && importRefItem.Path.Length > 1)
+                            if (chosenRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package) && currentRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
                             {
-                                for (int pathIndex = importRefItem.Path.Length - 1; pathIndex > 0; pathIndex--)
+                                bool isParentCentrallyPinned = false;
+
+                                if (isCentralPackageTransitivePinningEnabled && importRefItem.Path.Length > 1)
                                 {
-                                    LibraryRangeIndex parentLibraryRangeIndex = importRefItem.Path[pathIndex];
-
-                                    if (findLibraryEntryCache.TryGetValue(parentLibraryRangeIndex, out Task<FindLibraryEntryResult>? parentCacheEntryTask))
+                                    for (int pathIndex = importRefItem.Path.Length - 1; pathIndex > 0; pathIndex--)
                                     {
-                                        FindLibraryEntryResult result = await parentCacheEntryTask;
+                                        LibraryRangeIndex parentLibraryRangeIndex = importRefItem.Path[pathIndex];
 
-                                        if (chosenResolvedItems.TryGetValue(result.DependencyIndex, out var parentChosenResolvedItem))
+                                        if (findLibraryEntryCache.TryGetValue(parentLibraryRangeIndex, out Task<FindLibraryEntryResult>? parentCacheEntryTask))
                                         {
-                                            isParentCentrallyPinned = parentChosenResolvedItem.IsCentrallyPinnedTransitivePackage;
+                                            FindLibraryEntryResult result = await parentCacheEntryTask;
 
-                                            if (isParentCentrallyPinned)
+                                            if (chosenResolvedItems.TryGetValue(result.DependencyIndex, out var parentChosenResolvedItem))
                                             {
-                                                break;
+                                                isParentCentrallyPinned = parentChosenResolvedItem.IsCentrallyPinnedTransitivePackage;
+
+                                                if (isParentCentrallyPinned)
+                                                {
+                                                    break;
+                                                }
                                             }
                                         }
                                     }
                                 }
-                            }
 
-                            if (!isParentCentrallyPinned)
-                            {
-                                if (chosenResolvedItem.Parents != null)
+                                if (!isParentCentrallyPinned)
                                 {
-                                    bool atLeastOneCommonAncestor = false;
-
-                                    foreach (LibraryRangeIndex parentRangeIndex in chosenResolvedItem.Parents.NoAllocEnumerate())
+                                    if (chosenResolvedItem.Parents != null)
                                     {
-                                        if (importRefItem.Path.Length > 2 && importRefItem.Path[importRefItem.Path.Length - 2] == parentRangeIndex)
+                                        bool atLeastOneCommonAncestor = false;
+
+                                        foreach (LibraryRangeIndex parentRangeIndex in chosenResolvedItem.Parents.NoAllocEnumerate())
                                         {
-                                            atLeastOneCommonAncestor = true;
-                                            break;
+                                            if (importRefItem.Path.Length > 2 && importRefItem.Path[importRefItem.Path.Length - 2] == parentRangeIndex)
+                                            {
+                                                atLeastOneCommonAncestor = true;
+                                                break;
+                                            }
+                                        }
+
+                                        if (atLeastOneCommonAncestor)
+                                        {
+                                            continue;
                                         }
                                     }
 
-                                    if (atLeastOneCommonAncestor)
+                                    if (HasCommonAncestor(chosenResolvedItem.Path, importRefItem.Path))
                                     {
                                         continue;
                                     }
-                                }
 
-                                if (HasCommonAncestor(chosenResolvedItem.Path, importRefItem.Path))
-                                {
-                                    continue;
-                                }
-
-                                if (chosenResolvedItem.ParentPathsThatHaveBeenEclipsed != null)
-                                {
-                                    bool hasAlreadyBeenEclipsed = false;
-
-                                    foreach (LibraryRangeIndex parentRangeIndex in chosenResolvedItem.ParentPathsThatHaveBeenEclipsed)
+                                    if (chosenResolvedItem.ParentPathsThatHaveBeenEclipsed != null)
                                     {
-                                        if (importRefItem.Path.Contains(parentRangeIndex))
+                                        bool hasAlreadyBeenEclipsed = false;
+
+                                        foreach (LibraryRangeIndex parentRangeIndex in chosenResolvedItem.ParentPathsThatHaveBeenEclipsed)
                                         {
-                                            hasAlreadyBeenEclipsed = true;
-                                            break;
+                                            if (importRefItem.Path.Contains(parentRangeIndex))
+                                            {
+                                                hasAlreadyBeenEclipsed = true;
+                                                break;
+                                            }
                                         }
-                                    }
 
-                                    if (hasAlreadyBeenEclipsed)
-                                    {
-                                        continue;
+                                        if (hasAlreadyBeenEclipsed)
+                                        {
+                                            continue;
+                                        }
                                     }
                                 }
                             }

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -1712,12 +1712,14 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.PackageSpec.RestoreMetadata.CentralPackageTransitivePinningEnabled.Should().BeFalse();
             result.LockFile.Targets.Should().HaveCount(1);
             result.LockFile.Targets[0].Libraries.Should().HaveCount(5);
-            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageB");
-            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.5.187"));
-            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("ProjectAndPackage");
-            result.LockFile.Targets[0].Libraries[2].Type.Should().Be("project");
-            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("Project3");
-            result.LockFile.Targets[0].Libraries[4].Name.Should().Be("Project4");
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("packageB");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.5.187"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project3");
+            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("Project4");
+            result.LockFile.Targets[0].Libraries[4].Name.Should().Be("ProjectAndPackage");
+            result.LockFile.Targets[0].Libraries[4].Type.Should().Be("project");
+
         }
 
         // Here's why package driven dependencies should flow.

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -1621,11 +1621,11 @@ namespace NuGet.Commands.FuncTest
             using var pathContext = new SimpleTestPathContext();
 
             // Setup packages
-            var packageA = new SimpleTestPackageContext("Microsoft.VisualStudio.Copilot.UI.Apex", "17.13.37-alpha")
+            var packageA = new SimpleTestPackageContext("packageA", "17.13.37-alpha")
             {
-                Dependencies = [new SimpleTestPackageContext("MessagePack", "2.5.168"), new SimpleTestPackageContext("Project2", "17.5.33530.100")]
+                Dependencies = [new SimpleTestPackageContext("packageB", "2.5.168"), new SimpleTestPackageContext("ProjectAndPackage", "17.5.33530.100")]
             };
-            var packageB = new SimpleTestPackageContext("MessagePack", "2.5.187");
+            var packageB = new SimpleTestPackageContext("packageB", "2.5.187");
 
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(
                 pathContext.PackageSource,
@@ -1634,72 +1634,72 @@ namespace NuGet.Commands.FuncTest
                 packageB);
 
             var rootProject = @"
-                {
-                    ""restore"": {
-                                    ""centralPackageVersionsManagementEnabled"": true,
-                    },
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                                ""Microsoft.VisualStudio.Copilot.UI.Apex"": {
-                                    ""version"": ""[17.13.37-alpha,)"",
-                                    ""target"": ""Package"",
-                                    ""versionCentrallyManaged"": true
-                                },
+        {
+            ""restore"": {
+                            ""centralPackageVersionsManagementEnabled"": true,
+            },
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[17.13.37-alpha,)"",
+                            ""target"": ""Package"",
+                            ""versionCentrallyManaged"": true
                         },
-                        ""centralPackageVersions"": {
-                            ""Microsoft.VisualStudio.Copilot.UI.Apex"": ""[17.13.37-alpha,)"",
-                            ""MessagePack"": ""[2.5.187,)""
-                        }
-                    }
-                  }
-                }";
+                },
+                ""centralPackageVersions"": {
+                    ""packageA"": ""[17.13.37-alpha,)"",
+                    ""packageB"": ""[2.5.187,)""
+                }
+            }
+          }
+        }";
 
             var baseEmptyProject = @"
-                {
-                    ""restore"": {
-                                    ""centralPackageVersionsManagementEnabled"": true,
-                                    ""CentralPackageTransitivePinningEnabled"": true,
-                    },
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                        },
-                        ""centralPackageVersions"": {
-                            ""Microsoft.VisualStudio.Copilot.UI.Apex"": ""[17.13.37-alpha,)"",
-                            ""MessagePack"": ""[2.5.187,)""
-                        }
-                    }
-                  }
-                }";
+        {
+            ""restore"": {
+                            ""centralPackageVersionsManagementEnabled"": true,
+                            ""CentralPackageTransitivePinningEnabled"": true,
+            },
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                },
+                ""centralPackageVersions"": {
+                    ""packageA"": ""[17.13.37-alpha,)"",
+                    ""packageB"": ""[2.5.187,)""
+                }
+            }
+          }
+        }";
 
             var leafProject = @"
-                {
-                    ""version"": ""17.13.35421.60"",
-                    ""restore"": {
-                                    ""centralPackageVersionsManagementEnabled"": true,
-                                    ""CentralPackageTransitivePinningEnabled"": true,
-                    },
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                                ""MessagePack"": {
-                                    ""version"": ""[2.5.187,)"",
-                                    ""target"": ""Package"",
-                                    ""versionCentrallyManaged"": true
-                                },
+        {
+            ""version"": ""17.13.35421.60"",
+            ""restore"": {
+                            ""centralPackageVersionsManagementEnabled"": true,
+                            ""CentralPackageTransitivePinningEnabled"": true,
+            },
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageB"": {
+                            ""version"": ""[2.5.187,)"",
+                            ""target"": ""Package"",
+                            ""versionCentrallyManaged"": true
                         },
-                        ""centralPackageVersions"": {
-                            ""Microsoft.VisualStudio.Copilot.UI.Apex"": ""[17.13.37-alpha,)"",
-                            ""MessagePack"": ""[2.5.187,)""
-                        }
-                    }
-                  }
-                }";
+                },
+                ""centralPackageVersions"": {
+                    ""packageA"": ""[17.13.37-alpha,)"",
+                    ""packageB"": ""[2.5.187,)""
+                }
+            }
+          }
+        }";
 
             // Setup project
             var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
-            var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, baseEmptyProject);
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("ProjectAndPackage", pathContext.SolutionRoot, baseEmptyProject);
             var projectSpec3 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project3", pathContext.SolutionRoot, baseEmptyProject);
             var projectSpec4 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project4", pathContext.SolutionRoot, leafProject);
             projectSpec3 = projectSpec3.WithTestProjectReference(projectSpec4);
@@ -1712,9 +1712,9 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.PackageSpec.RestoreMetadata.CentralPackageTransitivePinningEnabled.Should().BeFalse();
             result.LockFile.Targets.Should().HaveCount(1);
             result.LockFile.Targets[0].Libraries.Should().HaveCount(5);
-            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("MessagePack");
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageB");
             result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.5.187"));
-            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("ProjectAndPackage");
             result.LockFile.Targets[0].Libraries[2].Type.Should().Be("project");
             result.LockFile.Targets[0].Libraries[3].Name.Should().Be("Project3");
             result.LockFile.Targets[0].Libraries[4].Name.Should().Be("Project4");


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13888

## Description

Take the following setup:

```
        // Project1 -> (project) ProjectAndPackage 1.0.0 -> Project3 -> Project4 -> PackageB 2.0.0
        //                -> packageA 1.0.0 -> PackageB 1.0.0
        //                                              -> ProjectAndPackage 2.0.0
```

The old algorithm would choose packageB 2.0.0, but the new one chose PackageB 1.0.0.

Follow-up https://github.com/NuGet/Home/issues/13889

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. - https://github.com/NuGet/Home/issues/13890
