### PR TITLE
Update MarkdownPreview to allow passing in cancellation tokens

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,7 +67,7 @@
     <PackageVersion Include="Microsoft.Test.Apex.VisualStudio" Version="17.13.35619.14" />
     <PackageVersion Include="Microsoft.TestPlatform.Portable" Version="17.1.0" />
     <PackageVersion Include="Microsoft.VisualStudio.LanguageServices" Version="4.3.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.Markdown.Platform" Version="17.13.161" />
+    <PackageVersion Include="Microsoft.VisualStudio.Markdown.Platform" Version="17.13.213" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem" Version="17.4.221-pre" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.Managed" Version="17.2.0-beta1-20502-01" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS" Version="17.2.0-beta1-20502-01" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageDetailsTabViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageDetailsTabViewModel.cs
@@ -13,6 +13,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
     {
         private bool _disposed = false;
         private bool _readmeTabEnabled;
+        private CancellationTokenSource _cancelationTokenSource = new CancellationTokenSource();
 
         public ReadmePreviewViewModel ReadmePreviewViewModel { get; private set; }
 
@@ -72,6 +73,8 @@ namespace NuGet.PackageManagement.UI.ViewModels
                 return;
             }
             _disposed = true;
+            _cancelationTokenSource.Cancel();
+            _cancelationTokenSource.Dispose();
             DetailControlModel.PropertyChanged -= DetailControlModel_PropertyChanged;
             foreach (var tab in Tabs)
             {
@@ -108,7 +111,11 @@ namespace NuGet.PackageManagement.UI.ViewModels
             {
                 if (_readmeTabEnabled && e.PropertyName == nameof(DetailControlModel.PackageMetadata))
                 {
-                    await ReadmePreviewViewModel.SetPackageMetadataAsync(DetailControlModel.PackageMetadata, CancellationToken.None);
+                    var newCts = new CancellationTokenSource();
+                    var oldCts = Interlocked.Exchange(ref _cancelationTokenSource, newCts);
+                    oldCts?.Cancel();
+                    oldCts?.Dispose();
+                    await ReadmePreviewViewModel.SetPackageMetadataAsync(DetailControlModel.PackageMetadata, _cancelationTokenSource.Token);
                 }
             }).PostOnFailure(nameof(PackageDetailsTabViewModel), nameof(DetailControlModel_PropertyChanged));
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageDetailsTabViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageDetailsTabViewModel.cs
@@ -13,7 +13,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
     {
         private bool _disposed = false;
         private bool _readmeTabEnabled;
-        private CancellationTokenSource _cancelationTokenSource = new CancellationTokenSource();
+        private CancellationTokenSource _readmeRenderingCancellationTokenSource = new CancellationTokenSource();
 
         public ReadmePreviewViewModel ReadmePreviewViewModel { get; private set; }
 
@@ -73,8 +73,8 @@ namespace NuGet.PackageManagement.UI.ViewModels
                 return;
             }
             _disposed = true;
-            _cancelationTokenSource.Cancel();
-            _cancelationTokenSource.Dispose();
+            _readmeRenderingCancellationTokenSource.Cancel();
+            _readmeRenderingCancellationTokenSource.Dispose();
             DetailControlModel.PropertyChanged -= DetailControlModel_PropertyChanged;
             foreach (var tab in Tabs)
             {
@@ -112,10 +112,10 @@ namespace NuGet.PackageManagement.UI.ViewModels
                 if (_readmeTabEnabled && e.PropertyName == nameof(DetailControlModel.PackageMetadata))
                 {
                     var newCts = new CancellationTokenSource();
-                    var oldCts = Interlocked.Exchange(ref _cancelationTokenSource, newCts);
+                    var oldCts = Interlocked.Exchange(ref _readmeRenderingCancellationTokenSource, newCts);
                     oldCts?.Cancel();
                     oldCts?.Dispose();
-                    await ReadmePreviewViewModel.SetPackageMetadataAsync(DetailControlModel.PackageMetadata, _cancelationTokenSource.Token);
+                    await ReadmePreviewViewModel.SetPackageMetadataAsync(DetailControlModel.PackageMetadata, _readmeRenderingCancellationTokenSource.Token);
                 }
             }).PostOnFailure(nameof(PackageDetailsTabViewModel), nameof(DetailControlModel_PropertyChanged));
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
@@ -138,10 +138,13 @@ namespace NuGet.PackageManagement.UI.ViewModels
             }
             finally
             {
-                ReadmeMarkdown = readme;
-                IsVisible = !string.IsNullOrWhiteSpace(readme);
-                ErrorWithReadme = false;
-                IsBusy = false;
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    ReadmeMarkdown = readme;
+                    IsVisible = !string.IsNullOrWhiteSpace(readme);
+                    ErrorWithReadme = false;
+                    IsBusy = false;
+                }
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TaskExtensions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TaskExtensions.cs
@@ -24,6 +24,10 @@ namespace NuGet.VisualStudio.Telemetry
                     await task.ConfigureAwait(false);
 #pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
                 }
+                catch (OperationCanceledException)
+                {
+                    //We ignore this exception as it is expected to be thrown when the task is cancelled.
+                }
                 catch (Exception e)
                 {
                     await TelemetryUtility.PostFaultAsync(e, callerClassName, callerMemberName);
@@ -46,6 +50,10 @@ namespace NuGet.VisualStudio.Telemetry
 #pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
                 await task.ConfigureAwait(false);
 #pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+            }
+            catch (OperationCanceledException)
+            {
+                //We ignore this exception as it is expected to be thrown when the task is cancelled.
             }
             catch (Exception e)
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3119

## Description
Update MarkdownPreview to a version that allows cancellation tokens to be passed into UpdateContentAsync. Allowing for the cancellation token to be honored if rendering the README, not just downloading the README from the source. The token is cancelled when the PM UI is closed and when a new package is selected in the PM UI. 
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
