### PR TITLE
Tweak test run settings and skip a test

### DIFF
--- a/build/xunit.runsettings
+++ b/build/xunit.runsettings
@@ -10,7 +10,7 @@
 
       The number of distinct DLLs in the run determines the actual number of testhosts started.
     -->
-    <MaxCpuCount>4</MaxCpuCount>
+    <MaxCpuCount>0</MaxCpuCount>
 
     <!-- Specify a Boolean value, which defines the exit code when no tests are discovered. If the value is true and no tests are discovered, a nonzero exit code is returned. Otherwise, zero is returned. -->
     <TreatNoTestsAsError>true</TreatNoTestsAsError>
@@ -22,18 +22,37 @@
     <DiagnosticMessages>true</DiagnosticMessages>
 
     <!-- Set this value to enable long-running (hung) test detection. When the runner is idle waiting for tests to finished, it will report that fact once the timeout has passed. Use a value of 0 to disable the feature, or a positive integer value to enable the feature (time in seconds). -->
-    <LongRunningTestSeconds>120</LongRunningTestSeconds>
+    <LongRunningTestSeconds>90</LongRunningTestSeconds>
 
     <!-- Set this to override the maximum number of threads to be used when parallelizing tests within this assembly. Use a value of 0 or "default" to indicate that you would like the default behavior; use a value of -1 or "unlimited" to indicate that you do not wish to limit the number of threads used for parallelization. -->
-    <MaxParallelThreads>4</MaxParallelThreads>
+    <MaxParallelThreads>0</MaxParallelThreads>
 
     <!-- Set this to true if this assembly is willing to participate in parallelization with other assemblies. Test runners can use this information to automatically enable parallelization across assemblies if all the assemblies agree to it. -->
-    <ParallelizeAssembly>false</ParallelizeAssembly>
+    <ParallelizeAssembly>true</ParallelizeAssembly>
 
     <!-- Set this to true if the assembly is willing to run tests inside this assembly in parallel against each other. Tests in the same test collection will be run sequentially against each other, but tests in different test collections will be run in parallel against each other. Set this to false to disable all parallelization within this test assembly. -->
-    <ParallelizeTestCollections>false</ParallelizeTestCollections>
+    <ParallelizeTestCollections>true</ParallelizeTestCollections>
 
     <!-- Set this to true to use shadow copying when running tests in separate App Domains; set to false to run tests without shadow copying. When running tests without App Domains, this value is ignored. -->
     <ShadowCopy>false</ShadowCopy>
   </xUnit>
+
+  <LoggerRunSettings>
+    <Loggers>
+      <Logger friendlyName="blame" enabled="True" />
+    </Loggers>
+  </LoggerRunSettings>
+
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <!-- Enables blame -->
+      <DataCollector friendlyName="blame" enabled="True">
+        <Configuration>
+          <!-- Enables hang dump or testhost and its child processes when a test hangs for more than 5 minutes. Dump type "Full", "Mini" or "None" (just kill the processes). -->
+          <CollectDumpOnTestSessionHang TestTimeout="5min" HangDumpType="Mini" />
+          <ResultsDirectory>%BINLOGDIRECTORY%</ResultsDirectory>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
 </RunSettings>

--- a/build/xunit.runsettings
+++ b/build/xunit.runsettings
@@ -50,7 +50,6 @@
         <Configuration>
           <!-- Enables hang dump or testhost and its child processes when a test hangs for more than 5 minutes. Dump type "Full", "Mini" or "None" (just kill the processes). -->
           <CollectDumpOnTestSessionHang TestTimeout="5min" HangDumpType="Mini" />
-          <ResultsDirectory>%BINLOGDIRECTORY%</ResultsDirectory>
         </Configuration>
       </DataCollector>
     </DataCollectors>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -172,7 +172,7 @@ namespace NuGet.XPlat.FuncTest
                 });
         }
 
-        [PlatformFact(Platform.Windows)]
+        [PlatformFact(Platform.Windows, Skip="https://github.com/NuGet/Home/issues/13874")]
         public async Task ListPackage_WithPrivateHttpSourceCredentialServiceIsInvokedAsNeeded_Succeeds()
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -172,7 +172,7 @@ namespace NuGet.XPlat.FuncTest
                 });
         }
 
-        [PlatformFact(Platform.Windows, Skip="https://github.com/NuGet/Home/issues/13874")]
+        [PlatformFact(Platform.Windows, Skip = "https://github.com/NuGet/Home/issues/13874")]
         public async Task ListPackage_WithPrivateHttpSourceCredentialServiceIsInvokedAsNeeded_Succeeds()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Related: https://github.com/NuGet/Home/issues/13874

## Description
I've been looking into test hangs and have finally found some success with the blame hang detector.  It was able to report a hung test and attach a minidump.  It found that `ListPackage_WithPrivateHttpSourceCredentialServiceIsInvokedAsNeeded_Succeeds` was hung.  This pull request skips that test for now.

I also tweaked the parallelization settings to the max to see if tests run faster.  Early results seem promising but not huge.  Now that some tests run by themselves, I would imagine it could help overall.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
