### PR TITLE
Revert NuGetAuditMode to .NET 8 defaults

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -73,17 +73,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Report all severity vulnerabilities (low severity and higher). Allowed values are: low, moderate, high, critical -->
     <NuGetAuditLevel Condition=" '$(NuGetAuditLevel)' == '' ">low</NuGetAuditLevel>
     <!-- Report known vulnerabilities on direct and transitive dependencies, unless SdkAnalysisLevel (or equalivant) is lower than 9.0.100. Allowed values are: direct, all -->
-    <NuGetAuditMode Condition="'$(NuGetAuditMode)' == ''
-                    AND '$(NuGetExeSkipSdkAnalysisLevelCheck)' != 'true'
-                    AND '$(SdkAnalysisLevel)' != ''
-                    AND $([MSBuild]::VersionLessThan('$(SdkAnalysisLevel)', '9.0.100'))"
-                    >direct</NuGetAuditMode>
-    <NuGetAuditMode Condition="'$(NuGetAuditMode)' == ''
-                    AND '$(NuGetExeSkipSdkAnalysisLevelCheck)' != 'true'
-                    AND '$(UsingMicrosoftNETSdk)' == 'true'
-                    AND '$(SdkAnalysisLevel)' == ''"
-                    >direct</NuGetAuditMode>
-    <NuGetAuditMode Condition=" '$(NuGetAuditMode)' == '' ">all</NuGetAuditMode>
+    <NuGetAuditMode Condition=" '$(NuGetAuditMode)' == '' ">direct</NuGetAuditMode>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -1158,7 +1148,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <TargetPlatformMinVersion>$(TargetPlatformMinVersion)</TargetPlatformMinVersion>
         <CLRSupport>$(CLRSupport)</CLRSupport>
         <RuntimeIdentifierGraphPath>$(RuntimeIdentifierGraphPath)</RuntimeIdentifierGraphPath>
-        <WindowsTargetPlatformMinVersion>$(WindowsTargetPlatformMinVersion)</WindowsTargetPlatformMinVersion>      
+        <WindowsTargetPlatformMinVersion>$(WindowsTargetPlatformMinVersion)</WindowsTargetPlatformMinVersion>
     </_RestoreGraphEntry>
     </ItemGroup>
   </Target>

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/NuGetAuditDefaultsTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/NuGetAuditDefaultsTests.cs
@@ -22,11 +22,11 @@ namespace Msbuild.Integration.Test
 
         [Theory]
         // .NET 9 SDK
-        [InlineData("9.0.100", "true", "all")]
+        [InlineData("9.0.100", "true", "direct")]
         // .NET 8 SDK
         [InlineData(null, "true", "direct")]
         // non-SDK style project
-        [InlineData(null, null, "all")]
+        [InlineData(null, null, "direct")]
         // non-SDK style project explicit opt-out
         [InlineData("8.0", null, "direct")]
         public void NuGetAuditModeDefaults(string SdkAnalysisLevel, string UsingMicrosoftNETSdk, string expected)
@@ -50,35 +50,6 @@ namespace Msbuild.Integration.Test
 
             // Assert
             resultText.Should().Be(expected);
-        }
-
-        [Fact]
-        // Some customers run the latest Nuget.exe with old versions of MSBuild. MSBuild only added intrinsic functions
-        // needed for SdkAnalysisVersion comparisons in dev16, so NuGet.exe detects the MSBuild version and adds a
-        // global property when invoking MSBuild, so that our MSBuild script can avoid calling intrinstic functions
-        // that don't exist. In order to test this with a "real" integration test, we'd need an old version of MSBuild
-        // installed, which is not worth the effort, assuming it's even feasible. Therefore, while this test can't
-        // validate that the intrinstic functions are not called, it can set the same global property and validate that
-        // the default values are what we expect.
-        public void NuGetAuditModeDefaults_NuGetExeWithOldMSBuildEmulation()
-        {
-            // Arrange
-            using var testDirectory = TestDirectory.Create();
-
-            string projectText = @"<Project>
-    <Import Project=""$(NuGetRestoreTargets)"" />
-</Project>";
-            var projectFilePath = Path.Combine(testDirectory, "my.proj");
-            File.WriteAllText(projectFilePath, projectText);
-
-            string args = $"{projectFilePath} -getProperty:NuGetAuditMode -p:NuGetExeSkipSdkAnalysisLevelCheck=true";
-
-            // Act
-            var result = _fixture.RunMsBuild(testDirectory, args);
-            var resultText = result.Output.Trim();
-
-            // Assert
-            resultText.Should().Be("all");
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13945

## Description

Cherry picks #6151 to the dev branch

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/13946
