### PR TITLE
Collect assets file change telemetry

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -61,6 +61,9 @@ namespace NuGet.Commands
         private const string TreatWarningsAsErrors = nameof(TreatWarningsAsErrors);
         private const string SDKAnalysisLevel = nameof(SDKAnalysisLevel);
         private const string UsingMicrosoftNETSdk = nameof(UsingMicrosoftNETSdk);
+        private const string UpdatedAssetsFile = nameof(UpdatedAssetsFile);
+        private const string UpdatedMSBuildFiles = nameof(UpdatedMSBuildFiles);
+        private const string IsPackageInstallationTrigger = nameof(IsPackageInstallationTrigger);
 
         // no-op data names
         private const string NoOpDuration = nameof(NoOpDuration);
@@ -71,6 +74,7 @@ namespace NuGet.Commands
         private const string NoOpRestoreOutputEvaluationResult = nameof(NoOpRestoreOutputEvaluationResult);
         private const string NoOpReplayLogsDuration = nameof(NoOpReplayLogsDuration);
         private const string NoOpCacheFileAgeDays = nameof(NoOpCacheFileAgeDays);
+        private const string ForceRestore = nameof(ForceRestore);
 
         // lock file data names
         private const string EvaluateLockFileDuration = nameof(EvaluateLockFileDuration);
@@ -292,7 +296,7 @@ namespace NuGet.Commands
                 restoreTime.Stop();
 
                 // Create result
-                return new RestoreResult(
+                var restoreResult = new RestoreResult(
                     _success,
                     graphs,
                     checkResults,
@@ -311,6 +315,11 @@ namespace NuGet.Commands
                 {
                     AuditRan = auditRan
                 };
+
+                telemetry.TelemetryEvent[UpdatedAssetsFile] = restoreResult._isAssetsFileDirty.Value;
+                telemetry.TelemetryEvent[UpdatedMSBuildFiles] = restoreResult._dirtyMSBuildFiles.Value.Count > 0;
+
+                return restoreResult;
             }
         }
 
@@ -329,9 +338,9 @@ namespace NuGet.Commands
             telemetry.TelemetryEvent[TargetFrameworksCount] = _request.Project.RestoreMetadata.TargetFrameworks.Count;
             telemetry.TelemetryEvent[RuntimeIdentifiersCount] = _request.Project.RuntimeGraph.Runtimes.Count;
             telemetry.TelemetryEvent[TreatWarningsAsErrors] = _request.Project.RestoreMetadata.ProjectWideWarningProperties.AllWarningsAsErrors;
-
             telemetry.TelemetryEvent[SDKAnalysisLevel] = _request.Project.RestoreMetadata.SdkAnalysisLevel;
             telemetry.TelemetryEvent[UsingMicrosoftNETSdk] = _request.Project.RestoreMetadata.UsingMicrosoftNETSdk;
+            telemetry.TelemetryEvent[IsPackageInstallationTrigger] = !_request.IsRestoreOriginalAction;
             _operationId = telemetry.OperationId;
 
             var isCpvmEnabled = _request.Project.RestoreMetadata?.CentralPackageVersionsEnabled ?? false;
@@ -357,6 +366,8 @@ namespace NuGet.Commands
             if (NuGetEventSource.IsEnabled) TraceEvents.CalcNoOpRestoreStop(_request.Project.FilePath);
 
             telemetry.TelemetryEvent[NoOpCacheFileEvaluationResult] = noOp;
+            telemetry.TelemetryEvent[ForceRestore] = !_request.AllowNoOp;
+
             telemetry.EndIntervalMeasure(NoOpCacheFileEvaluateDuration);
             if (noOp)
             {
@@ -381,6 +392,9 @@ namespace NuGet.Commands
                     telemetry.TelemetryEvent[RestoreSuccess] = _success;
                     telemetry.TelemetryEvent[TotalUniquePackagesCount] = cacheFile.ExpectedPackageFilePaths?.Count ?? -1;
                     telemetry.TelemetryEvent[NewPackagesInstalledCount] = 0;
+                    telemetry.TelemetryEvent[UpdatedAssetsFile] = false;
+                    telemetry.TelemetryEvent[UpdatedMSBuildFiles] = false;
+
                     if (cacheFileAge.HasValue) { telemetry.TelemetryEvent[NoOpCacheFileAgeDays] = cacheFileAge.Value.TotalDays; }
 
                     return (new NoOpRestoreResult(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -90,8 +90,8 @@ namespace NuGet.Commands
 
         private readonly DependencyGraphSpec _dependencyGraphSpec;
 
-        private readonly Lazy<bool> _isAssetsFileDirty;
-        private readonly Lazy<List<MSBuildOutputFile>> _dirtyMSBuildFiles;
+        internal readonly Lazy<bool> _isAssetsFileDirty;
+        internal readonly Lazy<List<MSBuildOutputFile>> _dirtyMSBuildFiles;
 
 
         public RestoreResult(

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -2907,6 +2907,10 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 ["TreatWarningsAsErrors"] = value => value.Should().Be(false),
                 ["SDKAnalysisLevel"] = value => value.Should().Be(null),
                 ["UsingMicrosoftNETSdk"] = value => value.Should().Be(false),
+                ["IsPackageInstallationTrigger"] = value => value.Should().Be(false),
+                ["ForceRestore"] = value => value.Should().Be(false),
+                ["UpdatedAssetsFile"] = value => value.Should().Be(true),
+                ["UpdatedMSBuildFiles"] = value => value.Should().Be(true),
             };
 
             HashSet<string> actualProperties = new();
@@ -2981,7 +2985,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
             var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
 
-            projectInformationEvent.Count.Should().Be(30);
+            projectInformationEvent.Count.Should().Be(34);
             projectInformationEvent["RestoreSuccess"].Should().Be(true);
             projectInformationEvent["NoOpResult"].Should().Be(true);
             projectInformationEvent["IsCentralVersionManagementEnabled"].Should().Be(false);
@@ -3012,6 +3016,10 @@ namespace NuGet.Commands.Test.RestoreCommandTests
             projectInformationEvent["TreatWarningsAsErrors"].Should().Be(true);
             projectInformationEvent["SDKAnalysisLevel"].Should().Be(NuGetVersion.Parse("9.0.100"));
             projectInformationEvent["UsingMicrosoftNETSdk"].Should().Be(true);
+            projectInformationEvent["IsPackageInstallationTrigger"].Should().Be(false);
+            projectInformationEvent["ForceRestore"].Should().Be(false);
+            projectInformationEvent["UpdatedAssetsFile"].Should().Be(false);
+            projectInformationEvent["UpdatedMSBuildFiles"].Should().Be(false);
         }
 
         [Fact]
@@ -3069,12 +3077,16 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
             var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
 
-            projectInformationEvent.Count.Should().Be(36);
+            projectInformationEvent.Count.Should().Be(40);
             projectInformationEvent["RestoreSuccess"].Should().Be(true);
             projectInformationEvent["NoOpResult"].Should().Be(false);
             projectInformationEvent["TotalUniquePackagesCount"].Should().Be(2);
             projectInformationEvent["NewPackagesInstalledCount"].Should().Be(1);
             projectInformationEvent["PackageSourceMapping.IsMappingEnabled"].Should().Be(false);
+            projectInformationEvent["UpdatedAssetsFile"].Should().Be(true);
+            projectInformationEvent["UpdatedMSBuildFiles"].Should().Be(true);
+            projectInformationEvent["IsPackageInstallationTrigger"].Should().Be(false);
+            projectInformationEvent["ForceRestore"].Should().Be(false);
         }
 
         /// A 1.0.0 -> C 1.0.0 -> D 1.1.0


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Related: https://github.com/NuGet/Home/issues/6987 

## Description

I have a theory that a very, very large majority of force restore (or effective VS rebuild) events *do not* change the assets file.
The idea is that we don't need to do force restore during a rebuild, thus saving CPU time.

In this change, I'll add new properties to the restore event, to help me validate that theory.

- ForceRestore (I know the name is opposite from the property, but that ship has sailed, in vs/nuget/restoreinformation we already have this property so this just makes the values consistent).
- UpdatedAssetsFile - indicates whether the assets file needs to be updated as a consequence of this restore
- UpdatedMSBuildFiles - indicates whether the msbuild files need to be updated as a consequence of this restore
- IsPackageInstallationTrigger - tells that a restore was triggered due to a PM UI or PMC package installation. In this case, we should ignore any no-op specifics. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
