### PR TITLE
Refactor PluginDiscovererTests.cs

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
@@ -293,7 +293,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 File.WriteAllText(myPlugin, string.Empty);
                 Mock<IEnvironmentVariableReader> environmentalVariableReader = new Mock<IEnvironmentVariableReader>();
                 environmentalVariableReader.Setup(env => env.GetEnvironmentVariable(EnvironmentVariableConstants.PluginPaths)).Returns(pluginPath);
-                SetFileExecutable(pluginPath, true);
+                SetFileExecutable(myPlugin, true);
                 using (var discoverer = new PluginDiscoverer(environmentalVariableReader.Object))
                 {
                     // Act
@@ -701,7 +701,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 using (var process = new Process())
                 {
                     process.StartInfo.FileName = "/bin/bash";
-                    process.StartInfo.Arguments = $"-c \"chmod {(executable ? "+x" : "-x")} {filePath}\"";
+                    process.StartInfo.Arguments = $"-c \"chmod {(executable ? "+x" : "-x")} '{filePath}'\"";
                     process.StartInfo.UseShellExecute = false;
                     process.StartInfo.RedirectStandardOutput = true;
                     process.StartInfo.RedirectStandardError = true;

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 # if !NET8_0_OR_GREATER
-using System.Diagnostics;
+using Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess;
 #endif
 using System.IO;
 using System.Linq;
@@ -14,11 +14,19 @@ using Moq;
 using NuGet.Common;
 using NuGet.Test.Utility;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.Protocol.Plugins.Tests
 {
     public class PluginDiscovererTests
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public PluginDiscovererTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
         [Theory]
         [InlineData(null)]
         [InlineData("")]
@@ -678,7 +686,7 @@ namespace NuGet.Protocol.Plugins.Tests
 
 #endif
 
-        private static void SetFileExecutable(string filePath, bool executable)
+        private void SetFileExecutable(string filePath, bool executable)
         {
             if (!File.Exists(filePath))
             {
@@ -698,22 +706,14 @@ namespace NuGet.Protocol.Plugins.Tests
 #else
             try
             {
-                using (var process = new Process())
+                CommandRunnerResult result = CommandRunner.Run(
+                    filename: "/bin/bash",
+                    arguments: $"-c \"chmod {(executable ? "+x" : "-x")} '{filePath}'\"",
+                    testOutputHelper: _testOutputHelper);
+
+                if (!result.Success)
                 {
-                    process.StartInfo.FileName = "/bin/bash";
-                    process.StartInfo.Arguments = $"-c \"chmod {(executable ? "+x" : "-x")} '{filePath}'\"";
-                    process.StartInfo.UseShellExecute = false;
-                    process.StartInfo.RedirectStandardOutput = true;
-                    process.StartInfo.RedirectStandardError = true;
-
-                    process.Start();
-                    string errorOutput = process.StandardError.ReadToEnd();
-                    process.WaitForExit();
-
-                    if (process.ExitCode != 0)
-                    {
-                        throw new InvalidOperationException($"Failed to set execute permissions for {filePath}. Error: {errorOutput}");
-                    }
+                    throw new InvalidOperationException($"Failed to set execute permissions for {filePath}. Error: {result.Errors}");
                 }
             }
             catch (Exception ex)

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
@@ -209,14 +209,7 @@ namespace NuGet.Protocol.Plugins.Tests
                     var result = await discoverer.DiscoverAsync(CancellationToken.None);
 
                     // Assert
-                    var discovered = false;
-
-                    foreach (PluginDiscoveryResult discoveryResult in result)
-                    {
-                        if (myPlugin == discoveryResult.PluginFile.Path) discovered = true;
-                    }
-
-                    Assert.True(discovered);
+                    Assert.Contains(result, discoveryResult => myPlugin == discoveryResult.PluginFile.Path);
                 }
             }
         }
@@ -243,14 +236,7 @@ namespace NuGet.Protocol.Plugins.Tests
                     var result = await discoverer.DiscoverAsync(CancellationToken.None);
 
                     // Assert
-                    var discovered = false;
-
-                    foreach (PluginDiscoveryResult discoveryResult in result)
-                    {
-                        if (myPlugin == discoveryResult.PluginFile.Path) discovered = true;
-                    }
-
-                    Assert.True(discovered);
+                    Assert.Contains(result, discoveryResult => myPlugin == discoveryResult.PluginFile.Path);
                 }
             }
         }
@@ -277,14 +263,7 @@ namespace NuGet.Protocol.Plugins.Tests
                     var result = await discoverer.DiscoverAsync(CancellationToken.None);
 
                     // Assert
-                    var discovered = false;
-
-                    foreach (PluginDiscoveryResult discoveryResult in result)
-                    {
-                        if (myPlugin == discoveryResult.PluginFile.Path) discovered = true;
-                    }
-
-                    Assert.False(discovered);
+                    Assert.DoesNotContain(result, discoveryResult => myPlugin == discoveryResult.PluginFile.Path);
                 }
             }
         }
@@ -308,14 +287,7 @@ namespace NuGet.Protocol.Plugins.Tests
                     var result = await discoverer.DiscoverAsync(CancellationToken.None);
 
                     // Assert
-                    var discovered = false;
-
-                    foreach (PluginDiscoveryResult discoveryResult in result)
-                    {
-                        if (myPlugin == discoveryResult.PluginFile.Path) discovered = true;
-                    }
-
-                    Assert.True(discovered);
+                    Assert.Contains(result, discoveryResult => myPlugin == discoveryResult.PluginFile.Path);
                 }
             }
         }
@@ -342,14 +314,7 @@ namespace NuGet.Protocol.Plugins.Tests
                     var result = await discoverer.DiscoverAsync(CancellationToken.None);
 
                     // Assert
-                    var discovered = false;
-
-                    foreach (PluginDiscoveryResult discoveryResult in result)
-                    {
-                        if (myPlugin == discoveryResult.PluginFile.Path) discovered = true;
-                    }
-
-                    Assert.True(discovered);
+                    Assert.Contains(result, discoveryResult => myPlugin == discoveryResult.PluginFile.Path);
                 }
             }
         }
@@ -375,14 +340,7 @@ namespace NuGet.Protocol.Plugins.Tests
                     var result = await discoverer.DiscoverAsync(CancellationToken.None);
 
                     // Assert
-                    var discovered = false;
-
-                    foreach (PluginDiscoveryResult discoveryResult in result)
-                    {
-                        if (myPlugin == discoveryResult.PluginFile.Path) discovered = true;
-                    }
-
-                    Assert.False(discovered);
+                    Assert.DoesNotContain(result, discoveryResult => myPlugin == discoveryResult.PluginFile.Path);
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+# if !NET8_0_OR_GREATER
 using System.Diagnostics;
+#endif
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -291,35 +293,21 @@ namespace NuGet.Protocol.Plugins.Tests
                 File.WriteAllText(myPlugin, string.Empty);
                 Mock<IEnvironmentVariableReader> environmentalVariableReader = new Mock<IEnvironmentVariableReader>();
                 environmentalVariableReader.Setup(env => env.GetEnvironmentVariable(EnvironmentVariableConstants.PluginPaths)).Returns(pluginPath);
-
-                using (var process = new Process())
+                SetFileExecutable(pluginPath, true);
+                using (var discoverer = new PluginDiscoverer(environmentalVariableReader.Object))
                 {
-                    // Use a shell command to make the file executable
-                    process.StartInfo.FileName = "/bin/bash";
-                    process.StartInfo.Arguments = $"-c \"chmod +x {myPlugin}\"";
-                    process.StartInfo.UseShellExecute = false;
-                    process.StartInfo.RedirectStandardOutput = true;
-                    process.Start();
-                    process.WaitForExit();
+                    // Act
+                    var result = await discoverer.DiscoverAsync(CancellationToken.None);
 
-                    if (process.ExitCode == 0)
+                    // Assert
+                    var discovered = false;
+
+                    foreach (PluginDiscoveryResult discoveryResult in result)
                     {
-                        using (var discoverer = new PluginDiscoverer(environmentalVariableReader.Object))
-                        {
-                            // Act
-                            var result = await discoverer.DiscoverAsync(CancellationToken.None);
-
-                            // Assert
-                            var discovered = false;
-
-                            foreach (PluginDiscoveryResult discoveryResult in result)
-                            {
-                                if (myPlugin == discoveryResult.PluginFile.Path) discovered = true;
-                            }
-
-                            Assert.True(discovered);
-                        }
+                        if (myPlugin == discoveryResult.PluginFile.Path) discovered = true;
                     }
+
+                    Assert.True(discovered);
                 }
             }
         }
@@ -338,34 +326,22 @@ namespace NuGet.Protocol.Plugins.Tests
                 environmentalVariableReader.Setup(env => env.GetEnvironmentVariable(EnvironmentVariableConstants.PluginPaths)).Returns(pluginPath);
                 environmentalVariableReader.Setup(env => env.GetEnvironmentVariable("PATHS")).Returns("");
 
-                using (var process = new Process())
+                SetFileExecutable(myPlugin, true);
+
+                using (var discoverer = new PluginDiscoverer(environmentalVariableReader.Object))
                 {
-                    // Use a shell command to make the file executable
-                    process.StartInfo.FileName = "/bin/bash";
-                    process.StartInfo.Arguments = $"-c \"chmod +x {myPlugin}\"";
-                    process.StartInfo.UseShellExecute = false;
-                    process.StartInfo.RedirectStandardOutput = true;
-                    process.Start();
-                    process.WaitForExit();
+                    // Act
+                    var result = await discoverer.DiscoverAsync(CancellationToken.None);
 
-                    if (process.ExitCode == 0)
+                    // Assert
+                    var discovered = false;
+
+                    foreach (PluginDiscoveryResult discoveryResult in result)
                     {
-                        using (var discoverer = new PluginDiscoverer(environmentalVariableReader.Object))
-                        {
-                            // Act
-                            var result = await discoverer.DiscoverAsync(CancellationToken.None);
-
-                            // Assert
-                            var discovered = false;
-
-                            foreach (PluginDiscoveryResult discoveryResult in result)
-                            {
-                                if (myPlugin == discoveryResult.PluginFile.Path) discovered = true;
-                            }
-
-                            Assert.True(discovered);
-                        }
+                        if (myPlugin == discoveryResult.PluginFile.Path) discovered = true;
                     }
+
+                    Assert.True(discovered);
                 }
             }
         }
@@ -383,34 +359,22 @@ namespace NuGet.Protocol.Plugins.Tests
                 Mock<IEnvironmentVariableReader> environmentalVariableReader = new Mock<IEnvironmentVariableReader>();
                 environmentalVariableReader.Setup(env => env.GetEnvironmentVariable(EnvironmentVariableConstants.PluginPaths)).Returns(pluginPath);
 
-                using (var process = new Process())
+                SetFileExecutable(myPlugin, false);
+
+                using (var discoverer = new PluginDiscoverer(environmentalVariableReader.Object))
                 {
-                    // Use a shell command to make the file not executable
-                    process.StartInfo.FileName = "/bin/bash";
-                    process.StartInfo.Arguments = $"-c \"chmod -x {myPlugin}\"";
-                    process.StartInfo.UseShellExecute = false;
-                    process.StartInfo.RedirectStandardOutput = true;
-                    process.Start();
-                    process.WaitForExit();
+                    // Act
+                    var result = await discoverer.DiscoverAsync(CancellationToken.None);
 
-                    if (process.ExitCode == 0)
+                    // Assert
+                    var discovered = false;
+
+                    foreach (PluginDiscoveryResult discoveryResult in result)
                     {
-                        using (var discoverer = new PluginDiscoverer(environmentalVariableReader.Object))
-                        {
-                            // Act
-                            var result = await discoverer.DiscoverAsync(CancellationToken.None);
-
-                            // Assert
-                            var discovered = false;
-
-                            foreach (PluginDiscoveryResult discoveryResult in result)
-                            {
-                                if (myPlugin == discoveryResult.PluginFile.Path) discovered = true;
-                            }
-
-                            Assert.False(discovered);
-                        }
+                        if (myPlugin == discoveryResult.PluginFile.Path) discovered = true;
                     }
+
+                    Assert.False(discovered);
                 }
             }
         }
@@ -636,14 +600,7 @@ namespace NuGet.Protocol.Plugins.Tests
             // Set execute permissions
             File.SetUnixFileMode(pluginFilePath, UnixFileMode.UserExecute | UnixFileMode.UserRead);
 #else
-            // Use chmod to set execute permissions
-            var process = new Process();
-            process.StartInfo.FileName = "/bin/bash";
-            process.StartInfo.Arguments = $"-c \"chmod +x {pluginFilePath}\"";
-            process.StartInfo.UseShellExecute = false;
-            process.StartInfo.RedirectStandardOutput = true;
-            process.Start();
-            process.WaitForExit();
+            SetFileExecutable(pluginFilePath, true);
 #endif
 
             var fileInfo = new FileInfo(pluginFilePath);
@@ -666,13 +623,7 @@ namespace NuGet.Protocol.Plugins.Tests
             File.Create(pluginFilePath);
 
             // Set execute permissions
-            var process = new Process();
-            process.StartInfo.FileName = "/bin/bash";
-            process.StartInfo.Arguments = $"-c \"chmod +x {pluginFilePath}\"";
-            process.StartInfo.UseShellExecute = false;
-            process.StartInfo.RedirectStandardOutput = true;
-            process.Start();
-            process.WaitForExit();
+            SetFileExecutable(pluginFilePath, true);
 
             var fileInfo = new FileInfo(pluginFilePath);
 
@@ -693,13 +644,7 @@ namespace NuGet.Protocol.Plugins.Tests
             File.Create(pluginFilePath);
 
             // Remove execute permissions
-            var process = new Process();
-            process.StartInfo.FileName = "/bin/bash";
-            process.StartInfo.Arguments = $"-c \"chmod -x {pluginFilePath}\"";
-            process.StartInfo.UseShellExecute = false;
-            process.StartInfo.RedirectStandardOutput = true;
-            process.Start();
-            process.WaitForExit();
+            SetFileExecutable(pluginFilePath, false);
 
             var fileInfo = new FileInfo(pluginFilePath);
 
@@ -720,13 +665,7 @@ namespace NuGet.Protocol.Plugins.Tests
             File.Create(pluginFilePath).Dispose();
 
             // Set execute permissions
-            var process = new Process();
-            process.StartInfo.FileName = "/bin/bash";
-            process.StartInfo.Arguments = $"-c \"chmod +x '{pluginFilePath}'\"";
-            process.StartInfo.UseShellExecute = false;
-            process.StartInfo.RedirectStandardOutput = true;
-            process.Start();
-            process.WaitForExit();
+            SetFileExecutable(pluginFilePath, true);
 
             var fileInfo = new FileInfo(pluginFilePath);
 
@@ -738,5 +677,50 @@ namespace NuGet.Protocol.Plugins.Tests
         }
 
 #endif
+
+        private static void SetFileExecutable(string filePath, bool executable)
+        {
+            if (!File.Exists(filePath))
+            {
+                throw new FileNotFoundException($"File not found: {filePath}");
+            }
+#if NET8_0_OR_GREATER
+            try
+            {
+                File.SetUnixFileMode(filePath, executable ?
+                    UnixFileMode.UserExecute | UnixFileMode.UserRead | UnixFileMode.UserWrite :
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Error while setting file mode for: {filePath}", ex);
+            }
+#else
+            try
+            {
+                using (var process = new Process())
+                {
+                    process.StartInfo.FileName = "/bin/bash";
+                    process.StartInfo.Arguments = $"-c \"chmod {(executable ? "+x" : "-x")} {filePath}\"";
+                    process.StartInfo.UseShellExecute = false;
+                    process.StartInfo.RedirectStandardOutput = true;
+                    process.StartInfo.RedirectStandardError = true;
+
+                    process.Start();
+                    string errorOutput = process.StandardError.ReadToEnd();
+                    process.WaitForExit();
+
+                    if (process.ExitCode != 0)
+                    {
+                        throw new InvalidOperationException($"Failed to set execute permissions for {filePath}. Error: {errorOutput}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Error setting file executable permission for {filePath}", ex);
+            }
+#endif
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/13975

## Description

Refactored tests in PluginDiscovererTests.cs to remove duplication by introducing the `SetFileExecutable(path, executable)` method. This method ensures all tests consistently set and unset executable permissions on Linux.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
