### PR TITLE
Use hosted agents with Visual Studio 2022 17.12 temporarily

### DIFF
--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -60,7 +60,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Unit
@@ -77,7 +77,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Unit
@@ -94,7 +94,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Unit
@@ -111,7 +111,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Functional
@@ -129,7 +129,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Functional
@@ -148,7 +148,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Functional
@@ -168,7 +168,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Functional
@@ -186,7 +186,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Functional
@@ -205,7 +205,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Functional


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
Our CI is failing because the Azure DevOps MSBuild@v1 task fails on Visual Studio 2022 17.13 Preview 1 and Preview 2 at the moment.  This is being fixed in Preview 3 but those images won't be deployed until next Wednesday at the earliest.  This unblocks us for now by using hosted images with Visual Studio 17.12.

Fix for Preview 3 that we're waiting on: https://github.com/dotnet/msbuild/pull/11254

More long-term fix for the problem is in review as well: https://github.com/microsoft/azure-pipelines-tasks-common-packages/pull/422

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
