### PR TITLE
Use new serializer library to parse solution files

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -193,6 +193,7 @@
       <_allowBuildFromSourcePackage Include="Microsoft.Extensions.CommandLineUtils.Sources" />
       <_allowBuildFromSourcePackage Include="Microsoft.Extensions.FileProviders.Abstractions" />
       <_allowBuildFromSourcePackage Include="Microsoft.Extensions.FileSystemGlobbing" />
+      <_allowBuildFromSourcePackage Include="Microsoft.VisualStudio.SolutionPersistence" />
       <_allowBuildFromSourcePackage Include="Microsoft.Web.Xdt" />
       <_allowBuildFromSourcePackage Include="Newtonsoft.Json" />
       <_allowBuildFromSourcePackage Include="System.Collections.Immutable" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -72,6 +72,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.Managed" Version="17.2.0-beta1-20502-01" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS" Version="17.2.0-beta1-20502-01" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.VS" Version="17.4.221-pre" />
+    <PackageVersion Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.28" />
     <!-- Microsoft.VisualStudio.SDK has vulnerable dependencies System.Text.json and Microsoft.IO.Redist. When it's upgraded, try removing the pinned packages -->
     <PackageVersion Include="Microsoft.VisualStudio.SDK" Version="17.11.39714" />
     <PackageVersion Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" Version="17.11.8" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -30,6 +30,7 @@
       <package pattern="Microsoft.*" />
       <package pattern="Microsoft.Build.Framework" />
       <package pattern="Microsoft.NET.StringTools" />
+      <package pattern="Microsoft.VisualStudio.SolutionPersistence" />
       <package pattern="Microsoft.VisualStudio.TemplateWizardInterface" />
       <package pattern="moq" />
       <package pattern="MSTest.TestAdapter" />

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -46,6 +46,7 @@
     <UsagePattern IdentityGlob="Microsoft.NETCore.Platforms/*" />
     <UsagePattern IdentityGlob="Microsoft.NETCore.Targets/*" />
     <UsagePattern IdentityGlob="Microsoft.VisualStudio.Setup.Configuration.Interop/*" />
+    <UsagePattern IdentityGlob="Microsoft.VisualStudio.SolutionPersistence/*" />
     <UsagePattern IdentityGlob="Microsoft.Web.Xdt/*" />
     <UsagePattern IdentityGlob="Microsoft.Win32.Registry/*" />
     <UsagePattern IdentityGlob="Microsoft.Win32.SystemEvents/*" />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -58,8 +58,10 @@ namespace NuGet.CommandLine.XPlat
 
             //If the given file is a solution, get the list of projects
             //If not, then it's a project, which is put in a list
-            var projectsPaths = Path.GetExtension(listPackageArgs.Path).Equals(".sln", PathUtility.GetStringComparisonBasedOnOS()) ?
-                           MSBuildAPIUtility.GetProjectsFromSolution(listPackageArgs.Path).Where(f => File.Exists(f)) :
+            var projectsPaths =
+                (Path.GetExtension(listPackageArgs.Path).Equals(".sln", PathUtility.GetStringComparisonBasedOnOS()) ||
+                     Path.GetExtension(listPackageArgs.Path).Equals(".slnx", PathUtility.GetStringComparisonBasedOnOS())) ?
+                           (await MSBuildAPIUtility.GetProjectsFromSolution(listPackageArgs.Path, listPackageArgs.CancellationToken)).Where(f => File.Exists(f)) :
                            new List<string>(new string[] { listPackageArgs.Path });
 
             MSBuildAPIUtility msBuild = listPackageReportModel.MSBuildAPIUtility;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommandArgs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommandArgs.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace NuGet.CommandLine.XPlat.Commands.Why
 {
@@ -14,6 +15,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         public string Package { get; }
         public List<string> Frameworks { get; }
         public ILoggerWithColor Logger { get; }
+        public CancellationToken CancellationToken { get; }
 
         /// <summary>
         /// A constructor for the arguments of the 'why' command.
@@ -22,16 +24,19 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         /// <param name="package">The package for which we show the dependency graphs.</param>
         /// <param name="frameworks">The target framework(s) for which we show the dependency graphs.</param>
         /// <param name="logger"></param>
+        /// <param name="cancellationToken"></param>
         public WhyCommandArgs(
             string path,
             string package,
             List<string> frameworks,
-            ILoggerWithColor logger)
+            ILoggerWithColor logger,
+            CancellationToken cancellationToken)
         {
             Path = path ?? throw new ArgumentNullException(nameof(path));
             Package = package ?? throw new ArgumentNullException(nameof(package));
             Frameworks = frameworks ?? throw new ArgumentNullException(nameof(frameworks));
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            CancellationToken = cancellationToken; // can't use null-coalescing because CancellationToken is a struct
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommandArgs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommandArgs.cs
@@ -36,7 +36,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
             Package = package ?? throw new ArgumentNullException(nameof(package));
             Frameworks = frameworks ?? throw new ArgumentNullException(nameof(frameworks));
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            CancellationToken = cancellationToken; // can't use null-coalescing because CancellationToken is a struct
+            CancellationToken = cancellationToken;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
     <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" />
   </ItemGroup>
 
   <!-- Microsoft.Build.Locator is needed when debugging, but should not be used in the assemblies we insert. -->

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs
@@ -132,7 +132,7 @@ namespace NuGet.CommandLine.XPlat
             {
                 var extension = System.IO.Path.GetExtension(fileName);
 
-                return string.Equals(extension, ".sln", StringComparison.OrdinalIgnoreCase);
+                return string.Equals(extension, ".sln", StringComparison.OrdinalIgnoreCase) || string.Equals(extension, ".slnx", StringComparison.OrdinalIgnoreCase);
             }
 
             return false;

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatWhyTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.CommandLine.XPlat;
 using NuGet.CommandLine.XPlat.Commands.Why;
@@ -53,10 +54,11 @@ namespace NuGet.XPlat.FuncTest
                     project.ProjectPath,
                     packageY.Id,
                     [projectFramework],
-                    logger);
+                    logger,
+                    CancellationToken.None);
 
             // Act
-            var result = WhyCommandRunner.ExecuteCommand(whyCommandArgs);
+            var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
 
             // Assert
             var output = logger.ShowMessages();
@@ -95,10 +97,11 @@ namespace NuGet.XPlat.FuncTest
                     project.ProjectPath,
                     packageZ.Id,
                     [projectFramework],
-                    logger);
+                    logger,
+                    CancellationToken.None);
 
             // Act
-            var result = WhyCommandRunner.ExecuteCommand(whyCommandArgs);
+            var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
 
             // Assert
             var output = logger.ShowMessages();
@@ -108,7 +111,7 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
-        public void WhyCommand_ProjectDidNotRunRestore_Fails()
+        public async Task WhyCommand_ProjectDidNotRunRestore_Fails()
         {
             // Arrange
             var logger = new TestCommandOutputLogger(_testOutputHelper);
@@ -128,10 +131,11 @@ namespace NuGet.XPlat.FuncTest
                     project.ProjectPath,
                     packageY.Id,
                     [projectFramework],
-                    logger);
+                    logger,
+                    CancellationToken.None);
 
             // Act
-            var result = WhyCommandRunner.ExecuteCommand(whyCommandArgs);
+            var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
 
             // Assert
             var output = logger.ShowMessages();
@@ -141,7 +145,7 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
-        public void WhyCommand_EmptyProjectArgument_Fails()
+        public async Task WhyCommand_EmptyProjectArgument_Fails()
         {
             // Arrange
             var logger = new TestCommandOutputLogger(_testOutputHelper);
@@ -150,10 +154,11 @@ namespace NuGet.XPlat.FuncTest
                     "",
                     "PackageX",
                     [],
-                    logger);
+                    logger,
+                    CancellationToken.None);
 
             // Act
-            var result = WhyCommandRunner.ExecuteCommand(whyCommandArgs);
+            var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
 
             // Assert
             var errorOutput = logger.ShowErrors();
@@ -163,7 +168,7 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
-        public void WhyCommand_EmptyPackageArgument_Fails()
+        public async Task WhyCommand_EmptyPackageArgument_Fails()
         {
             // Arrange
             var logger = new TestCommandOutputLogger(_testOutputHelper);
@@ -176,10 +181,11 @@ namespace NuGet.XPlat.FuncTest
                     project.ProjectPath,
                     "",
                     [],
-                    logger);
+                    logger,
+                    CancellationToken.None);
 
             // Act
-            var result = WhyCommandRunner.ExecuteCommand(whyCommandArgs);
+            var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
 
             // Assert
             var errorOutput = logger.ShowErrors();
@@ -189,7 +195,7 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
-        public void WhyCommand_InvalidProject_Fails()
+        public async Task WhyCommand_InvalidProject_Fails()
         {
             // Arrange
             var logger = new TestCommandOutputLogger(_testOutputHelper);
@@ -200,10 +206,11 @@ namespace NuGet.XPlat.FuncTest
                     fakeProjectPath,
                     "PackageX",
                     [],
-                    logger);
+                    logger,
+                    CancellationToken.None);
 
             // Act
-            var result = WhyCommandRunner.ExecuteCommand(whyCommandArgs);
+            var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
 
             // Assert
             var errorOutput = logger.ShowErrors();
@@ -243,10 +250,11 @@ namespace NuGet.XPlat.FuncTest
                     project.ProjectPath,
                     packageY.Id,
                     [inputFrameworksOption, projectFramework],
-                    logger);
+                    logger,
+                    CancellationToken.None);
 
             // Act
-            var result = WhyCommandRunner.ExecuteCommand(whyCommandArgs);
+            var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
 
             // Assert
             var output = logger.ShowMessages();

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Why/WhyCommandLineParsingTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Why/WhyCommandLineParsingTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.CommandLine;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NuGet.CommandLine.XPlat.Commands;
 using NuGet.CommandLine.XPlat.Commands.Why;
@@ -38,7 +39,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
                 whyCommandArgs.Path.Should().Be(@"path\to\my.proj");
                 whyCommandArgs.Package.Should().Be("packageid");
                 whyCommandArgs.Frameworks.Should().BeNullOrEmpty();
-                return 0;
+                return Task.FromResult(0);
             });
 
             // Act
@@ -59,7 +60,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
                 whyCommandArgs.Path.Should().NotBeNull();
                 whyCommandArgs.Package.Should().Be("packageid");
                 whyCommandArgs.Frameworks.Should().BeNullOrEmpty();
-                return 0;
+                return Task.FromResult(0);
             });
 
             // Act
@@ -117,7 +118,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
                 whyCommandArgs.Path.Should().Be("my.proj");
                 whyCommandArgs.Package.Should().Be("packageid");
                 whyCommandArgs.Frameworks.Should().Equal(["net8.0"]);
-                return 0;
+                return Task.FromResult(0);
             });
 
             // Act
@@ -140,7 +141,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
                 whyCommandArgs.Path.Should().Be("my.proj");
                 whyCommandArgs.Package.Should().Be("packageid");
                 whyCommandArgs.Frameworks.Should().Equal(["net8.0"]);
-                return 0;
+                return Task.FromResult(0);
             });
 
             // Act
@@ -161,7 +162,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
                 whyCommandArgs.Path.Should().Be("my.proj");
                 whyCommandArgs.Package.Should().Be("packageid");
                 whyCommandArgs.Frameworks.Should().Equal(["net8.0", "net481"]);
-                return 0;
+                return Task.FromResult(0);
             });
 
             // Act
@@ -182,7 +183,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
                 whyCommandArgs.Path.Should().Be("my.proj");
                 whyCommandArgs.Package.Should().Be("packageid");
                 whyCommandArgs.Frameworks.Should().Equal(["net8.0", "net481"]);
-                return 0;
+                return Task.FromResult(0);
             });
 
             // Act

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Locator;
@@ -57,8 +58,8 @@ namespace NuGet.CommandLine.Xplat.Tests
             File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);
 
             string projectContent =
-@$"<Project Sdk=""Microsoft.NET.Sdk"">    
-	<PropertyGroup>                   
+@$"<Project Sdk=""Microsoft.NET.Sdk"">
+	<PropertyGroup>
 	<TargetFramework>net6.0</TargetFramework>
 	</PropertyGroup>
 </Project>";
@@ -97,7 +98,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             // Arrange project file
             string projectContent =
 @$"<Project Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>                   
+<PropertyGroup>
 <TargetFramework>net6.0</TargetFramework>
 </PropertyGroup>
 </Project>";
@@ -151,7 +152,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             // Arrange project file
             string projectContent =
 @$"<Project Sdk=""Microsoft.NET.Sdk"">
-<PropertyGroup>                   
+<PropertyGroup>
 <TargetFramework>net6.0</TargetFramework>
 </PropertyGroup>
 <ItemGroup>
@@ -219,8 +220,8 @@ namespace NuGet.CommandLine.Xplat.Tests
 
             // Arrange project file
             string projectContent =
-@$"<Project Sdk=""Microsoft.NET.Sdk"">    
-	<PropertyGroup>                   
+@$"<Project Sdk=""Microsoft.NET.Sdk"">
+	<PropertyGroup>
 	<TargetFramework>net6.0</TargetFramework>
 	</PropertyGroup>
 </Project>";
@@ -287,8 +288,8 @@ namespace NuGet.CommandLine.Xplat.Tests
 
             // Arrange project file
             string projectContent =
-@$"<Project Sdk=""Microsoft.NET.Sdk"">    
-	<PropertyGroup>                   
+@$"<Project Sdk=""Microsoft.NET.Sdk"">
+	<PropertyGroup>
 	<TargetFramework>net6.0</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -356,8 +357,8 @@ namespace NuGet.CommandLine.Xplat.Tests
 
             // Arrange project file
             string projectContent =
-@$"<Project Sdk=""Microsoft.NET.Sdk"">    
-	<PropertyGroup>                   
+@$"<Project Sdk=""Microsoft.NET.Sdk"">
+	<PropertyGroup>
 	<TargetFramework>net6.0</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
@@ -459,7 +460,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         }
 
         [Fact]
-        public void GetListOfProjectsFromPathArgument_WithProjectFile_ReturnsCorrectPaths()
+        public async Task GetListOfProjectsFromPathArgument_WithProjectFile_ReturnsCorrectPaths()
         {
             // Arrange
             var pathContext = new SimpleTestPathContext();
@@ -470,7 +471,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             projectA.Save();
 
             // Act
-            var projectList = MSBuildAPIUtility.GetListOfProjectsFromPathArgument(projectA.ProjectPath);
+            var projectList = await MSBuildAPIUtility.GetListOfProjectsFromPathArgumentAsync(projectA.ProjectPath);
 
             // Assert
             Assert.Equal(projectList.Count(), 1);
@@ -478,7 +479,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         }
 
         [Fact]
-        public void GetListOfProjectsFromPathArgument_WithProjectDirectory_ReturnsCorrectPaths()
+        public async Task GetListOfProjectsFromPathArgument_WithProjectDirectory_ReturnsCorrectPaths()
         {
             // Arrange
             var pathContext = new SimpleTestPathContext();
@@ -489,7 +490,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             projectA.Save();
 
             // Act
-            var projectList = MSBuildAPIUtility.GetListOfProjectsFromPathArgument(Path.GetDirectoryName(projectA.ProjectPath));
+            var projectList = await MSBuildAPIUtility.GetListOfProjectsFromPathArgumentAsync(Path.GetDirectoryName(projectA.ProjectPath));
 
             // Assert
             Assert.Equal(projectList.Count(), 1);
@@ -497,7 +498,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         }
 
         [Fact]
-        public void GetListOfProjectsFromPathArgument_WithSolutionFile_ReturnsCorrectPaths()
+        public async Task GetListOfProjectsFromPathArgument_WithSolutionFile_ReturnsCorrectPaths()
         {
             // Arrange
             var pathContext = new SimpleTestPathContext();
@@ -512,7 +513,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             solution.Create(pathContext.SolutionRoot);
 
             // Act
-            var projectList = MSBuildAPIUtility.GetListOfProjectsFromPathArgument(Path.GetDirectoryName(solution.SolutionPath));
+            var projectList = await MSBuildAPIUtility.GetListOfProjectsFromPathArgumentAsync(Path.GetDirectoryName(solution.SolutionPath));
 
             // Assert
             Assert.Equal(projectList.Count(), 2);
@@ -521,7 +522,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         }
 
         [Fact]
-        public void GetListOfProjectsFromPathArgument_WithSolutionDirectory_ReturnsCorrectPaths()
+        public async Task GetListOfProjectsFromPathArgument_WithSolutionDirectory_ReturnsCorrectPaths()
         {
             // Arrange
             var pathContext = new SimpleTestPathContext();
@@ -536,7 +537,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             solution.Create(pathContext.SolutionRoot);
 
             // Act
-            var projectList = MSBuildAPIUtility.GetListOfProjectsFromPathArgument(pathContext.SolutionRoot);
+            var projectList = await MSBuildAPIUtility.GetListOfProjectsFromPathArgumentAsync(pathContext.SolutionRoot);
 
             // Assert
             Assert.Equal(projectList.Count(), 2);
@@ -550,7 +551,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         [InlineData("X.sln", "A.csproj")]
         [InlineData()]
         [InlineData("random.txt")]
-        public void GetListOfProjectsFromPathArgument_WithDirectoryWithInvalidNumberOfSolutionsOrProjects_ThrowsException(params string[] directoryFiles)
+        public async Task GetListOfProjectsFromPathArgument_WithDirectoryWithInvalidNumberOfSolutionsOrProjects_ThrowsException(params string[] directoryFiles)
         {
             // Arrange
             var pathContext = new SimpleTestPathContext();
@@ -563,7 +564,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             }
 
             // Act & Assert
-            Assert.Throws<ArgumentException>(() => MSBuildAPIUtility.GetListOfProjectsFromPathArgument(pathContext.SolutionRoot));
+            await Assert.ThrowsAsync<ArgumentException>(() => MSBuildAPIUtility.GetListOfProjectsFromPathArgumentAsync(pathContext.SolutionRoot));
         }
 
         [Fact]

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSolutionContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSolutionContext.cs
@@ -14,9 +14,13 @@ namespace NuGet.Test.Utility
     /// </summary>
     public class SimpleTestSolutionContext
     {
-        public SimpleTestSolutionContext(string solutionRoot, params SimpleTestProjectContext[] projects)
+        public SimpleTestSolutionContext(string solutionRoot, params SimpleTestProjectContext[] projects) : this(solutionRoot, false, projects)
         {
-            SolutionPath = Path.Combine(solutionRoot, "solution.sln");
+        }
+
+        public SimpleTestSolutionContext(string solutionRoot, bool useSlnx, params SimpleTestProjectContext[] projects)
+        {
+            SolutionPath = Path.Combine(solutionRoot, useSlnx ? "solution.slnx" : "solution.sln");
 
             Projects.AddRange(projects);
         }
@@ -50,42 +54,71 @@ namespace NuGet.Test.Utility
 
         public StringBuilder GetContent()
         {
-            StringBuilder sb = new StringBuilder();
-
-            sb.AppendLine("Microsoft Visual Studio Solution File, Format Version 12.00");
-            sb.AppendLine("# Visual Studio 2012");
-
-            foreach (var project in Projects)
+            if (Path.GetExtension(SolutionPath) == ".sln")
             {
-                sb.AppendLine("Project(\"{" + "FAE04EC0-301F-11D3-BF4B-00C04F79EFBC" + "}"
-                    + $"\") = \"{project.ProjectName}\", " + "\"" + project.ProjectPath + "\", \"{" + project.ProjectGuid.ToString().ToUpperInvariant() + "}\"");
-                sb.AppendLine("EndProject");
+                return GetContentForSln();
+            }
+            else if (Path.GetExtension(SolutionPath) == ".slnx")
+            {
+                return GetContentForSlnx();
+            }
+            else
+            {
+                throw new InvalidOperationException("Unknown solution file type");
             }
 
-            sb.AppendLine("Global");
-            sb.AppendLine("  GlobalSection(SolutionConfigurationPlatforms) = preSolution");
-            sb.AppendLine("    Debug|Any CPU = Debug|Any CPU");
-            sb.AppendLine("    Release|Any CPU = Release|Any CPU");
-            sb.AppendLine("  EndGlobalSection");
-            sb.AppendLine("  GlobalSection(ProjectConfigurationPlatforms) = postSolution");
-            foreach (var project in Projects)
+            StringBuilder GetContentForSln()
             {
-                // this should probably be uppercase?
-                sb.AppendLine("    {" + project.ProjectGuid.ToString().ToUpperInvariant() + "}.Debug|Any CPU.ActiveCfg = Debug|Any CPU");
-                sb.AppendLine("    {" + project.ProjectGuid.ToString().ToUpperInvariant() + "}.Debug|Any CPU.Build.0 = Debug|Any CPU");
-                sb.AppendLine("    {" + project.ProjectGuid.ToString().ToUpperInvariant() + "}.Release|Any CPU.ActiveCfg = Release|Any CPU");
-                sb.AppendLine("    {" + project.ProjectGuid.ToString().ToUpperInvariant() + "}.Release|Any CPU.Build.0 = Release|Any CPU");
-            }
-            sb.AppendLine("  EndGlobalSection");
-            sb.AppendLine("  GlobalSection(SolutionProperties) = preSolution");
-            sb.AppendLine("    HideSolutionNode = FALSE");
-            sb.AppendLine("  EndGlobalSection");
-            sb.AppendLine("  GlobalSection(ExtensibilityGlobals) = postSolution");
-            sb.AppendLine("    SolutionGuid = {" + SolutionGuid.ToString() + "}");
-            sb.AppendLine("  EndGlobalSection");
-            sb.AppendLine("EndGlobal");
+                StringBuilder sb = new StringBuilder();
 
-            return sb;
+                sb.AppendLine("Microsoft Visual Studio Solution File, Format Version 12.00");
+                sb.AppendLine("# Visual Studio 2012");
+
+                foreach (var project in Projects)
+                {
+                    sb.AppendLine("Project(\"{" + "FAE04EC0-301F-11D3-BF4B-00C04F79EFBC" + "}"
+                        + $"\") = \"{project.ProjectName}\", " + "\"" + project.ProjectPath + "\", \"{" + project.ProjectGuid.ToString().ToUpperInvariant() + "}\"");
+                    sb.AppendLine("EndProject");
+                }
+
+                sb.AppendLine("Global");
+                sb.AppendLine("  GlobalSection(SolutionConfigurationPlatforms) = preSolution");
+                sb.AppendLine("    Debug|Any CPU = Debug|Any CPU");
+                sb.AppendLine("    Release|Any CPU = Release|Any CPU");
+                sb.AppendLine("  EndGlobalSection");
+                sb.AppendLine("  GlobalSection(ProjectConfigurationPlatforms) = postSolution");
+                foreach (var project in Projects)
+                {
+                    // this should probably be uppercase?
+                    sb.AppendLine("    {" + project.ProjectGuid.ToString().ToUpperInvariant() + "}.Debug|Any CPU.ActiveCfg = Debug|Any CPU");
+                    sb.AppendLine("    {" + project.ProjectGuid.ToString().ToUpperInvariant() + "}.Debug|Any CPU.Build.0 = Debug|Any CPU");
+                    sb.AppendLine("    {" + project.ProjectGuid.ToString().ToUpperInvariant() + "}.Release|Any CPU.ActiveCfg = Release|Any CPU");
+                    sb.AppendLine("    {" + project.ProjectGuid.ToString().ToUpperInvariant() + "}.Release|Any CPU.Build.0 = Release|Any CPU");
+                }
+                sb.AppendLine("  EndGlobalSection");
+                sb.AppendLine("  GlobalSection(SolutionProperties) = preSolution");
+                sb.AppendLine("    HideSolutionNode = FALSE");
+                sb.AppendLine("  EndGlobalSection");
+                sb.AppendLine("  GlobalSection(ExtensibilityGlobals) = postSolution");
+                sb.AppendLine("    SolutionGuid = {" + SolutionGuid.ToString() + "}");
+                sb.AppendLine("  EndGlobalSection");
+                sb.AppendLine("EndGlobal");
+
+                return sb;
+            }
+
+            StringBuilder GetContentForSlnx()
+            {
+                StringBuilder sb = new StringBuilder();
+                sb.AppendLine("<Solution>");
+                foreach (var project in Projects)
+                {
+                    sb.AppendLine($"<Project Path=\"{project.ProjectPath}\" />");
+                }
+                sb.AppendLine("</Solution>");
+
+                return sb;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Because the library is async-only, this required a bit of bubbling-up of async signatures and CancellationToken-passing through the List and Why commands.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug 

Fixes: https://github.com/NuGet/Home/issues/14034
Contributes to https://github.com/dotnet/sdk/issues/40913

## Description

Minimal work to
* add the new library
* Use it when loading solutions
* Expand the set of extensions that are recognized as 'solution-like'
* Flow through viral async-ness through the `why` and `package list` commands.
* Update existing tests due to internal API changes
* Add new tests showing successful usage of `list package` with the slnx format

Note that this _does not_ remove all usage of the now-deprecated SolutionFile MSBuild API in NuGet (the only location of which I could find was [`GetProjectGraphEntryPoints`](https://github.com/nuget/nuget.client/blob/7a2520d1347e3f11f558fc286cc0ba9170973b0e/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs#L667) - that seemed a bit above my knowledge level (though conceptually should also be simple).

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
