### PR TITLE
dotnet nuget why test reports missing argument when only path provided

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommand.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Help;
+using System.CommandLine.Parsing;
 using System.IO;
 using Microsoft.Extensions.CommandLineUtils;
 
@@ -49,7 +50,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
                 Arity = ArgumentArity.ZeroOrMore,
                 CustomParser = ar =>
                 {
-                    if (ar.Tokens.Count > 1)
+                    if (HasPathArgument(ar))
                     {
                         var value = ar.Tokens[0];
                         ar.OnlyTake(1);
@@ -59,6 +60,18 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
                     ar.OnlyTake(0);
                     var currentDirectory = Directory.GetCurrentDirectory();
                     return currentDirectory;
+
+                    bool HasPathArgument(ArgumentResult ar)
+                    {
+                        // If there's only one argument, it could be the path, or the package.
+                        if (ar.Tokens.Count == 1)
+                        {
+                            var value = ar.Tokens[0].Value;
+                            return File.Exists(value) || Directory.Exists(value);
+                        }
+
+                        return ar.Tokens.Count > 1;
+                    }
                 }
             };
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
@@ -169,7 +169,7 @@ namespace Dotnet.Integration.Test
             Assert.Contains($"Required argument missing for command: 'why'.", result.Errors);
         }
 
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/14030")]
+        [Fact]
         public void WhyCommand_EmptyPackageArgument_Fails()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14030

## Description

When `dotnet nuget why` only gets a single argument, check if the argument matches a file or directory name, and if so, use it as the path, rather than a package id. This allows System.CommandLine to correctly output a "required argument missing" error.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ n/a
