### PR TITLE
Clear package search cache after installing/uninstalling a package.

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/NuGetSearchServiceReconnector.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/NuGetSearchServiceReconnector.cs
@@ -114,6 +114,11 @@ namespace NuGet.PackageManagement.UI.Utility
                 _parent = service;
             }
 
+            public void ClearFromCache(string id, IReadOnlyCollection<PackageSourceContextInfo> packageSources, bool includePrerelease)
+            {
+                _parent._service.ClearFromCache(id, packageSources, includePrerelease);
+            }
+
             public ValueTask<SearchResultContextInfo> ContinueSearchAsync(CancellationToken cancellationToken)
             {
                 return _parent._service.ContinueSearchAsync(cancellationToken);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -936,12 +936,17 @@ namespace NuGet.PackageManagement.UI
                 .PostOnFailure(nameof(PackageItemViewModel), nameof(UpdatePackageMaxVulnerabilityAsync));
         }
 
-        public void UpdatePackageStatus(IEnumerable<PackageCollectionItem> installedPackages)
+        public void UpdatePackageStatus(IEnumerable<PackageCollectionItem> installedPackages, bool clearCache = false)
         {
             // Get the maximum version installed in any target project/solution
             InstalledVersion = installedPackages
                 .GetPackageVersions(Id)
                 .MaxOrDefault();
+
+            if (clearCache && InstalledVersion != null)
+            {
+                _searchService.ClearFromCache(Id, Sources, IncludePrerelease);
+            }
 
             // Set auto referenced to true any reference for the given id contains the flag.
             AutoReferenced = installedPackages.IsAutoReferenced(Id);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
@@ -78,7 +78,11 @@ namespace NuGet.PackageManagement.UI.ViewModels
 
         public async Task SetPackageMetadataAsync(DetailedPackageMetadata packageMetadata, CancellationToken cancellationToken)
         {
-            if (packageMetadata != null && (!string.Equals(packageMetadata.Id, _packageMetadata?.Id) || packageMetadata.Version != _packageMetadata?.Version))
+            if (packageMetadata != null && (
+                !string.Equals(packageMetadata.Id, _packageMetadata?.Id)
+                || packageMetadata.Version != _packageMetadata?.Version
+                || !string.Equals(packageMetadata.ReadmeFileUrl, _packageMetadata?.ReadmeFileUrl)
+                ))
             {
                 _packageMetadata = packageMetadata;
                 await LoadReadmeAsync(cancellationToken);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -604,7 +604,7 @@ namespace NuGet.PackageManagement.UI
             _loadingStatusBar.ItemsLoaded = 0;
         }
 
-        public void UpdatePackageStatus(PackageCollectionItem[] installedPackages)
+        public void UpdatePackageStatus(PackageCollectionItem[] installedPackages, bool clearCache = false)
         {
             // in this case, we only need to update PackageStatus of
             // existing items in the package list
@@ -612,7 +612,7 @@ namespace NuGet.PackageManagement.UI
             {
                 if (package.PackageLevel == PackageLevel.TopLevel)
                 {
-                    package.UpdatePackageStatus(installedPackages);
+                    package.UpdatePackageStatus(installedPackages, clearCache);
                 }
                 else
                 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1307,7 +1307,7 @@ namespace NuGet.PackageManagement.UI
                     Model.Context.ServiceBroker,
                     Model.Context.Projects,
                     CancellationToken.None);
-                _packageList.UpdatePackageStatus(installedPackages.ToArray(), true);
+                _packageList.UpdatePackageStatus(installedPackages.ToArray(), clearCache: true);
 
                 await RefreshInstalledAndUpdatesTabsAsync();
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1307,7 +1307,7 @@ namespace NuGet.PackageManagement.UI
                     Model.Context.ServiceBroker,
                     Model.Context.Projects,
                     CancellationToken.None);
-                _packageList.UpdatePackageStatus(installedPackages.ToArray());
+                _packageList.UpdatePackageStatus(installedPackages.ToArray(), true);
 
                 await RefreshInstalledAndUpdatesTabsAsync();
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1293,7 +1293,7 @@ namespace NuGet.PackageManagement.UI
         /// <summary>
         /// Refreshes the control after packages are installed or uninstalled.
         /// </summary>
-        private async ValueTask RefreshAsync()
+        private async ValueTask RefreshAsync(bool clearCache = false)
         {
             if (_topPanel.Filter != ItemFilter.All)
             {
@@ -1307,7 +1307,7 @@ namespace NuGet.PackageManagement.UI
                     Model.Context.ServiceBroker,
                     Model.Context.Projects,
                     CancellationToken.None);
-                _packageList.UpdatePackageStatus(installedPackages.ToArray(), clearCache: true);
+                _packageList.UpdatePackageStatus(installedPackages.ToArray(), clearCache);
 
                 await RefreshInstalledAndUpdatesTabsAsync();
             }
@@ -1634,7 +1634,7 @@ namespace NuGet.PackageManagement.UI
                     _isExecutingAction = false;
                     if (_isRefreshRequired)
                     {
-                        await RunAndEmitRefreshAsync(async () => await RefreshAsync(), RefreshOperationSource.ExecuteAction, GetTimeSinceLastRefreshAndRestart(), sw);
+                        await RunAndEmitRefreshAsync(async () => await RefreshAsync(clearCache: true), RefreshOperationSource.ExecuteAction, GetTimeSinceLastRefreshAndRestart(), sw);
                         _isRefreshRequired = false;
                     }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
@@ -382,6 +382,12 @@ namespace NuGet.PackageManagement.VisualStudio
             return allLocalFolders;
         }
 
+        public void ClearFromCache(string id, IReadOnlyCollection<PackageSourceContextInfo> packageSources, bool includePrerelease)
+        {
+            string cacheId = PackageSearchMetadataCacheItem.GetCacheId(id, includePrerelease, packageSources);
+            PackageSearchMetadataMemoryCache.Remove(cacheId);
+        }
+
         internal async Task<IPackageFeed?> CreatePackageFeedAsync(
             IReadOnlyCollection<IProjectContextInfo> projectContextInfos,
             IReadOnlyCollection<string> targetFrameworks,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetSearchService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetSearchService.cs
@@ -83,5 +83,10 @@ namespace NuGet.VisualStudio.Internal.Contracts
         Task<IReadOnlyList<SourceRepository>> GetAllPackageFoldersAsync(
             IReadOnlyCollection<IProjectContextInfo> projectContextInfos,
             CancellationToken cancellationToken);
+
+        void ClearFromCache(
+            string id,
+            IReadOnlyCollection<PackageSourceContextInfo> packageSources,
+            bool includePrerelease);
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
@@ -276,6 +276,38 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
+        public void ClearFromCache_WhenCalled_PackageSearchMetadataMemoryCacheHasItemCleared()
+        {
+            using (NuGetPackageSearchService searchService = SetupSearchService())
+            {
+                IPackageSearchMetadata packageMetadata = PackageSearchMetadataBuilder.FromIdentity(new PackageIdentity("microsoft.extensions.logging.abstractions", NuGetVersion.Parse("5.0.0-rc.2.20475.5"))).Build();
+                IPackageSearchMetadata packageMetadataToRemove = PackageSearchMetadataBuilder.FromIdentity(new PackageIdentity("microsoft.extensions.test", NuGetVersion.Parse("5.0.0-rc.2.20475.5"))).Build();
+                var packageSources = new List<PackageSourceContextInfo> { PackageSourceContextInfo.Create(_sourceRepository.PackageSource) };
+                var metadataProvider = Mock.Of<IPackageMetadataProvider>();
+                CacheItemPolicy _cacheItemPolicy = new CacheItemPolicy
+                {
+                    SlidingExpiration = ObjectCache.NoSlidingExpiration,
+                    AbsoluteExpiration = ObjectCache.InfiniteAbsoluteExpiration,
+                };
+
+                string cacheId = PackageSearchMetadataCacheItem.GetCacheId(packageMetadata.Identity.Id, true, packageSources);
+                var cacheEntry = new PackageSearchMetadataCacheItem(packageMetadata, metadataProvider);
+                NuGetPackageSearchService.PackageSearchMetadataMemoryCache.AddOrGetExisting(cacheId, cacheEntry, _cacheItemPolicy);
+
+                string cacheIdToRemove = PackageSearchMetadataCacheItem.GetCacheId(packageMetadataToRemove.Identity.Id, true, packageSources);
+                var cacheEntryToRemove = new PackageSearchMetadataCacheItem(packageMetadataToRemove, metadataProvider);
+                NuGetPackageSearchService.PackageSearchMetadataMemoryCache.AddOrGetExisting(cacheIdToRemove, cacheEntryToRemove, _cacheItemPolicy);
+
+
+                searchService.ClearFromCache(packageMetadataToRemove.Identity.Id, packageSources, true);
+
+                Assert.Equal(1, NuGetPackageSearchService.PackageSearchMetadataMemoryCache.Count());
+                Assert.Null(NuGetPackageSearchService.PackageSearchMetadataMemoryCache.Get(cacheIdToRemove));
+                Assert.NotNull(NuGetPackageSearchService.PackageSearchMetadataMemoryCache.Get(cacheId));
+            }
+        }
+
+        [Fact]
         public async Task GetPackageVersionsAsync_WithProjectAndIsTransitiveAndCacheIsNotPopulatedAsync()
         {
             using (NuGetPackageSearchService searchService = SetupSearchService())

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
@@ -276,7 +276,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public void ClearFromCache_WhenCalled_PackageSearchMetadataMemoryCacheHasItemCleared()
+        public void ClearFromCache_WhenPackageSearchMetadataMemoryCacheHasItem_ItemCleared()
         {
             using (NuGetPackageSearchService searchService = SetupSearchService())
             {
@@ -290,16 +290,16 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     AbsoluteExpiration = ObjectCache.InfiniteAbsoluteExpiration,
                 };
 
-                string cacheId = PackageSearchMetadataCacheItem.GetCacheId(packageMetadata.Identity.Id, true, packageSources);
+                string cacheId = PackageSearchMetadataCacheItem.GetCacheId(packageMetadata.Identity.Id, includePrerelease: true, packageSources);
                 var cacheEntry = new PackageSearchMetadataCacheItem(packageMetadata, metadataProvider);
                 NuGetPackageSearchService.PackageSearchMetadataMemoryCache.AddOrGetExisting(cacheId, cacheEntry, _cacheItemPolicy);
 
-                string cacheIdToRemove = PackageSearchMetadataCacheItem.GetCacheId(packageMetadataToRemove.Identity.Id, true, packageSources);
+                string cacheIdToRemove = PackageSearchMetadataCacheItem.GetCacheId(packageMetadataToRemove.Identity.Id, includePrerelease: true, packageSources);
                 var cacheEntryToRemove = new PackageSearchMetadataCacheItem(packageMetadataToRemove, metadataProvider);
                 NuGetPackageSearchService.PackageSearchMetadataMemoryCache.AddOrGetExisting(cacheIdToRemove, cacheEntryToRemove, _cacheItemPolicy);
 
 
-                searchService.ClearFromCache(packageMetadataToRemove.Identity.Id, packageSources, true);
+                searchService.ClearFromCache(packageMetadataToRemove.Identity.Id, packageSources, includePrerelease: true);
 
                 Assert.Equal(1, NuGetPackageSearchService.PackageSearchMetadataMemoryCache.Count());
                 Assert.Null(NuGetPackageSearchService.PackageSearchMetadataMemoryCache.Get(cacheIdToRemove));


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13924
Fixes: https://github.com/NuGet/Client.Engineering/issues/3105

## Description
When a package is selected, we get its information from the search cache. However, for the README if the package was installed at some point after the cache was set, the cache results do not include the path to the README. This update allows for the cache to be reset and resets it after an install/uninstall operation has been completed. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
