### PR TITLE
Account for no-op restore when deciding to update the info bar

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -4,5 +4,5 @@
     <Artifact Include="$(ArtifactsDir)nupkgs/*.nupkg"
               PublishFlatContainer="false" />
   </ItemGroup>
-  
+
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -4,5 +4,5 @@
     <Artifact Include="$(ArtifactsDir)nupkgs/*.nupkg"
               PublishFlatContainer="false" />
   </ItemGroup>
-
+  
 </Project>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -68,7 +68,7 @@ namespace NuGet.SolutionRestoreManager
         private int _currentCount;
         private AuditCheckResult _auditCheckResult;
         private bool _solutionHasVulnerabilities;
-        private bool _newVulnerabilityCheckToBeConsidered;
+        private bool _didNewAuditCheckRun;
 
         /// <summary>
         /// Restore end status. For testing purposes
@@ -268,7 +268,7 @@ namespace NuGet.SolutionRestoreManager
                     }
 
                     // Display info bar in SolutionExplorer if there is a vulnerability during restore.
-                    if (_newVulnerabilityCheckToBeConsidered)
+                    if (_didNewAuditCheckRun)
                     {
                         await _vulnerabilitiesFoundService.Value.ReportVulnerabilitiesAsync(_solutionHasVulnerabilities, token);
                     }
@@ -512,7 +512,7 @@ namespace NuGet.SolutionRestoreManager
                                     isRestoreSucceeded = restoreSummaries.All(summary => summary.Success == true);
                                     _noOpProjectsCount += restoreSummaries.Count(summary => summary.NoOpRestore == true);
                                     _solutionUpToDateChecker.SaveRestoreStatus(restoreSummaries);
-                                    _newVulnerabilityCheckToBeConsidered = true; //  this has a bug about vulnerability if the project with vulnerabilities was never updated.
+                                    _didNewAuditCheckRun = true;
                                     _solutionHasVulnerabilities |= AnyProjectHasVulnerablePackageWarning(restoreSummaries);
                                 }
                                 catch
@@ -713,7 +713,7 @@ namespace NuGet.SolutionRestoreManager
                         _status = NuGetOperationStatus.Succeeded;
                     }
                     _auditResultCachingService.LastAuditCheckResult = _auditCheckResult;
-                    _newVulnerabilityCheckToBeConsidered = true;
+                    _didNewAuditCheckRun = true;
                 }
                 else
                 {
@@ -727,7 +727,7 @@ namespace NuGet.SolutionRestoreManager
                         AuditChecker auditChecker = new(sourceRepositories, sourceCacheContext, _logger);
                         AuditCheckResult result = await auditChecker.CheckPackageVulnerabilitiesAsync(packages, auditProperties, token);
                         _auditResultCachingService.LastAuditCheckResult = result;
-                        _newVulnerabilityCheckToBeConsidered = true;
+                        _didNewAuditCheckRun = true;
                     }
                     else
                     {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -68,6 +68,7 @@ namespace NuGet.SolutionRestoreManager
         private int _currentCount;
         private AuditCheckResult _auditCheckResult;
         private bool _solutionHasVulnerabilities;
+        private bool _newVulnerabilityCheckToBeConsidered;
 
         /// <summary>
         /// Restore end status. For testing purposes
@@ -267,7 +268,10 @@ namespace NuGet.SolutionRestoreManager
                     }
 
                     // Display info bar in SolutionExplorer if there is a vulnerability during restore.
-                    await _vulnerabilitiesFoundService.Value.ReportVulnerabilitiesAsync(_solutionHasVulnerabilities, token);
+                    if (_newVulnerabilityCheckToBeConsidered)
+                    {
+                        await _vulnerabilitiesFoundService.Value.ReportVulnerabilitiesAsync(_solutionHasVulnerabilities, token);
+                    }
                 }
                 catch (OperationCanceledException)
                 {
@@ -508,6 +512,7 @@ namespace NuGet.SolutionRestoreManager
                                     isRestoreSucceeded = restoreSummaries.All(summary => summary.Success == true);
                                     _noOpProjectsCount += restoreSummaries.Count(summary => summary.NoOpRestore == true);
                                     _solutionUpToDateChecker.SaveRestoreStatus(restoreSummaries);
+                                    _newVulnerabilityCheckToBeConsidered = true; //  this has a bug about vulnerability if the project with vulnerabilities was never updated.
                                     _solutionHasVulnerabilities |= AnyProjectHasVulnerablePackageWarning(restoreSummaries);
                                 }
                                 catch
@@ -708,6 +713,7 @@ namespace NuGet.SolutionRestoreManager
                         _status = NuGetOperationStatus.Succeeded;
                     }
                     _auditResultCachingService.LastAuditCheckResult = _auditCheckResult;
+                    _newVulnerabilityCheckToBeConsidered = true;
                 }
                 else
                 {
@@ -721,6 +727,7 @@ namespace NuGet.SolutionRestoreManager
                         AuditChecker auditChecker = new(sourceRepositories, sourceCacheContext, _logger);
                         AuditCheckResult result = await auditChecker.CheckPackageVulnerabilitiesAsync(packages, auditProperties, token);
                         _auditResultCachingService.LastAuditCheckResult = result;
+                        _newVulnerabilityCheckToBeConsidered = true;
                     }
                     else
                     {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13318

## Description

Account for no-op restore when deciding to update the info bar. 

If we perform a full no-op for restore, it usually means that we have *not* performed an audit check, which means we won't have updates for the info-bar.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~ Unfortunately this is incredibly difficult to test in an automated way. Our vendors will cover this.
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
