### PR TITLE
Add .NET 9 and .NET 10 TFMs to FrameworkConstants

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
@@ -110,11 +110,14 @@ namespace NuGet.Frameworks
             /// <summary>net481 (.NETFramework,Version=v4.8.1)</summary>
             public static readonly NuGetFramework Net481 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 8, 1, 0));
 
-            /// <summary>net11 (.NETFramework,Version=v1.1)</summary>
+            /// <summary>netcore45 (.NETCore,Version=v4.5)</summary>
+            /// <remarks>This is not .NET Core. You are probably looking for netcoreapp.</remarks>
             public static readonly NuGetFramework NetCore45 = new NuGetFramework(FrameworkIdentifiers.NetCore, new Version(4, 5, 0, 0));
-            /// <summary>net11 (.NETFramework,Version=v1.1)</summary>
+            /// <summary>netcore451 (.NETCore,Version=v4.5.1)</summary>
+            /// <remarks>This is not .NET Core. You are probably looking for netcoreapp.</remarks>
             public static readonly NuGetFramework NetCore451 = new NuGetFramework(FrameworkIdentifiers.NetCore, new Version(4, 5, 1, 0));
-            /// <summary>net11 (.NETFramework,Version=v1.1)</summary>
+            /// <summary>netcore50 (.NETCore,Version=v5.0)</summary>
+            /// <remarks>This is not .NET 5. You are probably looking for net50 (.NETCoreApp,Version=v5.0)</remarks>
             public static readonly NuGetFramework NetCore50 = new NuGetFramework(FrameworkIdentifiers.NetCore, new Version(5, 0, 0, 0));
 
             public static readonly NuGetFramework Win8 = new NuGetFramework(FrameworkIdentifiers.Windows, new Version(8, 0, 0, 0));

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
@@ -75,24 +75,46 @@ namespace NuGet.Frameworks
         /// </summary>
         public static class CommonFrameworks
         {
+            /// <summary>net11 (.NETFramework,Version=v1.1)</summary>
             public static readonly NuGetFramework Net11 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(1, 1, 0, 0));
+            /// <summary>net20 (.NETFramework,Version=v2.0)</summary>
             public static readonly NuGetFramework Net2 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(2, 0, 0, 0));
+            /// <summary>net35 (.NETFramework,Version=v3.5)</summary>
             public static readonly NuGetFramework Net35 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(3, 5, 0, 0));
+            /// <summary>net40 (.NETFramework,Version=v4.0)</summary>
             public static readonly NuGetFramework Net4 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 0, 0, 0));
+            /// <summary>net403 (.NETFramework,Version=v4.0.3)</summary>
             public static readonly NuGetFramework Net403 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 0, 3, 0));
+            /// <summary>net45 (.NETFramework,Version=v4.5)</summary>
             public static readonly NuGetFramework Net45 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 5, 0, 0));
+            /// <summary>net451 (.NETFramework,Version=v4.5.1)</summary>
             public static readonly NuGetFramework Net451 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 5, 1, 0));
+            /// <summary>net452 (.NETFramework,Version=v4.5.2)</summary>
             public static readonly NuGetFramework Net452 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 5, 2, 0));
+            /// <summary>net46 (.NETFramework,Version=v4.6)</summary>
             public static readonly NuGetFramework Net46 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 6, 0, 0));
+            /// <summary>net461 (.NETFramework,Version=v4.6.1)</summary>
             public static readonly NuGetFramework Net461 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 6, 1, 0));
+            /// <summary>net462 (.NETFramework,Version=v4.6.2)</summary>
             public static readonly NuGetFramework Net462 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 6, 2, 0));
+            /// <summary>net463 (.NETFramework,Version=v4.6.3)</summary>
             public static readonly NuGetFramework Net463 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 6, 3, 0));
+            /// <summary>net47 (.NETFramework,Version=v4.7)</summary>
             public static readonly NuGetFramework Net47 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 7, 0, 0));
+            /// <summary>net471 (.NETFramework,Version=v4.7.1)</summary>
             public static readonly NuGetFramework Net471 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 7, 1, 0));
+            /// <summary>net472 (.NETFramework,Version=v4.7.2)</summary>
             public static readonly NuGetFramework Net472 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 7, 2, 0));
+            /// <summary>net48 (.NETFramework,Version=v4.8)</summary>
+            public static readonly NuGetFramework Net48 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 8, 0, 0));
+            /// <summary>net481 (.NETFramework,Version=v4.8.1)</summary>
+            public static readonly NuGetFramework Net481 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 8, 1, 0));
 
+            /// <summary>net11 (.NETFramework,Version=v1.1)</summary>
             public static readonly NuGetFramework NetCore45 = new NuGetFramework(FrameworkIdentifiers.NetCore, new Version(4, 5, 0, 0));
+            /// <summary>net11 (.NETFramework,Version=v1.1)</summary>
             public static readonly NuGetFramework NetCore451 = new NuGetFramework(FrameworkIdentifiers.NetCore, new Version(4, 5, 1, 0));
+            /// <summary>net11 (.NETFramework,Version=v1.1)</summary>
             public static readonly NuGetFramework NetCore50 = new NuGetFramework(FrameworkIdentifiers.NetCore, new Version(5, 0, 0, 0));
 
             public static readonly NuGetFramework Win8 = new NuGetFramework(FrameworkIdentifiers.Windows, new Version(8, 0, 0, 0));
@@ -143,24 +165,34 @@ namespace NuGet.Frameworks
 
             public static readonly NuGetFramework NetStandard
                 = new NuGetFramework(FrameworkIdentifiers.NetStandard, EmptyVersion);
+            /// <summary>netstandard1.0 (.NETStandard,Version=v1.0)</summary>
             public static readonly NuGetFramework NetStandard10
                 = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(1, 0, 0, 0));
+            /// <summary>netstandard1.1 (.NETStandard,Version=v1.1)</summary>
             public static readonly NuGetFramework NetStandard11
                 = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(1, 1, 0, 0));
+            /// <summary>netstandard1.2 (.NETStandard,Version=v1.2)</summary>
             public static readonly NuGetFramework NetStandard12
                 = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(1, 2, 0, 0));
+            /// <summary>netstandard1.3 (.NETStandard,Version=v1.3)</summary>
             public static readonly NuGetFramework NetStandard13
                 = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(1, 3, 0, 0));
+            /// <summary>netstandard1.4 (.NETStandard,Version=v1.4)</summary>
             public static readonly NuGetFramework NetStandard14
                 = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(1, 4, 0, 0));
+            /// <summary>netstandard1.5 (.NETStandard,Version=v1.5)</summary>
             public static readonly NuGetFramework NetStandard15
                 = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(1, 5, 0, 0));
+            /// <summary>netstandard1.6 (.NETStandard,Version=v1.6)</summary>
             public static readonly NuGetFramework NetStandard16
                 = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(1, 6, 0, 0));
+            /// <summary>netstandard1.7 (.NETStandard,Version=v1.7</summary>
             public static readonly NuGetFramework NetStandard17
                 = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(1, 7, 0, 0));
+            /// <summary>netstandard2.0 (.NETStandard,Version=v2.0)</summary>
             public static readonly NuGetFramework NetStandard20
                 = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(2, 0, 0, 0));
+            /// <summary>netstandard2.1 (.NETStandard,Version=v2.1)</summary>
             public static readonly NuGetFramework NetStandard21
                 = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(2, 1, 0, 0));
 
@@ -170,27 +202,40 @@ namespace NuGet.Frameworks
             public static readonly NuGetFramework UAP10
                 = new NuGetFramework(FrameworkIdentifiers.UAP, Version10);
 
+            /// <summary>netcoreapp1.0 (.NETCoreApp,Version=v1.0)</summary>
             public static readonly NuGetFramework NetCoreApp10
                 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, new Version(1, 0, 0, 0));
+            /// <summary>netcoreapp1.1 (.NETCoreApp,Version=v1.1)</summary>
             public static readonly NuGetFramework NetCoreApp11
                 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, new Version(1, 1, 0, 0));
+            /// <summary>netcoreapp2.0 (.NETCoreApp,Version=v2.0)</summary>
             public static readonly NuGetFramework NetCoreApp20
                 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, new Version(2, 0, 0, 0));
+            /// <summary>netcoreapp2.1 (.NETCoreApp,Version=v2.1)</summary>
             public static readonly NuGetFramework NetCoreApp21
                 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, new Version(2, 1, 0, 0));
+            /// <summary>netcoreapp2.2 (.NETCoreApp,Version=v2.2)</summary>
             public static readonly NuGetFramework NetCoreApp22
                 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, new Version(2, 2, 0, 0));
+            /// <summary>netcoreapp3.0 (.NETCoreApp,Version=v3.0)</summary>
             public static readonly NuGetFramework NetCoreApp30
                 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, new Version(3, 0, 0, 0));
+            /// <summary>netcoreapp3.1 (.NETCoreApp,Version=v3.1)</summary>
             public static readonly NuGetFramework NetCoreApp31
                 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, new Version(3, 1, 0, 0));
 
             // .NET 5.0 and later has NetCoreApp identifier
+            /// <summary>net5.0 (.NETCoreApp,Version=v5.0)</summary>
             public static readonly NuGetFramework Net50 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version5);
+            /// <summary>net6.0 (.NETCoreApp,Version=v6.0)</summary>
             public static readonly NuGetFramework Net60 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6);
+            /// <summary>net7.0 (.NETCoreApp,Version=v7.0)</summary>
             public static readonly NuGetFramework Net70 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7);
+            /// <summary>net8.0 (.NETCoreApp,Version=v8.0)</summary>
             public static readonly NuGetFramework Net80 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8);
+            /// <summary>net9.0 (.NETCoreApp,Version=v9.0)</summary>
             public static readonly NuGetFramework Net90 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version9);
+            /// <summary>net10.0 (.NETCoreApp,Version=v10.0)</summary>
             public static readonly NuGetFramework Net10_0 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version10);
 
             public static readonly NuGetFramework Native = new NuGetFramework(FrameworkIdentifiers.Native, new Version(0, 0, 0, 0));

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
@@ -13,6 +13,7 @@ namespace NuGet.Frameworks
         public static readonly Version Version6 = new Version(6, 0, 0, 0);
         public static readonly Version Version7 = new Version(7, 0, 0, 0);
         public static readonly Version Version8 = new Version(8, 0, 0, 0);
+        public static readonly Version Version9 = new Version(9, 0, 0, 0);
         public static readonly Version Version10 = new Version(10, 0, 0, 0);
         public static readonly FrameworkRange DotNetAll = new FrameworkRange(
                         new NuGetFramework(FrameworkIdentifiers.NetPlatform, FrameworkConstants.EmptyVersion),
@@ -189,6 +190,8 @@ namespace NuGet.Frameworks
             public static readonly NuGetFramework Net60 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6);
             public static readonly NuGetFramework Net70 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7);
             public static readonly NuGetFramework Net80 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8);
+            public static readonly NuGetFramework Net90 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version9);
+            public static readonly NuGetFramework Net10_0 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version10);
 
             public static readonly NuGetFramework Native = new NuGetFramework(FrameworkIdentifiers.Native, new Version(0, 0, 0, 0));
         }

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
@@ -547,11 +547,17 @@ namespace NuGet.Frameworks
                 case "net4":
                     framework = FrameworkConstants.CommonFrameworks.Net4;
                     break;
+                case "net403":
+                    framework = FrameworkConstants.CommonFrameworks.Net403;
+                    break;
                 case "net45":
                     framework = FrameworkConstants.CommonFrameworks.Net45;
                     break;
                 case "net451":
                     framework = FrameworkConstants.CommonFrameworks.Net451;
+                    break;
+                case "net452":
+                    framework = FrameworkConstants.CommonFrameworks.Net452;
                     break;
                 case "net46":
                     framework = FrameworkConstants.CommonFrameworks.Net46;
@@ -561,6 +567,9 @@ namespace NuGet.Frameworks
                     break;
                 case "net462":
                     framework = FrameworkConstants.CommonFrameworks.Net462;
+                    break;
+                case "net463":
+                    framework = FrameworkConstants.CommonFrameworks.Net463;
                     break;
                 case "net47":
                     framework = FrameworkConstants.CommonFrameworks.Net47;
@@ -620,9 +629,21 @@ namespace NuGet.Frameworks
                 case "netstandard21":
                     framework = FrameworkConstants.CommonFrameworks.NetStandard21;
                     break;
+                case "netcoreapp1.0":
+                    framework = FrameworkConstants.CommonFrameworks.NetCoreApp10;
+                    break;
+                case "netcoreapp1.1":
+                    framework = FrameworkConstants.CommonFrameworks.NetCoreApp11;
+                    break;
+                case "netcoreapp2.0":
+                    framework = FrameworkConstants.CommonFrameworks.NetCoreApp20;
+                    break;
                 case "netcoreapp2.1":
                 case "netcoreapp21":
                     framework = FrameworkConstants.CommonFrameworks.NetCoreApp21;
+                    break;
+                case "netcoreapp2.2":
+                    framework = FrameworkConstants.CommonFrameworks.NetCoreApp22;
                     break;
                 case "netcoreapp3.0":
                 case "netcoreapp30":
@@ -655,6 +676,12 @@ namespace NuGet.Frameworks
                 case "net8.0":
                 case "net80":
                     framework = FrameworkConstants.CommonFrameworks.Net80;
+                    break;
+                case "net9.0":
+                    framework = FrameworkConstants.CommonFrameworks.Net90;
+                    break;
+                case "net10.0":
+                    framework = FrameworkConstants.CommonFrameworks.Net10_0;
                     break;
             }
 

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
@@ -580,6 +580,12 @@ namespace NuGet.Frameworks
                 case "net472":
                     framework = FrameworkConstants.CommonFrameworks.Net472;
                     break;
+                case "net48":
+                    framework = FrameworkConstants.CommonFrameworks.Net48;
+                    break;
+                case "net481":
+                    framework = FrameworkConstants.CommonFrameworks.Net481;
+                    break;
                 case "win8":
                     framework = FrameworkConstants.CommonFrameworks.Win8;
                     break;

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net10_0 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net48 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net481 -> NuGet.Frameworks.NuGetFramework!
 static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net90 -> NuGet.Frameworks.NuGetFramework!
 static readonly NuGet.Frameworks.FrameworkConstants.Version9 -> System.Version!

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net10_0 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net90 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.Version9 -> System.Version!

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace NuGet.Frameworks.Test
@@ -438,24 +437,32 @@ namespace NuGet.Frameworks.Test
             Assert.Same(framework1, framework2);
         }
 
-        public static IEnumerable<object[]> NuGetFramework_Parse_CommonFramework_ReturnsStaticInstance_Data()
+        [Fact]
+        public void NuGetFramework_Parse_CommonFramework_ReturnsStaticInstance()
         {
-            yield return new object[] { "net472", FrameworkConstants.CommonFrameworks.Net472 };
-            yield return new object[] { "net5.0", FrameworkConstants.CommonFrameworks.Net50 };
-            yield return new object[] { "net6.0", FrameworkConstants.CommonFrameworks.Net60 };
-            yield return new object[] { "net7.0", FrameworkConstants.CommonFrameworks.Net70 };
-            yield return new object[] { "net8.0", FrameworkConstants.CommonFrameworks.Net80 };
-        }
+            var commonFrameworksType = typeof(FrameworkConstants.CommonFrameworks);
 
-        [Theory]
-        [MemberData(nameof(NuGetFramework_Parse_CommonFramework_ReturnsStaticInstance_Data))]
-        public void NuGetFramework_Parse_CommonFramework_ReturnsStaticInstance(string frameworkString, NuGetFramework frameworkObject)
-        {
-            // Act
-            NuGetFramework parsedFramework = NuGetFramework.Parse(frameworkString);
+            foreach (var field in commonFrameworksType.GetFields())
+            {
+                var frameworkObject = field.GetValue(null) as NuGetFramework;
+                if (frameworkObject is null)
+                {
+                    Assert.Fail($"FrameworkConstants.CommonFrameworks.{field.Name} is not a NuGetFramework");
+                }
 
-            // Assert
-            Assert.Same(frameworkObject, parsedFramework);
+                if ((frameworkObject.Framework == FrameworkConstants.FrameworkIdentifiers.Net && frameworkObject.Version.Major >= 4)
+                    || frameworkObject.Framework == FrameworkConstants.FrameworkIdentifiers.NetStandard
+                    || frameworkObject.Framework == FrameworkConstants.FrameworkIdentifiers.NetCoreApp)
+                {
+                    var shortFolderName = frameworkObject.GetShortFolderName();
+
+                    // Act
+                    NuGetFramework parsedFramework = NuGetFramework.Parse(shortFolderName);
+
+                    // Assert
+                    Assert.Same(frameworkObject, parsedFramework);
+                }
+            }
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace NuGet.Frameworks.Test
@@ -437,8 +438,7 @@ namespace NuGet.Frameworks.Test
             Assert.Same(framework1, framework2);
         }
 
-        [Fact]
-        public void NuGetFramework_Parse_CommonFramework_ReturnsStaticInstance()
+        public static IEnumerable<object[]> NuGetFramework_Parse_CommonFramework_ReturnsStaticInstance_Data()
         {
             var commonFrameworksType = typeof(FrameworkConstants.CommonFrameworks);
 
@@ -450,19 +450,33 @@ namespace NuGet.Frameworks.Test
                     Assert.Fail($"FrameworkConstants.CommonFrameworks.{field.Name} is not a NuGetFramework");
                 }
 
-                if ((frameworkObject.Framework == FrameworkConstants.FrameworkIdentifiers.Net && frameworkObject.Version.Major >= 4)
-                    || frameworkObject.Framework == FrameworkConstants.FrameworkIdentifiers.NetStandard
+                // Check all versions of .NET Standard and .NET (CoreApp)
+                if (frameworkObject.Framework == FrameworkConstants.FrameworkIdentifiers.NetStandard
                     || frameworkObject.Framework == FrameworkConstants.FrameworkIdentifiers.NetCoreApp)
                 {
                     var shortFolderName = frameworkObject.GetShortFolderName();
+                    yield return [shortFolderName, frameworkObject];
+                }
 
-                    // Act
-                    NuGetFramework parsedFramework = NuGetFramework.Parse(shortFolderName);
-
-                    // Assert
-                    Assert.Same(frameworkObject, parsedFramework);
+                // For .NET Framework, only check versions 4.0 and above, since few packages target older versions
+                if (frameworkObject.Framework == FrameworkConstants.FrameworkIdentifiers.Net
+                    && frameworkObject.Version.Major >= 4)
+                {
+                    var shortFolderName = frameworkObject.GetShortFolderName();
+                    yield return [shortFolderName, frameworkObject];
                 }
             }
+        }
+
+        [Theory]
+        [MemberData(nameof(NuGetFramework_Parse_CommonFramework_ReturnsStaticInstance_Data))]
+        public void NuGetFramework_Parse_CommonFramework_ReturnsStaticInstance(string frameworkString, NuGetFramework frameworkObject)
+        {
+            // Act
+            NuGetFramework parsedFramework = NuGetFramework.Parse(frameworkString);
+
+            // Assert
+            Assert.Same(frameworkObject, parsedFramework);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14067

## Description

* Add `FrameworkConstants.CommonFrameworks` fields for .NET 9 and .NET 10
* Change test to make sure any future constants added have the zero-allocation parsing implemented.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ n/a
