### PR TITLE
Fix floating version comparison in new dependency resolver

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -1505,10 +1505,8 @@ namespace NuGet.Commands
                 }
 
                 return typeConstraint1 == typeConstraint2
-                    && VersionRangeComparer.Default.Equals(x.VersionRange, y.VersionRange)
                     && x.Name.Equals(y.Name, StringComparison.OrdinalIgnoreCase)
-                    && x.VersionRange.IsFloating == y.VersionRange.IsFloating
-                    && EqualityUtility.EqualsWithNullCheck(x.VersionRange.Float, y.VersionRange.Float);
+                    && x.VersionRange.Equals(y.VersionRange);
             }
 
             public int GetHashCode(LibraryRange obj)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -1504,9 +1504,11 @@ namespace NuGet.Commands
                         break;
                 }
 
-                return typeConstraint1 == typeConstraint2 &&
-                       VersionRangeComparer.Default.Equals(x.VersionRange, y.VersionRange) &&
-                       x.Name.Equals(y.Name, StringComparison.OrdinalIgnoreCase);
+                return typeConstraint1 == typeConstraint2
+                    && VersionRangeComparer.Default.Equals(x.VersionRange, y.VersionRange)
+                    && x.Name.Equals(y.Name, StringComparison.OrdinalIgnoreCase)
+                    && x.VersionRange.IsFloating == y.VersionRange.IsFloating
+                    && EqualityUtility.EqualsWithNullCheck(x.VersionRange.Float, y.VersionRange.Float);
             }
 
             public int GetHashCode(LibraryRange obj)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13992

## Description
The dependency resolver uses a comparison that was not taking into account floating versions.  This is because the `VersionRange` object has special logic that was missed:

https://github.com/NuGet/NuGet.Client/blob/acc521c647aa484fc2202024f624c7a56bf9fe0f/src/NuGet.Core/NuGet.Versioning/VersionRange.cs?plain=1#L429-L430

This change updates the version range comparison to take into account floating versions which fixes the reported issue where restore is resolving the wrong graph in some situations.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
