### PR TITLE
Disable manual GitHub status for PrivateDev

### DIFF
--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -54,6 +54,7 @@ variables:
   NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY: 3,1000
   Codeql.Enabled: false
   Codeql.TSAEnabled: false
+  ManualGitHubChecks: false
   RunBuildForPublishing: ${{ parameters.RunBuildForPublishing }}
   RunCrossFrameworkTestsOnWindows: ${{ parameters.RunCrossFrameworkTestsOnWindows }}
   RunUnitTestsOnWindows: ${{ parameters.RunUnitTestsOnWindows }}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
Since making the PrivateDev pipeline trigger for pull requests, the manual GitHub status isn't needed.  The pipeline reports itself now.

Once this is merged, we should remove the required checks `Build_and_UnitTest_NonRTM` and `Build_and_UnitTest_RTM`, but add `NuGet.Client-PrivateDev`.

![image](https://github.com/user-attachments/assets/c3788b40-317e-4393-8ffa-c5b21f4dbc3c)


## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
