### PR TITLE
Remove extra spaces in Publishing.props

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -4,5 +4,5 @@
     <Artifact Include="$(ArtifactsDir)nupkgs/*.nupkg"
               PublishFlatContainer="false" />
   </ItemGroup>
-  
+
 </Project>


### PR DESCRIPTION
This removes some extraneous whitespace characters introduced in https://github.com/NuGet/NuGet.Client/pull/6233.
The VMR synchronization has problems with these thanks to the CRLF in this repo and we are unable to remove a patch for this in https://github.com/dotnet/sdk/pull/46361
