### PR TITLE
Do not post fault telemetry for cancellation exceptions

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -814,13 +814,13 @@ namespace NuGet.PackageManagement.UI
                 LatestVersion = result;
                 Status = GetPackageStatus(LatestVersion, InstalledVersion, AutoReferenced);
             }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException)
             {
                 // UI requested cancellation
             }
-            catch (TaskCanceledException)
+            catch (TimeoutException)
             {
-                // HttpClient throws TaskCanceledExceptions for HTTP timeouts
+                // Our code throws a TimeoutException for HTTP timeouts
                 try
                 {
                     await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
@@ -851,13 +851,13 @@ namespace NuGet.PackageManagement.UI
 
                 SetVulnerabilityMaxSeverity(identity.Version, packageMetadata?.Vulnerabilities?.FirstOrDefault()?.Severity ?? -1);
             }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException)
             {
                 // UI requested cancellation.
             }
-            catch (TaskCanceledException)
+            catch (TimeoutException)
             {
-                // HttpClient throws TaskCanceledExceptions for HTTP timeouts
+                // Our code throws a TimeoutException for HTTP timeouts
                 try
                 {
                     await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
@@ -882,13 +882,13 @@ namespace NuGet.PackageManagement.UI
                     await UpdatePackageMaxVulnerabilityAsync(identity, cancellationToken);
                 }
             }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException)
             {
                 // UI requested cancellation.
             }
-            catch (TaskCanceledException)
+            catch (TimeoutException)
             {
-                // HttpClient throws TaskCanceledExceptions for HTTP timeouts
+                // Our code throws a TimeoutException for HTTP timeouts
                 try
                 {
                     await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
@@ -34,6 +34,13 @@ namespace NuGet.VisualStudio.Telemetry
                 throw new ArgumentNullException(nameof(e));
             }
 
+            if (e is OperationCanceledException)
+            {
+                // Don't post telemetry for cancellation exceptions since these should only happen for user initiated actions.
+                // Any other cancellation exceptions like a timeout should be a TimeoutException instead.
+                return;
+            }
+
             var caller = $"{callerClassName}.{callerMemberName}";
             var description = $"{e.GetType().Name} - {e.Message}";
 

--- a/src/NuGet.Core/NuGet.Protocol/Providers/ServiceIndexResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/ServiceIndexResourceV3Provider.cs
@@ -21,7 +21,7 @@ namespace NuGet.Protocol
     /// </summary>
     public class ServiceIndexResourceV3Provider : ResourceProvider
     {
-        private static readonly TimeSpan _defaultCacheDuration = TimeSpan.FromMinutes(40);
+        private static readonly TimeSpan DefaultCacheDuration = TimeSpan.FromMinutes(40);
         private readonly ConcurrentDictionary<string, ServiceIndexCacheInfo> _cache;
         private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
         private readonly EnhancedHttpRetryHelper _enhancedHttpRetryHelper;
@@ -40,7 +40,7 @@ namespace NuGet.Protocol
                   NuGetResourceProviderPositions.Last)
         {
             _cache = new ConcurrentDictionary<string, ServiceIndexCacheInfo>(StringComparer.OrdinalIgnoreCase);
-            MaxCacheDuration = _defaultCacheDuration;
+            MaxCacheDuration = DefaultCacheDuration;
             _enhancedHttpRetryHelper = new EnhancedHttpRetryHelper(environmentVariableReader);
         }
 
@@ -85,10 +85,10 @@ namespace NuGet.Protocol
                     }
                     finally
                     {
-                            _semaphore.Release();
-                        }
+                        _semaphore.Release();
                     }
                 }
+            }
 
             if (index == null && cacheInfo != null)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Providers/ServiceIndexResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/ServiceIndexResourceV3Provider.cs
@@ -62,15 +62,10 @@ namespace NuGet.Protocol
                 if (!_cache.TryGetValue(url, out cacheInfo) ||
                     entryValidCutoff > cacheInfo.CachedTime)
                 {
-                    // Track if the semaphore needs to be released
-                    var release = false;
+                    await _semaphore.WaitAsync(token);
+
                     try
                     {
-                        await _semaphore.WaitAsync(token);
-                        release = true;
-
-                        token.ThrowIfCancellationRequested();
-
                         // check the cache again, another thread may have finished this one waited for the lock
                         if (!_cache.TryGetValue(url, out cacheInfo) ||
                             entryValidCutoff > cacheInfo.CachedTime)
@@ -90,13 +85,10 @@ namespace NuGet.Protocol
                     }
                     finally
                     {
-                        if (release)
-                        {
                             _semaphore.Release();
                         }
                     }
                 }
-            }
 
             if (index == null && cacheInfo != null)
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3013

## Description
Our code is posting fault telemetry for cancellations and it should not be.  The `PackageItemViewModel` was assuming that HTTP timeouts were throwing a `TaskCanceledException` but that is not the case.  In `TimeoutUtility` we detect a timeout and throw a `TimeoutException` instead:

https://github.com/NuGet/NuGet.Client/blob/38729596a6549df3cd1eed37b93d51df1bf62bff/src/NuGet.Core/NuGet.Protocol/Utility/TimeoutUtility.cs#L46

This change updates the view model based on my findings and blocks any `OperationCancelledException` from posting telemetry.  Any code in the future where we want to post fault telemetry but its not really a cancellation should wrap the exception as something else like a `TimeoutException`.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
