### PR TITLE
Address accessibility and bug bash issues.

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml
@@ -30,7 +30,7 @@
     HorizontalScrollBarVisibility="Disabled"
     AutomationProperties.Name="{Binding Text, ElementName=_packageId}">
     <Grid
-      Margin="24,0,7,0">
+      Margin="0,0,7,0">
       <Grid.RowDefinitions>
         <RowDefinition
           Height="Auto" />
@@ -49,7 +49,7 @@
       <Grid
         Grid.Row="0"
         MinHeight="32"
-        Margin="0,8">
+        Margin="24,8,0,8">
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="auto"/>
           <ColumnDefinition Width="*"/>
@@ -124,7 +124,7 @@
       <!-- project action when in project package manager -->
       <nuget:ProjectView
         Grid.Row="1"
-        Margin="0,8"
+        Margin="24,8,0,8"
         x:Name="_projectView"
         Visibility="{Binding Path=IsSolution, Converter={StaticResource NegatedBooleanToVisibilityConverter}}" />
 
@@ -133,7 +133,7 @@
         AutomationProperties.AutomationId="SolutionView"
         x:Name="_solutionView"
         Grid.Row="1"
-        Margin="0,8"
+        Margin="24,8,0,8"
         Visibility="{Binding Path=IsSolution,Converter={StaticResource BooleanToVisibilityConverter}}" />
 
       <!-- the splitter is shown when in solution package manager -->
@@ -153,6 +153,7 @@
       <!-- options -->
       <Border
         Grid.Row="3"
+        Margin="24,0,0,0"
         BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
         BorderThickness="0,1,0,1">
         <Grid>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml
@@ -131,11 +131,11 @@
             <DataTemplate DataType="{x:Type nuget:DetailControlModel}">
               <nuget:PackageMetadataControl
                 Focusable="True"
-                Margin="0,12,0,0"/>
+                Margin="0,5,0,0"/>
             </DataTemplate>
             <DataTemplate DataType="{x:Type vm:ReadmePreviewViewModel}">
               <nuget:PackageReadmeControl
-                Margin="22,0,0,0"
+                Margin="22,5,0,0"
                 x:Name="_packageReadmeControl"/>
             </DataTemplate>
           </ContentControl.Resources>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml
@@ -32,7 +32,7 @@
         <Setter Property="Background" Value="{DynamicResource {x:Static nuget:Brushes.HeaderBackground}}" />
         <Setter Property="FontSize" Value="{Binding FontSize, RelativeSource={RelativeSource AncestorType=UserControl},Converter={StaticResource Font122PercentSizeConverter}}"/>
         <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}" />
-        <Setter Property="Padding" Value="20,0,20,0" />
+        <Setter Property="Padding" Value="5,0,5,0" />
         <Setter Property="FocusVisualStyle" Value="{DynamicResource ControlsFocusVisualStyle}" />
         <Setter Property="Template">
           <Setter.Value>
@@ -97,7 +97,7 @@
                   <RowDefinition x:Name="RowDefinition1" Height="Auto"/>
                   <RowDefinition x:Name="RowDefinition2"/>
                 </Grid.RowDefinitions>
-                <TabPanel x:Name="headerPanel" Background="Transparent" Grid.Column="0" IsItemsHost="true" Grid.Row="0" KeyboardNavigation.TabIndex="1" Panel.ZIndex="1"/>
+                <TabPanel x:Name="headerPanel" Margin="24,0,0,0" Background="Transparent" Grid.Column="0" IsItemsHost="true" Grid.Row="0" KeyboardNavigation.TabIndex="1" Panel.ZIndex="1"/>
                 <ContentPresenter
                     Grid.Row="2"
                     ClipToBounds="True"
@@ -135,6 +135,7 @@
             </DataTemplate>
             <DataTemplate DataType="{x:Type vm:ReadmePreviewViewModel}">
               <nuget:PackageReadmeControl
+                Margin="22,0,0,0"
                 x:Name="_packageReadmeControl"/>
             </DataTemplate>
           </ContentControl.Resources>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml
@@ -32,7 +32,7 @@
         <Setter Property="Background" Value="{DynamicResource {x:Static nuget:Brushes.HeaderBackground}}" />
         <Setter Property="FontSize" Value="{Binding FontSize, RelativeSource={RelativeSource AncestorType=UserControl},Converter={StaticResource Font122PercentSizeConverter}}"/>
         <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}" />
-        <Setter Property="Padding" Value="5,0,5,0" />
+        <Setter Property="Padding" Value="12,0,12,0" />
         <Setter Property="FocusVisualStyle" Value="{DynamicResource ControlsFocusVisualStyle}" />
         <Setter Property="Template">
           <Setter.Value>
@@ -97,7 +97,7 @@
                   <RowDefinition x:Name="RowDefinition1" Height="Auto"/>
                   <RowDefinition x:Name="RowDefinition2"/>
                 </Grid.RowDefinitions>
-                <TabPanel x:Name="headerPanel" Margin="24,0,0,0" Background="Transparent" Grid.Column="0" IsItemsHost="true" Grid.Row="0" KeyboardNavigation.TabIndex="1" Panel.ZIndex="1"/>
+                <TabPanel x:Name="headerPanel" Margin="12,0,0,0" Background="Transparent" Grid.Column="0" IsItemsHost="true" Grid.Row="0" KeyboardNavigation.TabIndex="1" Panel.ZIndex="1"/>
                 <ContentPresenter
                     Grid.Row="2"
                     ClipToBounds="True"
@@ -135,7 +135,7 @@
             </DataTemplate>
             <DataTemplate DataType="{x:Type vm:ReadmePreviewViewModel}">
               <nuget:PackageReadmeControl
-                Margin="22,5,0,0"
+                Margin="22,0,0,0"
                 x:Name="_packageReadmeControl"/>
             </DataTemplate>
           </ContentControl.Resources>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -9,6 +9,7 @@
   xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
   xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
   xmlns:glob="clr-namespace:System.Globalization;assembly=mscorlib"
+  AutomationProperties.Name=" "
   Background="{DynamicResource {x:Static nuget:Brushes.DetailPaneBackground}}"
   Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
   mc:Ignorable="d"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -85,6 +85,7 @@
     <!-- vulnerabilities info -->
     <Border
      Grid.Row="0"
+      Margin="22,0,0,0"
      BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
      Visibility="{Binding Path=IsPackageVulnerable,Converter={StaticResource BooleanToVisibilityConverter}}"
      BorderThickness="0,0,0,1">
@@ -100,6 +101,7 @@
     <Border
       Grid.Row="1"
       BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+      Margin="22,0,0,0"
       Visibility="{Binding Path=IsPackageDeprecated,Converter={StaticResource BooleanToVisibilityConverter}}"
       BorderThickness="0,0,0,1">
       <Grid>
@@ -124,6 +126,7 @@
 
       <!-- descriptions -->
       <TextBlock
+        Margin="22,0,0,0"
         Grid.Row="0"
         x:Name="_descriptionLabel"
         Text="{x:Static nuget:Resources.Label_Description}"
@@ -133,7 +136,7 @@
         Grid.Row="1"
         x:Name="_description"
         AutomationProperties.LabeledBy="{Binding ElementName=_descriptionLabel}"
-        Margin="0,8,0,0"
+        Margin="22,8,0,0"
         TextWrapping="Wrap"
         Text="{Binding Path=PackageMetadata.Description}" />
 
@@ -141,7 +144,7 @@
       <Grid
         Grid.Row="2"
         x:Name="_metadataGrid"
-        Margin="0,8">
+        Margin="22,8,0,8">
         <Grid.RowDefinitions>
           <RowDefinition />
           <RowDefinition />
@@ -412,7 +415,7 @@
       <TreeView
         x:Name="_dependencies"
         Grid.Row="3"
-        Margin="-21,0,0,0"
+        Margin="2,0,0,0"
         BorderThickness="0"
         Background="{x:Null}"
         TreeViewItem.Selected="OnItemSelected"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13879
Fixes: https://github.com/NuGet/Home/issues/13910
Fixes: https://github.com/NuGet/Home/issues/13878

## Description
Adjust how the margins were being set for the details, allowing the dependencies list to have its border. Also reduced the padding for the tab headers. 

![image](https://github.com/user-attachments/assets/157c5867-e975-4b10-92eb-d66868c2ed13)

Adjusted header tab margins so they left align with contents
![image](https://github.com/user-attachments/assets/5dc4514c-a719-43bd-9fa8-b037f3351df3)
![image](https://github.com/user-attachments/assets/9cda0bb6-f2c2-40fd-8c2f-57dbec7dc685)


Fixed issue with JAWs reading full contents of the package details tab
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
