### PR TITLE
Fix formatting in GraphOperations

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -872,7 +872,7 @@ namespace NuGet.DependencyResolver
                 // Some node were marked ambiguous, thus we need another run to check if nodes previously not marked ambiguous should be marked ambiguous this time.
                 if (!nodeMarkedAmbiguous)
                     break;
-            };
+            }
         }
 
         private static void RejectCentralTransitiveBecauseOfRejectedParents<TItem>(this GraphNode<TItem> root, Tracker<TItem> tracker, List<GraphNode<TItem>> centralTransitiveNodes)


### PR DESCRIPTION
When using the latest daily build of .NET 10 SDK to build this repo, it causes the following error:

```
/__w/1/vmr/src/nuget-client/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs(875,14): error IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [/__w/1/vmr/src/nuget-client/src/NuGet.Core/NuGet.DependencyResolver.Core/NuGet.DependencyResolver.Core.csproj]
```

This is fixed by removing an unnecessary semi-colon in the `GraphOperations` class.