### PR TITLE
Plugin discovery: make "nuget-plugin-*" plugin pattern matching cases sensitive

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
@@ -192,8 +192,7 @@ namespace NuGet.Protocol.Plugins
                     if (File.Exists(path))
                     {
                         FileInfo fileInfo = new FileInfo(path);
-                        StringComparison comparisonType = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
-                        if (fileInfo.Name.StartsWith("nuget-plugin-", comparisonType))
+                        if (fileInfo.Name.StartsWith("nuget-plugin-", PathUtility.GetStringComparisonBasedOnOS()))
                         {
                             // A DotNet tool plugin
                             if (IsValidPluginFile(fileInfo))

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
@@ -192,7 +192,8 @@ namespace NuGet.Protocol.Plugins
                     if (File.Exists(path))
                     {
                         FileInfo fileInfo = new FileInfo(path);
-                        if (fileInfo.Name.StartsWith("nuget-plugin-", StringComparison.CurrentCultureIgnoreCase))
+                        StringComparison comparisonType = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+                        if (fileInfo.Name.StartsWith("nuget-plugin-", comparisonType))
                         {
                             // A DotNet tool plugin
                             if (IsValidPluginFile(fileInfo))

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
@@ -192,14 +192,11 @@ namespace NuGet.Protocol.Plugins
                     if (File.Exists(path))
                     {
                         FileInfo fileInfo = new FileInfo(path);
-                        if (fileInfo.Name.StartsWith("nuget-plugin-", PathUtility.GetStringComparisonBasedOnOS()))
+                        if (IsValidPluginFile(fileInfo))
                         {
                             // A DotNet tool plugin
-                            if (IsValidPluginFile(fileInfo))
-                            {
-                                PluginFile pluginFile = new PluginFile(fileInfo.FullName, new Lazy<PluginFileState>(() => PluginFileState.Valid), requiresDotnetHost: false);
-                                pluginFiles.Add(pluginFile);
-                            }
+                            PluginFile pluginFile = new PluginFile(fileInfo.FullName, new Lazy<PluginFileState>(() => PluginFileState.Valid), requiresDotnetHost: false);
+                            pluginFiles.Add(pluginFile);
                         }
                         else
                         {
@@ -274,6 +271,11 @@ namespace NuGet.Protocol.Plugins
         /// <returns></returns>
         internal static bool IsValidPluginFile(FileInfo fileInfo)
         {
+            if (!fileInfo.Name.StartsWith("nuget-plugin-", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return fileInfo.Extension.Equals(".exe", StringComparison.OrdinalIgnoreCase) ||

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
@@ -519,6 +519,7 @@ namespace NuGet.Protocol.Plugins.Tests
             Assert.Empty(plugins);
         }
 
+#if !IS_DESKTOP
         [PlatformFact(Platform.Windows)]
         public void GetPluginsInNuGetPluginPaths_Windows_CaseInsensitiveMatching()
         {
@@ -540,8 +541,8 @@ namespace NuGet.Protocol.Plugins.Tests
             var plugins = pluginDiscoverer.GetPluginsInNuGetPluginPaths();
 
             // Assert
-            Assert.Contains(plugins, p => p.Path == pluginFilePath1);
-            Assert.Contains(plugins, p => p.Path == pluginFilePath2);
+            Assert.Contains(plugins, p => p.Path == pluginFilePath1 && p.RequiresDotnetHost == false);
+            Assert.Contains(plugins, p => p.Path == pluginFilePath2 && p.RequiresDotnetHost == false);
         }
 
         [PlatformFact(Platform.Linux)]
@@ -568,9 +569,10 @@ namespace NuGet.Protocol.Plugins.Tests
             var plugins = pluginDiscoverer.GetPluginsInNuGetPluginPaths();
 
             // Assert
-            Assert.Contains(plugins, p => p.Path == correctCasePlugin);
-            Assert.DoesNotContain(plugins, p => p.Path == incorrectCasePlugin);
+            Assert.Contains(plugins, p => p.Path == correctCasePlugin && p.RequiresDotnetHost == false);
+            Assert.DoesNotContain(plugins, p => p.Path == incorrectCasePlugin && p.RequiresDotnetHost == false);
         }
+#endif
 
         [PlatformFact(Platform.Windows)]
         public void IsValidPluginFile_ExeFile_ReturnsTrue()

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
@@ -541,6 +541,8 @@ namespace NuGet.Protocol.Plugins.Tests
 
             // Assert
             Assert.Equal(2, plugins.Count);
+            Assert.Contains(plugins, p => p.Path == pluginFilePath1);
+            Assert.Contains(plugins, p => p.Path == pluginFilePath2);
         }
 
         [PlatformFact(Platform.Linux)]
@@ -569,6 +571,7 @@ namespace NuGet.Protocol.Plugins.Tests
             // Assert
             Assert.Single(plugins);
             Assert.Contains(plugins, p => p.Path == correctCasePlugin);
+            Assert.DoesNotContain(plugins, p => p.Path == incorrectCasePlugin);
         }
 
         [PlatformFact(Platform.Windows)]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
@@ -520,6 +520,73 @@ namespace NuGet.Protocol.Plugins.Tests
         }
 
         [PlatformFact(Platform.Windows)]
+        public void GetPluginsInNuGetPluginPaths_Windows_CaseInsensitiveMatching()
+        {
+            // Arrange
+            using var testDirectory = TestDirectory.Create();
+
+            var pluginFilePath1 = Path.Combine(testDirectory.Path, "nuget-plugin-test.exe");
+            var pluginFilePath2 = Path.Combine(testDirectory.Path, "NUGET-PLUGIN-TEST.exe"); // Different casing
+
+            File.Create(pluginFilePath1).Dispose();
+            File.Create(pluginFilePath2).Dispose();
+
+            var environmentalVariableReader = new Mock<IEnvironmentVariableReader>();
+            environmentalVariableReader.Setup(env => env.GetEnvironmentVariable(EnvironmentVariableConstants.PluginPaths)).Returns($"{pluginFilePath1}{Path.PathSeparator}{pluginFilePath2}");
+
+            var pluginDiscoverer = new PluginDiscoverer(environmentalVariableReader.Object);
+
+            // Act
+            var plugins = pluginDiscoverer.GetPluginsInNuGetPluginPaths();
+
+            // Assert
+            Assert.Equal(2, plugins.Count);
+        }
+
+        [PlatformFact(Platform.Linux)]
+        public void GetPluginsInNuGetPluginPaths_Linux_CaseSensitiveMatching()
+        {
+            // Arrange
+            using var testDirectory = TestDirectory.Create();
+
+            var correctCasePlugin = Path.Combine(testDirectory.Path, "nuget-plugin-test");
+            var incorrectCasePlugin = Path.Combine(testDirectory.Path, "NUGET-PLUGIN-TEST"); // Different casing
+
+            File.Create(correctCasePlugin).Dispose();
+            File.Create(incorrectCasePlugin).Dispose();
+
+#if NET8_0_OR_GREATER
+            File.SetUnixFileMode(correctCasePlugin, UnixFileMode.UserExecute | UnixFileMode.UserRead);
+#else
+            // Use chmod for older .NET versions
+            var process = new Process();
+            process.StartInfo.FileName = "/bin/bash";
+            process.StartInfo.Arguments = $"-c \"chmod +x {correctCasePlugin} {incorrectCasePlugin}\"";
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.Start();
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                throw new InvalidOperationException($"Failed to set execute permissions for {correctCasePlugin} or {incorrectCasePlugin}");
+            }
+#endif
+
+            var environmentalVariableReader = new Mock<IEnvironmentVariableReader>();
+            environmentalVariableReader.Setup(env => env.GetEnvironmentVariable(EnvironmentVariableConstants.PluginPaths)).Returns($"{correctCasePlugin}{Path.PathSeparator}{incorrectCasePlugin}");
+
+            var pluginDiscoverer = new PluginDiscoverer(environmentalVariableReader.Object);
+
+            // Act
+            var plugins = pluginDiscoverer.GetPluginsInNuGetPluginPaths();
+
+            // Assert
+            Assert.Single(plugins);
+            Assert.Contains(plugins, p => p.Path == correctCasePlugin);
+        }
+
+        [PlatformFact(Platform.Windows)]
         public void IsValidPluginFile_ExeFile_ReturnsTrue()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
@@ -555,23 +555,8 @@ namespace NuGet.Protocol.Plugins.Tests
             File.Create(correctCasePlugin).Dispose();
             File.Create(incorrectCasePlugin).Dispose();
 
-#if NET8_0_OR_GREATER
-            File.SetUnixFileMode(correctCasePlugin, UnixFileMode.UserExecute | UnixFileMode.UserRead);
-#else
-            // Use chmod for older .NET versions
-            var process = new Process();
-            process.StartInfo.FileName = "/bin/bash";
-            process.StartInfo.Arguments = $"-c \"chmod +x {correctCasePlugin} {incorrectCasePlugin}\"";
-            process.StartInfo.UseShellExecute = false;
-            process.StartInfo.RedirectStandardOutput = true;
-            process.Start();
-            process.WaitForExit();
-
-            if (process.ExitCode != 0)
-            {
-                throw new InvalidOperationException($"Failed to set execute permissions for {correctCasePlugin} or {incorrectCasePlugin}");
-            }
-#endif
+            SetFileExecutable(correctCasePlugin, executable: true);
+            SetFileExecutable(incorrectCasePlugin, executable: true);
 
             var environmentalVariableReader = new Mock<IEnvironmentVariableReader>();
             environmentalVariableReader.Setup(env => env.GetEnvironmentVariable(EnvironmentVariableConstants.PluginPaths)).Returns($"{correctCasePlugin}{Path.PathSeparator}{incorrectCasePlugin}");

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
@@ -519,60 +519,26 @@ namespace NuGet.Protocol.Plugins.Tests
             Assert.Empty(plugins);
         }
 
-#if !IS_DESKTOP
-        [PlatformFact(Platform.Windows)]
-        public void GetPluginsInNuGetPluginPaths_Windows_CaseInsensitiveMatching()
+        [PlatformTheory(Platform.Windows)]
+        [InlineData("nuget-plugin-auth.exe", true)]
+        [InlineData("nuget-plugin-AUTH.bat", true)]
+        [InlineData("nuGet-plugin-auth.exe", false)]
+        [InlineData("NUGet-PLUGIN-auth.bat", false)]
+        public void IsValidPlugin_IsCaseSensitive(string file, bool isValid)
         {
             // Arrange
-            using var testDirectory = TestDirectory.Create();
-
-            var pluginFilePath1 = Path.Combine(testDirectory.Path, "nuget-plugin-test.exe");
-            var pluginFilePath2 = Path.Combine(testDirectory.Path, "NUGET-PLUGIN-TEST.exe"); // Different casing
-
-            File.Create(pluginFilePath1).Dispose();
-            File.Create(pluginFilePath2).Dispose();
-
-            var environmentalVariableReader = new Mock<IEnvironmentVariableReader>();
-            environmentalVariableReader.Setup(env => env.GetEnvironmentVariable(EnvironmentVariableConstants.PluginPaths)).Returns($"{pluginFilePath1}{Path.PathSeparator}{pluginFilePath2}");
-
-            var pluginDiscoverer = new PluginDiscoverer(environmentalVariableReader.Object);
+            using TestDirectory testDirectory = TestDirectory.Create();
+            var workingPath = testDirectory.Path;
+            var pluginFilePath = Path.Combine(workingPath, file);
+            File.Create(pluginFilePath);
+            var fileInfo = new FileInfo(pluginFilePath);
 
             // Act
-            var plugins = pluginDiscoverer.GetPluginsInNuGetPluginPaths();
+            bool result = PluginDiscoverer.IsValidPluginFile(fileInfo);
 
             // Assert
-            Assert.Contains(plugins, p => p.Path == pluginFilePath1 && p.RequiresDotnetHost == false);
-            Assert.Contains(plugins, p => p.Path == pluginFilePath2 && p.RequiresDotnetHost == false);
+            Assert.Equal(isValid, result);
         }
-
-        [PlatformFact(Platform.Linux)]
-        public void GetPluginsInNuGetPluginPaths_Linux_CaseSensitiveMatching()
-        {
-            // Arrange
-            using var testDirectory = TestDirectory.Create();
-
-            var correctCasePlugin = Path.Combine(testDirectory.Path, "nuget-plugin-test");
-            var incorrectCasePlugin = Path.Combine(testDirectory.Path, "NUGET-PLUGIN-TEST"); // Different casing
-
-            File.Create(correctCasePlugin).Dispose();
-            File.Create(incorrectCasePlugin).Dispose();
-
-            SetFileExecutable(correctCasePlugin, executable: true);
-            SetFileExecutable(incorrectCasePlugin, executable: true);
-
-            var environmentalVariableReader = new Mock<IEnvironmentVariableReader>();
-            environmentalVariableReader.Setup(env => env.GetEnvironmentVariable(EnvironmentVariableConstants.PluginPaths)).Returns($"{correctCasePlugin}{Path.PathSeparator}{incorrectCasePlugin}");
-
-            var pluginDiscoverer = new PluginDiscoverer(environmentalVariableReader.Object);
-
-            // Act
-            var plugins = pluginDiscoverer.GetPluginsInNuGetPluginPaths();
-
-            // Assert
-            Assert.Contains(plugins, p => p.Path == correctCasePlugin && p.RequiresDotnetHost == false);
-            Assert.DoesNotContain(plugins, p => p.Path == incorrectCasePlugin && p.RequiresDotnetHost == false);
-        }
-#endif
 
         [PlatformFact(Platform.Windows)]
         public void IsValidPluginFile_ExeFile_ReturnsTrue()
@@ -580,7 +546,7 @@ namespace NuGet.Protocol.Plugins.Tests
             // Arrange
             using TestDirectory testDirectory = TestDirectory.Create();
             var workingPath = testDirectory.Path;
-            var pluginFilePath = Path.Combine(workingPath, "plugin.exe");
+            var pluginFilePath = Path.Combine(workingPath, "nuget-plugin.exe");
             File.Create(pluginFilePath);
             var fileInfo = new FileInfo(pluginFilePath);
 
@@ -597,7 +563,7 @@ namespace NuGet.Protocol.Plugins.Tests
             // Arrange
             using TestDirectory testDirectory = TestDirectory.Create();
             var workingPath = testDirectory.Path;
-            var nonPluginFilePath = Path.Combine(workingPath, "plugin.txt");
+            var nonPluginFilePath = Path.Combine(workingPath, "nuget-plugin.txt");
             File.Create(nonPluginFilePath);
             var fileInfo = new FileInfo(nonPluginFilePath);
 
@@ -614,7 +580,7 @@ namespace NuGet.Protocol.Plugins.Tests
             // Arrange
             using TestDirectory testDirectory = TestDirectory.Create();
             var workingPath = testDirectory.Path;
-            var pluginFilePath = Path.Combine(workingPath, "plugin");
+            var pluginFilePath = Path.Combine(workingPath, "nuget-plugin");
             File.Create(pluginFilePath).Dispose();
 
 #if NET8_0_OR_GREATER
@@ -640,7 +606,7 @@ namespace NuGet.Protocol.Plugins.Tests
             // Arrange
             using TestDirectory testDirectory = TestDirectory.Create();
             var workingPath = testDirectory.Path;
-            var pluginFilePath = Path.Combine(workingPath, "plugin");
+            var pluginFilePath = Path.Combine(workingPath, "nuget-plugin");
             File.Create(pluginFilePath);
 
             // Set execute permissions
@@ -661,7 +627,7 @@ namespace NuGet.Protocol.Plugins.Tests
             // Arrange
             using TestDirectory testDirectory = TestDirectory.Create();
             var workingPath = testDirectory.Path;
-            var pluginFilePath = Path.Combine(workingPath, "plugin");
+            var pluginFilePath = Path.Combine(workingPath, "nuget-plugin");
             File.Create(pluginFilePath);
 
             // Remove execute permissions
@@ -682,7 +648,7 @@ namespace NuGet.Protocol.Plugins.Tests
             // Arrange
             using TestDirectory testDirectory = TestDirectory.Create();
             var workingPath = testDirectory.Path;
-            var pluginFilePath = Path.Combine(workingPath, "plugin with space");
+            var pluginFilePath = Path.Combine(workingPath, "nuget-plugin with space");
             File.Create(pluginFilePath).Dispose();
 
             // Set execute permissions

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
@@ -546,7 +546,7 @@ namespace NuGet.Protocol.Plugins.Tests
             // Arrange
             using TestDirectory testDirectory = TestDirectory.Create();
             var workingPath = testDirectory.Path;
-            var pluginFilePath = Path.Combine(workingPath, "nuget-plugin.exe");
+            var pluginFilePath = Path.Combine(workingPath, "nuget-plugin-.exe");
             File.Create(pluginFilePath);
             var fileInfo = new FileInfo(pluginFilePath);
 
@@ -563,7 +563,7 @@ namespace NuGet.Protocol.Plugins.Tests
             // Arrange
             using TestDirectory testDirectory = TestDirectory.Create();
             var workingPath = testDirectory.Path;
-            var nonPluginFilePath = Path.Combine(workingPath, "nuget-plugin.txt");
+            var nonPluginFilePath = Path.Combine(workingPath, "nuget-plugin-.txt");
             File.Create(nonPluginFilePath);
             var fileInfo = new FileInfo(nonPluginFilePath);
 
@@ -580,7 +580,7 @@ namespace NuGet.Protocol.Plugins.Tests
             // Arrange
             using TestDirectory testDirectory = TestDirectory.Create();
             var workingPath = testDirectory.Path;
-            var pluginFilePath = Path.Combine(workingPath, "nuget-plugin");
+            var pluginFilePath = Path.Combine(workingPath, "nuget-plugin-");
             File.Create(pluginFilePath).Dispose();
 
 #if NET8_0_OR_GREATER
@@ -606,7 +606,7 @@ namespace NuGet.Protocol.Plugins.Tests
             // Arrange
             using TestDirectory testDirectory = TestDirectory.Create();
             var workingPath = testDirectory.Path;
-            var pluginFilePath = Path.Combine(workingPath, "nuget-plugin");
+            var pluginFilePath = Path.Combine(workingPath, "nuget-plugin-");
             File.Create(pluginFilePath);
 
             // Set execute permissions
@@ -627,7 +627,7 @@ namespace NuGet.Protocol.Plugins.Tests
             // Arrange
             using TestDirectory testDirectory = TestDirectory.Create();
             var workingPath = testDirectory.Path;
-            var pluginFilePath = Path.Combine(workingPath, "nuget-plugin");
+            var pluginFilePath = Path.Combine(workingPath, "nuget-plugin-");
             File.Create(pluginFilePath);
 
             // Remove execute permissions
@@ -648,7 +648,7 @@ namespace NuGet.Protocol.Plugins.Tests
             // Arrange
             using TestDirectory testDirectory = TestDirectory.Create();
             var workingPath = testDirectory.Path;
-            var pluginFilePath = Path.Combine(workingPath, "nuget-plugin with space");
+            var pluginFilePath = Path.Combine(workingPath, "nuget-plugin- with space");
             File.Create(pluginFilePath).Dispose();
 
             // Set execute permissions

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
@@ -540,7 +540,6 @@ namespace NuGet.Protocol.Plugins.Tests
             var plugins = pluginDiscoverer.GetPluginsInNuGetPluginPaths();
 
             // Assert
-            Assert.Equal(2, plugins.Count);
             Assert.Contains(plugins, p => p.Path == pluginFilePath1);
             Assert.Contains(plugins, p => p.Path == pluginFilePath2);
         }
@@ -569,7 +568,6 @@ namespace NuGet.Protocol.Plugins.Tests
             var plugins = pluginDiscoverer.GetPluginsInNuGetPluginPaths();
 
             // Assert
-            Assert.Single(plugins);
             Assert.Contains(plugins, p => p.Path == correctCasePlugin);
             Assert.DoesNotContain(plugins, p => p.Path == incorrectCasePlugin);
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/NuGet.Client/pull/6138#discussion_r1832936363
one of many fixes from https://github.com/NuGet/Home/issues/13975

This PR makes sure plugin discovery is cases sensitive for "nuget-plugin-*" plugins. This is platform independent. 

## Description

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/14141
