### PR TITLE
Add copy command for the content of the gold bar in the PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -664,6 +664,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to _Copy.
+        /// </summary>
+        public static string CopyMenuCommandLabel {
+            get {
+                return ResourceManager.GetString("CopyMenuCommandLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Highest.
         /// </summary>
         public static string DependencyBehavior_Highest {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1099,4 +1099,7 @@ Only the package maintainer can add a README. If you are not the maintainer, ple
 For instructions on how to add a README, please visit [aka.ms/nuget/readme](https://aka.ms/nuget/readme)</value>
     <comment>{Locked="[aka.ms/nuget/readme](https://aka.ms/nuget/readme)"} "[aka.ms/nuget/readme](https://aka.ms/nuget/readme)" this is a URL link and should not be translated</comment>
   </data>
+  <data name="CopyMenuCommandLabel" xml:space="preserve">
+    <value>_Copy</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml
@@ -3,36 +3,43 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              Loaded="UserControl_Loaded"
              xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
+             xmlns:vsui="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
              Visibility="{Binding InnerVisibility, Mode=OneWay}">
-    <UserControl.Resources>
-      <Storyboard x:Key="ShowSmoothly">
-        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="InnerVisibility" Storyboard.Target="{Binding}">
-          <DiscreteObjectKeyFrame KeyTime="0:0:0.3" Value="{x:Static Visibility.Visible}"/>
-        </ObjectAnimationUsingKeyFrames>
-        <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="RestoreBar">
-          <EasingDoubleKeyFrame KeyTime="0:0:0.3" Value="0"/>
-          <EasingDoubleKeyFrame KeyTime="0:0:0.9" Value="1"/>
-        </DoubleAnimationUsingKeyFrames>
-      </Storyboard>
-      <Storyboard x:Key="HideSmoothly">
-        <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="RestoreBar">
-          <EasingDoubleKeyFrame KeyTime="0:0:0.6" Value="0"/>
-        </DoubleAnimationUsingKeyFrames>
-        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="InnerVisibility" Storyboard.Target="{Binding}">
-          <DiscreteObjectKeyFrame KeyTime="0:0:0.6" Value="{x:Static Visibility.Collapsed}"/>
-        </ObjectAnimationUsingKeyFrames>
-      </Storyboard>
-    </UserControl.Resources>
-    <Border x:Name="RestoreBar" VerticalAlignment="Center" Visibility="{Binding InnerVisibility, Mode=OneWay}" Opacity="0" BorderThickness="0,0,0,1">
-        <Grid Margin="0,4,0,6">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            
-            <TextBlock x:Name="StatusMessage" Grid.Column="0" Text="{x:Static resx:Resources.AskForRestoreMessage}" TextWrapping="Wrap" TextOptions.TextFormattingMode="Display" VerticalAlignment="Center" Margin="5,0,5,0" />
-            <Button x:Name="RestoreButton" VerticalAlignment="Center" Grid.Column="1" Content="{x:Static resx:Resources.RestoreButtonLabel}" Click="OnRestoreLinkClick" Margin="5,0,3,0" Padding="8,2,8,2" />
+  <UserControl.Resources>
+    <Storyboard x:Key="ShowSmoothly">
+      <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="InnerVisibility" Storyboard.Target="{Binding}">
+        <DiscreteObjectKeyFrame KeyTime="0:0:0.3" Value="{x:Static Visibility.Visible}"/>
+      </ObjectAnimationUsingKeyFrames>
+      <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="RestoreBar">
+        <EasingDoubleKeyFrame KeyTime="0:0:0.3" Value="0"/>
+        <EasingDoubleKeyFrame KeyTime="0:0:0.9" Value="1"/>
+      </DoubleAnimationUsingKeyFrames>
+    </Storyboard>
+    <Storyboard x:Key="HideSmoothly">
+      <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="RestoreBar">
+        <EasingDoubleKeyFrame KeyTime="0:0:0.6" Value="0"/>
+      </DoubleAnimationUsingKeyFrames>
+      <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="InnerVisibility" Storyboard.Target="{Binding}">
+        <DiscreteObjectKeyFrame KeyTime="0:0:0.6" Value="{x:Static Visibility.Collapsed}"/>
+      </ObjectAnimationUsingKeyFrames>
+    </Storyboard>
+  </UserControl.Resources>
+  <Border x:Name="RestoreBar" VerticalAlignment="Center" Visibility="{Binding InnerVisibility, Mode=OneWay}" Opacity="0" BorderThickness="0,0,0,1">
+    <Grid Margin="0,4,0,6">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="Auto" />
+      </Grid.ColumnDefinitions>
+
+      <TextBlock x:Name="StatusMessage" Grid.Column="0" Text="{x:Static resx:Resources.AskForRestoreMessage}" TextWrapping="Wrap" TextOptions.TextFormattingMode="Display" VerticalAlignment="Center" Margin="5,0,5,0">
+        <TextBlock.ContextMenu>
+          <ContextMenu Style="{DynamicResource {x:Static vsui:VsResourceKeys.ContextMenuStyleKey}}">
+            <MenuItem Header="{x:Static resx:Resources.CopyMenuCommandLabel}" Command="{Binding CopyCommand}" />
+          </ContextMenu>
+        </TextBlock.ContextMenu>
+      </TextBlock>
+      <Button x:Name="RestoreButton" VerticalAlignment="Center" Grid.Column="1" Content="{x:Static resx:Resources.RestoreButtonLabel}" Click="OnRestoreLinkClick" Margin="5,0,3,0" Padding="8,2,8,2" />
       <ProgressBar x:Name="ProgressBar" Grid.Column="1" IsIndeterminate="{Binding RelativeSource={RelativeSource Self}, Path=IsVisible}" Height="{Binding ActualHeight, ElementName=RestoreButton, Mode=OneWay}" Width="170" Margin="5,0,3,0" />
-        </Grid>
-    </Border>
+    </Grid>
+  </Border>
 </UserControl>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14074

## Description
Added a content menu and menu item to the gold bar in the PM UI to allow users to copy the message being displayed. This will allow users to copy full error messages. This behavior mimics that of the info bar in the solution explorer.

Tested by deleting the assets file for a project and opening the NuGet Package Manager for said project. An error message and restore button appears in the gold bar. Right clicked on the error message and validated that a context menu and Copy menu item appears. Validated the context menu is styled with the look and feel of VS context menus and that it was appropriately themed.

Without highlight: 
![image](https://github.com/user-attachments/assets/af61773c-f6a5-4d75-ae9e-fb35616a16e8)
![image](https://github.com/user-attachments/assets/5fb87046-b0fc-4fc1-8a00-6398b3e7051c) 

With highlight: 
![image](https://github.com/user-attachments/assets/85a2a7af-533e-432f-994d-6d8d916b0ec2)
![image](https://github.com/user-attachments/assets/5075c911-0d21-49e5-a08d-d7959f9c95b8)


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~ Tested manually. See screenshots for theming tests.
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
