### PR TITLE
Fix release-6.6.x after recent change

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -3,6 +3,10 @@ parameters:
   type: boolean
 - name: NuGetLocalizationType
   type: string
+- name: RunUnitTests
+  displayName: Run unit tests
+  type: boolean
+  default: true
 
 steps:
 - task: PowerShell@1
@@ -147,23 +151,25 @@ steps:
     msbuildArguments: "/restore:false /target:CopyFinalNuGetExeToOutputPath /binarylogger:$(Build.StagingDirectory)\\binlog\\06.CopyFinalNuGetExeToOutputPath.binlog"
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
-- task: MSBuild@1
-  displayName: "Run unit tests (stop on error)"
-  continueOnError: "false"
-  inputs:
-    solution: "build\\build.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /target:CoreUnitTests;UnitTestsVS /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:SkipILMergeOfNuGetExe=true /binarylogger:$(Build.StagingDirectory)\\binlog\\07.RunUnitTests.binlog"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['IsOfficialBuild'], 'true')))"
+- ${{ if eq(parameters.RunUnitTests, true) }}:
+  - task: MSBuild@1
+    displayName: "Run unit tests (stop on error)"
+    continueOnError: "false"
+    inputs:
+      solution: "build\\build.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore:false /target:CoreUnitTests;UnitTestsVS /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:SkipILMergeOfNuGetExe=true /binarylogger:$(Build.StagingDirectory)\\binlog\\07.RunUnitTests.binlog"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['IsOfficialBuild'], 'true')))"
 
-- task: MSBuild@1
-  displayName: "Run unit tests (continue on error)"
-  continueOnError: "true"
-  inputs:
-    solution: "build\\build.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /target:CoreUnitTests;UnitTestsVS /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:SkipILMergeOfNuGetExe=true /binarylogger:$(Build.StagingDirectory)\\binlog\\08.RunUnitTests.binlog"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['IsOfficialBuild'], 'true'))"
+- ${{ if eq(parameters.RunUnitTests, true) }}:
+  - task: MSBuild@1
+    displayName: "Run unit tests (continue on error)"
+    continueOnError: "true"
+    inputs:
+      solution: "build\\build.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore:false /target:CoreUnitTests;UnitTestsVS /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:SkipILMergeOfNuGetExe=true /binarylogger:$(Build.StagingDirectory)\\binlog\\08.RunUnitTests.binlog"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: PublishTestResults@2
   displayName: "Publish Test Results"

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -21,6 +21,10 @@ parameters:
   displayName: Run functional tests on Windows
   type: boolean
   default: true
+- name: RunUnitTestsOnWindows
+  displayName: Run unit tests on Windows
+  type: boolean
+  default: false
 - name: RunSourceBuild
   displayName: Run source build
   type: boolean
@@ -35,6 +39,10 @@ parameters:
   default: true
 - name: RunMonoTestsOnMac
   displayName: Run Mono tests on Mac
+  type: boolean
+  default: false
+- name: RunStaticAnalysis
+  displayName: Run static analysis
   type: boolean
   default: false
 
@@ -70,6 +78,7 @@ stages:
   jobs:
   - job: RunStaticSourceAnalysis
     displayName: Run Static Source Analysis
+    condition: "ne(variables['RunStaticAnalysis'], 'false')"
     timeoutInMinutes: 15
     pool:
       name: AzurePipelines-EO
@@ -206,6 +215,7 @@ stages:
       parameters:
         BuildRTM: false
         NuGetLocalizationType: ${{ parameters.NuGetLocalizationType }}
+        RunUnitTests: ${{ parameters.RunUnitTestsOnWindows }}
 
 - stage: Build_For_Publishing
   displayName: Build NuGet published to nuget.org


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
When disabling tests for the official build of `release-6.6.x` in https://github.com/NuGet/NuGet.Client/pull/6155, I accidentally broke it because some of the templates didn't have the parameters when I thought they did.  This change puts the parameters in place to get the build working again.  This time I pushed to Trusted so I could actually run the build ahead of time to verify.

https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=10596490

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
