### PR TITLE
Detect cycle between root project and transitive dependency in new dependency resolver

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.DependencyGraphItem.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.DependencyGraphItem.cs
@@ -46,12 +46,12 @@ namespace NuGet.Commands
             /// <summary>
             /// Gets or initializes the <see cref="LibraryDependencyIndex" /> associated with this dependency graph item.
             /// </summary>
-            public LibraryDependencyIndex LibraryDependencyIndex { get; init; } = LibraryDependencyIndex.Invalid;
+            public LibraryDependencyIndex LibraryDependencyIndex { get; init; }
 
             /// <summary>
             /// Gets or initializes the <see cref="LibraryRangeIndex" /> associated with this dependency graph item.
             /// </summary>
-            public LibraryRangeIndex LibraryRangeIndex { get; init; } = LibraryRangeIndex.Invalid;
+            public LibraryRangeIndex LibraryRangeIndex { get; init; }
 
             /// <summary>
             /// Gets or initializes the <see cref="LibraryRangeIndex" /> of this dependency graph item's parent.

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.DependencyGraphItemIndexer.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.DependencyGraphItemIndexer.cs
@@ -87,6 +87,16 @@ namespace NuGet.Commands
             private LibraryRangeIndex _nextLibraryRangeIndex = LibraryRangeIndex.Project + 1;
 
             /// <summary>
+            /// Initializes a new instance of the <see cref="DependencyGraphItemIndexer" /> class.
+            /// </summary>
+            /// <param name="libraryDependency">A <see cref="LibraryDependency" /> representing the root project.</param>
+            public DependencyGraphItemIndexer(LibraryDependency libraryDependency)
+            {
+                _libraryDependencyTable.TryAdd(libraryDependency.Name, LibraryDependencyIndex.Project);
+                _libraryRangeTable.TryAdd(libraryDependency.LibraryRange, LibraryRangeIndex.Project);
+            }
+
+            /// <summary>
             /// Indexes a <see cref="LibraryDependency" /> and returns a <see cref="LibraryDependencyIndex" /> associated with the its name.
             /// </summary>
             /// <param name="libraryDependency">The <see cref="LibraryDependency" /> of the library to index.</param>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.DependencyGraphItemIndexer.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.DependencyGraphItemIndexer.cs
@@ -17,11 +17,6 @@ namespace NuGet.Commands
         public enum LibraryDependencyIndex : int
         {
             /// <summary>
-            /// An invalid value used only for default initialization.
-            /// </summary>
-            Invalid = -1,
-
-            /// <summary>
             /// The index of the root project.
             /// </summary>
             Project = 0,
@@ -32,11 +27,6 @@ namespace NuGet.Commands
         /// </summary>
         public enum LibraryRangeIndex : int
         {
-            /// <summary>
-            /// An invalid value used only for default initialization.
-            /// </summary>
-            Invalid = -2,
-
             /// <summary>
             /// The index used as a parent of the root project.
             /// </summary>

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -52,6 +52,56 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[2].Name.Should().Be("X");
         }
 
+        // LightGbm (project) -> Microsoft.ML.LightGbm -> LightGBM 2.0.0 (package)
+        // This should result in an error with the cycle
+        [Fact]
+        public async Task RestoreCommand_WithCycleContainingProject_FailsAndLogsMessage()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                new SimpleTestPackageContext("Microsoft.ML.LightGbm", "4.0.1")
+                {
+                    Dependencies =
+                    [
+                        new SimpleTestPackageContext("LightGBM", "3.3.5"),
+                    ]
+                });
+
+            PackageSpec projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec(
+                "LightGbm",
+                pathContext.SolutionRoot,
+                @"
+                {
+                    ""frameworks"": {
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""Microsoft.ML.LightGbm"": ""4.0.1""
+                        }
+                    }
+                    }
+                }");
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec);
+
+            // Additional assert
+            result.Success.Should().BeFalse();
+
+            result.LogMessages.Should().HaveCount(1);
+
+            IAssetsLogMessage logMessage = result.LogMessages.Single();
+            logMessage.Code.Should().Be(NuGetLogCode.NU1108);
+            logMessage.Message.Should().Contain("LightGbm -> Microsoft.ML.LightGbm 4.0.1 -> LightGBM (>= 3.3.5)");
+
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("Microsoft.ML.LightGbm");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("4.0.1"));
+        }
+
         // Project 1 -> a 1.0.0 -> b 1.0.0
         //           -> b 2.0.0
         // Does not install b 1.0.0 since it is eclipsed by a direct package reference


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14052

## Description
The new dependency resolver does not check if a transitive dependency happens to have the same name as the root project and instead replaces the root project in the graph with a dependency with a higher version.  When the algorithm then tries to create a flattened graph, it throws a `KeyNotFoundException` trying to find the root project in the resolved graph.

This was unintentionally fixed in https://github.com/NuGet/NuGet.Client/pull/6231 which made the root project always have its own ID but during resolution the algorithm now adds the package with the cycle and its detected during the flattening.

This change makes it so the name of the root project is indexed as `0` and then subsequent calls to index it will return the ID of the project.  Then during resolution, there's a check to see a transitive dependency has a cyclic relationship with the root project and if so, leaves it out of the resolved graph.  During the flattening of the graph, the cycle is then detected and an error message is emitted.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
