### PR TITLE
Promote NU3043 warning to error in mssign and reposign commands

### DIFF
--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignAbstract.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignAbstract.cs
@@ -154,7 +154,7 @@ namespace NuGet.MSSigning.Extensions
             }
         }
 
-        protected void ValidateCertificateInputs(ILogger logger)
+        protected void ValidateCertificateInputs()
         {
             if (string.IsNullOrEmpty(CertificateFile))
             {
@@ -176,22 +176,13 @@ namespace NuGet.MSSigning.Extensions
                         nameof(KeyContainer)));
             }
 
-            if (string.IsNullOrEmpty(CertificateFingerprint))
+            if (string.IsNullOrEmpty(CertificateFingerprint) ||
+                !CertificateUtility.TryDeduceHashAlgorithm(CertificateFingerprint, out Common.HashAlgorithmName hashAlgorithmName) ||
+                hashAlgorithmName == Common.HashAlgorithmName.SHA1)
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
                         NuGetMSSignCommand.MSSignCommandInvalidCertificateFingerprint,
-                        nameof(CertificateFingerprint)));
-            }
-            else
-            {
-                if (!CertificateUtility.TryDeduceHashAlgorithm(CertificateFingerprint, out Common.HashAlgorithmName hashAlgorithmName))
-                {
-                    throw new ArgumentException(NuGetMSSignCommand.MSSignCommandInvalidCertificateFingerprint);
-                }
-                else if (hashAlgorithmName == Common.HashAlgorithmName.SHA1)
-                {
-                    logger.Log(LogMessage.CreateWarning(NuGetLogCode.NU3043, NuGetMSSignCommand.MSSignCommandInvalidCertificateFingerprint));
-                }
+                        NuGetLogCode.NU3043));
             }
         }
 

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignCommand.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignCommand.cs
@@ -40,7 +40,7 @@ namespace NuGet.MSSigning.Extensions
         {
             ValidatePackagePath();
             WarnIfNoTimestamper(Console);
-            ValidateCertificateInputs(Console);
+            ValidateCertificateInputs();
             EnsureOutputDirectory();
 
             var signingSpec = SigningSpecifications.V1;

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.Designer.cs
@@ -115,7 +115,7 @@ namespace NuGet.MSSigning.Extensions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid value for &apos;CertificateFingerprint&apos; option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal)..
+        ///   Looks up a localized string similar to {0}: Invalid value for &apos;CertificateFingerprint&apos; option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal)..
         /// </summary>
         internal static string MSSignCommandInvalidCertificateFingerprint {
             get {

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.resx
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -203,6 +203,6 @@ nuget reposign MyPackage.nupkg -Timestamper http://timestamper.test -Certificate
     <value>Repository V3 service index URL.</value>
   </data>
   <data name="MSSignCommandInvalidCertificateFingerprint" xml:space="preserve">
-    <value>Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</value>
+    <value>{0}: Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/RepoSignCommand.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/RepoSignCommand.cs
@@ -53,7 +53,7 @@ namespace NuGet.MSSigning.Extensions
         {
             ValidatePackagePath();
             WarnIfNoTimestamper(Console);
-            ValidateCertificateInputs(Console);
+            ValidateCertificateInputs();
             EnsureOutputDirectory();
             ValidatePackageOwners();
 

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/MSSignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/MSSignCommandTests.cs
@@ -289,12 +289,12 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
         }
 
         [CIOnlyFact]
-        public async Task MSSignCommand_SignPackageWithSHA1CertificateFingerprint_Raises_WarningAsync()
+        public async Task MSSignCommand_SignPackageWithSHA1CertificateFingerprint_RaisesExceptionAsync()
         {
             var result = await ExecuteMSSignCommandAsync(Common.HashAlgorithmName.SHA1);
 
-            result.Success.Should().BeTrue();
-            result.AllOutput.Should().Contain(_invalidCertificateFingerprintCode);
+            result.Success.Should().BeFalse();
+            result.Errors.Should().Contain(_invalidCertificateFingerprintCode);
         }
 
         [CIOnlyTheory]

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/ReposignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/ReposignCommandTests.cs
@@ -370,12 +370,12 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
         }
 
         [CIOnlyFact]
-        public async Task RepoSignCommand_SignPackageWithSHA1CertificateFingerprint_Raises_WarningAsync()
+        public async Task RepoSignCommand_SignPackageWithSHA1CertificateFingerprint_RaisesExceptionAsync()
         {
             var result = await ExecuteRepoSignCommandAsync(Common.HashAlgorithmName.SHA1);
 
-            result.Success.Should().BeTrue();
-            result.AllOutput.Should().Contain(_invalidCertificateFingerprintCode);
+            result.Success.Should().BeFalse();
+            result.Errors.Should().Contain(_invalidCertificateFingerprintCode);
         }
 
         [CIOnlyTheory]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Tracking: https://github.com/NuGet/Home/issues/13962

## Description

Updated mssign and reposign commands to accept fingerprints from the SHA-2 family (SHA256, SHA384, or SHA512) instead of SHA-1. If a SHA-1 fingerprint or invalid value is passed, the commands raise an [NU3043](https://learn.microsoft.com/nuget/reference/errors-and-warnings/nu3043) error indicating that SHA-1 is insecure. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~