### PR TITLE
Add new test cases for Transitive Package into NuGet.Client-VSDaily Tests pipeline

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
@@ -498,6 +498,106 @@ namespace NuGet.Tests.Apex.Daily
         }
 
         [TestMethod]
+        [Timeout(DefaultTimeout)]
+        public async Task SearchTopLevelPackageInInstalledTabFromUI_WhenThePackageHasTransitivePackage()
+        {
+            // Arrange
+            var transitivePackageName = "Contoso.B";
+            await CommonUtility.CreateDependenciesPackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1, transitivePackageName, TestPackageVersionV1);
+
+            NuGetApexTestService nugetTestService = GetNuGetTestService();
+
+            var solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
+            var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.NetCoreClassLib, "TestProject");
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
+
+            var uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI(TestPackageName, TestPackageVersionV1);
+            solutionService.Build();
+
+            CommonUtility.AssertPackageReferenceExists(VisualStudio, project, TestPackageName, TestPackageVersionV1, Logger);
+            uiwindow.AssertPackageNameAndType(TestPackageName, NuGet.VisualStudio.PackageLevel.TopLevel);
+            uiwindow.AssertPackageNameAndType(transitivePackageName, NuGet.VisualStudio.PackageLevel.Transitive);
+
+            // Act
+            uiwindow.SearchPackageFromUI(TestPackageName);
+
+            // Assert
+            VisualStudio.AssertNoErrors();
+            uiwindow.AssertPackageNameAndType(TestPackageName, NuGet.VisualStudio.PackageLevel.TopLevel);
+        }
+
+        [TestMethod]
+        [Timeout(DefaultTimeout)]
+        public async Task InstallTopLevelPackage_WhenHasTransitivePackageFromUI()
+        {
+            // Arrange
+            var transitivePackageName = "Contoso.B";
+            await CommonUtility.CreateDependenciesPackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1, transitivePackageName, TestPackageVersionV1);
+
+            NuGetApexTestService nugetTestService = GetNuGetTestService();
+
+            var solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
+            var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.NetCoreConsoleApp, "TestProject");
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
+
+            // Act
+            var uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI(TestPackageName, TestPackageVersionV1);
+            solutionService.Build();
+
+            // Assert
+            VisualStudio.AssertNoErrors();
+            uiwindow.AssertPackageNameAndType(TestPackageName, NuGet.VisualStudio.PackageLevel.TopLevel);
+            uiwindow.AssertPackageNameAndType(transitivePackageName, NuGet.VisualStudio.PackageLevel.Transitive);
+            CommonUtility.AssertPackageReferenceExists(VisualStudio, project, TestPackageName, TestPackageVersionV1, Logger);
+        }
+
+        [TestMethod]
+        [Timeout(DefaultTimeout)]
+        public async Task UninstallTopLevelPackage_WhenHasTransitivePackage()
+        {
+            // Arrange
+            var transitivePackageName = "Contoso.B";
+            await CommonUtility.CreateDependenciesPackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1, transitivePackageName, TestPackageVersionV1);
+
+            NuGetApexTestService nugetTestService = GetNuGetTestService();
+
+            var solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
+            var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.NetCoreClassLib, "Testproject");
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
+
+            var uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI(TestPackageName, TestPackageVersionV1);
+            solutionService.Build();
+
+            CommonUtility.AssertPackageReferenceExists(VisualStudio, project, TestPackageName, TestPackageVersionV1, Logger);
+            uiwindow.AssertPackageNameAndType(TestPackageName, NuGet.VisualStudio.PackageLevel.TopLevel);
+            uiwindow.AssertPackageNameAndType(transitivePackageName, NuGet.VisualStudio.PackageLevel.Transitive);
+
+            // Act
+            uiwindow.UninstallPackageFromUI(TestPackageName);
+            solutionService.Build();
+
+            // Assert
+            VisualStudio.AssertNoErrors();
+            uiwindow.AssertPackageListIsNullIninsatlltab();
+            CommonUtility.AssertPackageReferenceDoesNotExist(VisualStudio, project, TestPackageName, Logger);
+        }
+
+        [TestMethod]
         [DataRow(ProjectTemplate.NetCoreConsoleApp)]
         [DataRow(ProjectTemplate.ConsoleApplication)]
         [Timeout(DefaultTimeout)]

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
@@ -533,7 +533,7 @@ namespace NuGet.Tests.Apex.Daily
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
-        public async Task InstallTopLevelPackage()
+        public async Task InstallTopLevelPackageFromUI()
         {
             // Arrange
             var transitivePackageName = "Contoso.B";
@@ -563,7 +563,7 @@ namespace NuGet.Tests.Apex.Daily
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
-        public async Task UninstallTopLevelPackage()
+        public async Task UninstallTopLevelPackageFromUI()
         {
             // Arrange
             var transitivePackageName = "Contoso.B";

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
@@ -499,7 +499,7 @@ namespace NuGet.Tests.Apex.Daily
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
-        public async Task SearchTopLevelPackageInInstalledTabFromUI_WhenThePackageHasTransitivePackage()
+        public async Task SearchTopLevelPackageInInstalledTabFromUI()
         {
             // Arrange
             var transitivePackageName = "Contoso.B";
@@ -533,7 +533,7 @@ namespace NuGet.Tests.Apex.Daily
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
-        public async Task InstallTopLevelPackage_WhenHasTransitivePackageFromUI()
+        public async Task InstallTopLevelPackage()
         {
             // Arrange
             var transitivePackageName = "Contoso.B";
@@ -563,7 +563,7 @@ namespace NuGet.Tests.Apex.Daily
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
-        public async Task UninstallTopLevelPackage_WhenHasTransitivePackage()
+        public async Task UninstallTopLevelPackage()
         {
             // Arrange
             var transitivePackageName = "Contoso.B";

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
@@ -593,7 +593,7 @@ namespace NuGet.Tests.Apex.Daily
 
             // Assert
             VisualStudio.AssertNoErrors();
-            uiwindow.AssertPackageListIsNullIninsatlltab();
+            uiwindow.AssertPackageListIsNullOrEmpty();
             CommonUtility.AssertPackageReferenceDoesNotExist(VisualStudio, project, TestPackageName, Logger);
         }
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
@@ -533,6 +533,41 @@ namespace NuGet.Tests.Apex.Daily
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
+        public async Task SearchTopLevelAndTransitivePackagePublicFieldInInstalledTabFromUI()
+        {
+            // Arrange
+            var transitivePackageName = "Contoso.B";
+            await CommonUtility.CreateDependenciesPackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1, transitivePackageName, TestPackageVersionV1);
+
+            NuGetApexTestService nugetTestService = GetNuGetTestService();
+
+            var solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
+            var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.NetCoreClassLib, "TestProject");
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
+
+            var uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI(TestPackageName, TestPackageVersionV1);
+            solutionService.Build();
+
+            CommonUtility.AssertPackageReferenceExists(VisualStudio, project, TestPackageName, TestPackageVersionV1, Logger);
+            uiwindow.AssertPackageNameAndType(TestPackageName, NuGet.VisualStudio.PackageLevel.TopLevel);
+            uiwindow.AssertPackageNameAndType(transitivePackageName, NuGet.VisualStudio.PackageLevel.Transitive);
+
+            // Act
+            uiwindow.SearchPackageFromUI("Contoso");
+
+            // Assert
+            VisualStudio.AssertNoErrors();
+            uiwindow.AssertPackageNameAndType(TestPackageName, NuGet.VisualStudio.PackageLevel.TopLevel);
+            uiwindow.AssertPackageNameAndType(transitivePackageName, NuGet.VisualStudio.PackageLevel.Transitive);
+        }
+
+        [TestMethod]
+        [Timeout(DefaultTimeout)]
         public async Task InstallTopLevelPackageFromUI()
         {
             // Arrange

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetUIProjectTestExtension.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetUIProjectTestExtension.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using FluentAssertions;
-using Microsoft.TeamFoundation.Common;
 using Microsoft.Test.Apex.Services;
 using NuGet.PackageManagement.UI;
 using NuGet.PackageManagement.UI.TestContract;
@@ -77,9 +76,9 @@ namespace NuGet.Tests.Apex
             package.Id.Should().Be(packageId);
         }
 
-        public bool AssertPackageListIsNullOrEmpty()
+        public void AssertPackageListIsNullOrEmpty()
         {
-            return _uiproject.PackageItems.IsNullOrEmpty();
+            _uiproject.GetPackageItemsOnInstalledTab().Should().BeNullOrEmpty("Package items list isn't null or empty on installed tab."); ;
         }
 
         public bool InstallPackageFromUI(string packageId, string version)

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetUIProjectTestExtension.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetUIProjectTestExtension.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using FluentAssertions;
+using Microsoft.TeamFoundation.Common;
 using Microsoft.Test.Apex.Services;
 using NuGet.PackageManagement.UI;
 using NuGet.PackageManagement.UI.TestContract;
@@ -74,6 +75,11 @@ namespace NuGet.Tests.Apex
 
             package.PackageLevel.Should().Be(packageLevel);
             package.Id.Should().Be(packageId);
+        }
+
+        public bool AssertPackageListIsNullIninsatlltab()
+        {
+            return _uiproject.PackageItems.IsNullOrEmpty();
         }
 
         public bool InstallPackageFromUI(string packageId, string version)

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetUIProjectTestExtension.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetUIProjectTestExtension.cs
@@ -77,7 +77,7 @@ namespace NuGet.Tests.Apex
             package.Id.Should().Be(packageId);
         }
 
-        public bool AssertPackageListIsNullIninsatlltab()
+        public bool AssertPackageListIsNullOrEmpty()
         {
             return _uiproject.PackageItems.IsNullOrEmpty();
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3070

## Description
Add the below three new test cases about the "Transitive Package" feature to the NuGet.Client-VSDaily Tests pipeline.

[Search a top-level package in "Installed" tab](https://microsoft.sharepoint.com/teams/NuGet/_layouts/15/Doc.aspx?sourcedoc=%7b8a3c6685-1661-47f4-8807-b765ca62aea1%7d&action=edit&wd=target%28Daily%20Manual%20Test.one%7C5cce9d00-efb1-411c-a3c5-268c164f5fe3%2F---Consume%20package%20in%20PM%20UI%20of%20an%20%7C92ec4e8e-331e-49dd-8e3b-d889318e1efd%2F%29&wdorigin=703)
[Install a top level package which have a transitive package](https://microsoft.sharepoint.com/teams/NuGet/_layouts/15/Doc.aspx?sourcedoc=%7b8a3c6685-1661-47f4-8807-b765ca62aea1%7d&action=edit&wd=target%28Daily%20Manual%20Test.one%7C5cce9d00-efb1-411c-a3c5-268c164f5fe3%2FTransitive%20Package%20%286%5C%29%7Ccb6b1233-03ae-4e4b-8891-11e6c0cbcdb6%2F%29&wdorigin=703)
[Verify uninstalling a top-level package will uninstall the transitive package automatically](https://microsoft.sharepoint.com/teams/NuGet/_layouts/15/Doc.aspx?sourcedoc=%7b8a3c6685-1661-47f4-8807-b765ca62aea1%7d&action=edit&wd=target%28Daily%20Manual%20Test.one%7C5cce9d00-efb1-411c-a3c5-268c164f5fe3%2FTransitive%20Package%20%286%5C%29%7Ccb6b1233-03ae-4e4b-8891-11e6c0cbcdb6%2F%29&wdorigin=703)

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
