### PR TITLE
Make Xplat locals tests use a known directory for child processes

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
@@ -66,7 +66,7 @@ namespace NuGet.XPlat.FuncTest
                 // Act
                 var result = CommandRunner.Run(
                     DotnetCli,
-                    Directory.GetCurrentDirectory(),
+                    mockBaseDirectory,
                     $"{XplatDll} {args}",
                     environmentVariables: new Dictionary<string, string>
                     {
@@ -127,7 +127,7 @@ namespace NuGet.XPlat.FuncTest
                 // Act
                 var result = CommandRunner.Run(
                     DotnetCli,
-                    Directory.GetCurrentDirectory(),
+                    mockBaseDirectory,
                     $"{XplatDll} {args}",
                     environmentVariables: new Dictionary<string, string>
                     {
@@ -228,7 +228,7 @@ namespace NuGet.XPlat.FuncTest
             // Act
             var result = CommandRunner.Run(
                 DotnetCli,
-                Directory.GetCurrentDirectory(),
+                Path.GetDirectoryName(XplatDll),
                 $"{XplatDll} {args}",
                 testOutputHelper: _testOutputHelper);
 
@@ -252,7 +252,7 @@ namespace NuGet.XPlat.FuncTest
             // Act
             var result = CommandRunner.Run(
                 DotnetCli,
-                Directory.GetCurrentDirectory(),
+                Path.GetDirectoryName(XplatDll),
                 $"{XplatDll} {args}",
                 testOutputHelper: _testOutputHelper);
 
@@ -276,7 +276,7 @@ namespace NuGet.XPlat.FuncTest
             // Act
             var result = CommandRunner.Run(
                 DotnetCli,
-                Directory.GetCurrentDirectory(),
+                Path.GetDirectoryName(XplatDll),
                 $"{XplatDll} {args}",
                 testOutputHelper: _testOutputHelper);
 
@@ -301,7 +301,7 @@ namespace NuGet.XPlat.FuncTest
             // Act
             var result = CommandRunner.Run(
                 DotnetCli,
-                Directory.GetCurrentDirectory(),
+                Path.GetDirectoryName(XplatDll),
                 $"{XplatDll} {args}",
                 testOutputHelper: _testOutputHelper);
 
@@ -332,7 +332,7 @@ namespace NuGet.XPlat.FuncTest
             // Act
             var result = CommandRunner.Run(
                 DotnetCli,
-                Directory.GetCurrentDirectory(),
+                Path.GetDirectoryName(XplatDll),
                 $"{XplatDll} {args}",
                 testOutputHelper: _testOutputHelper);
 

--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/ChildProcess/CommandRunner.cs
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/ChildProcess/CommandRunner.cs
@@ -29,6 +29,17 @@ namespace Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess
         /// <returns>A <see cref="CommandRunnerResult" /> containing details about the result of the running the executable including the exit code and console output.</returns>
         public static CommandRunnerResult Run(string filename, string workingDirectory = null, string arguments = null, int timeOutInMilliseconds = 60000, Action<StreamWriter> inputAction = null, IDictionary<string, string> environmentVariables = null, ITestOutputHelper testOutputHelper = null, int timeoutRetryCount = 1)
         {
+            if (workingDirectory is null)
+            {
+                workingDirectory = Environment.CurrentDirectory;
+            }
+            workingDirectory = Path.GetFullPath(workingDirectory);
+
+            if (!Directory.Exists(workingDirectory))
+            {
+                throw new DirectoryNotFoundException($"The working directory '{workingDirectory}' does not exist.");
+            }
+
             return RetryRunner.RunWithRetries<CommandRunnerResult, TimeoutException>(() =>
             {
                 StringBuilder output = new();
@@ -40,7 +51,7 @@ namespace Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess
                     EnableRaisingEvents = true,
                     StartInfo = new ProcessStartInfo(Path.GetFullPath(filename), arguments)
                     {
-                        WorkingDirectory = Path.GetFullPath(workingDirectory ?? Environment.CurrentDirectory),
+                        WorkingDirectory = workingDirectory,
                         UseShellExecute = false,
                         RedirectStandardError = true,
                         RedirectStandardOutput = true,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: test code

## Description

I have no idea if `dotnet test` does something weird with the process current directory when running tests, but we've been getting a lot of test failures on mac where `Directory.GetCurrentDirectory()` is failing because some filesystem entry can't be found.

So, put some validation in our child process runner, to make sure the working directory exists, and give a good error message when it doesn't.

Also change all the locals command tests to use working directories we know exists (not the process')

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
