### PR TITLE
Handle negative value for SolutionView width

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml.cs
@@ -259,7 +259,10 @@ namespace NuGet.PackageManagement.UI
             }
 
             var newWidth = _projectColumnHeader.ActualWidth + width;
-            _projectColumn.Width = newWidth;
+            if (newWidth > 0)
+            {
+                _projectColumn.SetValue(Canvas.WidthProperty, newWidth);
+            }
 
             // this width adjustment is only done once.
             _projectList.SizeChanged -= ListView_SizeChanged;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13928

## Description
If the user has a scaling/font size that affects the PM UI size and make it really small, this affects when we calculate the width of SolutionView, which with the new column it can make it a negative value

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- ~[] Added tests~ UI change, tests width different scaling and font size
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
