### PR TITLE
Fix HttpRetryHandler_MultipleTriesTimed

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpRetryHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpRetryHandlerTests.cs
@@ -15,6 +15,7 @@ using FluentAssertions;
 using NuGet.Test.Utility;
 using Test.Utility;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.Protocol.Tests
 {
@@ -24,6 +25,12 @@ namespace NuGet.Protocol.Tests
         private const string TestUrl = "https://local.test/test.json";
         private static readonly TimeSpan SmallTimeout = TimeSpan.FromMilliseconds(50);
         private static readonly TimeSpan LargeTimeout = TimeSpan.FromSeconds(5);
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public HttpRetryHandlerTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
 
         // Add an additional header and verify that it was send in the request.
         [Fact]
@@ -40,7 +47,7 @@ namespace NuGet.Protocol.Tests
 
                 var id = Guid.NewGuid().ToString();
                 request.AddHeaders.Add(new KeyValuePair<string, IEnumerable<string>>(ProtocolConstants.SessionId, new[] { id }));
-                var log = new TestLogger();
+                var log = new TestLogger(_testOutputHelper);
 
                 // Act
                 using (var actualResponse = await retryHandler.SendAsync(request, log, CancellationToken.None))
@@ -76,7 +83,7 @@ namespace NuGet.Protocol.Tests
             var request = new HttpRetryHandlerRequest(
                 httpClient,
                 () => new HttpRequestMessage(HttpMethod.Get, TestUrl));
-            var log = new TestLogger();
+            var log = new TestLogger(_testOutputHelper);
 
             // Act
             var actualResponse = await retryHandler.SendAsync(request, log, CancellationToken.None);
@@ -118,7 +125,7 @@ namespace NuGet.Protocol.Tests
                 RequestTimeout = Timeout.InfiniteTimeSpan,
                 RetryDelay = retryDelay
             };
-            var log = new TestLogger();
+            var log = new TestLogger(_testOutputHelper);
 
             // Act
             using (await retryHandler.SendAsync(request, log, CancellationToken.None))
@@ -208,6 +215,8 @@ namespace NuGet.Protocol.Tests
             TestEnvironmentVariableReader testEnvironmentVariableReader = GetEnhancedHttpRetryEnvironmentVariables();
             Func<HttpRequestMessage, HttpResponseMessage> handler = requestMessage =>
             {
+                Thread.Sleep(TimeSpan.FromMilliseconds(10));
+
                 return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
             };
 
@@ -222,7 +231,7 @@ namespace NuGet.Protocol.Tests
                 RequestTimeout = Timeout.InfiniteTimeSpan,
                 RetryDelay = retryDelay
             };
-            var log = new TestLogger();
+            var log = new TestLogger(_testOutputHelper);
 
             // Act
             var timer = new Stopwatch();
@@ -265,7 +274,7 @@ namespace NuGet.Protocol.Tests
                 RequestTimeout = Timeout.InfiniteTimeSpan,
                 RetryDelay = retryDelay
             };
-            var log = new TestLogger();
+            var log = new TestLogger(_testOutputHelper);
 
             // Act
             using (await retryHandler.SendAsync(request, log, CancellationToken.None))
@@ -300,7 +309,7 @@ namespace NuGet.Protocol.Tests
                 RequestTimeout = Timeout.InfiniteTimeSpan,
                 RetryDelay = retryDelay
             };
-            var log = new TestLogger();
+            var log = new TestLogger(_testOutputHelper);
 
             // Act
             using (var response = await retryHandler.SendAsync(request, log, CancellationToken.None))
@@ -335,7 +344,7 @@ namespace NuGet.Protocol.Tests
                 RequestTimeout = Timeout.InfiniteTimeSpan,
                 RetryDelay = retryDelay
             };
-            var log = new TestLogger();
+            var log = new TestLogger(_testOutputHelper);
 
             // Act
             using (var response = await retryHandler.SendAsync(request, log, CancellationToken.None))
@@ -373,7 +382,7 @@ namespace NuGet.Protocol.Tests
                 DownloadTimeout = TimeSpan.FromMilliseconds(expectedMilliseconds)
             };
             var destinationStream = new MemoryStream();
-            var log = new TestLogger();
+            var log = new TestLogger(_testOutputHelper);
 
             // Act
             using (var response = await retryHandler.SendAsync(request, log, CancellationToken.None))
@@ -426,7 +435,7 @@ namespace NuGet.Protocol.Tests
                 RequestTimeout = Timeout.InfiniteTimeSpan,
                 RetryDelay = retryDelay
             };
-            var log = new TestLogger();
+            var log = new TestLogger(_testOutputHelper);
 
             // Act
             using (var response = await retryHandler.SendAsync(request, log, CancellationToken.None))
@@ -475,7 +484,7 @@ namespace NuGet.Protocol.Tests
                 // so set this to a value that will cause test timeout if the correct value is not honored.
                 RetryDelay = TimeSpan.FromMilliseconds(int.MaxValue) // = about 24 days
             };
-            var log = new TestLogger();
+            var log = new TestLogger(_testOutputHelper);
 
             // Act
             using (CancellationTokenSource cts = new CancellationTokenSource(millisecondsDelay: 60 * 1000))
@@ -507,7 +516,7 @@ namespace NuGet.Protocol.Tests
             var httpRetryHandlerRequest = new HttpRetryHandlerRequest(client, () => new HttpRequestMessage(HttpMethod.Get, TestUrl));
             TestEnvironmentVariableReader environmentVariables = GetEnhancedHttpRetryEnvironmentVariables(retry429: retry429);
             var httpRetryHandler = new HttpRetryHandler(environmentVariables);
-            var logger = new TestLogger();
+            var logger = new TestLogger(_testOutputHelper);
 
             // Act
             var response = await httpRetryHandler.SendAsync(httpRetryHandlerRequest, logger, CancellationToken.None);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpRetryHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpRetryHandlerTests.cs
@@ -140,8 +140,6 @@ namespace NuGet.Protocol.Tests
         public async Task HttpRetryHandler_CancelsRequestAfterTimeout()
         {
             // Arrange
-            TimeSpan retryDelay = TimeSpan.Zero;
-
             TestEnvironmentVariableReader testEnvironmentVariableReader = GetEnhancedHttpRetryEnvironmentVariables();
             var requestToken = CancellationToken.None;
             Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler = async (requestMessage, token) =>
@@ -157,14 +155,14 @@ namespace NuGet.Protocol.Tests
             var request = new HttpRetryHandlerRequest(httpClient, () => new HttpRequestMessage(HttpMethod.Get, TestUrl))
             {
                 MaxTries = 1,
-                RequestTimeout = SmallTimeout,
-                RetryDelay = retryDelay
+                RequestTimeout = TimeSpan.FromSeconds(1),
+                RetryDelay = TimeSpan.Zero
             };
 
             // Act
             Func<Task> actionAsync = () => retryHandler.SendAsync(
                 request,
-                new TestLogger(),
+                new TestLogger(_testOutputHelper),
                 CancellationToken.None);
 
             // Assert
@@ -199,7 +197,7 @@ namespace NuGet.Protocol.Tests
             // Act
             Func<Task> actionAsync = () => retryHandler.SendAsync(
                 request,
-                new TestLogger(),
+                new TestLogger(_testOutputHelper),
                 CancellationToken.None);
 
             // Assert


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13196

## Description
`HttpRetryHandler_MultipleTriesTimed` has failed 6 times in the last 30 days in the dev branch because its flaky.  I added logging and figured out that retries are returning immediately.  Adding a delay seems to help.  I also added logging to all of the calls via the `ITestOutputHelper`.

Before:
```
INFO :   GET https://local.test/test.json
INFO :   ServiceUnavailable https://local.test/test.json 25ms
INFO :   GET https://local.test/test.json
INFO :   ServiceUnavailable https://local.test/test.json 0ms
INFO :   GET https://local.test/test.json
INFO :   ServiceUnavailable https://local.test/test.json 0ms
TRACE: Enhanced retry: HttpRetryHandler is in a state that retry would have been abandoned or not waited if it were not enabled.
INFO :   GET https://local.test/test.json
INFO :   ServiceUnavailable https://local.test/test.json 0ms
TRACE: Enhanced retry: HttpRetryHandler is in a state that retry would have been abandoned or not waited if it were not enabled.
INFO :   GET https://local.test/test.json
INFO :   ServiceUnavailable https://local.test/test.json 0ms
```

After:
```
INFO :   GET https://local.test/test.json
INFO :   ServiceUnavailable https://local.test/test.json 25ms
INFO :   GET https://local.test/test.json
INFO :   ServiceUnavailable https://local.test/test.json 12ms
INFO :   GET https://local.test/test.json
INFO :   ServiceUnavailable https://local.test/test.json 15ms
TRACE: Enhanced retry: HttpRetryHandler is in a state that retry would have been abandoned or not waited if it were not enabled.
INFO :   GET https://local.test/test.json
INFO :   ServiceUnavailable https://local.test/test.json 15ms
TRACE: Enhanced retry: HttpRetryHandler is in a state that retry would have been abandoned or not waited if it were not enabled.
INFO :   GET https://local.test/test.json
INFO :   ServiceUnavailable https://local.test/test.json 15ms
```

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
