### PR TITLE
Cleanup ServiceProviderExtensions, remove GetFreeThreadedServiceAsync as it's not longer needed

### DIFF
--- a/build/BannedSymbols.txt
+++ b/build/BannedSymbols.txt
@@ -14,9 +14,8 @@ M: System.Xml.XmlReader.Create(string inputUri, System.Xml.XmlReaderSettings? se
 M:Microsoft.VisualStudio.Shell.VsTaskLibraryHelper.FileAndForget(System.Threading.Tasks.Task,System.String,System.String,System.Func{System.Exception,System.Boolean}); NuGet.VisualStudio.Telemetry.INuGetTelemetryProvider.PostFault, NuGet.VisualStudio.Telemetry.TelemetryUtility.PostFaultAsync or NuGet.VisualStudio.Telemetry.INuGetTelemetryProvider.PostFaultAsync
 M:Microsoft.VisualStudio.Shell.VsTaskLibraryHelper.FileAndForget(Microsoft.VisualStudio.Threading.JoinableTask,System.String,System.String,System.Func{System.Exception,System.Boolean}); NuGet.VisualStudio.Telemetry.INuGetTelemetryProvider.PostFault, NuGet.VisualStudio.Telemetry.TelemetryUtility.PostFaultAsync or NuGet.VisualStudio.Telemetry.INuGetTelemetryProvider.PostFaultAsync
 
-M:Microsoft.VisualStudio.Shell.IAsyncServiceProvider.GetServiceAsync(System.Type); Do not use this method. Use the Microsoft.VisualStudio.Shell.ServiceExtensions.GetServiceAsync for services that have UI thread affinity or that you don't know about their affinity, and use NuGet.VisualStudio.ServiceProviderExtensions.GetFreeThreadedServiceAsync<TService, TInterface> for free threaded services.
-M:Microsoft.VisualStudio.Shell.AsyncPackage.GetServiceAsync(System.Type); Do not retrieve services from AsyncPackage, use the Async Service provider instead, which that class implements. Use the Microsoft.VisualStudio.Shell.ServiceExtensions.GetServiceAsync for services that have UI thread affinity or that you don't know about their affinity, and use NuGet.VisualStudio.ServiceProviderExtensions.GetFreeThreadedServiceAsync<TService, TInterface> for free threaded services.
-
+M:Microsoft.VisualStudio.Shell.IAsyncServiceProvider.GetServiceAsync(System.Type); Do not use this method. Use Microsoft.VisualStudio.Shell.ServiceExtensions.GetServiceAsync instead.
+M:Microsoft.VisualStudio.Shell.AsyncPackage.GetServiceAsync(System.Type); Do not retrieve services from AsyncPackage, use the Async Service provider instead, which that class implements. Use Microsoft.VisualStudio.Shell.ServiceExtensions.GetServiceAsync instead.
 M:System.IO.Path.GetTempPath(); Use NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp)
 
 M:NuGet.Protocol.Core.Types.SourceRepository.GetResource`1(); Pass a cancellation token

--- a/src/NuGet.Clients/NuGet.Console/OutputConsole/ChannelOutputConsole.cs
+++ b/src/NuGet.Clients/NuGet.Console/OutputConsole/ChannelOutputConsole.cs
@@ -10,9 +10,9 @@ using Microsoft;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.RpcContracts.OutputChannel;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
 using Microsoft.VisualStudio.Threading;
-using NuGet.VisualStudio;
 using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
 using Task = System.Threading.Tasks.Task;
 
@@ -50,7 +50,7 @@ namespace NuGetConsole
 
             _serviceBrokerClient = new AsyncLazy<ServiceBrokerClient>(async () =>
             {
-                IBrokeredServiceContainer container = await asyncServiceProvider.GetFreeThreadedServiceAsync<SVsBrokeredServiceContainer, IBrokeredServiceContainer>();
+                IBrokeredServiceContainer container = await asyncServiceProvider.GetServiceAsync<SVsBrokeredServiceContainer, IBrokeredServiceContainer>();
                 Assumes.Present(container);
                 IServiceBroker serviceBroker = container.GetFullAccessServiceBroker();
                 return new ServiceBrokerClient(serviceBroker, _joinableTaskFactory);

--- a/src/NuGet.Clients/NuGet.Console/Utils/CommandUiUtilities.cs
+++ b/src/NuGet.Clients/NuGet.Console/Utils/CommandUiUtilities.cs
@@ -16,7 +16,7 @@ namespace NuGetConsole
         static CommandUiUtilities()
         {
             CommandStateCacheInvalidator = new AsyncLazy<IVsInvalidateCachedCommandState>(
-                () => ServiceLocator.GetGlobalServiceFreeThreadedAsync<SVsInvalidateCachedCommandState, IVsInvalidateCachedCommandState>(),
+                () => ServiceLocator.GetGlobalServiceAsync<SVsInvalidateCachedCommandState, IVsInvalidateCachedCommandState>(),
                 NuGetUIThreadHelper.JoinableTaskFactory);
         }
 

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -192,7 +192,7 @@ namespace NuGetVSExtension
 
             VsShellUtilities.ShutdownToken.Register(InstanceCloseTelemetryEmitter.OnShutdown);
 
-            var componentModel = await this.GetFreeThreadedServiceAsync<SComponentModel, IComponentModel>();
+            var componentModel = await this.GetServiceAsync<SComponentModel, IComponentModel>();
             Assumes.Present(componentModel);
             componentModel.DefaultCompositionService.SatisfyImportsOnce(this);
         }
@@ -209,7 +209,7 @@ namespace NuGetVSExtension
                     return;
                 }
 
-                var componentModel = await this.GetFreeThreadedServiceAsync<SComponentModel, IComponentModel>();
+                var componentModel = await this.GetServiceAsync<SComponentModel, IComponentModel>();
                 Assumes.Present(componentModel);
 
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
@@ -52,27 +52,6 @@ namespace NuGet.VisualStudio
         }
 
         /// <summary>
-        /// Fetches a service from the service provider in a free threaded fashion (ie. no UI thread transitions).
-        /// </summary>
-        /// <typeparam name="TService">Service type</typeparam>
-        /// <typeparam name="TInterface">Service interface</typeparam>
-        /// <returns>The service if available, null otherwise.</returns>
-        public static async Task<TInterface> GetGlobalServiceFreeThreadedAsync<TService, TInterface>() where TInterface : class
-        {
-            if (PackageServiceProvider != null)
-            {
-                TInterface service = await PackageServiceProvider.GetFreeThreadedServiceAsync<TService, TInterface>();
-
-                if (service != null)
-                {
-                    return service;
-                }
-            }
-
-            return await AsyncServiceProvider.GlobalProvider.GetServiceAsync<TService, TInterface>();
-        }
-
-        /// <summary>
         /// Fetches a MEF registered service if available.
         /// This method should be called from a background thread only. 
         /// </summary>
@@ -96,7 +75,7 @@ namespace NuGet.VisualStudio
 
         public static async Task<IComponentModel> GetComponentModelAsync()
         {
-            return await GetGlobalServiceFreeThreadedAsync<SComponentModel, IComponentModel>();
+            return await GetGlobalServiceAsync<SComponentModel, IComponentModel>();
         }
 
         public static async Task<IServiceProvider> GetServiceProviderAsync()

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
@@ -42,13 +42,7 @@ namespace NuGet.VisualStudio
                 }
             }
 
-            // VS Threading Rule #1
-            // Access to ServiceProvider and a lot of casts are performed in this method,
-            // and so this method can RPC into main thread. Switch to main thread explictly, since method has STA requirement
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-            // This is a fallback, primarily hit in tests.
-            return Package.GetGlobalService(typeof(TService)) as TInterface;
+            return await AsyncServiceProvider.GlobalProvider.GetServiceAsync<TService, TInterface>(throwOnFailure: false);
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceProviderExtensions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceProviderExtensions.cs
@@ -25,24 +25,6 @@ namespace NuGet.VisualStudio
         {
             return site.GetServiceAsync<SComponentModel, IComponentModel>();
         }
-
-#pragma warning disable RS0030 // Do not used banned APIs
-        /// <summary>
-        /// Use this to acquire services that *do not* have UI thread dependencies.
-        /// Under the hood, this method simply justs <see cref="IAsyncServiceProvider.GetServiceAsync(Type)"/>
-        /// </summary>
-        /// <typeparam name="TService">Service type</typeparam>
-        /// <typeparam name="TInterface">Interface type</typeparam>
-        /// <param name="site">Service Provider</param>
-        /// <returns>Service from the given ServiceProvider.</returns>
-        public static async Task<TInterface> GetFreeThreadedServiceAsync<TService, TInterface>(this IAsyncServiceProvider site) where TInterface : class
-        {
-            // Note that using Microsoft.VisualStudio.Shell.ServiceExtensions.GetServiceAsync<TService, TInterface>()
-            // is not appropriate because that method always switches to the UI thread to cast to the Interface.
-            object service = await site.GetServiceAsync(typeof(TService));
-            return service as TInterface;
-        }
-#pragma warning restore RS0030 // Do not used banned APIs
     }
 }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VsCredentialProviderImporterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VsCredentialProviderImporterTests.cs
@@ -81,16 +81,5 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             providers.Should().BeEmpty();
             _errorMessages.Should().BeEmpty();
         }
-
-        [Fact]
-        public async Task WhenVstsIntializerThrows_ThenExceptionBubblesOut()
-        {
-            // Arrange
-            var importer = new VsCredentialProviderImporter(_errorDelegate);
-
-            // Act & Assert
-            await Assert.ThrowsAsync<ServiceUnavailableException>(() => importer.GetProvidersAsync());
-            _errorMessages.Should().BeEmpty();
-        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/14007

## Description

Use the extension method https://learn.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.serviceextensions.getserviceasync?view=visualstudiosdk-2022 for service provider lookups. We no longer need our custom free threaded lookups.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~ All existing tests should catch this.
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
