### PR TITLE
Avoid recreating IMarkdownPreview control

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/MarkdownPreviewSingleton.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/MarkdownPreviewSingleton.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Markdown.Platform;
+
+namespace NuGet.PackageManagement.UI
+{
+    public class MarkdownPreviewSingleton
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        private static IMarkdownPreview Instance;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        public static IMarkdownPreview GetInstance()
+#pragma warning restore CS0618 // Type or member is obsolete
+        {
+            if (Instance == null)
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                Instance = new PreviewBuilder().Build();
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
+
+            return Instance;
+        }
+
+        public static void ResetInstance()
+        {
+            if (Instance != null)
+            {
+                Instance.Dispose();
+                Instance = null;
+            }
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageDetailsTabViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageDetailsTabViewModel.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Markdown.Platform;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
 using NuGet.VisualStudio.Telemetry;
@@ -38,8 +39,9 @@ namespace NuGet.PackageManagement.UI.ViewModels
         {
             var nuGetFeatureFlagService = await ServiceLocator.GetComponentModelServiceAsync<INuGetFeatureFlagService>();
             _readmeTabEnabled = await nuGetFeatureFlagService.IsFeatureEnabledAsync(NuGetFeatureFlagConstants.RenderReadmeInPMUI);
-
-            ReadmePreviewViewModel = new ReadmePreviewViewModel(nugetPackageFileService, currentFilter, _readmeTabEnabled);
+#pragma warning disable CS0618 // Type or member is obsolete
+            ReadmePreviewViewModel = new ReadmePreviewViewModel(nugetPackageFileService, currentFilter, new PreviewBuilder().Build(), _readmeTabEnabled);
+#pragma warning restore CS0618 // Type or member is obsolete
             DetailControlModel = detailControlModel;
 
             if (_readmeTabEnabled)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageDetailsTabViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageDetailsTabViewModel.cs
@@ -4,7 +4,6 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.Markdown.Platform;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
 using NuGet.VisualStudio.Telemetry;
@@ -40,7 +39,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
             var nuGetFeatureFlagService = await ServiceLocator.GetComponentModelServiceAsync<INuGetFeatureFlagService>();
             _readmeTabEnabled = await nuGetFeatureFlagService.IsFeatureEnabledAsync(NuGetFeatureFlagConstants.RenderReadmeInPMUI);
 #pragma warning disable CS0618 // Type or member is obsolete
-            ReadmePreviewViewModel = new ReadmePreviewViewModel(nugetPackageFileService, currentFilter, new PreviewBuilder().Build(), _readmeTabEnabled);
+            ReadmePreviewViewModel = new ReadmePreviewViewModel(nugetPackageFileService, currentFilter, _readmeTabEnabled);
 #pragma warning restore CS0618 // Type or member is obsolete
             DetailControlModel = detailControlModel;
 
@@ -78,7 +77,6 @@ namespace NuGet.PackageManagement.UI.ViewModels
             }
             _disposed = true;
             DetailControlModel.PropertyChanged -= DetailControlModel_PropertyChanged;
-            ReadmePreviewViewModel.Dispose();
             foreach (var tab in Tabs)
             {
                 tab.PropertyChanged -= IsVisible_PropertyChanged;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageDetailsTabViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageDetailsTabViewModel.cs
@@ -76,7 +76,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
             }
             _disposed = true;
             DetailControlModel.PropertyChanged -= DetailControlModel_PropertyChanged;
-
+            ReadmePreviewViewModel.Dispose();
             foreach (var tab in Tabs)
             {
                 tab.PropertyChanged -= IsVisible_PropertyChanged;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
@@ -5,25 +5,23 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.Markdown.Platform;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.PackageManagement.UI.ViewModels
 {
-    public sealed class ReadmePreviewViewModel : TitledPageViewModelBase, IDisposable
+    public sealed class ReadmePreviewViewModel : TitledPageViewModelBase
     {
         private bool _errorWithReadme;
         private INuGetPackageFileService _nugetPackageFileService;
         private string _rawReadme;
         private DetailedPackageMetadata _packageMetadata;
         private bool _canRenderLocalReadme;
-        private bool _disposed = false;
         private bool _isBusy;
 
 #pragma warning disable CS0618 // Type or member is obsolete
-        public ReadmePreviewViewModel(INuGetPackageFileService packageFileService, ItemFilter itemFilter, IMarkdownPreview markdownPreview, bool isReadmeFeatureEnabled)
+        public ReadmePreviewViewModel(INuGetPackageFileService packageFileService, ItemFilter itemFilter, bool isReadmeFeatureEnabled)
 #pragma warning restore CS0618 // Type or member is obsolete
         {
             _nugetPackageFileService = packageFileService ?? throw new ArgumentNullException(nameof(packageFileService));
@@ -35,7 +33,6 @@ namespace NuGet.PackageManagement.UI.ViewModels
             _packageMetadata = null;
             Title = Resources.Label_Readme_Tab;
             IsVisible = isReadmeFeatureEnabled;
-            MarkdownPreview = markdownPreview;
         }
 
         public bool IsReadmeReady { get => !IsBusy && !ErrorWithReadme; }
@@ -59,10 +56,6 @@ namespace NuGet.PackageManagement.UI.ViewModels
                 RaisePropertyChanged(nameof(IsReadmeReady));
             }
         }
-
-#pragma warning disable CS0618 // Type or member is obsolete
-        public IMarkdownPreview MarkdownPreview { get; }
-#pragma warning restore CS0618 // Type or member is obsolete
 
         public string ReadmeMarkdown
         {
@@ -90,16 +83,6 @@ namespace NuGet.PackageManagement.UI.ViewModels
                 _packageMetadata = packageMetadata;
                 await LoadReadmeAsync(cancellationToken);
             }
-        }
-
-        public void Dispose()
-        {
-            if (_disposed)
-            {
-                return;
-            }
-            _disposed = true;
-            MarkdownPreview.Dispose();
         }
 
         private static bool CanRenderLocalReadme(ItemFilter filter)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
@@ -22,7 +22,9 @@ namespace NuGet.PackageManagement.UI.ViewModels
         private bool _disposed = false;
         private bool _isBusy;
 
-        public ReadmePreviewViewModel(INuGetPackageFileService packageFileService, ItemFilter itemFilter, bool isReadmeFeatureEnabled)
+#pragma warning disable CS0618 // Type or member is obsolete
+        public ReadmePreviewViewModel(INuGetPackageFileService packageFileService, ItemFilter itemFilter, IMarkdownPreview markdownPreview, bool isReadmeFeatureEnabled)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             _nugetPackageFileService = packageFileService ?? throw new ArgumentNullException(nameof(packageFileService));
             _canRenderLocalReadme = CanRenderLocalReadme(itemFilter);
@@ -33,9 +35,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
             _packageMetadata = null;
             Title = Resources.Label_Readme_Tab;
             IsVisible = isReadmeFeatureEnabled;
-#pragma warning disable CS0618 // Type or member is obsolete
-            MarkdownPreview = new PreviewBuilder().Build();
-#pragma warning restore CS0618 // Type or member is obsolete
+            MarkdownPreview = markdownPreview;
         }
 
         public bool IsReadmeReady { get => !IsBusy && !ErrorWithReadme; }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
@@ -5,19 +5,21 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Markdown.Platform;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.PackageManagement.UI.ViewModels
 {
-    public sealed class ReadmePreviewViewModel : TitledPageViewModelBase
+    public sealed class ReadmePreviewViewModel : TitledPageViewModelBase, IDisposable
     {
         private bool _errorWithReadme;
         private INuGetPackageFileService _nugetPackageFileService;
         private string _rawReadme;
         private DetailedPackageMetadata _packageMetadata;
         private bool _canRenderLocalReadme;
+        private bool _disposed = false;
         private bool _isBusy;
 
         public ReadmePreviewViewModel(INuGetPackageFileService packageFileService, ItemFilter itemFilter, bool isReadmeFeatureEnabled)
@@ -31,6 +33,9 @@ namespace NuGet.PackageManagement.UI.ViewModels
             _packageMetadata = null;
             Title = Resources.Label_Readme_Tab;
             IsVisible = isReadmeFeatureEnabled;
+#pragma warning disable CS0618 // Type or member is obsolete
+            MarkdownPreview = new PreviewBuilder().Build();
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public bool IsReadmeReady { get => !IsBusy && !ErrorWithReadme; }
@@ -54,6 +59,10 @@ namespace NuGet.PackageManagement.UI.ViewModels
                 RaisePropertyChanged(nameof(IsReadmeReady));
             }
         }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        public IMarkdownPreview MarkdownPreview { get; }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         public string ReadmeMarkdown
         {
@@ -81,6 +90,16 @@ namespace NuGet.PackageManagement.UI.ViewModels
                 _packageMetadata = packageMetadata;
                 await LoadReadmeAsync(cancellationToken);
             }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+            MarkdownPreview.Dispose();
         }
 
         private static bool CanRenderLocalReadme(ItemFilter filter)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -104,6 +104,11 @@ namespace NuGet.PackageManagement.UI
             }).PostOnFailure(nameof(DetailControl));
         }
 
+        public void Cleanup()
+        {
+            _packageDetailsTabControl.Dispose();
+        }
+
         private void ProjectInstallButtonClicked(object sender, EventArgs e)
         {
             var model = (PackageDetailControlModel)DataContext;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml.cs
@@ -23,6 +23,7 @@ namespace NuGet.PackageManagement.UI
         public PackageDetailsTabControl()
         {
             InitializeComponent();
+            MarkdownPreviewSingleton.GetInstance();
             DataContext = new PackageDetailsTabViewModel();
         }
 
@@ -41,6 +42,7 @@ namespace NuGet.PackageManagement.UI
             if (disposing)
             {
                 PackageDetailsTabViewModel.Dispose();
+                MarkdownPreviewSingleton.ResetInstance();
             }
             _disposed = true;
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml.cs
@@ -23,7 +23,6 @@ namespace NuGet.PackageManagement.UI
         public PackageDetailsTabControl()
         {
             InitializeComponent();
-            MarkdownPreviewSingleton.GetInstance();
             DataContext = new PackageDetailsTabViewModel();
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1580,6 +1580,7 @@ namespace NuGet.PackageManagement.UI
             _refreshCts?.Dispose();
             _cancelSelectionChangedSource?.Dispose();
 
+            _packageDetail.Cleanup();
             _detailModel.Dispose();
             _packageList.SelectionChanged -= PackageList_SelectionChanged;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml
@@ -28,14 +28,13 @@
   <Grid>
     <ContentControl
       x:Name="descriptionMarkdownPreview"
-      x:Uid="descriptionMarkdownPreview"
       ClipToBounds="True"
       Focusable="False"
-      Visibility="{Binding Path=IsReadmeReady, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+      Visibility="{Binding Path=IsReadmeReady, Mode=OneWay, FallbackValue=Collapsed, Converter={StaticResource BooleanToVisibilityConverter}}" />
     <Grid
       HorizontalAlignment="Center"
       VerticalAlignment="Center"
-      Visibility="{Binding Path=IsBusy, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" >
+      Visibility="{Binding Path=IsBusy, Mode=OneWay, FallbackValue=Visible, Converter={StaticResource BooleanToVisibilityConverter}}" >
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="Auto"/>
         <ColumnDefinition Width="Auto"/>
@@ -75,6 +74,6 @@
     <TextBlock
       TextWrapping="Wrap"
       Text="{x:Static nuget:Resources.Error_UnableToLoadReadme}"
-      Visibility="{Binding Path=ErrorWithReadme, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+      Visibility="{Binding Path=ErrorWithReadme, Mode=OneWay, FallbackValue=Collapsed, Converter={StaticResource BooleanToVisibilityConverter}}" />
   </Grid>
 </UserControl>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
@@ -25,14 +25,6 @@ namespace NuGet.PackageManagement.UI
 
         public ReadmePreviewViewModel ReadmeViewModel { get => (ReadmePreviewViewModel)DataContext; }
 
-        public FrameworkElement MarkdownPreviewControl
-        {
-            get => (FrameworkElement)GetValue(MarkdownPreviewControlProperty);
-            set => SetValue(MarkdownPreviewControlProperty, value);
-        }
-        public static readonly DependencyProperty MarkdownPreviewControlProperty =
-            DependencyProperty.Register(nameof(MarkdownPreviewControl), typeof(FrameworkElement), typeof(PackageReadmeControl));
-
         private void ReadmeViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(ReadmePreviewViewModel.ReadmeMarkdown))

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
@@ -38,7 +38,6 @@ namespace NuGet.PackageManagement.UI
         {
             try
             {
-                descriptionMarkdownPreview.Content = descriptionMarkdownPreview.Content ?? _markdownPreview.VisualElement;
                 if (!string.IsNullOrWhiteSpace(ReadmeViewModel.ReadmeMarkdown))
                 {
                     await ReadmeViewModel.MarkdownPreview.UpdateContentAsync(ReadmeViewModel.ReadmeMarkdown, ScrollHint.None);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
@@ -19,9 +19,15 @@ namespace NuGet.PackageManagement.UI
     /// </summary>
     public partial class PackageReadmeControl : UserControl
     {
+#pragma warning disable CS0618 // Type or member is obsolete
+        public IMarkdownPreview markdownPreview;
+#pragma warning restore CS0618 // Type or member is obsolete
+
         public PackageReadmeControl()
         {
             InitializeComponent();
+            markdownPreview = MarkdownPreviewSingleton.GetInstance();
+            descriptionMarkdownPreview.Content = markdownPreview.VisualElement;
         }
 
         public ReadmePreviewViewModel ReadmeViewModel { get => (ReadmePreviewViewModel)DataContext; }
@@ -40,7 +46,7 @@ namespace NuGet.PackageManagement.UI
             {
                 if (!string.IsNullOrWhiteSpace(ReadmeViewModel.ReadmeMarkdown))
                 {
-                    await ReadmeViewModel.MarkdownPreview.UpdateContentAsync(ReadmeViewModel.ReadmeMarkdown, ScrollHint.None);
+                    await markdownPreview.UpdateContentAsync(ReadmeViewModel.ReadmeMarkdown, ScrollHint.None);
                 }
             }
             catch (Exception ex) when (ex is ArgumentException || ex is InvalidOperationException)
@@ -57,13 +63,12 @@ namespace NuGet.PackageManagement.UI
             {
                 ThreadHelper.JoinableTaskFactory.Run(async () =>
                 {
-                    await oldMetadata.MarkdownPreview.UpdateContentAsync("", ScrollHint.None);
+                    await markdownPreview.UpdateContentAsync("", ScrollHint.None);
                 });
                 oldMetadata.PropertyChanged -= ReadmeViewModel_PropertyChanged;
             }
             if (ReadmeViewModel is not null)
             {
-                descriptionMarkdownPreview.Content = ReadmeViewModel.MarkdownPreview.VisualElement;
                 ReadmeViewModel.PropertyChanged += ReadmeViewModel_PropertyChanged;
             }
         }
@@ -74,7 +79,7 @@ namespace NuGet.PackageManagement.UI
             {
                 ThreadHelper.JoinableTaskFactory.Run(async () =>
                 {
-                    await ReadmeViewModel.MarkdownPreview.UpdateContentAsync("", ScrollHint.None);
+                    await markdownPreview.UpdateContentAsync("", ScrollHint.None);
                 });
                 ReadmeViewModel.PropertyChanged -= ReadmeViewModel_PropertyChanged;
             }
@@ -82,8 +87,7 @@ namespace NuGet.PackageManagement.UI
 
         private void PackageReadmeControl_Loaded(object sender, RoutedEventArgs e)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(UpdateMarkdownAsync)
-                .PostOnFailure(nameof(PackageReadmeControl), nameof(PackageReadmeControl_Loaded));
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(UpdateMarkdownAsync);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
@@ -16,22 +16,22 @@ namespace NuGet.PackageManagement.UI
     /// <summary>
     /// Interaction logic for PackageReadmeControl.xaml
     /// </summary>
-    public partial class PackageReadmeControl : UserControl, IDisposable
+    public partial class PackageReadmeControl : UserControl
     {
-#pragma warning disable CS0618 // Type or member is obsolete
-        private IMarkdownPreview _markdownPreview;
-#pragma warning restore CS0618 // Type or member is obsolete
-        private bool _disposed = false;
-
         public PackageReadmeControl()
         {
             InitializeComponent();
-#pragma warning disable CS0618 // Type or member is obsolete
-            _markdownPreview = new PreviewBuilder().Build();
-#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public ReadmePreviewViewModel ReadmeViewModel { get => (ReadmePreviewViewModel)DataContext; }
+
+        public FrameworkElement MarkdownPreviewControl
+        {
+            get => (FrameworkElement)GetValue(MarkdownPreviewControlProperty);
+            set => SetValue(MarkdownPreviewControlProperty, value);
+        }
+        public static readonly DependencyProperty MarkdownPreviewControlProperty =
+            DependencyProperty.Register(nameof(MarkdownPreviewControl), typeof(FrameworkElement), typeof(PackageReadmeControl));
 
         private void ReadmeViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
@@ -41,31 +41,6 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        public void Dispose()
-        {
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (_disposed)
-            {
-                return;
-            }
-
-            if (disposing)
-            {
-                _markdownPreview?.Dispose();
-                if (ReadmeViewModel is not null)
-                {
-                    ReadmeViewModel.PropertyChanged -= ReadmeViewModel_PropertyChanged;
-                }
-            }
-
-            _disposed = true;
-        }
-
         private async Task UpdateMarkdownAsync()
         {
             try
@@ -73,7 +48,7 @@ namespace NuGet.PackageManagement.UI
                 descriptionMarkdownPreview.Content = descriptionMarkdownPreview.Content ?? _markdownPreview.VisualElement;
                 if (!string.IsNullOrWhiteSpace(ReadmeViewModel.ReadmeMarkdown))
                 {
-                    await _markdownPreview.UpdateContentAsync(ReadmeViewModel.ReadmeMarkdown, ScrollHint.None);
+                    await ReadmeViewModel.MarkdownPreview.UpdateContentAsync(ReadmeViewModel.ReadmeMarkdown, ScrollHint.None);
                 }
             }
             catch (Exception ex) when (ex is ArgumentException || ex is InvalidOperationException)
@@ -88,17 +63,29 @@ namespace NuGet.PackageManagement.UI
         {
             if (e.OldValue is ReadmePreviewViewModel oldMetadata)
             {
+                ThreadHelper.JoinableTaskFactory.Run(async () =>
+                {
+                    await oldMetadata.MarkdownPreview.UpdateContentAsync("", ScrollHint.None);
+                });
                 oldMetadata.PropertyChanged -= ReadmeViewModel_PropertyChanged;
             }
             if (ReadmeViewModel is not null)
             {
+                descriptionMarkdownPreview.Content = ReadmeViewModel.MarkdownPreview.VisualElement;
                 ReadmeViewModel.PropertyChanged += ReadmeViewModel_PropertyChanged;
             }
         }
 
         private void PackageReadmeControl_Unloaded(object sender, RoutedEventArgs e)
         {
-            Dispose();
+            if (ReadmeViewModel is not null)
+            {
+                ThreadHelper.JoinableTaskFactory.Run(async () =>
+                {
+                    await ReadmeViewModel.MarkdownPreview.UpdateContentAsync("", ScrollHint.None);
+                });
+                ReadmeViewModel.PropertyChanged -= ReadmeViewModel_PropertyChanged;
+            }
         }
 
         private void PackageReadmeControl_Loaded(object sender, RoutedEventArgs e)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
@@ -20,14 +20,14 @@ namespace NuGet.PackageManagement.UI
     public partial class PackageReadmeControl : UserControl
     {
 #pragma warning disable CS0618 // Type or member is obsolete
-        public IMarkdownPreview markdownPreview;
+        private IMarkdownPreview _markdownPreview;
 #pragma warning restore CS0618 // Type or member is obsolete
 
         public PackageReadmeControl()
         {
             InitializeComponent();
-            markdownPreview = MarkdownPreviewSingleton.GetInstance();
-            descriptionMarkdownPreview.Content = markdownPreview.VisualElement;
+            _markdownPreview = MarkdownPreviewSingleton.GetInstance();
+            descriptionMarkdownPreview.Content = _markdownPreview.VisualElement;
         }
 
         public ReadmePreviewViewModel ReadmeViewModel { get => (ReadmePreviewViewModel)DataContext; }
@@ -46,7 +46,7 @@ namespace NuGet.PackageManagement.UI
             {
                 if (!string.IsNullOrWhiteSpace(ReadmeViewModel.ReadmeMarkdown))
                 {
-                    await markdownPreview.UpdateContentAsync(ReadmeViewModel.ReadmeMarkdown, ScrollHint.None);
+                    await _markdownPreview.UpdateContentAsync(ReadmeViewModel.ReadmeMarkdown, ScrollHint.None);
                 }
             }
             catch (Exception ex) when (ex is ArgumentException || ex is InvalidOperationException)
@@ -63,7 +63,7 @@ namespace NuGet.PackageManagement.UI
             {
                 ThreadHelper.JoinableTaskFactory.Run(async () =>
                 {
-                    await markdownPreview.UpdateContentAsync("", ScrollHint.None);
+                    await _markdownPreview.UpdateContentAsync("", ScrollHint.None);
                 });
                 oldMetadata.PropertyChanged -= ReadmeViewModel_PropertyChanged;
             }
@@ -79,7 +79,7 @@ namespace NuGet.PackageManagement.UI
             {
                 ThreadHelper.JoinableTaskFactory.Run(async () =>
                 {
-                    await markdownPreview.UpdateContentAsync("", ScrollHint.None);
+                    await _markdownPreview.UpdateContentAsync("", ScrollHint.None);
                 });
                 ReadmeViewModel.PropertyChanged -= ReadmeViewModel_PropertyChanged;
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using Microsoft.VisualStudio.Markdown.Platform;
+using Microsoft.VisualStudio.Shell;
 using NuGet.PackageManagement.UI.ViewModels;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Telemetry;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/ReadmePreviewViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/ReadmePreviewViewModelTests.cs
@@ -22,7 +22,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
-                new ReadmePreviewViewModel(null, ItemFilter.All, null, true);
+                new ReadmePreviewViewModel(null, ItemFilter.All, true);
             });
         }
 
@@ -33,7 +33,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             var mockFileService = new Mock<INuGetPackageFileService>();
 
             //Act
-            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.All, null, true);
+            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.All, true);
 
             //Assert
             Assert.False(target.ErrorWithReadme);
@@ -48,7 +48,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
         {
             //Arrange
             var mockFileService = new Mock<INuGetPackageFileService>();
-            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.Installed, null, true);
+            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.Installed, true);
             var package = new DetailedPackageMetadata();
             package.ReadmeFileUrl = readmeUrl;
 
@@ -68,7 +68,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             using Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(readmeContents));
             var mockFileService = new Mock<INuGetPackageFileService>();
             mockFileService.Setup(x => x.GetReadmeAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>())).ReturnsAsync(stream);
-            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.Installed, null, true);
+            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.Installed, true);
             var package = new DetailedPackageMetadata();
             package.ReadmeFileUrl = "C://path/to/readme.md";
             await target.SetPackageMetadataAsync(package, CancellationToken.None);
@@ -92,7 +92,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             using Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(readmeContents));
             var mockFileService = new Mock<INuGetPackageFileService>();
             mockFileService.Setup(x => x.GetReadmeAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>())).ReturnsAsync(stream);
-            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.All, null, true);
+            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.All, true);
             var package = new DetailedPackageMetadata();
             package.ReadmeFileUrl = "C://path/to/readme.md";
             await target.SetPackageMetadataAsync(package, CancellationToken.None);
@@ -113,7 +113,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             using Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(readmeContents));
             var mockFileService = new Mock<INuGetPackageFileService>();
             mockFileService.Setup(x => x.GetReadmeAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>())).ReturnsAsync(stream);
-            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.Installed, null, true);
+            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.Installed, true);
             var package = new DetailedPackageMetadata();
             package.ReadmeFileUrl = "C://path/to/readme.md";
 
@@ -133,7 +133,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             using Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(readmeContents));
             var mockFileService = new Mock<INuGetPackageFileService>();
             mockFileService.Setup(x => x.GetReadmeAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>())).ReturnsAsync(stream);
-            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.All, null, true);
+            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.All, true);
             var package = new DetailedPackageMetadata();
             package.ReadmeFileUrl = "C://path/to/readme.md";
 
@@ -151,7 +151,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             //Arrange
             var mockFileService = new Mock<INuGetPackageFileService>();
             mockFileService.Setup(x => x.GetReadmeAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>())).Returns(null);
-            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.Installed, null, true);
+            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.Installed, true);
             var package = new DetailedPackageMetadata();
             package.ReadmeFileUrl = "C://path/to/readme.md";
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/ReadmePreviewViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/ReadmePreviewViewModelTests.cs
@@ -22,7 +22,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
-                new ReadmePreviewViewModel(null, ItemFilter.All, true);
+                new ReadmePreviewViewModel(null, ItemFilter.All, null, true);
             });
         }
 
@@ -33,7 +33,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             var mockFileService = new Mock<INuGetPackageFileService>();
 
             //Act
-            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.All, true);
+            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.All, null, true);
 
             //Assert
             Assert.False(target.ErrorWithReadme);
@@ -48,7 +48,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
         {
             //Arrange
             var mockFileService = new Mock<INuGetPackageFileService>();
-            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.Installed, true);
+            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.Installed, null, true);
             var package = new DetailedPackageMetadata();
             package.ReadmeFileUrl = readmeUrl;
 
@@ -68,7 +68,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             using Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(readmeContents));
             var mockFileService = new Mock<INuGetPackageFileService>();
             mockFileService.Setup(x => x.GetReadmeAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>())).ReturnsAsync(stream);
-            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.Installed, true);
+            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.Installed, null, true);
             var package = new DetailedPackageMetadata();
             package.ReadmeFileUrl = "C://path/to/readme.md";
             await target.SetPackageMetadataAsync(package, CancellationToken.None);
@@ -92,7 +92,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             using Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(readmeContents));
             var mockFileService = new Mock<INuGetPackageFileService>();
             mockFileService.Setup(x => x.GetReadmeAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>())).ReturnsAsync(stream);
-            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.All, true);
+            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.All, null, true);
             var package = new DetailedPackageMetadata();
             package.ReadmeFileUrl = "C://path/to/readme.md";
             await target.SetPackageMetadataAsync(package, CancellationToken.None);
@@ -113,7 +113,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             using Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(readmeContents));
             var mockFileService = new Mock<INuGetPackageFileService>();
             mockFileService.Setup(x => x.GetReadmeAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>())).ReturnsAsync(stream);
-            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.Installed, true);
+            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.Installed, null, true);
             var package = new DetailedPackageMetadata();
             package.ReadmeFileUrl = "C://path/to/readme.md";
 
@@ -133,7 +133,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             using Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(readmeContents));
             var mockFileService = new Mock<INuGetPackageFileService>();
             mockFileService.Setup(x => x.GetReadmeAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>())).ReturnsAsync(stream);
-            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.All, true);
+            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.All, null, true);
             var package = new DetailedPackageMetadata();
             package.ReadmeFileUrl = "C://path/to/readme.md";
 
@@ -151,7 +151,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             //Arrange
             var mockFileService = new Mock<INuGetPackageFileService>();
             mockFileService.Setup(x => x.GetReadmeAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>())).Returns(null);
-            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.Installed, true);
+            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.Installed, null, true);
             var package = new DetailedPackageMetadata();
             package.ReadmeFileUrl = "C://path/to/readme.md";
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
The tab control unloads the PackageReadmeControl when the tab is switched away. This was causing PackageReadmeControl to recreate the IMarkdownPreview every time the README tab was loaded. I created a singleton to ensure we reuse the MarkdownPreview. 
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
