### PR TITLE
Make CLI parser public for dotnet nuget why

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommand.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.CommandLineUtils;
 
 namespace NuGet.CommandLine.XPlat.Commands.Why
 {
-    internal static class WhyCommand
+    public static class WhyCommand
     {
         internal static void Register(CommandLineApplication app)
         {
@@ -23,6 +23,16 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         internal static void Register(CliCommand rootCommand, Func<ILoggerWithColor> getLogger)
         {
             Register(rootCommand, getLogger, WhyCommandRunner.ExecuteCommand);
+        }
+
+        /// <summary>
+        /// This is a temporary API until NuGet migrates all our commands to System.CommandLine, at which time I suspect we'll have a NuGetParser.GetNuGetCommand for all the `dotnet nuget *` commands.
+        /// For now, this allows the dotnet CLI to invoke why directly, instead of running NuGet.CommandLine.XPlat as a child process.
+        /// </summary>
+        /// <param name="rootCommand">The <c>dotnet nuget</c> command handler, to add <c>why</c> to.</param>
+        public static void GetWhyCommand(CliCommand rootCommand)
+        {
+            Register(rootCommand, CommandOutputLogger.Create, WhyCommandRunner.ExecuteCommand);
         }
 
         internal static void Register(CliCommand rootCommand, Func<ILoggerWithColor> getLogger, Func<WhyCommandArgs, int> action)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+NuGet.CommandLine.XPlat.Commands.Why.WhyCommand
+static NuGet.CommandLine.XPlat.Commands.Why.WhyCommand.GetWhyCommand(System.CommandLine.CliCommand rootCommand) -> void

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/CommandOutputLogger.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/CommandOutputLogger.cs
@@ -19,6 +19,17 @@ namespace NuGet.CommandLine.XPlat
             VerbosityLevel = logLevel;
         }
 
+        /// <summary>
+        /// Create a CommandOutputLogger for commands invoked by the .NET CLI
+        /// </summary>
+        /// <returns></returns>
+        public static CommandOutputLogger Create()
+        {
+            var logger = new CommandOutputLogger(LogLevel.Information);
+            logger.HidePrefixForInfoAndMinimal = true;
+            return logger;
+        }
+
         public override void LogDebug(string data)
         {
             LogInternal(LogLevel.Debug, data);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: engineering issue

## Description

Running `dotnet nuget why` without a directory, solution, or project file reports an error saying that a required argument is missing:
![image](https://github.com/user-attachments/assets/cdca0386-1511-4cc3-9764-7856c9ee0ccd)

But you'll notice that the command ran anyway.

The reason is that the dotnet/sdk repo has a duplicate set of CLI parser definitions to enable tab-completion. There was previously a bug, which required the target to be supplied, but https://github.com/NuGet/NuGet.Client/pull/5969 fixed it by making it implicit. However, the dotnet/sdk's duplicate definition was not updated to contain the same change.

Since `dotnet nuget why` is using System.CommandLine, rather than duplicating the same change in the second repo, I intend on making dotnet/sdk use the new public API introduced by this PR, so that NuGet.Client will be a single source of truth for how to parse `dotnet nuget why`. It will also mean that why will run in the dotnet CLI's process, rather than the NuGet.CommandLine.XPlat child process.  But this is our long term plan with migrating to System.CommandLine anyway. 

So, this is step 1, create a public API that the dotnet CLI can call.  Once this change has been inserted in the dotnet/sdk repo, I can create a PR there to delete their WhyCommandParser and call this instead.

## Alternative

I investigated moving the logic of invoking NuGet.CommandLine.XPlat as a child process into NuGet.Client, and also all the NuGetCommandParser definitions from the dotnet/sdk repo here. However, it was looking to be a lot of work, and I want to get this CX bug fixed more quickly.

If the team feels strongly that we shouldn't create the "temporary" public API, I can focus more effort on this.

I did however create https://github.com/NuGet/NuGet.Client/pull/6117 as a first step towards making it easier to move all that dotnet/sdk code into NuGet.Client. Whether or not that PR gets accepted has a big impact on how to implement the rest of the move of `dotnet nuget` parser out of the dotnet/sdk repo and into here.


## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~ (no product changes, it's more of a refactoring change)
- [x] ~Added tests~ it will be covered by the existing Dotnet.Integration.Tests once the change is commit in the dotnet/sdk repo.
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ no customer facing changes.
