### PR TITLE
reduce memory in ManifestMetadata

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
@@ -187,7 +187,7 @@ namespace NuGet.Packaging
 
         public RepositoryMetadata Repository { get; set; }
 
-        private IEnumerable<PackageDependencyGroup> _dependencyGroups = new List<PackageDependencyGroup>();
+        private IEnumerable<PackageDependencyGroup> _dependencyGroups = [];
         public IEnumerable<PackageDependencyGroup> DependencyGroups
         {
             get
@@ -200,11 +200,11 @@ namespace NuGet.Packaging
             }
         }
 
-        public IEnumerable<FrameworkReferenceGroup> FrameworkReferenceGroups { get; set; } = new List<FrameworkReferenceGroup>();
+        public IEnumerable<FrameworkReferenceGroup> FrameworkReferenceGroups { get; set; } = [];
 
-        public IEnumerable<FrameworkAssemblyReference> FrameworkReferences { get; set; } = new List<FrameworkAssemblyReference>();
+        public IEnumerable<FrameworkAssemblyReference> FrameworkReferences { get; set; } = [];
 
-        private IEnumerable<PackageReferenceSet> _packageAssemblyReferences = new List<PackageReferenceSet>();
+        private IEnumerable<PackageReferenceSet> _packageAssemblyReferences = [];
 
         [ManifestVersion(2)]
         public IEnumerable<PackageReferenceSet> PackageAssemblyReferences


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

reduce memory in ManifestMetadata by using collection expressions that will result in those `IEnumerable` members being compiled to a `.Empty`.

let me know if u want to use explicit `Enumerable.Empty`s

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
