### PR TITLE
Promote NU3043 warning to error in NuGet.exe sign command

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SignCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SignCommand.cs
@@ -78,7 +78,7 @@ namespace NuGet.CommandLine
         {
             ValidatePackagePath();
             WarnIfNoTimestamper(Console);
-            ValidateCertificateInputs(Console);
+            ValidateCertificateInputs();
             ValidateOutputDirectory();
 
             var signingSpec = SigningSpecifications.V1;
@@ -164,7 +164,7 @@ namespace NuGet.CommandLine
             }
         }
 
-        private void ValidateCertificateInputs(ILogger logger)
+        private void ValidateCertificateInputs()
         {
             if (string.IsNullOrEmpty(CertificatePath) &&
                 string.IsNullOrEmpty(CertificateFingerprint) &&
@@ -189,13 +189,12 @@ namespace NuGet.CommandLine
             }
             else if (CertificateFingerprint != null)
             {
-                if (!CertificateUtility.TryDeduceHashAlgorithm(CertificateFingerprint, out HashAlgorithmName hashAlgorithmName))
+                if (!CertificateUtility.TryDeduceHashAlgorithm(CertificateFingerprint, out HashAlgorithmName hashAlgorithmName) ||
+                    hashAlgorithmName == HashAlgorithmName.SHA1)
                 {
-                    throw new ArgumentException(NuGetCommand.SignCommandInvalidCertificateFingerprint);
-                }
-                else if (hashAlgorithmName == HashAlgorithmName.SHA1)
-                {
-                    logger.Log(LogMessage.CreateWarning(NuGetLogCode.NU3043, NuGetCommand.SignCommandInvalidCertificateFingerprint));
+                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
+                        NuGetCommand.SignCommandInvalidCertificateFingerprint,
+                        NuGetLogCode.NU3043));
                 }
             }
         }

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -1609,7 +1609,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid value for &apos;CertificateFingerprint&apos; option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal)..
+        ///   Looks up a localized string similar to {0}: Invalid value for &apos;CertificateFingerprint&apos; option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal)..
         /// </summary>
         internal static string SignCommandInvalidCertificateFingerprint {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -938,6 +938,7 @@ nuget client-certs List</value>
     <value>Allows HTTP connections for adding or updating packages. Note: This method is not secure. For secure options, see https://aka.ms/nuget-https-everywhere for more information.</value>
   </data>
   <data name="SignCommandInvalidCertificateFingerprint" xml:space="preserve">
-    <value>Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</value>
+    <value>{0}: Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</value>
+    <comment>{0} - error code</comment>
   </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -722,9 +722,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
         }
 
         [CIOnlyFact]
-        public async Task SignCommand_SignPackageWithInsecureCertificateFingerprint_RaisesWarningAsync()
+        public async Task SignCommand_SignPackageWithInsecureCertificateFingerprint_RaisesExceptionAsync()
         {
-            await ExecuteSignPackageTestWithCertificateFingerprintAsync(HashAlgorithmName.SHA1, expectInsecureFingerprintWarning: true);
+            var result = await ExecuteSignPackageTestWithCertificateFingerprintAsync(HashAlgorithmName.SHA1);
+
+            Assert.False(result.Success, result.AllOutput);
+            Assert.True(result.Errors.Contains(_insecureCertificateFingerprintCode), result.AllOutput);
         }
 
         [CIOnlyTheory]
@@ -733,12 +736,13 @@ namespace NuGet.CommandLine.FuncTest.Commands
         [InlineData(HashAlgorithmName.SHA512)]
         public async Task SignCommand_SignPackageWithSecureCertificateFingerprint_SucceedsAsync(HashAlgorithmName hashAlgorithmName)
         {
-            await ExecuteSignPackageTestWithCertificateFingerprintAsync(hashAlgorithmName, expectInsecureFingerprintWarning: false);
+            var result = await ExecuteSignPackageTestWithCertificateFingerprintAsync(hashAlgorithmName);
+
+            Assert.True(result.Success, result.AllOutput);
+            Assert.False(result.AllOutput.Contains(_insecureCertificateFingerprintCode), result.AllOutput);
         }
 
-        private async Task ExecuteSignPackageTestWithCertificateFingerprintAsync(
-            HashAlgorithmName hashAlgorithmName,
-            bool expectInsecureFingerprintWarning)
+        private async Task<CommandRunnerResult> ExecuteSignPackageTestWithCertificateFingerprintAsync(HashAlgorithmName hashAlgorithmName)
         {
             // Arrange
             var testServer = await _testFixture.GetSigningTestServerAsync();
@@ -755,7 +759,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 using var certificate = _testFixture.UntrustedSelfIssuedCertificateInCertificateStore;
 
-                string certFingerprint = expectInsecureFingerprintWarning ? certificate.Thumbprint :
+                string certFingerprint = hashAlgorithmName == HashAlgorithmName.SHA1 ? certificate.Thumbprint :
                     SignatureTestUtility.GetFingerprint(certificate, hashAlgorithmName);
 
                 var result = CommandRunner.Run(
@@ -764,16 +768,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     $"sign {packageFile.FullName} -CertificateFingerprint {certFingerprint} -Timestamper {timestampService.Url}",
                 testOutputHelper: _testOutputHelper);
 
-                // Assert
-                Assert.True(result.Success, result.AllOutput);
-                if (expectInsecureFingerprintWarning)
-                {
-                    Assert.True(result.AllOutput.Contains(_insecureCertificateFingerprintCode), result.AllOutput);
-                }
-                else
-                {
-                    Assert.False(result.AllOutput.Contains(_insecureCertificateFingerprintCode), result.AllOutput);
-                }
+                return result;
             }
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13962

## Description

Updated NuGet.exe sign command to accept fingerprints from the SHA-2 family (SHA256, SHA384, or SHA512) instead of SHA-1. If a SHA-1 fingerprint or invalid value is passed, the commands raise an [NU3043](https://learn.microsoft.com/nuget/reference/errors-and-warnings/nu3043) error indicating that SHA-1 is insecure. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. - https://github.com/NuGet/Home/issues/13963
