### PR TITLE
Copy signed assemblies to the localize artifacts folder

### DIFF
--- a/build/loc.proj
+++ b/build/loc.proj
@@ -89,11 +89,8 @@
   </Target>
 
   <!-- Prepares localization artifact -->
-  <Target Name="CopyBinariesToLocalizationArtifacts" AfterTargets="Localize">
+  <Target Name="CopyLocalizationArtifacts" AfterTargets="Localize">
     <ItemGroup>
-      <_EnglishBinaries Include="@(FilesToLocalize)">
-        <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\artifacts\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(FilesToLocalize.RootDir)%(FilesToLocalize.Directory)))\%(FilesToLocalize.Filename)%(FilesToLocalize.Extension)</DestinationPath>
-      </_EnglishBinaries>
       <_LocalizeFolder Include="$(ArtifactsDirectory)localize\**\*" Exclude="$(ArtifactsDirectory)localize\ResponseFiles\**\*" />
       <_LocalizeFiles Include="@(_LocalizeFolder)">
         <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\artifacts\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(_LocalizeFolder.Identity)))</DestinationPath>
@@ -103,7 +100,23 @@
         <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\ENU\LocProject.json</DestinationPath>
       </_LocalizeFiles>
     </ItemGroup>
-    <Copy SourceFiles="@(_EnglishBinaries)" DestinationFiles="@(_EnglishBinaries->'%(DestinationPath)')" />
     <Copy SourceFiles="@(_LocalizeFiles)" DestinationFiles="@(_LocalizeFiles->'%(DestinationPath)')" />
+  </Target>
+
+   <Target Name="CopyBinariesToLocalizationArtifacts">
+    <MSBuild
+      Projects="@(SolutionProjectsWithoutVSIX)"
+      Properties="BuildProjectReferences=false;"
+      Targets="GetLocalizationInputs">
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="FilesToLocalize" />
+    </MSBuild>
+    <ItemGroup>
+      <_EnglishBinaries Include="@(FilesToLocalize)">
+        <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\artifacts\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(FilesToLocalize.RootDir)%(FilesToLocalize.Directory)))\%(FilesToLocalize.Filename)%(FilesToLocalize.Extension)</DestinationPath>
+      </_EnglishBinaries>
+    </ItemGroup>
+    <Copy SourceFiles="@(_EnglishBinaries)" DestinationFiles="@(_EnglishBinaries->'%(DestinationPath)')" />
   </Target>
 </Project>

--- a/build/loc.proj
+++ b/build/loc.proj
@@ -95,7 +95,7 @@
       <_LocalizeFiles Include="@(_LocalizeFolder)">
         <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\artifacts\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(_LocalizeFolder.Identity)))</DestinationPath>
       </_LocalizeFiles>
-      <!-- Second Localize run creates appropiate LocProject.json -->
+      <!-- Second Localize run creates appropriate LocProject.json -->
       <_LocalizeFiles Include="$(ArtifactsDirectory)localize\ResponseFiles\*.loc.002\ENU\LocProject.json">
         <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\ENU\LocProject.json</DestinationPath>
       </_LocalizeFiles>
@@ -103,6 +103,7 @@
     <Copy SourceFiles="@(_LocalizeFiles)" DestinationFiles="@(_LocalizeFiles->'%(DestinationPath)')" />
   </Target>
 
+  <!-- Copy binaries to the localization artifacts folder -->
    <Target Name="CopyBinariesToLocalizationArtifacts">
     <MSBuild
       Projects="@(SolutionProjectsWithoutVSIX)"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -180,6 +180,13 @@ steps:
     msbuildArguments: "/restore /binarylogger:$(Build.StagingDirectory)\\binlog\\09.SignAssemblies.binlog"
 
 - task: MSBuild@1
+  displayName: "Copy signed assemblies to localize artifacts folder"
+  inputs:
+    solution: "build\\loc.proj"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/restore /t:CopyBinariesToLocalizationArtifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\09.LocalizeFolderAssemblies.binlog"
+
+- task: MSBuild@1
   displayName: "Pack Nupkgs"
   inputs:
     solution: "build\\build.proj"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3024

## Description

- Localization no longer copies NuGet assemblies to the output directory.
- A new build step runs after localization and signing completes: `Copy signed assemblies to localize artifacts folder`
- The build step runs an MSBuild target which copies the signed assemblies from `artifacts\`  to `artifacts\localizationArtifacts\artifacts` as shown in this binlog snippet:
![image](https://github.com/user-attachments/assets/601c2efe-c8f9-42d0-8ed7-517bbba8a3da)

### Validation of signed loc files:

#### Before this PR
Checking artifacts shows a test-signed assembly.
```
 sn -vf C:\users\____\Downloads\localizationArtifacts\localizationArtifacts\artifacts\NuGet.Credentials\bin\release\net8.0\NuGet.Credentials.dll

C:\users\____\Downloads\localizationArtifacts\localizationArtifacts\artifacts\NuGet.Credentials\bin\release\net8.0\NuGet.Credentials.dll is a delay-signed or test-signed assembly

```
#### After this PR

Checking artifacts shows a valid, signed assembly.
```
sn -vf C:\users\____\Downloads\Signed_localizationArtifacts\localizationArtifacts\artifacts\NuGet.Credentials\bin\release\net8.0\NuGet.Credentials.dll

Microsoft (R) .NET Framework Strong Name Utility  Version 4.0.30319.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Assembly 'C:\users\____\Downloads\Signed_localizationArtifacts\localizationArtifacts\artifacts\NuGet.Credentials\bin\release\net8.0\NuGet.Credentials.dll' is valid
```

They are also Authenticode signed
![image](https://github.com/user-attachments/assets/438ac888-1c66-4d34-983f-6ac95ef66535)


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~ - Checked artifacts on a build and reviewed binlog.
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/NuGet.Client/pull/6172
