### PR TITLE
React to NuGet package pruning warnings

### DIFF
--- a/src/NuGet.Core/NuGet.Common/NuGet.Common.csproj
+++ b/src/NuGet.Core/NuGet.Common/NuGet.Common.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Collections.Immutable" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.LibraryModel/NuGet.LibraryModel.csproj
+++ b/src/NuGet.Core/NuGet.LibraryModel/NuGet.LibraryModel.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Collections.Immutable" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGet.PackageManagement.csproj
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGet.PackageManagement.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Web.Xdt" />
-    <PackageReference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.CSharp" Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGet.PackageManagement.csproj
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGet.PackageManagement.csproj
@@ -28,6 +28,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
@@ -66,7 +66,7 @@
       This package is a dependency of System.Security.Cryptography.Pkcs
       When it is upgraded to a newer version, try deleting the below PackageReference
       -->
-    <PackageReference Include="System.Formats.Asn1" Condition=" '$(TargetFramework)' != '$(NETFXTargetFramework)'" />
+    <PackageReference Include="System.Formats.Asn1" Condition="'$(TargetFramework)' != '$(NETFXTargetFramework)' and '$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.ProjectModel/NuGet.ProjectModel.csproj
+++ b/src/NuGet.Core/NuGet.ProjectModel/NuGet.ProjectModel.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Collections.Immutable" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/sdk/pull/46642

NuGet added a new feature that automatically prunes package and project references that are provided by the shared framework that is targeted.

Resolve the 5 warnings that got emitted when source-building the repository.