### PR TITLE
[release-6.13.x] Skip resolved child dependencies in the new resolver if an identical one has already been resolved

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -661,11 +661,6 @@ namespace NuGet.Commands
 
                         VersionRange? pinnedVersionRange = null;
 
-                        if (!isDirectPackageReferenceFromRootProject && directPackageReferences?.Contains(depIndex) == true)
-                        {
-                            continue;
-                        }
-
                         bool isCentrallyPinnedTransitiveDependency = isCentralPackageTransitivePinningEnabled
                             && isPackage
                             && pinnedPackageVersions?.TryGetValue(depIndex, out pinnedVersionRange) == true;
@@ -688,6 +683,26 @@ namespace NuGet.Commands
                         else
                         {
                             rangeIndex = refItemResult.GetRangeIndexForDependency(i);
+                        }
+
+                        if (!isDirectPackageReferenceFromRootProject && directPackageReferences?.Contains(depIndex) == true)
+                        {
+                            continue;
+                        }
+
+                        // See if a dependency with the same version and no suppressions has already been resolved.  If so, its children have already been added to the queue.
+                        if (chosenResolvedItems.TryGetValue(depIndex, out ResolvedDependencyGraphItem? childResolvedDependencyGraphItem)
+                            && childResolvedDependencyGraphItem.LibraryRangeIndex == rangeIndex
+                            && childResolvedDependencyGraphItem.Suppressions.Count == 1
+                            && childResolvedDependencyGraphItem.Suppressions[0].Count == 0)
+                        {
+                            if (!childResolvedDependencyGraphItem.IsDirectPackageReferenceFromRootProject)
+                            {
+                                // Keep track of the parents of this item
+                                childResolvedDependencyGraphItem.Parents?.Add(importRefItem.LibraryRangeIndex);
+                            }
+
+                            continue;
                         }
 
                         DependencyGraphItem dependencyGraphItem = new()


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14025

## Description

Cherry pick https://github.com/NuGet/NuGet.Client/commit/e716e78fa66a29f3e417462256cc340479e25ce2 onto release-6.13.x

It's more of a port, as the dependency resolver code was completely refactored in the dev branch, making the cherry-pick impossible. But this change was manually validated on a number of repos.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
