### PR TITLE
Change CacheFile.LogMessages type to Ilist<AssetsLogMessage>

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/NoOpRestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/NoOpRestoreResult.cs
@@ -22,7 +22,7 @@ namespace NuGet.Commands
                 cacheFile: cacheFile, cacheFilePath: cacheFilePath, packagesLockFilePath: null, packagesLockFile: null, dependencyGraphSpecFilePath: null, dependencyGraphSpec: null, projectStyle: projectStyle, elapsedTime: elapsedTime)
         {
             _lockFileLazy = lockFileLazy ?? throw new ArgumentNullException(nameof(lockFileLazy));
-            LogMessages = cacheFile?.LogMessages ?? new List<IAssetsLogMessage>();
+            LogMessages = (IList<IAssetsLogMessage>)(cacheFile?.LogMessages ?? new List<AssetsLogMessage>());
         }
 
         public override LockFile LockFile => _lockFileLazy.Value;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/NoOpRestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/NoOpRestoreResult.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -22,7 +23,7 @@ namespace NuGet.Commands
                 cacheFile: cacheFile, cacheFilePath: cacheFilePath, packagesLockFilePath: null, packagesLockFile: null, dependencyGraphSpecFilePath: null, dependencyGraphSpec: null, projectStyle: projectStyle, elapsedTime: elapsedTime)
         {
             _lockFileLazy = lockFileLazy ?? throw new ArgumentNullException(nameof(lockFileLazy));
-            LogMessages = (IList<IAssetsLogMessage>)(cacheFile?.LogMessages ?? new List<AssetsLogMessage>());
+            LogMessages = cacheFile?.LogMessages?.Cast<IAssetsLogMessage>().ToList() ?? new List<IAssetsLogMessage>();
         }
 
         public override LockFile LockFile => _lockFileLazy.Value;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -470,7 +470,7 @@ namespace NuGet.Commands
                     {
                         cacheFile.Success = _success;
                         cacheFile.ProjectFilePath = _request.Project.FilePath;
-                        cacheFile.LogMessages = assetsFile.LogMessages;
+                        cacheFile.LogMessages = assetsFile.LogMessages.Select(m => (AssetsLogMessage)m).ToList();
                         cacheFile.ExpectedPackageFilePaths = NoOpRestoreUtilities.GetRestoreOutput(_request, assetsFile);
                         telemetry.TelemetryEvent[TotalUniquePackagesCount] = cacheFile?.ExpectedPackageFilePaths.Count;
                     }

--- a/src/NuGet.Core/NuGet.ProjectModel/CacheFile.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/CacheFile.cs
@@ -38,7 +38,7 @@ namespace NuGet.ProjectModel
         /// </summary>
         public string ProjectFilePath { get; set; }
 
-        public IList<IAssetsLogMessage> LogMessages { get; set; }
+        public IList<AssetsLogMessage> LogMessages { get; set; }
 
         public bool IsValid { get { return Version == CurrentVersion && Success && DgSpecHash != null; } }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -246,7 +246,7 @@ namespace NuGet.ProjectModel
 
             var logMessage = (flags & LockFileReadFlags.LogMessages) == LockFileReadFlags.LogMessages
                 ? ReadLogMessageArray(cursor[LogsProperty] as JArray, packagesSpec?.RestoreMetadata?.ProjectPath)
-                : Array.Empty<IAssetsLogMessage>();
+                : Array.Empty<AssetsLogMessage>();
 
             var lockFile = new LockFile()
             {
@@ -259,7 +259,7 @@ namespace NuGet.ProjectModel
                 CentralTransitiveDependencyGroups = centralTransitiveDependencyGroups
             };
 
-            lockFile.LogMessages = logMessage;
+            lockFile.LogMessages = (IList<IAssetsLogMessage>)logMessage;
 
             return lockFile;
         }
@@ -493,7 +493,7 @@ namespace NuGet.ProjectModel
         /// </summary>
         /// <param name="json"><code>JObject</code> containg the json representation of the log message.</param>
         /// <returns><code>IAssetsLogMessage</code> representing the log message.</returns>
-        private static IAssetsLogMessage ReadLogMessage(JObject json, string projectPath)
+        private static AssetsLogMessage ReadLogMessage(JObject json, string projectPath)
         {
             AssetsLogMessage assetsLogMessage = null;
 
@@ -905,14 +905,14 @@ namespace NuGet.ProjectModel
             return items;
         }
 
-        internal static IList<IAssetsLogMessage> ReadLogMessageArray(JArray json, string projectPath)
+        internal static IList<AssetsLogMessage> ReadLogMessageArray(JArray json, string projectPath)
         {
             if (json == null)
             {
-                return new List<IAssetsLogMessage>();
+                return new List<AssetsLogMessage>();
             }
 
-            var items = new List<IAssetsLogMessage>(json.Count);
+            var items = new List<AssetsLogMessage>(json.Count);
             foreach (var child in json)
             {
                 var logMessage = ReadLogMessage(child as JObject, projectPath);

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -259,7 +259,7 @@ namespace NuGet.ProjectModel
                 CentralTransitiveDependencyGroups = centralTransitiveDependencyGroups
             };
 
-            lockFile.LogMessages = (IList<IAssetsLogMessage>)logMessage;
+            lockFile.LogMessages = logMessage?.Cast<IAssetsLogMessage>().ToList();
 
             return lockFile;
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Shipped.txt
@@ -44,7 +44,6 @@ NuGet.ProjectModel.CacheFile
 NuGet.ProjectModel.CacheFile.HasAnyMissingPackageFiles.get -> bool
 NuGet.ProjectModel.CacheFile.HasAnyMissingPackageFiles.set -> void
 NuGet.ProjectModel.CacheFile.IsValid.get -> bool
-~NuGet.ProjectModel.CacheFile.LogMessages.get -> System.Collections.Generic.IList<NuGet.ProjectModel.IAssetsLogMessage>
 ~NuGet.ProjectModel.CacheFile.LogMessages.set -> void
 ~NuGet.ProjectModel.CacheFile.ProjectFilePath.get -> string
 ~NuGet.ProjectModel.CacheFile.ProjectFilePath.set -> void

--- a/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 NuGet.ProjectModel.TargetFrameworkInformation.AssetTargetFallback.init -> void
 NuGet.ProjectModel.TargetFrameworkInformation.Warn.init -> void
+~NuGet.ProjectModel.CacheFile.LogMessages.get -> System.Collections.Generic.IList<NuGet.ProjectModel.AssetsLogMessage>
 ~NuGet.ProjectModel.TargetFrameworkInformation.CentralPackageVersions.get -> System.Collections.Generic.IReadOnlyDictionary<string, NuGet.LibraryModel.CentralPackageVersion>
 ~NuGet.ProjectModel.TargetFrameworkInformation.CentralPackageVersions.init -> void
 ~NuGet.ProjectModel.TargetFrameworkInformation.Dependencies.get -> System.Collections.Immutable.ImmutableArray<NuGet.LibraryModel.LibraryDependency>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
@@ -341,7 +341,7 @@ namespace NuGet.Commands.Test
             var cacheFile = new CacheFile("hash")
             {
                 Success = true,
-                LogMessages = new List<IAssetsLogMessage>() { cacheLogMessage },
+                LogMessages = new List<AssetsLogMessage>() { cacheLogMessage },
             };
 
             // Act 
@@ -382,7 +382,7 @@ namespace NuGet.Commands.Test
             var cacheFile = new CacheFile("hash")
             {
                 Success = true,
-                LogMessages = new List<IAssetsLogMessage>() { cacheLogMessage },
+                LogMessages = new List<AssetsLogMessage>() { cacheLogMessage },
             };
 
             // Act

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/CacheFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/CacheFileFormatTests.cs
@@ -131,7 +131,7 @@ namespace NuGet.ProjectModel.Test
                     file1,
                     file2
                 },
-                    LogMessages = new List<IAssetsLogMessage>
+                    LogMessages = new List<AssetsLogMessage>
                 {
                     new AssetsLogMessage(LogLevel.Information, NuGetLogCode.NU1000, "Test")
                 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13898

## Description

The `IAssetsLogMessage` interface was removed in favor of using the concrete `AssetsLogMessage` class directly in `CacheFile.LogMessages` because `AssetsLogMessage` is a Data Transfer Object (DTO) with no business logic. DTOs do not require interfaces since they serve solely as data carriers, and no need for polymorphism. This change simplifies serialization by removing the need for custom converters and reduces unnecessary abstraction.

**This will be useful for the following PR:** https://github.com/NuGet/NuGet.Client/pull/6081
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
