### PR TITLE
Add .git-blame-ignore-revs for filtering out commits in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Specifies commit IDs to ignore when using git blame
+# These commits are ignored in GitHub blame view (https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view)
+# To make it work locally for the git blame command, you must run "git config blame.ignoreRevsFile .git-blame-ignore-revs" in the repository first
+
+# automatic formatting (https://github.com/NuGet/NuGet.Client/pull/3587)
+65abcc61f73ab3d87928495f789ec74011edde7f


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
Some commits can be ignored when running `git blame` by adding a `.git-blame-ignore-revs` file to the repository.  In particular, commits that format code can make git blame not as useful.

This adds a `.git-blame-ignore-revs` file to the repository to filter out commits in git blame view, documented at https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view

You can disable the filter as well:

> If the blame view for a file shows Ignoring revisions in .git-blame-ignore-revs, you can still bypass .git-blame-ignore-revs and see the normal blame view. In the URL, append a ~ to the SHA and the Ignoring revisions in .git-blame-ignore-revs banner will disappear.

I only added one commit for now, we can add more later.

65abcc61f73ab3d87928495f789ec74011edde7f

## PR Checklist

- [x] Meaningful title, helpful description and ~~a linked NuGet/Home issue~~
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
