### PR TITLE
Don't select transitive packages in PM UI when updating a package

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -612,7 +612,7 @@ namespace NuGet.PackageManagement.UI
             {
                 foreach (PackageInstallationInfo project in Projects)
                 {
-                    project.IsSelected = project.InstalledVersion != null;
+                    project.IsSelected = project.InstalledVersion != null && project.PackageLevel.Equals(PackageLevel.TopLevel);
                 }
             }
             finally


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13893

## Description
Transitive packages are automatically selected when you are in the Updates tab and clicking the Update button will update the package reference for the top-level packages but also add a package reference in all the projects where the package is used as a transitive dependency, promoting them to top-level, which is not the desired behavior in most of the cases.

Promoting a package from transitive to top-level is not a very common scenario, most likely only done when fixing a vulnerability or resolving a dependency conflict. 

![image](https://github.com/user-attachments/assets/3dd94538-c438-4cb8-bf1e-7db061873797)


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests ~I'm not adding since it's a UI change in a code path with no tests, I could try to add a unit test if team wants~
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
