### PR TITLE
Add indicator for deprecated and vulnerable packages to Package Details tab

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -444,7 +444,6 @@ namespace NuGet.PackageManagement.UI
                 OnPropertyChanged(nameof(PackageVulnerabilities));
                 OnPropertyChanged(nameof(PackageVulnerabilityMaxSeverity));
                 OnPropertyChanged(nameof(IsPackageVulnerable));
-                OnPropertyChanged(nameof(IsPackageVulnerableOrDeprecated));
                 OnPropertyChanged(nameof(PackageVulnerabilityCount));
             }
         }
@@ -535,9 +534,9 @@ namespace NuGet.PackageManagement.UI
                     OnPropertyChanged(nameof(PackageMetadata));
                     OnPropertyChanged(nameof(IsPackageDeprecated));
                     OnPropertyChanged(nameof(IsPackageVulnerable));
-                    OnPropertyChanged(nameof(IsPackageVulnerableOrDeprecated));
                     OnPropertyChanged(nameof(PackageVulnerabilityCount));
                     OnPropertyChanged(nameof(PackageVulnerabilities));
+                    OnPropertyChanged(nameof(IsPackageVulnerableOrDeprecated));
                     OnPropertyChanged(nameof(PackageVulnerabilityMaxSeverity));
                 }
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -444,6 +444,7 @@ namespace NuGet.PackageManagement.UI
                 OnPropertyChanged(nameof(PackageVulnerabilities));
                 OnPropertyChanged(nameof(PackageVulnerabilityMaxSeverity));
                 OnPropertyChanged(nameof(IsPackageVulnerable));
+                OnPropertyChanged(nameof(IsPackageVulnerableOrDeprecated));
                 OnPropertyChanged(nameof(PackageVulnerabilityCount));
             }
         }
@@ -456,6 +457,11 @@ namespace NuGet.PackageManagement.UI
         public bool IsPackageVulnerable
         {
             get => PackageVulnerabilities?.Count > 0;
+        }
+
+        public bool IsPackageVulnerableOrDeprecated
+        {
+            get => IsPackageVulnerable || IsPackageDeprecated;
         }
 
         public int PackageVulnerabilityCount
@@ -529,6 +535,7 @@ namespace NuGet.PackageManagement.UI
                     OnPropertyChanged(nameof(PackageMetadata));
                     OnPropertyChanged(nameof(IsPackageDeprecated));
                     OnPropertyChanged(nameof(IsPackageVulnerable));
+                    OnPropertyChanged(nameof(IsPackageVulnerableOrDeprecated));
                     OnPropertyChanged(nameof(PackageVulnerabilityCount));
                     OnPropertyChanged(nameof(PackageVulnerabilities));
                     OnPropertyChanged(nameof(PackageVulnerabilityMaxSeverity));

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -533,11 +533,7 @@ namespace NuGet.PackageManagement.UI
 
                     OnPropertyChanged(nameof(PackageMetadata));
                     OnPropertyChanged(nameof(IsPackageDeprecated));
-                    OnPropertyChanged(nameof(IsPackageVulnerable));
-                    OnPropertyChanged(nameof(PackageVulnerabilityCount));
-                    OnPropertyChanged(nameof(PackageVulnerabilities));
                     OnPropertyChanged(nameof(IsPackageVulnerableOrDeprecated));
-                    OnPropertyChanged(nameof(PackageVulnerabilityMaxSeverity));
                 }
             }
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DeprecationControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DeprecationControl.xaml
@@ -18,7 +18,7 @@
     </ResourceDictionary>
   </UserControl.Resources>
   <Grid
-    Margin="0,12,0,16">
+    Margin="0,0,0,16">
       <StackPanel
         Orientation="Vertical">
         <StackPanel

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml
@@ -150,6 +150,7 @@
             <DataTemplate DataType="{x:Type nuget:DetailControlModel}">
               <nuget:PackageMetadataControl
                 Focusable="True"
+                AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PackageMetadata}"
                 Margin="0,5,0,0"/>
             </DataTemplate>
             <DataTemplate DataType="{x:Type vm:ReadmePreviewViewModel}">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml
@@ -31,7 +31,7 @@
     <TabControl.Resources>
       <Style TargetType="TabItem">
         <Setter Property="Background" Value="{DynamicResource {x:Static nuget:Brushes.HeaderBackground}}" />
-        <Setter Property="FontSize" Value="{Binding FontSize, RelativeSource={RelativeSource AncestorType=UserControl},Converter={StaticResource Font122PercentSizeConverter}}"/>
+        <Setter Property="FontSize" Value="{Binding FontSize, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource Font122PercentSizeConverter}}"/>
         <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}" />
         <Setter Property="Padding" Value="12,0,12,0" />
         <Setter Property="FocusVisualStyle" Value="{DynamicResource ControlsFocusVisualStyle}" />
@@ -125,7 +125,7 @@
             <imaging:CrispImage.ToolTip>
               <StackPanel>
                 <TextBlock
-                  Visibility="{Binding IsPackageVulnerable,Converter={StaticResource BooleanToVisibilityConverter}}">
+                  Visibility="{Binding IsPackageVulnerable, Converter={StaticResource BooleanToVisibilityConverter}}">
                   <TextBlock.Text>
                     <MultiBinding Converter="{StaticResource StringFormatConverter}">
                       <Binding Source="{x:Static nuget:Resources.Label_PackageVulnerableToolTip}" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml
@@ -19,7 +19,8 @@
       <ResourceDictionary.MergedDictionaries>
         <nuget:SharedResources />
       </ResourceDictionary.MergedDictionaries>
-      <nuget:AccessibleConverter x:Key="AccNameWorkaround" />
+      <nuget:StringFormatConverter
+        x:Key="StringFormatConverter" />
     </ResourceDictionary>
   </UserControl.Resources>
   <TabControl
@@ -115,12 +116,30 @@
     </TabControl.Resources>
     <TabControl.ItemTemplate>
       <DataTemplate>
-        <TextBlock Text="{Binding Title}" />
-        <DataTemplate.Triggers>
-          <DataTrigger Binding="{Binding IsVisible}" Value="False">
-            <Setter Property="Visibility" Value="Collapsed" />
-          </DataTrigger>
-        </DataTemplate.Triggers>
+        <StackPanel Orientation="Horizontal" >
+          <TextBlock Text="{Binding Title}" />
+          <imaging:CrispImage
+            Margin="3,0"
+            Visibility="{Binding Path=IsPackageVulnerableOrDeprecated, FallbackValue=Collapsed, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
+            Moniker="{x:Static catalog:KnownMonikers.StatusWarning}">
+            <imaging:CrispImage.ToolTip>
+              <StackPanel>
+                <TextBlock
+                  Visibility="{Binding IsPackageVulnerable,Converter={StaticResource BooleanToVisibilityConverter}}">
+                  <TextBlock.Text>
+                    <MultiBinding Converter="{StaticResource StringFormatConverter}">
+                      <Binding Source="{x:Static nuget:Resources.Label_PackageVulnerableToolTip}" />
+                      <Binding Path="PackageVulnerabilityMaxSeverity" Converter="{StaticResource IntToVulnerabilitySeverityConverter}" />
+                    </MultiBinding>
+                  </TextBlock.Text>
+                </TextBlock>
+                <TextBlock
+                  Text="{x:Static nuget:Resources.Label_PackageDeprecatedToolTip}"
+                  Visibility="{Binding IsPackageDeprecated, FallbackValue=Collapsed, Converter={StaticResource BooleanToVisibilityConverter}}" />
+              </StackPanel>
+            </imaging:CrispImage.ToolTip>
+          </imaging:CrispImage>
+        </StackPanel>
       </DataTemplate>
     </TabControl.ItemTemplate>
     <TabControl.ContentTemplate>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageDetailsTabControl.xaml
@@ -150,7 +150,6 @@
             <DataTemplate DataType="{x:Type nuget:DetailControlModel}">
               <nuget:PackageMetadataControl
                 Focusable="True"
-                AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PackageMetadata}"
                 Margin="0,5,0,0"/>
             </DataTemplate>
             <DataTemplate DataType="{x:Type vm:ReadmePreviewViewModel}">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -86,7 +86,7 @@
     <!-- vulnerabilities info -->
     <Border
      Grid.Row="0"
-      Margin="22,0,0,0"
+     Margin="22,0,0,16"
      BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
      Visibility="{Binding Path=IsPackageVulnerable,Converter={StaticResource BooleanToVisibilityConverter}}"
      BorderThickness="0,0,0,1">
@@ -102,7 +102,7 @@
     <Border
       Grid.Row="1"
       BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
-      Margin="22,0,0,0"
+      Margin="22,0,0,16"
       Visibility="{Binding Path=IsPackageDeprecated,Converter={StaticResource BooleanToVisibilityConverter}}"
       BorderThickness="0,0,0,1">
       <Grid>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -9,7 +9,6 @@
   xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
   xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
   xmlns:glob="clr-namespace:System.Globalization;assembly=mscorlib"
-  AutomationProperties.Name=" "
   Background="{DynamicResource {x:Static nuget:Brushes.DetailPaneBackground}}"
   Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
   mc:Ignorable="d"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Threading;
 using System.Windows;
+using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using NuGet.VisualStudio;
@@ -23,6 +24,11 @@ namespace NuGet.PackageManagement.UI
 
             Visibility = Visibility.Collapsed;
             DataContextChanged += PackageMetadataControl_DataContextChanged;
+        }
+
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return null;
         }
 
         private void ViewLicense_Click(object sender, RoutedEventArgs e)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/VulnerabilitiesControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/VulnerabilitiesControl.xaml
@@ -20,7 +20,7 @@
     </ResourceDictionary>
   </UserControl.Resources>
   <Grid
-      Margin="0,12,0,16">
+      Margin="0,0,0,16">
     <StackPanel
         Orientation="Vertical">
       <StackPanel
@@ -84,6 +84,7 @@
                 <TextBlock
                   Grid.Column="1"
                   Margin="8,1,0,1"
+                  TextWrapping="Wrap"
                   ToolTip="{Binding AdvisoryUrl}">
                   <Hyperlink
                     NavigateUri="{Binding Path=AdvisoryUrl}"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13974

## Description
Add warning icon to the Package Details tab to indicate to users when the selected package has a vulnerability or is deprecated.
![image](https://github.com/user-attachments/assets/a0eaaa60-627e-45e9-ab3b-11151e91976b)
![image](https://github.com/user-attachments/assets/874bd414-f667-46c1-91e2-c590f12458f4)
![image](https://github.com/user-attachments/assets/ea683349-8cf3-4ffe-a83c-85de94dd749f)
![image](https://github.com/user-attachments/assets/c51d3968-6112-487d-9d3b-aa9ac40d4008)
![image](https://github.com/user-attachments/assets/65b3f89e-cba2-4274-8e13-dd0d95d5b8ee)

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
