### PR TITLE
Do not raise NU5100 when dll in buildTransitive

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Rules/MisplaceAssemblyOutsideLibRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/MisplaceAssemblyOutsideLibRule.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -18,9 +19,20 @@ namespace NuGet.Packaging.Rules
         {
             MessageFormat = messageFormat;
         }
+
+        internal MisplacedAssemblyOutsideLibRule()
+            : this(AnalysisResources.AssemblyOutsideLibWarning)
+        {
+        }
+
         public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
         {
-            foreach (var packageFile in builder.GetFiles())
+            return Validate(builder.GetFiles);
+        }
+
+        internal IEnumerable<PackagingLogMessage> Validate(Func<IEnumerable<string>> getFiles)
+        {
+            foreach (var packageFile in getFiles())
             {
                 var file = PathUtility.GetPathWithDirectorySeparator(packageFile);
                 var directory = Path.GetDirectoryName(file);
@@ -48,20 +60,17 @@ namespace NuGet.Packaging.Rules
         /// <summary>
         /// Folders that are expected to have .dll and .winmd files
         /// </summary>
-        private static IEnumerable<string> ValidFolders
-        {
-            get
-            {
-                yield return PackagingConstants.Folders.Lib + Path.DirectorySeparatorChar;
-                yield return PackagingConstants.Folders.Analyzers + Path.DirectorySeparatorChar;
-                yield return PackagingConstants.Folders.Ref + Path.DirectorySeparatorChar;
-                yield return PackagingConstants.Folders.Runtimes + Path.DirectorySeparatorChar;
-                yield return PackagingConstants.Folders.Native + Path.DirectorySeparatorChar;
-                yield return PackagingConstants.Folders.Build + Path.DirectorySeparatorChar;
-                yield return PackagingConstants.Folders.BuildCrossTargeting + Path.DirectorySeparatorChar;
-                yield return PackagingConstants.Folders.Tools + Path.DirectorySeparatorChar;
-                yield break;
-            }
-        }
+        private static ImmutableArray<string> ValidFolders =
+        [
+            PackagingConstants.Folders.Lib + Path.DirectorySeparatorChar,
+            PackagingConstants.Folders.Analyzers + Path.DirectorySeparatorChar,
+            PackagingConstants.Folders.Ref + Path.DirectorySeparatorChar,
+            PackagingConstants.Folders.Runtimes + Path.DirectorySeparatorChar,
+            PackagingConstants.Folders.Native + Path.DirectorySeparatorChar,
+            PackagingConstants.Folders.Build + Path.DirectorySeparatorChar,
+            PackagingConstants.Folders.BuildCrossTargeting + Path.DirectorySeparatorChar,
+            PackagingConstants.Folders.BuildTransitive + Path.DirectorySeparatorChar,
+            PackagingConstants.Folders.Tools + Path.DirectorySeparatorChar,
+         ];
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/Rules/MisplacedAssemblyOutsideLibRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/Rules/MisplacedAssemblyOutsideLibRuleTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using NuGet.Common;
+using NuGet.Packaging.Rules;
+using Xunit;
+
+namespace NuGet.Commands.Test.Rules
+{
+    public class MisplacedAssemblyOutsideLibRuleTests
+    {
+        [Fact]
+        public void Validate_DllsInKnownPaths_DoesNotReturnWarnings()
+        {
+            // Arrange
+            var target = new MisplacedAssemblyOutsideLibRule();
+            Func<IEnumerable<string>> getFiles = () =>
+            [
+                "lib/netstandard2.0/a.dll",
+                "analyzers/a.dll",
+                "ref/a.dll",
+                "runtimes/a.dll",
+                "native/a.dll",
+                "build/a.dll",
+                "buildTransitive/a.dll",
+                "buildCrossTargeting/a.dll",
+                "tools/a.dll",
+            ];
+
+            // Act
+            var result = target.Validate(getFiles);
+
+            // Assert
+            result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Validate_DllsNotInKnownPaths_ReturnWarnings()
+        {
+            // Arrange
+            var target = new MisplacedAssemblyOutsideLibRule();
+            string[] files =
+            [
+                "a.dll",
+                Path.Combine("content", "a.dll"),
+                Path.Combine("contentFiles", "a.dll"),
+                Path.Combine("bin", "a.dll"),
+                Path.Combine("contoso", "a.dll"),
+            ];
+            Func<IEnumerable<string>> getFiles = () => files;
+
+            // Act
+            var result = target.Validate(getFiles).ToList();
+
+            // Assert
+            result.Count.Should().Be(files.Length);
+            for (int i = 0; i < files.Length; i++)
+            {
+                result[i].Code.Should().Be(NuGetLogCode.NU5100);
+                result[i].Message.Should().Contain(files[i]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14080

## Description

* Add buildTransitive to NU5100's rule's allow list.
* I have a natural instinct to replace `IEnumerable<T>` with something that doesn't cause heap allocations on enumeration, especially in trivial cases like this.
   * Thinking a bit more about it, I'm not sure it actually has any benefit in this case. It will only be called in pack, and it's guaranteed to be called only once. So, my change is replacing a single state machine allocation with a fixed size array allocation. I don't know how many elements an array needs to have until its allocation is larger than the state machine. So, in this specific case, it might not be better, but it's still a better pattern any time the IEnumerable is enumerated more than once.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
