### PR TITLE
Remove line under Tabs in Details Pane and newline in text when there's no README

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -2081,9 +2081,7 @@ namespace NuGet.PackageManagement.UI {
         /// <summary>
         ///   Looks up a localized string similar to Could not read package README from selected package.
         ///
-        ///Only the package maintainer can add a README.
-        ///
-        ///If you are not the maintainer, please consider filing an issue or contacting the maintainer to request a README.
+        ///Only the package maintainer can add a README. If you are not the maintainer, please consider filing an issue or contacting the maintainer to request a README.
         ///
         ///For instructions on how to add a README, please visit [aka.ms/nuget/readme](https://aka.ms/nuget/readme).
         /// </summary>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1088,9 +1088,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Text_NoReadme" xml:space="preserve">
     <value>Could not read package README from selected package.
 
-Only the package maintainer can add a README.
-
-If you are not the maintainer, please consider filing an issue or contacting the maintainer to request a README.
+Only the package maintainer can add a README. If you are not the maintainer, please consider filing an issue or contacting the maintainer to request a README.
 
 For instructions on how to add a README, please visit [aka.ms/nuget/readme](https://aka.ms/nuget/readme)</value>
     <comment>{Locked="[aka.ms/nuget/readme](https://aka.ms/nuget/readme)"} "[aka.ms/nuget/readme](https://aka.ms/nuget/readme)" this is a URL link and should not be translated</comment>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml
@@ -97,7 +97,7 @@
                   <RowDefinition x:Name="RowDefinition1" Height="Auto"/>
                   <RowDefinition x:Name="RowDefinition2"/>
                 </Grid.RowDefinitions>
-                <TabPanel x:Name="headerPanel" Background="Transparent" Grid.Column="0" IsItemsHost="true" Margin="0,0,0,-1" Grid.Row="0" KeyboardNavigation.TabIndex="1" Panel.ZIndex="1"/>
+                <TabPanel x:Name="headerPanel" Background="Transparent" Grid.Column="0" IsItemsHost="true" Grid.Row="0" KeyboardNavigation.TabIndex="1" Panel.ZIndex="1"/>
                 <ContentPresenter
                     Grid.Row="2"
                     ClipToBounds="True"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml
@@ -98,14 +98,6 @@
                   <RowDefinition x:Name="RowDefinition2"/>
                 </Grid.RowDefinitions>
                 <TabPanel x:Name="headerPanel" Background="Transparent" Grid.Column="0" IsItemsHost="true" Margin="0,0,0,-1" Grid.Row="0" KeyboardNavigation.TabIndex="1" Panel.ZIndex="1"/>
-                <Rectangle
-                    x:Name="gridBorder"
-                    Grid.Row="1"
-                    Height="1"
-                    Panel.ZIndex="-1"
-                    Margin="0,1,0,0"
-                    HorizontalAlignment="Stretch"
-                    Fill="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"/>
                 <ContentPresenter
                     Grid.Row="2"
                     ClipToBounds="True"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/13880

## Description

- Before & After: Removed a new line between two sentences in the text when a package does not have a README.
![image](https://github.com/user-attachments/assets/fbe7d5a5-8a97-4948-88d3-09942f39ccf3)

- Before: horizontal rule under Tab panel
![image](https://github.com/user-attachments/assets/5997df4a-18ec-42f0-b7a8-d04c2186c298)

 After: no horizontal rule under Tab panel plus added 1 pixel to margin.
![image](https://github.com/user-attachments/assets/ab1306e9-adc5-4e9b-ab0b-67c00be905e4)


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
