### PR TITLE
Promote NU3043 warning to error in dotnet nuget sign command

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Signing/SignCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Signing/SignCommand.cs
@@ -5,6 +5,7 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.CommandLineUtils;
 using NuGet.Commands;
@@ -224,23 +225,28 @@ namespace NuGet.CommandLine.XPlat
                  !string.IsNullOrEmpty(location.Value()) ||
                  !string.IsNullOrEmpty(store.Value())))
             {
-                // Thow if the user provided a path and any one of the other options
+                // Throw if the user provided a path and any one of the other options
                 throw new ArgumentException(Strings.SignCommandMultipleCertificateException);
             }
             else if (!string.IsNullOrEmpty(fingerprint.Value()) && !string.IsNullOrEmpty(subject.Value()))
             {
-                // Thow if the user provided a fingerprint and a subject
+                // Throw if the user provided a fingerprint and a subject
                 throw new ArgumentException(Strings.SignCommandMultipleCertificateException);
             }
             else if (fingerprint.Value() != null)
             {
-                if (!CertificateUtility.TryDeduceHashAlgorithm(fingerprint.Value(), out HashAlgorithmName hashAlgorithmName))
+                bool isValidFingerprint = CertificateUtility.TryDeduceHashAlgorithm(fingerprint.Value(), out HashAlgorithmName hashAlgorithmName);
+                bool isSHA1 = hashAlgorithmName == HashAlgorithmName.SHA1;
+                int assemblyVersion = typeof(int).Assembly.GetName().Version.Major;
+                string message = string.Format(CultureInfo.CurrentCulture, Strings.SignCommandInvalidCertificateFingerprint, NuGetLogCode.NU3043);
+
+                if (!isValidFingerprint || (assemblyVersion >= 10 && isSHA1))
                 {
-                    throw new ArgumentException(Strings.SignCommandInvalidCertificateFingerprint);
+                    throw new ArgumentException(message);
                 }
-                else if (hashAlgorithmName == HashAlgorithmName.SHA1)
+                else if (isSHA1)
                 {
-                    logger.Log(LogMessage.CreateWarning(NuGetLogCode.NU3043, Strings.SignCommandInvalidCertificateFingerprint));
+                    logger.Log(LogMessage.Create(LogLevel.Warning, message));
                 }
             }
         }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Signing/SignCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Signing/SignCommand.cs
@@ -5,7 +5,6 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.CommandLineUtils;
 using NuGet.Commands;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -1782,7 +1782,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid value for &apos;--certificate-fingerprint&apos; option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal)..
+        ///   Looks up a localized string similar to {0}: Invalid value for &apos;--certificate-fingerprint&apos; option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal)..
         /// </summary>
         internal static string SignCommandInvalidCertificateFingerprint {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -971,7 +971,8 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
     <value>Allows HTTP connections for adding or updating packages. Note: This method is not secure. For secure options, see https://aka.ms/nuget-https-everywhere for more information.</value>
   </data>
   <data name="SignCommandInvalidCertificateFingerprint" xml:space="preserve">
-    <value>Invalid value for '--certificate-fingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</value>
+    <value>{0}: Invalid value for '--certificate-fingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</value>
+    <comment>{0} - error code</comment>
   </data>
   <data name="Error_ProjectAssetsFilePropertyNotFound" xml:space="preserve">
     <value>Project '{0}' does not have MSBuild property ProjectAssetsFile defined. This may indicate that this project does not support NuGet PackageReference, or that project customization has prevented the .NET SDK setting default values.</value>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
@@ -525,8 +525,16 @@ namespace Dotnet.Integration.Test
         {
             var result = await ExecuteSignPackageTestWithCertificateFingerprintAsync(HashAlgorithmName.SHA1);
 
-            Assert.True(result.Success, result.AllOutput);
-            Assert.True(result.AllOutput.Contains(_insecureCertificateFingerprintCode), result.AllOutput);
+            if (typeof(int).Assembly.GetName().Version.Major >= 10)
+            {
+                Assert.False(result.Success, result.AllOutput);
+                Assert.True(result.Errors.Contains(_insecureCertificateFingerprintCode), result.Errors);
+            }
+            else
+            {
+                Assert.True(result.Success, result.AllOutput);
+                Assert.True(result.AllOutput.Contains(_insecureCertificateFingerprintCode), result.AllOutput);
+            }
         }
 
         [PlatformTheory(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Client.Engineering/issues/2781

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
@@ -523,7 +523,10 @@ namespace Dotnet.Integration.Test
         [PlatformFact(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Client.Engineering/issues/2781
         public async Task DotnetSign_SignPackageWithInsecureCertificateFingerprint_RaisesWarningAsync()
         {
-            await ExecuteSignPackageTestWithCertificateFingerprintAsync(HashAlgorithmName.SHA1, expectInsecureFingerprintWarning: true);
+            var result = await ExecuteSignPackageTestWithCertificateFingerprintAsync(HashAlgorithmName.SHA1);
+
+            Assert.True(result.Success, result.AllOutput);
+            Assert.True(result.AllOutput.Contains(_insecureCertificateFingerprintCode), result.AllOutput);
         }
 
         [PlatformTheory(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Client.Engineering/issues/2781
@@ -532,12 +535,13 @@ namespace Dotnet.Integration.Test
         [InlineData(HashAlgorithmName.SHA512)]
         public async Task DotnetSign_SignPackageWithSecureCertificateFingerprint_SucceedsAsync(HashAlgorithmName hashAlgorithmName)
         {
-            await ExecuteSignPackageTestWithCertificateFingerprintAsync(hashAlgorithmName, expectInsecureFingerprintWarning: false);
+            var result = await ExecuteSignPackageTestWithCertificateFingerprintAsync(hashAlgorithmName);
+
+            Assert.True(result.Success, result.AllOutput);
+            Assert.False(result.AllOutput.Contains(_insecureCertificateFingerprintCode), result.AllOutput);
         }
 
-        private async Task ExecuteSignPackageTestWithCertificateFingerprintAsync(
-            HashAlgorithmName hashAlgorithmName,
-            bool expectInsecureFingerprintWarning)
+        private async Task<CommandRunnerResult> ExecuteSignPackageTestWithCertificateFingerprintAsync(HashAlgorithmName hashAlgorithmName)
         {
             // Arrange
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
@@ -553,7 +557,7 @@ namespace Dotnet.Integration.Test
             var options = new TimestampServiceOptions() { SignatureHashAlgorithm = new Oid(Oids.Sha256) };
             TimestampService timestampService = TimestampService.Create(certificateAuthority, options);
             IX509StoreCertificate storeCertificate = _signFixture.UntrustedSelfIssuedCertificateInCertificateStore;
-            string certFingerprint = expectInsecureFingerprintWarning ? storeCertificate.Certificate.Thumbprint :
+            string certFingerprint = hashAlgorithmName == HashAlgorithmName.SHA1 ? storeCertificate.Certificate.Thumbprint :
                 SignatureTestUtility.GetFingerprint(storeCertificate.Certificate, hashAlgorithmName);
 
             using (testServer.RegisterResponder(timestampService))
@@ -566,16 +570,7 @@ namespace Dotnet.Integration.Test
                     $"--timestamper {timestampService.Url}",
                     testOutputHelper: _testOutputHelper);
 
-                // Assert
-                Assert.True(result.Success, result.AllOutput);
-                if (expectInsecureFingerprintWarning)
-                {
-                    Assert.True(result.AllOutput.Contains(_insecureCertificateFingerprintCode), result.AllOutput);
-                }
-                else
-                {
-                    Assert.False(result.AllOutput.Contains(_insecureCertificateFingerprintCode), result.AllOutput);
-                }
+                return result;
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatSignTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatSignTests.cs
@@ -476,8 +476,7 @@ namespace NuGet.XPlat.FuncTest
                     //Act & Assert
                     var ex = Assert.Throws<AggregateException>(() => testApp.Execute(argList.ToArray()));
                     Assert.IsType<ArgumentException>(ex.InnerException);
-                    Assert.Equal(expected: Strings.SignCommandInvalidCertificateFingerprint, actual: ex.InnerException.Message);
-
+                    Assert.True(ex.InnerException.Message.Contains(NuGetLogCode.NU3043.ToString()));
                 });
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13814

## Description

Updated dotnet nuget sign command to accept fingerprints from the SHA-2 family (SHA256, SHA384, or SHA512) instead of SHA-1. If a SHA-1 fingerprint or invalid value is passed, the commands raise an [NU3043](https://learn.microsoft.com/nuget/reference/errors-and-warnings/nu3043) error indicating that SHA-1 is insecure. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. - https://github.com/NuGet/Home/issues/13963
