### PR TITLE
ErrorListTableDataSourceTests use MockedVS to fix flaky tests

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/ErrorListTableDataSourceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/ErrorListTableDataSourceTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.VisualStudio.Sdk.TestFramework;
 using Microsoft.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.Shell.TableManager;
 using Moq;
@@ -11,8 +12,14 @@ using Xunit;
 
 namespace NuGet.VisualStudio.Common.Test
 {
+    [Collection(MockedVS.Collection)]
     public class ErrorListTableDataSourceTests
     {
+        public ErrorListTableDataSourceTests(GlobalServiceProvider sp)
+        {
+            sp.Reset();
+        }
+
         [Fact]
         public void ErrorListTableDataSource_AddEntriesVerifyEntryExists()
         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/14035

## Description

The ErrorListTableDataSourceTests should be using a MockedVS instance so that the service provider can obtain dependent services.

This PR adds the MockedVS collection to the tests, which resolves the flaky tests.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
