### PR TITLE
Add new test cases for "ASP.NET Dynamic Data Linq to SQL Web Site" project into Daily Tests pipeline

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
@@ -27,12 +27,13 @@ namespace NuGet.Tests.Apex.Daily
         }
 
         [TestMethod]
-        [DataRow(ProjectTemplate.WebSiteEmpty)]
-        [DataRow(ProjectTemplate.WebSite)]
-        [DataRow(ProjectTemplate.WebSiteRazorV3)]
-        [DataRow(ProjectTemplate.WebSiteDynamicDataEntityFramework)]
+        [DataRow(ProjectTemplate.WebSiteEmpty, ProjectTargetFramework.V48)]
+        [DataRow(ProjectTemplate.WebSite, ProjectTargetFramework.V48)]
+        [DataRow(ProjectTemplate.WebSiteRazorV3, ProjectTargetFramework.V48)]
+        [DataRow(ProjectTemplate.WebSiteDynamicDataEntityFramework, ProjectTargetFramework.V48)]
+        [DataRow(ProjectTemplate.WebSiteDynamicDataLinqToSql, ProjectTargetFramework.V452)]
         [Timeout(DefaultTimeout)]
-        public async Task InstallPackageToWebSiteProjectFromUI(ProjectTemplate projectTemplate)
+        public async Task InstallPackageToWebSiteProjectFromUI(ProjectTemplate projectTemplate, ProjectTargetFramework projectTargetFramework)
         {
             // Arrange
             await CommonUtility.CreatePackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1);
@@ -41,7 +42,7 @@ namespace NuGet.Tests.Apex.Daily
 
             SolutionService solutionService = VisualStudio.Get<SolutionService>();
             solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
-            ProjectTestExtension project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V48, "TestProject");
+            ProjectTestExtension project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, projectTargetFramework, "TestProject");
 
             VisualStudio.ClearOutputWindow();
             solutionService.SaveAll();
@@ -56,12 +57,13 @@ namespace NuGet.Tests.Apex.Daily
         }
 
         [TestMethod]
-        [DataRow(ProjectTemplate.WebSiteEmpty)]
-        [DataRow(ProjectTemplate.WebSite)]
-        [DataRow(ProjectTemplate.WebSiteRazorV3)]
-        [DataRow(ProjectTemplate.WebSiteDynamicDataEntityFramework)]
+        [DataRow(ProjectTemplate.WebSiteEmpty, ProjectTargetFramework.V48)]
+        [DataRow(ProjectTemplate.WebSite, ProjectTargetFramework.V48)]
+        [DataRow(ProjectTemplate.WebSiteRazorV3, ProjectTargetFramework.V48)]
+        [DataRow(ProjectTemplate.WebSiteDynamicDataEntityFramework, ProjectTargetFramework.V48)]
+        [DataRow(ProjectTemplate.WebSiteDynamicDataLinqToSql, ProjectTargetFramework.V452)]
         [Timeout(DefaultTimeout)]
-        public async Task UpdateWebSitePackageFromUI(ProjectTemplate projectTemplate)
+        public async Task UpdateWebSitePackageFromUI(ProjectTemplate projectTemplate, ProjectTargetFramework projectTargetFramework)
         {
             // Arrange
             await CommonUtility.CreatePackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1);
@@ -71,7 +73,7 @@ namespace NuGet.Tests.Apex.Daily
 
             SolutionService solutionService = VisualStudio.Get<SolutionService>();
             solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
-            ProjectTestExtension project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V48, "TestProject");
+            ProjectTestExtension project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, projectTargetFramework, "TestProject");
 
             VisualStudio.ClearOutputWindow();
             solutionService.SaveAll();
@@ -88,12 +90,13 @@ namespace NuGet.Tests.Apex.Daily
         }
 
         [TestMethod]
-        [DataRow(ProjectTemplate.WebSiteEmpty)]
-        [DataRow(ProjectTemplate.WebSite)]
-        [DataRow(ProjectTemplate.WebSiteRazorV3)]
-        [DataRow(ProjectTemplate.WebSiteDynamicDataEntityFramework)]
+        [DataRow(ProjectTemplate.WebSiteEmpty, ProjectTargetFramework.V48)]
+        [DataRow(ProjectTemplate.WebSite, ProjectTargetFramework.V48)]
+        [DataRow(ProjectTemplate.WebSiteRazorV3, ProjectTargetFramework.V48)]
+        [DataRow(ProjectTemplate.WebSiteDynamicDataEntityFramework, ProjectTargetFramework.V48)]
+        [DataRow(ProjectTemplate.WebSiteDynamicDataLinqToSql, ProjectTargetFramework.V452)]
         [Timeout(DefaultTimeout)]
-        public async Task UninstallWebSitePackageFromUI(ProjectTemplate projectTemplate)
+        public async Task UninstallWebSitePackageFromUI(ProjectTemplate projectTemplate, ProjectTargetFramework projectTargetFramework)
         {
             // Arrange
             await CommonUtility.CreatePackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1);
@@ -102,7 +105,7 @@ namespace NuGet.Tests.Apex.Daily
 
             SolutionService solutionService = VisualStudio.Get<SolutionService>();
             solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
-            ProjectTestExtension project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V48, "TestProject");
+            ProjectTestExtension project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, projectTargetFramework, "TestProject");
 
             VisualStudio.ClearOutputWindow();
             solutionService.SaveAll();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3116

## Description
1. Add the "ASP.NET Dynamic Data Linq to SQL Web Site" project template to web site test case.
2. Adjust the ProjectTargetFramework call to apply different web site project since the "ASP.NET Dynamic Data Linq to SQL Web Site" ProjectTargetFramework is V452 and the ProjectTargetFramework for other web site projects is V48.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
