### PR TITLE
avoid Any call in GetCommandAttribute

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -270,14 +270,16 @@ namespace NuGet.CommandLine
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "This method does quite a bit of processing.")]
         public virtual CommandAttribute GetCommandAttribute()
         {
-            var attributes = GetType().GetCustomAttributes(typeof(CommandAttribute), true);
-            if (attributes.Any())
+            var type = GetType();
+            var attributes = type.GetCustomAttributes(typeof(CommandAttribute), true);
+            var attribute = attributes.FirstOrDefault();
+            if (attribute != null)
             {
-                return (CommandAttribute)attributes.FirstOrDefault();
+                return (CommandAttribute)attribute;
             }
 
             // Use the command name minus the suffix if present and default description
-            var name = GetType().Name;
+            var name = type.Name;
             var idx = name.LastIndexOf(CommandSuffix, StringComparison.OrdinalIgnoreCase);
             if (idx >= 0)
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  removes an unnecessary `Any()` and a duplicate `GetType()`

## Description

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
