### PR TITLE
Expand Locale parser to support three-character language codes

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs
@@ -171,6 +171,8 @@ namespace NuGet.Client
                 }
             }
 
+            // We use a heuristic here for common locale codes. Locale codes are often
+            // * two characters for the language: en, es, fr, de
             if (name.Length == 2)
             {
                 if (matchOnly)
@@ -179,7 +181,9 @@ namespace NuGet.Client
                 }
                 return name.ToString();
             }
-            else if (name.Length >= 4 && name.Span[2] == '-')
+
+            // * a language portion that is two or three characters followed by a '-' and a country code
+            else if (name.Length >= 4 && name.Span[2] == '-') // e.g. en-US
             {
                 if (matchOnly)
                 {
@@ -187,6 +191,15 @@ namespace NuGet.Client
                 }
                 return name.ToString();
             }
+            else if (name.Length >= 5 && name.Span[3] == '-') // e.g agq-CM
+            {
+                return name;
+            }
+
+            // there are other variations, but this heuristic doesn't cover them all. A future-proof implementation would make
+            // use of the .NET CultureInfo APIs to compare the locale against the underlying system ICU database. This would
+            // be correct, but potentially more expensive because the CultureInfo APIs are lazily-loaded and throw if an
+            // invalid/unknown locale is used.
 
             return null;
         }

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs
@@ -198,7 +198,7 @@ namespace NuGet.Client
                 {
                     return string.Empty;
                 }
-                return name;
+                return name.ToString();
             }
 
             // there are other variations, but this heuristic doesn't cover them all. A future-proof implementation would make

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs
@@ -160,7 +160,7 @@ namespace NuGet.Client
         /// If matchOnly is true, then an empty string may be returned as a performance optimization.
         /// If matchOnly is false, the parsed result will be returned.
         /// </summary>
-        private static object Locale_Parser(ReadOnlyMemory<char> name, PatternTable table, bool matchOnly)
+        internal static object Locale_Parser(ReadOnlyMemory<char> name, PatternTable table, bool matchOnly)
         {
             if (table != null)
             {
@@ -173,7 +173,8 @@ namespace NuGet.Client
 
             // We use a heuristic here for common locale codes. Locale codes are often
             // * two characters for the language: en, es, fr, de
-            if (name.Length == 2)
+            // * three characters for the language: agq
+            if (name.Length == 2 || name.Length == 3)
             {
                 if (matchOnly)
                 {
@@ -193,6 +194,10 @@ namespace NuGet.Client
             }
             else if (name.Length >= 5 && name.Span[3] == '-') // e.g agq-CM
             {
+                if (matchOnly)
+                {
+                    return string.Empty;
+                }
                 return name;
             }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ContentModelTests/ContentModelResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ContentModelTests/ContentModelResourceTests.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Xunit;
+
+namespace NuGet.Client.Test
+{
+    public class ContentModelResourceTests
+    {
+        [MemberData(nameof(AllCultures))]
+        [Theory]
+        public void CanParseEverySystemKnownCultureResource(CultureInfo culture)
+        {
+            var result = ManagedCodeConventions.Locale_Parser(culture.Name.AsMemory(), null, false);
+            Assert.Equal(culture.Name, result as string);
+        }
+
+        public static IEnumerable<object[]> AllCultures()
+        {
+            return CultureInfo.GetCultures(CultureTypes.AllCultures).Where(c => !string.IsNullOrEmpty(c.Name)).Select(culture => new[] { culture });
+        }
+    }
+}
+


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/12253

## Description

Per https://github.com/NuGet/Home/issues/12253#issuecomment-2442827723, I found that all cultures known to .NET on my Windows and Linux hosts used 2 or 3-character language codes, so I expanded the heuristic in the `Locale_Parser` to this to enable handling of resources for these locales in .NET packages. I also added comments explaining _why_ these decisions were made and a note about future fully-correct implementations if those become required.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests - I would appreciate some pointers where to add tests for this
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
