### PR TITLE
Skip resolved child dependencies in the new resolver if an identical one has already been resolved

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -1320,17 +1320,15 @@ namespace NuGet.Commands
                     if (resolvedDependencyGraphItems.TryGetValue(childLibraryDependencyIndex, out ResolvedDependencyGraphItem? childResolvedDependencyGraphItem)
                         && childResolvedDependencyGraphItem.LibraryRangeIndex == childLibraryRangeIndex
                         && childResolvedDependencyGraphItem.Suppressions.Count == 1
-                        && childResolvedDependencyGraphItem.Suppressions[0].Count == 0)
+                        && childResolvedDependencyGraphItem.Suppressions[0].Count == 0
+                        && HasCommonAncestor(childResolvedDependencyGraphItem.Path, currentDependencyGraphItem.Path))
                     {
-                        if (childResolvedDependencyGraphItem.IsCentrallyPinnedTransitivePackage)
-                        {
-                            childResolvedDependencyGraphItem.Parents ??= new HashSet<LibraryRangeIndex>();
+                        childResolvedDependencyGraphItem.Parents ??= new HashSet<LibraryRangeIndex>();
 
-                            if (!childResolvedDependencyGraphItem.IsRootPackageReference)
-                            {
-                                // Keep track of the parents of this item
-                                childResolvedDependencyGraphItem.Parents?.Add(currentDependencyGraphItem.LibraryRangeIndex);
-                            }
+                        if (!childResolvedDependencyGraphItem.IsRootPackageReference)
+                        {
+                            // Keep track of the parents of this item
+                            childResolvedDependencyGraphItem.Parents?.Add(currentDependencyGraphItem.LibraryRangeIndex);
                         }
 
                         continue;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -1310,7 +1310,7 @@ namespace NuGet.Commands
                         continue;
                     }
 
-                    // See if a dependency with the same version and suppressions has already been chosen
+                    // See if a dependency with the same version and no suppressions has already been resolved.  If so, its children have already been added to the queue.
                     if (resolvedDependencyGraphItems.TryGetValue(childLibraryDependencyIndex, out ResolvedDependencyGraphItem? childResolvedDependencyGraphItem)
                         && childResolvedDependencyGraphItem.LibraryRangeIndex == childLibraryRangeIndex
                         && childResolvedDependencyGraphItem.Suppressions.Count == 1

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -1301,15 +1301,7 @@ namespace NuGet.Commands
                         continue;
                     }
 
-                    HashSet<LibraryDependency>? runtimeDependencies = default;
-
-                    // Evaluate the runtime dependencies if any
-                    if (EvaluateRuntimeDependencies(ref childDependency, runtimeGraph, pair.RuntimeIdentifier, ref runtimeDependencies))
-                    {
-                        // EvaluateRuntimeDependencies() returns true if the version of the dependency was changed, which also changes the LibraryRangeIndex so that must be updated in the chosen item's array of library range indices.
-                        chosenResolvedItem.SetRangeIndexForDependencyAt(i, _indexingTable.Index(childDependency.LibraryRange));
-                    }
-
+                    LibraryRangeIndex childLibraryRangeIndex = chosenResolvedItem.GetRangeIndexForDependencyAt(i);
                     bool isPackage = childDependency.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package);
                     bool isRootPackageReference = (currentDependencyGraphItem.LibraryDependencyIndex == LibraryDependencyIndex.Project) && isPackage;
 
@@ -1324,14 +1316,41 @@ namespace NuGet.Commands
                         continue;
                     }
 
+                    // See if a dependency with the same version and suppressions has already been chosen
+                    if (resolvedDependencyGraphItems.TryGetValue(childLibraryDependencyIndex, out ResolvedDependencyGraphItem? childResolvedDependencyGraphItem)
+                        && childResolvedDependencyGraphItem.LibraryRangeIndex == childLibraryRangeIndex
+                        && childResolvedDependencyGraphItem.Suppressions.Count == 1
+                        && childResolvedDependencyGraphItem.Suppressions[0].Count == 0)
+                    {
+                        if (childResolvedDependencyGraphItem.IsCentrallyPinnedTransitivePackage)
+                        {
+                            childResolvedDependencyGraphItem.Parents ??= new HashSet<LibraryRangeIndex>();
+
+                            if (!childResolvedDependencyGraphItem.IsRootPackageReference)
+                            {
+                                // Keep track of the parents of this item
+                                childResolvedDependencyGraphItem.Parents?.Add(currentDependencyGraphItem.LibraryRangeIndex);
+                            }
+                        }
+
+                        continue;
+                    }
+
+                    HashSet<LibraryDependency>? runtimeDependencies = default;
+
+                    // Evaluate the runtime dependencies if any
+                    if (EvaluateRuntimeDependencies(ref childDependency, runtimeGraph, pair.RuntimeIdentifier, ref runtimeDependencies))
+                    {
+                        // EvaluateRuntimeDependencies() returns true if the version of the dependency was changed, which also changes the LibraryRangeIndex so that must be updated in the chosen item's array of library range indices.
+                        chosenResolvedItem.SetRangeIndexForDependencyAt(i, _indexingTable.Index(childDependency.LibraryRange));
+                    }
+
                     VersionRange? pinnedVersionRange = null;
 
                     // Determine if the package is transitively pinned
                     bool isCentrallyPinnedTransitiveDependency = isCentralPackageTransitivePinningEnabled
                         && isPackage
                         && pinnedPackageVersions?.TryGetValue(childLibraryDependencyIndex, out pinnedVersionRange) == true;
-
-                    LibraryRangeIndex childLibraryRangeIndex = chosenResolvedItem.GetRangeIndexForDependencyAt(i);
 
                     if (isCentrallyPinnedTransitiveDependency && !isRootPackageReference)
                     {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -968,7 +968,6 @@ namespace NuGet.Commands
                     // Create a resolved dependency graph item and add it to the list of chosen items
                     chosenResolvedItem = new ResolvedDependencyGraphItem(currentGraphItem, currentDependencyGraphItem, _indexingTable)
                     {
-                        Parents = currentDependencyGraphItem.IsCentrallyPinnedTransitivePackage && !currentDependencyGraphItem.IsRootPackageReference ? new HashSet<LibraryRangeIndex>() { currentDependencyGraphItem.Parent } : null,
                         IsCentrallyPinnedTransitivePackage = currentDependencyGraphItem.IsCentrallyPinnedTransitivePackage,
                         IsRootPackageReference = currentDependencyGraphItem.IsRootPackageReference,
                         Suppressions = new List<HashSet<LibraryDependencyIndex>>
@@ -1116,7 +1115,6 @@ namespace NuGet.Commands
                         // Add the item to the list of chosen items
                         chosenResolvedItem = new ResolvedDependencyGraphItem(currentGraphItem, currentDependencyGraphItem, _indexingTable)
                         {
-                            Parents = currentDependencyGraphItem.IsCentrallyPinnedTransitivePackage && !currentDependencyGraphItem.IsRootPackageReference ? new HashSet<LibraryRangeIndex>() { currentDependencyGraphItem.Parent } : null,
                             IsCentrallyPinnedTransitivePackage = currentDependencyGraphItem.IsCentrallyPinnedTransitivePackage,
                             IsRootPackageReference = currentDependencyGraphItem.IsRootPackageReference,
                             Suppressions = new List<HashSet<LibraryDependencyIndex>>
@@ -1159,8 +1157,6 @@ namespace NuGet.Commands
                     }
                     else // The current item and chosen item have the same version
                     {
-                        chosenResolvedItem.Parents ??= new HashSet<LibraryRangeIndex>();
-
                         if (!chosenResolvedItem.IsRootPackageReference)
                         {
                             // Keep track of the parents of this item
@@ -1177,9 +1173,8 @@ namespace NuGet.Commands
                             // Replace the chosen item with the current one since they are basically the same and process its children
                             resolvedDependencyGraphItems.Remove(currentDependencyGraphItem.LibraryDependencyIndex);
 
-                            chosenResolvedItem = new ResolvedDependencyGraphItem(currentGraphItem, currentDependencyGraphItem, _indexingTable)
+                            chosenResolvedItem = new ResolvedDependencyGraphItem(currentGraphItem, currentDependencyGraphItem, _indexingTable, chosenResolvedItem.Parents)
                             {
-                                Parents = chosenResolvedItem.Parents,
                                 IsCentrallyPinnedTransitivePackage = chosenResolvedItem.IsCentrallyPinnedTransitivePackage,
                                 IsRootPackageReference = chosenResolvedItem.IsRootPackageReference,
                                 Suppressions = new List<HashSet<LibraryDependencyIndex>>
@@ -1211,9 +1206,8 @@ namespace NuGet.Commands
                                 // Replace the chosen item with the current item with the the combined list of suppressions and process its children
                                 resolvedDependencyGraphItems.Remove(currentDependencyGraphItem.LibraryDependencyIndex);
 
-                                chosenResolvedItem = new ResolvedDependencyGraphItem(currentGraphItem, currentDependencyGraphItem, _indexingTable)
+                                chosenResolvedItem = new ResolvedDependencyGraphItem(currentGraphItem, currentDependencyGraphItem, _indexingTable, chosenResolvedItem.Parents)
                                 {
-                                    Parents = chosenResolvedItem.Parents,
                                     IsCentrallyPinnedTransitivePackage = chosenResolvedItem.IsCentrallyPinnedTransitivePackage,
                                     IsRootPackageReference = chosenResolvedItem.IsRootPackageReference,
                                     Suppressions =
@@ -1324,8 +1318,6 @@ namespace NuGet.Commands
                     {
                         if (!childResolvedDependencyGraphItem.IsRootPackageReference)
                         {
-                            childResolvedDependencyGraphItem.Parents ??= new HashSet<LibraryRangeIndex>();
-
                             // Keep track of the parents of this item
                             childResolvedDependencyGraphItem.Parents?.Add(currentDependencyGraphItem.LibraryRangeIndex);
                         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -1320,13 +1320,12 @@ namespace NuGet.Commands
                     if (resolvedDependencyGraphItems.TryGetValue(childLibraryDependencyIndex, out ResolvedDependencyGraphItem? childResolvedDependencyGraphItem)
                         && childResolvedDependencyGraphItem.LibraryRangeIndex == childLibraryRangeIndex
                         && childResolvedDependencyGraphItem.Suppressions.Count == 1
-                        && childResolvedDependencyGraphItem.Suppressions[0].Count == 0
-                        && HasCommonAncestor(childResolvedDependencyGraphItem.Path, currentDependencyGraphItem.Path))
+                        && childResolvedDependencyGraphItem.Suppressions[0].Count == 0)
                     {
-                        childResolvedDependencyGraphItem.Parents ??= new HashSet<LibraryRangeIndex>();
-
                         if (!childResolvedDependencyGraphItem.IsRootPackageReference)
                         {
+                            childResolvedDependencyGraphItem.Parents ??= new HashSet<LibraryRangeIndex>();
+
                             // Keep track of the parents of this item
                             childResolvedDependencyGraphItem.Parents?.Add(currentDependencyGraphItem.LibraryRangeIndex);
                         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14025

## Description
The new dependency resolver queues up all of the children of a dependency as long as they are not suppressed or are direct package references.  Depending on your graph, this is fine but in some cases it was discovered that the algorithm would queue up millions of items.  This causes restore to be very slow compared to the legacy one and in some cases restore fails with an exception because it cannot create a queue big enough for the items.

This fix checks child dependencies before queuing them.  They can be skipped if a resolved dependency has already been selected with the same version and same suppressions.  This mimics the same behavior when the resolver dequeues an item to process so this really just keeps dependencies from being queued in the first place.

I also rearranged some checks in an attempt to make perf a little better, there is no point in evaluating runtime dependencies of a child that is going to be skipped.

Unfortunately, there's no good test for this since I was only able to reproduce it with a very large project set.  I verified these changes fix [that scenario](https://github.com/marcin-krystianc/TestSolutions/blob/master/LargeAppWithPrivatePackagesCentralisedNGBVRemoved/solution/LargeAppWithPrivatePackagesCentralisedNGBVRemoved.sln), as well as verified these changes to not break a few other large repositories.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
