### PR TITLE
Read vulnerability data only once

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -264,6 +264,9 @@ namespace NuGet.PackageManagement.UI
 
             var listItemViewModels = new Dictionary<string, PackageItemViewModel>();
 
+            // refresh vulnerability data before listing packages
+            _packageVulnerabilityService?.RefreshVulnerabilityData();
+
             foreach (PackageSearchMetadataContextInfo metadataContextInfo in _state.Results.PackageSearchItems)
             {
                 var packageId = metadataContextInfo.Identity.Id;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -264,9 +264,6 @@ namespace NuGet.PackageManagement.UI
 
             var listItemViewModels = new Dictionary<string, PackageItemViewModel>();
 
-            // refresh vulnerability data before listing packages
-            _packageVulnerabilityService?.RefreshVulnerabilityData();
-
             foreach (PackageSearchMetadataContextInfo metadataContextInfo in _state.Results.PackageSearchItems)
             {
                 var packageId = metadataContextInfo.Identity.Id;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -904,7 +904,7 @@ namespace NuGet.PackageManagement.UI
         private async Task UpdatePackageMaxVulnerabilityAsync(PackageIdentity packageIdentity, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfoList = await _vulnerabilityService.GetVulnerabilityInfoAsync(packageIdentity, cancellationToken);
+            IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfoList = await _vulnerabilityService.GetVulnerabilityInfoAsync(packageIdentity);
 
             SetVulnerabilityMaxSeverity(packageIdentity.Version, vulnerabilityInfoList?.FirstOrDefault()?.Severity ?? -1);
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -904,7 +904,9 @@ namespace NuGet.PackageManagement.UI
         private async Task UpdatePackageMaxVulnerabilityAsync(PackageIdentity packageIdentity, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfoList = await _vulnerabilityService.GetVulnerabilityInfoAsync(packageIdentity);
+
+            IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfoList =
+                        await _vulnerabilityService.GetVulnerabilityInfoAsync(packageIdentity, cancellationToken);
 
             SetVulnerabilityMaxSeverity(packageIdentity.Version, vulnerabilityInfoList?.FirstOrDefault()?.Severity ?? -1);
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -904,8 +904,7 @@ namespace NuGet.PackageManagement.UI
         private async Task UpdatePackageMaxVulnerabilityAsync(PackageIdentity packageIdentity, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var vulnerabilityInfoResult = await _vulnerabilityService.GetAllVulnerabilityDataAsync(cancellationToken);
-            IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfoList = _vulnerabilityService.GetVulnerabilityInfoAsync(packageIdentity, vulnerabilityInfoResult, cancellationToken);
+            IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfoList = await _vulnerabilityService.GetVulnerabilityInfoAsync(packageIdentity, cancellationToken);
 
             SetVulnerabilityMaxSeverity(packageIdentity.Version, vulnerabilityInfoList?.FirstOrDefault()?.Severity ?? -1);
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -904,9 +904,8 @@ namespace NuGet.PackageManagement.UI
         private async Task UpdatePackageMaxVulnerabilityAsync(PackageIdentity packageIdentity, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-
-            IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfoList =
-                        await _vulnerabilityService.GetVulnerabilityInfoAsync(packageIdentity, cancellationToken);
+            var vulnerabilityInfoResult = await _vulnerabilityService.GetAllVulnerabilityDataAsync(cancellationToken);
+            IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfoList = _vulnerabilityService.GetVulnerabilityInfoAsync(packageIdentity, vulnerabilityInfoResult, cancellationToken);
 
             SetVulnerabilityMaxSeverity(packageIdentity.Version, vulnerabilityInfoList?.FirstOrDefault()?.Severity ?? -1);
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -905,7 +905,7 @@ namespace NuGet.PackageManagement.UI
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            // Use ShutdownToken to avoid canceling on search changes, only on VS shutdown.
+            // Use ShutdownToken to ensure the operation is canceled if it's still running when VS shuts down.
             IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfoList =
                         await _vulnerabilityService.GetVulnerabilityInfoAsync(packageIdentity, VsShellUtilities.ShutdownToken);
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -905,8 +905,9 @@ namespace NuGet.PackageManagement.UI
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            // Use ShutdownToken to avoid canceling on search changes, only on VS shutdown.
             IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfoList =
-                        await _vulnerabilityService.GetVulnerabilityInfoAsync(packageIdentity, cancellationToken);
+                        await _vulnerabilityService.GetVulnerabilityInfoAsync(packageIdentity, VsShellUtilities.ShutdownToken);
 
             SetVulnerabilityMaxSeverity(packageIdentity.Version, vulnerabilityInfoList?.FirstOrDefault()?.Severity ?? -1);
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1051,7 +1051,7 @@ namespace NuGet.PackageManagement.UI
             IInstalledAndTransitivePackages installedAndTransitivePackages = await PackageCollection.GetInstalledAndTransitivePackagesAsync(loadContext.ServiceBroker, loadContext.Projects, includeTransitiveOrigins: true, token);
             installedPackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.InstalledPackages);
             PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.TransitivePackages.Where(p => p.TransitiveOrigins.Any()));
-            IEnumerable<PackageVulnerabilityMetadataContextInfo>[] transitivePackageVulnerabilities = await Task.WhenAll(transitivePackageCollection.Select(p => _packageVulnerabilityService.GetVulnerabilityInfoAsync(p, token)));
+            IEnumerable<PackageVulnerabilityMetadataContextInfo>[] transitivePackageVulnerabilities = await Task.WhenAll(transitivePackageCollection.Select(p => _packageVulnerabilityService.GetVulnerabilityInfoAsync(p)));
 
             foreach (IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfo in transitivePackageVulnerabilities)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1051,7 +1051,10 @@ namespace NuGet.PackageManagement.UI
             IInstalledAndTransitivePackages installedAndTransitivePackages = await PackageCollection.GetInstalledAndTransitivePackagesAsync(loadContext.ServiceBroker, loadContext.Projects, includeTransitiveOrigins: true, token);
             installedPackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.InstalledPackages);
             PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.TransitivePackages.Where(p => p.TransitiveOrigins.Any()));
-            IEnumerable<PackageVulnerabilityMetadataContextInfo>[] transitivePackageVulnerabilities = await Task.WhenAll(transitivePackageCollection.Select(p => _packageVulnerabilityService.GetVulnerabilityInfoAsync(p, token)));
+            var vulnerabilityInfoResult = await _packageVulnerabilityService.GetAllVulnerabilityDataAsync(token);
+            var transitivePackageVulnerabilities = transitivePackageCollection
+                .Select(p => _packageVulnerabilityService.GetVulnerabilityInfoAsync(p, vulnerabilityInfoResult, token))
+                .ToArray();
 
             foreach (IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfo in transitivePackageVulnerabilities)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -940,6 +940,7 @@ namespace NuGet.PackageManagement.UI
                 _packageList.ClearPackageLevelGrouping();
 
                 bool useRecommender = GetUseRecommendedPackages(loadContext, searchText);
+                _packageVulnerabilityService.Refresh();
                 var loader = await PackageItemLoader.CreateAsync(
                     Model.Context.ServiceBroker,
                     Model.Context.NuGetSearchService,
@@ -1051,6 +1052,7 @@ namespace NuGet.PackageManagement.UI
             IInstalledAndTransitivePackages installedAndTransitivePackages = await PackageCollection.GetInstalledAndTransitivePackagesAsync(loadContext.ServiceBroker, loadContext.Projects, includeTransitiveOrigins: true, token);
             installedPackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.InstalledPackages);
             PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.TransitivePackages.Where(p => p.TransitiveOrigins.Any()));
+            _packageVulnerabilityService.Refresh();
             IEnumerable<PackageVulnerabilityMetadataContextInfo>[] transitivePackageVulnerabilities = await Task.WhenAll(transitivePackageCollection.Select(p => _packageVulnerabilityService.GetVulnerabilityInfoAsync(p)));
 
             foreach (IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfo in transitivePackageVulnerabilities)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -183,7 +183,7 @@ namespace NuGet.PackageManagement.UI
             }
 
             var sourceRepositories = sourceRepositoryProvider.GetRepositories();
-            _packageVulnerabilityService = new PackageVulnerabilityService(sourceRepositories, _uiLogger, _refreshCts.Token);
+            _packageVulnerabilityService = new PackageVulnerabilityService(sourceRepositories, _uiLogger);
 
             var solutionManager = Model.Context.SolutionManagerService;
             solutionManager.ProjectAdded += OnProjectChanged;
@@ -940,7 +940,6 @@ namespace NuGet.PackageManagement.UI
                 _packageList.ClearPackageLevelGrouping();
 
                 bool useRecommender = GetUseRecommendedPackages(loadContext, searchText);
-                _packageVulnerabilityService.Refresh();
                 var loader = await PackageItemLoader.CreateAsync(
                     Model.Context.ServiceBroker,
                     Model.Context.NuGetSearchService,
@@ -1052,8 +1051,7 @@ namespace NuGet.PackageManagement.UI
             IInstalledAndTransitivePackages installedAndTransitivePackages = await PackageCollection.GetInstalledAndTransitivePackagesAsync(loadContext.ServiceBroker, loadContext.Projects, includeTransitiveOrigins: true, token);
             installedPackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.InstalledPackages);
             PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.TransitivePackages.Where(p => p.TransitiveOrigins.Any()));
-            _packageVulnerabilityService.Refresh();
-            IEnumerable<PackageVulnerabilityMetadataContextInfo>[] transitivePackageVulnerabilities = await Task.WhenAll(transitivePackageCollection.Select(_packageVulnerabilityService.GetVulnerabilityInfoAsync));
+            IEnumerable<List<PackageVulnerabilityMetadataContextInfo>> transitivePackageVulnerabilities = await _packageVulnerabilityService.GetVulnerabilityInfoAsync(transitivePackageCollection, token);
 
             foreach (IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfo in transitivePackageVulnerabilities)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1053,7 +1053,7 @@ namespace NuGet.PackageManagement.UI
             installedPackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.InstalledPackages);
             PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.TransitivePackages.Where(p => p.TransitiveOrigins.Any()));
             _packageVulnerabilityService.Refresh();
-            IEnumerable<PackageVulnerabilityMetadataContextInfo>[] transitivePackageVulnerabilities = await Task.WhenAll(transitivePackageCollection.Select(p => _packageVulnerabilityService.GetVulnerabilityInfoAsync(p)));
+            IEnumerable<PackageVulnerabilityMetadataContextInfo>[] transitivePackageVulnerabilities = await Task.WhenAll(transitivePackageCollection.Select(_packageVulnerabilityService.GetVulnerabilityInfoAsync));
 
             foreach (IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfo in transitivePackageVulnerabilities)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -183,7 +183,7 @@ namespace NuGet.PackageManagement.UI
             }
 
             var sourceRepositories = sourceRepositoryProvider.GetRepositories();
-            _packageVulnerabilityService = new PackageVulnerabilityService(sourceRepositories, _uiLogger, cancellationToken);
+            _packageVulnerabilityService = new PackageVulnerabilityService(sourceRepositories, _uiLogger, _refreshCts.Token);
 
             var solutionManager = Model.Context.SolutionManagerService;
             solutionManager.ProjectAdded += OnProjectChanged;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -183,7 +183,7 @@ namespace NuGet.PackageManagement.UI
             }
 
             var sourceRepositories = sourceRepositoryProvider.GetRepositories();
-            _packageVulnerabilityService = new PackageVulnerabilityService(sourceRepositories, _uiLogger);
+            _packageVulnerabilityService = new PackageVulnerabilityService(sourceRepositories, _uiLogger, cancellationToken);
 
             var solutionManager = Model.Context.SolutionManagerService;
             solutionManager.ProjectAdded += OnProjectChanged;
@@ -1051,10 +1051,7 @@ namespace NuGet.PackageManagement.UI
             IInstalledAndTransitivePackages installedAndTransitivePackages = await PackageCollection.GetInstalledAndTransitivePackagesAsync(loadContext.ServiceBroker, loadContext.Projects, includeTransitiveOrigins: true, token);
             installedPackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.InstalledPackages);
             PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.TransitivePackages.Where(p => p.TransitiveOrigins.Any()));
-            var vulnerabilityInfoResult = await _packageVulnerabilityService.GetAllVulnerabilityDataAsync(token);
-            var transitivePackageVulnerabilities = transitivePackageCollection
-                .Select(p => _packageVulnerabilityService.GetVulnerabilityInfoAsync(p, vulnerabilityInfoResult, token))
-                .ToArray();
+            IEnumerable<PackageVulnerabilityMetadataContextInfo>[] transitivePackageVulnerabilities = await Task.WhenAll(transitivePackageCollection.Select(p => _packageVulnerabilityService.GetVulnerabilityInfoAsync(p, token)));
 
             foreach (IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfo in transitivePackageVulnerabilities)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1771,6 +1771,8 @@ namespace NuGet.PackageManagement.UI
 
         private async Task ExecuteRestartSearchCommandAsync()
         {
+            // reset vulnerability data
+            _packageVulnerabilityService?.ResetVulnerabilityData();
             await SearchPackagesAndRefreshUpdateCountAsync(useCacheForUpdates: false);
             await RefreshConsolidatablePackagesCountAsync();
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1051,7 +1051,7 @@ namespace NuGet.PackageManagement.UI
             IInstalledAndTransitivePackages installedAndTransitivePackages = await PackageCollection.GetInstalledAndTransitivePackagesAsync(loadContext.ServiceBroker, loadContext.Projects, includeTransitiveOrigins: true, token);
             installedPackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.InstalledPackages);
             PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.TransitivePackages.Where(p => p.TransitiveOrigins.Any()));
-            IEnumerable<List<PackageVulnerabilityMetadataContextInfo>> transitivePackageVulnerabilities = await _packageVulnerabilityService.GetVulnerabilityInfoAsync(transitivePackageCollection, token);
+            IEnumerable<IEnumerable<PackageVulnerabilityMetadataContextInfo>> transitivePackageVulnerabilities = await _packageVulnerabilityService.GetVulnerabilityInfoAsync(transitivePackageCollection, token);
 
             foreach (IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfo in transitivePackageVulnerabilities)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1051,7 +1051,8 @@ namespace NuGet.PackageManagement.UI
             IInstalledAndTransitivePackages installedAndTransitivePackages = await PackageCollection.GetInstalledAndTransitivePackagesAsync(loadContext.ServiceBroker, loadContext.Projects, includeTransitiveOrigins: true, token);
             installedPackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.InstalledPackages);
             PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.TransitivePackages.Where(p => p.TransitiveOrigins.Any()));
-            IEnumerable<IEnumerable<PackageVulnerabilityMetadataContextInfo>> transitivePackageVulnerabilities = await _packageVulnerabilityService.GetVulnerabilityInfoAsync(transitivePackageCollection, token);
+            // Use ShutdownToken to avoid canceling on search changes, only on VS shutdown.
+            IEnumerable<IEnumerable<PackageVulnerabilityMetadataContextInfo>> transitivePackageVulnerabilities = await _packageVulnerabilityService.GetVulnerabilityInfoAsync(transitivePackageCollection, VsShellUtilities.ShutdownToken);
 
             foreach (IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfo in transitivePackageVulnerabilities)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1051,8 +1051,8 @@ namespace NuGet.PackageManagement.UI
             IInstalledAndTransitivePackages installedAndTransitivePackages = await PackageCollection.GetInstalledAndTransitivePackagesAsync(loadContext.ServiceBroker, loadContext.Projects, includeTransitiveOrigins: true, token);
             installedPackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.InstalledPackages);
             PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.TransitivePackages.Where(p => p.TransitiveOrigins.Any()));
-            // Use ShutdownToken to avoid canceling on search changes, only on VS shutdown.
-            IEnumerable<IEnumerable<PackageVulnerabilityMetadataContextInfo>> transitivePackageVulnerabilities = await _packageVulnerabilityService.GetVulnerabilityInfoAsync(transitivePackageCollection, VsShellUtilities.ShutdownToken);
+            //Use ShutdownToken to ensure the operation is canceled if it's still running when VS shuts down.
+            IEnumerable<PackageVulnerabilityMetadataContextInfo>[] transitivePackageVulnerabilities = await Task.WhenAll(transitivePackageCollection.Select(p => _packageVulnerabilityService.GetVulnerabilityInfoAsync(p, VsShellUtilities.ShutdownToken)));
 
             foreach (IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfo in transitivePackageVulnerabilities)
             {
@@ -1772,7 +1772,6 @@ namespace NuGet.PackageManagement.UI
 
         private async Task ExecuteRestartSearchCommandAsync()
         {
-            // reset vulnerability data
             _packageVulnerabilityService?.ResetVulnerabilityData();
             await SearchPackagesAndRefreshUpdateCountAsync(useCacheForUpdates: false);
             await RefreshConsolidatablePackagesCountAsync();

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
@@ -11,5 +11,6 @@ namespace NuGet.PackageManagement.VisualStudio
     public interface IPackageVulnerabilityService
     {
         Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId);
+        void Refresh();
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
@@ -5,12 +5,14 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
+using NuGet.Protocol.Model;
 using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
     public interface IPackageVulnerabilityService
     {
-        Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken);
+        List<PackageVulnerabilityMetadataContextInfo> GetVulnerabilityInfoAsync(PackageIdentity packageId, GetVulnerabilityInfoResult vulnerabilities, CancellationToken cancellationToken);
+        Task<GetVulnerabilityInfoResult> GetAllVulnerabilityDataAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
@@ -12,7 +12,7 @@ namespace NuGet.PackageManagement.VisualStudio
     public interface IPackageVulnerabilityService
     {
         Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken);
-        Task<IEnumerable<List<PackageVulnerabilityMetadataContextInfo>>> GetVulnerabilityInfoAsync(PackageCollection packageCollection, CancellationToken cancellationToken);
+        Task<IEnumerable<IEnumerable<PackageVulnerabilityMetadataContextInfo>>> GetVulnerabilityInfoAsync(PackageCollection packageCollection, CancellationToken cancellationToken);
         void RefreshVulnerabilityData();
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
 using NuGet.VisualStudio.Internal.Contracts;
@@ -11,6 +10,6 @@ namespace NuGet.PackageManagement.VisualStudio
 {
     public interface IPackageVulnerabilityService
     {
-        Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken);
+        Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId);
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
@@ -12,7 +12,7 @@ namespace NuGet.PackageManagement.VisualStudio
     public interface IPackageVulnerabilityService
     {
         Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken);
-        Task<IEnumerable<IEnumerable<PackageVulnerabilityMetadataContextInfo>>> GetVulnerabilityInfoAsync(PackageCollection packageCollection, CancellationToken cancellationToken);
+        Task<List<List<PackageVulnerabilityMetadataContextInfo>>> GetVulnerabilityInfoAsync(PackageCollection packageCollection, CancellationToken cancellationToken);
         void ResetVulnerabilityData();
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
@@ -5,14 +5,12 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
-using NuGet.Protocol.Model;
 using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
     public interface IPackageVulnerabilityService
     {
-        List<PackageVulnerabilityMetadataContextInfo> GetVulnerabilityInfoAsync(PackageIdentity packageId, GetVulnerabilityInfoResult vulnerabilities, CancellationToken cancellationToken);
-        Task<GetVulnerabilityInfoResult> GetAllVulnerabilityDataAsync(CancellationToken cancellationToken);
+        Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken);
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
@@ -13,6 +13,6 @@ namespace NuGet.PackageManagement.VisualStudio
     {
         Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken);
         Task<IEnumerable<IEnumerable<PackageVulnerabilityMetadataContextInfo>>> GetVulnerabilityInfoAsync(PackageCollection packageCollection, CancellationToken cancellationToken);
-        void RefreshVulnerabilityData();
+        void ResetVulnerabilityData();
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
 using NuGet.VisualStudio.Internal.Contracts;
@@ -10,7 +11,8 @@ namespace NuGet.PackageManagement.VisualStudio
 {
     public interface IPackageVulnerabilityService
     {
-        Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId);
-        void Refresh();
+        Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken);
+        Task<IEnumerable<List<PackageVulnerabilityMetadataContextInfo>>> GetVulnerabilityInfoAsync(PackageCollection packageCollection, CancellationToken cancellationToken);
+        void RefreshVulnerabilityData();
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
@@ -12,7 +12,6 @@ namespace NuGet.PackageManagement.VisualStudio
     public interface IPackageVulnerabilityService
     {
         Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken);
-        Task<List<List<PackageVulnerabilityMetadataContextInfo>>> GetVulnerabilityInfoAsync(PackageCollection packageCollection, CancellationToken cancellationToken);
         void ResetVulnerabilityData();
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
@@ -156,7 +156,13 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public async Task<IEnumerable<IEnumerable<PackageVulnerabilityMetadataContextInfo>>> GetVulnerabilityInfoAsync(PackageCollection packageCollection, CancellationToken cancellationToken)
         {
-            _vulnerabilitiesTask ??= GetAllVulnerabilityDataAsync(cancellationToken);
+            if (_vulnerabilitiesTask == null)
+            {
+                lock (_lock)
+                {
+                    _vulnerabilitiesTask ??= GetAllVulnerabilityDataAsync(cancellationToken);
+                }
+            }
 
             GetVulnerabilityInfoResult vulnerabilities = await _vulnerabilitiesTask;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
@@ -18,20 +18,22 @@ namespace NuGet.PackageManagement.VisualStudio
     public class PackageVulnerabilityService : IPackageVulnerabilityService
     {
         private readonly IEnumerable<SourceRepository> _sourceRepositories;
-        private readonly AsyncLazy<GetVulnerabilityInfoResult> _vulnerabilitiesLazy;
+        private AsyncLazy<GetVulnerabilityInfoResult> _vulnerabilities;
         private INuGetUILogger _logger;
+        private readonly CancellationToken _cancellationToken;
 
         public PackageVulnerabilityService(IEnumerable<SourceRepository> sourceRepositories, INuGetUILogger logger, CancellationToken cancellationToken)
         {
             _sourceRepositories = sourceRepositories ?? throw new ArgumentNullException(nameof(sourceRepositories));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _vulnerabilitiesLazy = new AsyncLazy<GetVulnerabilityInfoResult>(async () => await GetAllVulnerabilityDataAsync(CancellationToken.None));
+            _cancellationToken = cancellationToken;
+            _vulnerabilities = new AsyncLazy<GetVulnerabilityInfoResult>(async () => await GetAllVulnerabilityDataAsync(cancellationToken));
         }
 
         public async Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId)
         {
             IEnumerable<PackageVulnerabilityInfo> packageVulnerabilities = Enumerable.Empty<PackageVulnerabilityInfo>();
-            GetVulnerabilityInfoResult vulnerabilityInfoResult = await _vulnerabilitiesLazy;
+            GetVulnerabilityInfoResult vulnerabilityInfoResult = await _vulnerabilities;
             if (vulnerabilityInfoResult?.Exceptions is not null)
             {
                 ReplayErrors(vulnerabilityInfoResult.Exceptions);
@@ -44,6 +46,11 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             return ConvertToPackageVulnerabilityMetadataContextInfo(packageVulnerabilities);
+        }
+
+        public void Refresh()
+        {
+            _vulnerabilities = new AsyncLazy<GetVulnerabilityInfoResult>(async () => await GetAllVulnerabilityDataAsync(_cancellationToken));
         }
 
         // Copied and adapted from NuGet.Commands.Restore.Utility.AuditUtility.GetAllVulnerabilityDataAsync

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
@@ -18,8 +18,8 @@ namespace NuGet.PackageManagement.VisualStudio
     public class PackageVulnerabilityService : IPackageVulnerabilityService
     {
         private readonly IEnumerable<SourceRepository> _sourceRepositories;
-        private INuGetUILogger _logger;
         private readonly AsyncLazy<GetVulnerabilityInfoResult> _vulnerabilitiesLazy;
+        private INuGetUILogger _logger;
 
         public PackageVulnerabilityService(IEnumerable<SourceRepository> sourceRepositories, INuGetUILogger logger, CancellationToken cancellationToken)
         {
@@ -28,7 +28,7 @@ namespace NuGet.PackageManagement.VisualStudio
             _vulnerabilitiesLazy = new AsyncLazy<GetVulnerabilityInfoResult>(async () => await GetAllVulnerabilityDataAsync(CancellationToken.None));
         }
 
-        public async Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken)
+        public async Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId)
         {
             IEnumerable<PackageVulnerabilityInfo> packageVulnerabilities = Enumerable.Empty<PackageVulnerabilityInfo>();
             GetVulnerabilityInfoResult vulnerabilityInfoResult = await _vulnerabilitiesLazy;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
@@ -17,7 +17,6 @@ namespace NuGet.PackageManagement.VisualStudio
     public class PackageVulnerabilityService : IPackageVulnerabilityService
     {
         private readonly IEnumerable<SourceRepository> _sourceRepositories;
-        private GetVulnerabilityInfoResult _vulnerabilities;
         private INuGetUILogger _logger;
 
         public PackageVulnerabilityService(IEnumerable<SourceRepository> sourceRepositories, INuGetUILogger logger)
@@ -26,17 +25,16 @@ namespace NuGet.PackageManagement.VisualStudio
             _logger = logger ?? throw new ArgumentNullException(nameof(logger)); ;
         }
 
-        public async Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken)
+        public List<PackageVulnerabilityMetadataContextInfo> GetVulnerabilityInfoAsync(PackageIdentity packageId, GetVulnerabilityInfoResult vulnerabilities, CancellationToken cancellationToken)
         {
-            _vulnerabilities = await GetAllVulnerabilityDataAsync(cancellationToken);
             IEnumerable<PackageVulnerabilityInfo> packageVulnerabilities = Enumerable.Empty<PackageVulnerabilityInfo>();
 
-            if (_vulnerabilities?.Exceptions is not null)
+            if (vulnerabilities?.Exceptions is not null)
             {
-                ReplayErrors(_vulnerabilities.Exceptions);
+                ReplayErrors(vulnerabilities.Exceptions);
             }
 
-            IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> allVulnerabilities = _vulnerabilities?.KnownVulnerabilities;
+            IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> allVulnerabilities = vulnerabilities?.KnownVulnerabilities;
             if (allVulnerabilities is not null && allVulnerabilities.Any())
             {
                 packageVulnerabilities = GetKnownVulnerabilities(packageId.Id, packageId.Version, allVulnerabilities);
@@ -46,7 +44,7 @@ namespace NuGet.PackageManagement.VisualStudio
         }
 
         // Copied and adapted from NuGet.Commands.Restore.Utility.AuditUtility.GetAllVulnerabilityDataAsync
-        private async Task<GetVulnerabilityInfoResult> GetAllVulnerabilityDataAsync(CancellationToken cancellationToken)
+        public async Task<GetVulnerabilityInfoResult> GetAllVulnerabilityDataAsync(CancellationToken cancellationToken)
         {
             IEnumerable<Task<GetVulnerabilityInfoResult>> results = _sourceRepositories.Select(sr => sr.GetVulnerabilityInfoAsync(cancellationToken));
             await Task.WhenAll(results);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Model;
@@ -18,23 +19,25 @@ namespace NuGet.PackageManagement.VisualStudio
     {
         private readonly IEnumerable<SourceRepository> _sourceRepositories;
         private INuGetUILogger _logger;
+        private readonly AsyncLazy<GetVulnerabilityInfoResult> _vulnerabilitiesLazy;
 
-        public PackageVulnerabilityService(IEnumerable<SourceRepository> sourceRepositories, INuGetUILogger logger)
+        public PackageVulnerabilityService(IEnumerable<SourceRepository> sourceRepositories, INuGetUILogger logger, CancellationToken cancellationToken)
         {
             _sourceRepositories = sourceRepositories ?? throw new ArgumentNullException(nameof(sourceRepositories));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger)); ;
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _vulnerabilitiesLazy = new AsyncLazy<GetVulnerabilityInfoResult>(async () => await GetAllVulnerabilityDataAsync(CancellationToken.None));
         }
 
-        public List<PackageVulnerabilityMetadataContextInfo> GetVulnerabilityInfoAsync(PackageIdentity packageId, GetVulnerabilityInfoResult vulnerabilities, CancellationToken cancellationToken)
+        public async Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken)
         {
             IEnumerable<PackageVulnerabilityInfo> packageVulnerabilities = Enumerable.Empty<PackageVulnerabilityInfo>();
-
-            if (vulnerabilities?.Exceptions is not null)
+            GetVulnerabilityInfoResult vulnerabilityInfoResult = await _vulnerabilitiesLazy;
+            if (vulnerabilityInfoResult?.Exceptions is not null)
             {
-                ReplayErrors(vulnerabilities.Exceptions);
+                ReplayErrors(vulnerabilityInfoResult.Exceptions);
             }
 
-            IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> allVulnerabilities = vulnerabilities?.KnownVulnerabilities;
+            IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> allVulnerabilities = vulnerabilityInfoResult?.KnownVulnerabilities;
             if (allVulnerabilities is not null && allVulnerabilities.Any())
             {
                 packageVulnerabilities = GetKnownVulnerabilities(packageId.Id, packageId.Version, allVulnerabilities);
@@ -44,7 +47,7 @@ namespace NuGet.PackageManagement.VisualStudio
         }
 
         // Copied and adapted from NuGet.Commands.Restore.Utility.AuditUtility.GetAllVulnerabilityDataAsync
-        public async Task<GetVulnerabilityInfoResult> GetAllVulnerabilityDataAsync(CancellationToken cancellationToken)
+        private async Task<GetVulnerabilityInfoResult> GetAllVulnerabilityDataAsync(CancellationToken cancellationToken)
         {
             IEnumerable<Task<GetVulnerabilityInfoResult>> results = _sourceRepositories.Select(sr => sr.GetVulnerabilityInfoAsync(cancellationToken));
             await Task.WhenAll(results);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
@@ -154,7 +154,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
         }
 
-        public async Task<IEnumerable<IEnumerable<PackageVulnerabilityMetadataContextInfo>>> GetVulnerabilityInfoAsync(PackageCollection packageCollection, CancellationToken cancellationToken)
+        public async Task<List<List<PackageVulnerabilityMetadataContextInfo>>> GetVulnerabilityInfoAsync(PackageCollection packageCollection, CancellationToken cancellationToken)
         {
             if (_vulnerabilitiesTask == null)
             {
@@ -166,7 +166,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             GetVulnerabilityInfoResult vulnerabilities = await _vulnerabilitiesTask;
 
-            List<IEnumerable<PackageVulnerabilityMetadataContextInfo>> packageVulnerabilitiesList = new List<IEnumerable<PackageVulnerabilityMetadataContextInfo>>();
+            List<List<PackageVulnerabilityMetadataContextInfo>> packageVulnerabilitiesList = new List<List<PackageVulnerabilityMetadataContextInfo>>();
 
             foreach (PackageIdentity package in packageCollection)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
@@ -19,6 +19,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private readonly IEnumerable<SourceRepository> _sourceRepositories;
         private Task<GetVulnerabilityInfoResult> _vulnerabilitiesTask;
         private INuGetUILogger _logger;
+        private readonly object _lock = new();
 
         public PackageVulnerabilityService(IEnumerable<SourceRepository> sourceRepositories, INuGetUILogger logger)
         {
@@ -28,7 +29,13 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public async Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken)
         {
-            _vulnerabilitiesTask ??= GetAllVulnerabilityDataAsync(cancellationToken);
+            if (_vulnerabilitiesTask == null)
+            {
+                lock (_lock)
+                {
+                    _vulnerabilitiesTask ??= GetAllVulnerabilityDataAsync(cancellationToken);
+                }
+            }
 
             GetVulnerabilityInfoResult vulnerabilities = await _vulnerabilitiesTask;
 
@@ -48,9 +55,12 @@ namespace NuGet.PackageManagement.VisualStudio
             return ConvertToPackageVulnerabilityMetadataContextInfo(packageVulnerabilities);
         }
 
-        public void RefreshVulnerabilityData()
+        public void ResetVulnerabilityData()
         {
-            _vulnerabilitiesTask = null;
+            lock (_lock)
+            {
+                _vulnerabilitiesTask = null;
+            }
         }
 
         // Copied and adapted from NuGet.Commands.Restore.Utility.AuditUtility.GetAllVulnerabilityDataAsync

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
@@ -66,7 +66,7 @@ namespace NuGet.PackageManagement.VisualStudio
         // Copied and adapted from NuGet.Commands.Restore.Utility.AuditUtility.GetAllVulnerabilityDataAsync
         private async Task<GetVulnerabilityInfoResult> GetAllVulnerabilityDataAsync(CancellationToken cancellationToken)
         {
-            IEnumerable<Task<GetVulnerabilityInfoResult>> results = _sourceRepositories.Select(sr => sr.GetVulnerabilityInfoAsync(cancellationToken));
+            List<Task<GetVulnerabilityInfoResult>> results = _sourceRepositories.Select(sr => sr.GetVulnerabilityInfoAsync(cancellationToken)).ToList();
             await Task.WhenAll(results);
 
             if (cancellationToken.IsCancellationRequested)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Model;
@@ -18,28 +17,29 @@ namespace NuGet.PackageManagement.VisualStudio
     public class PackageVulnerabilityService : IPackageVulnerabilityService
     {
         private readonly IEnumerable<SourceRepository> _sourceRepositories;
-        private AsyncLazy<GetVulnerabilityInfoResult> _vulnerabilities;
+        private Task<GetVulnerabilityInfoResult> _vulnerabilitiesTask;
         private INuGetUILogger _logger;
-        private readonly CancellationToken _cancellationToken;
 
-        public PackageVulnerabilityService(IEnumerable<SourceRepository> sourceRepositories, INuGetUILogger logger, CancellationToken cancellationToken)
+        public PackageVulnerabilityService(IEnumerable<SourceRepository> sourceRepositories, INuGetUILogger logger)
         {
             _sourceRepositories = sourceRepositories ?? throw new ArgumentNullException(nameof(sourceRepositories));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _cancellationToken = cancellationToken;
-            _vulnerabilities = new AsyncLazy<GetVulnerabilityInfoResult>(async () => await GetAllVulnerabilityDataAsync(cancellationToken));
         }
 
-        public async Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId)
+        public async Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken)
         {
+            _vulnerabilitiesTask ??= GetAllVulnerabilityDataAsync(cancellationToken);
+
+            GetVulnerabilityInfoResult vulnerabilities = await _vulnerabilitiesTask;
+
             IEnumerable<PackageVulnerabilityInfo> packageVulnerabilities = Enumerable.Empty<PackageVulnerabilityInfo>();
-            GetVulnerabilityInfoResult vulnerabilityInfoResult = await _vulnerabilities;
-            if (vulnerabilityInfoResult?.Exceptions is not null)
+
+            if (vulnerabilities?.Exceptions is not null)
             {
-                ReplayErrors(vulnerabilityInfoResult.Exceptions);
+                ReplayErrors(vulnerabilities.Exceptions);
             }
 
-            IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> allVulnerabilities = vulnerabilityInfoResult?.KnownVulnerabilities;
+            IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> allVulnerabilities = vulnerabilities?.KnownVulnerabilities;
             if (allVulnerabilities is not null && allVulnerabilities.Any())
             {
                 packageVulnerabilities = GetKnownVulnerabilities(packageId.Id, packageId.Version, allVulnerabilities);
@@ -48,9 +48,9 @@ namespace NuGet.PackageManagement.VisualStudio
             return ConvertToPackageVulnerabilityMetadataContextInfo(packageVulnerabilities);
         }
 
-        public void Refresh()
+        public void RefreshVulnerabilityData()
         {
-            _vulnerabilities = new AsyncLazy<GetVulnerabilityInfoResult>(async () => await GetAllVulnerabilityDataAsync(_cancellationToken));
+            _vulnerabilitiesTask = null;
         }
 
         // Copied and adapted from NuGet.Commands.Restore.Utility.AuditUtility.GetAllVulnerabilityDataAsync
@@ -142,6 +142,34 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 _logger.Log(ProjectManagement.MessageLevel.Warning, Strings.Error_VulnerabilityDataFetch, exception.Message);
             }
+        }
+
+        public async Task<IEnumerable<List<PackageVulnerabilityMetadataContextInfo>>> GetVulnerabilityInfoAsync(PackageCollection packageCollection, CancellationToken cancellationToken)
+        {
+            _vulnerabilitiesTask ??= GetAllVulnerabilityDataAsync(cancellationToken);
+
+            GetVulnerabilityInfoResult vulnerabilities = await _vulnerabilitiesTask;
+
+            List<IEnumerable<PackageVulnerabilityInfo>> packageVulnerabilitiesList = new List<IEnumerable<PackageVulnerabilityInfo>>();
+
+            foreach (PackageCollectionItem package in packageCollection)
+            {
+                IEnumerable<PackageVulnerabilityInfo> packageVulnerabilities = Enumerable.Empty<PackageVulnerabilityInfo>();
+
+                if (vulnerabilities?.Exceptions is not null)
+                {
+                    ReplayErrors(vulnerabilities.Exceptions);
+                }
+
+                IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> allVulnerabilities = vulnerabilities?.KnownVulnerabilities;
+                if (allVulnerabilities is not null && allVulnerabilities.Any())
+                {
+                    packageVulnerabilities = GetKnownVulnerabilities(package.Id, package.Version, allVulnerabilities);
+                    packageVulnerabilitiesList.Add(packageVulnerabilities);
+                }
+            }
+
+            return packageVulnerabilitiesList.Select(ConvertToPackageVulnerabilityMetadataContextInfo);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
@@ -144,32 +144,20 @@ namespace NuGet.PackageManagement.VisualStudio
             }
         }
 
-        public async Task<IEnumerable<List<PackageVulnerabilityMetadataContextInfo>>> GetVulnerabilityInfoAsync(PackageCollection packageCollection, CancellationToken cancellationToken)
+        public async Task<IEnumerable<IEnumerable<PackageVulnerabilityMetadataContextInfo>>> GetVulnerabilityInfoAsync(PackageCollection packageCollection, CancellationToken cancellationToken)
         {
             _vulnerabilitiesTask ??= GetAllVulnerabilityDataAsync(cancellationToken);
 
             GetVulnerabilityInfoResult vulnerabilities = await _vulnerabilitiesTask;
 
-            List<IEnumerable<PackageVulnerabilityInfo>> packageVulnerabilitiesList = new List<IEnumerable<PackageVulnerabilityInfo>>();
+            List<IEnumerable<PackageVulnerabilityMetadataContextInfo>> packageVulnerabilitiesList = new List<IEnumerable<PackageVulnerabilityMetadataContextInfo>>();
 
-            foreach (PackageCollectionItem package in packageCollection)
+            foreach (PackageIdentity package in packageCollection)
             {
-                IEnumerable<PackageVulnerabilityInfo> packageVulnerabilities = Enumerable.Empty<PackageVulnerabilityInfo>();
-
-                if (vulnerabilities?.Exceptions is not null)
-                {
-                    ReplayErrors(vulnerabilities.Exceptions);
-                }
-
-                IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> allVulnerabilities = vulnerabilities?.KnownVulnerabilities;
-                if (allVulnerabilities is not null && allVulnerabilities.Any())
-                {
-                    packageVulnerabilities = GetKnownVulnerabilities(package.Id, package.Version, allVulnerabilities);
-                    packageVulnerabilitiesList.Add(packageVulnerabilities);
-                }
+                packageVulnerabilitiesList.Add(await GetVulnerabilityInfoAsync(packageId: package, cancellationToken));
             }
 
-            return packageVulnerabilitiesList.Select(ConvertToPackageVulnerabilityMetadataContextInfo);
+            return packageVulnerabilitiesList;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
@@ -153,27 +153,5 @@ namespace NuGet.PackageManagement.VisualStudio
                 _logger.Log(ProjectManagement.MessageLevel.Warning, Strings.Error_VulnerabilityDataFetch, exception.Message);
             }
         }
-
-        public async Task<List<List<PackageVulnerabilityMetadataContextInfo>>> GetVulnerabilityInfoAsync(PackageCollection packageCollection, CancellationToken cancellationToken)
-        {
-            if (_vulnerabilitiesTask == null)
-            {
-                lock (_lock)
-                {
-                    _vulnerabilitiesTask ??= GetAllVulnerabilityDataAsync(cancellationToken);
-                }
-            }
-
-            GetVulnerabilityInfoResult vulnerabilities = await _vulnerabilitiesTask;
-
-            List<List<PackageVulnerabilityMetadataContextInfo>> packageVulnerabilitiesList = new List<List<PackageVulnerabilityMetadataContextInfo>>();
-
-            foreach (PackageIdentity package in packageCollection)
-            {
-                packageVulnerabilitiesList.Add(await GetVulnerabilityInfoAsync(packageId: package, cancellationToken));
-            }
-
-            return packageVulnerabilitiesList;
-        }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/PackageVulnerabilityServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/PackageVulnerabilityServiceTests.cs
@@ -1,0 +1,262 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Model;
+using NuGet.Versioning;
+using NuGet.VisualStudio.Internal.Contracts;
+using Xunit;
+using Xunit.Abstractions;
+
+#nullable enable
+
+namespace NuGet.PackageManagement.VisualStudio.Test
+{
+    public class PackageVulnerabilityServiceTests
+    {
+        TestNuGetUILogger _testLogger;
+        ITestOutputHelper _testOutputHelper;
+
+        public PackageVulnerabilityServiceTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+            _testLogger = new TestNuGetUILogger(_testOutputHelper);
+        }
+
+        [Fact]
+        public async Task GetVulnerabilityInfoAsync_ValidPackageId_ReturnsVulnerabilityInfo()
+        {
+            // Arrange
+            PackageSource source = new PackageSource("https://contoso.com/vulnerability/v3/index.json");
+            List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities = new List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>()
+            {
+                new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>
+                {
+                    {
+                        "Package1",
+                        new PackageVulnerabilityInfo[] {
+                            new PackageVulnerabilityInfo(new Uri("https://vulnerability1"), PackageVulnerabilitySeverity.Low, VersionRange.Parse("[1.0.0,2.0.0)"))
+                        }
+                    }
+                }
+            };
+
+            Dictionary<string, GetVulnerabilityInfoResult> vulnerabilityResults = new()
+            {
+                { source.Name, new GetVulnerabilityInfoResult(knownVulnerabilities, exceptions: null) }
+            };
+
+            var providers = new List<INuGetResourceProvider> { new VulnerabilityInfoResourceProvider(vulnerabilityResults) };
+
+            var sourceRepository = new SourceRepository(source, providers);
+            PackageVulnerabilityService packageVulnerabilityService = new PackageVulnerabilityService(new List<SourceRepository> { sourceRepository }, _testLogger);
+
+            // Act
+            List<PackageVulnerabilityMetadataContextInfo> vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
+
+            // Assert
+            Assert.True(vulnerabilities.Count == 1);
+        }
+
+        [Fact]
+        public async Task GetVulnerabilityInfoAsync_MultipleTimes_LoadsVulnerabilityDataOnce()
+        {
+            // Arrange
+            PackageSource source = new PackageSource("https://contoso.com/vulnerability/v3/index.json");
+            List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities = new List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>()
+            {
+                new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>
+                {
+                    {
+                        "Package1",
+                        new PackageVulnerabilityInfo[] {
+                            new PackageVulnerabilityInfo(new Uri("https://vulnerability1"), PackageVulnerabilitySeverity.Low, VersionRange.Parse("[1.0.0,2.0.0)"))
+                        }
+                    }
+                }
+            };
+
+            GetVulnerabilityInfoResult getVulnerabilityInfoResult = new GetVulnerabilityInfoResult(knownVulnerabilities, exceptions: null);
+
+            int getVulnerabilityCallCount = 0;
+
+            var vulnerabilityResource = new Mock<IVulnerabilityInfoResource>();
+            vulnerabilityResource.Setup(resource => resource.GetVulnerabilityInfoAsync(
+                It.IsAny<SourceCacheContext>(),
+                It.IsAny<ILogger>(),
+                It.IsAny<CancellationToken>()))
+                .Callback(() => getVulnerabilityCallCount++)
+                .ReturnsAsync(getVulnerabilityInfoResult);
+
+            var sourceRepository = new Mock<SourceRepository>();
+
+            sourceRepository.Setup(s => s.GetResourceAsync<IVulnerabilityInfoResource>(CancellationToken.None))
+                .ReturnsAsync(vulnerabilityResource.Object);
+
+            PackageVulnerabilityService packageVulnerabilityService = new PackageVulnerabilityService(new List<SourceRepository> { sourceRepository.Object }, _testLogger);
+
+            // Act & Assert
+            List<PackageVulnerabilityMetadataContextInfo> vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
+            Assert.True(vulnerabilities.Count == 1);
+            Assert.Equal(1, getVulnerabilityCallCount);
+            vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
+            Assert.True(vulnerabilities.Count == 1);
+            Assert.Equal(1, getVulnerabilityCallCount);
+            vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
+            Assert.True(vulnerabilities.Count == 1);
+            Assert.Equal(1, getVulnerabilityCallCount);
+        }
+
+
+        [Fact]
+        public async Task GetVulnerabilityInfoAsync_ResetVulnerabilityData_ResetsVulnerabilityData()
+        {
+            // Arrange
+            PackageSource source = new PackageSource("https://contoso.com/vulnerability/v3/index.json");
+            List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities = new List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>()
+            {
+                new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>
+                {
+                    {
+                        "Package1",
+                        new PackageVulnerabilityInfo[] {
+                            new PackageVulnerabilityInfo(new Uri("https://vulnerability1"), PackageVulnerabilitySeverity.Low, VersionRange.Parse("[1.0.0,2.0.0)"))
+                        }
+                    }
+                }
+            };
+
+            GetVulnerabilityInfoResult getVulnerabilityInfoResult = new GetVulnerabilityInfoResult(knownVulnerabilities, exceptions: null);
+
+            int getVulnerabilityCallCount = 0;
+
+            var vulnerabilityResource = new Mock<IVulnerabilityInfoResource>();
+            vulnerabilityResource.Setup(resource => resource.GetVulnerabilityInfoAsync(
+                It.IsAny<SourceCacheContext>(),
+                It.IsAny<ILogger>(),
+                It.IsAny<CancellationToken>()))
+                .Callback(() => getVulnerabilityCallCount++)
+                .ReturnsAsync(getVulnerabilityInfoResult);
+
+            var sourceRepository = new Mock<SourceRepository>();
+
+            sourceRepository.Setup(s => s.GetResourceAsync<IVulnerabilityInfoResource>(CancellationToken.None))
+                .ReturnsAsync(vulnerabilityResource.Object);
+
+            PackageVulnerabilityService packageVulnerabilityService = new PackageVulnerabilityService(new List<SourceRepository> { sourceRepository.Object }, _testLogger);
+
+            // Act & Assert
+            List<PackageVulnerabilityMetadataContextInfo> vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
+            Assert.True(vulnerabilities.Count == 1);
+            Assert.Equal(1, getVulnerabilityCallCount);
+            // Reset the vulnerability data
+            packageVulnerabilityService.ResetVulnerabilityData();
+            vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
+            Assert.True(vulnerabilities.Count == 1);
+            Assert.Equal(2, getVulnerabilityCallCount);
+            // Reset the vulnerability data again
+            packageVulnerabilityService.ResetVulnerabilityData();
+            vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
+            Assert.True(vulnerabilities.Count == 1);
+            Assert.Equal(3, getVulnerabilityCallCount);
+        }
+
+        [Fact]
+        public async Task GetVulnerabilityInfoAsync_MultipleTimesMultiplePackages_LoadsVulnerabilityDataOnce()
+        {
+            // Arrange
+            PackageSource source = new PackageSource("https://contoso.com/vulnerability/v3/index.json");
+            List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities = new List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>()
+            {
+                new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>
+                {
+                    {
+                        "Package1",
+                        new PackageVulnerabilityInfo[] {
+                            new PackageVulnerabilityInfo(new Uri("https://vulnerability1"), PackageVulnerabilitySeverity.Low, VersionRange.Parse("[1.0.0,2.0.0)"))
+                        }
+                    }
+                }
+            };
+
+            var packageCollection = new PackageCollection([
+                new PackageCollectionItem("Package1", new NuGetVersion("1.0.0"), Array.Empty<PackageReferenceContextInfo>()),
+                new PackageCollectionItem("Package1", new NuGetVersion("1.0.1"), Array.Empty<PackageReferenceContextInfo>()),
+                new PackageCollectionItem("Package1", new NuGetVersion("1.0.2"), Array.Empty<PackageReferenceContextInfo>())]);
+
+
+            GetVulnerabilityInfoResult getVulnerabilityInfoResult = new GetVulnerabilityInfoResult(knownVulnerabilities, exceptions: null);
+
+            int getVulnerabilityCallCount = 0;
+
+            var vulnerabilityResource = new Mock<IVulnerabilityInfoResource>();
+            vulnerabilityResource.Setup(resource => resource.GetVulnerabilityInfoAsync(
+                It.IsAny<SourceCacheContext>(),
+                It.IsAny<ILogger>(),
+                It.IsAny<CancellationToken>()))
+                .Callback(() => getVulnerabilityCallCount++)
+                .ReturnsAsync(getVulnerabilityInfoResult);
+
+            var sourceRepository = new Mock<SourceRepository>();
+
+            sourceRepository.Setup(s => s.GetResourceAsync<IVulnerabilityInfoResource>(CancellationToken.None))
+                .ReturnsAsync(vulnerabilityResource.Object);
+
+            PackageVulnerabilityService packageVulnerabilityService = new PackageVulnerabilityService(new List<SourceRepository> { sourceRepository.Object }, _testLogger);
+
+            // Act & Assert
+            IEnumerable<IEnumerable<PackageVulnerabilityMetadataContextInfo>> vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(packageCollection, CancellationToken.None);
+            Assert.Equal(1, getVulnerabilityCallCount);
+            vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(packageCollection, CancellationToken.None);
+            Assert.Equal(1, getVulnerabilityCallCount);
+            vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(packageCollection, CancellationToken.None);
+            Assert.Equal(1, getVulnerabilityCallCount);
+        }
+
+        internal class VulnerabilityInfoResourceProvider : ResourceProvider
+        {
+            private readonly Dictionary<string, GetVulnerabilityInfoResult> _vulnerabilityInfoResults;
+
+            public VulnerabilityInfoResourceProvider(Dictionary<string, GetVulnerabilityInfoResult> vulnerabilityInfoResults)
+                : base(typeof(IVulnerabilityInfoResource), nameof(VulnerabilityInfoResourceProvider))
+            {
+                _vulnerabilityInfoResults = vulnerabilityInfoResults ?? throw new ArgumentNullException(nameof(vulnerabilityInfoResults));
+            }
+
+            public override Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
+            {
+                if (_vulnerabilityInfoResults.TryGetValue(source.PackageSource.Source, out GetVulnerabilityInfoResult? value))
+                {
+                    var resource = new VulnerabilityInfoResourceImplementation(source, value);
+                    var result = new Tuple<bool, INuGetResource?>(true, resource);
+                    return Task.FromResult(result);
+                }
+                return Task.FromResult(new Tuple<bool, INuGetResource?>(false, null));
+            }
+        }
+
+        internal class VulnerabilityInfoResourceImplementation : IVulnerabilityInfoResource
+        {
+            internal GetVulnerabilityInfoResult Result { get; }
+            internal SourceRepository SourceRepository { get; }
+            public VulnerabilityInfoResourceImplementation(SourceRepository sourceRepository, GetVulnerabilityInfoResult result)
+            {
+                SourceRepository = sourceRepository;
+                Result = result;
+            }
+            public Task<GetVulnerabilityInfoResult> GetVulnerabilityInfoAsync(SourceCacheContext cacheContext, ILogger logger, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(Result);
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/PackageVulnerabilityServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/PackageVulnerabilityServiceTests.cs
@@ -116,7 +116,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.Equal(1, getVulnerabilityCallCount);
         }
 
-
         [Fact]
         public async Task GetVulnerabilityInfoAsync_ResetVulnerabilityData_ResetsVulnerabilityData()
         {
@@ -168,58 +167,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
             Assert.True(vulnerabilities.Count == 1);
             Assert.Equal(3, getVulnerabilityCallCount);
-        }
-
-        [Fact]
-        public async Task GetVulnerabilityInfoAsync_MultipleTimesMultiplePackages_LoadsVulnerabilityDataOnce()
-        {
-            // Arrange
-            PackageSource source = new PackageSource("https://contoso.test/vulnerability/v3/index.json");
-            List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities = new List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>()
-            {
-                new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>
-                {
-                    {
-                        "Package1",
-                        new PackageVulnerabilityInfo[] {
-                            new PackageVulnerabilityInfo(new Uri("https://vulnerability1"), PackageVulnerabilitySeverity.Low, VersionRange.Parse("[1.0.0,2.0.0)"))
-                        }
-                    }
-                }
-            };
-
-            var packageCollection = new PackageCollection([
-                new PackageCollectionItem("Package1", new NuGetVersion("1.0.0"), Array.Empty<PackageReferenceContextInfo>()),
-                new PackageCollectionItem("Package1", new NuGetVersion("1.0.1"), Array.Empty<PackageReferenceContextInfo>()),
-                new PackageCollectionItem("Package1", new NuGetVersion("1.0.2"), Array.Empty<PackageReferenceContextInfo>())]);
-
-
-            GetVulnerabilityInfoResult getVulnerabilityInfoResult = new GetVulnerabilityInfoResult(knownVulnerabilities, exceptions: null);
-
-            int getVulnerabilityCallCount = 0;
-
-            var vulnerabilityResource = new Mock<IVulnerabilityInfoResource>();
-            vulnerabilityResource.Setup(resource => resource.GetVulnerabilityInfoAsync(
-                It.IsAny<SourceCacheContext>(),
-                It.IsAny<ILogger>(),
-                It.IsAny<CancellationToken>()))
-                .Callback(() => getVulnerabilityCallCount++)
-                .ReturnsAsync(getVulnerabilityInfoResult);
-
-            var sourceRepository = new Mock<SourceRepository>();
-
-            sourceRepository.Setup(s => s.GetResourceAsync<IVulnerabilityInfoResource>(CancellationToken.None))
-                .ReturnsAsync(vulnerabilityResource.Object);
-
-            PackageVulnerabilityService packageVulnerabilityService = new PackageVulnerabilityService(new List<SourceRepository> { sourceRepository.Object }, _testLogger);
-
-            // Act & Assert
-            IEnumerable<IEnumerable<PackageVulnerabilityMetadataContextInfo>> vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(packageCollection, CancellationToken.None);
-            Assert.Equal(1, getVulnerabilityCallCount);
-            vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(packageCollection, CancellationToken.None);
-            Assert.Equal(1, getVulnerabilityCallCount);
-            vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(packageCollection, CancellationToken.None);
-            Assert.Equal(1, getVulnerabilityCallCount);
         }
 
         internal class VulnerabilityInfoResourceProvider : ResourceProvider

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/PackageVulnerabilityServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/PackageVulnerabilityServiceTests.cs
@@ -36,7 +36,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         public async Task GetVulnerabilityInfoAsync_ValidPackageId_ReturnsVulnerabilityInfo()
         {
             // Arrange
-            PackageSource source = new PackageSource("https://contoso.com/vulnerability/v3/index.json");
+            PackageSource source = new PackageSource("https://contoso.test/vulnerability/v3/index.json");
             List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities = new List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>()
             {
                 new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>
@@ -71,7 +71,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         public async Task GetVulnerabilityInfoAsync_MultipleTimes_LoadsVulnerabilityDataOnce()
         {
             // Arrange
-            PackageSource source = new PackageSource("https://contoso.com/vulnerability/v3/index.json");
+            PackageSource source = new PackageSource("https://contoso.test/vulnerability/v3/index.json");
             List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities = new List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>()
             {
                 new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>
@@ -121,7 +121,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         public async Task GetVulnerabilityInfoAsync_ResetVulnerabilityData_ResetsVulnerabilityData()
         {
             // Arrange
-            PackageSource source = new PackageSource("https://contoso.com/vulnerability/v3/index.json");
+            PackageSource source = new PackageSource("https://contoso.test/vulnerability/v3/index.json");
             List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities = new List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>()
             {
                 new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>
@@ -174,7 +174,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         public async Task GetVulnerabilityInfoAsync_MultipleTimesMultiplePackages_LoadsVulnerabilityDataOnce()
         {
             // Arrange
-            PackageSource source = new PackageSource("https://contoso.com/vulnerability/v3/index.json");
+            PackageSource source = new PackageSource("https://contoso.test/vulnerability/v3/index.json");
             List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities = new List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>()
             {
                 new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/TestNuGetUILogger.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/TestNuGetUILogger.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Common;
+using NuGet.ProjectManagement;
+using Xunit.Abstractions;
+
+namespace NuGet.PackageManagement.VisualStudio.Test
+{
+    /// <summary>
+    /// NuGet UI Logger to print messages to Xunit test output
+    /// </summary>
+    public class TestNuGetUILogger : INuGetUILogger
+    {
+        private readonly ITestOutputHelper _out;
+
+        public TestNuGetUILogger(ITestOutputHelper outputHelper)
+        {
+            _out = outputHelper;
+        }
+
+        public void End()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Log(MessageLevel level, string message, params object[] args)
+        {
+            _out.WriteLine($"[{level}] {string.Format(message, args)}");
+        }
+
+        public void Log(ILogMessage message)
+        {
+            Log(FromLogLevel(message.Level), message.Message);
+        }
+
+        public void ReportError(string message)
+        {
+            Log(MessageLevel.Error, message);
+        }
+
+        public void ReportError(ILogMessage message)
+        {
+            Log(MessageLevel.Error, message.Message);
+        }
+
+        public void Start()
+        {
+            throw new NotImplementedException();
+        }
+
+        private MessageLevel FromLogLevel(LogLevel logLevel)
+        {
+            switch (logLevel)
+            {
+                case LogLevel.Error:
+                    return MessageLevel.Error;
+                case LogLevel.Warning:
+                    return MessageLevel.Warning;
+                case LogLevel.Verbose:
+                case LogLevel.Debug:
+                    return MessageLevel.Debug;
+                case LogLevel.Minimal:
+                case LogLevel.Information:
+                    return MessageLevel.Info;
+                default:
+                    return MessageLevel.Warning;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2729

## Description


We are reading Vulnerability data per package and that is resulting in a lot of allocations from the parser in https://github.com/NuGet/NuGet.Client/blob/e716e78fa66a29f3e417462256cc340479e25ce2/src/NuGet.Core/NuGet.Protocol/Resources/VulnerabilityInfoResourceV3.cs#L50. 

This PR eliminates redundant allocations caused by multiple calls to `_packageVulnerabilityService.GetVulnerabilityInfoAsync(p, token)` for each transitive package. Previously, this led to repeated parsing of vulnerability data due to redundant calls to `VulnerabilityInfoResourceV3.GetVulnerabilityDataAsync`.  

**Fixes:**  
- **Package Listing:** Ensures vulnerability data is only refreshed once using a "load-if-null" check.  
- **Vulnerable Package Counting:** Processes all transitive packages in a single iteration, avoiding repeated data loads.  

This improves efficiency by reducing unnecessary vulnerability data parsing.


For testing, I created a project with just `newtonsoft.json` and `task` packages from nuget.org and here are the results before change and after the change.
When opening the VS PMUI and navigating to the installed tab:
**Before change**: The JSON parser was called around 900 times for the project.
**After change**: The JSON parser was called once to parse vulnerability data.
### Perfview test 
* tested on the following large project with a thousand references https://github.com/Nigusu-Allehu/LargeProject/tree/main
**Before**
![image](https://github.com/user-attachments/assets/fa48a67f-1d38-4fac-abcd-63411ca4e9fa)
**After**
It was not even collected
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
