### PR TITLE
Add support for PrunePackageReference in the new resolver

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -91,7 +91,7 @@ namespace NuGet.Commands
                     hasInstallBeenCalledAlready = true;
                 }
 
-                TargetFrameworkInformation? projectTargetFramework = _request.Project.GetTargetFramework(pair.Framework);
+                TargetFrameworkInformation projectTargetFramework = _request.Project.GetTargetFramework(pair.Framework)!;
 
                 var unresolvedPackages = new HashSet<LibraryRange>();
 
@@ -104,7 +104,7 @@ namespace NuGet.Commands
                     // This is guaranteed to be computed before any graph with a RID, so we can assume this will return a value.
 
                     // PCL Projects with Supports have a runtime graph but no matching framework.
-                    var runtimeGraphPath = projectTargetFramework?.RuntimeIdentifierGraphPath;
+                    var runtimeGraphPath = projectTargetFramework.RuntimeIdentifierGraphPath;
 
                     RuntimeGraph? projectProviderRuntimeGraph = default;
                     if (runtimeGraphPath != null)
@@ -635,9 +635,20 @@ namespace NuGet.Commands
                         suppressions = currentSuppressions;
                     }
 
+                    List<int>? prunedPackageIndices = null;
                     for (int i = 0; i < refItemResult.Item.Data.Dependencies.Count; i++)
                     {
                         LibraryDependency dep = refItemResult.Item.Data.Dependencies[i];
+                        bool isPackage = dep.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package);
+                        bool isDirectPackageReferenceFromRootProject = (currentRefRangeIndex == rootProjectRefItem.LibraryRangeIndex) && isPackage;
+
+                        if (ShouldPrunePackage(projectTargetFramework!, refItemResult, dep, isPackage, isDirectPackageReferenceFromRootProject))
+                        {
+                            prunedPackageIndices ??= [];
+                            prunedPackageIndices.Add(i);
+                            continue;
+                        }
+
                         LibraryDependencyIndex depIndex = refItemResult.GetDependencyIndexForDependency(i);
 
                         // Skip this node if the VersionRange is null or if its not transitively pinned and PrivateAssets=All
@@ -647,9 +658,6 @@ namespace NuGet.Commands
                         }
 
                         VersionRange? pinnedVersionRange = null;
-
-                        bool isPackage = dep.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package);
-                        bool isDirectPackageReferenceFromRootProject = (currentRefRangeIndex == rootProjectRefItem.LibraryRangeIndex) && isPackage;
 
                         if (!isDirectPackageReferenceFromRootProject && directPackageReferences?.Contains(depIndex) == true)
                         {
@@ -752,6 +760,14 @@ namespace NuGet.Commands
                         {
                             foreach (var dep in runtimeDependencies)
                             {
+                                if (ShouldPrunePackage(projectTargetFramework!, refItemResult, dep, isPackage: true, isDirectPackageReferenceFromRootProject: false))
+                                {
+                                    prunedPackageIndices ??= [];
+                                    prunedPackageIndices.Add(runtimeDependencyIndex);
+                                    runtimeDependencyIndex++;
+                                    continue;
+                                }
+
                                 DependencyGraphItem runtimeDependencyGraphItem = new()
                                 {
                                     LibraryDependency = dep,
@@ -785,6 +801,12 @@ namespace NuGet.Commands
                                 runtimeDependencyIndex++;
                             }
                         }
+                    }
+
+                    // If the latest item was chosen, keep track of the pruned dependency indices.
+                    if (chosenResolvedItems.TryGetValue(currentRefDependencyIndex, out ResolvedDependencyGraphItem? resolvedGraphItem))
+                    {
+                        resolvedGraphItem.PrunedDependencyIndices = prunedPackageIndices;
                     }
                 }
 
@@ -829,18 +851,20 @@ namespace NuGet.Commands
                     LibraryRangeIndex[] pathToChosenRef = foundItem.Path;
                     bool directPackageReferenceFromRootProject = foundItem.IsDirectPackageReferenceFromRootProject;
                     List<HashSet<LibraryDependencyIndex>> chosenSuppressions = foundItem.Suppressions;
-
                     if (findLibraryEntryCache.TryGetValue(chosenRefRangeIndex, out Task<FindLibraryEntryResult>? nodeTask))
                     {
                         FindLibraryEntryResult node = await nodeTask;
-
-                        flattenedGraphItems.Add(node.Item);
 
                         for (int i = 0; i < node.Item.Data.Dependencies.Count; i++)
                         {
                             var dep = node.Item.Data.Dependencies[i];
 
                             if (dep.LibraryRange.VersionRange == null)
+                            {
+                                continue;
+                            }
+
+                            if (foundItem.PrunedDependencyIndices != null && foundItem.PrunedDependencyIndices.Contains(i))
                             {
                                 continue;
                             }
@@ -1034,6 +1058,31 @@ namespace NuGet.Commands
                                 range: newGraphNode.Key.VersionRange,
                                 child: newGraphNode.Item.Key));
                         }
+
+                        if (foundItem.PrunedDependencyIndices != null && foundItem.PrunedDependencyIndices!.Count > 0)
+                        {
+                            int dependencyCount = node.Item.Data.Dependencies.Count - foundItem.PrunedDependencyIndices.Count;
+
+                            List<LibraryDependency> dependencies = dependencyCount > 0 ? new(dependencyCount) : [];
+
+                            for (int i = 0; dependencyCount > 0 && i < node.Item.Data.Dependencies.Count; i++)
+                            {
+                                if (!foundItem.PrunedDependencyIndices.Contains(i))
+                                {
+                                    dependencies.Add(node.Item.Data.Dependencies[i]);
+                                }
+                            }
+
+                            RemoteResolveResult remoteResolveResult = new RemoteResolveResult()
+                            {
+                                Match = node.Item.Data.Match,
+                                Dependencies = dependencies,
+                            };
+
+                            node.Item.Data = remoteResolveResult;
+                        }
+
+                        flattenedGraphItems.Add(node.Item);
                     }
                 }
 
@@ -1204,6 +1253,42 @@ namespace NuGet.Commands
             return (_success, allGraphs, allRuntimes);
         }
 
+        private bool ShouldPrunePackage(TargetFrameworkInformation projectTargetFramework, FindLibraryEntryResult refItemResult, LibraryDependency dep, bool isPackage, bool isDirectPackageReferenceFromRootProject)
+        {
+            if (projectTargetFramework!.PackagesToPrune.TryGetValue(dep.Name, out PrunePackageReference? prunableVersion))
+            {
+                if (dep.LibraryRange!.VersionRange!.Satisfies(prunableVersion.VersionRange!.MaxVersion!))
+                {
+                    if (!isPackage)
+                    {
+                        if (SdkAnalysisLevelMinimums.IsEnabled(
+                            _request.Project!.RestoreMetadata!.SdkAnalysisLevel,
+                            _request.Project.RestoreMetadata.UsingMicrosoftNETSdk,
+                            SdkAnalysisLevelMinimums.PruningWarnings))
+                        {
+                            _logger.Log(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1511, string.Format(CultureInfo.CurrentCulture, Strings.Error_RestorePruningProjectReference, dep.Name)));
+                        }
+                    }
+                    else if (isDirectPackageReferenceFromRootProject)
+                    {
+                        if (SdkAnalysisLevelMinimums.IsEnabled(
+                            _request.Project!.RestoreMetadata!.SdkAnalysisLevel,
+                            _request.Project.RestoreMetadata.UsingMicrosoftNETSdk,
+                            SdkAnalysisLevelMinimums.PruningWarnings))
+                        {
+                            _logger.Log(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1510, string.Format(CultureInfo.CurrentCulture, Strings.Error_RestorePruningDirectPackageReference, dep.Name)));
+                        }
+                    }
+                    else
+                    {
+                        _logger.LogDebug(string.Format(CultureInfo.CurrentCulture, Strings.RestoreDebugPruningPackageReference, $"{dep.Name} {dep.LibraryRange.VersionRange.OriginalString}", refItemResult.Item.Key, prunableVersion.VersionRange.MaxVersion));
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
         private static bool EvictOnTypeConstraint(LibraryDependencyTarget current, LibraryDependencyTarget previous)
         {
             if (current == previous)
@@ -1295,6 +1380,8 @@ namespace NuGet.Commands
             public required LibraryRangeIndex[] Path { get; set; }
 
             public required List<HashSet<LibraryDependencyIndex>> Suppressions { get; set; }
+
+            public List<int>? PrunedDependencyIndices { get; set; }
         }
 
         internal sealed class LibraryDependencyInterningTable

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -1274,7 +1274,13 @@ namespace NuGet.Commands
             return prunedPackageVersions;
         }
 
-        private bool ShouldPrunePackage(IReadOnlyDictionary<LibraryDependencyIndex, VersionRange>? packagesToPrune, FindLibraryEntryResult refItemResult, LibraryDependency dep, LibraryDependencyIndex libraryDependencyIndex, bool isPackage, bool isDirectPackageReferenceFromRootProject)
+        private bool ShouldPrunePackage(
+            IReadOnlyDictionary<LibraryDependencyIndex, VersionRange>? packagesToPrune,
+            FindLibraryEntryResult refItemResult,
+            LibraryDependency dep,
+            LibraryDependencyIndex libraryDependencyIndex,
+            bool isPackage,
+            bool isDirectPackageReferenceFromRootProject)
         {
             if (packagesToPrune?.TryGetValue(libraryDependencyIndex, out VersionRange? prunableVersion) == true)
             {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -91,7 +91,7 @@ namespace NuGet.Commands
                     hasInstallBeenCalledAlready = true;
                 }
 
-                TargetFrameworkInformation projectTargetFramework = _request.Project.GetTargetFramework(pair.Framework)!;
+                TargetFrameworkInformation? projectTargetFramework = _request.Project.GetTargetFramework(pair.Framework);
 
                 var unresolvedPackages = new HashSet<LibraryRange>();
 
@@ -151,6 +151,8 @@ namespace NuGet.Commands
                         pinnedPackageVersions[depIndex] = item.Value.VersionRange;
                     }
                 }
+
+                Dictionary<LibraryDependencyIndex, VersionRange>? prunedPackageVersions = GetAndIndexPackagesToPrune(libraryDependencyInterningTable, projectTargetFramework);
 
                 DependencyGraphItem rootProjectRefItem = new()
                 {
@@ -635,21 +637,21 @@ namespace NuGet.Commands
                         suppressions = currentSuppressions;
                     }
 
-                    List<int>? prunedPackageIndices = null;
+                    HashSet<int>? prunedPackageIndices = null;
                     for (int i = 0; i < refItemResult.Item.Data.Dependencies.Count; i++)
                     {
                         LibraryDependency dep = refItemResult.Item.Data.Dependencies[i];
                         bool isPackage = dep.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package);
                         bool isDirectPackageReferenceFromRootProject = (currentRefRangeIndex == rootProjectRefItem.LibraryRangeIndex) && isPackage;
 
-                        if (ShouldPrunePackage(projectTargetFramework!, refItemResult, dep, isPackage, isDirectPackageReferenceFromRootProject))
+                        LibraryDependencyIndex depIndex = refItemResult.GetDependencyIndexForDependency(i);
+
+                        if (ShouldPrunePackage(prunedPackageVersions, refItemResult, dep, depIndex, isPackage, isDirectPackageReferenceFromRootProject))
                         {
                             prunedPackageIndices ??= [];
                             prunedPackageIndices.Add(i);
                             continue;
                         }
-
-                        LibraryDependencyIndex depIndex = refItemResult.GetDependencyIndexForDependency(i);
 
                         // Skip this node if the VersionRange is null or if its not transitively pinned and PrivateAssets=All
                         if (dep.LibraryRange.VersionRange == null || (!importRefItem.IsCentrallyPinnedTransitivePackage && suppressions!.Contains(depIndex)))
@@ -760,7 +762,8 @@ namespace NuGet.Commands
                         {
                             foreach (var dep in runtimeDependencies)
                             {
-                                if (ShouldPrunePackage(projectTargetFramework!, refItemResult, dep, isPackage: true, isDirectPackageReferenceFromRootProject: false))
+                                var libraryDependencyIndex = findLibraryCachedAsyncResult.GetDependencyIndexForDependency(runtimeDependencyIndex);
+                                if (ShouldPrunePackage(prunedPackageVersions, refItemResult, dep, libraryDependencyIndex, isPackage: true, isDirectPackageReferenceFromRootProject: false))
                                 {
                                     prunedPackageIndices ??= [];
                                     prunedPackageIndices.Add(runtimeDependencyIndex);
@@ -771,7 +774,7 @@ namespace NuGet.Commands
                                 DependencyGraphItem runtimeDependencyGraphItem = new()
                                 {
                                     LibraryDependency = dep,
-                                    LibraryDependencyIndex = findLibraryCachedAsyncResult.GetDependencyIndexForDependency(runtimeDependencyIndex),
+                                    LibraryDependencyIndex = libraryDependencyIndex,
                                     LibraryRangeIndex = findLibraryCachedAsyncResult.GetRangeIndexForDependency(runtimeDependencyIndex),
                                     Path = LibraryRangeInterningTable.CreatePathToRef(pathToCurrentRef, currentRefRangeIndex),
                                     Parent = currentRefRangeIndex,
@@ -806,7 +809,7 @@ namespace NuGet.Commands
                     // If the latest item was chosen, keep track of the pruned dependency indices.
                     if (chosenResolvedItems.TryGetValue(currentRefDependencyIndex, out ResolvedDependencyGraphItem? resolvedGraphItem))
                     {
-                        resolvedGraphItem.PrunedDependencyIndices = prunedPackageIndices;
+                        resolvedGraphItem.PrunedDependencies = prunedPackageIndices;
                     }
                 }
 
@@ -864,7 +867,7 @@ namespace NuGet.Commands
                                 continue;
                             }
 
-                            if (foundItem.PrunedDependencyIndices != null && foundItem.PrunedDependencyIndices.Contains(i))
+                            if (foundItem.PrunedDependencies?.Contains(i) == true)
                             {
                                 continue;
                             }
@@ -1059,15 +1062,15 @@ namespace NuGet.Commands
                                 child: newGraphNode.Item.Key));
                         }
 
-                        if (foundItem.PrunedDependencyIndices != null && foundItem.PrunedDependencyIndices!.Count > 0)
+                        if (foundItem.PrunedDependencies?.Count > 0)
                         {
-                            int dependencyCount = node.Item.Data.Dependencies.Count - foundItem.PrunedDependencyIndices.Count;
+                            int dependencyCount = node.Item.Data.Dependencies.Count - foundItem.PrunedDependencies.Count;
 
                             List<LibraryDependency> dependencies = dependencyCount > 0 ? new(dependencyCount) : [];
 
                             for (int i = 0; dependencyCount > 0 && i < node.Item.Data.Dependencies.Count; i++)
                             {
-                                if (!foundItem.PrunedDependencyIndices.Contains(i))
+                                if (!foundItem.PrunedDependencies.Contains(i))
                                 {
                                     dependencies.Add(node.Item.Data.Dependencies[i]);
                                 }
@@ -1253,11 +1256,29 @@ namespace NuGet.Commands
             return (_success, allGraphs, allRuntimes);
         }
 
-        private bool ShouldPrunePackage(TargetFrameworkInformation projectTargetFramework, FindLibraryEntryResult refItemResult, LibraryDependency dep, bool isPackage, bool isDirectPackageReferenceFromRootProject)
+        private static Dictionary<LibraryDependencyIndex, VersionRange>? GetAndIndexPackagesToPrune(LibraryDependencyInterningTable libraryDependencyInterningTable, TargetFrameworkInformation? projectTargetFramework)
         {
-            if (projectTargetFramework!.PackagesToPrune.TryGetValue(dep.Name, out PrunePackageReference? prunableVersion))
+            Dictionary<LibraryDependencyIndex, VersionRange>? prunedPackageVersions = null;
+
+            if (projectTargetFramework?.PackagesToPrune.Count > 0)
             {
-                if (dep.LibraryRange!.VersionRange!.Satisfies(prunableVersion.VersionRange!.MaxVersion!))
+                prunedPackageVersions = new Dictionary<LibraryDependencyIndex, VersionRange>(capacity: projectTargetFramework.PackagesToPrune.Count);
+
+                foreach (var item in projectTargetFramework.PackagesToPrune)
+                {
+                    LibraryDependencyIndex depIndex = libraryDependencyInterningTable.Intern(item.Value);
+                    prunedPackageVersions[depIndex] = item.Value.VersionRange;
+                }
+            }
+
+            return prunedPackageVersions;
+        }
+
+        private bool ShouldPrunePackage(IReadOnlyDictionary<LibraryDependencyIndex, VersionRange>? packagesToPrune, FindLibraryEntryResult refItemResult, LibraryDependency dep, LibraryDependencyIndex libraryDependencyIndex, bool isPackage, bool isDirectPackageReferenceFromRootProject)
+        {
+            if (packagesToPrune?.TryGetValue(libraryDependencyIndex, out VersionRange? prunableVersion) == true)
+            {
+                if (dep.LibraryRange!.VersionRange!.Satisfies(prunableVersion!.MaxVersion!))
                 {
                     if (!isPackage)
                     {
@@ -1281,7 +1302,7 @@ namespace NuGet.Commands
                     }
                     else
                     {
-                        _logger.LogDebug(string.Format(CultureInfo.CurrentCulture, Strings.RestoreDebugPruningPackageReference, $"{dep.Name} {dep.LibraryRange.VersionRange.OriginalString}", refItemResult.Item.Key, prunableVersion.VersionRange.MaxVersion));
+                        _logger.LogDebug(string.Format(CultureInfo.CurrentCulture, Strings.RestoreDebugPruningPackageReference, $"{dep.Name} {dep.LibraryRange.VersionRange.OriginalString}", refItemResult.Item.Key, prunableVersion.MaxVersion));
                         return true;
                     }
                 }
@@ -1381,7 +1402,7 @@ namespace NuGet.Commands
 
             public required List<HashSet<LibraryDependencyIndex>> Suppressions { get; set; }
 
-            public List<int>? PrunedDependencyIndices { get; set; }
+            public HashSet<int>? PrunedDependencies { get; set; }
         }
 
         internal sealed class LibraryDependencyInterningTable
@@ -1420,6 +1441,21 @@ namespace NuGet.Commands
                 }
 
                 return index;
+            }
+
+            public LibraryDependencyIndex Intern(PrunePackageReference prunePackageReference)
+            {
+                lock (_lockObject)
+                {
+                    string key = prunePackageReference.Name;
+                    if (!_table.TryGetValue(key, out LibraryDependencyIndex index))
+                    {
+                        index = (LibraryDependencyIndex)_nextIndex++;
+                        _table.TryAdd(key, index);
+                    }
+
+                    return index;
+                }
             }
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilderCache.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilderCache.cs
@@ -29,7 +29,7 @@ namespace NuGet.Commands
         private readonly ConcurrentDictionary<CriteriaKey, List<(List<SelectionCriteria>, bool)>> _criteriaSets =
             new();
 
-        private readonly ConcurrentDictionary<(CriteriaKey, string path, string aliases, LibraryIncludeFlags, int), Lazy<(LockFileTargetLibrary, bool)>> _lockFileTargetLibraryCache =
+        private readonly ConcurrentDictionary<(CriteriaKey, string path, string aliases, LibraryIncludeFlags, int dependencyCount), Lazy<(LockFileTargetLibrary, bool)>> _lockFileTargetLibraryCache =
             new();
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilderCache.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilderCache.cs
@@ -29,7 +29,7 @@ namespace NuGet.Commands
         private readonly ConcurrentDictionary<CriteriaKey, List<(List<SelectionCriteria>, bool)>> _criteriaSets =
             new();
 
-        private readonly ConcurrentDictionary<(CriteriaKey, string path, string aliases, LibraryIncludeFlags), Lazy<(LockFileTargetLibrary, bool)>> _lockFileTargetLibraryCache =
+        private readonly ConcurrentDictionary<(CriteriaKey, string path, string aliases, LibraryIncludeFlags, int), Lazy<(LockFileTargetLibrary, bool)>> _lockFileTargetLibraryCache =
             new();
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace NuGet.Commands
         /// <summary>
         /// Try to get a LockFileTargetLibrary from the cache.
         /// </summary>
-        internal (LockFileTargetLibrary, bool) GetLockFileTargetLibrary(RestoreTargetGraph graph, NuGetFramework framework, LocalPackageInfo localPackageInfo, string aliases, LibraryIncludeFlags libraryIncludeFlags, Func<(LockFileTargetLibrary, bool)> valueFactory)
+        internal (LockFileTargetLibrary, bool) GetLockFileTargetLibrary(RestoreTargetGraph graph, NuGetFramework framework, LocalPackageInfo localPackageInfo, string aliases, LibraryIncludeFlags libraryIncludeFlags, List<LibraryDependency> dependencies, Func<(LockFileTargetLibrary, bool)> valueFactory)
         {
             // Comparing RuntimeGraph for equality is very expensive,
             // so in case of a request where the RuntimeGraph is not empty we avoid using the cache.
@@ -114,7 +114,7 @@ namespace NuGet.Commands
             localPackageInfo = localPackageInfo ?? throw new ArgumentNullException(nameof(localPackageInfo));
             var criteriaKey = new CriteriaKey(graph.TargetGraphName, framework);
             var packagePath = localPackageInfo.ExpandedPath;
-            return _lockFileTargetLibraryCache.GetOrAdd((criteriaKey, packagePath, aliases, libraryIncludeFlags),
+            return _lockFileTargetLibraryCache.GetOrAdd((criteriaKey, packagePath, aliases, libraryIncludeFlags, dependencies.Count),
                 key => new Lazy<(LockFileTargetLibrary, bool)>(valueFactory)).Value;
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -69,7 +69,7 @@ namespace NuGet.Commands
             var runtimeIdentifier = targetGraph.RuntimeIdentifier;
             var framework = targetFrameworkOverride ?? targetGraph.Framework;
 
-            return cache.GetLockFileTargetLibrary(targetGraph, framework, package, aliases, dependencyType,
+            return cache.GetLockFileTargetLibrary(targetGraph, framework, package, aliases, dependencyType, dependencies,
                 () =>
                 {
                     LockFileTargetLibrary lockFileLib = null;

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -799,6 +799,24 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A direct PackageReference cannot be pruned, {0}. Consider removing this package from your dependencies, as it is likely unnecessary..
+        /// </summary>
+        internal static string Error_RestorePruningDirectPackageReference {
+            get {
+                return ResourceManager.GetString("Error_RestorePruningDirectPackageReference", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A ProjectReference cannot be pruned, {0}..
+        /// </summary>
+        internal static string Error_RestorePruningProjectReference {
+            get {
+                return ResourceManager.GetString("Error_RestorePruningProjectReference", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The repository service index &apos;{0}&apos; is not a valid HTTPS url..
         /// </summary>
         internal static string Error_ServiceIndexShouldBeHttps {
@@ -1876,6 +1894,15 @@ namespace NuGet.Commands {
         internal static string ResolverRequest_ToStringFormat {
             get {
                 return ResourceManager.GetString("ResolverRequest_ToStringFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pruning the package &apos;{0}&apos; as a dependency of &apos;{1}&apos;. The maximum prunable version is &apos;{2}&apos;.
+        /// </summary>
+        internal static string RestoreDebugPruningPackageReference {
+            get {
+                return ResourceManager.GetString("RestoreDebugPruningPackageReference", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -799,7 +799,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A direct PackageReference cannot be pruned, {0}. Consider removing this package from your dependencies, as it is likely unnecessary..
+        ///   Looks up a localized string similar to PackageReference {0} will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary..
         /// </summary>
         internal static string Error_RestorePruningDirectPackageReference {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1132,7 +1132,7 @@ NuGet requires HTTPS sources. Refer to https://aka.ms/nuget-https-everywhere for
     <comment>0 - package id and version, 1 - version</comment>
   </data>
   <data name="Error_RestorePruningDirectPackageReference" xml:space="preserve">
-    <value>A direct PackageReference cannot be pruned, {0}. Consider removing this package from your dependencies, as it is likely unnecessary.</value>
+    <value>PackageReference {0} will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.</value>
     <comment>0 - package id and version</comment>
   </data>
   <data name="Error_RestorePruningProjectReference" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1127,4 +1127,16 @@ NuGet requires HTTPS sources. Refer to https://aka.ms/nuget-https-everywhere for
     <value>Audit source '{0}' did not provide any vulnerability data.</value>
     <comment>{0} is the source name</comment>
   </data>
+  <data name="RestoreDebugPruningPackageReference" xml:space="preserve">
+    <value>Pruning the package '{0}' as a dependency of '{1}'. The maximum prunable version is '{2}'</value>
+    <comment>0 - package id and version, 1 - version</comment>
+  </data>
+  <data name="Error_RestorePruningDirectPackageReference" xml:space="preserve">
+    <value>A direct PackageReference cannot be pruned, {0}. Consider removing this package from your dependencies, as it is likely unnecessary.</value>
+    <comment>0 - package id and version</comment>
+  </data>
+  <data name="Error_RestorePruningProjectReference" xml:space="preserve">
+    <value>A ProjectReference cannot be pruned, {0}.</value>
+    <comment>0 - project reference</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Utility/SdkAnalysisLevelMinimums.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/SdkAnalysisLevelMinimums.cs
@@ -16,6 +16,11 @@ namespace NuGet.Commands
         internal static readonly NuGetVersion HttpErrorSdkAnalysisLevelMinimumValue = new("9.0.100");
 
         /// <summary>
+        /// Minimum SDK Analysis Level required for warning for packages and projects that cannot be pruned.
+        /// </summary>
+        internal static readonly NuGetVersion PruningWarnings = new("10.0.100");
+
+        /// <summary>
         /// Determines whether the feature is enabled based on the SDK analysis level.
         /// </summary>
         /// <param name="sdkAnalysisLevel">The project SdkAnalysisLevel value </param>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -298,6 +298,16 @@ namespace NuGet.Common
         NU1509 = 1509,
 
         /// <summary>
+        /// Direct reference to a package that cannot be pruned.
+        /// </summary>
+        NU1510 = 1510,
+
+        /// <summary>
+        /// Project references cannot be pruned
+        /// </summary>
+        NU1511 = 1511,
+
+        /// <summary>
         /// Dependency bumped up
         /// </summary>
         NU1601 = 1601,

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -298,7 +298,7 @@ namespace NuGet.Common
         NU1509 = 1509,
 
         /// <summary>
-        /// Direct reference to a package that cannot be pruned.
+        /// Direct reference to a package that will not be pruned.
         /// </summary>
         NU1510 = 1510,
 

--- a/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
 NuGet.Common.NuGetLogCode.NU1509 = 1509 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1510 = 1510 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1511 = 1511 -> NuGet.Common.NuGetLogCode
 static NuGet.Common.MSBuildStringUtility.GetNuGetLogCodes(string! s) -> System.Collections.Immutable.ImmutableArray<NuGet.Common.NuGetLogCode>

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -4276,6 +4276,987 @@ namespace NuGet.Commands.FuncTest
             logger.Errors.Should().Be(0, because: logger.ShowErrors());
             logger.Warnings.Should().Be(1, because: logger.ShowWarnings());
         }
+
+        // P -> A 1.0.0 -> B 1.0.0
+        // Prune B 1.0.0
+        [Fact]
+        public async Task RestoreCommand_WithPrunePackageReferences_PrunesTransitivesDependencies_AndVerifiesEquivalency()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("packageA", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("packageB", "1.0.0")]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA);
+
+            var rootProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""packageB"" : ""(,1.0.0]"" 
+                }
+            }
+          }
+        }";
+
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+
+            // Act & Assert
+            var result = await RunRestoreAsync(pathContext, projectSpec);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().BeEmpty();
+            ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
+            installedPackages.Should().HaveCount(1);
+        }
+
+        // P -> A 1.0.0 -> B 1.0.0
+        //              -> C 1.0.0
+        //              -> D 1.0.0
+        // Prune C 1.0.0
+        [Fact]
+        public async Task RestoreCommand_WithPrunePackageReferencesAndManyDependencies_PrunesTransitiveDependencies_AndVerifiesEquivalency()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("A", "1.0.0")
+            {
+                Dependencies = [
+                    new SimpleTestPackageContext("B", "1.0.0"),
+                    new SimpleTestPackageContext("C", "1.0.0"),
+                    new SimpleTestPackageContext("D", "1.0.0")
+                    ]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA);
+
+            var rootProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""A"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""C"" : ""(,1.0.0]"" 
+                }
+            }
+          }
+        }";
+
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+
+            // Act & Assert
+            var result = await RunRestoreAsync(pathContext, projectSpec);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("A");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().HaveCount(2);
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("B");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Dependencies.Should().BeEmpty();
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("D");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[2].Dependencies.Should().BeEmpty();
+
+            ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
+            installedPackages.Should().HaveCount(3);
+        }
+
+        // P -> A 1.0.0 -> B 1.0.0
+        // P -> C 1.0.0
+        // Prune C 1.0.0
+        [Fact]
+        public async Task RestoreCommand_WithPrunePackageReferences_DoesNotPruneDirectDependencies_AndVerifiesEquivalency()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("A", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("B", "1.0.0")]
+            };
+            var packageC = new SimpleTestPackageContext("C", "1.0.0");
+
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA,
+                packageC);
+
+            var rootProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""A"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                        ""C"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""C"" : ""(,1.0.0]"" 
+                }
+            }
+          }
+        }";
+
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+
+            // Act & Assert
+            var result = await RunRestoreAsync(pathContext, projectSpec);
+
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("A");
+            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("B");
+            result.LockFile.Targets[0].Libraries[1].Dependencies.Should().HaveCount(0);
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("C");
+            result.LockFile.Targets[0].Libraries[2].Dependencies.Should().HaveCount(0);
+            result.LockFile.LogMessages.Should().HaveCount(1);
+            result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1510);
+            ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
+            installedPackages.Should().HaveCount(3);
+        }
+
+        // P -> P2 -> B 1.0.0 -> C 1.0.0
+        // P -> A 1.0.0
+        // Prune B 1.0.0
+        [Fact]
+        public async Task RestoreCommand_WithPrunePackageReferences_PrunesTransitivesDependenciesThroughProjects_AndVerifiesEquivalency()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("packageA", "1.0.0");
+            var packageB = new SimpleTestPackageContext("packageB", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("packageC", "1.0.0")]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA,
+                packageB);
+
+            var rootProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""packageB"" : ""(,1.0.0]"" 
+                }
+            }
+          }
+        }";
+            var leafProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageB"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                }
+            }
+          }
+        }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, leafProject);
+            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+
+            // Act & Assert
+            var result = await RunRestoreAsync(pathContext, projectSpec, projectSpec2);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().BeEmpty();
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Dependencies.Should().BeEmpty();
+            ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
+            installedPackages.Should().HaveCount(1);
+        }
+
+        // P -> A 1.0.0 -> B 1.0.0
+        //              -> C 1.0.0
+        //              -> D 1.0.0 -> E 2.0.0
+        //              -> F 1.0.0 -> G 2.0.0
+        // P -> F 2.0.0 -> G 3.0.0
+        // P -> H 1.0.0 -> B 2.0.0
+        //
+        // Prune C 1.0.0, D 1.0.0, G 2.0.0, B 1.5.0
+        // Leaves: A 1.0.0, B 2.0.0, F 2.0.0, G 3.0.0, H 1.0.0
+        [Fact]
+        public async Task RestoreCommand_WithPrunePackageReferences_PrunesManyDependenciesFromSinglePackage_AndVerifiesEquivalency()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                 new SimpleTestPackageContext("A", "1.0.0")
+                 {
+                     Dependencies = [
+                         new SimpleTestPackageContext("B", "1.0.0"),
+                         new SimpleTestPackageContext("C", "1.0.0"),
+                         new SimpleTestPackageContext("D", "1.0.0")
+                         {
+                             Dependencies = [
+                                 new SimpleTestPackageContext("E", "2.0.0"),
+                             ]
+                         },
+                         new SimpleTestPackageContext("F", "1.0.0")
+                         {
+                             Dependencies = [
+                                 new SimpleTestPackageContext("G", "2.0.0"),
+                             ]
+                         }
+                     ]
+                 },
+                 new SimpleTestPackageContext("F", "2.0.0")
+                 {
+                     Dependencies = [
+                         new SimpleTestPackageContext("G", "3.0.0"),
+                     ]
+                 },
+                 new SimpleTestPackageContext("H", "1.0.0")
+                 {
+                     Dependencies = [
+                         new SimpleTestPackageContext("B", "2.0.0"),
+                     ]
+                 });
+
+            var rootProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""A"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                        ""F"": {
+                            ""version"": ""[2.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                        ""H"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""C"" : ""(,1.0.0]"",
+                    ""D"" : ""(,1.0.0]"",
+                    ""G"" : ""(,2.0.0]"",
+                    ""B"" : ""(,1.5.0]""
+                }
+            }
+          }
+        }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+
+            // Act & Assert
+            var result = await RunRestoreAsync(pathContext, projectSpec);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(5);
+
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("A");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[0].Dependencies[0].Id.Should().Be("F");
+
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("B");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Dependencies.Should().BeEmpty();
+
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("F");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("2.0.0"));
+            result.LockFile.Targets[0].Libraries[2].Dependencies.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[2].Dependencies[0].Id.Should().Be("G");
+
+            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("G");
+            result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("3.0.0"));
+            result.LockFile.Targets[0].Libraries[3].Dependencies.Should().BeEmpty();
+
+            result.LockFile.Targets[0].Libraries[4].Name.Should().Be("H");
+            result.LockFile.Targets[0].Libraries[4].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[4].Dependencies.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[4].Dependencies[0].Id.Should().Be("B");
+        }
+
+        // P -> A 1.0.0 -> B 1.0.0
+        // Prune B 1.0.0
+        [Fact]
+        public async Task RestoreCommand_WithMultiTargetedPrunePackageReferences_PrunesTransitivesDependencies_AndVerifiesEquivalency()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("packageA", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("packageB", "1.0.0")]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA);
+
+            var rootProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""packageB"" : ""(,1.0.0]"" 
+                }
+            },
+            ""net48"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                }
+            }
+          }
+        }";
+
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+
+            // Act & Assert
+            var result = await RunRestoreAsync(pathContext, projectSpec);
+            result.LockFile.Targets.Should().HaveCount(2);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(1);
+            result.LockFile.Targets[1].Libraries.Should().HaveCount(2);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().BeEmpty();
+            result.LockFile.Targets[1].Libraries[0].Name.Should().Be("packageA");
+            result.LockFile.Targets[1].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[1].Libraries[0].Dependencies.Should().HaveCount(1);
+            result.LockFile.Targets[1].Libraries[1].Name.Should().Be("packageB");
+            result.LockFile.Targets[1].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[1].Libraries[1].Dependencies.Should().BeEmpty();
+            ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
+            installedPackages.Should().HaveCount(2);
+        }
+
+        // P1 -> A 1.0.0 -> B 1.0.0
+        // P1 -> P2 (project)
+        // Prune B 1.0.0
+        [Theory]
+        [InlineData("10.0.100", true, true)]
+        [InlineData("9.0.100", true, false)]
+        [InlineData("", false, true)]
+        public async Task RestoreCommand_WithDirectProjectReferenceSpecifiedForPruning_SkipsPruning(string sdkAnalysisLevel, bool usingMicrosoftNETSdk, bool shouldWarn)
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("packageA", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("packageB", "1.0.0")]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA);
+
+            var rootProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""packageB"" : ""(,1.0.0]"",
+                    ""Project2"" : ""(,3.0.0]"" 
+                }
+            }
+          }
+        }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+            projectSpec.RestoreMetadata.SdkAnalysisLevel = !string.IsNullOrEmpty(sdkAnalysisLevel) ? NuGetVersion.Parse(sdkAnalysisLevel) : null;
+            projectSpec.RestoreMetadata.UsingMicrosoftNETSdk = usingMicrosoftNETSdk;
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpec("Project2", framework: "net472");
+
+            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+
+            // Act & Assert
+            var result = await RunRestoreAsync(pathContext, projectSpec, projectSpec2);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().BeEmpty();
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Dependencies.Should().BeEmpty();
+            if (shouldWarn)
+            {
+                result.LockFile.LogMessages.Should().HaveCount(1);
+                result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1511);
+            }
+            ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
+            installedPackages.Should().HaveCount(1);
+        }
+
+        // P1 -> A 1.0.0 -> B 1.0.0
+        // P1 -> P2 (project) -> P3 (project)
+        // Prune B 1.0.0
+        [Theory]
+        [InlineData("10.0.100", true, true)]
+        [InlineData("9.0.100", true, false)]
+        [InlineData("", false, true)]
+        public async Task RestoreCommand_WithTransitiveProjectReferenceSpecifiedForPruning_SkipsPruning_AndVerifiesEquivalency(string sdkAnalysisLevel, bool usingMicrosoftNETSdk, bool shouldWarn)
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("packageA", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("packageB", "1.0.0")]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA);
+
+            var rootProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""packageB"" : ""(,1.0.0]"",
+                    ""Project3"" : ""(,3.0.0]"" 
+                }
+            }
+          }
+        }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+            projectSpec.RestoreMetadata.SdkAnalysisLevel = !string.IsNullOrEmpty(sdkAnalysisLevel) ? NuGetVersion.Parse(sdkAnalysisLevel) : null;
+            projectSpec.RestoreMetadata.UsingMicrosoftNETSdk = usingMicrosoftNETSdk;
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpec("Project2", framework: "net472");
+            var projectSpec3 = ProjectTestHelpers.GetPackageSpec("Project3", framework: "net472");
+
+            projectSpec2 = projectSpec2.WithTestProjectReference(projectSpec3);
+            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+
+            // Act & Assert
+            var result = await RunRestoreAsync(pathContext, projectSpec, projectSpec2, projectSpec3);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().BeEmpty();
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Dependencies.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project3");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[2].Dependencies.Should().BeEmpty();
+            if (shouldWarn)
+            {
+                result.LockFile.LogMessages.Should().HaveCount(1);
+                result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1511);
+            }
+            ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
+            installedPackages.Should().HaveCount(1);
+        }
+
+        // P -> A 1.0.0 -> B 1.0.0
+        // Prune B 1.0.0
+        [Fact]
+        public async Task RestoreCommand_WithPrunePackageReferences_AndMissingVersion_PrunesTransitivesDependencies_AndVerifiesEquivalency()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("packageA", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("packageB", "1.0.0")]
+            };
+            var packageB200 = new SimpleTestPackageContext("packageB", "2.0.0");
+
+            await SimpleTestPackageUtility.CreatePackagesWithoutDependenciesAsync(
+                pathContext.PackageSource,
+                packageA,
+                packageB200);
+
+            var rootProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""packageB"" : ""(,1.0.0]"" 
+                }
+            },
+            ""net48"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                }
+            }
+          }
+        }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+
+            // Act & Assert
+            var result = await RunRestoreAsync(pathContext, projectSpec);
+            result.LockFile.Targets.Should().HaveCount(2);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(1);
+            result.LockFile.Targets[1].Libraries.Should().HaveCount(2);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().BeEmpty();
+            result.LockFile.Targets[1].Libraries[0].Name.Should().Be("packageA");
+            result.LockFile.Targets[1].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[1].Libraries[0].Dependencies.Should().HaveCount(1);
+            result.LockFile.Targets[1].Libraries[1].Name.Should().Be("packageB");
+            result.LockFile.Targets[1].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
+            result.LockFile.Targets[1].Libraries[1].Dependencies.Should().BeEmpty();
+            ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
+            installedPackages.Should().HaveCount(2);
+        }
+
+        // P -> A 1.0.0 -> B (, 2.0.0]
+        // Prune B 1.0.0
+        // It prunes B 1.0.0, because the missing lower bound means min version. 
+        [Fact]
+        public async Task RestoreCommand_WithPrunePackageReferences_AndMissingLowerBoundVersion_PrunesTransitivesDependencies_AndVerifiesEquivalency()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("packageA", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("packageB", "(, 2.0.0]")]
+            };
+            var packageB = new SimpleTestPackageContext("packageB", "1.0.0");
+
+            await SimpleTestPackageUtility.CreatePackagesWithoutDependenciesAsync(
+                pathContext.PackageSource,
+                packageA,
+                packageB);
+
+            var rootProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""packageB"" : ""(,1.0.0]"" 
+                }
+            }
+          }
+        }";
+
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+
+            // Act & Assert
+            var result = await RunRestoreAsync(pathContext, projectSpec);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().BeEmpty();
+            ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
+            installedPackages.Should().HaveCount(1);
+        }
+
+        // P -> A 1.0.0 -> B 1.0.0
+        //              -> (win) runtime.a 1.0.0
+        //              -> (win) runtime.a.win 1.0.0
+        // Prune runtime.A 1.0.0
+        // Leaves B and runtime.a.win
+
+        [Fact]
+        public async Task RestoreCommand_WithPrunePackageReferences_PrunesRuntimeDependencies_AndVerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                new SimpleTestPackageContext("a", "1.0.0")
+                {
+                    Dependencies = [new SimpleTestPackageContext("b", "1.0.0")],
+                    RuntimeJson = @"{
+                  ""runtimes"": {
+                    ""win"": {
+                            ""a"": {
+                                ""runtime.a"": ""1.0.0"",
+                                ""runtime.a.win"": ""1.0.0""
+                            }
+                          }
+                        }
+                  }"
+                },
+                new SimpleTestPackageContext("runtime.a", "1.0.0"),
+                new SimpleTestPackageContext("runtime.a.win", "1.0.0"));
+            var rootProject = @"
+        {
+          ""runtimes"": {
+                        ""win"": {}
+                  },
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""a"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""runtime.A"" : ""(,1.0.0]"" 
+                }
+            }
+          }
+        }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+
+            // Act & Assert
+            var result = await RunRestoreAsync(pathContext, projectSpec);
+            result.Success.Should().BeTrue(because: string.Join(Environment.NewLine, result.LogMessages.Select(e => e.Message)));
+            result.LockFile.Targets.Should().HaveCount(2);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+            result.LockFile.Targets[1].Libraries.Should().HaveCount(3);
+
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().HaveCount(1);
+            result.LockFile.Targets[1].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[1].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[1].Libraries[0].Dependencies.Should().HaveCount(2);
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Dependencies.Should().BeEmpty();
+            result.LockFile.Targets[1].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[1].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[1].Libraries[1].Dependencies.Should().BeEmpty();
+            result.LockFile.Targets[1].Libraries[2].Name.Should().Be("runtime.a.win");
+            result.LockFile.Targets[1].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[1].Libraries[2].Dependencies.Should().BeEmpty();
+
+            ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
+            installedPackages.Should().HaveCount(3);
+        }
+
+        // P -> A 1.0.0 -> (win) runtime.a 1.0.0 -> runtime.a.core 1.0.0
+        //                                       -> runtime.a.extensions 1.0.0
+        // Prune runtime.a.core 1.0.0
+        // Leaves A, runtime.a and runtime.a.extensions
+
+        [Fact]
+        public async Task RestoreCommand_WithPrunePackageReferences_PrunesTransitiveRuntimeDependencies_AndVerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                new SimpleTestPackageContext("a", "1.0.0")
+                {
+                    RuntimeJson = @"{
+                  ""runtimes"": {
+                    ""win"": {
+                            ""a"": {
+                                ""runtime.a"": ""1.0.0"",
+                            }
+                          }
+                        }
+                  }"
+                },
+                new SimpleTestPackageContext("runtime.a", "1.0.0")
+                {
+                    Dependencies = [new SimpleTestPackageContext("runtime.a.core", "1.0.0"), new SimpleTestPackageContext("runtime.a.extensions", "1.0.0")]
+                }
+                );
+            var rootProject = @"
+        {
+          ""runtimes"": {
+                        ""win"": {}
+                  },
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""a"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""runtime.a.core"" : ""(,1.0.0]"" 
+                }
+            }
+          }
+        }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+
+            // Act & Assert
+            var result = await RunRestoreAsync(pathContext, projectSpec);
+            result.Success.Should().BeTrue(because: string.Join(Environment.NewLine, result.LogMessages.Select(e => e.Message)));
+            result.LockFile.Targets.Should().HaveCount(2);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(1);
+            result.LockFile.Targets[1].Libraries.Should().HaveCount(3);
+
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().BeEmpty();
+
+            result.LockFile.Targets[1].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[1].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[1].Libraries[0].Dependencies.Should().HaveCount(1);
+            result.LockFile.Targets[1].Libraries[1].Name.Should().Be("runtime.a");
+            result.LockFile.Targets[1].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[1].Libraries[1].Dependencies.Should().HaveCount(1);
+            result.LockFile.Targets[1].Libraries[2].Name.Should().Be("runtime.a.extensions");
+            result.LockFile.Targets[1].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[1].Libraries[2].Dependencies.Should().BeEmpty();
+
+            ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
+            installedPackages.Should().HaveCount(3);
+        }
+
+        // P -> A 1.0.0 -> B 1.0.0
+        //              -> (win) runtime.a 1.0.0
+        //              -> (win) runtime.a.win 1.0.0
+        // Prune runtime.A 1.0.0, B 1.0.0
+        // Leaves only runtime.a.win
+        [Fact]
+        public async Task RestoreCommand_WithPrunePackageReferences_PrunesBothTypesOfDependencies_AndVerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                new SimpleTestPackageContext("a", "1.0.0")
+                {
+                    Dependencies = [new SimpleTestPackageContext("b", "1.0.0")],
+                    RuntimeJson = @"{
+                  ""runtimes"": {
+                    ""win"": {
+                            ""a"": {
+                                ""runtime.a"": ""1.0.0"",
+                                ""runtime.a.win"": ""1.0.0""
+                            }
+                          }
+                        }
+                  }"
+                },
+                new SimpleTestPackageContext("runtime.a", "1.0.0"),
+                new SimpleTestPackageContext("runtime.a.win", "1.0.0"));
+            var rootProject = @"
+        {
+          ""runtimes"": {
+                        ""win"": {}
+                  },
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""a"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""runtime.A"" : ""(,1.0.0]"",
+                    ""B"" : ""(,3.0.0]"" 
+                }
+            }
+          }
+        }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+
+            // Act & Assert
+            var result = await RunRestoreAsync(pathContext, projectSpec);
+            result.Success.Should().BeTrue(because: string.Join(Environment.NewLine, result.LogMessages.Select(e => e.Message)));
+            result.LockFile.Targets.Should().HaveCount(2);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(1);
+            result.LockFile.Targets[1].Libraries.Should().HaveCount(2);
+
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().BeEmpty();
+            result.LockFile.Targets[1].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[1].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[1].Libraries[0].Dependencies.Should().HaveCount(1);
+            result.LockFile.Targets[1].Libraries[1].Name.Should().Be("runtime.a.win");
+            result.LockFile.Targets[1].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[1].Libraries[1].Dependencies.Should().BeEmpty();
+
+            ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
+            installedPackages.Should().HaveCount(2);
+        }
+
+        // P1 -> A 1.0.0 -> ProjectAndPackage 1.0.0
+        // P1 -> P2 (project) -> ProjectAndPackage (project)
+        [Fact]
+        public async Task RestoreCommand_WithTransitiveProjectReferenceSpecifiedForPruningCoalescingWithPackageReference_SkipsPruning_AndVerifiesEquivalency()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("packageA", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("ProjectAndPackage", "1.0.0")]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA);
+
+            var rootProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""ProjectAndPackage"" : ""(,3.0.0]"" 
+                }
+            }
+          }
+        }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+            projectSpec.RestoreMetadata.SdkAnalysisLevel = !string.IsNullOrEmpty("10.0.100") ? NuGetVersion.Parse("10.0.100") : null;
+            projectSpec.RestoreMetadata.UsingMicrosoftNETSdk = true;
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpec("Project2", framework: "net472");
+            var projectSpec3 = ProjectTestHelpers.GetPackageSpec("ProjectAndPackage", framework: "net472");
+
+            projectSpec2 = projectSpec2.WithTestProjectReference(projectSpec3);
+            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+
+            // Act & Assert
+            var result = await RunRestoreAsync(pathContext, projectSpec, projectSpec2, projectSpec3);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().BeEmpty();
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Dependencies.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("ProjectAndPackage");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[2].Dependencies.Should().BeEmpty();
+
+            result.LockFile.LogMessages.Should().HaveCount(1);
+            result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1511);
+
+            ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
+            installedPackages.Should().HaveCount(1);
+        }
+
         private static void CreateFakeProjectFile(PackageSpec project2spec)
         {
             Directory.CreateDirectory(Path.GetDirectoryName(project2spec.RestoreMetadata.ProjectUniqueName));


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/7344

## Description

For reference, the design is at https://github.com/NuGet/Home/blob/dev/accepted/2024/prune-package-reference.md
This PR implements the full scope of the pruning in the new resolver. 
Primary functions are *not downloading* and skipping packages to be pruned, and *not* representing them as dependencies in the targets section of the framework they were skipped for.
This PR *does not* add a list of pruned packages anywhere, and that's intentional at this point. The design lists that as a future possibility too. 

Some pointers: 

- Meat of the changes is in `DependecyGraphResolver`. As we walk the graph, if a graph item is eligible (package and lower min version than the one specified in the PrunePackageReference, we skip it). We do that by tracking the indices of the packages we skip. This is the safe way, since it preserves the index calculation for the items in the graph. 
At flattening time, we then *skip* those dependencies and we "recreate" the RemoteResolveResult *dependencies* section to ensure the assets file contains the correct information.
- LockFileUtils.CreateLockFileTargetLibrary now contains the dependencies count in the hashing to avoid issues where things were pruned in one framework but not in the other.
- [SdkAnalysisLevelMinimums.cs](https://github.com/NuGet/NuGet.Client/pull/6142/files#diff-da63ad102af316a0c509f299a34f7ee7c5ae6f0b6fd28cda0f9e158a0ddc2d51) adds warnings for project pruning and direct package reference pruning only in .NET 10 SDK Analysis level scenarios. The feature is still disabled by default for all frameworks anyways. 
- The tests [RestoreCommandTests.cs](https://github.com/NuGet/NuGet.Client/pull/6142/files#diff-5e6f2fe813945cf26d2d437dc5bccfa9c63f632ee21285f11f678c7feb528d4c) are exhaustive and they contain all scenarios called out in the spec & combinations of pruning normal and runtime dependencies, across different or same frameworks.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. - https://github.com/NuGet/Home/issues/14002
