### PR TITLE
Add CliCommand wrapper that adds help URL

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigCommand.cs
@@ -8,6 +8,7 @@ using System.CommandLine.Parsing;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
+using NuGet.CommandLine.XPlat.Commands;
 using NuGet.Common;
 
 namespace NuGet.CommandLine.XPlat
@@ -95,13 +96,13 @@ namespace NuGet.CommandLine.XPlat
 
         internal static CliCommand Register(CliCommand app, Func<ILogger> getLogger)
         {
-            var ConfigCmd = new CliCommand(name: "config", description: Strings.Config_Description);
+            var ConfigCmd = new DocumentedCommand(name: "config", description: Strings.Config_Description, "https://aka.ms/dotnet/nuget/config");
             ConfigCmd.Options.Add(HelpOption);
 
             // Options directly under the verb 'config'
 
             // noun sub-command: config paths
-            var PathsCmd = new CliCommand(name: "paths", description: Strings.ConfigPathsCommandDescription);
+            var PathsCmd = new DocumentedCommand(name: "paths", description: Strings.ConfigPathsCommandDescription, "https://aka.ms/dotnet/nuget/config/paths");
 
             // Options under sub-command: config paths
             RegisterOptionsForCommandConfigPaths(PathsCmd, getLogger);
@@ -109,7 +110,7 @@ namespace NuGet.CommandLine.XPlat
             ConfigCmd.Subcommands.Add(PathsCmd);
 
             // noun sub-command: config get
-            var GetCmd = new CliCommand(name: "get", description: Strings.ConfigGetCommandDescription);
+            var GetCmd = new DocumentedCommand(name: "get", description: Strings.ConfigGetCommandDescription, "https://aka.ms/dotnet/nuget/config/get");
 
             // Options under sub-command: config get
             RegisterOptionsForCommandConfigGet(GetCmd, getLogger);
@@ -117,7 +118,7 @@ namespace NuGet.CommandLine.XPlat
             ConfigCmd.Subcommands.Add(GetCmd);
 
             // noun sub-command: config set
-            var SetCmd = new CliCommand(name: "set", description: Strings.ConfigSetCommandDescription);
+            var SetCmd = new DocumentedCommand(name: "set", description: Strings.ConfigSetCommandDescription, "https://aka.ms/dotnet/nuget/config/set");
 
             // Options under sub-command: config set
             RegisterOptionsForCommandConfigSet(SetCmd, getLogger);
@@ -125,7 +126,7 @@ namespace NuGet.CommandLine.XPlat
             ConfigCmd.Subcommands.Add(SetCmd);
 
             // noun sub-command: config unset
-            var UnsetCmd = new CliCommand(name: "unset", description: Strings.ConfigUnsetCommandDescription);
+            var UnsetCmd = new DocumentedCommand(name: "unset", description: Strings.ConfigUnsetCommandDescription, "https://aka.ms/dotnet/nuget/config/unset");
 
             // Options under sub-command: config unset
             RegisterOptionsForCommandConfigUnset(UnsetCmd, getLogger);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/DocumentedCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/DocumentedCommand.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.CommandLine;
+
+namespace NuGet.CommandLine.XPlat.Commands
+{
+    public class DocumentedCommand : CliCommand
+    {
+        public DocumentedCommand(string name, string description, string helpUrl)
+            : base(name, description)
+        {
+            HelpUrl = helpUrl;
+        }
+
+        public string HelpUrl { get; }
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchCommand.cs
@@ -8,6 +8,7 @@ using System.CommandLine.Help;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.CommandLine.XPlat.Commands;
 using NuGet.Configuration;
 using NuGet.Credentials;
 
@@ -22,7 +23,7 @@ namespace NuGet.CommandLine.XPlat
 
         public static void Register(CliCommand rootCommand, Func<ILoggerWithColor> getLogger, Func<PackageSearchArgs, string, CancellationToken, Task<int>> setupSettingsAndRunSearchAsync)
         {
-            var searchCommand = new CliCommand("search", Strings.pkgSearch_Description);
+            var searchCommand = new DocumentedCommand("search", Strings.pkgSearch_Description, "https://aka.ms/dotnet/package/search");
 
             var searchTerm = new CliArgument<string>("Search Term")
             {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommand.cs
@@ -37,7 +37,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
 
         internal static void Register(CliCommand rootCommand, Func<ILoggerWithColor> getLogger, Func<WhyCommandArgs, int> action)
         {
-            var whyCommand = new CliCommand("why", Strings.WhyCommand_Description);
+            var whyCommand = new DocumentedCommand("why", Strings.WhyCommand_Description, "https://aka.ms/dotnet/nuget/why");
 
             CliArgument<string> path = new CliArgument<string>("PROJECT|SOLUTION")
             {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/PublicAPI.Unshipped.txt
@@ -1,2 +1,5 @@
+NuGet.CommandLine.XPlat.Commands.DocumentedCommand
+NuGet.CommandLine.XPlat.Commands.DocumentedCommand.DocumentedCommand(string name, string description, string helpUrl) -> void
+NuGet.CommandLine.XPlat.Commands.DocumentedCommand.HelpUrl.get -> string
 NuGet.CommandLine.XPlat.Commands.Why.WhyCommand
 static NuGet.CommandLine.XPlat.Commands.Why.WhyCommand.GetWhyCommand(System.CommandLine.CliCommand rootCommand) -> void

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Why/WhyCommandLineParsingTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Why/WhyCommandLineParsingTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.CommandLine;
 using FluentAssertions;
+using NuGet.CommandLine.XPlat.Commands;
 using NuGet.CommandLine.XPlat.Commands.Why;
 using Xunit;
 
@@ -11,6 +12,20 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
 {
     public class WhyCommandLineParsingTests
     {
+        [Fact]
+        public void WhyCommand_HasHelpUrl()
+        {
+            // Arrange
+            CliCommand rootCommand = new("nuget");
+
+            // Act
+            WhyCommand.Register(rootCommand, NullLoggerWithColor.GetInstance);
+
+            // Assert
+            rootCommand.Subcommands[0].Should().BeAssignableTo<DocumentedCommand>();
+            ((DocumentedCommand)rootCommand.Subcommands[0]).HelpUrl.Should().NotBeNullOrEmpty();
+        }
+
         [Fact]
         public void WithTwoArguments_PathAndPackageAreSet()
         {

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/config/ConfigCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/config/ConfigCommandTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.CommandLine;
+using FluentAssertions;
+using NuGet.CommandLine.XPlat;
+using NuGet.CommandLine.XPlat.Commands;
+using Xunit;
+
+namespace NuGet.CommandLine.Xplat.Tests.Commands.config
+{
+    public class ConfigCommandTests
+    {
+        [Fact]
+        public void ConfigCommand_HasHelpUrl()
+        {
+            // Arrange
+            CliCommand rootCommand = new("nuget");
+
+            // Act
+            ConfigCommand.Register(rootCommand, NullLoggerWithColor.GetInstance);
+
+            // Assert
+            rootCommand.Subcommands[0].Should().BeAssignableTo<DocumentedCommand>();
+            ((DocumentedCommand)rootCommand.Subcommands[0]).HelpUrl.Should().NotBeNullOrEmpty();
+
+            foreach (var subcommand in rootCommand.Subcommands)
+            {
+                subcommand.Should().BeAssignableTo<DocumentedCommand>();
+                ((DocumentedCommand)subcommand).HelpUrl.Should().NotBeNullOrEmpty();
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchCommandTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Globalization;
+using FluentAssertions;
 using NuGet.CommandLine.XPlat;
+using NuGet.CommandLine.XPlat.Commands;
 using Xunit;
 using static NuGet.CommandLine.XPlat.PackageSearchCommand;
 
@@ -10,6 +12,18 @@ namespace NuGet.CommandLine.Xplat.Tests
 {
     public class PackageSearchCommandTests : PackageSearchTestInitializer
     {
+        [Fact]
+        public void Register_HasHelpUrl()
+        {
+            // Arrange
+            // Act
+            Register(RootCommand, GetLogger, SetupSettingsAndRunSearchAsync);
+
+            // Assert
+            RootCommand.Subcommands[0].Should().BeAssignableTo<DocumentedCommand>();
+            ((DocumentedCommand)RootCommand.Subcommands[0]).HelpUrl.Should().NotBeNullOrEmpty();
+        }
+
         [Fact]
         public void Register_withSearchTermOnly_SetsSearchTerm()
         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/dotnet/sdk/pull/44614#discussion_r1827170176

## Description

The `dotnet` CLI has a command `dotnet help <command>` which will open the default browser and take you to the help page for the `<command>`.  For this to work, the commands need to tell the `dotnet` CLI what the help URL is.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
