### PR TITLE
Use .NET SDK 9.0.2xx to build repository and .NET SDK 9.0.3xx for integration tests

### DIFF
--- a/build/DotNetSdkTestVersions.txt
+++ b/build/DotNetSdkTestVersions.txt
@@ -1,3 +1,3 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Channel 9.0.2xx -Quality daily
+-Channel 9.0.3xx -Quality daily
 -Channel 8.0 -Runtime dotnet

--- a/build/DotNetSdkVersions.txt
+++ b/build/DotNetSdkVersions.txt
@@ -1,4 +1,4 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
 -Channel 3.1 -Runtime dotnet
 -Channel 8.0 -Runtime dotnet
--Channel 9.0.1xx
+-Channel 9.0.2xx

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -412,6 +412,7 @@ namespace NuGet.Test.Utility
             context.Frameworks.AddRange(frameworks.Select(f => new SimpleTestProjectFrameworkContext(NuGetFramework.Parse(f)) { TargetAlias = f }));
             context.ToolingVersion15 = true;
             context.Properties.Add("RestoreProjectStyle", "PackageReference");
+            context.Properties.Add("BuildWithNetFrameworkHostedCompiler", bool.FalseString);
             return context;
         }
 


### PR DESCRIPTION
Use .NET SDK 9.0.2xx when building our repository and .NET SDK 9.0.3xx for the .NET integration tests. 

You can look at https://github.com/NuGet/NuGet.Client/commits/dev/build/DotNetSdkTestVersions.txt for more examples of when this configuration is changed.

This also started setting the MSBuild property `BuildWithNetFrameworkHostedCompiler` so that the compilers aren't downloaded as NuGet package when tests are running.