### PR TITLE
Bump runnables to net9.0

### DIFF
--- a/build/DotNetSdkVersions.txt
+++ b/build/DotNetSdkVersions.txt
@@ -1,3 +1,4 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
 -Channel 3.1 -Runtime dotnet
--Channel 8.0.4xx
+-Channel 8.0 -Runtime dotnet
+-Channel 9.0.1xx

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -11,7 +11,7 @@
     <NETFXTargetFrameworkVersion>v4.7.2</NETFXTargetFrameworkVersion>
     <NETFXTargetFramework>net472</NETFXTargetFramework>
     <NetStandardVersion>netstandard2.0</NetStandardVersion>
-    <NETCoreTargetFramework>net8.0</NETCoreTargetFramework>
+    <NETCoreTargetFramework>net9.0</NETCoreTargetFramework>
     <NETCoreTargetFramework Condition="'$(DotNetBuildSourceOnly)' == 'true'">net10.0</NETCoreTargetFramework>
     <NETCoreLegacyTargetFramework>netcoreapp3.1</NETCoreLegacyTargetFramework>
     <NETCoreLegacyTargetFramework Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(NETCoreTargetFramework)</NETCoreLegacyTargetFramework>

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -68,12 +68,12 @@ stages:
 
 - ${{ if eq(parameters.RunUnitTestsOnWindows, true) }}:
   - stage:
-    displayName: Unit Tests on Windows (.NET 8.0)
+    displayName: Unit Tests on Windows (.NET 9.0)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Unit Tests on Windows (.NET 8.0)
+        displayName: Unit Tests on Windows (.NET 9.0)
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
@@ -81,7 +81,7 @@ stages:
         ${{ else }}:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Unit
-        testTargetFramework: net8.0
+        testTargetFramework: net9.0
 
 - ${{ if eq(parameters.RunUnitTestsOnWindows, true) }}:
   - stage:
@@ -177,12 +177,12 @@ stages:
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
-    displayName: Dotnet.Integration.Test on Windows (.NET 8.0)
+    displayName: Dotnet.Integration.Test on Windows (.NET 9.0)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Dotnet.Integration.Test on Windows (.NET 8.0)
+        displayName: Dotnet.Integration.Test on Windows (.NET 9.0)
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
@@ -190,18 +190,18 @@ stages:
         ${{ else }}:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Functional
-        testTargetFramework: net8.0
+        testTargetFramework: net9.0
         testProjectName: Dotnet.Integration.Test
         timeoutInMinutes: 45
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
-    displayName: NuGet.Packaging.FuncTest on Windows (.NET 8.0)
+    displayName: NuGet.Packaging.FuncTest on Windows (.NET 9.0)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: NuGet.Packaging.FuncTest on Windows (.NET 8.0)
+        displayName: NuGet.Packaging.FuncTest on Windows (.NET 9.0)
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
@@ -209,21 +209,21 @@ stages:
         ${{ else }}:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Functional
-        testTargetFramework: net8.0
+        testTargetFramework: net9.0
         testProjectName: NuGet.Packaging.FuncTest
 
 - ${{ if eq(parameters.RunUnitTestsOnLinux, true) }}:
   - stage:
-    displayName: Unit Tests on Linux (.NET 8.0)
+    displayName: Unit Tests on Linux (.NET 9.0)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Unit Tests on Linux (.NET 8.0)
+        displayName: Unit Tests on Linux (.NET 9.0)
         osName: Linux
         vmImage: ubuntu-latest
         testType: Unit
-        testTargetFramework: net8.0
+        testTargetFramework: net9.0
 
 - ${{ if eq(parameters.RunUnitTestsOnLinux, true) }}:
   - stage:
@@ -240,30 +240,30 @@ stages:
 
 - ${{ if eq(parameters.RunFunctionalTestsOnLinux, true) }}:
   - stage:
-    displayName: Functional Tests on Linux (.NET 8.0)
+    displayName: Functional Tests on Linux (.NET 9.0)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Functional Tests on Linux (.NET 8.0)
+        displayName: Functional Tests on Linux (.NET 9.0)
         osName: Linux
         vmImage: ubuntu-latest
         testType: Functional
-        testTargetFramework: net8.0
+        testTargetFramework: net9.0
         timeoutInMinutes: 30
 
 - ${{ if eq(parameters.RunUnitTestsOnMacOS, true) }}:
   - stage:
-    displayName: Unit Tests on MacOS (.NET 8.0)
+    displayName: Unit Tests on MacOS (.NET 9.0)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Unit Tests on MacOS (.NET 8.0)
+        displayName: Unit Tests on MacOS (.NET 9.0)
         osName: MacOS
         vmImage: macos-latest
         testType: Unit
-        testTargetFramework: net8.0
+        testTargetFramework: net9.0
 
 - ${{ if eq(parameters.RunUnitTestsOnMacOS, true) }}:
   - stage:
@@ -280,16 +280,16 @@ stages:
 
 - ${{ if eq(parameters.RunFunctionalTestsOnMacOS, true) }}:
   - stage:
-    displayName: Functional Tests on MacOS (.NET 8.0)
+    displayName: Functional Tests on MacOS (.NET 9.0)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Functional Tests on MacOS (.NET 8.0)
+        displayName: Functional Tests on MacOS (.NET 9.0)
         osName: MacOS
         vmImage: macos-latest
         testType: Functional
-        testTargetFramework: net8.0
+        testTargetFramework: net9.0
         timeoutInMinutes: 30
 
 - ${{ if or(eq(parameters.RunSourceBuild, true), eq(parameters.RunStaticAnalysis, true)) }}:

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
@@ -102,7 +102,9 @@ namespace NuGet.Commands
                                     options.CertificatePath)));
 
                         default:
-                            throw;
+                            throw new SignCommandException(
+                                LogMessage.CreateError(NuGetLogCode.NU3001,
+                                $"HRResult: '{ex.HResult}'"));
                     }
                 }
                 catch (FileNotFoundException)

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
@@ -32,9 +32,7 @@ namespace NuGet.Commands
 
         private const int MACOS_INVALID_CERT = -25257;
 
-#if NET9_0_OR_GREATER
         private const int CRYPT_E_BAD_DECODE = unchecked((int)0x80092002);
-#endif
 
 #if IS_SIGNING_SUPPORTED && IS_CORECLR
         //Generic exception ASN1 corrupted data
@@ -86,9 +84,7 @@ namespace NuGet.Commands
                                     options.CertificatePath)));
 
                         case CRYPT_E_NO_MATCH_HRESULT:
-#if NET9_0_OR_GREATER
                         case CRYPT_E_BAD_DECODE:
-#endif
 #if IS_SIGNING_SUPPORTED && IS_CORECLR
                         case OPENSSL_ASN1_CORRUPTED_DATA_ERROR:
 #else
@@ -102,9 +98,7 @@ namespace NuGet.Commands
                                     options.CertificatePath)));
 
                         default:
-                            throw new SignCommandException(
-                                LogMessage.CreateError(NuGetLogCode.NU3001,
-                                $"HRResult: '{ex.HResult}'"));
+                            throw;
                     }
                 }
                 catch (FileNotFoundException)

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
@@ -41,6 +41,10 @@ namespace NuGet.Commands
             {
                 success = false;
                 ExceptionUtilities.LogException(e, signArgs.Logger);
+                if (e is System.Security.Cryptography.CryptographicException ce)
+                {
+                    signArgs.Logger.LogError(ce.HResult.ToString(CultureInfo.InvariantCulture));
+                }
             }
 
             if (success)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -10025,7 +10025,7 @@ namespace NuGet.CommandLine.Test
                 var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
                     "proj",
                     pathContext.SolutionRoot,
-                    "net8.0-windows");
+                    "net9.0-windows");
 
                 project.AddPackageToAllFrameworks(packageX);
                 solution.Projects.Add(project);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -10044,7 +10044,7 @@ namespace NuGet.CommandLine.Test
 
                 var propsItemGroups = propsXML.Root.Elements().Where(e => e.Name.LocalName == "ItemGroup").ToList();
 
-                Assert.Contains("'$(TargetFramework)' == 'net8.0-windows' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Contains("'$(TargetFramework)' == 'net9.0-windows' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningUtilityTests.cs
@@ -29,7 +29,11 @@ namespace NuGet.Packaging.FuncTest
         [CIOnlyFact]
         public void Verify_WithValidInput_DoesNotThrow()
         {
+#if NET9_0_OR_GREATER
+            using (X509Certificate2 certificate = X509CertificateLoader.LoadCertificate(_testFixture.TrustedTestCertificate.Source.PublicCert.RawData))
+#else
             using (var certificate = new X509Certificate2(_testFixture.TrustedTestCertificate.Source.PublicCert.RawData))
+#endif
             using (var request = new AuthorSignPackageRequest(certificate, HashAlgorithmName.SHA256, HashAlgorithmName.SHA256))
             {
                 SigningUtility.Verify(request, NullLogger.Instance);

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatClientCertTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatClientCertTests.cs
@@ -930,7 +930,7 @@ namespace NuGet.XPlat.FuncTest
                 using (var store = new X509Store(CertificateStoreName, CertificateStoreLocation))
                 {
                     store.Open(OpenFlags.ReadWrite);
-                    Certificate = X509CertificateLoader.LoadCertificate(CreateCertificate());
+                    Certificate = X509CertificateLoader.LoadPkcs12(CreateCertificate(), CertificatePassword, X509KeyStorageFlags.Exportable);
                     store.Add(Certificate);
                 }
             }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatClientCertTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatClientCertTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using NuGet.CommandLine.XPlat;
@@ -931,18 +930,8 @@ namespace NuGet.XPlat.FuncTest
                 using (var store = new X509Store(CertificateStoreName, CertificateStoreLocation))
                 {
                     store.Open(OpenFlags.ReadWrite);
-
-                    using (var password = new SecureString())
-                    {
-                        foreach (var symbol in CertificatePassword)
-                        {
-                            password.AppendChar(symbol);
-                        }
-
-                        Certificate = new X509Certificate2(CreateCertificate(), password, X509KeyStorageFlags.Exportable);
-
-                        store.Add(Certificate);
-                    }
+                    Certificate = X509CertificateLoader.LoadCertificate(CreateCertificate());
+                    store.Add(Certificate);
                 }
             }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
@@ -60,12 +60,13 @@ namespace NuGet.Commands.Test
 
                 testContext.Args.CertificatePath = certificateFilePath;
 
-                await testContext.Runner.ExecuteCommandAsync(testContext.Args);
+                int result = await testContext.Runner.ExecuteCommandAsync(testContext.Args);
 
                 var expectedMessage = $"Certificate file '{certificateFilePath}' is invalid. For a list of accepted ways to provide a certificate, visit https://docs.nuget.org/docs/reference/command-line-reference";
-
-                Assert.Equal(1, testContext.Logger.LogMessages.Count(
-                    message => message.Level == LogLevel.Error && message.Code == NuGetLogCode.NU3001 && message.Message.Equals(expectedMessage)));
+                Assert.Equal(1, result);
+                Assert.True(1 == testContext.Logger.LogMessages.Count(
+                    message => message.Level == LogLevel.Error && message.Code == NuGetLogCode.NU3001 && message.Message.Equals(expectedMessage)),
+                    string.Join(Environment.NewLine, testContext.Logger.LogMessages));
             }
         }
 

--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/Asn1/OcspSignature.cs
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/Asn1/OcspSignature.cs
@@ -61,8 +61,11 @@ namespace Microsoft.Internal.NuGet.Testing.SignedPackages.Asn1
                 while (certsSequenceReader.HasData)
                 {
                     ReadOnlyMemory<byte> data = certsSequenceReader.ReadEncodedValue();
+#if NET9_0_OR_GREATER
+                    X509Certificate2 certificate = X509CertificateLoader.LoadCertificate(data.Span.ToArray());
+#else
                     X509Certificate2 certificate = new(data.Span.ToArray());
-
+#endif
                     certs.Add(certificate);
                 }
             }

--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/Asn1/TestSignedCms.cs
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/Asn1/TestSignedCms.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Formats.Asn1;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Microsoft.Internal.NuGet.Testing.SignedPackages.Asn1
 {

--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/Asn1/TestSignedCms.cs
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/Asn1/TestSignedCms.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Formats.Asn1;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Microsoft.Internal.NuGet.Testing.SignedPackages.Asn1
 {
@@ -104,8 +105,11 @@ namespace Microsoft.Internal.NuGet.Testing.SignedPackages.Asn1
                 while (certificatesReader.HasData)
                 {
                     ReadOnlyMemory<byte> value = certificatesReader.ReadEncodedValue();
+#if NET9_0_OR_GREATER
+                    X509Certificate2 certificate = X509CertificateLoader.LoadCertificate(value.Span.ToArray());
+#else
                     X509Certificate2 certificate = new(value.Span.ToArray());
-
+#endif
                     certificates ??= new X509Certificate2Collection();
 
                     certificates.Add(certificate);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

I followed https://github.com/NuGet/NuGet.Client/blob/dev/docs/updating-target-frameworks.md and here's the diff. 
You can see the complete frameworks in the details below:
```diff
-Dotnet.Integration.Test.csproj = net8.0
+Dotnet.Integration.Test.csproj = net9.0
-NuGet.Commands.FuncTest.csproj = net472;net8.0;netcoreapp3.1
+NuGet.Commands.FuncTest.csproj = net472;net9.0;netcoreapp3.1
-NuGet.Packaging.FuncTest.csproj = net472;net8.0;netcoreapp3.1
+NuGet.Packaging.FuncTest.csproj = net472;net9.0;netcoreapp3.1
-NuGet.Protocol.FuncTest.csproj = net472;net8.0;netcoreapp3.1
+NuGet.Protocol.FuncTest.csproj = net472;net9.0;netcoreapp3.1
-NuGet.Signing.CrossFramework.Test.csproj = net472;net8.0
+NuGet.Signing.CrossFramework.Test.csproj = net472;net9.0
-NuGet.XPlat.FuncTest.csproj = net8.0
+NuGet.XPlat.FuncTest.csproj = net9.0
-Microsoft.Build.NuGetSdkResolver.Test.csproj = net472;net8.0
+Microsoft.Build.NuGetSdkResolver.Test.csproj = net472;net9.0
-NuGet.Build.Tasks.Console.Test.csproj = net472;net8.0
+NuGet.Build.Tasks.Console.Test.csproj = net472;net9.0
-NuGet.Build.Tasks.Pack.Test.csproj = net472;net8.0
+NuGet.Build.Tasks.Pack.Test.csproj = net472;net9.0
-NuGet.Build.Tasks.Test.csproj = net472;net8.0
+NuGet.Build.Tasks.Test.csproj = net472;net9.0
-NuGet.CommandLine.Xplat.Tests.csproj = net8.0
+NuGet.CommandLine.Xplat.Tests.csproj = net9.0
-NuGet.Commands.Test.csproj = net472;net8.0;netcoreapp3.1
+NuGet.Commands.Test.csproj = net472;net9.0;netcoreapp3.1
-NuGet.Common.Test.csproj = net472;net8.0
+NuGet.Common.Test.csproj = net472;net9.0
-NuGet.Configuration.Test.csproj = net472;net8.0;netcoreapp3.1
+NuGet.Configuration.Test.csproj = net472;net9.0;netcoreapp3.1
-NuGet.Credentials.Test.csproj = net472;net8.0
+NuGet.Credentials.Test.csproj = net472;net9.0
-NuGet.DependencyResolver.Core.Tests.csproj = net472;net8.0;netcoreapp3.1
+NuGet.DependencyResolver.Core.Tests.csproj = net472;net9.0;netcoreapp3.1
-NuGet.Frameworks.Test.csproj = net472;net8.0
+NuGet.Frameworks.Test.csproj = net472;net9.0
-NuGet.LibraryModel.Tests.csproj = net472;net8.0
+NuGet.LibraryModel.Tests.csproj = net472;net9.0
-NuGet.PackageManagement.Test.csproj = net472;net8.0
+NuGet.PackageManagement.Test.csproj = net472;net9.0
-NuGet.Packaging.Test.csproj = net472;net8.0;netcoreapp3.1
+NuGet.Packaging.Test.csproj = net472;net9.0;netcoreapp3.1
-NuGet.ProjectModel.Test.csproj = net472;net8.0;netcoreapp3.1
+NuGet.ProjectModel.Test.csproj = net472;net9.0;netcoreapp3.1
-NuGet.Protocol.Tests.csproj = net472;net8.0;netcoreapp3.1
+NuGet.Protocol.Tests.csproj = net472;net9.0;netcoreapp3.1
-NuGet.Resolver.Test.csproj = net472;net8.0;netcoreapp3.1
+NuGet.Resolver.Test.csproj = net472;net9.0;netcoreapp3.1
-NuGet.Shared.Tests.csproj = net472;net8.0
+NuGet.Shared.Tests.csproj = net472;net9.0
-NuGet.Versioning.Test.csproj = net472;net8.0
+NuGet.Versioning.Test.csproj = net472;net9.0
-TestablePlugin.csproj = net472;net8.0;netcoreapp3.1
+TestablePlugin.csproj = net472;net9.0;netcoreapp3.1
-Microsoft.Internal.NuGet.Testing.SignedPackages.csproj = net472;net8.0;netcoreapp3.1
+Microsoft.Internal.NuGet.Testing.SignedPackages.csproj = net472;net9.0;netcoreapp3.1
-Test.Utility.csproj = net472;net8.0;netcoreapp3.1
+Test.Utility.csproj = net472;net9.0;netcoreapp3.1
-Microsoft.Build.NuGetSdkResolver.csproj = net472;net8.0
+Microsoft.Build.NuGetSdkResolver.csproj = net472;net9.0
-NuGet.Build.Tasks.Console.csproj = net472;net8.0
+NuGet.Build.Tasks.Console.csproj = net472;net9.0
-NuGet.Build.Tasks.csproj = net472;net8.0
+NuGet.Build.Tasks.csproj = net472;net9.0
-NuGet.CommandLine.XPlat.csproj = net8.0
+NuGet.CommandLine.XPlat.csproj = net9.0
```

I also had to fix some obsolete constructor usage in the new utility project. 
Followed the same pattern as https://github.com/NuGet/NuGet.Client/pull/5911

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~

<details>

Frameworks before: 
```
msbuild .\build\build.proj /t:GetAllTargetFrameworks /v:m /restore:false

  NuGet.CommandLine.FuncTest.csproj = net472
  NuGet.MSSigning.Extensions.FuncTest.csproj = net472
  NuGet.CommandLine.Test.csproj = net472
  NuGet.Indexing.Test.csproj = net472
  NuGet.MSSigning.Extensions.Test.csproj = net472
  NuGet.PackageManagement.UI.Test.csproj = net472
  NuGet.PackageManagement.VisualStudio.Test.csproj = net472
  NuGet.SolutionRestoreManager.Test.csproj = net472
  NuGet.Tools.Test.csproj = net472
  NuGet.VisualStudio.Common.Test.csproj = net472
  NuGet.VisualStudio.Implementation.Test.csproj = net472
  NuGet.VisualStudio.Internal.Contracts.Test.csproj = net472
  NuGet.VisualStudio.Test.csproj = net472
  NuGetConsole.Host.PowerShell.Test.csproj = net472
  Dotnet.Integration.Test.csproj = net9.0
  Msbuild.Integration.Test.csproj = net472
  NuGet.Commands.FuncTest.csproj = net472;net9.0;netcoreapp3.1
  NuGet.Packaging.FuncTest.csproj = net472;net9.0;netcoreapp3.1
  NuGet.Protocol.FuncTest.csproj = net472;net9.0;netcoreapp3.1
  NuGet.Signing.CrossFramework.Test.csproj = net472;net9.0
  NuGet.XPlat.FuncTest.csproj = net9.0
  Microsoft.Build.NuGetSdkResolver.Test.csproj = net472;net9.0
  NuGet.Build.Tasks.Console.Test.csproj = net472;net9.0
  NuGet.Build.Tasks.Pack.Test.csproj = net472;net9.0
  NuGet.Build.Tasks.Test.csproj = net472;net9.0
  NuGet.CommandLine.Xplat.Tests.csproj = net9.0
  NuGet.Commands.Test.csproj = net472;net9.0;netcoreapp3.1
  NuGet.Common.Test.csproj = net472;net9.0
  NuGet.Configuration.Test.csproj = net472;net9.0;netcoreapp3.1
  NuGet.Credentials.Test.csproj = net472;net9.0
  NuGet.DependencyResolver.Core.Tests.csproj = net472;net9.0;netcoreapp3.1
  NuGet.Frameworks.Test.csproj = net472;net9.0
  NuGet.LibraryModel.Tests.csproj = net472;net9.0
  NuGet.PackageManagement.Test.csproj = net472;net9.0
  NuGet.Packaging.Test.csproj = net472;net9.0;netcoreapp3.1
  NuGet.ProjectModel.Test.csproj = net472;net9.0;netcoreapp3.1
  NuGet.Protocol.Tests.csproj = net472;net9.0;netcoreapp3.1
  NuGet.Resolver.Test.csproj = net472;net9.0;netcoreapp3.1
  NuGet.Shared.Tests.csproj = net472;net9.0
  NuGet.Versioning.Test.csproj = net472;net9.0
  API.Test.csproj = net472
  GenerateLicenseList.csproj = net8.0
  GenerateTestPackages.csproj = net472
  SampleCommandLineExtensions.csproj = net472
  TestableCredentialProvider.csproj = net472
  TestablePlugin.csproj = net472;net9.0;netcoreapp3.1
  Microsoft.Internal.NuGet.Testing.SignedPackages.csproj = net472;net9.0;netcoreapp3.1
  Test.Utility.csproj = net472;net9.0;netcoreapp3.1
  NuGet.CommandLine.csproj = net472
  NuGet.Console.csproj = net472
  NuGet.Indexing.csproj = net472
  NuGet.MSSigning.Extensions.csproj = net472
  NuGet.PackageManagement.PowerShellCmdlets.csproj = net472
  NuGet.PackageManagement.UI.csproj = net472
  NuGet.PackageManagement.VisualStudio.csproj = net472
  NuGet.SolutionRestoreManager.csproj = net472
  NuGet.Tools.csproj = net472
  NuGet.VisualStudio.Client.csproj = net472
  NuGet.VisualStudio.Common.csproj = net472
  NuGet.VisualStudio.Contracts.csproj = netstandard2.0
  NuGet.VisualStudio.Implementation.csproj = net472
  NuGet.VisualStudio.Internal.Contracts.csproj = net472
  NuGet.VisualStudio.Interop.csproj = net472
  NuGet.VisualStudio.OnlineEnvironment.Client.csproj = net472
  NuGet.VisualStudio.csproj = net472
  Microsoft.Build.NuGetSdkResolver.csproj = net472;net9.0
  NuGet.Build.Tasks.Console.csproj = net472;net9.0
  NuGet.Build.Tasks.Pack.csproj = net472;netstandard2.0
  NuGet.Build.Tasks.csproj = net472;net9.0
  NuGet.CommandLine.XPlat.csproj = net9.0
  NuGet.Commands.csproj = net472;netstandard2.0;net8.0
  NuGet.Common.csproj = net472;netstandard2.0
  NuGet.Configuration.csproj = net472;netstandard2.0
  NuGet.Credentials.csproj = net472;netstandard2.0;net8.0
  NuGet.DependencyResolver.Core.csproj = net472;netstandard2.0;net8.0
  NuGet.Frameworks.csproj = net472;netstandard2.0
  NuGet.LibraryModel.csproj = net472;netstandard2.0
  NuGet.Localization.csproj = netstandard2.0
  NuGet.PackageManagement.csproj = net472;netstandard2.0
  NuGet.Packaging.csproj = net472;netstandard2.0;net8.0
  NuGet.ProjectModel.csproj = net472;netstandard2.0;net8.0
  NuGet.Protocol.csproj = net472;netstandard2.0;net8.0
  NuGet.Resolver.csproj = net472;netstandard2.0;net8.0
  NuGet.Versioning.csproj = net472;netstandard2.0
  NuGet.Console.TestContract.csproj = net472
  NuGet.OptProf.csproj = net472
  NuGet.PackageManagement.UI.TestContract.csproj = net472
  NuGet.Tests.Apex.Daily.csproj = net472
  NuGet.Tests.Apex.csproj = net472

msbuild .\build\build.proj /t:GetAllTargetFrameworks /v:m /restore:false /p:DotNetBuildSourceOnly="true"

  NuGet.CommandLine.FuncTest.csproj = net472
  NuGet.MSSigning.Extensions.FuncTest.csproj = net472
  NuGet.CommandLine.Test.csproj = net472
  NuGet.Indexing.Test.csproj = net472
  NuGet.MSSigning.Extensions.Test.csproj = net472
  NuGet.PackageManagement.UI.Test.csproj = net472
  NuGet.PackageManagement.VisualStudio.Test.csproj = net472
  NuGet.SolutionRestoreManager.Test.csproj = net472
  NuGet.Tools.Test.csproj = net472
  NuGet.VisualStudio.Common.Test.csproj = net472
  NuGet.VisualStudio.Implementation.Test.csproj = net472
  NuGet.VisualStudio.Internal.Contracts.Test.csproj = net472
  NuGet.VisualStudio.Test.csproj = net472
  NuGetConsole.Host.PowerShell.Test.csproj = net472
  Dotnet.Integration.Test.csproj = net10.0
  Msbuild.Integration.Test.csproj = net472
  NuGet.Commands.FuncTest.csproj = net10.0
  NuGet.Packaging.FuncTest.csproj = net10.0
  NuGet.Protocol.FuncTest.csproj = net10.0
  NuGet.Signing.CrossFramework.Test.csproj = net10.0
  NuGet.XPlat.FuncTest.csproj = net10.0
  Microsoft.Build.NuGetSdkResolver.Test.csproj = net10.0
  NuGet.Build.Tasks.Console.Test.csproj = net10.0
  NuGet.Build.Tasks.Pack.Test.csproj = net10.0
  NuGet.Build.Tasks.Test.csproj = net10.0
  NuGet.CommandLine.Xplat.Tests.csproj = net10.0
  NuGet.Commands.Test.csproj = net10.0
  NuGet.Common.Test.csproj = net10.0
  NuGet.Configuration.Test.csproj = net10.0
  NuGet.Credentials.Test.csproj = net10.0
  NuGet.DependencyResolver.Core.Tests.csproj = net10.0
  NuGet.Frameworks.Test.csproj = net10.0
  NuGet.LibraryModel.Tests.csproj = net10.0
  NuGet.PackageManagement.Test.csproj = net10.0
  NuGet.Packaging.Test.csproj = net10.0
  NuGet.ProjectModel.Test.csproj = net10.0
  NuGet.Protocol.Tests.csproj = net10.0
  NuGet.Resolver.Test.csproj = net10.0
  NuGet.Shared.Tests.csproj = net10.0
  NuGet.Versioning.Test.csproj = net10.0
  API.Test.csproj = net472
  GenerateLicenseList.csproj = net8.0
  GenerateTestPackages.csproj = net472
  SampleCommandLineExtensions.csproj = net472
  TestableCredentialProvider.csproj = net472
  TestablePlugin.csproj = net10.0
  Microsoft.Internal.NuGet.Testing.SignedPackages.csproj = net10.0
  Test.Utility.csproj = net10.0
  NuGet.CommandLine.csproj = net472
  NuGet.Console.csproj = net472
  NuGet.Indexing.csproj = net472
  NuGet.MSSigning.Extensions.csproj = net472
  NuGet.PackageManagement.PowerShellCmdlets.csproj = net472
  NuGet.PackageManagement.UI.csproj = net472
  NuGet.PackageManagement.VisualStudio.csproj = net472
  NuGet.SolutionRestoreManager.csproj = net472
  NuGet.Tools.csproj = net472
  NuGet.VisualStudio.Client.csproj = net472
  NuGet.VisualStudio.Common.csproj = net472
  NuGet.VisualStudio.Contracts.csproj = netstandard2.0
  NuGet.VisualStudio.Implementation.csproj = net472
  NuGet.VisualStudio.Internal.Contracts.csproj = net472
  NuGet.VisualStudio.Interop.csproj = net472
  NuGet.VisualStudio.OnlineEnvironment.Client.csproj = net472
  NuGet.VisualStudio.csproj = net472
  Microsoft.Build.NuGetSdkResolver.csproj = net10.0
  NuGet.Build.Tasks.Console.csproj = net10.0
  NuGet.Build.Tasks.Pack.csproj = net10.0;netstandard2.0
  NuGet.Build.Tasks.csproj = net10.0
  NuGet.CommandLine.XPlat.csproj = net10.0
  NuGet.Commands.csproj = net10.0;netstandard2.0
  NuGet.Common.csproj = net10.0;netstandard2.0
  NuGet.Configuration.csproj = net10.0;netstandard2.0
  NuGet.Credentials.csproj = net10.0;netstandard2.0
  NuGet.DependencyResolver.Core.csproj = net10.0;netstandard2.0
  NuGet.Frameworks.csproj = net10.0;netstandard2.0
  NuGet.LibraryModel.csproj = net10.0;netstandard2.0
  NuGet.Localization.csproj = netstandard2.0
  NuGet.PackageManagement.csproj = net10.0;netstandard2.0
  NuGet.Packaging.csproj = net10.0;netstandard2.0
  NuGet.ProjectModel.csproj = net10.0;netstandard2.0
  NuGet.Protocol.csproj = net10.0;netstandard2.0
  NuGet.Resolver.csproj = net10.0;netstandard2.0
  NuGet.Versioning.csproj = net10.0;netstandard2.0
  NuGet.Console.TestContract.csproj = net472
  NuGet.OptProf.csproj = net472
  NuGet.PackageManagement.UI.TestContract.csproj = net472
  NuGet.Tests.Apex.Daily.csproj = net472
  NuGet.Tests.Apex.csproj = net472
```

Frameworks after:
```
msbuild .\build\build.proj /t:GetAllTargetFrameworks /v:m /restore:false

  NuGet.CommandLine.FuncTest.csproj = net472
  NuGet.MSSigning.Extensions.FuncTest.csproj = net472
  NuGet.CommandLine.Test.csproj = net472
  NuGet.Indexing.Test.csproj = net472
  NuGet.MSSigning.Extensions.Test.csproj = net472
  NuGet.PackageManagement.UI.Test.csproj = net472
  NuGet.PackageManagement.VisualStudio.Test.csproj = net472
  NuGet.SolutionRestoreManager.Test.csproj = net472
  NuGet.Tools.Test.csproj = net472
  NuGet.VisualStudio.Common.Test.csproj = net472
  NuGet.VisualStudio.Implementation.Test.csproj = net472
  NuGet.VisualStudio.Internal.Contracts.Test.csproj = net472
  NuGet.VisualStudio.Test.csproj = net472
  NuGetConsole.Host.PowerShell.Test.csproj = net472
  Dotnet.Integration.Test.csproj = net8.0
  Msbuild.Integration.Test.csproj = net472
  NuGet.Commands.FuncTest.csproj = net472;net8.0;netcoreapp3.1
  NuGet.Packaging.FuncTest.csproj = net472;net8.0;netcoreapp3.1
  NuGet.Protocol.FuncTest.csproj = net472;net8.0;netcoreapp3.1
  NuGet.Signing.CrossFramework.Test.csproj = net472;net8.0
  NuGet.XPlat.FuncTest.csproj = net8.0
  Microsoft.Build.NuGetSdkResolver.Test.csproj = net472;net8.0
  NuGet.Build.Tasks.Console.Test.csproj = net472;net8.0
  NuGet.Build.Tasks.Pack.Test.csproj = net472;net8.0
  NuGet.Build.Tasks.Test.csproj = net472;net8.0
  NuGet.CommandLine.Xplat.Tests.csproj = net8.0
  NuGet.Commands.Test.csproj = net472;net8.0;netcoreapp3.1
  NuGet.Common.Test.csproj = net472;net8.0
  NuGet.Configuration.Test.csproj = net472;net8.0;netcoreapp3.1
  NuGet.Credentials.Test.csproj = net472;net8.0
  NuGet.DependencyResolver.Core.Tests.csproj = net472;net8.0;netcoreapp3.1
  NuGet.Frameworks.Test.csproj = net472;net8.0
  NuGet.LibraryModel.Tests.csproj = net472;net8.0
  NuGet.PackageManagement.Test.csproj = net472;net8.0
  NuGet.Packaging.Test.csproj = net472;net8.0;netcoreapp3.1
  NuGet.ProjectModel.Test.csproj = net472;net8.0;netcoreapp3.1
  NuGet.Protocol.Tests.csproj = net472;net8.0;netcoreapp3.1
  NuGet.Resolver.Test.csproj = net472;net8.0;netcoreapp3.1
  NuGet.Shared.Tests.csproj = net472;net8.0
  NuGet.Versioning.Test.csproj = net472;net8.0
  API.Test.csproj = net472
  GenerateLicenseList.csproj = net8.0
  GenerateTestPackages.csproj = net472
  SampleCommandLineExtensions.csproj = net472
  TestableCredentialProvider.csproj = net472
  TestablePlugin.csproj = net472;net8.0;netcoreapp3.1
  Microsoft.Internal.NuGet.Testing.SignedPackages.csproj = net472;net8.0;netcoreapp3.1
  Test.Utility.csproj = net472;net8.0;netcoreapp3.1
  NuGet.CommandLine.csproj = net472
  NuGet.Console.csproj = net472
  NuGet.Indexing.csproj = net472
  NuGet.MSSigning.Extensions.csproj = net472
  NuGet.PackageManagement.PowerShellCmdlets.csproj = net472
  NuGet.PackageManagement.UI.csproj = net472
  NuGet.PackageManagement.VisualStudio.csproj = net472
  NuGet.SolutionRestoreManager.csproj = net472
  NuGet.Tools.csproj = net472
  NuGet.VisualStudio.Client.csproj = net472
  NuGet.VisualStudio.Common.csproj = net472
  NuGet.VisualStudio.Contracts.csproj = netstandard2.0
  NuGet.VisualStudio.Implementation.csproj = net472
  NuGet.VisualStudio.Internal.Contracts.csproj = net472
  NuGet.VisualStudio.Interop.csproj = net472
  NuGet.VisualStudio.OnlineEnvironment.Client.csproj = net472
  NuGet.VisualStudio.csproj = net472
  Microsoft.Build.NuGetSdkResolver.csproj = net472;net8.0
  NuGet.Build.Tasks.Console.csproj = net472;net8.0
  NuGet.Build.Tasks.Pack.csproj = net472;netstandard2.0
  NuGet.Build.Tasks.csproj = net472;net8.0
  NuGet.CommandLine.XPlat.csproj = net8.0
  NuGet.Commands.csproj = net472;netstandard2.0;net8.0
  NuGet.Common.csproj = net472;netstandard2.0
  NuGet.Configuration.csproj = net472;netstandard2.0
  NuGet.Credentials.csproj = net472;netstandard2.0;net8.0
  NuGet.DependencyResolver.Core.csproj = net472;netstandard2.0;net8.0
  NuGet.Frameworks.csproj = net472;netstandard2.0
  NuGet.LibraryModel.csproj = net472;netstandard2.0
  NuGet.Localization.csproj = netstandard2.0
  NuGet.PackageManagement.csproj = net472;netstandard2.0
  NuGet.Packaging.csproj = net472;netstandard2.0;net8.0
  NuGet.ProjectModel.csproj = net472;netstandard2.0;net8.0
  NuGet.Protocol.csproj = net472;netstandard2.0;net8.0
  NuGet.Resolver.csproj = net472;netstandard2.0;net8.0
  NuGet.Versioning.csproj = net472;netstandard2.0
  NuGet.Console.TestContract.csproj = net472
  NuGet.OptProf.csproj = net472
  NuGet.PackageManagement.UI.TestContract.csproj = net472
  NuGet.Tests.Apex.Daily.csproj = net472
  NuGet.Tests.Apex.csproj = net472

msbuild .\build\build.proj /t:GetAllTargetFrameworks /v:m /restore:false /p:DotNetBuildSourceOnly="true"

  NuGet.CommandLine.FuncTest.csproj = net472
  NuGet.MSSigning.Extensions.FuncTest.csproj = net472
  NuGet.CommandLine.Test.csproj = net472
  NuGet.Indexing.Test.csproj = net472
  NuGet.MSSigning.Extensions.Test.csproj = net472
  NuGet.PackageManagement.UI.Test.csproj = net472
  NuGet.PackageManagement.VisualStudio.Test.csproj = net472
  NuGet.SolutionRestoreManager.Test.csproj = net472
  NuGet.Tools.Test.csproj = net472
  NuGet.VisualStudio.Common.Test.csproj = net472
  NuGet.VisualStudio.Implementation.Test.csproj = net472
  NuGet.VisualStudio.Internal.Contracts.Test.csproj = net472
  NuGet.VisualStudio.Test.csproj = net472
  NuGetConsole.Host.PowerShell.Test.csproj = net472
  Dotnet.Integration.Test.csproj = net10.0
  Msbuild.Integration.Test.csproj = net472
  NuGet.Commands.FuncTest.csproj = net10.0
  NuGet.Packaging.FuncTest.csproj = net10.0
  NuGet.Protocol.FuncTest.csproj = net10.0
  NuGet.Signing.CrossFramework.Test.csproj = net10.0
  NuGet.XPlat.FuncTest.csproj = net10.0
  Microsoft.Build.NuGetSdkResolver.Test.csproj = net10.0
  NuGet.Build.Tasks.Console.Test.csproj = net10.0
  NuGet.Build.Tasks.Pack.Test.csproj = net10.0
  NuGet.Build.Tasks.Test.csproj = net10.0
  NuGet.CommandLine.Xplat.Tests.csproj = net10.0
  NuGet.Commands.Test.csproj = net10.0
  NuGet.Common.Test.csproj = net10.0
  NuGet.Configuration.Test.csproj = net10.0
  NuGet.Credentials.Test.csproj = net10.0
  NuGet.DependencyResolver.Core.Tests.csproj = net10.0
  NuGet.Frameworks.Test.csproj = net10.0
  NuGet.LibraryModel.Tests.csproj = net10.0
  NuGet.PackageManagement.Test.csproj = net10.0
  NuGet.Packaging.Test.csproj = net10.0
  NuGet.ProjectModel.Test.csproj = net10.0
  NuGet.Protocol.Tests.csproj = net10.0
  NuGet.Resolver.Test.csproj = net10.0
  NuGet.Shared.Tests.csproj = net10.0
  NuGet.Versioning.Test.csproj = net10.0
  API.Test.csproj = net472
  GenerateLicenseList.csproj = net8.0
  GenerateTestPackages.csproj = net472
  SampleCommandLineExtensions.csproj = net472
  TestableCredentialProvider.csproj = net472
  TestablePlugin.csproj = net10.0
  Microsoft.Internal.NuGet.Testing.SignedPackages.csproj = net10.0
  Test.Utility.csproj = net10.0
  NuGet.CommandLine.csproj = net472
  NuGet.Console.csproj = net472
  NuGet.Indexing.csproj = net472
  NuGet.MSSigning.Extensions.csproj = net472
  NuGet.PackageManagement.PowerShellCmdlets.csproj = net472
  NuGet.PackageManagement.UI.csproj = net472
  NuGet.PackageManagement.VisualStudio.csproj = net472
  NuGet.SolutionRestoreManager.csproj = net472
  NuGet.Tools.csproj = net472
  NuGet.VisualStudio.Client.csproj = net472
  NuGet.VisualStudio.Common.csproj = net472
  NuGet.VisualStudio.Contracts.csproj = netstandard2.0
  NuGet.VisualStudio.Implementation.csproj = net472
  NuGet.VisualStudio.Internal.Contracts.csproj = net472
  NuGet.VisualStudio.Interop.csproj = net472
  NuGet.VisualStudio.OnlineEnvironment.Client.csproj = net472
  NuGet.VisualStudio.csproj = net472
  Microsoft.Build.NuGetSdkResolver.csproj = net10.0
  NuGet.Build.Tasks.Console.csproj = net10.0
  NuGet.Build.Tasks.Pack.csproj = net10.0;netstandard2.0
  NuGet.Build.Tasks.csproj = net10.0
  NuGet.CommandLine.XPlat.csproj = net10.0
  NuGet.Commands.csproj = net10.0;netstandard2.0
  NuGet.Common.csproj = net10.0;netstandard2.0
  NuGet.Configuration.csproj = net10.0;netstandard2.0
  NuGet.Credentials.csproj = net10.0;netstandard2.0
  NuGet.DependencyResolver.Core.csproj = net10.0;netstandard2.0
  NuGet.Frameworks.csproj = net10.0;netstandard2.0
  NuGet.LibraryModel.csproj = net10.0;netstandard2.0
  NuGet.Localization.csproj = netstandard2.0
  NuGet.PackageManagement.csproj = net10.0;netstandard2.0
  NuGet.Packaging.csproj = net10.0;netstandard2.0
  NuGet.ProjectModel.csproj = net10.0;netstandard2.0
  NuGet.Protocol.csproj = net10.0;netstandard2.0
  NuGet.Resolver.csproj = net10.0;netstandard2.0
  NuGet.Versioning.csproj = net10.0;netstandard2.0
  NuGet.Console.TestContract.csproj = net472
  NuGet.OptProf.csproj = net472
  NuGet.PackageManagement.UI.TestContract.csproj = net472
  NuGet.Tests.Apex.Daily.csproj = net472
  NuGet.Tests.Apex.csproj = net472
```
</details>