### PR TITLE
Test: test certificates not removed from certificate root store after test run

### DIFF
--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/InstallCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/InstallCommandTests.cs
@@ -33,16 +33,17 @@ namespace NuGet.CommandLine.FuncTest.Commands
         private static readonly string NU3018Message = "The author primary signature's signing certificate is not trusted by the trust provider.";
         private static readonly string NU3018 = "NU3018: {0}";
 
-        private SignCommandTestFixture _testFixture;
+        private readonly SignCommandTestFixture _testFixture;
         private readonly ITestOutputHelper _testOutputHelper;
-        private TrustedTestCert<TestCertificate> _trustedTestCert;
-        private string _nugetExePath;
+        private readonly TrustedTestCert<TestCertificate> _trustedTestCert;
+        private readonly string _nugetExePath;
 
         public InstallCommandTests(SignCommandTestFixture fixture, ITestOutputHelper testOutputHelper)
         {
             _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
             _testOutputHelper = testOutputHelper;
-            _trustedTestCert = SigningTestUtility.GenerateTrustedTestCertificate();
+            // Do not dispose this.  The fixture will dispose it.
+            _trustedTestCert = fixture.TrustedTestCertificate;
             _nugetExePath = _testFixture.NuGetExePath;
         }
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
@@ -37,16 +37,17 @@ namespace NuGet.CommandLine.FuncTest.Commands
         private static readonly string NU3005CompressedMessage = "The package signature file entry is invalid. The central directory header field 'compression method' has an invalid value (8).";
         private static readonly string NU3005 = "NU3005: {0}";
 
-        private SignCommandTestFixture _testFixture;
+        private readonly SignCommandTestFixture _testFixture;
         private readonly ITestOutputHelper _testOutputHelper;
-        private TrustedTestCert<TestCertificate> _trustedTestCert;
+        private readonly TrustedTestCert<TestCertificate> _trustedTestCert;
         private readonly string _nugetExePath;
 
         public RestoreCommandSignPackagesTests(SignCommandTestFixture fixture, ITestOutputHelper testOutputHelper)
         {
             _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
             _testOutputHelper = testOutputHelper;
-            _trustedTestCert = SigningTestUtility.GenerateTrustedTestCertificate();
+            // Do not dispose this.  The fixture will dispose it.
+            _trustedTestCert = fixture.TrustedTestCertificate;
             _nugetExePath = _testFixture.NuGetExePath;
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
@@ -33,7 +33,7 @@ namespace NuGet.Packaging.FuncTest
         {
             _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
             // Do not dispose this.  The fixture will dispose it.
-            _trustedRepoTestCert = fixture.TrustedTestCertificate;
+            _trustedRepoTestCert = fixture.TrustedRepositoryCertificate;
         }
 
         [CIOnlyFact]

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
@@ -21,7 +21,7 @@ using Xunit;
 namespace NuGet.Packaging.FuncTest
 {
     [Collection(SigningTestCollection.Name)]
-    public class AllowListVerificationProviderTests : IDisposable
+    public class AllowListVerificationProviderTests
     {
         private const string _noMatchInAllowList = "The package signature certificate fingerprint does not match any certificate fingerprint in the allow list.";
         private const string _noAllowList = "A list of trusted signers is required but none was found.";
@@ -32,12 +32,8 @@ namespace NuGet.Packaging.FuncTest
         public AllowListVerificationProviderTests(SigningTestFixture fixture)
         {
             _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
-            _trustedRepoTestCert = SigningTestUtility.GenerateTrustedTestCertificate();
-        }
-
-        public void Dispose()
-        {
-            _trustedRepoTestCert.Dispose();
+            // Do not dispose this.  The fixture will dispose it.
+            _trustedRepoTestCert = fixture.TrustedTestCertificate;
         }
 
         [CIOnlyFact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/13929

## Description

This change ensures that some test certificates are removed from the certificate root store upon test completion.

## PR Checklist

- [X] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~~Added tests~~ N/A
- [ ] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~ N/A
