### PR TITLE
Add new test cases for restore package

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
@@ -878,10 +878,8 @@ namespace NuGet.Tests.Apex.Daily
         }
 
         [TestMethod]
-        [DataRow(ProjectTemplate.ConsoleApplication)]
-        [DataRow(ProjectTemplate.NetCoreConsoleApp)]
         [Timeout(DefaultTimeout)]
-        public async Task VerifyPackageRestoreAfterDeletingAssetsJsonFile(ProjectTemplate projectTemplate)
+        public async Task VerifyDeletedAssetsFileIsBackByRestoringPackage()
         {
             // Arrange
             await CommonUtility.CreatePackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1);
@@ -891,7 +889,7 @@ namespace NuGet.Tests.Apex.Daily
 
             SolutionService solutionService = VisualStudio.Get<SolutionService>();
             solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
-            ProjectTestExtension project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, "TestProject");
+            ProjectTestExtension project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ConsoleApplication, "TestProject");
             VisualStudio.ClearOutputWindow();
             solutionService.SaveAll();
 
@@ -904,16 +902,38 @@ namespace NuGet.Tests.Apex.Daily
             File.Delete(assetsFilePath);
 
             // Act
-            if (projectTemplate.Equals(ProjectTemplate.ConsoleApplication))
-            {
-                CommonUtility.RestoreNuGetPackages(VisualStudio, Logger);
-            }
-            else
-            {
-                project.Unload();
-                project.Reload();
-                nugetTestService.WaitForAutoRestore();
-            }
+            CommonUtility.RestoreNuGetPackages(VisualStudio, Logger);
+
+            // Assert
+            CommonUtility.WaitForFileExists(new FileInfo(assetsFilePath));
+        }
+
+        [TestMethod]
+        [Timeout(DefaultTimeout)]
+        public async Task VerifyDeletedAssetsFileIsBackByReloadingProject()
+        {
+            // Arrange
+            await CommonUtility.CreatePackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1);
+
+            NuGetApexTestService nugetTestService = GetNuGetTestService();
+            _pathContext.Settings.SetPackageFormatToPackageReference();
+
+            SolutionService solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
+            ProjectTestExtension project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.NetCoreConsoleApp, "TestProject");
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
+            NuGetUIProjectTestExtension uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI(TestPackageName, TestPackageVersionV1);
+
+            var assetsFilePath = CommonUtility.GetAssetsFilePath(project.FullPath);
+            CommonUtility.WaitForFileExists(new FileInfo(assetsFilePath));
+            File.Delete(assetsFilePath);
+
+            // Act
+            CommonUtility.AutoRestorePackageByReloadingProject(VisualStudio, project);
 
             // Assert
             CommonUtility.WaitForFileExists(new FileInfo(assetsFilePath));

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
@@ -910,6 +910,8 @@ namespace NuGet.Tests.Apex.Daily
             }
             else
             {
+                project.Unload();
+                project.Reload();
                 nugetTestService.WaitForAutoRestore();
             }
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
@@ -877,6 +877,46 @@ namespace NuGet.Tests.Apex.Daily
             CommonUtility.AssertPackageNotInAssetsFile(VisualStudio, project, TestPackageName, TestPackageVersionV1, Logger);
         }
 
+        [TestMethod]
+        [DataRow(ProjectTemplate.ConsoleApplication)]
+        [DataRow(ProjectTemplate.NetCoreConsoleApp)]
+        [Timeout(DefaultTimeout)]
+        public async Task VerifyPackageRestoreAfterDeletingAssetsJsonFile(ProjectTemplate projectTemplate)
+        {
+            // Arrange
+            await CommonUtility.CreatePackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1);
+
+            NuGetApexTestService nugetTestService = GetNuGetTestService();
+            _pathContext.Settings.SetPackageFormatToPackageReference();
+
+            SolutionService solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
+            ProjectTestExtension project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, "TestProject");
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
+            NuGetUIProjectTestExtension uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI(TestPackageName, TestPackageVersionV1);
+
+            var assetsFilePath = CommonUtility.GetAssetsFilePath(project.FullPath);
+            CommonUtility.WaitForFileExists(new FileInfo(assetsFilePath));
+            File.Delete(assetsFilePath);
+
+            // Act
+            if (projectTemplate.Equals(ProjectTemplate.ConsoleApplication))
+            {
+                CommonUtility.RestoreNuGetPackages(VisualStudio, Logger);
+            }
+            else
+            {
+                nugetTestService.WaitForAutoRestore();
+            }
+
+            // Assert
+            CommonUtility.WaitForFileExists(new FileInfo(assetsFilePath));
+        }
+
         public override void Dispose()
         {
             _pathContext.Dispose();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
@@ -425,7 +425,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        private static string GetAssetsFilePath(string projectPath)
+        public static string GetAssetsFilePath(string projectPath)
         {
             var projectDirectory = Path.GetDirectoryName(projectPath);
             return Path.Combine(projectDirectory, "obj", "project.assets.json");

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
@@ -338,6 +338,15 @@ namespace NuGet.Tests.Apex
             visualStudio.Dte.ExecuteCommand("ProjectAndSolutionContextMenus.Solution.RestoreNuGetPackages");
         }
 
+        public static void AutoRestorePackageByReloadingProject(VisualStudioHost visualStudio, ProjectTestExtension project)
+        {
+            var testService = visualStudio.Get<NuGetApexTestService>();
+
+            project.Unload();
+            project.Reload();
+            testService.WaitForAutoRestore();
+        }
+
         private static void WaitForCommandAvailable(VisualStudioHost visualStudio, string commandName, TimeSpan timeout, ITestLogger logger)
         {
             WaitForCommandAvailable(visualStudio.Dte.Commands.Item(commandName), timeout, logger);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3108

## Description
Add the below two new test cases about the "Restore Package" feature to the NuGet.Client-VSDaily Tests pipeline.

1. [Verify the deleted "project.assets.json" file can be restored with context menu “Restore NuGet Packages” in a non-SDK style project](https://microsoft.sharepoint.com/teams/NuGet/_layouts/OneNote.aspx?id=%2Fteams%2FNuGet%2FTeam%2FManual%20tests%2FTest%20Cases&wd=target%28Daily%20Manual%20Test.one%7C5CCE9D00-EFB1-411C-A3C5-268C164F5FE3%2FRestore%20Package%20%284%5C%29%7C8CC67692-3ED9-4205-B855-E6056C3BD099%2F%29)
2. [Verify the deleted "project.assets.json" file can be restored with auto-restore when reloading an SDK style project](https://microsoft.sharepoint.com/teams/NuGet/_layouts/OneNote.aspx?id=%2Fteams%2FNuGet%2FTeam%2FManual%20tests%2FTest%20Cases&wd=target%28Daily%20Manual%20Test.one%7C5CCE9D00-EFB1-411C-A3C5-268C164F5FE3%2FRestore%20Package%20%284%5C%29%7C8CC67692-3ED9-4205-B855-E6056C3BD099%2F%29)
## PR Checklist

- [X] Meaningful title, helpful description and a linked NuGet/Home issue
- [X] Added tests
- [X] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
