### PR TITLE
Enable PrunePackageReference for .NET Core and .NET Standard 2.0 and above

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -79,9 +79,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <RestoreEnablePackagePruning Condition="'$(RestoreEnablePackagePruning)' == ''
                     AND '$(UsingMicrosoftNETSdk)' == 'true'
+                    AND '$(SdkAnalysisLevel)' != ''
                     AND $([MSBuild]::VersionGreaterThanOrEquals('$(SdkAnalysisLevel)', '10.0.100'))
                     AND ('$(TargetFrameworkIdentifier)' == '.NETCoreApp'
-                        OR ('$(TargetFrameworkIdentifier)' == '.NETStandard' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 2.0))))"
+                        OR ('$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion)' != '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '2.0'))))"
                     >true</RestoreEnablePackagePruning>
     <RestoreEnablePackagePruning Condition="$(RestoreEnablePackagePruning) == '' ">false</RestoreEnablePackagePruning>
   </PropertyGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -77,6 +77,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
+    <RestoreEnablePackagePruning Condition="'$(RestoreEnablePackagePruning)' == ''
+                    AND '$(UsingMicrosoftNETSdk)' == 'true'
+                    AND $([MSBuild]::VersionGreaterThanOrEquals('$(SdkAnalysisLevel)', '10.0.100'))
+                    AND ('$(TargetFrameworkIdentifier)' == '.NETCoreApp'
+                        OR ('$(TargetFrameworkIdentifier)' == '.NETStandard' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 2.0))))"
+                    >true</RestoreEnablePackagePruning>
     <RestoreEnablePackagePruning Condition="$(RestoreEnablePackagePruning) == '' ">false</RestoreEnablePackagePruning>
   </PropertyGroup>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -79,6 +79,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <RestoreEnablePackagePruning Condition="'$(RestoreEnablePackagePruning)' == ''
                     AND '$(UsingMicrosoftNETSdk)' == 'true'
+                    AND '$(NuGetExeSkipSdkAnalysisLevelCheck)' != 'true'
                     AND '$(SdkAnalysisLevel)' != ''
                     AND $([MSBuild]::VersionGreaterThanOrEquals('$(SdkAnalysisLevel)', '10.0.100'))
                     AND ('$(TargetFrameworkIdentifier)' == '.NETCoreApp'


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3110

## Description

Enable package pruning for .NET 10 preview 1. 

Note that while we double insert into .NET 9 and .NET 10, the SDKAnalysisLevel check ensures we only enable it for .NET 10.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. - https://github.com/NuGet/Home/issues/14002
