### PR TITLE
Update PackageUpdateResource to receive bool to indicate if snupkg are enabled

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -54,11 +54,17 @@ namespace NuGet.Commands
 
             // figure out from index.json if pushing snupkg is supported
             var sourceUri = packageUpdateResource.SourceUri;
+            var symbeSourceUri = symbolSource;
 
-            // assume we allow snupkg when the symbol source is set
             if (!string.IsNullOrEmpty(symbolSource) && !noSymbols)
             {
-                allowSnupkg = true;
+                //If the symbol source is set we try try to get the symbol package resource to determine if Snupkg are supported.
+                symbolPackageUpdateResource = await CommandRunnerUtility.GetSymbolPackageUpdateResource(sourceProvider, symbolSource, CancellationToken.None);
+                if (symbolPackageUpdateResource != null)
+                {
+                    allowSnupkg = true;
+                    symbeSourceUri = symbolPackageUpdateResource.SourceUri.AbsoluteUri;
+                }
             }
             else if (!noSymbols
                 && !sourceUri.IsFile
@@ -68,7 +74,7 @@ namespace NuGet.Commands
                 if (symbolPackageUpdateResource != null)
                 {
                     allowSnupkg = true;
-                    symbolSource = symbolPackageUpdateResource.SourceUri.AbsoluteUri;
+                    symbeSourceUri = symbolPackageUpdateResource.SourceUri.AbsoluteUri;
                 }
             }
 
@@ -78,7 +84,7 @@ namespace NuGet.Commands
             // Precedence for symbol package API key: -SymbolApiKey param, config, package API key (Only for symbol source from SymbolPackagePublish service)
             if (!string.IsNullOrEmpty(symbolSource))
             {
-                symbolApiKey ??= CommandRunnerUtility.GetApiKey(settings, symbolSource, symbolSource);
+                symbolApiKey ??= CommandRunnerUtility.GetApiKey(settings, symbeSourceUri, symbolSource);
 
                 // Only allow falling back to API key when the symbol source was obtained from SymbolPackagePublish service
                 if (symbolPackageUpdateResource != null)
@@ -89,7 +95,7 @@ namespace NuGet.Commands
 
             await packageUpdateResource.PushAsync(
                 packagePaths,
-                symbolSource,
+                symbeSourceUri,
                 timeoutSeconds,
                 disableBuffering,
                 _ => apiKey,

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -78,6 +78,12 @@ namespace NuGet.Commands
                 {
                     symbolApiKey ??= apiKey;
                 }
+                // If the symbolPackageUpdateResource is null at this point that means symbolSource was set by the param
+                // symbolPackageUpdateResource is used to determine if snupgk is supported
+                else
+                {
+                    symbolPackageUpdateResource = new SymbolPackageUpdateResourceV3(symbolSource, null);
+                }
             }
 
             await packageUpdateResource.Push(

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -55,7 +55,8 @@ namespace NuGet.Commands
             // figure out from index.json if pushing snupkg is supported
             var sourceUri = packageUpdateResource.SourceUri;
 
-            if (!string.IsNullOrEmpty(symbolSource))
+            // assume we allow snupkg when the symbol source is set
+            if (!string.IsNullOrEmpty(symbolSource) && !noSymbols)
             {
                 allowSnupkg = true;
             }

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -49,18 +49,24 @@ namespace NuGet.Commands
             }
 
             packageUpdateResource.Settings = settings;
+            bool allowSnupkg = false;
             SymbolPackageUpdateResourceV3 symbolPackageUpdateResource = null;
 
             // figure out from index.json if pushing snupkg is supported
             var sourceUri = packageUpdateResource.SourceUri;
-            if (string.IsNullOrEmpty(symbolSource)
-                && !noSymbols
+
+            if (!string.IsNullOrEmpty(symbolSource))
+            {
+                allowSnupkg = true;
+            }
+            else if (!noSymbols
                 && !sourceUri.IsFile
                 && sourceUri.IsAbsoluteUri)
             {
                 symbolPackageUpdateResource = await CommandRunnerUtility.GetSymbolPackageUpdateResource(sourceProvider, source, CancellationToken.None);
                 if (symbolPackageUpdateResource != null)
                 {
+                    allowSnupkg = true;
                     symbolSource = symbolPackageUpdateResource.SourceUri.AbsoluteUri;
                 }
             }
@@ -78,15 +84,9 @@ namespace NuGet.Commands
                 {
                     symbolApiKey ??= apiKey;
                 }
-                // If the symbolPackageUpdateResource is null at this point that means symbolSource was set by the param
-                // symbolPackageUpdateResource is used to determine if snupgk is supported
-                else
-                {
-                    symbolPackageUpdateResource = new SymbolPackageUpdateResourceV3(symbolSource, null);
-                }
             }
 
-            await packageUpdateResource.Push(
+            await packageUpdateResource.PushAsync(
                 packagePaths,
                 symbolSource,
                 timeoutSeconds,
@@ -95,7 +95,7 @@ namespace NuGet.Commands
                 _ => symbolApiKey,
                 noServiceEndpoint,
                 skipDuplicate,
-                symbolPackageUpdateResource,
+                allowSnupkg,
                 packageSource.AllowInsecureConnections,
                 logger);
         }

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -54,16 +54,16 @@ namespace NuGet.Commands
 
             // figure out from index.json if pushing snupkg is supported
             var sourceUri = packageUpdateResource.SourceUri;
-            var symbeSourceUri = symbolSource;
+            var symbolSourceUri = symbolSource;
 
             if (!string.IsNullOrEmpty(symbolSource) && !noSymbols)
             {
-                //If the symbol source is set we try try to get the symbol package resource to determine if Snupkg are supported.
+                //If the symbol source is set we try to get the symbol package resource to determine if Snupkg are supported.
                 symbolPackageUpdateResource = await CommandRunnerUtility.GetSymbolPackageUpdateResource(sourceProvider, symbolSource, CancellationToken.None);
                 if (symbolPackageUpdateResource != null)
                 {
                     allowSnupkg = true;
-                    symbeSourceUri = symbolPackageUpdateResource.SourceUri.AbsoluteUri;
+                    symbolSourceUri = symbolPackageUpdateResource.SourceUri.AbsoluteUri;
                 }
             }
             else if (!noSymbols
@@ -74,7 +74,7 @@ namespace NuGet.Commands
                 if (symbolPackageUpdateResource != null)
                 {
                     allowSnupkg = true;
-                    symbolSource = symbeSourceUri = symbolPackageUpdateResource.SourceUri.AbsoluteUri;
+                    symbolSource = symbolSourceUri = symbolPackageUpdateResource.SourceUri.AbsoluteUri;
                 }
             }
 
@@ -84,7 +84,7 @@ namespace NuGet.Commands
             // Precedence for symbol package API key: -SymbolApiKey param, config, package API key (Only for symbol source from SymbolPackagePublish service)
             if (!string.IsNullOrEmpty(symbolSource))
             {
-                symbolApiKey ??= CommandRunnerUtility.GetApiKey(settings, symbeSourceUri, symbolSource);
+                symbolApiKey ??= CommandRunnerUtility.GetApiKey(settings, symbolSourceUri, symbolSource);
 
                 // Only allow falling back to API key when the symbol source was obtained from SymbolPackagePublish service
                 if (symbolPackageUpdateResource != null)
@@ -95,7 +95,7 @@ namespace NuGet.Commands
 
             await packageUpdateResource.PushAsync(
                 packagePaths,
-                symbeSourceUri,
+                symbolSourceUri,
                 timeoutSeconds,
                 disableBuffering,
                 _ => apiKey,

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -74,7 +74,7 @@ namespace NuGet.Commands
                 if (symbolPackageUpdateResource != null)
                 {
                     allowSnupkg = true;
-                    symbeSourceUri = symbolPackageUpdateResource.SourceUri.AbsoluteUri;
+                    symbolSource = symbeSourceUri = symbolPackageUpdateResource.SourceUri.AbsoluteUri;
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
+~NuGet.Protocol.Core.Types.PackageUpdateResource.PushAsync(System.Collections.Generic.IList<string> packagePaths, string symbolSource, int timeoutInSecond, bool disableBuffering, System.Func<string, string> getApiKey, System.Func<string, string> getSymbolApiKey, bool noServiceEndpoint, bool skipDuplicate, bool allowSnupkg, bool allowInsecureConnections, NuGet.Common.ILogger log) -> System.Threading.Tasks.Task
 ~NuGet.Protocol.PackageVulnerabilityMetadata.PackageVulnerabilityMetadata(System.Uri advisoryUrl, int severity) -> void
 ~NuGet.Protocol.Plugins.PluginFile.PluginFile(string filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState> state) -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
+~NuGet.Protocol.Core.Types.PackageUpdateResource.PushAsync(System.Collections.Generic.IList<string> packagePaths, string symbolSource, int timeoutInSecond, bool disableBuffering, System.Func<string, string> getApiKey, System.Func<string, string> getSymbolApiKey, bool noServiceEndpoint, bool skipDuplicate, bool allowSnupkg, bool allowInsecureConnections, NuGet.Common.ILogger log) -> System.Threading.Tasks.Task
 ~NuGet.Protocol.PackageVulnerabilityMetadata.PackageVulnerabilityMetadata(System.Uri advisoryUrl, int severity) -> void
 ~NuGet.Protocol.Plugins.PluginFile.PluginFile(string filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState> state) -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
+~NuGet.Protocol.Core.Types.PackageUpdateResource.PushAsync(System.Collections.Generic.IList<string> packagePaths, string symbolSource, int timeoutInSecond, bool disableBuffering, System.Func<string, string> getApiKey, System.Func<string, string> getSymbolApiKey, bool noServiceEndpoint, bool skipDuplicate, bool allowSnupkg, bool allowInsecureConnections, NuGet.Common.ILogger log) -> System.Threading.Tasks.Task
 ~NuGet.Protocol.PackageVulnerabilityMetadata.PackageVulnerabilityMetadata(System.Uri advisoryUrl, int severity) -> void
 ~NuGet.Protocol.Plugins.PluginFile.PluginFile(string filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState> state) -> void

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
@@ -561,9 +561,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        /// <summary>
-        /// When pushing *.Nupkg, (no skip duplicate) a 409 Conflict is returned and halts the secondary symbols push.
-        /// </summary>
         [Fact]
         public void PushCommand_Server_Nupkg_ByWildcard_NupkgAndSnupkgPushed()
         {
@@ -616,9 +613,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        /// <summary>
-        /// When pushing *.Nupkg, (no skip duplicate) a 409 Conflict is returned and halts the secondary symbols push.
-        /// </summary>
         [Fact]
         public void PushCommand_Server_Nupkg_ByWildcard_SeparateSymbolUrl_NupkgAndSnupkgPushedToDifferentSources()
         {

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
@@ -589,11 +589,9 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 CommandRunnerResult result = null;
 
                 using (var server = CreateAndStartMockV3Server(pathContext.WorkingDirectory, out string sourceName))
-                using (var symbolServer = CreateAndStartMockV3Server(pathContext.WorkingDirectory, out string symbolSourceName))
                 {
                     sourcePushUrl = SetupMockServerAlwaysCreate(server);
                     pathContext.Settings.AddSource(sourceName, sourceName, "true");
-                    pathContext.Settings.AddSource(symbolSourceName, symbolSourceName, "true");
 
                     // Act
                     //Since this is V3, this will trigger 2 pushes: one for nupkgs, and one for snupkgs.
@@ -681,7 +679,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
         /// When pushing *.Nupkg, (no skip duplicate) a 409 Conflict is returned and halts the secondary symbols push.
         /// </summary>
         [Fact]
-        public void PushCommand_Server_Nupkg_SeperateSymbolUrl_NoSymbolTrue_SnupkgNotPushed()
+        public void PushCommand_Server_Nupkg_SeparateSymbolUrl_NoSymbolTrue_SnupkgNotPushed()
         {
             // Arrange
             using (SimpleTestPathContext pathContext = new SimpleTestPathContext())

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
@@ -659,7 +659,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     result = CommandRunner.Run(
                         nuget,
                         pathContext.WorkingDirectory,
-                        $"push {wildcardPush} -Source {sourceName} -SymbolSource {symbolPushUrl} -Timeout 110",
+                        $"push {wildcardPush} -Source {sourceName} -SymbolSource {symbolSourceName} -Timeout 110",
                         timeOutInMilliseconds: 120000,
                         testOutputHelper: _testOutputHelper); // 120 seconds
                 }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
@@ -669,9 +669,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        /// <summary>
-        /// When pushing *.Nupkg, (no skip duplicate) a 409 Conflict is returned and halts the secondary symbols push.
-        /// </summary>
         [Fact]
         public void PushCommand_Server_Nupkg_SeparateSymbolUrl_NoSymbolTrue_SnupkgNotPushed()
         {

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
@@ -565,6 +565,181 @@ namespace NuGet.CommandLine.FuncTest.Commands
         /// When pushing *.Nupkg, (no skip duplicate) a 409 Conflict is returned and halts the secondary symbols push.
         /// </summary>
         [Fact]
+        public void PushCommand_Server_Nupkg_ByWildcard_NupkgAndSnupkgPushed()
+        {
+            // Arrange
+            using (SimpleTestPathContext pathContext = new SimpleTestPathContext())
+            {
+                var nuget = Util.GetNuGetExePath();
+
+                string packageId = "packageWithSnupkg";
+
+                //Create a nupkg in test directory.
+                string version = "1.1.0";
+                Util.CreateTestPackage(packageId, version, pathContext.WorkingDirectory);
+                string nupkgFileName = Util.BuildPackageString(packageId, version, NuGetConstants.PackageExtension);
+                string snupkgFileName = Util.BuildPackageString(packageId, version, NuGetConstants.SnupkgExtension);
+                string snupkgFullPath = Path.Combine(pathContext.WorkingDirectory, snupkgFileName);
+                //Create snupkg in test directory.
+                WriteSnupkgFile(snupkgFullPath);
+
+                string wildcardPush = "*.nupkg";
+                var sourcePushUrl = string.Empty;
+
+                CommandRunnerResult result = null;
+
+                using (var server = CreateAndStartMockV3Server(pathContext.WorkingDirectory, out string sourceName))
+                using (var symbolServer = CreateAndStartMockV3Server(pathContext.WorkingDirectory, out string symbolSourceName))
+                {
+                    sourcePushUrl = SetupMockServerAlwaysCreate(server);
+                    pathContext.Settings.AddSource(sourceName, sourceName, "true");
+                    pathContext.Settings.AddSource(symbolSourceName, symbolSourceName, "true");
+
+                    // Act
+                    //Since this is V3, this will trigger 2 pushes: one for nupkgs, and one for snupkgs.
+                    result = CommandRunner.Run(
+                        nuget,
+                        pathContext.WorkingDirectory,
+                        $"push {wildcardPush} -Source {sourceName} -Timeout 110",
+                        timeOutInMilliseconds: 120000,
+                        testOutputHelper: _testOutputHelper); // 120 seconds
+                }
+
+                // Assert
+                string genericFileNotFoundError = WITHOUT_FILENAME_MESSAGE_FILE_DOES_NOT_EXIST;
+                string pushingMessage = "Pushing {0} to '{1}'";
+
+                //Both should push, but to different servers
+                Assert.True(result.Success);
+                Assert.Contains(MESSAGE_PACKAGE_PUSHED, result.AllOutput); // files pushed
+                Assert.DoesNotContain(genericFileNotFoundError, result.Errors);
+                Assert.Contains(string.Format(pushingMessage, nupkgFileName, sourcePushUrl), result.AllOutput); //nupkg push to source
+                Assert.Contains(string.Format(pushingMessage, snupkgFileName, sourcePushUrl), result.AllOutput); //snupkg push to source
+            }
+        }
+
+        /// <summary>
+        /// When pushing *.Nupkg, (no skip duplicate) a 409 Conflict is returned and halts the secondary symbols push.
+        /// </summary>
+        [Fact]
+        public void PushCommand_Server_Nupkg_ByWildcard_SeparateSymbolUrl_NupkgAndSnupkgPushedToDifferentSources()
+        {
+            // Arrange
+            using (SimpleTestPathContext pathContext = new SimpleTestPathContext())
+            {
+                var nuget = Util.GetNuGetExePath();
+
+                string packageId = "packageWithSnupkg";
+
+                //Create a nupkg in test directory.
+                string version = "1.1.0";
+                Util.CreateTestPackage(packageId, version, pathContext.WorkingDirectory);
+                string nupkgFileName = Util.BuildPackageString(packageId, version, NuGetConstants.PackageExtension);
+                string snupkgFileName = Util.BuildPackageString(packageId, version, NuGetConstants.SnupkgExtension);
+                string snupkgFullPath = Path.Combine(pathContext.WorkingDirectory, snupkgFileName);
+                //Create snupkg in test directory.
+                WriteSnupkgFile(snupkgFullPath);
+
+                string wildcardPush = "*.nupkg";
+                var sourcePushUrl = string.Empty;
+                var symbolPushUrl = string.Empty;
+
+                CommandRunnerResult result = null;
+
+                using (var server = CreateAndStartMockV3Server(pathContext.WorkingDirectory, out string sourceName))
+                using (var symbolServer = CreateAndStartMockV3Server(pathContext.WorkingDirectory, out string symbolSourceName))
+                {
+                    sourcePushUrl = SetupMockServerAlwaysCreate(server);
+                    symbolPushUrl = SetupMockServerAlwaysCreate(symbolServer);
+                    pathContext.Settings.AddSource(sourceName, sourceName, "true");
+                    pathContext.Settings.AddSource(symbolSourceName, symbolSourceName, "true");
+
+                    // Act
+                    //Since this is V3, this will trigger 2 pushes: one for nupkgs, and one for snupkgs.
+                    result = CommandRunner.Run(
+                        nuget,
+                        pathContext.WorkingDirectory,
+                        $"push {wildcardPush} -Source {sourceName} -SymbolSource {symbolPushUrl} -Timeout 110",
+                        timeOutInMilliseconds: 120000,
+                        testOutputHelper: _testOutputHelper); // 120 seconds
+                }
+
+                // Assert
+                string genericFileNotFoundError = WITHOUT_FILENAME_MESSAGE_FILE_DOES_NOT_EXIST;
+                string pushingMessage = "Pushing {0} to '{1}'";
+
+                //Both should push, but to different servers
+                Assert.True(result.Success);
+                Assert.Contains(MESSAGE_PACKAGE_PUSHED, result.AllOutput); // files pushed
+                Assert.DoesNotContain(genericFileNotFoundError, result.Errors);
+                Assert.Contains(string.Format(pushingMessage, nupkgFileName, sourcePushUrl), result.AllOutput); //nupkg push to source
+                Assert.Contains(string.Format(pushingMessage, snupkgFileName, symbolPushUrl), result.AllOutput); //snupkg push to symbol source
+            }
+        }
+
+        /// <summary>
+        /// When pushing *.Nupkg, (no skip duplicate) a 409 Conflict is returned and halts the secondary symbols push.
+        /// </summary>
+        [Fact]
+        public void PushCommand_Server_Nupkg_SeperateSymbolUrl_NoSymbolTrue_SnupkgNotPushed()
+        {
+            // Arrange
+            using (SimpleTestPathContext pathContext = new SimpleTestPathContext())
+            {
+                var nuget = Util.GetNuGetExePath();
+
+                string packageId = "packageWithSnupkg";
+
+                //Create a nupkg in test directory.
+                string version = "1.1.0";
+                Util.CreateTestPackage(packageId, version, pathContext.WorkingDirectory);
+                string nupkgFileName = Util.BuildPackageString(packageId, version, NuGetConstants.PackageExtension);
+                string snupkgFileName = Util.BuildPackageString(packageId, version, NuGetConstants.SnupkgExtension);
+                string snupkgFullPath = Path.Combine(pathContext.WorkingDirectory, snupkgFileName);
+                //Create snupkg in test directory.
+                WriteSnupkgFile(snupkgFullPath);
+
+                string wildcardPush = "*.nupkg";
+                var sourcePushUrl = string.Empty;
+                var symbolPushUrl = string.Empty;
+
+                CommandRunnerResult result = null;
+
+                using (var server = CreateAndStartMockV3Server(pathContext.WorkingDirectory, out string sourceName))
+                using (var symbolServer = CreateAndStartMockV3Server(pathContext.WorkingDirectory, out string symbolSourceName))
+                {
+                    sourcePushUrl = SetupMockServerAlwaysCreate(server);
+                    symbolPushUrl = SetupMockServerAlwaysCreate(symbolServer);
+                    pathContext.Settings.AddSource(sourceName, sourceName, "true");
+                    pathContext.Settings.AddSource(symbolSourceName, symbolSourceName, "true");
+
+                    // Act
+                    //Since this is V3, this will trigger 2 pushes: one for nupkgs, and one for snupkgs.
+                    result = CommandRunner.Run(
+                        nuget,
+                        pathContext.WorkingDirectory,
+                        $"push {wildcardPush} -Source {sourceName} -SymbolSource {symbolPushUrl} -noSymbol -Timeout 110",
+                        timeOutInMilliseconds: 120000,
+                        testOutputHelper: _testOutputHelper); // 120 seconds
+                }
+
+                // Assert
+                string genericFileNotFoundError = WITHOUT_FILENAME_MESSAGE_FILE_DOES_NOT_EXIST;
+                string pushingMessage = "Pushing {0} to '{1}'";
+
+                //Both should push, but to different servers
+                Assert.True(result.Success);
+                Assert.Contains(MESSAGE_PACKAGE_PUSHED, result.AllOutput); // files pushed
+                Assert.DoesNotContain(genericFileNotFoundError, result.Errors);
+                Assert.Contains(string.Format(pushingMessage, nupkgFileName, sourcePushUrl), result.AllOutput); //nupkg push to source
+                Assert.DoesNotContain(".snupkg", result.AllOutput); //snupkg not pushed
+            }
+        }
+
+        /// <summary>
+        /// When pushing *.Nupkg, (no skip duplicate) a 409 Conflict is returned and halts the secondary symbols push.
+        /// </summary>
+        [Fact]
         public void PushCommand_Server_Nupkg_ByWildcard_FindsMatchingSnupkgs_Conflict()
         {
             // Arrange
@@ -918,12 +1093,13 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }));
         }
 
-        private static void SetupMockServerAlwaysCreate(MockServer server)
+        private static string SetupMockServerAlwaysCreate(MockServer server)
         {
             server.Put.Add("/push", (Func<HttpListenerRequest, object>)((r) =>
             {
                 return HttpStatusCode.Created;
             }));
+            return server.Uri + "push";
         }
 
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/11871

## Description
SymbolPackageUpdateResource is currently only being used in PackageUpdateResource to determine if snupkg are enabled for symbol sources. Since the push command allows users to specify a SymbolSource, there may not be a SymbolPackageUpdateResource available. This created a new function which takes in "allowSnupkg" as a parameter instead of trying to determine if it's available based on whether or not SymbolPackageUpdateResource is null. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
