### PR TITLE
Update README loading text

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -2043,6 +2043,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Loading README....
+        /// </summary>
+        public static string Text_LoadingReadme {
+            get {
+                return ResourceManager.GetString("Text_LoadingReadme", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You can manage these settings in .
         /// </summary>
         public static string Text_ManageSettings {
@@ -2232,6 +2241,15 @@ namespace NuGet.PackageManagement.UI {
         public static string Text_PackageSources {
             get {
                 return ResourceManager.GetString("Text_PackageSources", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to readme loaded.
+        /// </summary>
+        public static string Text_ReadmeLoaded {
+            get {
+                return ResourceManager.GetString("Text_ReadmeLoaded", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -2245,7 +2245,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to readme loaded.
+        ///   Looks up a localized string similar to README loaded.
         /// </summary>
         public static string Text_ReadmeLoaded {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -283,7 +283,7 @@
     <value>Loading README...</value>
   </data>
   <data name="Text_ReadmeLoaded" xml:space="preserve">
-    <value>readme loaded</value>
+    <value>README loaded</value>
   </data>
   <data name="Text_NoPackagesFound" xml:space="preserve">
     <value>No packages found</value>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -279,6 +279,12 @@
   <data name="Text_Loading" xml:space="preserve">
     <value>Loading...</value>
   </data>
+  <data name="Text_LoadingReadme" xml:space="preserve">
+    <value>Loading README...</value>
+  </data>
+  <data name="Text_ReadmeLoaded" xml:space="preserve">
+    <value>readme loaded</value>
+  </data>
   <data name="Text_NoPackagesFound" xml:space="preserve">
     <value>No packages found</value>
   </data>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml
@@ -58,7 +58,20 @@
         Visibility="Collapsed"
         IsFrequencyLimited="True"
         Focusable="False"
-        AutomationProperties.IsOffscreenBehavior="Offscreen" />
+        AutomationProperties.IsOffscreenBehavior="Offscreen">
+        <vs:LiveTextBlock.Resources>
+          <Style TargetType="vs:LiveTextBlock">
+            <Style.Triggers>
+              <DataTrigger Binding="{Binding Path=IsBusy}" Value="True">
+                <Setter Property="Text" Value="{x:Static nuget:Resources.Text_LoadingReadme}"/>
+              </DataTrigger>
+              <DataTrigger Binding="{Binding Path=IsBusy}" Value="False">
+                <Setter Property="Text" Value="{x:Static nuget:Resources.Text_ReadmeLoaded}"/>
+              </DataTrigger>
+            </Style.Triggers>
+          </Style>
+        </vs:LiveTextBlock.Resources>
+      </vs:LiveTextBlock>
     </Grid>
     <TextBlock
       TextWrapping="Wrap"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml
@@ -9,6 +9,7 @@
   xmlns:imagingTheme="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
   xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
   xmlns:ui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Utilities"
+  xmlns:vs="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
   Background="{DynamicResource {x:Static nuget:Brushes.DetailPaneBackground}}"
   Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
   DataContextChanged="UserControl_DataContextChanged"
@@ -31,10 +32,34 @@
       ClipToBounds="True"
       Focusable="False"
       Visibility="{Binding Path=IsReadmeReady, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
-    <TextBlock
-      TextWrapping="Wrap"
-      Text="{x:Static nuget:Resources.Text_Loading}"
-      Visibility="{Binding Path=IsBusy, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+    <Grid
+      HorizontalAlignment="Center"
+      VerticalAlignment="Center"
+      Visibility="{Binding Path=IsBusy, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" >
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="Auto"/>
+        <ColumnDefinition Width="Auto"/>
+      </Grid.ColumnDefinitions>
+      <nuget:Spinner
+        Grid.Column="0"
+        Height="20"
+        Width="20"/>
+      <TextBlock
+        Padding="10,0,0,0"
+        Grid.Column="1"
+        TextWrapping="Wrap"
+        Text="{x:Static nuget:Resources.Text_LoadingReadme}" />
+      <!--
+        Special TextBlock to report loading status to assistive technologies (narrator).
+        Code behind changes to the Text property will trigger a narrator event.
+      -->
+      <vs:LiveTextBlock
+        x:Name="_ltbLoading"
+        Visibility="Collapsed"
+        IsFrequencyLimited="True"
+        Focusable="False"
+        AutomationProperties.IsOffscreenBehavior="Offscreen" />
+    </Grid>
     <TextBlock
       TextWrapping="Wrap"
       Text="{x:Static nuget:Resources.Error_UnableToLoadReadme}"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml
@@ -54,7 +54,6 @@
         Code behind changes to the Text property will trigger a narrator event.
       -->
       <vs:LiveTextBlock
-        x:Name="_ltbLoading"
         Visibility="Collapsed"
         IsFrequencyLimited="True"
         Focusable="False"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
@@ -10,7 +10,6 @@ using Microsoft.VisualStudio.Markdown.Platform;
 using NuGet.PackageManagement.UI.ViewModels;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Telemetry;
-using Resx = NuGet.PackageManagement.UI.Resources;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -30,7 +29,6 @@ namespace NuGet.PackageManagement.UI
 #pragma warning disable CS0618 // Type or member is obsolete
             _markdownPreview = new PreviewBuilder().Build();
 #pragma warning restore CS0618 // Type or member is obsolete
-            descriptionMarkdownPreview.Content = _markdownPreview.VisualElement;
         }
 
         public ReadmePreviewViewModel ReadmeViewModel { get => (ReadmePreviewViewModel)DataContext; }
@@ -40,16 +38,6 @@ namespace NuGet.PackageManagement.UI
             if (e.PropertyName == nameof(ReadmePreviewViewModel.ReadmeMarkdown))
             {
                 NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(UpdateMarkdownAsync).PostOnFailure(nameof(PackageReadmeControl), nameof(ReadmeViewModel_PropertyChanged));
-            }
-            if (e.PropertyName == nameof(ReadmePreviewViewModel.IsBusy))
-            {
-                var loadingStatusText = ReadmeViewModel.IsBusy
-                    ? Resx.Text_LoadingReadme
-                    : Resx.Text_ReadmeLoaded;
-                if (!string.Equals(_ltbLoading.Text, loadingStatusText, StringComparison.OrdinalIgnoreCase))
-                {
-                    _ltbLoading.Text = loadingStatusText;
-                }
             }
         }
 
@@ -82,6 +70,7 @@ namespace NuGet.PackageManagement.UI
         {
             try
             {
+                descriptionMarkdownPreview.Content = descriptionMarkdownPreview.Content ?? _markdownPreview.VisualElement;
                 if (!string.IsNullOrWhiteSpace(ReadmeViewModel.ReadmeMarkdown))
                 {
                     await _markdownPreview.UpdateContentAsync(ReadmeViewModel.ReadmeMarkdown, ScrollHint.None);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.Markdown.Platform;
 using NuGet.PackageManagement.UI.ViewModels;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Telemetry;
+using Resx = NuGet.PackageManagement.UI.Resources;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -39,6 +40,16 @@ namespace NuGet.PackageManagement.UI
             if (e.PropertyName == nameof(ReadmePreviewViewModel.ReadmeMarkdown))
             {
                 NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(UpdateMarkdownAsync).PostOnFailure(nameof(PackageReadmeControl), nameof(ReadmeViewModel_PropertyChanged));
+            }
+            if (e.PropertyName == nameof(ReadmePreviewViewModel.IsBusy))
+            {
+                var loadingStatusText = ReadmeViewModel.IsBusy
+                    ? Resx.Text_LoadingReadme
+                    : Resx.Text_ReadmeLoaded;
+                if (!string.Equals(_ltbLoading.Text, loadingStatusText, StringComparison.OrdinalIgnoreCase))
+                {
+                    _ltbLoading.Text = loadingStatusText;
+                }
             }
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
Update the message displayed to the user when the README is loading, per the recommendation from the UX board. Ensure screen readers announce when the README is loading. 
![image](https://github.com/user-attachments/assets/d0e30708-0964-46e1-b4da-297b57cd4503)

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
