### PR TITLE
Fix new resolver when using transitive pinning to resolve subgraphs correctly

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -489,7 +489,7 @@ namespace NuGet.Commands
                             }
 
                             //If the one we already have chosen is pure, then we can skip this one.  Processing it wont bring any new info
-                            if (chosenSuppressions.Count == 1 && chosenSuppressions[0].Count == 0)
+                            if (chosenSuppressions.Count == 1 && chosenSuppressions[0].Count == 0 && HasCommonAncestor(chosenResolvedItem.Path, pathToCurrentRef))
                             {
                                 continue;
                             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -161,6 +161,8 @@ namespace NuGet.Commands
                     IsDirectPackageReferenceFromRootProject = false,
                 };
 
+                LibraryRangeIndex[] rootedDependencyPath = new[] { rootProjectRefItem.LibraryRangeIndex };
+
                 _ = findLibraryEntryCache.GetOrAddAsync(
                     rootProjectRefItem.LibraryRangeIndex,
                     async static (state) =>
@@ -309,74 +311,46 @@ namespace NuGet.Commands
                         {
                             if (chosenRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package) && currentRef.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
                             {
-                                bool isParentCentrallyPinned = false;
-
-                                if (isCentralPackageTransitivePinningEnabled && importRefItem.Path.Length > 1)
+                                if (chosenResolvedItem.Parents != null)
                                 {
-                                    for (int pathIndex = importRefItem.Path.Length - 1; pathIndex > 0; pathIndex--)
+                                    bool atLeastOneCommonAncestor = false;
+
+                                    foreach (LibraryRangeIndex parentRangeIndex in chosenResolvedItem.Parents.NoAllocEnumerate())
                                     {
-                                        LibraryRangeIndex parentLibraryRangeIndex = importRefItem.Path[pathIndex];
-
-                                        if (findLibraryEntryCache.TryGetValue(parentLibraryRangeIndex, out Task<FindLibraryEntryResult>? parentCacheEntryTask))
+                                        if (importRefItem.Path.Length > 2 && importRefItem.Path[importRefItem.Path.Length - 2] == parentRangeIndex)
                                         {
-                                            FindLibraryEntryResult result = await parentCacheEntryTask;
-
-                                            if (chosenResolvedItems.TryGetValue(result.DependencyIndex, out var parentChosenResolvedItem))
-                                            {
-                                                isParentCentrallyPinned = parentChosenResolvedItem.IsCentrallyPinnedTransitivePackage;
-
-                                                if (isParentCentrallyPinned)
-                                                {
-                                                    break;
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-
-                                if (!isParentCentrallyPinned)
-                                {
-                                    if (chosenResolvedItem.Parents != null)
-                                    {
-                                        bool atLeastOneCommonAncestor = false;
-
-                                        foreach (LibraryRangeIndex parentRangeIndex in chosenResolvedItem.Parents.NoAllocEnumerate())
-                                        {
-                                            if (importRefItem.Path.Length > 2 && importRefItem.Path[importRefItem.Path.Length - 2] == parentRangeIndex)
-                                            {
-                                                atLeastOneCommonAncestor = true;
-                                                break;
-                                            }
-                                        }
-
-                                        if (atLeastOneCommonAncestor)
-                                        {
-                                            continue;
+                                            atLeastOneCommonAncestor = true;
+                                            break;
                                         }
                                     }
 
-                                    if (HasCommonAncestor(chosenResolvedItem.Path, importRefItem.Path))
+                                    if (atLeastOneCommonAncestor)
                                     {
                                         continue;
                                     }
+                                }
 
-                                    if (chosenResolvedItem.ParentPathsThatHaveBeenEclipsed != null)
+                                if (HasCommonAncestor(chosenResolvedItem.Path, importRefItem.Path))
+                                {
+                                    continue;
+                                }
+
+                                if (chosenResolvedItem.ParentPathsThatHaveBeenEclipsed != null)
+                                {
+                                    bool hasAlreadyBeenEclipsed = false;
+
+                                    foreach (LibraryRangeIndex parentRangeIndex in chosenResolvedItem.ParentPathsThatHaveBeenEclipsed)
                                     {
-                                        bool hasAlreadyBeenEclipsed = false;
-
-                                        foreach (LibraryRangeIndex parentRangeIndex in chosenResolvedItem.ParentPathsThatHaveBeenEclipsed)
+                                        if (importRefItem.Path.Contains(parentRangeIndex))
                                         {
-                                            if (importRefItem.Path.Contains(parentRangeIndex))
-                                            {
-                                                hasAlreadyBeenEclipsed = true;
-                                                break;
-                                            }
+                                            hasAlreadyBeenEclipsed = true;
+                                            break;
                                         }
+                                    }
 
-                                        if (hasAlreadyBeenEclipsed)
-                                        {
-                                            continue;
-                                        }
+                                    if (hasAlreadyBeenEclipsed)
+                                    {
+                                        continue;
                                     }
                                 }
                             }
@@ -462,7 +436,7 @@ namespace NuGet.Commands
                                 {
                                     LibraryDependency = currentRef,
                                     LibraryRangeIndex = currentRefRangeIndex,
-                                    Parents = isCentrallyPinnedTransitivePackage ? new HashSet<LibraryRangeIndex>() { pathToCurrentRef[pathToCurrentRef.Length - 1] } : null,
+                                    Parents = isCentrallyPinnedTransitivePackage && !directPackageReferenceFromRootProject ? new HashSet<LibraryRangeIndex>() { importRefItem.Parent } : null,
                                     Path = pathToCurrentRef,
                                     IsCentrallyPinnedTransitivePackage = isCentrallyPinnedTransitivePackage,
                                     IsDirectPackageReferenceFromRootProject = directPackageReferenceFromRootProject,
@@ -509,7 +483,10 @@ namespace NuGet.Commands
                                 chosenResolvedItem.Parents = new HashSet<LibraryRangeIndex>();
                             }
 
-                            chosenResolvedItem.Parents?.Add(pathToCurrentRef[pathToCurrentRef.Length - 1]);
+                            if (!chosenResolvedItem.IsDirectPackageReferenceFromRootProject)
+                            {
+                                chosenResolvedItem.Parents?.Add(importRefItem.Parent);
+                            }
 
                             //If the one we already have chosen is pure, then we can skip this one.  Processing it wont bring any new info
                             if (chosenSuppressions.Count == 1 && chosenSuppressions[0].Count == 0)
@@ -597,7 +574,7 @@ namespace NuGet.Commands
                             {
                                 LibraryDependency = currentRef,
                                 LibraryRangeIndex = currentRefRangeIndex,
-                                Parents = isCentrallyPinnedTransitivePackage ? new HashSet<LibraryRangeIndex>() { pathToCurrentRef[pathToCurrentRef.Length - 1] } : null,
+                                Parents = isCentrallyPinnedTransitivePackage && !directPackageReferenceFromRootProject ? new HashSet<LibraryRangeIndex>() { importRefItem.Parent } : null,
                                 Path = pathToCurrentRef,
                                 IsCentrallyPinnedTransitivePackage = isCentrallyPinnedTransitivePackage,
                                 IsDirectPackageReferenceFromRootProject = directPackageReferenceFromRootProject,
@@ -658,7 +635,6 @@ namespace NuGet.Commands
                         bool isDirectPackageReferenceFromRootProject = (currentRefRangeIndex == rootProjectRefItem.LibraryRangeIndex) && isPackage;
 
                         bool isCentrallyPinnedTransitiveDependency = isCentralPackageTransitivePinningEnabled
-                            && !isDirectPackageReferenceFromRootProject
                             && isPackage
                             && pinnedPackageVersions?.TryGetValue(depIndex, out pinnedVersionRange) == true;
 
@@ -666,7 +642,7 @@ namespace NuGet.Commands
 
                         LibraryDependency actualLibraryDependency = dep;
 
-                        if (isCentrallyPinnedTransitiveDependency)
+                        if (isCentrallyPinnedTransitiveDependency && !isDirectPackageReferenceFromRootProject)
                         {
                             actualLibraryDependency = new LibraryDependency(dep)
                             {
@@ -687,7 +663,8 @@ namespace NuGet.Commands
                             LibraryDependency = actualLibraryDependency,
                             LibraryDependencyIndex = depIndex,
                             LibraryRangeIndex = rangeIndex,
-                            Path = LibraryRangeInterningTable.CreatePathToRef(pathToCurrentRef, currentRefRangeIndex),
+                            Path = isCentrallyPinnedTransitiveDependency || isDirectPackageReferenceFromRootProject ? rootedDependencyPath : LibraryRangeInterningTable.CreatePathToRef(pathToCurrentRef, currentRefRangeIndex),
+                            Parent = currentRefRangeIndex,
                             Suppressions = suppressions,
                             IsDirectPackageReferenceFromRootProject = isDirectPackageReferenceFromRootProject,
                             IsCentrallyPinnedTransitivePackage = isCentrallyPinnedTransitiveDependency
@@ -759,6 +736,7 @@ namespace NuGet.Commands
                                     LibraryDependencyIndex = findLibraryCachedAsyncResult.GetDependencyIndexForDependency(runtimeDependencyIndex),
                                     LibraryRangeIndex = findLibraryCachedAsyncResult.GetRangeIndexForDependency(runtimeDependencyIndex),
                                     Path = LibraryRangeInterningTable.CreatePathToRef(pathToCurrentRef, currentRefRangeIndex),
+                                    Parent = currentRefRangeIndex,
                                     Suppressions = suppressions,
                                     IsDirectPackageReferenceFromRootProject = false,
                                 };
@@ -935,9 +913,9 @@ namespace NuGet.Commands
                                         {
                                             foreach (var parent in chosenItem.Parents)
                                             {
-                                                if (foundItem.Path.Contains(parent))
+                                                if (foundItem.Path.Contains(parent) && !foundItem.IsDirectPackageReferenceFromRootProject)
                                                 {
-                                                    downgrades.Add(chosenItemRangeIndex, (foundItem.LibraryRangeIndex, dep, parent, chosenItem.LibraryDependency, false));
+                                                    downgrades.Add(chosenItemRangeIndex, (foundItem.LibraryRangeIndex, dep, parent, chosenItem.LibraryDependency, isCentralPackageTransitivePinningEnabled ? chosenItem.IsCentrallyPinnedTransitivePackage : false));
 
                                                     foundParentDowngrade = true;
                                                     break;
@@ -945,9 +923,9 @@ namespace NuGet.Commands
                                             }
                                         }
 
-                                        if (!foundParentDowngrade)
+                                        if (!foundParentDowngrade && (!isCentralPackageTransitivePinningEnabled || !chosenItem.IsDirectPackageReferenceFromRootProject))
                                         {
-                                            downgrades.Add(chosenItemRangeIndex, (foundItem.LibraryRangeIndex, dep, chosenItem.Path[chosenItem.Path.Length - 1], chosenItem.LibraryDependency, false));
+                                            downgrades.Add(chosenItemRangeIndex, (foundItem.LibraryRangeIndex, dep, chosenItem.Path[chosenItem.Path.Length - 1], chosenItem.LibraryDependency, isCentralPackageTransitivePinningEnabled ? chosenItem.IsCentrallyPinnedTransitivePackage : false));
                                         }
                                     }
 
@@ -980,7 +958,7 @@ namespace NuGet.Commands
                             var newGraphNode = new GraphNode<RemoteResolveResult>(actualDep.LibraryRange);
                             newGraphNode.Item = findLibraryEntryResult.Item;
 
-                            if (chosenItem.IsCentrallyPinnedTransitivePackage)
+                            if (chosenItem.IsCentrallyPinnedTransitivePackage && !chosenItem.IsDirectPackageReferenceFromRootProject)
                             {
                                 newGraphNode.Disposition = Disposition.Accepted;
                                 newGraphNode.Item.IsCentralTransitive = true;
@@ -993,7 +971,7 @@ namespace NuGet.Commands
                                 currentGraphNode.InnerNodes.Add(newGraphNode);
                             }
 
-                            if (dep.SuppressParent != LibraryIncludeFlags.All && isCentralPackageTransitivePinningEnabled && !downgrades.ContainsKey(chosenItemRangeIndex) && !RemoteDependencyWalker.IsGreaterThanOrEqualTo(chosenItem.LibraryDependency.LibraryRange.VersionRange, dep.LibraryRange.VersionRange))
+                            if (dep.SuppressParent != LibraryIncludeFlags.All && isCentralPackageTransitivePinningEnabled && !chosenItem.IsDirectPackageReferenceFromRootProject && !downgrades.ContainsKey(chosenItemRangeIndex) && !RemoteDependencyWalker.IsGreaterThanOrEqualTo(chosenItem.LibraryDependency.LibraryRange.VersionRange, dep.LibraryRange.VersionRange))
                             {
                                 downgrades.Add(chosenItem.LibraryRangeIndex, (currentLibraryRangeIndex, dep, rootProjectRefItem.LibraryRangeIndex, chosenItem.LibraryDependency, true));
                             }
@@ -1081,7 +1059,7 @@ namespace NuGet.Commands
                                 {
                                     IsCentralTransitive = downgrade.Value.IsCentralTransitive
                                 },
-                                OuterNode = toNode,
+                                OuterNode = downgrade.Value.IsCentralTransitive ? rootGraphNode : toNode,
                             }
                         });
                     }
@@ -1093,7 +1071,7 @@ namespace NuGet.Commands
                     {
                         ResolvedDependencyGraphItem chosenResolvedItem = item.Value;
 
-                        if (!chosenResolvedItem.IsCentrallyPinnedTransitivePackage || chosenResolvedItem.Parents == null || chosenResolvedItem.Parents.Count == 0)
+                        if (!chosenResolvedItem.IsCentrallyPinnedTransitivePackage || chosenResolvedItem.IsDirectPackageReferenceFromRootProject || chosenResolvedItem.Parents == null || chosenResolvedItem.Parents.Count == 0)
                         {
                             continue;
                         }
@@ -1385,6 +1363,8 @@ namespace NuGet.Commands
             public LibraryRangeIndex LibraryRangeIndex { get; set; } = LibraryRangeIndex.Invalid;
 
             public LibraryRangeIndex[] Path { get; set; } = Array.Empty<LibraryRangeIndex>();
+
+            public LibraryRangeIndex Parent { get; set; }
 
             public HashSet<LibraryDependencyIndex>? Suppressions { get; set; }
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -9948,7 +9948,7 @@ namespace NuGet.CommandLine.Test
                 var assetFileReader = new LockFileFormat();
                 var assetsFile = assetFileReader.Read(projectA.AssetsFileOutputPath);
 
-                var expectedLibraries = new List<string>() { "B.1.0.0", "C.2.0.0", "F.1.0.0", "G.1.0.0", "H.3.0.0", "O.3.0.0", "P.3.0.0", "S.3.0.0", "SS.3.0.0", "U.1.0.0", "V.1.0.0", "X.1.0.0", "Y.3.0.0" };
+                var expectedLibraries = new List<string>() { "B.1.0.0", "C.2.0.0", "F.1.0.0", "G.1.0.0", "H.3.0.0", "O.3.0.0", "P.3.0.0", "S.3.0.0", "SS.3.0.0", "U.1.0.0", "V.3.0.0", "X.1.0.0", "Y.3.0.0" };
                 var libraries = assetsFile.Libraries.Select(l => $"{l.Name}.{l.Version}").OrderBy(n => n).ToList();
                 Assert.Equal(expectedLibraries, libraries);
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -52,6 +52,9 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[2].Name.Should().Be("X");
         }
 
+        // Project 1 -> X 1.0 -> B 2.0 -> E 1.0
+        //           -> C 2.0 -> D 1.0 -> B 3.0
+        // Expected: X 1.0, B 3.0, C 2.0, D 1.0
         [Fact]
         public async Task RestoreCommand_WithNewPackageEvictedByVersionBump()
         {
@@ -129,6 +132,7 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
+        // Project 1 -> Project 2 -> a (null)
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -194,6 +198,8 @@ namespace NuGet.Commands.FuncTest
             }
         }
 
+        // Project 1 -> a 1.0.0 -> b 1.0.0
+        //                      -> c 1.0.0 -> b 2.0.0
         [Fact]
         public async Task RestoreCommand_WithPackageDrivenDowngrade_RespectsDowngrade_AndRaisesWarning()
         {
@@ -242,6 +248,8 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
+        // Project 1 -> a 1.0.0 -> b 1.0.0
+        //                      -> c 1.0.0 -> -> d 1.0.0 -> b 2.0.0
         [Fact]
         public async Task RestoreCommand_WithPackageDrivenDowngradeAndDepthDifferenceMoreThanOne_RespectsDowngrade_AndRaisesWarning()
         {
@@ -300,6 +308,8 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
+        // Project 1 -> a 1.0.0 -> b 1.0.0
+        //                      -> c 1.0.0 -> b 2.0.0
         [Fact]
         public async Task RestoreCommand_WithPackageDrivenDowngradeAndMissingVersion_RespectsDowngrade_AndRaisesWarning()
         {
@@ -703,6 +713,9 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
+        // Project 1 -> d 1.0.0 -> b 1.0.0
+        // Project 1 -> a 1.0.0 -> b 1.0.0
+        //                      -> c 1.0.0 -> b 2.0.0
         [Fact]
         public async Task RestoreCommand_WithPackageDrivenDowngradeWithMultipleAncestors_RespectsDowngrade_AndRaisesWarning()
         {
@@ -769,9 +782,9 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
-        // P1 -> a 1.0.0 -> b 1.0.0
-        //                  c 1.0.0 -> b 3.0.0
-        //       d 1.0.0 -> b 2.0.0
+        // Project 1 -> d 1.0.0 -> b 2.0.0
+        // Project 1 -> a 1.0.0 -> b 1.0.0
+        //                      -> c 1.0.0 -> b 3.0.0
         [Fact]
         public async Task RestoreCommand_WithPackageDrivenDowngradeWithMultipleAncestorsAndCousin_RespectsDowngrade_AndDoesNotRaiseWarning()
         {

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -80,11 +80,11 @@ namespace NuGet.Commands.FuncTest
                         Dependencies =
                         [
                             new SimpleTestPackageContext("b", "3.0.0")
-                        {
-                            Dependencies =
-                            [
-                                /*new SimpleTestPackageContext("e", "1.0.0")*/
-                            ]
+                            {
+                                Dependencies =
+                                [
+                                    /*new SimpleTestPackageContext("e", "1.0.0")*/
+                                ]
                             },
                         ]
                     },
@@ -351,6 +351,91 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
             result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
             result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        // P1 -> a 1.0.0 -> b 1.0.0
+        //                  c 1.0.0 -> b 3.0.0
+        //       d 1.0.0 -> b 2.0.0
+        [Fact]
+        public async Task RestoreCommand_WithPackageDrivenDowngradeAndTransitivePinning_RespectsDowngrade_AndDoesNotRaiseWarning()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            var packageA = new SimpleTestPackageContext("a", "1.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "1.0.0"),
+                    new SimpleTestPackageContext("c", "1.0.0")
+                    {
+                        Dependencies =
+                        [
+                            new SimpleTestPackageContext("b", "3.0.0")
+                        ]
+                    },
+                ]
+            };
+
+            var packageD = new SimpleTestPackageContext("d", "1.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "2.0.0"),
+                ]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA,
+                packageD);
+
+            var projectSpec = @"
+                {
+                  ""restore"": {
+                    ""centralPackageVersionsManagementEnabled"": true,
+                    ""CentralPackageTransitivePinningEnabled"": true,
+                  },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""d"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionCentrallyManaged"": true
+                                },
+                                ""a"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionCentrallyManaged"": true
+                                },
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""[1.0.0,)"",
+                            ""c"": ""[1.0.0,)"",
+                        }
+                    }
+                  }
+                }";
+
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, projectSpec));
+
+            // Assert
+            result.Success.Should().BeTrue();
+            result.LogMessages.Should().BeEmpty();
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(4);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("3.0.0"));
+
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("d");
+            result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -792,75 +792,6 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
-        // Project 1 -> d 1.0.0 -> b 2.0.0
-        // Project 1 -> a 1.0.0 -> b 1.0.0
-        //                      -> c 1.0.0 -> b 3.0.0
-        [Fact]
-        public async Task RestoreCommand_WithPackageDrivenDowngradeWithMultipleAncestorsAndCousin_RespectsDowngrade_AndDoesNotRaiseWarning()
-        {
-            // Arrange
-            using var pathContext = new SimpleTestPathContext();
-            var packageA = new SimpleTestPackageContext("a", "1.0.0")
-            {
-                Dependencies =
-                [
-                    new SimpleTestPackageContext("b", "1.0.0"),
-                    new SimpleTestPackageContext("c", "1.0.0")
-                    {
-                        Dependencies =
-                        [
-                            new SimpleTestPackageContext("b", "3.0.0")
-                        ]
-                    },
-                ]
-            };
-
-            var packageD = new SimpleTestPackageContext("d", "1.0.0")
-            {
-                Dependencies =
-                [
-                    new SimpleTestPackageContext("b", "2.0.0"),
-                ]
-            };
-
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                pathContext.PackageSource,
-                PackageSaveMode.Defaultv3,
-                packageA,
-                packageD);
-
-            var projectSpec = @"
-                {
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                                ""d"": ""1.0.0"",
-                                ""a"":  ""1.0.0""
-                        }
-                    }
-                  }
-                }";
-
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, projectSpec));
-
-            // Assert
-            result.Success.Should().BeTrue();
-            result.LogMessages.Should().BeEmpty();
-            result.LockFile.Targets.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(4);
-            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
-
-            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
-            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
-
-            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
-            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
-
-            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("d");
-            result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
-        }
-
         // Project 1 -> d 1.0.0 -> e 1.0.0 -> b 3.0.0
         // Project 1 -> a 1.0.0 -> b 1.0.0
         //                      -> c 1.0.0 -> b 3.0.0
@@ -937,6 +868,75 @@ namespace NuGet.Commands.FuncTest
 
             result.LockFile.Targets[0].Libraries[4].Name.Should().Be("e");
             result.LockFile.Targets[0].Libraries[4].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        // Project 1 -> d 1.0.0 -> b 2.0.0
+        // Project 1 -> a 1.0.0 -> b 1.0.0
+        //                      -> c 1.0.0 -> b 3.0.0
+        [Fact]
+        public async Task RestoreCommand_WithPackageDrivenDowngradeWithMultipleAncestorsAndCousin_RespectsDowngrade_AndDoesNotRaiseWarning()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            var packageA = new SimpleTestPackageContext("a", "1.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "1.0.0"),
+                    new SimpleTestPackageContext("c", "1.0.0")
+                    {
+                        Dependencies =
+                        [
+                            new SimpleTestPackageContext("b", "3.0.0")
+                        ]
+                    },
+                ]
+            };
+
+            var packageD = new SimpleTestPackageContext("d", "1.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "2.0.0"),
+                ]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA,
+                packageD);
+
+            var projectSpec = @"
+                {
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""d"": ""1.0.0"",
+                                ""a"": ""1.0.0""
+                        }
+                    }
+                  }
+                }";
+
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, projectSpec));
+
+            // Assert
+            result.Success.Should().BeTrue();
+            result.LogMessages.Should().BeEmpty();
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(4);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
+
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("d");
+            result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -820,12 +820,12 @@ namespace NuGet.Commands.FuncTest
                 Dependencies =
                 [
                     new SimpleTestPackageContext("e", "1.0.0")
-                        {
-                            Dependencies =
-                            [
-                                new SimpleTestPackageContext("b", "3.0.0"),
-                            ]
-                        }
+                    {
+                        Dependencies =
+                        [
+                            new SimpleTestPackageContext("b", "3.0.0"),
+                        ]
+                    }
                 ]
             };
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -61,6 +61,246 @@ namespace NuGet.Commands.FuncTest
         }
 
         [Fact]
+        // Project 1 -> f 1.0.0 -> a 1.0.0 -> b 1.0.0
+        //                                 -> c 1.0.0 -> b 2.0.0
+        // Centrally managed versions f & a, f 1.0.0 and a 1.0.0
+        public async Task RestoreCommand_WithPackageDrivenDowngradeAndTransitivePinning_RespectsDowngrade_AndRaisesWarning()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            var packageF = new SimpleTestPackageContext("f", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("a", "1.0.0")
+                {
+                    Dependencies = [new SimpleTestPackageContext("b", "1.0.0"),
+                        new SimpleTestPackageContext("c", "1.0.0")
+                        {
+                            Dependencies = new() { new SimpleTestPackageContext("b", "2.0.0") }
+                        }]
+                }]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageF);
+
+            var project1 = @"
+                {
+                    ""restore"": {
+                                    ""centralPackageVersionsManagementEnabled"": true,
+                                    ""CentralPackageTransitivePinningEnabled"": true,
+                    },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""f"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionCentrallyManaged"": true
+                                },
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""[1.0.0,)"",
+                            ""f"": ""[1.0.0,)"",
+                        }
+                    }
+                  }
+                }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
+
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec);
+
+            result.Success.Should().BeTrue();
+            result.LogMessages.Select(e => e.Code).Should().BeEquivalentTo([NuGetLogCode.NU1605]);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(4);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("f");
+            result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        [Fact]
+        // Project 1 -> f 1.0.0 -> a 1.0.0 -> b 1.0.0
+        //                                 -> c 1.0.0 -> b 2.0.0
+        // Centrally managed versions f & a, f 1.0.0 and a 2.0.0
+        public async Task RestoreCommand_WithPackageDrivenDowngradeAndTransitivePinningToHigherVersion_RespectsDowngrade_AndRaisesWarning()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            var packageF = new SimpleTestPackageContext("f", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("a", "1.0.0")
+                {
+                    Dependencies = [new SimpleTestPackageContext("b", "1.0.0"),
+                        new SimpleTestPackageContext("c", "1.0.0")
+                        {
+                            Dependencies = new() { new SimpleTestPackageContext("b", "2.0.0") }
+                        }]
+                }]
+            };
+
+            var packageA200 = new SimpleTestPackageContext("a", "2.0.0")
+            {
+                Dependencies = [
+                    new SimpleTestPackageContext("b", "1.0.0"),
+                    new SimpleTestPackageContext("c", "1.0.0")
+                    {
+                        Dependencies = new() { new SimpleTestPackageContext("b", "2.0.0") }
+                    }]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageF,
+                packageA200);
+
+            var project1 = @"
+                {
+                    ""restore"": {
+                                    ""centralPackageVersionsManagementEnabled"": true,
+                                    ""CentralPackageTransitivePinningEnabled"": true,
+                    },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""f"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionCentrallyManaged"": true
+                                },
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""[2.0.0,)"",
+                            ""f"": ""[1.0.0,)"",
+                        }
+                    }
+                  }
+                }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
+
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec);
+
+            result.Success.Should().BeTrue();
+            result.LogMessages.Select(e => e.Code).Should().BeEquivalentTo([NuGetLogCode.NU1605]);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(4);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0"));
+
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("f");
+            result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        [Fact]
+        // Project 1 -> f 1.0.0 -> a 1.0.0 -> b 1.0.0
+        //                                 -> c 1.0.0 -> b 2.0.0
+        // Centrally managed versions f & a, b, f 1.0.0, a 2.0.0 and b 1.0.0
+        public async Task RestoreCommand_WithPackageDrivenDowngradeAndTransitivePinningToDowngradedVersion_Fails()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            var packageF = new SimpleTestPackageContext("f", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("a", "1.0.0")
+                {
+                    Dependencies = [new SimpleTestPackageContext("b", "1.0.0"),
+                        new SimpleTestPackageContext("c", "1.0.0")
+                        {
+                            Dependencies = new() { new SimpleTestPackageContext("b", "2.0.0") }
+                        }]
+                }]
+            };
+
+            var packageA200 = new SimpleTestPackageContext("a", "2.0.0")
+            {
+                Dependencies = [
+                    new SimpleTestPackageContext("b", "1.0.0"),
+                    new SimpleTestPackageContext("c", "1.0.0")
+                    {
+                        Dependencies = new() { new SimpleTestPackageContext("b", "2.0.0") }
+                    }]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageF,
+                packageA200);
+
+            var project1 = @"
+                {
+                    ""restore"": {
+                                    ""centralPackageVersionsManagementEnabled"": true,
+                                    ""CentralPackageTransitivePinningEnabled"": true,
+                    },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""f"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionCentrallyManaged"": true
+                                },
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""[2.0.0,)"",
+                            ""f"": ""[1.0.0,)"",
+                            ""b"": ""[1.0.0,)"",
+                        }
+                    }
+                  }
+                }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
+
+
+            // Act & Assert
+            (RestoreResult result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec);
+
+            result.Success.Should().BeFalse();
+            result.LogMessages.Select(e => e.Code).Should().BeEquivalentTo([NuGetLogCode.NU1109]);
+
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(4);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0"));
+
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("f");
+            result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        [Fact]
         // Project 1 -> a 1.0.0 -> b 1.0.0
         //                      -> c 1.0.0 -> -> d 1.0.0 -> b 2.0.0
         public async Task RestoreCommand_WithPackageDrivenDowngradeAndDepthDifferenceMoreThanOne_RespectsDowngrade_AndRaisesWarning()

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -19,19 +19,201 @@ namespace NuGet.Commands.FuncTest
 {
     public partial class RestoreCommandTests
     {
+        // A -> - X - B/PrivateAssets=All -> C
+        //        X -> D -> E-> B -> C
+        // X, D & E
         [Fact]
-        // Project 1 -> a 1.0.0 -> b 1.0.0
-        //                      -> c 1.0.0 -> b 2.0.0
-        public async Task RestoreCommand_WithPackageDrivenDowngrade_RespectsDowngrade_AndRaisesWarning()
+        public async Task RestoreCommand_HigherLevelSuppressionsWin_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup project
+            var A = ProjectTestHelpers.GetPackageSpec("A", pathContext.SolutionRoot, framework: "net5.0");
+            var X = ProjectTestHelpers.GetPackageSpec("X", pathContext.SolutionRoot, framework: "net5.0");
+            var B = ProjectTestHelpers.GetPackageSpec("B", pathContext.SolutionRoot, framework: "net5.0");
+            var C = ProjectTestHelpers.GetPackageSpec("C", pathContext.SolutionRoot, framework: "net5.0");
+            var D = ProjectTestHelpers.GetPackageSpec("D", pathContext.SolutionRoot, framework: "net5.0");
+            var E = ProjectTestHelpers.GetPackageSpec("E", pathContext.SolutionRoot, framework: "net5.0");
+
+            X = X.WithTestProjectReference(B, LibraryIncludeFlags.All);
+            X = X.WithTestProjectReference(D);
+            D = D.WithTestProjectReference(E);
+            E = E.WithTestProjectReference(B);
+            B = B.WithTestProjectReference(C);
+            A = A.WithTestProjectReference(X);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, A, X, B, C, D, E);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("D");
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("E");
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("X");
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithNewPackageEvictedByVersionBump()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            var packageA = new SimpleTestPackageContext("a", "1.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "2.0.0")
+                    {
+                        Dependencies =
+                        [
+                            new SimpleTestPackageContext("e", "1.0"),
+                        ]
+                    },
+                ]
+            };
+
+            var packageC = new SimpleTestPackageContext("c", "2.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("d", "1.0.0")
+                    {
+                        Dependencies =
+                        [
+                            new SimpleTestPackageContext("b", "3.0.0")
+                        {
+                            Dependencies =
+                            [
+                                /*new SimpleTestPackageContext("e", "1.0.0")*/
+                            ]
+                            },
+                        ]
+                    },
+                ]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA,
+                packageC);
+
+            var projectSpec = @"
+                {
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""a"":  ""1.0.0"",
+                                ""c"": ""2.0.0""
+                        }
+                    }
+                  }
+                }";
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, projectSpec));
+
+            // Assert
+            result.Success.Should().BeTrue();
+            result.LogMessages.Should().HaveCount(0);
+
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(4);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("3.0.0"));
+
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("2.0.0"));
+
+            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("d");
+            result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task RestoreCommand_WithNullPackageVersion_AndRaisesErrorForOneProjectAndNotTheOther(bool isCPMEnabled)
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
             var packageA = new SimpleTestPackageContext("a", "1.0.0");
-            packageA.Dependencies.Add(new SimpleTestPackageContext("b", "1.0.0"));
-            packageA.Dependencies.Add(new SimpleTestPackageContext("c", "1.0.0")
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA);
+
+            var project2spec = ProjectTestHelpers.GetPackageSpec("Project2",
+                pathContext.SolutionRoot,
+                framework: "net472");
+
+            project2spec.TargetFrameworks[0] = new TargetFrameworkInformation(project2spec.TargetFrameworks[0])
             {
-                Dependencies = new() { new SimpleTestPackageContext("b", "2.0.0") }
-            });
+                Dependencies = [
+                    new LibraryDependency(new LibraryRange(
+                        "a",
+                        versionRange: isCPMEnabled ? null : VersionRange.All,
+                        LibraryDependencyTarget.PackageProjectExternal))
+                    ]
+            };
+
+            var project1spec = ProjectTestHelpers.GetPackageSpec("Project1",
+                pathContext.SolutionRoot,
+                framework: "net472")
+                .WithTestProjectReference(project2spec);
+
+            project1spec.RestoreMetadata.CentralPackageVersionsEnabled = isCPMEnabled;
+            project2spec.RestoreMetadata.CentralPackageVersionsEnabled = isCPMEnabled;
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1spec, project2spec);
+
+            if (isCPMEnabled)
+            {
+                // Additional assert
+                result.Success.Should().BeTrue();
+                result.LogMessages.Should().BeEmpty();
+
+                result.LockFile.Targets.Should().HaveCount(1);
+                result.LockFile.Targets[0].Libraries.Should().HaveCount(1);
+                result.LockFile.Targets[0].Libraries[0].Name.Should().Be("Project2");
+                result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            }
+            else
+            {
+                result.Success.Should().BeTrue();
+                result.LogMessages.Select(e => e.Code).Should().BeEquivalentTo([NuGetLogCode.NU1602]);
+
+                result.LockFile.Targets.Should().HaveCount(1);
+                result.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+                result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+                result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+                result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
+                result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithPackageDrivenDowngrade_RespectsDowngrade_AndRaisesWarning()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            var packageA = new SimpleTestPackageContext("a", "1.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "1.0.0"),
+                    new SimpleTestPackageContext("c", "1.0.0")
+                    {
+                        Dependencies =
+                        [
+                            new SimpleTestPackageContext("b", "2.0.0")
+                        ]
+                    },
+                ]
+            };
+
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(
                 pathContext.PackageSource,
                 PackageSaveMode.Defaultv3,
@@ -61,23 +243,140 @@ namespace NuGet.Commands.FuncTest
         }
 
         [Fact]
-        // Project 1 -> f 1.0.0 -> a 1.0.0 -> b 1.0.0
-        //                                 -> c 1.0.0 -> b 2.0.0
-        // Centrally managed versions f & a, f 1.0.0 and a 1.0.0
+        public async Task RestoreCommand_WithPackageDrivenDowngradeAndDepthDifferenceMoreThanOne_RespectsDowngrade_AndRaisesWarning()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            var packageA = new SimpleTestPackageContext("a", "1.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "1.0.0"),
+                    new SimpleTestPackageContext("c", "1.0.0")
+                    {
+                        Dependencies =
+                        [
+                            new SimpleTestPackageContext("d", "1.0.0")
+                            {
+                                Dependencies =
+                                [
+                                    new SimpleTestPackageContext("b", "2.0.0"),
+                                ]
+                            },
+                        ]
+                    },
+                ]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA);
+
+            var project1spec = ProjectTestHelpers.GetPackageSpec("Project1",
+                pathContext.SolutionRoot,
+                framework: "net472",
+                dependencyName: "a");
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1spec);
+
+            // Additional assert
+            result.Success.Should().BeTrue();
+            result.LogMessages.Select(e => e.Code).Should().BeEquivalentTo([NuGetLogCode.NU1605]);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(4);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("d");
+            result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithPackageDrivenDowngradeAndMissingVersion_RespectsDowngrade_AndRaisesWarning()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            var packageB100 = new SimpleTestPackageContext("b", "1.0.0");
+            var packageB200 = new SimpleTestPackageContext("b", "2.0.0");
+            var packageC = new SimpleTestPackageContext("c", "1.0.0")
+            {
+                Dependencies =
+                [
+                    packageB200,
+                ]
+            };
+
+            var packageA = new SimpleTestPackageContext("a", "1.0.0")
+            {
+                Dependencies =
+                [
+                    packageB100,
+                    packageC,
+                ]
+            };
+
+            await SimpleTestPackageUtility.CreatePackagesWithoutDependenciesAsync(
+                pathContext.PackageSource,
+                packageA,
+                packageB200,
+                packageC);
+
+            var project1spec = ProjectTestHelpers.GetPackageSpec("Project1",
+                pathContext.SolutionRoot,
+                framework: "net472",
+                dependencyName: "a");
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1spec);
+
+            // Additional assert
+            result.Success.Should().BeTrue();
+            result.LogMessages.Should().HaveCount(1);
+            result.LogMessages.Select(e => e.Code).Should().BeEquivalentTo([NuGetLogCode.NU1603]);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        [Fact]
         public async Task RestoreCommand_WithPackageDrivenDowngradeAndTransitivePinning_RespectsDowngrade_AndRaisesWarning()
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
             var packageF = new SimpleTestPackageContext("f", "1.0.0")
             {
-                Dependencies = [new SimpleTestPackageContext("a", "1.0.0")
-                {
-                    Dependencies = [new SimpleTestPackageContext("b", "1.0.0"),
-                        new SimpleTestPackageContext("c", "1.0.0")
-                        {
-                            Dependencies = new() { new SimpleTestPackageContext("b", "2.0.0") }
-                        }]
-                }]
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("a", "1.0.0")
+                    {
+                        Dependencies =
+                        [
+                            new SimpleTestPackageContext("c", "1.0.0")
+                            {
+                                Dependencies =
+                                [
+                                    new SimpleTestPackageContext("b", "2.0.0"),
+                                ]
+                            },
+                            new SimpleTestPackageContext("b", "1.0.0"),
+                        ]
+                    },
+                ]
             };
 
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(
@@ -111,7 +410,6 @@ namespace NuGet.Commands.FuncTest
             // Setup project
             var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
 
-
             // Act & Assert
             (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec);
 
@@ -133,116 +431,44 @@ namespace NuGet.Commands.FuncTest
         }
 
         [Fact]
-        // Project 1 -> f 1.0.0 -> a 1.0.0 -> b 1.0.0
-        //                                 -> c 1.0.0 -> b 2.0.0
-        // Centrally managed versions f & a, f 1.0.0 and a 2.0.0
-        public async Task RestoreCommand_WithPackageDrivenDowngradeAndTransitivePinningToHigherVersion_RespectsDowngrade_AndRaisesWarning()
-        {
-            // Arrange
-            using var pathContext = new SimpleTestPathContext();
-            var packageF = new SimpleTestPackageContext("f", "1.0.0")
-            {
-                Dependencies = [new SimpleTestPackageContext("a", "1.0.0")
-                {
-                    Dependencies = [new SimpleTestPackageContext("b", "1.0.0"),
-                        new SimpleTestPackageContext("c", "1.0.0")
-                        {
-                            Dependencies = new() { new SimpleTestPackageContext("b", "2.0.0") }
-                        }]
-                }]
-            };
-
-            var packageA200 = new SimpleTestPackageContext("a", "2.0.0")
-            {
-                Dependencies = [
-                    new SimpleTestPackageContext("b", "1.0.0"),
-                    new SimpleTestPackageContext("c", "1.0.0")
-                    {
-                        Dependencies = new() { new SimpleTestPackageContext("b", "2.0.0") }
-                    }]
-            };
-
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                pathContext.PackageSource,
-                PackageSaveMode.Defaultv3,
-                packageF,
-                packageA200);
-
-            var project1 = @"
-                {
-                    ""restore"": {
-                                    ""centralPackageVersionsManagementEnabled"": true,
-                                    ""CentralPackageTransitivePinningEnabled"": true,
-                    },
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                                ""f"": {
-                                    ""version"": ""[1.0.0,)"",
-                                    ""target"": ""Package"",
-                                    ""versionCentrallyManaged"": true
-                                },
-                        },
-                        ""centralPackageVersions"": {
-                            ""a"": ""[2.0.0,)"",
-                            ""f"": ""[1.0.0,)"",
-                        }
-                    }
-                  }
-                }";
-
-            // Setup project
-            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
-
-
-            // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec);
-
-            result.Success.Should().BeTrue();
-            result.LogMessages.Select(e => e.Code).Should().BeEquivalentTo([NuGetLogCode.NU1605]);
-            result.LockFile.Targets.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(4);
-            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0"));
-
-            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
-            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
-
-            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
-            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
-
-            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("f");
-            result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
-        }
-
-        [Fact]
-        // Project 1 -> f 1.0.0 -> a 1.0.0 -> b 1.0.0
-        //                                 -> c 1.0.0 -> b 2.0.0
-        // Centrally managed versions f & a, b, f 1.0.0, a 2.0.0 and b 1.0.0
         public async Task RestoreCommand_WithPackageDrivenDowngradeAndTransitivePinningToDowngradedVersion_Fails()
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
             var packageF = new SimpleTestPackageContext("f", "1.0.0")
             {
-                Dependencies = [new SimpleTestPackageContext("a", "1.0.0")
-                {
-                    Dependencies = [new SimpleTestPackageContext("b", "1.0.0"),
-                        new SimpleTestPackageContext("c", "1.0.0")
-                        {
-                            Dependencies = new() { new SimpleTestPackageContext("b", "2.0.0") }
-                        }]
-                }]
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("a", "1.0.0")
+                    {
+                        Dependencies =
+                        [
+                            new SimpleTestPackageContext("b", "1.0.0"),
+                            new SimpleTestPackageContext("c", "1.0.0")
+                            {
+                                Dependencies =
+                                [
+                                    new SimpleTestPackageContext("b", "2.0.0")
+                                ]
+                            },
+                        ]
+                    },
+                ]
             };
 
             var packageA200 = new SimpleTestPackageContext("a", "2.0.0")
             {
-                Dependencies = [
+                Dependencies =
+                [
                     new SimpleTestPackageContext("b", "1.0.0"),
                     new SimpleTestPackageContext("c", "1.0.0")
                     {
-                        Dependencies = new() { new SimpleTestPackageContext("b", "2.0.0") }
-                    }]
+                        Dependencies =
+                        [
+                            new SimpleTestPackageContext("b", "2.0.0"),
+                        ]
+                    },
+                ]
             };
 
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(
@@ -278,7 +504,6 @@ namespace NuGet.Commands.FuncTest
             // Setup project
             var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
 
-
             // Act & Assert
             (RestoreResult result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec);
 
@@ -301,53 +526,87 @@ namespace NuGet.Commands.FuncTest
         }
 
         [Fact]
-        // Project 1 -> a 1.0.0 -> b 1.0.0
-        //                      -> c 1.0.0 -> -> d 1.0.0 -> b 2.0.0
-        public async Task RestoreCommand_WithPackageDrivenDowngradeAndDepthDifferenceMoreThanOne_RespectsDowngrade_AndRaisesWarning()
+        public async Task RestoreCommand_WithPackageDrivenDowngradeAndTransitivePinningToHigherVersion_RespectsDowngrade_AndRaisesWarning()
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
-            var packageA = new SimpleTestPackageContext("a", "1.0.0")
+            var packageF = new SimpleTestPackageContext("f", "1.0.0")
             {
-                Dependencies = new()
-                {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("a", "1.0.0")
+                    {
+                        Dependencies =
+                        [
+                            new SimpleTestPackageContext("b", "1.0.0"),
+                            new SimpleTestPackageContext("c", "1.0.0")
+                            {
+                                Dependencies =
+                                [
+                                    new SimpleTestPackageContext("b", "2.0.0"),
+                                ]
+                            },
+                        ]
+                    },
+                ]
+            };
+
+            var packageA200 = new SimpleTestPackageContext("a", "2.0.0")
+            {
+                Dependencies =
+                [
                     new SimpleTestPackageContext("b", "1.0.0"),
                     new SimpleTestPackageContext("c", "1.0.0")
                     {
-                        Dependencies = new()
-                        {
-                            new SimpleTestPackageContext("d", "1.0.0")
-                            {
-                                Dependencies = new()
-                                {
-                                    new SimpleTestPackageContext("b", "2.0.0")
-                                }
-                            }
-                        }
-                    }
-                }
+                        Dependencies =
+                        [
+                            new SimpleTestPackageContext("b", "2.0.0"),
+                        ]
+                    },
+                ]
             };
 
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(
                 pathContext.PackageSource,
                 PackageSaveMode.Defaultv3,
-                packageA);
+                packageF,
+                packageA200);
 
-            var project1spec = ProjectTestHelpers.GetPackageSpec("Project1",
-                pathContext.SolutionRoot,
-                framework: "net472",
-                dependencyName: "a");
+            var project1 = @"
+                {
+                    ""restore"": {
+                                    ""centralPackageVersionsManagementEnabled"": true,
+                                    ""CentralPackageTransitivePinningEnabled"": true,
+                    },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""f"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionCentrallyManaged"": true
+                                },
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""[2.0.0,)"",
+                            ""f"": ""[1.0.0,)"",
+                        }
+                    }
+                  }
+                }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
 
             // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1spec);
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec);
 
-            // Additional assert
             result.Success.Should().BeTrue();
             result.LogMessages.Select(e => e.Code).Should().BeEquivalentTo([NuGetLogCode.NU1605]);
             result.LockFile.Targets.Should().HaveCount(1);
             result.LockFile.Targets[0].Libraries.Should().HaveCount(4);
             result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0"));
 
             result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
             result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
@@ -355,27 +614,36 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
             result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
 
-            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("d");
+            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("f");
             result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
         [Fact]
-        // Project 1 -> d 1.0.0 -> b 1.0.0
-        // Project 1 -> a 1.0.0 -> b 1.0.0
-        //                      -> c 1.0.0 -> b 2.0.0
         public async Task RestoreCommand_WithPackageDrivenDowngradeWithMultipleAncestors_RespectsDowngrade_AndRaisesWarning()
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
-            var packageA = new SimpleTestPackageContext("a", "1.0.0");
-            packageA.Dependencies.Add(new SimpleTestPackageContext("b", "1.0.0"));
-            packageA.Dependencies.Add(new SimpleTestPackageContext("c", "1.0.0")
+            var packageA = new SimpleTestPackageContext("a", "1.0.0")
             {
-                Dependencies = new() { new SimpleTestPackageContext("b", "2.0.0") }
-            });
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "1.0.0"),
+                    new SimpleTestPackageContext("c", "1.0.0")
+                    {
+                        Dependencies =
+                        [
+                            new SimpleTestPackageContext("b", "2.0.0"),
+                        ]
+                    },
+                ]
+            };
+
             var packageD = new SimpleTestPackageContext("d", "1.0.0")
             {
-                Dependencies = [new SimpleTestPackageContext("b", "1.0.0")]
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "1.0.0"),
+                ]
             };
 
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(
@@ -416,23 +684,35 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
+        // P1 -> a 1.0.0 -> b 1.0.0
+        //                  c 1.0.0 -> b 3.0.0
+        //       d 1.0.0 -> b 2.0.0
         [Fact]
-        // Project 1 -> d 1.0.0 -> b 2.0.0
-        // Project 1 -> a 1.0.0 -> b 1.0.0
-        //                      -> c 1.0.0 -> b 3.0.0
         public async Task RestoreCommand_WithPackageDrivenDowngradeWithMultipleAncestorsAndCousin_RespectsDowngrade_AndDoesNotRaiseWarning()
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
-            var packageA = new SimpleTestPackageContext("a", "1.0.0");
-            packageA.Dependencies.Add(new SimpleTestPackageContext("b", "1.0.0"));
-            packageA.Dependencies.Add(new SimpleTestPackageContext("c", "1.0.0")
+            var packageA = new SimpleTestPackageContext("a", "1.0.0")
             {
-                Dependencies = new() { new SimpleTestPackageContext("b", "3.0.0") }
-            });
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "1.0.0"),
+                    new SimpleTestPackageContext("c", "1.0.0")
+                    {
+                        Dependencies =
+                        [
+                            new SimpleTestPackageContext("b", "3.0.0")
+                        ]
+                    },
+                ]
+            };
+
             var packageD = new SimpleTestPackageContext("d", "1.0.0")
             {
-                Dependencies = [new SimpleTestPackageContext("b", "2.0.0")]
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "2.0.0"),
+                ]
             };
 
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(
@@ -474,491 +754,126 @@ namespace NuGet.Commands.FuncTest
         }
 
         [Fact]
-        // Project 1 -> a 1.0.0 -> b 1.0.0
-        //                      -> c 1.0.0 -> b 2.0.0
-        public async Task RestoreCommand_WithPackageDrivenDowngradeAndMissingVersion_RespectsDowngrade_AndRaisesWarning()
+        public async Task RestoreCommand_WithPackageWithAMissingDependencyVersion_VerifiesEquivalency()
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
-            var packageA = new SimpleTestPackageContext("a", "1.0.0");
-            var packageB100 = new SimpleTestPackageContext("b", "1.0.0");
-            var packageB200 = new SimpleTestPackageContext("b", "2.0.0");
-            var packageC = new SimpleTestPackageContext("c", "1.0.0")
-            {
-                Dependencies = new() { packageB200 }
-            };
-            packageA.Dependencies.Add(packageB100);
-            packageA.Dependencies.Add(packageC);
 
             await SimpleTestPackageUtility.CreatePackagesWithoutDependenciesAsync(
                 pathContext.PackageSource,
-                packageA,
-                packageB200,
-                packageC);
-
-            var project1spec = ProjectTestHelpers.GetPackageSpec("Project1",
-                pathContext.SolutionRoot,
-                framework: "net472",
-                dependencyName: "a");
-
-            // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1spec);
-
-            // Additional assert
-            result.Success.Should().BeTrue();
-            result.LogMessages.Should().HaveCount(1);
-            result.LogMessages.Select(e => e.Code).Should().BeEquivalentTo([NuGetLogCode.NU1603]);
-            result.LockFile.Targets.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
-            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
-            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
-            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
-            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
-            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
-        }
-
-        [Fact]
-        // Project 1 -> X 1.0 -> B 2.0 -> E 1.0
-        //           -> C 2.0 -> D 1.0 -> B 3.0
-        // Expected: X 1.0, B 3.0, C 2.0, D 1.0
-        public async Task RestoreCommand_WithNewPackageEvictedByVersionBump()
-        {
-            // Arrange
-            using var pathContext = new SimpleTestPathContext();
-            var packageA = new SimpleTestPackageContext("a", "1.0.0")
-            {
-                Dependencies = [new SimpleTestPackageContext("b", "2.0.0")
+                new SimpleTestPackageContext("a", "1.0.0")
                 {
-                    Dependencies = [new SimpleTestPackageContext("e", "1.0")]
-                }]
-            };
-            var packageC = new SimpleTestPackageContext("c", "2.0.0")
-            {
-                Dependencies = [new SimpleTestPackageContext("d", "1.0.0")
-                {
-                    Dependencies = [new SimpleTestPackageContext("b", "3.0.0")
-                    {
-                        Dependencies = [/*new SimpleTestPackageContext("e", "1.0.0")*/]
-                    }]
-                }]
-            };
+                    Dependencies =
+                    [
+                        new SimpleTestPackageContext("b", null),
+                    ],
+                },
+                new SimpleTestPackageContext("b", "2.0.0"));
 
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                pathContext.PackageSource,
-                PackageSaveMode.Defaultv3,
-                packageA,
-                packageC);
-
-            var projectSpec = @"
+            // Setup project
+            var spec1 = @"
                 {
+                  ""runtimes"": {
+                        ""win"": {}
+                  },
                   ""frameworks"": {
                     ""net472"": {
                         ""dependencies"": {
-                                ""a"":  ""1.0.0"",
-                                ""c"": ""2.0.0""
-                        }
-                    }
-                  }
-                }";
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, projectSpec));
-
-            // Assert
-            result.Success.Should().BeTrue();
-            result.LogMessages.Should().HaveCount(0);
-
-            result.LockFile.Targets.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(4);
-            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
-
-            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
-            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("3.0.0"));
-
-            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
-            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("2.0.0"));
-
-            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("d");
-            result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
-        }
-
-        // P1 -> P2 -> A (VersionOverride) -> B
-        // P1 -> P2 -> B (VersionOverride)
-        [Fact]
-        public async Task RestoreCommand_WithVersionOverrideAndTransitivePinning_VerifiesEquivalency()
-        {
-            using var pathContext = new SimpleTestPathContext();
-
-            // Setup packages
-            var packageA = new SimpleTestPackageContext("a", "1.0.0")
-            {
-                Dependencies = [new SimpleTestPackageContext("b", "1.0.0")]
-            };
-            var packageA200 = new SimpleTestPackageContext("a", "2.0.0")
-            {
-                Dependencies = [new SimpleTestPackageContext("b", "2.0.0")]
-            };
-
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                pathContext.PackageSource,
-                PackageSaveMode.Defaultv3,
-                packageA,
-                packageA200);
-
-            var project1 = @"
-                {
-                    ""restore"": {
-                                    ""centralPackageVersionsManagementEnabled"": true,
-                                    ""CentralPackageTransitivePinningEnabled"": true,
-                    },
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                        },
-                        ""centralPackageVersions"": {
-                            ""a"": ""[2.0.0,)"",
-                            ""b"": ""[2.0.0,)""
-                        }
-                    }
-                  }
-                }";
-
-            var project2 = @"
-                {
-                    ""restore"": {
-                                    ""centralPackageVersionsManagementEnabled"": true,
-                                    ""CentralPackageTransitivePinningEnabled"": true,
-                    },
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                                ""a"": {
-                                    ""version"": ""[1.0.0,)"",
-                                    ""target"": ""Package"",
-                                    ""versionOverride"": ""[1.0.0, )"",
-                                },
-                                ""b"": {
-                                    ""version"": ""[1.0.0,)"",
-                                    ""target"": ""Package"",
-                                    ""versionOverride"": ""[1.0.0, )"",
-                                }
-                        },
-                        ""centralPackageVersions"": {
-                            ""a"": ""[2.0.0,)"",
-                            ""b"": ""[2.0.0,)""
+                            ""a"": {
+                                ""version"": ""[1.0.0,)"",
+                                ""target"": ""Package"",
+                            },
+                            ""b"": {
+                                ""version"": ""[2.0.0,)"",
+                                ""target"": ""Package"",
+                            }
                         }
                     }
                   }
                 }";
 
             // Setup project
-            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
-            var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, project2);
-            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
-
+            var project1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, spec1);
 
             // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec, projectSpec2);
-            result.LockFile.Targets.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1);
+            result.Success.Should().BeTrue();
+            result.LockFile.Targets.Should().HaveCount(2);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(2);
             result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0"));
             result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
-            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
-            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
-            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
-
-            (var result2, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec2);
-            result2.LockFile.Targets.Should().HaveCount(1);
-            result2.LockFile.Targets[0].Libraries.Should().HaveCount(2);
-            result2.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result2.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
-            result2.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
-            result2.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
-        // P1 -> P2 -> A (VersionOverride) -> B
-        // P1 -> P2 -> B (PrivateAssets) VersionOverride
-        // Pinning is enabled for both P1 and P2, and P1s versions are higher than those of P2 (otherwise it'd be a downgrade error).
-        // P1 gets P2, A & B in the old algorithm, but per RestoreCommand_WithPrivateAssetsOfTransitivePackage_VerifiesEquivalency, it likely shouldn't, since if you disable pinning, B is suppressed.
-        // It's very likely that the old algorithm has a bug, likely a consequence of how the behavior was implemented to begin with.
-        // Similar as RestoreCommand_WithPrivateAssetsAndTransitivePinningEnabled_VerifiesEquivalency, because of RestoreCommand_WithPrivateAssetsOfTransitivePackage_VerifiesEquivalency, the new algorithm is arguably more correct.
-        [Fact]
-        public async Task RestoreCommand_WithVersionOverridePrivateAssetsAndTransitivePinningEnabled_VerifiesEquivalency()
+        // P1 -> P2 -> B 2.*-preview.*
+        // P1 -> A -> B 2.0.0-preview.1
+        [Theory]
+        [InlineData("*-rc.*")]
+        [InlineData("2.*-preview.*")]
+        [InlineData("2.0.*-preview.*")]
+        [InlineData("2.0.0.*-preview.*")]
+        public async Task RestoreCommand_WithPrereleaseTransitiveVersion_VerifiesEquivalency(string floatingVersion)
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
 
-            // Setup packages
-            var packageA = new SimpleTestPackageContext("a", "1.0.0")
-            {
-                Dependencies = [new SimpleTestPackageContext("b", "1.0.0")]
-            };
-            var packageA200 = new SimpleTestPackageContext("a", "2.0.0")
-            {
-                Dependencies = [new SimpleTestPackageContext("b", "2.0.0")]
-            };
+            var versionRange = VersionRange.Parse(floatingVersion);
 
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+            await SimpleTestPackageUtility.CreatePackagesAsync(
                 pathContext.PackageSource,
-                PackageSaveMode.Defaultv3,
-                packageA,
-                packageA200);
-
-            var project1 = @"
+                new SimpleTestPackageContext("a", "1.0.0")
                 {
-                    ""restore"": {
-                                    ""centralPackageVersionsManagementEnabled"": true,
-                                    ""CentralPackageTransitivePinningEnabled"": true,
-                    },
+                    Dependencies =
+                    [
+                        new SimpleTestPackageContext("b", "2.0.0-preview.1"),
+                    ],
+                },
+                new SimpleTestPackageContext("b", "2.0.0"));
+
+            // Setup project
+            var spec1 = @"
+                {
                   ""frameworks"": {
                     ""net472"": {
                         ""dependencies"": {
-                        },
-                        ""centralPackageVersions"": {
-                            ""a"": ""[2.0.0,)"",
-                            ""b"": ""[2.0.0,)""
+                            ""a"": {
+                                ""version"": ""[1.0.0,)"",
+                                ""target"": ""Package"",
+                            },
                         }
                     }
                   }
                 }";
 
-            var project2 = @"
+            var spec2 = @"
                 {
-                    ""restore"": {
-                                    ""centralPackageVersionsManagementEnabled"": true,
-                                    ""CentralPackageTransitivePinningEnabled"": true,
-                    },
                   ""frameworks"": {
                     ""net472"": {
                         ""dependencies"": {
-                                ""a"": {
-                                    ""version"": ""[1.0.0,)"",
-                                    ""target"": ""Package"",
-                                    ""versionOverride"": ""[1.0.0, )"",
-                                },
-                                ""b"": {
-                                    ""version"": ""[1.0.0,)"",
-                                    ""target"": ""Package"",
-                                    ""versionOverride"": ""[1.0.0, )"",
-                                    ""suppressParent"": ""All""
-                                }
-                        },
-                        ""centralPackageVersions"": {
-                            ""a"": ""[2.0.0,)"",
-                            ""b"": ""[2.0.0,)""
+                            ""b"": {
+                                ""version"": """ + versionRange.ToString() + @""",
+                                ""target"": ""Package"",
+                            },
                         }
                     }
                   }
                 }";
 
             // Setup project
-            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
-            var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, project2);
-            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+            var project1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, spec1);
+            var project2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, spec2);
+            project1 = project1.WithTestProjectReference(project2);
 
             // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec, projectSpec2);
-            result.LockFile.Targets.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
-            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0"));
-            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
-            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
-            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
-            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
-
-            (var result2, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec2);
-            result2.LockFile.Targets.Should().HaveCount(1);
-            result2.LockFile.Targets[0].Libraries.Should().HaveCount(2);
-            result2.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result2.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
-            result2.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
-            result2.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
-        }
-
-        // P1 -> P2 -> A (VersionOverride) 1.0.0
-        // P1 -> P2 -> B (VersionOverride) 1.0.0
-        // P1 and P2 centrally manages A to 2.0.0-preview.1, but not B.
-        [Fact]
-        public async Task RestoreCommand_WithVersionOverrideOfNotCentrallyManagedPackageAndTransitivePinning_VerifiesEquivalency()
-        {
-            using var pathContext = new SimpleTestPathContext();
-
-            // Setup packages
-            var packageA = new SimpleTestPackageContext("a", "1.0.0")
-            {
-                Dependencies = [new SimpleTestPackageContext("b", "1.0.0")]
-            };
-            var packageA200 = new SimpleTestPackageContext("a", "2.0.0-preview.1")
-            {
-                Dependencies = [new SimpleTestPackageContext("b", "2.0.0-preview.1")]
-            };
-
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                pathContext.PackageSource,
-                PackageSaveMode.Defaultv3,
-                packageA,
-                packageA200);
-
-            var project1 = @"
-                {
-                    ""restore"": {
-                                    ""centralPackageVersionsManagementEnabled"": true,
-                                    ""CentralPackageTransitivePinningEnabled"": true,
-                    },
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                        },
-                        ""centralPackageVersions"": {
-                            ""a"": ""2.0.0-preview.1"",
-                        }
-                    }
-                  }
-                }";
-
-            var project2 = @"
-                {
-                    ""restore"": {
-                                    ""centralPackageVersionsManagementEnabled"": true,
-                                    ""CentralPackageTransitivePinningEnabled"": true,
-                    },
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                                ""a"": {
-                                    ""version"": ""[1.0.0,)"",
-                                    ""target"": ""Package"",
-                                    ""versionOverride"": ""[1.0.0, )"",
-                                },
-                                ""b"": {
-                                    ""version"": ""[1.0.0,)"",
-                                    ""target"": ""Package"",
-                                    ""versionOverride"": ""[1.0.0, )"",
-                                }
-                        },
-                        ""centralPackageVersions"": {
-                            ""a"": ""2.0.0-preview.1"",
-                        }
-                    }
-                  }
-                }";
-
-            // Setup project
-            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
-            var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, project2);
-            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
-
-            // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec, projectSpec2);
-            result.LockFile.Targets.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
-            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0-preview.1"));
-            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
-            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0-preview.1"));
-            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
-            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
-
-            (var result2, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec2);
-            result2.LockFile.Targets.Should().HaveCount(1);
-            result2.LockFile.Targets[0].Libraries.Should().HaveCount(2);
-            result2.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result2.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
-            result2.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
-            result2.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
-        }
-
-        // P1 -> P2 -> A (VersionOverride) 1.0.0
-        // P1 -> P2 -> B (VersionOverride) 1.0.0
-        // P1 and P2 centrally manages A to 2.0.0-preview.1, but not B. No pinning means, only the version override versions are used.
-        [Fact]
-        public async Task RestoreCommand_WithVersionOverrideOfNotCentrallyManagedPackage_VerifiesEquivalency()
-        {
-            using var pathContext = new SimpleTestPathContext();
-
-            // Setup packages
-            var packageA = new SimpleTestPackageContext("a", "1.0.0")
-            {
-                Dependencies = [new SimpleTestPackageContext("b", "1.0.0")]
-            };
-            var packageA200 = new SimpleTestPackageContext("a", "2.0.0-preview.1")
-            {
-                Dependencies = [new SimpleTestPackageContext("b", "2.0.0-preview.1")]
-            };
-
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                pathContext.PackageSource,
-                PackageSaveMode.Defaultv3,
-                packageA,
-                packageA200);
-
-            var project1 = @"
-                {
-                    ""restore"": {
-                                    ""centralPackageVersionsManagementEnabled"": true,
-                    },
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                        },
-                        ""centralPackageVersions"": {
-                            ""a"": ""2.0.0-preview.1"",
-                        }
-                    }
-                  }
-                }";
-
-            var project2 = @"
-                {
-                    ""restore"": {
-                                    ""centralPackageVersionsManagementEnabled"": true,
-                    },
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                                ""a"": {
-                                    ""version"": ""[1.0.0,)"",
-                                    ""target"": ""Package"",
-                                    ""versionOverride"": ""[1.0.0, )"",
-                                },
-                                ""b"": {
-                                    ""version"": ""[1.0.0,)"",
-                                    ""target"": ""Package"",
-                                    ""versionOverride"": ""[1.0.0, )"",
-                                }
-                        },
-                        ""centralPackageVersions"": {
-                            ""a"": ""2.0.0-preview.1"",
-                        }
-                    }
-                  }
-                }";
-
-            // Setup project
-            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
-            var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, project2);
-            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
-
-            // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec, projectSpec2);
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2);
+            result.Success.Should().BeTrue();
             result.LockFile.Targets.Should().HaveCount(1);
             result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
             result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
             result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
             result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
-            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
             result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
             result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
-
-            (var result2, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec2);
-            result2.LockFile.Targets.Should().HaveCount(1);
-            result2.LockFile.Targets[0].Libraries.Should().HaveCount(2);
-            result2.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result2.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
-            result2.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
-            result2.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
         // P1 -> P2 -> A (VersionOverride) -> B
@@ -974,11 +889,17 @@ namespace NuGet.Commands.FuncTest
             // Setup packages
             var packageA = new SimpleTestPackageContext("a", "1.0.0")
             {
-                Dependencies = [new SimpleTestPackageContext("b", "1.0.0")]
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "1.0.0"),
+                ]
             };
             var packageA200 = new SimpleTestPackageContext("a", "2.0.0")
             {
-                Dependencies = [new SimpleTestPackageContext("b", "2.0.0")]
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "2.0.0"),
+                ]
             };
 
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(
@@ -1072,7 +993,10 @@ namespace NuGet.Commands.FuncTest
             // Setup packages
             var packageA = new SimpleTestPackageContext("a", "1.0.0")
             {
-                Dependencies = [new SimpleTestPackageContext("b", "1.0.0")]
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "1.0.0"),
+                ]
             };
 
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(
@@ -1132,53 +1056,6 @@ namespace NuGet.Commands.FuncTest
             result2.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
-        // Project1 -> Project2 -> (PrivateAssets) Project3 -> X 1.0.0
-        // Project1 expects Project2
-        // Project2 expects Project3 and X
-        // Project3 expects X
-        [Fact]
-        public async Task RestoreCommand_WithSuppressedProjectReferences_VerifiesEquivalency()
-        {
-            // Arrange
-            using var pathContext = new SimpleTestPathContext();
-
-            // Setup packages
-            var packageA = new SimpleTestPackageContext("a", "1.0.0");
-
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                pathContext.PackageSource,
-                PackageSaveMode.Defaultv3,
-                packageA);
-
-            // Setup project
-            var projectSpec = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot);
-            var projectSpec2 = ProjectTestHelpers.GetPackageSpec("Project2", pathContext.SolutionRoot);
-            var projectSpec3 = ProjectTestHelpers.GetPackageSpec("Project3", pathContext.SolutionRoot, "net5.0", dependencyName: "a");
-            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
-            projectSpec2 = projectSpec2.WithTestProjectReference(projectSpec3, LibraryIncludeFlags.All); // With PrivateAssetsAll
-
-            // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec, projectSpec2, projectSpec3);
-            result.LockFile.Targets.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("Project2");
-            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
-
-            (var result2, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec2, projectSpec3);
-            result2.LockFile.Targets.Should().HaveCount(1);
-            result2.LockFile.Targets[0].Libraries.Should().HaveCount(2);
-            result2.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result2.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
-            result2.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project3");
-            result2.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
-
-            (var result3, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec3);
-            result3.LockFile.Targets.Should().HaveCount(1);
-            result3.LockFile.Targets[0].Libraries.Should().HaveCount(1);
-            result3.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result3.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
-        }
-
         // Project1 -> Project2 -> (PrivateAssets) X 1.0.0
         [Fact]
         public async Task RestoreCommand_WithProjectReferenceWithSuppressedDependencies_VerifiesEquivalency()
@@ -1191,7 +1068,13 @@ namespace NuGet.Commands.FuncTest
             var projectSpec2 = ProjectTestHelpers.GetPackageSpec("Project2", pathContext.SolutionRoot, framework: "net5.0", dependencyName: "a");
             projectSpec2.TargetFrameworks[0] = new TargetFrameworkInformation(projectSpec2.TargetFrameworks[0])
             {
-                Dependencies = [new LibraryDependency(projectSpec2.TargetFrameworks[0].Dependencies[0]) { SuppressParent = LibraryIncludeFlags.All }]
+                Dependencies =
+                [
+                    new LibraryDependency(projectSpec2.TargetFrameworks[0].Dependencies[0])
+                    {
+                        SuppressParent = LibraryIncludeFlags.All
+                    },
+                ]
             };
             projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
 
@@ -1201,222 +1084,6 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries.Should().HaveCount(1);
             result.LockFile.Targets[0].Libraries[0].Name.Should().Be("Project2");
             result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
-        }
-
-        // Project1 -> Project2 -> X 1.0.0
-        //          -> Project3 -> X 2.0.0 (project)
-        // Project is chosen, cause higher.
-        [Fact]
-        public async Task RestoreCommand_WithSameTransitiveProjectPackageId_ChoosesProjectWithHigherVersion_VerifiesEquivalency()
-        {
-            // Arrange
-            using var pathContext = new SimpleTestPathContext();
-
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                pathContext.PackageSource,
-                PackageSaveMode.Defaultv3,
-                new SimpleTestPackageContext("a", "1.0.0"));
-
-            // Setup project
-            var project1 = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net5.0");
-            var project2 = ProjectTestHelpers.GetPackageSpec("Project2", pathContext.SolutionRoot, framework: "net5.0");
-            var project3 = ProjectTestHelpers.GetPackageSpec("Project3", pathContext.SolutionRoot, framework: "net5.0", dependencyName: "a");
-            var projectA = ProjectTestHelpers.GetPackageSpec("a", pathContext.SolutionRoot, framework: "net5.0");
-            projectA.Version = new NuGetVersion("2.0.0");
-
-            project2 = project2.WithTestProjectReference(projectA);
-            project1 = project1.WithTestProjectReference(project2);
-            project1 = project1.WithTestProjectReference(project3);
-
-            // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2, project3, projectA);
-            result.LockFile.Targets.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
-            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0"));
-            result.LockFile.Targets[0].Libraries[0].Type.Should().Be("project");
-            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
-            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
-            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project3");
-            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
-        }
-
-        // Project1 -> Project2 -> X 3.0.0
-        //          -> Project3 -> X 2.0.0 (project)
-        // Project is chosen, despite package having higher version.
-        [Fact]
-        public async Task RestoreCommand_WithSameTransitiveProjectPackageId_ChoosesProject_VerifiesEquivalency()
-        {
-            // Arrange
-            using var pathContext = new SimpleTestPathContext();
-
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                pathContext.PackageSource,
-                PackageSaveMode.Defaultv3,
-                new SimpleTestPackageContext("a", "3.0.0"));
-
-            // Setup project
-            var project1 = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net5.0");
-            var project2 = ProjectTestHelpers.GetPackageSpec("Project2", pathContext.SolutionRoot, framework: "net5.0");
-            var project3 = ProjectTestHelpers.GetPackageSpec("Project3", pathContext.SolutionRoot, framework: "net5.0", dependencyName: "a", dependencyVersion: "3.0.0");
-
-            var projectA = ProjectTestHelpers.GetPackageSpec("a", pathContext.SolutionRoot, framework: "net5.0");
-            projectA.Version = new NuGetVersion("2.0.0");
-
-            project2 = project2.WithTestProjectReference(projectA);
-            project1 = project1.WithTestProjectReference(project2);
-            project1 = project1.WithTestProjectReference(project3);
-
-            // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2, project3, projectA);
-            result.LockFile.Targets.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
-            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0"));
-            result.LockFile.Targets[0].Libraries[0].Type.Should().Be("project");
-            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
-            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
-            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project3");
-            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
-        }
-
-        // Project1 -> Project2 -> X 1.0.0
-        //          -> Project3 -> (PrivateAssets) X 2.0.0 (project)
-        // Package is chosen, since project is suppressed
-        [Fact]
-        public async Task RestoreCommand_WithSameTransitiveProjectPackageId_SuppressedProject_ChoosesPackage_VerifiesEquivalency()
-        {
-            // Arrange
-            using var pathContext = new SimpleTestPathContext();
-
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                pathContext.PackageSource,
-                PackageSaveMode.Defaultv3,
-                new SimpleTestPackageContext("a", "1.0.0"));
-
-            // Setup project
-            var project1 = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net5.0");
-            var project2 = ProjectTestHelpers.GetPackageSpec("Project2", pathContext.SolutionRoot, framework: "net5.0");
-            var project3 = ProjectTestHelpers.GetPackageSpec("Project3", pathContext.SolutionRoot, framework: "net5.0", dependencyName: "a");
-
-            var projectA = ProjectTestHelpers.GetPackageSpec("a", pathContext.SolutionRoot, framework: "net5.0");
-            projectA.Version = new NuGetVersion("2.0.0");
-
-            project2 = project2.WithTestProjectReference(projectA, LibraryIncludeFlags.All);
-            project1 = project1.WithTestProjectReference(project2);
-            project1 = project1.WithTestProjectReference(project3);
-
-            // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2, project3, projectA);
-            result.LockFile.Targets.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
-            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            //result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0")); // TODO NK - Unclear to me why suppressed project is getting selected.
-            //result.LockFile.Targets[0].Libraries[0].Type.Should().Be("package");
-            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
-            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
-            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project3");
-            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
-        }
-
-        // A -> - X - B/PrivateAssets=All -> C
-        //        X -> D -> E-> B -> C
-        // X, D & E
-        [Fact]
-        public async Task RestoreCommand_HigherLevelSuppressionsWin_VerifiesEquivalency()
-        {
-            // Arrange
-            using var pathContext = new SimpleTestPathContext();
-
-            // Setup project
-            var A = ProjectTestHelpers.GetPackageSpec("A", pathContext.SolutionRoot, framework: "net5.0");
-            var X = ProjectTestHelpers.GetPackageSpec("X", pathContext.SolutionRoot, framework: "net5.0");
-            var B = ProjectTestHelpers.GetPackageSpec("B", pathContext.SolutionRoot, framework: "net5.0");
-            var C = ProjectTestHelpers.GetPackageSpec("C", pathContext.SolutionRoot, framework: "net5.0");
-            var D = ProjectTestHelpers.GetPackageSpec("D", pathContext.SolutionRoot, framework: "net5.0");
-            var E = ProjectTestHelpers.GetPackageSpec("E", pathContext.SolutionRoot, framework: "net5.0");
-
-            X = X.WithTestProjectReference(B, LibraryIncludeFlags.All);
-            X = X.WithTestProjectReference(D);
-            D = D.WithTestProjectReference(E);
-            E = E.WithTestProjectReference(B);
-            B = B.WithTestProjectReference(C);
-            A = A.WithTestProjectReference(X);
-
-            // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, A, X, B, C, D, E);
-            result.LockFile.Targets.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
-            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("D");
-            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("E");
-            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("X");
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        // Project 1 -> Project 2 -> a (null)
-        public async Task RestoreCommand_WithNullPackageVersion_AndRaisesErrorForOneProjectAndNotTheOther(bool isCPMEnabled)
-        {
-            // Arrange
-            using var pathContext = new SimpleTestPathContext();
-            var packageA = new SimpleTestPackageContext("a", "1.0.0");
-
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                pathContext.PackageSource,
-                PackageSaveMode.Defaultv3,
-                packageA);
-
-            var project2spec = ProjectTestHelpers.GetPackageSpec("Project2",
-                pathContext.SolutionRoot,
-                framework: "net472");
-
-            project2spec.TargetFrameworks[0] = new TargetFrameworkInformation(project2spec.TargetFrameworks[0])
-            {
-                Dependencies = [
-                    new LibraryDependency(new LibraryRange(
-                        "a",
-                        versionRange: isCPMEnabled ? null : VersionRange.All,
-                        LibraryDependencyTarget.PackageProjectExternal))
-                    ]
-            };
-
-            var project1spec = ProjectTestHelpers.GetPackageSpec("Project1",
-                pathContext.SolutionRoot,
-                framework: "net472")
-                .WithTestProjectReference(project2spec);
-
-            project1spec.RestoreMetadata.CentralPackageVersionsEnabled = isCPMEnabled;
-            project2spec.RestoreMetadata.CentralPackageVersionsEnabled = isCPMEnabled;
-
-            // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1spec, project2spec);
-
-            if (isCPMEnabled)
-            {
-                // Additional assert
-                result.Success.Should().BeTrue();
-                result.LogMessages.Should().BeEmpty();
-
-                result.LockFile.Targets.Should().HaveCount(1);
-                result.LockFile.Targets[0].Libraries.Should().HaveCount(1);
-                result.LockFile.Targets[0].Libraries[0].Name.Should().Be("Project2");
-                result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
-            }
-            else
-            {
-
-                result.Success.Should().BeTrue();
-                result.LogMessages.Select(e => e.Code).Should().BeEquivalentTo([NuGetLogCode.NU1602]);
-
-                result.LockFile.Targets.Should().HaveCount(1);
-                result.LockFile.Targets[0].Libraries.Should().HaveCount(2);
-                result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-                result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
-
-                result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
-                result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
-            }
         }
 
         [Fact]
@@ -1430,7 +1097,10 @@ namespace NuGet.Commands.FuncTest
                 PackageSaveMode.Defaultv3,
                 new SimpleTestPackageContext("a", "1.0.0")
                 {
-                    Dependencies = [new SimpleTestPackageContext("b", "1.0.0")],
+                    Dependencies =
+                    [
+                        new SimpleTestPackageContext("b", "1.0.0"),
+                    ],
                     RuntimeJson = @"{
                   ""runtimes"": {
                     ""win"": {
@@ -1485,7 +1155,10 @@ namespace NuGet.Commands.FuncTest
                 PackageSaveMode.Defaultv3,
                 new SimpleTestPackageContext("a", "1.0.0")
                 {
-                    Dependencies = [new SimpleTestPackageContext("b", "1.0.0")],
+                    Dependencies =
+                    [
+                        new SimpleTestPackageContext("b", "1.0.0"),
+                    ],
                     RuntimeJson = @"{
                   ""runtimes"": {
                     ""win"": {
@@ -1536,326 +1209,6 @@ namespace NuGet.Commands.FuncTest
             (var resultWithLockFile, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1);
         }
 
-        [Fact]
-        public async Task RestoreCommand_WithPackageWithAMissingDependencyVersion_VerifiesEquivalency()
-        {
-            // Arrange
-            using var pathContext = new SimpleTestPathContext();
-
-            await SimpleTestPackageUtility.CreatePackagesWithoutDependenciesAsync(
-                pathContext.PackageSource,
-                new SimpleTestPackageContext("a", "1.0.0")
-                {
-                    Dependencies = [new SimpleTestPackageContext("b", null)],
-                },
-                new SimpleTestPackageContext("b", "2.0.0")
-                );
-
-            // Setup project
-            var spec1 = @"
-                {
-                  ""runtimes"": {
-                        ""win"": {}
-                  },
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                            ""a"": {
-                                ""version"": ""[1.0.0,)"",
-                                ""target"": ""Package"",
-                            },
-                            ""b"": {
-                                ""version"": ""[2.0.0,)"",
-                                ""target"": ""Package"",
-                            }
-                        }
-                    }
-                  }
-                }";
-
-            // Setup project
-            var project1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, spec1);
-
-            // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1);
-            result.Success.Should().BeTrue();
-            result.LockFile.Targets.Should().HaveCount(2);
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(2);
-            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
-        }
-
-        // P1 -> P2 -> B *
-        // P1 -> A -> B 1.0.0
-        [Theory]
-        [InlineData("*")]
-        [InlineData("*-*")]
-        [InlineData("*-rc.*")]
-        [InlineData("2.*")]
-        [InlineData("2.*-*")]
-        [InlineData("2.0.*")]
-        [InlineData("2.0.*-*")]
-        public async Task RestoreCommand_WithTransitiveFloatingVersion_VerifiesEquivalency(string floatingVersion)
-        {
-            // Arrange
-            using var pathContext = new SimpleTestPathContext();
-
-            var versionRange = VersionRange.Parse(floatingVersion);
-
-            await SimpleTestPackageUtility.CreatePackagesAsync(
-                pathContext.PackageSource,
-                new SimpleTestPackageContext("a", "1.0.0")
-                {
-                    Dependencies = [new SimpleTestPackageContext("b", "1.0.0")],
-                },
-                new SimpleTestPackageContext("b", "2.0.0")
-                );
-
-            // Setup project
-            var spec1 = @"
-                {
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                            ""a"": {
-                                ""version"": ""[1.0.0,)"",
-                                ""target"": ""Package"",
-                            },
-                        }
-                    }
-                  }
-                }";
-
-            var spec2 = @"
-                {
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                            ""b"": {
-                                ""version"": """ + versionRange.ToString() + @""",
-                                ""target"": ""Package"",
-                            },
-                        }
-                    }
-                  }
-                }";
-
-            // Setup project
-            var project1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, spec1);
-            var project2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, spec2);
-            project1 = project1.WithTestProjectReference(project2);
-
-            // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2);
-            result.Success.Should().BeTrue();
-            result.LockFile.Targets.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
-            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
-            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
-            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
-            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
-            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
-        }
-
-        // P1 -> P2 -> B 2.*-preview.*
-        // P1 -> A -> B 2.0.0-preview.1
-        [Theory]
-        [InlineData("*-rc.*")]
-        [InlineData("2.*-preview.*")]
-        [InlineData("2.0.*-preview.*")]
-        [InlineData("2.0.0.*-preview.*")]
-        public async Task RestoreCommand_WithPrereleaseTransitiveVersion_VerifiesEquivalency(string floatingVersion)
-        {
-            // Arrange
-            using var pathContext = new SimpleTestPathContext();
-
-            var versionRange = VersionRange.Parse(floatingVersion);
-
-            await SimpleTestPackageUtility.CreatePackagesAsync(
-                pathContext.PackageSource,
-                new SimpleTestPackageContext("a", "1.0.0")
-                {
-                    Dependencies = [new SimpleTestPackageContext("b", "2.0.0-preview.1")],
-                },
-                new SimpleTestPackageContext("b", "2.0.0")
-                );
-
-            // Setup project
-            var spec1 = @"
-                {
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                            ""a"": {
-                                ""version"": ""[1.0.0,)"",
-                                ""target"": ""Package"",
-                            },
-                        }
-                    }
-                  }
-                }";
-
-            var spec2 = @"
-                {
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                            ""b"": {
-                                ""version"": """ + versionRange.ToString() + @""",
-                                ""target"": ""Package"",
-                            },
-                        }
-                    }
-                  }
-                }";
-
-            // Setup project
-            var project1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, spec1);
-            var project2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, spec2);
-            project1 = project1.WithTestProjectReference(project2);
-
-            // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2);
-            result.Success.Should().BeTrue();
-            result.LockFile.Targets.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
-            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
-            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
-            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
-            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
-            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
-        }
-
-        // P1 -> P2 -> A [1.0.0] -> B 1.0.0
-        // P1 -> C 1.0.0 -> B 2.0.0
-        // P1 -> B 2.0.0
-        [Fact]
-        public async Task RestoreCommand_WithTransitiveExactVersionConflict_OverridenByDirectDependency_VerifiesEquivalency()
-        {
-            // Arrange
-            using var pathContext = new SimpleTestPathContext();
-
-            var versionRange = VersionRange.Parse("2.0.0");
-
-            await SimpleTestPackageUtility.CreatePackagesAsync(
-                pathContext.PackageSource,
-                new SimpleTestPackageContext("a", "1.0.0")
-                {
-                    Dependencies = [new SimpleTestPackageContext("b", "[1.0.0]")],
-                },
-                new SimpleTestPackageContext("c", "1.0.0")
-                {
-                    Dependencies = [new SimpleTestPackageContext("b", "2.0.0")],
-                }
-                );
-
-            // Setup project
-            var spec1 = @"
-                {
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                            ""c"": {
-                                ""version"": ""[1.0.0,)"",
-                                ""target"": ""Package"",
-                            },
-                            ""c"": {
-                                ""version"": ""[2.0.0,)"",
-                                ""target"": ""Package"",
-                            }
-                        }
-                    }
-                  }
-                }";
-
-            var spec2 = @"
-                {
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                            ""a"": {
-                                ""version"": """ + versionRange.ToString() + @""",
-                                ""target"": ""Package"",
-                            },
-                        }
-                    }
-                  }
-                }";
-
-            // Setup project
-            var project1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, spec1);
-            var project2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, spec2);
-            project1 = project1.WithTestProjectReference(project2);
-
-            // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2);
-            result.Success.Should().BeFalse();
-        }
-
-        // P1 -> P2 -> A [1.0.0] -> B 1.0.0
-        // P1 -> C 1.0.0 -> B 2.0.0
-        [Fact]
-        public async Task RestoreCommand_WithTransitiveExactVersionCausingVersionConflict_VerifiesEquivalency()
-        {
-            // Arrange
-            using var pathContext = new SimpleTestPathContext();
-
-            var versionRange = VersionRange.Parse("2.0.0");
-
-            await SimpleTestPackageUtility.CreatePackagesAsync(
-                pathContext.PackageSource,
-                new SimpleTestPackageContext("a", "1.0.0")
-                {
-                    Dependencies = [new SimpleTestPackageContext("b", "[1.0.0]")],
-                },
-                new SimpleTestPackageContext("c", "1.0.0")
-                {
-                    Dependencies = [new SimpleTestPackageContext("b", "2.0.0")],
-                }
-                );
-
-            // Setup project
-            var spec1 = @"
-                {
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                            ""c"": {
-                                ""version"": ""[1.0.0,)"",
-                                ""target"": ""Package"",
-                            },
-                        }
-                    }
-                  }
-                }";
-
-            var spec2 = @"
-                {
-                  ""frameworks"": {
-                    ""net472"": {
-                        ""dependencies"": {
-                            ""a"": {
-                                ""version"": """ + versionRange.ToString() + @""",
-                                ""target"": ""Package"",
-                            },
-                        }
-                    }
-                  }
-                }";
-
-            // Setup project
-            var project1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, spec1);
-            var project2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, spec2);
-            project1 = project1.WithTestProjectReference(project2);
-
-            // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2);
-            result.Success.Should().BeFalse();
-        }
-
-
         // Project1 -> (project) ProjectAndPackage 1.0.0 -> Project3 -> Project4 -> PackageB 2.0.0
         //          -> packageA 1.0.0 -> PackageB 1.0.0
         //                            -> ProjectAndPackage 2.0.0
@@ -1869,7 +1222,11 @@ namespace NuGet.Commands.FuncTest
             // Setup packages
             var packageA = new SimpleTestPackageContext("packageA", "1.0.0")
             {
-                Dependencies = [new SimpleTestPackageContext("packageB", "1.0.0"), new SimpleTestPackageContext("ProjectAndPackage", projectAndPackageVersion)]
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("packageB", "1.0.0"),
+                    new SimpleTestPackageContext("ProjectAndPackage", projectAndPackageVersion),
+                ]
             };
             var packageB = new SimpleTestPackageContext("packageB", "2.0.0");
 
@@ -1931,6 +1288,382 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[4].Type.Should().Be("project");
         }
 
+        // Project1 -> Project2 -> X 3.0.0
+        //          -> Project3 -> X 2.0.0 (project)
+        // Project is chosen, despite package having higher version.
+        [Fact]
+        public async Task RestoreCommand_WithSameTransitiveProjectPackageId_ChoosesProject_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                new SimpleTestPackageContext("a", "3.0.0"));
+
+            // Setup project
+            var project1 = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net5.0");
+            var project2 = ProjectTestHelpers.GetPackageSpec("Project2", pathContext.SolutionRoot, framework: "net5.0");
+            var project3 = ProjectTestHelpers.GetPackageSpec("Project3", pathContext.SolutionRoot, framework: "net5.0", dependencyName: "a", dependencyVersion: "3.0.0");
+
+            var projectA = ProjectTestHelpers.GetPackageSpec("a", pathContext.SolutionRoot, framework: "net5.0");
+            projectA.Version = new NuGetVersion("2.0.0");
+
+            project2 = project2.WithTestProjectReference(projectA);
+            project1 = project1.WithTestProjectReference(project2);
+            project1 = project1.WithTestProjectReference(project3);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2, project3, projectA);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0"));
+            result.LockFile.Targets[0].Libraries[0].Type.Should().Be("project");
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project3");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        // Project1 -> Project2 -> X 1.0.0
+        //          -> Project3 -> X 2.0.0 (project)
+        // Project is chosen, cause higher.
+        [Fact]
+        public async Task RestoreCommand_WithSameTransitiveProjectPackageId_ChoosesProjectWithHigherVersion_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                new SimpleTestPackageContext("a", "1.0.0"));
+
+            // Setup project
+            var project1 = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net5.0");
+            var project2 = ProjectTestHelpers.GetPackageSpec("Project2", pathContext.SolutionRoot, framework: "net5.0");
+            var project3 = ProjectTestHelpers.GetPackageSpec("Project3", pathContext.SolutionRoot, framework: "net5.0", dependencyName: "a");
+            var projectA = ProjectTestHelpers.GetPackageSpec("a", pathContext.SolutionRoot, framework: "net5.0");
+            projectA.Version = new NuGetVersion("2.0.0");
+
+            project2 = project2.WithTestProjectReference(projectA);
+            project1 = project1.WithTestProjectReference(project2);
+            project1 = project1.WithTestProjectReference(project3);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2, project3, projectA);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0"));
+            result.LockFile.Targets[0].Libraries[0].Type.Should().Be("project");
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project3");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        // Project1 -> Project2 -> X 1.0.0
+        //          -> Project3 -> (PrivateAssets) X 2.0.0 (project)
+        // Package is chosen, since project is suppressed
+        [Fact]
+        public async Task RestoreCommand_WithSameTransitiveProjectPackageId_SuppressedProject_ChoosesPackage_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                new SimpleTestPackageContext("a", "1.0.0"));
+
+            // Setup project
+            var project1 = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net5.0");
+            var project2 = ProjectTestHelpers.GetPackageSpec("Project2", pathContext.SolutionRoot, framework: "net5.0");
+            var project3 = ProjectTestHelpers.GetPackageSpec("Project3", pathContext.SolutionRoot, framework: "net5.0", dependencyName: "a");
+
+            var projectA = ProjectTestHelpers.GetPackageSpec("a", pathContext.SolutionRoot, framework: "net5.0");
+            projectA.Version = new NuGetVersion("2.0.0");
+
+            project2 = project2.WithTestProjectReference(projectA, LibraryIncludeFlags.All);
+            project1 = project1.WithTestProjectReference(project2);
+            project1 = project1.WithTestProjectReference(project3);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2, project3, projectA);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            //result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0")); // TODO NK - Unclear to me why suppressed project is getting selected.
+            //result.LockFile.Targets[0].Libraries[0].Type.Should().Be("package");
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project3");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        // Project1 -> Project2 -> (PrivateAssets) Project3 -> X 1.0.0
+        // Project1 expects Project2
+        // Project2 expects Project3 and X
+        // Project3 expects X
+        [Fact]
+        public async Task RestoreCommand_WithSuppressedProjectReferences_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("a", "1.0.0");
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA);
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot);
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpec("Project2", pathContext.SolutionRoot);
+            var projectSpec3 = ProjectTestHelpers.GetPackageSpec("Project3", pathContext.SolutionRoot, "net5.0", dependencyName: "a");
+            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+            projectSpec2 = projectSpec2.WithTestProjectReference(projectSpec3, LibraryIncludeFlags.All); // With PrivateAssetsAll
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec, projectSpec2, projectSpec3);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            (var result2, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec2, projectSpec3);
+            result2.LockFile.Targets.Should().HaveCount(1);
+            result2.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+            result2.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result2.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result2.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project3");
+            result2.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            (var result3, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec3);
+            result3.LockFile.Targets.Should().HaveCount(1);
+            result3.LockFile.Targets[0].Libraries.Should().HaveCount(1);
+            result3.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result3.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        // P1 -> P2 -> A [1.0.0] -> B 1.0.0
+        // P1 -> C 1.0.0 -> B 2.0.0
+        [Fact]
+        public async Task RestoreCommand_WithTransitiveExactVersionCausingVersionConflict_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            var versionRange = VersionRange.Parse("2.0.0");
+
+            await SimpleTestPackageUtility.CreatePackagesAsync(
+                pathContext.PackageSource,
+                new SimpleTestPackageContext("a", "1.0.0")
+                {
+                    Dependencies =
+                    [
+                        new SimpleTestPackageContext("b", "[1.0.0]"),
+                    ],
+                },
+                new SimpleTestPackageContext("c", "1.0.0")
+                {
+                    Dependencies =
+                    [
+                        new SimpleTestPackageContext("b", "2.0.0"),
+                    ],
+                }
+                );
+
+            // Setup project
+            var spec1 = @"
+                {
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                            ""c"": {
+                                ""version"": ""[1.0.0,)"",
+                                ""target"": ""Package"",
+                            },
+                        }
+                    }
+                  }
+                }";
+
+            var spec2 = @"
+                {
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                            ""a"": {
+                                ""version"": """ + versionRange.ToString() + @""",
+                                ""target"": ""Package"",
+                            },
+                        }
+                    }
+                  }
+                }";
+
+            // Setup project
+            var project1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, spec1);
+            var project2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, spec2);
+            project1 = project1.WithTestProjectReference(project2);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2);
+            result.Success.Should().BeFalse();
+        }
+
+        // P1 -> P2 -> A [1.0.0] -> B 1.0.0
+        // P1 -> C 1.0.0 -> B 2.0.0
+        // P1 -> B 2.0.0
+        [Fact]
+        public async Task RestoreCommand_WithTransitiveExactVersionConflict_OverridenByDirectDependency_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            var versionRange = VersionRange.Parse("2.0.0");
+
+            await SimpleTestPackageUtility.CreatePackagesAsync(
+                pathContext.PackageSource,
+                new SimpleTestPackageContext("a", "1.0.0")
+                {
+                    Dependencies =
+                    [
+                        new SimpleTestPackageContext("b", "[1.0.0]"),
+                    ],
+                },
+                new SimpleTestPackageContext("c", "1.0.0")
+                {
+                    Dependencies =
+                    [
+                        new SimpleTestPackageContext("b", "2.0.0"),
+                    ],
+                });
+
+            // Setup project
+            var spec1 = @"
+                {
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                            ""c"": {
+                                ""version"": ""[1.0.0,)"",
+                                ""target"": ""Package"",
+                            },
+                            ""c"": {
+                                ""version"": ""[2.0.0,)"",
+                                ""target"": ""Package"",
+                            }
+                        }
+                    }
+                  }
+                }";
+
+            var spec2 = @"
+                {
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                            ""a"": {
+                                ""version"": """ + versionRange.ToString() + @""",
+                                ""target"": ""Package"",
+                            },
+                        }
+                    }
+                  }
+                }";
+
+            // Setup project
+            var project1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, spec1);
+            var project2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, spec2);
+            project1 = project1.WithTestProjectReference(project2);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2);
+            result.Success.Should().BeFalse();
+        }
+
+        // P1 -> P2 -> B *
+        // P1 -> A -> B 1.0.0
+        [Theory]
+        [InlineData("*")]
+        [InlineData("*-*")]
+        [InlineData("*-rc.*")]
+        [InlineData("2.*")]
+        [InlineData("2.*-*")]
+        [InlineData("2.0.*")]
+        [InlineData("2.0.*-*")]
+        public async Task RestoreCommand_WithTransitiveFloatingVersion_VerifiesEquivalency(string floatingVersion)
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            var versionRange = VersionRange.Parse(floatingVersion);
+
+            await SimpleTestPackageUtility.CreatePackagesAsync(
+                pathContext.PackageSource,
+                new SimpleTestPackageContext("a", "1.0.0")
+                {
+                    Dependencies =
+                    [
+                        new SimpleTestPackageContext("b", "1.0.0"),
+                    ],
+                },
+                new SimpleTestPackageContext("b", "2.0.0"));
+
+            // Setup project
+            var spec1 = @"
+                {
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                            ""a"": {
+                                ""version"": ""[1.0.0,)"",
+                                ""target"": ""Package"",
+                            },
+                        }
+                    }
+                  }
+                }";
+
+            var spec2 = @"
+                {
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                            ""b"": {
+                                ""version"": """ + versionRange.ToString() + @""",
+                                ""target"": ""Package"",
+                            },
+                        }
+                    }
+                  }
+                }";
+
+            // Setup project
+            var project1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, spec1);
+            var project2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, spec2);
+            project1 = project1.WithTestProjectReference(project2);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2);
+            result.Success.Should().BeTrue();
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
         // Project1 -> Project3 -> (project) ProjectAndPackage 1.0.0 -> Project4 -> PackageB 2.0.0
         //          -> packageA 1.0.0 -> PackageB 1.0.0
         //                            -> ProjectAndPackage 2.0.0
@@ -1944,7 +1677,11 @@ namespace NuGet.Commands.FuncTest
             // Setup packages
             var packageA = new SimpleTestPackageContext("packageA", "1.0.0")
             {
-                Dependencies = [new SimpleTestPackageContext("packageB", "1.0.0"), new SimpleTestPackageContext("ProjectAndPackage", projectAndPackageVersion)]
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("packageB", "1.0.0"),
+                    new SimpleTestPackageContext("ProjectAndPackage", projectAndPackageVersion),
+                ]
             };
             var packageB = new SimpleTestPackageContext("packageB", "2.0.0");
 
@@ -1992,7 +1729,6 @@ namespace NuGet.Commands.FuncTest
             projectSpec2 = projectSpec2.WithTestProjectReference(projectSpec3);
             projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
 
-
             // Act & Assert
             (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec, projectSpec2, projectSpec3, projectSpec4);
             result.LockFile.PackageSpec.RestoreMetadata.CentralPackageTransitivePinningEnabled.Should().BeFalse();
@@ -2007,6 +1743,425 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[4].Type.Should().Be("project");
         }
 
+        // P1 -> P2 -> A (VersionOverride) -> B
+        // P1 -> P2 -> B (VersionOverride)
+        [Fact]
+        public async Task RestoreCommand_WithVersionOverrideAndTransitivePinning_VerifiesEquivalency()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("a", "1.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "1.0.0"),
+                ]
+            };
+
+            var packageA200 = new SimpleTestPackageContext("a", "2.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "2.0.0"),
+                ]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA,
+                packageA200);
+
+            var project1 = @"
+                {
+                    ""restore"": {
+                                    ""centralPackageVersionsManagementEnabled"": true,
+                                    ""CentralPackageTransitivePinningEnabled"": true,
+                    },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""[2.0.0,)"",
+                            ""b"": ""[2.0.0,)""
+                        }
+                    }
+                  }
+                }";
+
+            var project2 = @"
+                {
+                    ""restore"": {
+                                    ""centralPackageVersionsManagementEnabled"": true,
+                                    ""CentralPackageTransitivePinningEnabled"": true,
+                    },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""a"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionOverride"": ""[1.0.0, )"",
+                                },
+                                ""b"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionOverride"": ""[1.0.0, )"",
+                                }
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""[2.0.0,)"",
+                            ""b"": ""[2.0.0,)""
+                        }
+                    }
+                  }
+                }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, project2);
+            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec, projectSpec2);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            (var result2, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec2);
+            result2.LockFile.Targets.Should().HaveCount(1);
+            result2.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+            result2.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result2.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result2.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result2.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        // P1 -> P2 -> A (VersionOverride) 1.0.0
+        // P1 -> P2 -> B (VersionOverride) 1.0.0
+        // P1 and P2 centrally manages A to 2.0.0-preview.1, but not B. No pinning means, only the version override versions are used.
+        [Fact]
+        public async Task RestoreCommand_WithVersionOverrideOfNotCentrallyManagedPackage_VerifiesEquivalency()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("a", "1.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "1.0.0"),
+                ]
+            };
+            var packageA200 = new SimpleTestPackageContext("a", "2.0.0-preview.1")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "2.0.0-preview.1"),
+                ]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA,
+                packageA200);
+
+            var project1 = @"
+                {
+                    ""restore"": {
+                                    ""centralPackageVersionsManagementEnabled"": true,
+                    },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""2.0.0-preview.1"",
+                        }
+                    }
+                  }
+                }";
+
+            var project2 = @"
+                {
+                    ""restore"": {
+                                    ""centralPackageVersionsManagementEnabled"": true,
+                    },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""a"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionOverride"": ""[1.0.0, )"",
+                                },
+                                ""b"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionOverride"": ""[1.0.0, )"",
+                                }
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""2.0.0-preview.1"",
+                        }
+                    }
+                  }
+                }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, project2);
+            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec, projectSpec2);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            (var result2, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec2);
+            result2.LockFile.Targets.Should().HaveCount(1);
+            result2.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+            result2.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result2.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result2.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result2.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        // P1 -> P2 -> A (VersionOverride) 1.0.0
+        // P1 -> P2 -> B (VersionOverride) 1.0.0
+        // P1 and P2 centrally manages A to 2.0.0-preview.1, but not B.
+        [Fact]
+        public async Task RestoreCommand_WithVersionOverrideOfNotCentrallyManagedPackageAndTransitivePinning_VerifiesEquivalency()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("a", "1.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "1.0.0")
+                    {
+                        Dependencies =
+                        [
+                            new SimpleTestPackageContext("c", "1.0.0")
+                        ]
+                    },
+                ]
+            };
+            var packageA200 = new SimpleTestPackageContext("a", "2.0.0-preview.1")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "2.0.0-preview.1")
+                    {
+                        Dependencies =
+                        [
+                            new SimpleTestPackageContext("c", "2.0.0-preview.1")
+                        ]
+                    },
+                ]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA,
+                packageA200);
+
+            var project1 = @"
+                {
+                    ""restore"": {
+                                    ""centralPackageVersionsManagementEnabled"": true,
+                                    ""CentralPackageTransitivePinningEnabled"": true,
+                    },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""2.0.0-preview.1"",
+                        }
+                    }
+                  }
+                }";
+
+            var project2 = @"
+                {
+                    ""restore"": {
+                                    ""centralPackageVersionsManagementEnabled"": true,
+                                    ""CentralPackageTransitivePinningEnabled"": true,
+                    },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""a"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionOverride"": ""[1.0.0, )"",
+                                },
+                                ""b"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionOverride"": ""[1.0.0, )"",
+                                }
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""2.0.0-preview.1"",
+                        }
+                    }
+                  }
+                }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, project2);
+            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec, projectSpec2);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(4);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0-preview.1"));
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0-preview.1"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("2.0.0-preview.1"));
+            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            (var result2, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec2);
+            result2.LockFile.Targets.Should().HaveCount(1);
+            result2.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result2.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result2.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result2.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result2.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result2.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
+            result2.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+        // P1 -> P2 -> A (VersionOverride) -> B
+        // P1 -> P2 -> B (PrivateAssets) VersionOverride
+        // Pinning is enabled for both P1 and P2, and P1s versions are higher than those of P2 (otherwise it'd be a downgrade error).
+        // P1 gets P2, A & B in the old algorithm, but per RestoreCommand_WithPrivateAssetsOfTransitivePackage_VerifiesEquivalency, it likely shouldn't, since if you disable pinning, B is suppressed.
+        // It's very likely that the old algorithm has a bug, likely a consequence of how the behavior was implemented to begin with.
+        // Similar as RestoreCommand_WithPrivateAssetsAndTransitivePinningEnabled_VerifiesEquivalency, because of RestoreCommand_WithPrivateAssetsOfTransitivePackage_VerifiesEquivalency, the new algorithm is arguably more correct.
+        [Fact]
+        public async Task RestoreCommand_WithVersionOverridePrivateAssetsAndTransitivePinningEnabled_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("a", "1.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "1.0.0"),
+                ]
+            };
+            var packageA200 = new SimpleTestPackageContext("a", "2.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "2.0.0"),
+                ]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA,
+                packageA200);
+
+            var project1 = @"
+                {
+                    ""restore"": {
+                                    ""centralPackageVersionsManagementEnabled"": true,
+                                    ""CentralPackageTransitivePinningEnabled"": true,
+                    },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""[2.0.0,)"",
+                            ""b"": ""[2.0.0,)""
+                        }
+                    }
+                  }
+                }";
+
+            var project2 = @"
+                {
+                    ""restore"": {
+                                    ""centralPackageVersionsManagementEnabled"": true,
+                                    ""CentralPackageTransitivePinningEnabled"": true,
+                    },
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""a"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionOverride"": ""[1.0.0, )"",
+                                },
+                                ""b"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                    ""versionOverride"": ""[1.0.0, )"",
+                                    ""suppressParent"": ""All""
+                                }
+                        },
+                        ""centralPackageVersions"": {
+                            ""a"": ""[2.0.0,)"",
+                            ""b"": ""[2.0.0,)""
+                        }
+                    }
+                  }
+                }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, project2);
+            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec, projectSpec2);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            (var result2, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec2);
+            result2.LockFile.Targets.Should().HaveCount(1);
+            result2.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+            result2.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result2.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result2.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result2.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
         // Here's why package driven dependencies should flow.
         // Say we have P1 -> P2 -> P3 -> A 1.0.0 -> B 2.0.0
         //                            -> B 1.5.0
@@ -2015,29 +2170,12 @@ namespace NuGet.Commands.FuncTest
         // Then, say you have a mono repo with the above structure. Say you split P1 in one repo and P2 and P3 in another repo.
         // The restore behavior for P2 and P3 for package B would be different than the one for Package A.
         // To promote package/project duality, downgrades must be equivalent for both.
-        // Note that all of this downgrade logic should apply CPM or no CPM, VersionOverride or no VersionOverride, the rules are independent of how the version was specified. 
+        // Note that all of this downgrade logic should apply CPM or no CPM, VersionOverride or no VersionOverride, the rules are independent of how the version was specified.
         // Some of these behaviors are captured within tests, like package driven downgrade, we need to tests for the project one and the mixed one, the 2 repo case.
 
         // That leads to VersionOverride - VersionOverride as a concept is an input thing, not a resolver thing. When VersionOverride has a value, it's always translated to the Version property of the library dependency.
         // I think that there should be no VersionOverride checks in the DependencyGraphResolver, since the only reason is exists is
         // to raise a warning when you have VersionOverride but you have not enabled it, otherwise it would've never gone into the model.
-
-        internal static async Task<(RestoreResult, RestoreResult)> ValidateRestoreAlgorithmEquivalency(SimpleTestPathContext pathContext, params PackageSpec[] projects)
-        {
-            var legacyResolverProjects = DuplicateAndEnableLegacyAlgorithm(projects);
-
-            RestoreResult result = await RunRestoreAsync(pathContext, projects);
-            RestoreResult legacyResult = await RunRestoreAsync(pathContext, legacyResolverProjects);
-
-            // Assert
-            ValidateRestoreResults(result, legacyResult);
-            return (result, legacyResult);
-        }
-
-        internal static Task<RestoreResult> RunRestoreAsync(SimpleTestPathContext pathContext, params PackageSpec[] projects)
-        {
-            return new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, new TestLogger(), projects)).ExecuteAsync();
-        }
 
         internal static PackageSpec[] DuplicateAndEnableLegacyAlgorithm(PackageSpec[] projects)
         {
@@ -2050,6 +2188,23 @@ namespace NuGet.Commands.FuncTest
             }
 
             return result;
+        }
+
+        internal static Task<RestoreResult> RunRestoreAsync(SimpleTestPathContext pathContext, params PackageSpec[] projects)
+        {
+            return new RestoreCommand(ProjectTestHelpers.CreateRestoreRequest(pathContext, new TestLogger(), projects)).ExecuteAsync();
+        }
+
+        internal static async Task<(RestoreResult, RestoreResult)> ValidateRestoreAlgorithmEquivalency(SimpleTestPathContext pathContext, params PackageSpec[] projects)
+        {
+            var legacyResolverProjects = DuplicateAndEnableLegacyAlgorithm(projects);
+
+            RestoreResult result = await RunRestoreAsync(pathContext, projects);
+            RestoreResult legacyResult = await RunRestoreAsync(pathContext, legacyResolverProjects);
+
+            // Assert
+            ValidateRestoreResults(result, legacyResult);
+            return (result, legacyResult);
         }
 
         internal static void ValidateRestoreResults(RestoreResult newAlgorithmResult, RestoreResult legacyResult)

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -861,6 +861,84 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
+        // Project 1 -> d 1.0.0 -> e 1.0.0 -> b 3.0.0
+        // Project 1 -> a 1.0.0 -> b 1.0.0
+        //                      -> c 1.0.0 -> b 3.0.0
+        [Fact]
+        public async Task RestoreCommand_WithPackageDrivenDowngradeWithMultipleAncestorsAndCousin_CousinDependencyWins()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            var packageA = new SimpleTestPackageContext("a", "1.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("b", "1.0.0"),
+                    new SimpleTestPackageContext("c", "1.0.0")
+                    {
+                        Dependencies =
+                        [
+                            new SimpleTestPackageContext("b", "3.0.0")
+                        ]
+                    },
+                ]
+            };
+
+            var packageD = new SimpleTestPackageContext("d", "1.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("e", "1.0.0")
+                        {
+                            Dependencies =
+                            [
+                                new SimpleTestPackageContext("b", "3.0.0"),
+                            ]
+                        }
+                ]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA,
+                packageD);
+
+            var projectSpec = @"
+                {
+                  ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""a"":  ""1.0.0"",
+                                ""d"": ""1.0.0""
+                        }
+                    }
+                  }
+                }";
+
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, projectSpec));
+
+            // Assert
+            result.Success.Should().BeTrue();
+            result.LogMessages.Should().BeEmpty();
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(5);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("3.0.0"));
+
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("c");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("d");
+            result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
+
+            result.LockFile.Targets[0].Libraries[4].Name.Should().Be("e");
+            result.LockFile.Targets[0].Libraries[4].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
         [Fact]
         public async Task RestoreCommand_WithPackageWithAMissingDependencyVersion_VerifiesEquivalency()
         {

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -367,7 +367,7 @@ namespace NuGet.Commands.FuncTest
         //                  c 1.0.0 -> b 3.0.0
         //       d 1.0.0 -> b 2.0.0
         [Fact]
-        public async Task RestoreCommand_WithPackageDrivenDowngradeAndTransitivePinning_RespectsDowngrade_AndDoesNotRaiseWarning()
+        public async Task RestoreCommand_WithPackageDrivenDowngradeAndTransitivePinning_ElevatesTransitiveToDirect_AndDoesNotRaiseWarning()
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
@@ -448,6 +448,10 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
+        // Project 1 -> f 1.0.0 -> a 1.0.0 -> b 1.0.0
+        //                                 -> c 1.0.0 -> b 2.0.0
+        // Centrally managed versions f & a, f 1.0.0 and a 1.0.0
+
         [Fact]
         public async Task RestoreCommand_WithPackageDrivenDowngradeAndTransitivePinning_RespectsDowngrade_AndRaisesWarning()
         {
@@ -525,6 +529,9 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
+        // Project 1 -> f 1.0.0 -> a 1.0.0 -> b 1.0.0
+        //                                 -> c 1.0.0 -> b 2.0.0
+        // Centrally managed versions f & a, b, f 1.0.0, a 2.0.0 and b 1.0.0
         [Fact]
         public async Task RestoreCommand_WithPackageDrivenDowngradeAndTransitivePinningToDowngradedVersion_Fails()
         {
@@ -620,6 +627,9 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
+        // Project 1 -> f 1.0.0 -> a 1.0.0 -> b 1.0.0
+        //                                 -> c 1.0.0 -> b 2.0.0
+        // Centrally managed versions f & a, f 1.0.0 and a 2.0.0
         [Fact]
         public async Task RestoreCommand_WithPackageDrivenDowngradeAndTransitivePinningToHigherVersion_RespectsDowngrade_AndRaisesWarning()
         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13938

## Description

This fixes the new dependency resolver when transitive pinning is enabled and a package subgraph happens to contain versions that should or should not be eclipsed.

The way eclipsing works is for each subgraph, the first one wins:

```
Project1
└── A 1.0.0
    ├── B 1.0.0  
    └── C 1.0.0
        └── B 2.0.0
```
In this case, `B 2.0.0` is part of the graph of A which already depends on `B 1.0.0` so `B 1.0.0` is chosen.

However, if a higher version comes in through a different subgraph, a different version of `B` could win:

```
Project1
├── A 1.0.0
│   ├── B 1.0.0  
│   └── C 1.0.0
│       └── B 2.0.0
└── F 1.0.0
    └── B 3.0.0
```
In this case, `B 3.0.0` is not in the subgraph of `A` and its version eclipses `B 1.0.0`.

Transitive pinning is supposed to be syntactic sugar for a direct dependency and so if you pinned `C 1.0.0` in the first example, the resolver treats the graph as:

```
Project1
├── A 1.0.0
│   └── B 1.0.0  
└── C 1.0.0
    └── B 2.0.0
```

Now `B 2.0.0` is not part of the subgraph of `A` and the resolver should pick `B 2.0.0`.  However, the current implementation of the new resolver only looks to see if the proposed `B 2.0.0` and the already chosen `B 1.0.0` have the common ancestors.  This leads to the new resolver resolving the wrong graph and logging downgrade warnings as described in https://github.com/NuGet/Home/issues/13938

The fix is to modify the paths for each item if it is pinned to correctly assess if a package should eclipse another.  But when the paths are modified, the resolver must also keep track of the original parent in order to correctly create downgrade warnings if one exists. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
