### PR TITLE
Test:  ensure test certificate is removed from certificate store

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/CertificatesFixture.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/CertificatesFixture.cs
@@ -19,7 +19,7 @@ namespace NuGet.Commands.Test
         {
             _defaultCertificate = SigningTestUtility.GenerateCertificate("test", generator => { });
 
-            X509Certificate2 _defaultCertificateForTrust = SigningTestUtility.GenerateCertificate("test trusted", generator => { });
+            X509Certificate2 _defaultCertificateForTrust = SigningTestUtility.GenerateCertificate("NuGet Test Certificate", generator => { });
 
             _trustedDefaultCertificate = TrustedTestCert.Create(
                 new X509Certificate2(_defaultCertificateForTrust),
@@ -50,7 +50,8 @@ namespace NuGet.Commands.Test
 
         public X509Certificate2 GetTrustedCertificate()
         {
-            return _trustedDefaultCertificate.TrustedCert;
+            // Return a copy because we don't want the caller disposing our private copy.
+            return new X509Certificate2(_trustedDefaultCertificate.TrustedCert);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/13923

## Description

This change ensures that a test certificate is removed from its certificate store upon test completion.

This change also updates the certificate subject to be clear that it is for NuGet testing.  `test trusted` is pretty vague.

## PR Checklist

- [X] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~~Added tests~~ N/A
- [ ] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~ N/A
