### PR TITLE
OutputConsoleLogger supports not forcing focus onto the Error List

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/Commands/ClearNuGetLocalResourcesCommand.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Commands/ClearNuGetLocalResourcesCommand.cs
@@ -91,7 +91,7 @@ namespace NuGet.Tools.Commands
                 }
                 finally
                 {
-                    OutputConsoleLogger.End();
+                    OutputConsoleLogger.End(bringErrorListToFrontIfSettingsPermit: false);
                 }
             }).PostOnFailure(nameof(NuGetPackage), nameof(ExecuteClearNuGetLocalResourcesCommand));
         }
@@ -111,7 +111,7 @@ namespace NuGet.Tools.Commands
             }
             finally
             {
-                OutputConsoleLogger.End();
+                OutputConsoleLogger.End(bringErrorListToFrontIfSettingsPermit: false);
             }
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
@@ -99,13 +99,21 @@ namespace NuGet.VisualStudio.Common
 
         public void End()
         {
+            End(bringErrorListToFrontIfSettingsPermit: true);
+        }
+
+        public void End(bool bringErrorListToFrontIfSettingsPermit)
+        {
             Run(async () =>
             {
                 await _outputConsole.WriteLineAsync(Resources.Finished);
                 await _outputConsole.WriteLineAsync(string.Empty);
 
-                // Give the error list focus
-                await _errorList.Value.BringToFrontIfSettingsPermitAsync();
+                if (bringErrorListToFrontIfSettingsPermit)
+                {
+                    // Give the error list focus
+                    await _errorList.Value.BringToFrontIfSettingsPermitAsync();
+                }
             });
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/UserInterfaceService/INuGetUILogger.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/UserInterfaceService/INuGetUILogger.cs
@@ -31,5 +31,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
         /// <summary> End the logging. </summary>
         void End();
+
+        /// <summary> End the logging without possibly showing the Error List. </summary>
+        void End(bool bringErrorListToFrontIfSettingsPermit);
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/nuget/home/issues/11728

## Description

**Draft - for an upcoming Quality Week I want to investigate if I can improve 2 things:**

1. When "Clear NuGet Local resources" completes, the Output pane is concluded by calling `End()` which shows "---finished---" and similar text. Unfortunately, it also explicitly tells the ErrorList to appear, which doesn't make sense. This PR fixes that, but there could be a better re-design of how this all works and that's worth thinking through.

2. I'm not able to reproduce https://github.com/NuGet/Home/issues/6408 but need to spend more time with a real-world EF6 and EFCore scenario to ensure that. I'm wondering if there's a fix that can help Package Manager Console (PMC) as well.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
