### PR TITLE
Dotnet tools plugin discovery: Ignore invalid paths in PATH env variable

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
@@ -249,10 +249,6 @@ namespace NuGet.Protocol.Plugins
                 {
                     pluginFiles.AddRange(GetNetToolsPluginsInDirectory(path) ?? new List<PluginFile>());
                 }
-                else
-                {
-                    pluginFiles.Add(new PluginFile(path, new Lazy<PluginFileState>(() => PluginFileState.InvalidFilePath), requiresDotnetHost: false));
-                }
             }
 
             return pluginFiles;

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
@@ -484,6 +484,30 @@ namespace NuGet.Protocol.Plugins.Tests
         }
 
         [PlatformFact(Platform.Windows)]
+        public void GetPluginsInPATH_WithOneValueInPathEmpty_ReturnsPlugin()
+        {
+            // Arrange
+            using TestDirectory pluginPathDirectory = TestDirectory.Create();
+            using TestDirectory pathDirectory = TestDirectory.Create();
+            var pluginInNuGetPluginPathDirectoryFilePath = Path.Combine(pluginPathDirectory.Path, "nuget-plugin-auth.exe");
+            var pluginInPathDirectoryFilePath = Path.Combine(pathDirectory.Path, "nuget-plugin-in-path-directory.exe");
+            File.Create(pluginInNuGetPluginPathDirectoryFilePath);
+            File.Create(pluginInPathDirectoryFilePath);
+            Mock<IEnvironmentVariableReader> environmentalVariableReader = new Mock<IEnvironmentVariableReader>();
+            environmentalVariableReader.Setup(env => env.GetEnvironmentVariable(EnvironmentVariableConstants.PluginPaths)).Returns(Directory.GetParent(pluginInNuGetPluginPathDirectoryFilePath).FullName);
+            environmentalVariableReader.Setup(env => env.GetEnvironmentVariable("PATH")).Returns($"{Directory.GetParent(pluginInPathDirectoryFilePath).FullName}{Path.PathSeparator}");
+            PluginDiscoverer pluginDiscoverer = new PluginDiscoverer(environmentalVariableReader.Object);
+
+            // Act
+            var plugins = pluginDiscoverer.GetPluginsInPath();
+
+            // Assert
+            Assert.Single(plugins);
+            Assert.Equal(pluginInPathDirectoryFilePath, plugins[0].Path);
+            Assert.False(plugins[0].RequiresDotnetHost);
+        }
+
+        [PlatformFact(Platform.Windows)]
         public void GetPluginsInNuGetPluginPaths_NuGetPluginPathsPointsToAFile_TreatsAsPlugin()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
@@ -494,8 +494,8 @@ namespace NuGet.Protocol.Plugins.Tests
             File.Create(pluginInNuGetPluginPathDirectoryFilePath);
             File.Create(pluginInPathDirectoryFilePath);
             Mock<IEnvironmentVariableReader> environmentalVariableReader = new Mock<IEnvironmentVariableReader>();
-            environmentalVariableReader.Setup(env => env.GetEnvironmentVariable(EnvironmentVariableConstants.PluginPaths)).Returns(Directory.GetParent(pluginInNuGetPluginPathDirectoryFilePath).FullName);
-            environmentalVariableReader.Setup(env => env.GetEnvironmentVariable("PATH")).Returns($"{Directory.GetParent(pluginInPathDirectoryFilePath).FullName}{Path.PathSeparator}");
+            environmentalVariableReader.Setup(env => env.GetEnvironmentVariable(EnvironmentVariableConstants.PluginPaths)).Returns(pluginPathDirectory.Path);
+            environmentalVariableReader.Setup(env => env.GetEnvironmentVariable("PATH")).Returns($"{pathDirectory.Path}{Path.PathSeparator}");
             PluginDiscoverer pluginDiscoverer = new PluginDiscoverer(environmentalVariableReader.Object);
 
             // Act


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

There’s no need to notify users when an invalid path is found in the `PATH` environment variable. Instead, such paths should simply be ignored.

While investigating the cause of insertion failures, the only issue identified was the handling of invalid paths in `PATH`. Previously, the logic attempted to report these invalid paths to users, but this approach inadvertently caused exceptions to be thrown when the `PATH` environment variable contained invalid entries. This change resolves the issue by ignoring invalid paths, ensuring the process continues without disruption.

Insertion Build passes: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/595426
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
