### PR TITLE
Add ReadmeUriTemplateResource for download README from remote sources.

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageDetailsTabViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageDetailsTabViewModel.cs
@@ -110,7 +110,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
         {
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                if (_readmeTabEnabled)
+                if (_readmeTabEnabled && e.PropertyName == nameof(DetailControlModel.PackageMetadata))
                 {
                     await ReadmePreviewViewModel.SetPackageMetadataAsync(DetailControlModel.PackageMetadata, CancellationToken.None);
                 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
@@ -60,7 +60,6 @@ namespace NuGet.PackageManagement.UI.ViewModels
         {
             if (packageMetadata != null && (!string.Equals(packageMetadata.Id, _packageMetadata?.Id) || packageMetadata.Version != _packageMetadata?.Version))
             {
-                ReadmeMarkdown = Resources.Text_Loading;
                 _packageMetadata = packageMetadata;
                 await LoadReadmeAsync(cancellationToken);
             }
@@ -73,6 +72,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
 
         private async Task LoadReadmeAsync(CancellationToken cancellationToken)
         {
+            ReadmeMarkdown = Resources.Text_Loading;
             if (string.IsNullOrWhiteSpace(_packageMetadata.ReadmeFileUrl))
             {
                 ReadmeMarkdown = _canRenderLocalReadme && !string.IsNullOrWhiteSpace(_packageMetadata.PackagePath) ? Resources.Text_NoReadme : string.Empty;
@@ -91,20 +91,22 @@ namespace NuGet.PackageManagement.UI.ViewModels
             }
 
             var readme = Resources.Text_NoReadme;
-            await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            try
             {
-                await TaskScheduler.Default;
-                using var readmeStream = await _nugetPackageFileService.GetReadmeAsync(readmeUrl, cancellationToken);
-                if (readmeStream is null)
+                await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
-                    return;
-                }
+                    await TaskScheduler.Default;
+                    using var readmeStream = await _nugetPackageFileService.GetReadmeAsync(readmeUrl, cancellationToken);
+                    if (readmeStream is null)
+                    {
+                        return;
+                    }
 
-                using StreamReader streamReader = new StreamReader(readmeStream);
-                readme = await streamReader.ReadToEndAsync();
-            });
-
-            if (!cancellationToken.IsCancellationRequested)
+                    using StreamReader streamReader = new StreamReader(readmeStream);
+                    readme = await streamReader.ReadToEndAsync();
+                });
+            }
+            finally
             {
                 ReadmeMarkdown = readme;
                 IsVisible = !string.IsNullOrWhiteSpace(readme);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
@@ -18,6 +18,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
         private string _rawReadme;
         private DetailedPackageMetadata _packageMetadata;
         private bool _canRenderLocalReadme;
+        private bool _isBusy;
 
         public ReadmePreviewViewModel(INuGetPackageFileService packageFileService, ItemFilter itemFilter, bool isReadmeFeatureEnabled)
         {
@@ -25,16 +26,33 @@ namespace NuGet.PackageManagement.UI.ViewModels
             _canRenderLocalReadme = CanRenderLocalReadme(itemFilter);
             _nugetPackageFileService = packageFileService;
             _errorLoadingReadme = false;
+            _isBusy = false;
             _rawReadme = string.Empty;
             _packageMetadata = null;
             Title = Resources.Label_Readme_Tab;
             IsVisible = isReadmeFeatureEnabled;
         }
 
+        public bool IsReadmeReady { get => !IsBusy && !ErrorLoadingReadme; }
+
         public bool ErrorLoadingReadme
         {
             get => _errorLoadingReadme;
-            set => SetAndRaisePropertyChanged(ref _errorLoadingReadme, value);
+            set
+            {
+                SetAndRaisePropertyChanged(ref _errorLoadingReadme, value);
+                RaisePropertyChanged(nameof(IsReadmeReady));
+            }
+        }
+
+        public bool IsBusy
+        {
+            get => _isBusy;
+            set
+            {
+                SetAndRaisePropertyChanged(ref _isBusy, value);
+                RaisePropertyChanged(nameof(IsReadmeReady));
+            }
         }
 
         public string ReadmeMarkdown
@@ -72,12 +90,13 @@ namespace NuGet.PackageManagement.UI.ViewModels
 
         private async Task LoadReadmeAsync(CancellationToken cancellationToken)
         {
-            ReadmeMarkdown = Resources.Text_Loading;
+            IsBusy = true;
             if (string.IsNullOrWhiteSpace(_packageMetadata.ReadmeFileUrl))
             {
                 ReadmeMarkdown = _canRenderLocalReadme && !string.IsNullOrWhiteSpace(_packageMetadata.PackagePath) ? Resources.Text_NoReadme : string.Empty;
                 IsVisible = !string.IsNullOrWhiteSpace(ReadmeMarkdown);
                 ErrorLoadingReadme = false;
+                IsBusy = false;
                 return;
             }
 
@@ -87,6 +106,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
                 ReadmeMarkdown = string.Empty;
                 IsVisible = false;
                 ErrorLoadingReadme = false;
+                IsBusy = false;
                 return;
             }
 
@@ -111,6 +131,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
                 ReadmeMarkdown = readme;
                 IsVisible = !string.IsNullOrWhiteSpace(readme);
                 ErrorLoadingReadme = false;
+                IsBusy = false;
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
@@ -60,6 +60,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
         {
             if (packageMetadata != null && (!string.Equals(packageMetadata.Id, _packageMetadata?.Id) || packageMetadata.Version != _packageMetadata?.Version))
             {
+                ReadmeMarkdown = Resources.Text_Loading;
                 _packageMetadata = packageMetadata;
                 await LoadReadmeAsync(cancellationToken);
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
@@ -13,7 +13,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
 {
     public sealed class ReadmePreviewViewModel : TitledPageViewModelBase
     {
-        private bool _errorLoadingReadme;
+        private bool _errorWithReadme;
         private INuGetPackageFileService _nugetPackageFileService;
         private string _rawReadme;
         private DetailedPackageMetadata _packageMetadata;
@@ -25,7 +25,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
             _nugetPackageFileService = packageFileService ?? throw new ArgumentNullException(nameof(packageFileService));
             _canRenderLocalReadme = CanRenderLocalReadme(itemFilter);
             _nugetPackageFileService = packageFileService;
-            _errorLoadingReadme = false;
+            _errorWithReadme = false;
             _isBusy = false;
             _rawReadme = string.Empty;
             _packageMetadata = null;
@@ -33,14 +33,14 @@ namespace NuGet.PackageManagement.UI.ViewModels
             IsVisible = isReadmeFeatureEnabled;
         }
 
-        public bool IsReadmeReady { get => !IsBusy && !ErrorLoadingReadme; }
+        public bool IsReadmeReady { get => !IsBusy && !ErrorWithReadme; }
 
-        public bool ErrorLoadingReadme
+        public bool ErrorWithReadme
         {
-            get => _errorLoadingReadme;
+            get => _errorWithReadme;
             set
             {
-                SetAndRaisePropertyChanged(ref _errorLoadingReadme, value);
+                SetAndRaisePropertyChanged(ref _errorWithReadme, value);
                 RaisePropertyChanged(nameof(IsReadmeReady));
             }
         }
@@ -94,7 +94,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
             {
                 ReadmeMarkdown = _canRenderLocalReadme && !string.IsNullOrWhiteSpace(_packageMetadata.PackagePath) ? Resources.Text_NoReadme : string.Empty;
                 IsVisible = !string.IsNullOrWhiteSpace(ReadmeMarkdown);
-                ErrorLoadingReadme = false;
+                ErrorWithReadme = false;
                 return;
             }
 
@@ -103,7 +103,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
             {
                 ReadmeMarkdown = string.Empty;
                 IsVisible = false;
-                ErrorLoadingReadme = false;
+                ErrorWithReadme = false;
                 return;
             }
 
@@ -111,7 +111,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
             try
             {
                 IsBusy = true;
-                ErrorLoadingReadme = false;
+                ErrorWithReadme = false;
                 await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
                     await TaskScheduler.Default;
@@ -129,7 +129,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
             {
                 ReadmeMarkdown = readme;
                 IsVisible = !string.IsNullOrWhiteSpace(readme);
-                ErrorLoadingReadme = false;
+                ErrorWithReadme = false;
                 IsBusy = false;
             }
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
@@ -90,13 +90,11 @@ namespace NuGet.PackageManagement.UI.ViewModels
 
         private async Task LoadReadmeAsync(CancellationToken cancellationToken)
         {
-            IsBusy = true;
             if (string.IsNullOrWhiteSpace(_packageMetadata.ReadmeFileUrl))
             {
                 ReadmeMarkdown = _canRenderLocalReadme && !string.IsNullOrWhiteSpace(_packageMetadata.PackagePath) ? Resources.Text_NoReadme : string.Empty;
                 IsVisible = !string.IsNullOrWhiteSpace(ReadmeMarkdown);
                 ErrorLoadingReadme = false;
-                IsBusy = false;
                 return;
             }
 
@@ -106,13 +104,13 @@ namespace NuGet.PackageManagement.UI.ViewModels
                 ReadmeMarkdown = string.Empty;
                 IsVisible = false;
                 ErrorLoadingReadme = false;
-                IsBusy = false;
                 return;
             }
 
             var readme = Resources.Text_NoReadme;
             try
             {
+                IsBusy = true;
                 await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
                     await TaskScheduler.Default;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
@@ -111,6 +111,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
             try
             {
                 IsBusy = true;
+                ErrorLoadingReadme = false;
                 await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
                     await TaskScheduler.Default;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml
@@ -9,6 +9,8 @@
   xmlns:imagingTheme="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
   xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
   xmlns:ui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Utilities"
+  Background="{DynamicResource {x:Static nuget:Brushes.DetailPaneBackground}}"
+  Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
   DataContextChanged="UserControl_DataContextChanged"
   Unloaded="PackageReadmeControl_Unloaded"
   Loaded="PackageReadmeControl_Loaded"
@@ -28,8 +30,13 @@
       x:Uid="descriptionMarkdownPreview"
       ClipToBounds="True"
       Focusable="False"
-      Visibility="{Binding Path=ErrorLoadingReadme, Mode=OneWay, Converter={StaticResource NegatedBooleanToVisibilityConverter}}"
+      Visibility="{Binding Path=IsReadmeReady, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
     />
+    <TextBlock
+      TextWrapping="Wrap"
+      Text="{x:Static nuget:Resources.Text_Loading}"
+      Visibility="{Binding Path=IsBusy, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
+      />
     <TextBlock
       TextWrapping="Wrap"
       Text="{x:Static nuget:Resources.Error_UnableToLoadReadme}"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml
@@ -38,6 +38,6 @@
     <TextBlock
       TextWrapping="Wrap"
       Text="{x:Static nuget:Resources.Error_UnableToLoadReadme}"
-      Visibility="{Binding Path=ErrorLoadingReadme, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+      Visibility="{Binding Path=ErrorWithReadme, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
   </Grid>
 </UserControl>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml
@@ -30,17 +30,14 @@
       x:Uid="descriptionMarkdownPreview"
       ClipToBounds="True"
       Focusable="False"
-      Visibility="{Binding Path=IsReadmeReady, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
-    />
+      Visibility="{Binding Path=IsReadmeReady, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
     <TextBlock
       TextWrapping="Wrap"
       Text="{x:Static nuget:Resources.Text_Loading}"
-      Visibility="{Binding Path=IsBusy, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
-      />
+      Visibility="{Binding Path=IsBusy, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
     <TextBlock
       TextWrapping="Wrap"
       Text="{x:Static nuget:Resources.Error_UnableToLoadReadme}"
-      Visibility="{Binding Path=ErrorLoadingReadme, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
-      />
+      Visibility="{Binding Path=ErrorLoadingReadme, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
   </Grid>
 </UserControl>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using Microsoft.VisualStudio.Markdown.Platform;
-using Microsoft.VisualStudio.Shell;
 using NuGet.PackageManagement.UI.ViewModels;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Telemetry;
@@ -39,7 +38,7 @@ namespace NuGet.PackageManagement.UI
         {
             if (e.PropertyName == nameof(ReadmePreviewViewModel.ReadmeMarkdown))
             {
-                NuGetUIThreadHelper.JoinableTaskFactory.Run(UpdateMarkdownAsync);
+                NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(UpdateMarkdownAsync).PostOnFailure(nameof(PackageReadmeControl), nameof(ReadmeViewModel_PropertyChanged));
             }
         }
 
@@ -104,10 +103,8 @@ namespace NuGet.PackageManagement.UI
 
         private void PackageReadmeControl_Loaded(object sender, RoutedEventArgs e)
         {
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
-            {
-                await UpdateMarkdownAsync();
-            });
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(UpdateMarkdownAsync)
+                .PostOnFailure(nameof(PackageReadmeControl), nameof(PackageReadmeControl_Loaded));
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
@@ -78,7 +78,7 @@ namespace NuGet.PackageManagement.UI
             }
             catch (Exception ex) when (ex is ArgumentException || ex is InvalidOperationException)
             {
-                ReadmeViewModel.ErrorLoadingReadme = true;
+                ReadmeViewModel.ErrorWithReadme = true;
                 ReadmeViewModel.ReadmeMarkdown = string.Empty;
                 await TelemetryUtility.PostFaultAsync(ex, nameof(ReadmePreviewViewModel));
             }

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
@@ -106,7 +106,7 @@ namespace NuGet.Protocol
         [JsonConverter(typeof(SafeUriConverter))]
         public Uri ReadmeUrl { get; private set; }
 
-        [JsonProperty(PropertyName = JsonProperties.ReadmeFileUrl)]
+        [JsonIgnore]
         public string ReadmeFileUrl { get; internal set; }
 
         [JsonIgnore]

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
@@ -107,7 +107,7 @@ namespace NuGet.Protocol
         public Uri ReadmeUrl { get; private set; }
 
         [JsonProperty(PropertyName = JsonProperties.ReadmeFileUrl)]
-        public string ReadmeFileUrl { get; private set; }
+        public string ReadmeFileUrl { get; internal set; }
 
         [JsonIgnore]
         public Uri ReportAbuseUrl { get; set; }

--- a/src/NuGet.Core/NuGet.Protocol/Providers/PackageMetadataResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/PackageMetadataResourceV3Provider.cs
@@ -23,6 +23,7 @@ namespace NuGet.Protocol
             {
                 var regResource = await source.GetResourceAsync<RegistrationResourceV3>(token);
                 var reportAbuseResource = await source.GetResourceAsync<ReportAbuseResourceV3>(token);
+                var readmeResource = await source.GetResourceAsync<ReadmeUriTemplateResource>(token);
                 var packageDetailsUriResource = await source.GetResourceAsync<PackageDetailsUriResourceV3>(token);
 
                 var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
@@ -32,7 +33,8 @@ namespace NuGet.Protocol
                     httpSourceResource.HttpSource,
                     regResource,
                     reportAbuseResource,
-                    packageDetailsUriResource);
+                    packageDetailsUriResource,
+                    readmeResource);
             }
 
             return new Tuple<bool, INuGetResource>(curResource != null, curResource);

--- a/src/NuGet.Core/NuGet.Protocol/Providers/ReadmeUriTemplateResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/ReadmeUriTemplateResourceProvider.cs
@@ -9,6 +9,8 @@ using NuGet.Protocol.Core.Types;
 
 namespace NuGet.Protocol
 {
+    /// <summary>NuGet.Protocol resource provider for <see cref="ReadmeUriTemplateResource"/>.</summary>
+    /// <remarks>When successful, returns an instance of <see cref="ReadmeUriTemplateResource"/>.</remarks>
     internal class ReadmeUriTemplateResourceProvider : ResourceProvider
     {
         public ReadmeUriTemplateResourceProvider()
@@ -18,6 +20,7 @@ namespace NuGet.Protocol
         {
         }
 
+        /// <inheritdoc cref="ResourceProvider.TryCreate(SourceRepository, CancellationToken)"/>
         public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
             ReadmeUriTemplateResource? resource = null;

--- a/src/NuGet.Core/NuGet.Protocol/Providers/ReadmeUriTemplateResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/ReadmeUriTemplateResourceProvider.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+#nullable enable
 
 using System;
 using System.Threading;
@@ -17,9 +18,9 @@ namespace NuGet.Protocol
         {
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            ReadmeUriTemplateResource resource = null;
+            ReadmeUriTemplateResource? resource = null;
             var serviceIndex = await source.GetResourceAsync<ServiceIndexResourceV3>(token);
             if (serviceIndex != null)
             {
@@ -29,7 +30,7 @@ namespace NuGet.Protocol
                 resource = string.IsNullOrWhiteSpace(uriTemplate) ? null : new ReadmeUriTemplateResource(uriTemplate);
             }
 
-            return new Tuple<bool, INuGetResource>(resource != null, resource);
+            return new Tuple<bool, INuGetResource?>(resource != null, resource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Providers/ReadmeUriTemplateResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/ReadmeUriTemplateResourceProvider.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.Protocol
+{
+    internal class ReadmeUriTemplateResourceProvider : ResourceProvider
+    {
+        public ReadmeUriTemplateResourceProvider()
+            : base(typeof(ReadmeUriTemplateResource),
+                  nameof(ReadmeUriTemplateResource),
+                  NuGetResourceProviderPositions.Last)
+        {
+        }
+
+        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        {
+            ReadmeUriTemplateResource resource = null;
+            var serviceIndex = await source.GetResourceAsync<ServiceIndexResourceV3>(token);
+            if (serviceIndex != null)
+            {
+                var uriTemplate = serviceIndex.GetServiceEntryUri(ServiceTypes.ReadmeFileUrl)?.OriginalString;
+
+                // construct a new resource
+                resource = string.IsNullOrWhiteSpace(uriTemplate) ? null : new ReadmeUriTemplateResource(uriTemplate);
+            }
+
+            return new Tuple<bool, INuGetResource>(resource != null, resource);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Repository.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Repository.cs
@@ -53,6 +53,7 @@ namespace NuGet.Protocol.Core.Types
                 yield return new Lazy<INuGetResourceProvider>(() => new RegistrationResourceV3Provider());
                 yield return new Lazy<INuGetResourceProvider>(() => new SymbolPackageUpdateResourceV3Provider());
                 yield return new Lazy<INuGetResourceProvider>(() => new ReportAbuseResourceV3Provider());
+                yield return new Lazy<INuGetResourceProvider>(() => new ReadmeUriTemplateResourceProvider());
                 yield return new Lazy<INuGetResourceProvider>(() => new PackageDetailsUriResourceV3Provider());
                 yield return new Lazy<INuGetResourceProvider>(() => new ServiceIndexResourceV3Provider());
                 yield return new Lazy<INuGetResourceProvider>(() => new ODataServiceDocumentResourceV2Provider());

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
@@ -280,7 +280,10 @@ namespace NuGet.Protocol
                 {
                     catalogEntry.ReportAbuseUrl = _reportAbuseResource?.GetReportAbuseUrl(catalogEntry.PackageId, catalogEntry.Version);
                     catalogEntry.PackageDetailsUrl = _packageDetailsUriResource?.GetUri(catalogEntry.PackageId, catalogEntry.Version);
-                    catalogEntry.ReadmeFileUrl = _readmeUriTemplateResource?.GetReadmeUrl(catalogEntry.PackageId, catalogEntry.Version);
+                    if (string.IsNullOrWhiteSpace(catalogEntry.ReadmeFileUrl))
+                    {
+                        catalogEntry.ReadmeFileUrl = _readmeUriTemplateResource?.GetReadmeUrl(catalogEntry.PackageId, catalogEntry.Version);
+                    }
                     catalogEntry = metadataCache.GetObject(catalogEntry);
                     results.Add(catalogEntry);
                 }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
@@ -21,6 +21,7 @@ namespace NuGet.Protocol
     {
         private readonly RegistrationResourceV3 _regResource;
         private readonly ReportAbuseResourceV3 _reportAbuseResource;
+        private readonly ReadmeUriTemplateResource _readmeUriTemplateResource;
         private readonly PackageDetailsUriResourceV3 _packageDetailsUriResource;
         private readonly HttpSource _client;
 
@@ -34,6 +35,16 @@ namespace NuGet.Protocol
             _client = client;
             _reportAbuseResource = reportAbuseResource;
             _packageDetailsUriResource = packageDetailsUriResource;
+        }
+
+        internal PackageMetadataResourceV3(
+            HttpSource client,
+            RegistrationResourceV3 regResource,
+            ReportAbuseResourceV3 reportAbuseResource,
+            PackageDetailsUriResourceV3 packageDetailsUriResource,
+            ReadmeUriTemplateResource readmeResource) : this(client, regResource, reportAbuseResource, packageDetailsUriResource)
+        {
+            _readmeUriTemplateResource = readmeResource;
         }
 
         /// <param name="packageId">PackageId for package we're looking.</param>
@@ -269,6 +280,7 @@ namespace NuGet.Protocol
                 {
                     catalogEntry.ReportAbuseUrl = _reportAbuseResource?.GetReportAbuseUrl(catalogEntry.PackageId, catalogEntry.Version);
                     catalogEntry.PackageDetailsUrl = _packageDetailsUriResource?.GetUri(catalogEntry.PackageId, catalogEntry.Version);
+                    catalogEntry.ReadmeFileUrl = _readmeUriTemplateResource?.GetReadmeUrl(catalogEntry.PackageId, catalogEntry.Version);
                     catalogEntry = metadataCache.GetObject(catalogEntry);
                     results.Add(catalogEntry);
                 }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/ReadmeUriTemplateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/ReadmeUriTemplateResource.cs
@@ -10,6 +10,9 @@ using System;
 
 namespace NuGet.Protocol
 {
+    /// <summary>
+    /// A resource that provides the URI for downloading a README file based on a template.
+    /// </summary>
     internal class ReadmeUriTemplateResource : INuGetResource
     {
         private readonly string _uriTemplate;

--- a/src/NuGet.Core/NuGet.Protocol/Resources/ReadmeUriTemplateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/ReadmeUriTemplateResource.cs
@@ -20,11 +20,11 @@ namespace NuGet.Protocol
         }
 
         /// <summary>
-        /// Gets a URL for reporting package abuse. The URL will not be verified to exist.
+        /// Get  the URL for downloading the readme file.
         /// </summary>
-        /// <param name="id">The package id (natural casing)</param>
+        /// <param name="id">The package id</param>
         /// <param name="version">The package version</param>
-        /// <returns>The first URL from the resource, with the URI template applied.</returns>
+        /// <returns>URL to download README, built using the URI template.</returns>
         public string GetReadmeUrl(string id, NuGetVersion version)
         {
             if (_uriTemplate == null)

--- a/src/NuGet.Core/NuGet.Protocol/Resources/ReadmeUriTemplateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/ReadmeUriTemplateResource.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+#if NETCOREAPP
+using System;
+#endif
+
+namespace NuGet.Protocol
+{
+    internal class ReadmeUriTemplateResource : INuGetResource
+    {
+        private readonly string _uriTemplate;
+
+        public ReadmeUriTemplateResource(string uriTemplate)
+        {
+            _uriTemplate = uriTemplate;
+        }
+
+        /// <summary>
+        /// Gets a URL for reporting package abuse. The URL will not be verified to exist.
+        /// </summary>
+        /// <param name="id">The package id (natural casing)</param>
+        /// <param name="version">The package version</param>
+        /// <returns>The first URL from the resource, with the URI template applied.</returns>
+        public string GetReadmeUrl(string id, NuGetVersion version)
+        {
+            if (_uriTemplate == null)
+            {
+                return string.Empty;
+            }
+
+            var uriString = _uriTemplate
+#if NETCOREAPP
+               .Replace("{lower_id}", id.ToLowerInvariant(), StringComparison.OrdinalIgnoreCase)
+               .Replace("{lower_version}", version.ToNormalizedString().ToLowerInvariant(), StringComparison.OrdinalIgnoreCase);
+#else
+               .Replace("{lower_id}", id.ToLowerInvariant())
+               .Replace("{lower_version}", version.ToNormalizedString().ToLowerInvariant());
+#endif
+
+            return uriString;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Resources/ReadmeUriTemplateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/ReadmeUriTemplateResource.cs
@@ -16,6 +16,8 @@ namespace NuGet.Protocol
     internal class ReadmeUriTemplateResource : INuGetResource
     {
         private readonly string _uriTemplate;
+        private const string LowerId = "{lower_id}";
+        private const string LowerVersion = "{lower_version}";
 
         public ReadmeUriTemplateResource(string uriTemplate)
         {
@@ -23,7 +25,7 @@ namespace NuGet.Protocol
         }
 
         /// <summary>
-        /// Get  the URL for downloading the readme file.
+        /// Get the URL for downloading the readme file.
         /// </summary>
         /// <param name="id">The package id</param>
         /// <param name="version">The package version</param>
@@ -37,11 +39,11 @@ namespace NuGet.Protocol
 
             var uriString = _uriTemplate
 #if NETCOREAPP
-               .Replace("{lower_id}", id.ToLowerInvariant(), StringComparison.OrdinalIgnoreCase)
-               .Replace("{lower_version}", version.ToNormalizedString().ToLowerInvariant(), StringComparison.OrdinalIgnoreCase);
+               .Replace(LowerId, id.ToLowerInvariant(), StringComparison.OrdinalIgnoreCase)
+               .Replace(LowerVersion, version.ToNormalizedString().ToLowerInvariant(), StringComparison.OrdinalIgnoreCase);
 #else
-               .Replace("{lower_id}", id.ToLowerInvariant())
-               .Replace("{lower_version}", version.ToNormalizedString().ToLowerInvariant());
+               .Replace(LowerId, id.ToLowerInvariant())
+               .Replace(LowerVersion, version.ToNormalizedString().ToLowerInvariant());
 #endif
 
             return uriString;

--- a/src/NuGet.Core/NuGet.Protocol/ServiceTypes.cs
+++ b/src/NuGet.Core/NuGet.Protocol/ServiceTypes.cs
@@ -18,13 +18,13 @@ namespace NuGet.Protocol
         public static readonly string Version510 = "/5.1.0";
         internal const string Version670 = "/6.7.0";
         internal const string Version6110 = "/6.11.0";
-        internal const string Version6120 = "/6.12.0";
+        internal const string Version6130 = "/6.13.0";
 
         public static readonly string[] SearchQueryService = { "SearchQueryService" + Versioned, "SearchQueryService" + Version340, "SearchQueryService" + Version300beta };
         public static readonly string[] RegistrationsBaseUrl = { $"RegistrationsBaseUrl{Versioned}", $"RegistrationsBaseUrl{Version360}", $"RegistrationsBaseUrl{Version340}", $"RegistrationsBaseUrl{Version300rc}", $"RegistrationsBaseUrl{Version300beta}", "RegistrationsBaseUrl" };
         public static readonly string[] SearchAutocompleteService = { "SearchAutocompleteService" + Versioned, "SearchAutocompleteService" + Version300beta };
         public static readonly string[] ReportAbuse = { "ReportAbuseUriTemplate" + Versioned, "ReportAbuseUriTemplate" + Version300 };
-        internal static readonly string[] ReadmeFileUrl = { "ReadmeUriTemplate" + Versioned, "ReadmeUriTemplate" + Version6120 };
+        internal static readonly string[] ReadmeFileUrl = { "ReadmeUriTemplate" + Versioned, "ReadmeUriTemplate" + Version6130 };
         public static readonly string[] PackageDetailsUriTemplate = { "PackageDetailsUriTemplate" + Version510 };
         public static readonly string[] LegacyGallery = { "LegacyGallery" + Versioned, "LegacyGallery" + Version200 };
         public static readonly string[] PackagePublish = { "PackagePublish" + Versioned, "PackagePublish" + Version200 };

--- a/src/NuGet.Core/NuGet.Protocol/ServiceTypes.cs
+++ b/src/NuGet.Core/NuGet.Protocol/ServiceTypes.cs
@@ -18,11 +18,13 @@ namespace NuGet.Protocol
         public static readonly string Version510 = "/5.1.0";
         internal const string Version670 = "/6.7.0";
         internal const string Version6110 = "/6.11.0";
+        internal const string Version6120 = "/6.12.0";
 
         public static readonly string[] SearchQueryService = { "SearchQueryService" + Versioned, "SearchQueryService" + Version340, "SearchQueryService" + Version300beta };
         public static readonly string[] RegistrationsBaseUrl = { $"RegistrationsBaseUrl{Versioned}", $"RegistrationsBaseUrl{Version360}", $"RegistrationsBaseUrl{Version340}", $"RegistrationsBaseUrl{Version300rc}", $"RegistrationsBaseUrl{Version300beta}", "RegistrationsBaseUrl" };
         public static readonly string[] SearchAutocompleteService = { "SearchAutocompleteService" + Versioned, "SearchAutocompleteService" + Version300beta };
         public static readonly string[] ReportAbuse = { "ReportAbuseUriTemplate" + Versioned, "ReportAbuseUriTemplate" + Version300 };
+        internal static readonly string[] ReadmeFileUrl = { "ReadmeUriTemplate" + Versioned, "ReadmeUriTemplate" + Version6120 };
         public static readonly string[] PackageDetailsUriTemplate = { "PackageDetailsUriTemplate" + Version510 };
         public static readonly string[] LegacyGallery = { "LegacyGallery" + Versioned, "LegacyGallery" + Version200 };
         public static readonly string[] PackagePublish = { "PackagePublish" + Versioned, "PackagePublish" + Version200 };

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/ReadmePreviewViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/ReadmePreviewViewModelTests.cs
@@ -36,7 +36,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.All, true);
 
             //Assert
-            Assert.False(target.ErrorLoadingReadme);
+            Assert.False(target.ErrorWithReadme);
             Assert.Equal(string.Empty, target.ReadmeMarkdown);
         }
 
@@ -56,7 +56,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             await target.SetPackageMetadataAsync(package, CancellationToken.None);
 
             //Assert
-            Assert.False(target.ErrorLoadingReadme);
+            Assert.False(target.ErrorWithReadme);
             Assert.Equal(string.Empty, target.ReadmeMarkdown);
         }
 
@@ -77,7 +77,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             await target.ItemFilterChangedAsync(ItemFilter.All);
 
             //Assert
-            Assert.False(target.ErrorLoadingReadme);
+            Assert.False(target.ErrorWithReadme);
             Assert.Equal(string.Empty, target.ReadmeMarkdown);
         }
 
@@ -101,7 +101,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             await target.ItemFilterChangedAsync(filter);
 
             //Assert
-            Assert.False(target.ErrorLoadingReadme);
+            Assert.False(target.ErrorWithReadme);
             Assert.Equal(readmeContents, target.ReadmeMarkdown);
         }
 
@@ -121,7 +121,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             await target.SetPackageMetadataAsync(package, CancellationToken.None);
 
             //Assert
-            Assert.False(target.ErrorLoadingReadme);
+            Assert.False(target.ErrorWithReadme);
             Assert.Equal(readmeContents, target.ReadmeMarkdown);
         }
 
@@ -141,7 +141,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             await target.SetPackageMetadataAsync(package, CancellationToken.None);
 
             //Assert
-            Assert.False(target.ErrorLoadingReadme);
+            Assert.False(target.ErrorWithReadme);
             Assert.Equal(string.Empty, target.ReadmeMarkdown);
         }
 
@@ -159,7 +159,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             await target.SetPackageMetadataAsync(package, CancellationToken.None);
 
             //Assert
-            Assert.False(target.ErrorLoadingReadme);
+            Assert.False(target.ErrorWithReadme);
             Assert.Equal(Resources.Text_NoReadme, target.ReadmeMarkdown);
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/ReadmeUriTemplateResourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/ReadmeUriTemplateResourceProviderTests.cs
@@ -8,7 +8,6 @@ using Moq;
 using Newtonsoft.Json.Linq;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
-using NuGet.Versioning;
 using Xunit;
 
 namespace NuGet.Protocol.Tests.Providers

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/ReadmeUriTemplateResourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/ReadmeUriTemplateResourceProviderTests.cs
@@ -57,9 +57,6 @@ namespace NuGet.Protocol.Tests.Providers
 
             Assert.True(result.Item1);
             Assert.IsType<ReadmeUriTemplateResource>(result.Item2);
-            Assert.Equal(
-                "https://unit.test/packages/mypackage/1.0.0/readme",
-                ((ReadmeUriTemplateResource)result.Item2).GetReadmeUrl("MyPackage", NuGetVersion.Parse("1.0.0")));
         }
 
         private static ServiceIndexResourceV3Provider CreateServiceIndexResourceV3Provider(params RawServiceIndexEntry[] entries)

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/ReadmeUriTemplateResourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/ReadmeUriTemplateResourceProviderTests.cs
@@ -1,0 +1,114 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json.Linq;
+using NuGet.Configuration;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Protocol.Tests.Providers
+{
+    public class ReadmeUriTemplateResourceProviderTests
+    {
+        private const string ResourceType = "ReadmeUriTemplate/6.13.0";
+
+        private readonly PackageSource _packageSource;
+        private readonly ReadmeUriTemplateResourceProvider _target;
+
+        public ReadmeUriTemplateResourceProviderTests()
+        {
+            _packageSource = new PackageSource("https://unit.test");
+            _target = new ReadmeUriTemplateResourceProvider();
+        }
+
+        [Fact]
+        public async Task TryCreate_WhenResourceDoesNotExist_ReturnsNull()
+        {
+            var resourceProviders = new ResourceProvider[]
+            {
+                CreateServiceIndexResourceV3Provider(),
+                _target
+            };
+            var sourceRepository = new SourceRepository(_packageSource, resourceProviders);
+
+            Tuple<bool, INuGetResource> result = await _target.TryCreate(sourceRepository, CancellationToken.None);
+
+            Assert.False(result.Item1);
+            Assert.Null(result.Item2);
+        }
+
+        [Fact]
+        public async Task TryCreate_WhenResourceExists_ReturnsValidResourceAsync()
+        {
+            var serviceEntry = new RawServiceIndexEntry("https://unit.test/packages/{lower_id}/{lower_version}/readme", ResourceType);
+            var resourceProviders = new ResourceProvider[]
+            {
+                CreateServiceIndexResourceV3Provider(serviceEntry),
+                _target
+            };
+            var sourceRepository = new SourceRepository(_packageSource, resourceProviders);
+
+            Tuple<bool, INuGetResource> result = await _target.TryCreate(sourceRepository, CancellationToken.None);
+
+            Assert.True(result.Item1);
+            Assert.IsType<ReadmeUriTemplateResource>(result.Item2);
+            Assert.Equal(
+                "https://unit.test/packages/mypackage/1.0.0/readme",
+                ((ReadmeUriTemplateResource)result.Item2).GetReadmeUrl("MyPackage", NuGetVersion.Parse("1.0.0")));
+        }
+
+        private static ServiceIndexResourceV3Provider CreateServiceIndexResourceV3Provider(params RawServiceIndexEntry[] entries)
+        {
+            var provider = new Mock<ServiceIndexResourceV3Provider>();
+
+            provider.Setup(x => x.Name)
+                .Returns(nameof(ServiceIndexResourceV3Provider));
+            provider.Setup(x => x.ResourceType)
+                .Returns(typeof(ServiceIndexResourceV3));
+
+            var resources = new JArray();
+
+            foreach (var entry in entries)
+            {
+                resources.Add(
+                    new JObject(
+                        new JProperty("@id", entry.Uri),
+                        new JProperty("@type", entry.Type)));
+            }
+
+            var index = new JObject();
+
+            index.Add("version", "3.0.0");
+            index.Add("resources", resources);
+            index.Add("@context",
+                new JObject(
+                    new JProperty("@vocab", "http://schema.nuget.org/schema#"),
+                    new JProperty("comment", "http://www.w3.org/2000/01/rdf-schema#comment")));
+
+            var serviceIndexResource = new ServiceIndexResourceV3(index, DateTime.UtcNow);
+            var tryCreateResult = new Tuple<bool, INuGetResource>(true, serviceIndexResource);
+
+            provider.Setup(x => x.TryCreate(It.IsAny<SourceRepository>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(tryCreateResult));
+
+            return provider.Object;
+        }
+
+        private class RawServiceIndexEntry
+        {
+            public RawServiceIndexEntry(string uri, string type)
+            {
+                Uri = uri;
+                Type = type ?? throw new ArgumentNullException(nameof(type));
+            }
+
+            public string Uri { get; }
+            public string Type { get; }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ReadmeUriTemplateResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ReadmeUriTemplateResourceTests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class ReadmeUriTemplateResourceTests
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void ReadmeUriTemplateResource_GetReadmeUrl_BlankTemplate_ReturnsEmptyString(string uriTemplate)
+        {
+            string expectedResult = string.Empty;
+            var resource = new ReadmeUriTemplateResource(uriTemplate);
+
+            var actual = resource.GetReadmeUrl("TestPackage", NuGetVersion.Parse("1.0.0"));
+
+            Assert.Equal(expectedResult, actual);
+        }
+
+        [Fact]
+        public void ReadmeUriTemplateResource_GetReadmeUrl_ReturnsFormedUrl()
+        {
+            const string uriTemplate = "https://test.nuget.org/{lower_id}/{lower_version}/readme";
+            const string expectedResult = "https://test.nuget.org/testpackage/1.0.0/readme";
+            var resource = new ReadmeUriTemplateResource(uriTemplate);
+
+            var actual = resource.GetReadmeUrl("TestPackage", NuGetVersion.Parse("1.0.0"));
+
+            Assert.Equal(expectedResult, actual.ToString());
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RepositoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RepositoryTests.cs
@@ -63,7 +63,7 @@ namespace NuGet.Protocol.Tests
 
             int actualCount = resourceProviders.Count();
 
-            Assert.Equal(48, actualCount);
+            Assert.Equal(49, actualCount);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2918

## Description
Created a new resource type for generating the README download URI. `ReadmeUriTemplate/6.13.0` is the resource we will be looking for in the service index. We use the URL set in the service index as the template for generating the URI for downloading the README. 

Instead of directly exposing this resource type, the PackageMetadataResourceV3 class has been updated to set the ReadmeFileUrl with the URI. 

Since the README will start pulling from remote sources there may be a delay while we download the README. I've added a loading message which will be displayed in the README control. 
![image](https://github.com/user-attachments/assets/4bd3d9be-fff3-49f6-ad08-b7055211b2fd)


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
