### PR TITLE
Enable AuditSource during dotnet list package  command

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageArgs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageArgs.cs
@@ -74,6 +74,21 @@ namespace NuGet.CommandLine.XPlat
             ArgumentText = GetReportParameters();
         }
 
+        public ListPackageArgs(
+            string path,
+            List<PackageSource> packageSources,
+            List<string> frameworks,
+            ReportType reportType,
+            IReportRenderer renderer,
+            bool includeTransitive,
+            bool prerelease,
+            bool highestPatch,
+            bool highestMinor,
+            ILogger logger,
+            CancellationToken cancellationToken) : this(path, packageSources, frameworks, reportType, renderer, includeTransitive, prerelease, highestPatch, highestMinor, new List<PackageSource>(), logger, cancellationToken)
+        {
+        }
+
         private string GetReportParameters()
         {
             StringBuilder sb = new StringBuilder();

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageArgs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageArgs.cs
@@ -17,6 +17,7 @@ namespace NuGet.CommandLine.XPlat
         public ILogger Logger { get; }
         public string Path { get; }
         public List<PackageSource> PackageSources { get; }
+        public List<PackageSource> AuditSources { get; }
         public List<string> Frameworks { get; }
         public ReportType ReportType { get; }
         public IReportRenderer Renderer { get; }
@@ -41,6 +42,7 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="prerelease"> Bool for --include-prerelease present </param>
         /// <param name="highestPatch"> Bool for --highest-patch present </param>
         /// <param name="highestMinor"> Bool for --highest-minor present </param>
+        /// <param name="auditSources"> A list of sources for performing vulnerability auditing</param>
         /// <param name="logger"></param>
         /// <param name="cancellationToken"></param>
         public ListPackageArgs(
@@ -53,6 +55,7 @@ namespace NuGet.CommandLine.XPlat
             bool prerelease,
             bool highestPatch,
             bool highestMinor,
+            List<PackageSource> auditSources,
             ILogger logger,
             CancellationToken cancellationToken)
         {
@@ -65,6 +68,7 @@ namespace NuGet.CommandLine.XPlat
             Prerelease = prerelease;
             HighestPatch = highestPatch;
             HighestMinor = highestMinor;
+            AuditSources = auditSources;
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             CancellationToken = cancellationToken;
             ArgumentText = GetReportParameters();

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
@@ -129,7 +129,7 @@ namespace NuGet.CommandLine.XPlat
                         isVulnerable: vulnerableReport.HasValue());
 
                     IReportRenderer reportRenderer = GetOutputType(outputFormat.Value(), outputVersionOption: outputVersion.Value());
-
+                    var provider = new PackageSourceProvider(settings);
                     var packageRefArgs = new ListPackageArgs(
                         path.Value,
                         packageSources,
@@ -140,6 +140,7 @@ namespace NuGet.CommandLine.XPlat
                         prerelease.HasValue(),
                         highestPatch.HasValue(),
                         highestMinor.HasValue(),
+                        provider.LoadAuditSources().ToList(),
                         logger,
                         CancellationToken.None);
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -291,7 +291,7 @@ namespace NuGet.CommandLine.XPlat
             List<FrameworkPackages> targetFrameworks,
             ListPackageArgs listPackageArgs)
         {
-            IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> vulnerabilityInfo = null;
+            var vulnerabilityInfo = new List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>();
 
             if (listPackageArgs.ReportType == ReportType.Vulnerable && listPackageArgs.AuditSources.Count > 0)
             {
@@ -308,8 +308,11 @@ namespace NuGet.CommandLine.XPlat
                             new SourceCacheContext(),
                             listPackageArgs.Logger,
                             listPackageArgs.CancellationToken);
-                        vulnerabilityInfo = vulnerabilityInfoResult.KnownVulnerabilities;
-                        break; // Use the first valid audit source
+
+                        if (vulnerabilityInfoResult?.KnownVulnerabilities != null)
+                        {
+                            vulnerabilityInfo.AddRange(vulnerabilityInfoResult.KnownVulnerabilities);
+                        }
                     }
                 }
             }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -16,6 +16,9 @@ using NuGet.Configuration;
 using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Model;
+using NuGet.Protocol.Providers;
+using NuGet.Protocol.Resources;
 using NuGet.Versioning;
 
 namespace NuGet.CommandLine.XPlat
@@ -276,6 +279,29 @@ namespace NuGet.CommandLine.XPlat
             List<FrameworkPackages> targetFrameworks,
             ListPackageArgs listPackageArgs)
         {
+            IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> vulnerabilityInfo = null;
+
+            if (listPackageArgs.ReportType == ReportType.Vulnerable && listPackageArgs.AuditSources.Count > 0)
+            {
+                foreach (var source in listPackageArgs.AuditSources)
+                {
+                    var repository = Repository.Factory.GetCoreV3(source);
+                    var vulnerabilityProvider = new VulnerabilityInfoResourceV3Provider();
+                    var result = await vulnerabilityProvider.TryCreate(repository, listPackageArgs.CancellationToken);
+                    var vulnerabilityResource = result.Item2 as VulnerabilityInfoResourceV3;
+
+                    if (vulnerabilityResource != null)
+                    {
+                        var vulnerabilityInfoResult = await vulnerabilityResource.GetVulnerabilityInfoAsync(
+                            new SourceCacheContext(),
+                            listPackageArgs.Logger,
+                            listPackageArgs.CancellationToken);
+                        vulnerabilityInfo = vulnerabilityInfoResult.KnownVulnerabilities;
+                        break; // Use the first valid audit source
+                    }
+                }
+            }
+
             List<string> allPackages = GetAllPackageIdentifiers(targetFrameworks, listPackageArgs.IncludeTransitive);
             var packageMetadataById = new Dictionary<string, List<IPackageSearchMetadata>>(capacity: allPackages.Count);
 
@@ -284,7 +310,7 @@ namespace NuGet.CommandLine.XPlat
                 : (Environment.ProcessorCount / listPackageArgs.PackageSources.Count) + 1;
 
             await ThrottledForEachAsync(allPackages,
-                async (packageId, cancellationToken) => await GetPackageVersionsAsync(packageId, listPackageArgs, cancellationToken),
+                async (packageId, cancellationToken) => await GetPackageVersionsAsync(packageId, listPackageArgs, vulnerabilityInfo, cancellationToken),
                 packageMetadata => packageMetadataById[packageMetadata.Key] = packageMetadata.Value,
                 maxParallel,
                 listPackageArgs.CancellationToken);
@@ -514,18 +540,20 @@ namespace NuGet.CommandLine.XPlat
         /// </summary>
         /// <param name="package">The package to get the latest version for</param>
         /// <param name="listPackageArgs">List args for the token and source provider></param>
+        /// <param name="vulnerabilityInfo">Vulnerability information database</param>
         /// <param name="cancellationToken"></param>
         /// <returns>A list of tasks for all latest versions for packages from all sources</returns>
         private async Task<KeyValuePair<string, List<IPackageSearchMetadata>>> GetPackageVersionsAsync(
             string package,
             ListPackageArgs listPackageArgs,
+            IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> vulnerabilityInfo,
             CancellationToken cancellationToken)
         {
             var results = new List<IPackageSearchMetadata>();
             var sources = listPackageArgs.PackageSources;
 
             await ThrottledForEachAsync(sources,
-                async (source, innerCancellationToken) => await GetLatestVersionPerSourceAsync(source, listPackageArgs, package, innerCancellationToken),
+                async (source, innerCancellationToken) => await GetLatestVersionPerSourceAsync(source, listPackageArgs, package, vulnerabilityInfo, innerCancellationToken),
                 continuation: results.AddRange,
                 maxParallel: listPackageArgs.PackageSources.Count,
                 cancellationToken);
@@ -572,12 +600,14 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="packageSource">The source to look for packages at</param>
         /// <param name="listPackageArgs">The list args for the cancellation token</param>
         /// <param name="package">Package to look for updates for</param>
+        /// <param name="vulnerabilityInfo">Vulnerabilty information database</param>
         /// <param name="cancellationToken"></param>
         /// <returns>An updated package with the highest version at a single source</returns>
         private async Task<IEnumerable<IPackageSearchMetadata>> GetLatestVersionPerSourceAsync(
             PackageSource packageSource,
             ListPackageArgs listPackageArgs,
             string package,
+            IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> vulnerabilityInfo,
             CancellationToken cancellationToken)
         {
             SourceRepository sourceRepository = _sourceRepositoryCache[packageSource];
@@ -593,7 +623,57 @@ namespace NuGet.CommandLine.XPlat
                     log: listPackageArgs.Logger,
                     token: listPackageArgs.CancellationToken);
 
+            if (listPackageArgs.ReportType == ReportType.Vulnerable && listPackageArgs.AuditSources.Count > 0)
+            {
+                if (vulnerabilityInfo?.Count > 0)
+                {
+                    var updatedPackages = new List<IPackageSearchMetadata>();
+
+                    foreach (var pkg in packages)
+                    {
+                        var pkgVulnerabilities = PackageVulnerabilities(vulnerabilityInfo, pkg.Identity.Id, pkg.Identity.Version.ToNormalizedString());
+
+                        if (pkgVulnerabilities?.Any() == true)
+                        {
+                            // Update the package metadata with vulnerability information
+                            var updatedPackage = PackageSearchMetadataBuilder.FromMetadata(pkg)
+                                .WithVulnerabilities(pkgVulnerabilities)
+                                .Build();
+
+                            updatedPackages.Add(updatedPackage);
+                        }
+                        else
+                        {
+                            updatedPackages.Add(pkg);
+                        }
+                    }
+
+                    packages = updatedPackages;
+                }
+            }
+
             return packages;
+        }
+
+        private static IEnumerable<PackageVulnerabilityMetadata> PackageVulnerabilities(IEnumerable<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> vulnerabilities, string id, string version)
+        {
+            var packageVulnerabilities = new List<PackageVulnerabilityMetadata>().AsEnumerable();
+            if (vulnerabilities == null)
+            {
+                return packageVulnerabilities;
+            }
+            foreach (var vulnFile in vulnerabilities)
+            {
+                vulnFile.TryGetValue(id, out IReadOnlyList<PackageVulnerabilityInfo> vulnPackages);
+                if (vulnPackages != null)
+                {
+                    // The package has vulnerabilities
+                    packageVulnerabilities = vulnPackages.Where(
+                        package => package.Versions.Satisfies(new NuGetVersion(version))).Select(v => JsonExtensions.FromJson<PackageVulnerabilityMetadata>($"{{ \"AdvisoryUrl\": \"{v.Url}\", \"Severity\": \"{(int)v.Severity}\" }}"));
+                    return packageVulnerabilities;
+                }
+            }
+            return packageVulnerabilities;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -179,6 +179,18 @@ namespace NuGet.CommandLine.XPlat
                 }
             }
 
+            foreach (PackageSource packageSource in listPackageArgs.AuditSources)
+            {
+                if (packageSource.IsHttp && !packageSource.IsHttps && !packageSource.AllowInsecureConnections)
+                {
+                    if (httpPackageSources == null)
+                    {
+                        httpPackageSources = new();
+                    }
+                    httpPackageSources.Add(packageSource);
+                }
+            }
+
             if (httpPackageSources != null && httpPackageSources.Count != 0)
             {
                 if (httpPackageSources.Count == 1)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -562,45 +562,12 @@ namespace NuGet.CommandLine.XPlat
         }
 
         /// <summary>
-        /// Prepares the calls to sources for current versions and updates
-        /// the list of tasks with the requests
-        /// </summary>
-        /// <param name="packageId">The package ID to get the current version metadata for</param>
-        /// <param name="requestedVersion">The version of the requested package</param>
-        /// <param name="listPackageArgs">List args for the token and source provider></param>
-        /// <param name="packagesVersionsDict">A reference to the unique packages in the project
-        /// to be able to handle different sources having different latest versions</param>
-        /// <returns>A list of tasks for all current versions for packages from all sources</returns>
-        private IList<Task> PrepareCurrentVersionsRequests(
-            string packageId,
-            NuGetVersion requestedVersion,
-            ListPackageArgs listPackageArgs,
-            Dictionary<string, IList<IPackageSearchMetadata>> packagesVersionsDict)
-        {
-            var requests = new List<Task>();
-            var sources = listPackageArgs.PackageSources;
-
-            foreach (var packageSource in sources)
-            {
-                requests.Add(
-                    GetPackageMetadataFromSourceAsync(
-                        packageSource,
-                        listPackageArgs,
-                        packageId,
-                        requestedVersion,
-                        packagesVersionsDict));
-            }
-
-            return requests;
-        }
-
-        /// <summary>
         /// Gets the highest version of a package from a specific source
         /// </summary>
         /// <param name="packageSource">The source to look for packages at</param>
         /// <param name="listPackageArgs">The list args for the cancellation token</param>
         /// <param name="package">Package to look for updates for</param>
-        /// <param name="vulnerabilityInfo">Vulnerabilty information database</param>
+        /// <param name="vulnerabilityInfo">Vulnerability information database</param>
         /// <param name="cancellationToken"></param>
         /// <returns>An updated package with the highest version at a single source</returns>
         private async Task<IEnumerable<IPackageSearchMetadata>> GetLatestVersionPerSourceAsync(
@@ -674,49 +641,6 @@ namespace NuGet.CommandLine.XPlat
                 }
             }
             return packageVulnerabilities;
-        }
-
-        /// <summary>
-        /// Gets the requested version of a package from a specific source
-        /// </summary>
-        /// <param name="packageSource">The source to look for packages at</param>
-        /// <param name="listPackageArgs">The list args for the cancellation token</param>
-        /// <param name="packageId">Package to look for</param>
-        /// <param name="requestedVersion">Requested package version</param>
-        /// <param name="packagesVersionsDict">A reference to the unique packages in the project
-        /// to be able to handle different sources having different latest versions</param>
-        /// <returns>An updated package with the resolved version metadata from a single source</returns>
-        private async Task GetPackageMetadataFromSourceAsync(
-            PackageSource packageSource,
-            ListPackageArgs listPackageArgs,
-            string packageId,
-            NuGetVersion requestedVersion,
-            Dictionary<string, IList<IPackageSearchMetadata>> packagesVersionsDict)
-        {
-            SourceRepository sourceRepository = _sourceRepositoryCache[packageSource];
-            var packageMetadataResource = await sourceRepository
-                .GetResourceAsync<PackageMetadataResource>(listPackageArgs.CancellationToken);
-
-            using var sourceCacheContext = new SourceCacheContext();
-            var packages = await packageMetadataResource.GetMetadataAsync(
-                packageId,
-                includePrerelease: true,
-                includeUnlisted: true, // Include unlisted because deprecated packages may be unlisted.
-                sourceCacheContext: sourceCacheContext,
-                log: listPackageArgs.Logger,
-                token: listPackageArgs.CancellationToken);
-
-            var resolvedVersionsForPackage = packagesVersionsDict
-                .Where(p => p.Key.Equals(packageId, StringComparison.OrdinalIgnoreCase))
-                .Single()
-                .Value;
-
-            var resolvedPackageVersionMetadata = packages.SingleOrDefault(p => p.Identity.Version.Equals(requestedVersion));
-            if (resolvedPackageVersionMetadata != null)
-            {
-                // Package version metadata found on source
-                resolvedVersionsForPackage.Add(resolvedPackageVersionMetadata);
-            }
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/ListPackage/ListPackageConsoleRenderer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/ListPackage/ListPackageConsoleRenderer.cs
@@ -73,6 +73,14 @@ namespace NuGet.CommandLine.XPlat.ListPackage
                 consoleOut.WriteLine();
                 consoleOut.WriteLine(Strings.ListPkg_SourcesUsedDescription);
                 PrintSources(consoleOut, listPackageArgs.PackageSources);
+
+                if (listPackageArgs.AuditSources.Count > 0)
+                {
+                    consoleOut.WriteLine();
+                    consoleOut.WriteLine(Strings.ListPkg_AuditSourcesUsedDescription);
+                    PrintSources(consoleOut, listPackageArgs.AuditSources);
+                }
+
                 consoleOut.WriteLine();
             }
         }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -853,6 +853,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The following vulnerability audit sources were used:.
+        /// </summary>
+        internal static string ListPkg_AuditSourcesUsedDescription {
+            get {
+                return ResourceManager.GetString("ListPkg_AuditSourcesUsedDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to (A) : Auto-referenced package..
         /// </summary>
         internal static string ListPkg_AutoReferenceDescription {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -978,4 +978,7 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
     <value>Project '{0}' does not have MSBuild property ProjectAssetsFile defined. This may indicate that this project does not support NuGet PackageReference, or that project customization has prevented the .NET SDK setting default values.</value>
     <comment>{0} - Path to the project with the error</comment>
   </data>
+  <data name="ListPkg_AuditSourcesUsedDescription" xml:space="preserve">
+    <value>The following vulnerability audit sources were used:</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataBuilder.cs
@@ -19,6 +19,7 @@ namespace NuGet.Protocol.Core.Types
         private readonly IPackageSearchMetadata _metadata;
         private AsyncLazy<IEnumerable<VersionInfo>> _lazyVersionsFactory;
         private AsyncLazy<PackageDeprecationMetadata> _lazyDeprecationFactory;
+        private IEnumerable<PackageVulnerabilityMetadata> _packageVulnerabilities;
 
         public class ClonedPackageSearchMetadata : IPackageSearchMetadata
         {
@@ -111,7 +112,7 @@ namespace NuGet.Protocol.Core.Types
                 PrefixReserved = _metadata.PrefixReserved,
                 LicenseMetadata = _metadata.LicenseMetadata,
                 LazyDeprecationFactory = _lazyDeprecationFactory ?? AsyncLazy.New(_metadata.GetDeprecationMetadataAsync),
-                Vulnerabilities = _metadata.Vulnerabilities,
+                Vulnerabilities = _packageVulnerabilities ?? _metadata.Vulnerabilities,
 #pragma warning disable CS0618 // Type or member is obsolete
                 PackageReader =
                     (_metadata as LocalPackageSearchMetadata)?.PackageReader ??
@@ -138,6 +139,12 @@ namespace NuGet.Protocol.Core.Types
                 Authors = string.Empty
             };
             return FromMetadata(metadata);
+        }
+
+        public PackageSearchMetadataBuilder WithVulnerabilities(IEnumerable<PackageVulnerabilityMetadata> pkgVulnerabilities)
+        {
+            _packageVulnerabilities = pkgVulnerabilities;
+            return this;
         }
     }
 

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 NuGet.Protocol.Plugins.PluginDiscoverer.PluginDiscoverer() -> void
 virtual NuGet.Protocol.Plugins.PluginFactory.Dispose() -> void
+~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.WithVulnerabilities(System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata> pkgVulnerabilities) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder
 ~NuGet.Protocol.Plugins.PluginFile.PluginFile(string filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState> state, bool requiresDotnetHost) -> void
 ~NuGet.Protocol.Plugins.PluginManager.PluginManager(NuGet.Common.IEnvironmentVariableReader reader, System.Lazy<NuGet.Protocol.Plugins.IPluginDiscoverer> pluginDiscoverer, System.Func<System.TimeSpan, NuGet.Protocol.Plugins.PluginFactory> pluginFactoryCreator, System.Lazy<string> pluginsCacheDirectoryPath) -> void
 ~virtual NuGet.Protocol.Plugins.PluginFactory.GetOrCreateAsync(NuGet.Protocol.Plugins.PluginFile pluginFile, System.Collections.Generic.IEnumerable<string> arguments, NuGet.Protocol.Plugins.IRequestHandlers requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 NuGet.Protocol.Plugins.PluginDiscoverer.PluginDiscoverer() -> void
 virtual NuGet.Protocol.Plugins.PluginFactory.Dispose() -> void
+~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.WithVulnerabilities(System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata> pkgVulnerabilities) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder
 ~NuGet.Protocol.Plugins.PluginFile.PluginFile(string filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState> state, bool requiresDotnetHost) -> void
 ~NuGet.Protocol.Plugins.PluginManager.PluginManager(NuGet.Common.IEnvironmentVariableReader reader, System.Lazy<NuGet.Protocol.Plugins.IPluginDiscoverer> pluginDiscoverer, System.Func<System.TimeSpan, NuGet.Protocol.Plugins.PluginFactory> pluginFactoryCreator, System.Lazy<string> pluginsCacheDirectoryPath) -> void
 ~virtual NuGet.Protocol.Plugins.PluginFactory.GetOrCreateAsync(NuGet.Protocol.Plugins.PluginFile pluginFile, System.Collections.Generic.IEnumerable<string> arguments, NuGet.Protocol.Plugins.IRequestHandlers requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 NuGet.Protocol.Plugins.PluginDiscoverer.PluginDiscoverer() -> void
 virtual NuGet.Protocol.Plugins.PluginFactory.Dispose() -> void
+~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.WithVulnerabilities(System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata> pkgVulnerabilities) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder
 ~NuGet.Protocol.Plugins.PluginFile.PluginFile(string filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState> state, bool requiresDotnetHost) -> void
 ~NuGet.Protocol.Plugins.PluginManager.PluginManager(NuGet.Common.IEnvironmentVariableReader reader, System.Lazy<NuGet.Protocol.Plugins.IPluginDiscoverer> pluginDiscoverer, System.Func<System.TimeSpan, NuGet.Protocol.Plugins.PluginFactory> pluginFactoryCreator, System.Lazy<string> pluginsCacheDirectoryPath) -> void
 ~virtual NuGet.Protocol.Plugins.PluginFactory.GetOrCreateAsync(NuGet.Protocol.Plugins.PluginFile pluginFile, System.Collections.Generic.IEnumerable<string> arguments, NuGet.Protocol.Plugins.IRequestHandlers requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -292,7 +292,7 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
-        public async Task ExecuteCommandAsync_ShouldUseAuditSources_WhenReportTypeIsVulnerable()
+        public async Task GetReportDataAsync_WhenReportTypeIsVulnerable_ShouldUseAuditSources()
         {
             // Arrange
             var advisoryUrl = "https://test/";

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Microsoft.Extensions.CommandLineUtils;
 using Moq;
 using NuGet.CommandLine.XPlat;
@@ -287,6 +288,178 @@ namespace NuGet.XPlat.FuncTest
                 var restoreResult = await command.ExecuteAsync(CancellationToken.None);
                 await restoreResult.CommitAsync(logger, CancellationToken.None);
                 Assert.True(restoreResult.Success, userMessage: logger.ShowMessages());
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteCommandAsync_ShouldUseAuditSources_WhenReportTypeIsVulnerable()
+        {
+            // Arrange
+            var advisoryUrl = "https://test/";
+            var severity = 2;
+            var mockRenderer = new Mock<IReportRenderer>();
+            var mockServer = new MockServer();
+            string index = $@"{{
+                    ""version"": ""3.0.0"",
+                    ""resources"": [
+                        {{
+                            ""@id"": ""{mockServer.Uri}v3/vulnerabilities/index.json"",
+                            ""@type"": ""VulnerabilityInfo/6.7.0"",
+                            ""comment"": ""This is a test feed for vulnerabilities""
+                        }}
+                    ]
+                }}";
+
+            string vulnerabilities = $@"
+[
+    {{
+        ""@name"": ""base"",
+        ""@id"": ""{mockServer.Uri}v3-vulnerabilities/2024.12.21.05.12.11/vulnerability.base.json"",
+        ""@updated"": ""2024-12-21T05:12:11.2008556Z"",
+        ""comment"": ""The base data for vulnerability update periodically""
+    }}
+]";
+
+            string baseVulnerability = $@"
+{{
+    ""mypkg"": [
+        {{
+            ""url"": ""{advisoryUrl}"",
+            ""severity"": {severity},
+            ""versions"": ""(, 5.8.4)""
+        }}
+    ]
+}}
+";
+            mockServer.Get.Add("/v3/index.json", r => index);
+            mockServer.Get.Add("/v3/vulnerabilities/index.json", r => vulnerabilities);
+            mockServer.Get.Add("/v3-vulnerabilities/2024.12.21.05.12.11/vulnerability.base.json", r => baseVulnerability);
+            mockServer.Start();
+
+            var auditSource = new PackageSource(mockServer.Uri + "v3/index.json");
+            auditSource.AllowInsecureConnections = true;
+
+            using (SimpleTestPathContext pathContext = new SimpleTestPathContext())
+            {
+                string projectFolder = Path.Combine(pathContext.SolutionRoot, "MyProject");
+                string csprojPath = Path.Combine(projectFolder, "MyProject.csproj");
+                string objFolder = Path.Combine(projectFolder, "obj");
+                string assetsPath = Path.Combine(objFolder, "project.assets.json");
+
+                //setup package
+                var packageContext = new SimpleTestPackageContext()
+                {
+                    Id = "mypkg",
+                    Version = "5.8.2",
+                    Nuspec = XDocument.Parse($@"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <package>
+                        <metadata>
+                            <id>mypkg</id>
+                            <version>5.8.2</version>
+                            <title />
+                            <frameworkAssemblies>
+                                <frameworkAssembly assemblyName=""System.Runtime"" />
+                            </frameworkAssemblies>
+                            <contentFiles>
+                                <files include=""lib/net45/mypkg.dll"" copyToOutput=""true"" flatten=""false"" />
+                            </contentFiles>
+                        </metadata>
+                        </package>")
+                };
+                await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packageContext);
+
+                // Define the content for csproj
+                var csprojContent = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include=""mypkg"" Version=""5.8.2"" />
+  </ItemGroup>
+</Project>";
+
+                // Define the content for assets.json
+                var assetsContent = @"
+{
+  ""version"": 3,
+  ""targets"": {
+    "".NETCoreApp,Version=v5.0"": {
+      ""mypkg/5.8.2"": {
+        ""type"": ""package"",
+        ""compile"": {
+          ""lib/net5.0/mypkg.dll"": {}
+        },
+        ""runtime"": {
+          ""lib/net5.0/mypkg.dll"": {}
+        }
+      }
+    }
+  },
+  ""libraries"": {
+    ""mypkg/5.8.2"": {
+      ""sha512"": ""<hash-value>"",
+      ""type"": ""package"",
+      ""path"": ""mypkg/5.8.2""
+    }
+  },
+  ""project"": {
+    ""version"": ""5.0"",
+    ""restore"": {
+      ""projectStyle"": ""PackageReference""
+    },
+    ""frameworks"": {
+      ""net5.0"": {
+        ""dependencies"": {
+          ""mypkg"": {
+            ""version"": ""5.8.2"",
+            ""type"": ""direct""
+          }
+        }
+      }
+    }
+  }
+}";
+                if (!Directory.Exists(projectFolder))
+                {
+                    Directory.CreateDirectory(projectFolder);
+                }
+
+                if (!Directory.Exists(objFolder))
+                {
+                    Directory.CreateDirectory(objFolder);
+                }
+
+                File.WriteAllText(csprojPath, csprojContent);
+                File.WriteAllText(assetsPath, assetsContent);
+
+                var listPackageArgs = new ListPackageArgs(
+                    path: csprojPath,
+                    packageSources: new List<PackageSource>() { new PackageSource(pathContext.PackageSource) },
+                    frameworks: new List<string>(),
+                    ReportType.Vulnerable,
+                    mockRenderer.Object,
+                    includeTransitive: true, prerelease: false, highestPatch: false, highestMinor: false,
+                    auditSources: new List<PackageSource> { auditSource },
+                    logger: new Mock<ILogger>().Object,
+                    CancellationToken.None);
+
+                var listPackageCommandRunner = new ListPackageCommandRunner();
+
+
+                // Act
+                var result = await listPackageCommandRunner.GetReportDataAsync(listPackageArgs);
+
+                // Assert
+                Assert.Equal(1, result.Item2.Projects.Count);
+                Assert.Equal(1, result.Item2.Projects.First().TargetFrameworkPackages.Count);
+                Assert.Equal(1, result.Item2.Projects.First().TargetFrameworkPackages.First().TopLevelPackages.Count);
+                Assert.Equal(1, result.Item2.Projects.First().TargetFrameworkPackages.First().TopLevelPackages.First().Vulnerabilities.Count);
+                Assert.Equal(severity, result.Item2.Projects[0].TargetFrameworkPackages[0].TopLevelPackages.First().Vulnerabilities.First().Severity);
+                Assert.Equal(advisoryUrl, result.Item2.Projects[0].TargetFrameworkPackages[0].TopLevelPackages.First().Vulnerabilities.First().AdvisoryUrl.ToString());
+
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -329,7 +329,7 @@ namespace NuGet.XPlat.FuncTest
         {
             Type listPackageArgsType = typeof(ListPackageArgs);
             FieldInfo[] fields = listPackageArgsType.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
-            Assert.True(12 == fields.Length, "Number of fields are changed in ListPackageArgs.cs. Please make sure this change is accounted for GetReportParameters method in that file.");
+            Assert.True(13 == fields.Length, "Number of fields are changed in ListPackageArgs.cs. Please make sure this change is accounted for GetReportParameters method in that file.");
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13767

## Description

This PR updates `dotnet list package --vulnerable` to use user configured `<AuditSources>`. 

Currently, the command only looks into `<PackageSources>` to load vulnerability data. However, with the introduction of NuGet Audit, other commands now support `<AuditSources>` to specify vulnerability data sources. This PR makes sure `dotnet list package --vulnerable` is also up to date and supports `<AuditSources>`

In order to do a manual test, I specified a package that has only one vulnerability data source. That source is only specified as an Audit source. This is what running `dotnet list package --vulnerable` results in before and after this PR

### Before
![image](https://github.com/user-attachments/assets/d05eda39-4495-48e7-9bfd-19c60047b1af)


### After
![image](https://github.com/user-attachments/assets/566c6619-da99-4153-b444-c7f9c12396c8)


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/14021
