### PR TITLE
Update SetPackageMetadataAsync to check for PackagePath

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
@@ -68,6 +68,9 @@ namespace NuGet.PackageManagement.UI.ViewModels
             set => SetAndRaisePropertyChanged(ref _rawReadme, value);
         }
 
+        //For testing purposes
+        internal DetailedPackageMetadata PackageMetadata => _packageMetadata;
+
         public async Task ItemFilterChangedAsync(ItemFilter filter)
         {
             var oldRenderLocalReadme = _canRenderLocalReadme;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ReadmePreviewViewModel.cs
@@ -87,6 +87,7 @@ namespace NuGet.PackageManagement.UI.ViewModels
                 !string.Equals(packageMetadata.Id, _packageMetadata?.Id)
                 || packageMetadata.Version != _packageMetadata?.Version
                 || !string.Equals(packageMetadata.ReadmeFileUrl, _packageMetadata?.ReadmeFileUrl)
+                || !string.Equals(packageMetadata.PackagePath, _packageMetadata?.PackagePath)
                 ))
             {
                 _packageMetadata = packageMetadata;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/ReadmePreviewViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/ReadmePreviewViewModelTests.cs
@@ -125,6 +125,72 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             Assert.Equal(readmeContents, target.ReadmeMarkdown);
         }
 
+
+        [Theory]
+        [InlineData("packageId", "2.0.0", "C://path/to/readme.md", "")]
+        [InlineData("packageId2", "1.0.0", "C://path/to/readme.md", "")]
+        [InlineData("packageId", "1.0.0", "C://path/to/readme.md", "C://path/to/package")]
+        [InlineData("packageId", "1.0.0", "", "")]
+        public async Task SetPackageMetadataAsync_NewReadmeRequiredToRender_PackageMetadataUpdated(string newId, string newVersion, string newReadme, string newPackagePath)
+        {
+            //Arrange
+            var readmeContents = "readme contents";
+            var mockFileService = new Mock<INuGetPackageFileService>();
+            mockFileService.Setup(x => x.GetReadmeAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>())).ReturnsAsync(() =>
+            {
+                return new MemoryStream(Encoding.UTF8.GetBytes(readmeContents));
+            });
+            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.Installed, true);
+            var package = new DetailedPackageMetadata();
+            package.Id = "packageId";
+            package.Version = new Versioning.NuGetVersion("1.0.0");
+            package.PackagePath = "";
+            package.ReadmeFileUrl = "C://path/to/readme.md";
+
+            var newPackage = new DetailedPackageMetadata();
+            newPackage.Id = newId;
+            newPackage.Version = new Versioning.NuGetVersion(newVersion);
+            newPackage.PackagePath = newPackagePath;
+            newPackage.ReadmeFileUrl = newReadme;
+            await target.SetPackageMetadataAsync(package, CancellationToken.None);
+
+            //Act
+            await target.SetPackageMetadataAsync(newPackage, CancellationToken.None);
+
+
+            //Assert
+            Assert.Equal(target.PackageMetadata, newPackage);
+        }
+
+        [Fact]
+        public async Task SetPackageMetadataAsync_PackageUpdates_NoNewReadmeRequiredToRender_PackageMetadataNotUpdated()
+        {
+            //Arrange
+            var readmeContents = "readme contents";
+            using Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(readmeContents));
+            var mockFileService = new Mock<INuGetPackageFileService>();
+            mockFileService.Setup(x => x.GetReadmeAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>())).ReturnsAsync(stream);
+            var target = new ReadmePreviewViewModel(mockFileService.Object, ItemFilter.Installed, true);
+            var package = new DetailedPackageMetadata();
+            package.Id = "packageId";
+            package.Version = new Versioning.NuGetVersion("1.0.0");
+            package.PackagePath = "";
+            package.ReadmeFileUrl = "C://path/to/readme.md";
+
+            var newPackage = new DetailedPackageMetadata();
+            newPackage.Id = "packageId";
+            newPackage.Version = new Versioning.NuGetVersion("1.0.0");
+            newPackage.PackagePath = "";
+            newPackage.ReadmeFileUrl = "C://path/to/readme.md";
+            await target.SetPackageMetadataAsync(package, CancellationToken.None);
+
+            //Act
+            await target.SetPackageMetadataAsync(newPackage, CancellationToken.None);
+
+            //Assert
+            Assert.NotEqual(target.PackageMetadata, newPackage);
+        }
+
         [Fact]
         public async Task SetPackageMetadataAsync_WithLocalReadmeUrl_RenderLocalReadmeFalse_NoLocalReadmeReturned()
         {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/ReadmePreviewViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/ReadmePreviewViewModelTests.cs
@@ -157,7 +157,6 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
             //Act
             await target.SetPackageMetadataAsync(newPackage, CancellationToken.None);
 
-
             //Assert
             Assert.Equal(target.PackageMetadata, newPackage);
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3147
Fixes: https://github.com/NuGet/Home/issues/14097

## Description
When we install a package the PackageMetadata was being set in the view before with an object that didn't have the PackagePath set, when it gets updated to include the PackagePath, we weren't reloading the README because the difference check was ignoring that field. 

## PR Checklist

- [X] Meaningful title, helpful description and a linked NuGet/Home issue
- [X] Added tests
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
