### PR TITLE
Port fix from "Skip resolved child dependencies in the new resolver if an identical one has already been resolved"

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -1333,6 +1333,21 @@ namespace NuGet.Commands
                         childLibraryRangeIndex = _indexingTable.Index(childDependency.LibraryRange);
                     }
 
+                    // See if a dependency with the same version and no suppressions has already been resolved.  If so, its children have already been added to the queue.
+                    if (resolvedDependencyGraphItems.TryGetValue(childLibraryDependencyIndex, out ResolvedDependencyGraphItem? childResolvedDependencyGraphItem)
+                        && childResolvedDependencyGraphItem.LibraryRangeIndex == childLibraryRangeIndex
+                        && childResolvedDependencyGraphItem.Suppressions.Count == 1
+                        && childResolvedDependencyGraphItem.Suppressions[0].Count == 0)
+                    {
+                        if (!childResolvedDependencyGraphItem.IsRootPackageReference)
+                        {
+                            // Keep track of the parents of this item
+                            childResolvedDependencyGraphItem.Parents?.Add(currentDependencyGraphItem.LibraryRangeIndex);
+                        }
+
+                        continue;
+                    }
+
                     // Create a DependencyGraphItem and add it to the queue for processing
                     DependencyGraphItem dependencyGraphItem = new()
                     {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
This is a port of the fix from e716e78fa66a29f3e417462256cc340479e25ce2 on top of the `release-6.14.preview1` branch for servicing.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.

## Validations

- [x] Issue reproduces on the `release-16.14.preview1` branch
- [x] Issue is fixed with this port
- [x] Large internal repo has same performance and outputs
- [x] Large internal repo with transitive pinning has same performance and outputs
