### PR TITLE
Navigation telemetry for 'Clear All NuGet Storage' Command in VS Settings

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.Threading;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.PackageManagement.Telemetry;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Telemetry;
@@ -153,6 +154,9 @@ namespace NuGet.PackageManagement.UI.Options
         private void OnLocalsCommandButtonOnClick(object sender, EventArgs e)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
+            var evt = NavigatedTelemetryEvent.CreateWithClearLocalsCommand(isUnifiedSettings: false);
+            TelemetryActivity.EmitTelemetryEvent(evt);
+
             UpdateLocalsCommandStatusText(string.Format(CultureInfo.CurrentCulture, Resources.ShowMessage_LocalsCommandWorking), visibility: true);
 
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/NavigatedTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/NavigatedTelemetryEvent.cs
@@ -21,6 +21,7 @@ namespace NuGet.PackageManagement.Telemetry
 
         internal const string SourcesCountPropertyName = "SourcesCount";
         internal const string IsGlobbingPropertyName = "IsGlobbing";
+        internal const string IsUnifiedSettingsPropertyName = "IsUnifiedSettings";
 
         internal const string AlternativePackageIdPropertyName = "AlternativePackageId";
 
@@ -107,6 +108,17 @@ namespace NuGet.PackageManagement.Telemetry
         {
             NavigatedTelemetryEvent navigatedTelemetryEvent = CreateWithExternalLink(hyperlinkType, currentTab, isSolutionView);
             navigatedTelemetryEvent.AddPiiData(AlternativePackageIdPropertyName, VSTelemetryServiceUtility.NormalizePackageId(alternativePackageId));
+
+            return navigatedTelemetryEvent;
+        }
+
+        public static NavigatedTelemetryEvent CreateWithClearLocalsCommand(bool isUnifiedSettings)
+        {
+            NavigationType navigationType = NavigationType.Button;
+            NavigationOrigin navigationOrigin = NavigationOrigin.Options_LocalsCommand_ClearAll;
+
+            NavigatedTelemetryEvent navigatedTelemetryEvent = new(navigationType, navigationOrigin);
+            navigatedTelemetryEvent[IsUnifiedSettingsPropertyName] = isUnifiedSettings;
 
             return navigatedTelemetryEvent;
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/NavigationOrigin.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/NavigationOrigin.cs
@@ -9,6 +9,7 @@ namespace NuGet.PackageManagement.Telemetry
         Options_PackageSourceMapping_Add,
         Options_PackageSourceMapping_Remove,
         Options_PackageSourceMapping_RemoveAll,
+        Options_LocalsCommand_ClearAll,
         PMUI_ExternalLink,
         PMUI_PackageSourceMapping_Configure
     }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NavigatedTelemetryEventTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NavigatedTelemetryEventTests.cs
@@ -221,6 +221,27 @@ namespace NuGet.PackageManagement.Test.Telemetry
             Assert.Contains(packageIdHyperlink, packageIds);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void CreateWithClearLocalsCommand_WithValidProperties_CreatedWithoutPiiData(bool isUnifiedSettings)
+        {
+            // Arrange
+            SetupTelemetryListener();
+
+            var evt = NavigatedTelemetryEvent.CreateWithClearLocalsCommand(isUnifiedSettings);
+
+            // Act
+            TelemetryActivity.NuGetTelemetryService.EmitTelemetryEvent(evt);
+
+            // Assert
+            Assert.NotNull(_lastTelemetryEvent);
+            Assert.Equal(3, _lastTelemetryEvent.Count);
+            Assert.Equal(NavigationType.Button, _lastTelemetryEvent[NavigatedTelemetryEvent.NavigationTypePropertyName]);
+            Assert.Equal(NavigationOrigin.Options_LocalsCommand_ClearAll, _lastTelemetryEvent[NavigatedTelemetryEvent.OriginPropertyName]);
+            Assert.Equal(isUnifiedSettings, _lastTelemetryEvent[NavigatedTelemetryEvent.IsUnifiedSettingsPropertyName]);
+            Assert.Empty(_lastTelemetryEvent.GetPiiData());
+        }
         private Mock<ITelemetrySession> SetupTelemetryListener()
         {
             var telemetrySession = new Mock<ITelemetrySession>();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13968

## Description

Instrument the `navigated` telemetry event for the 'Clear All NuGet Storage' command in the Visual Studio settings.
Since the event is standardized and already doesn't include PII, no assessment was done to attach another event.

- A property tracks whether the settings are existing legacy VS Settings, or Unified Settings which will be implemented later. For now, this is always `false`.
- Testing the functionality of the new helper method to create the event.

Example of the event after pressing "Clear All NuGet Storage":
![image](https://github.com/user-attachments/assets/c91a6ef6-034f-4351-8193-bb51f72b31c2)

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
