### PR TITLE
Add --configfile option to dotnet nuget push command

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
@@ -81,6 +81,11 @@ namespace NuGet.CommandLine.XPlat
                     Strings.PushCommandSkipDuplicateDescription,
                     CommandOptionType.NoValue);
 
+                var configurationFile = push.Option(
+                    "--configfile",
+                    Strings.Option_ConfigFile,
+                    CommandOptionType.SingleValue);
+
                 push.OnExecute(async () =>
                 {
                     if (arguments.Values.Count < 1)
@@ -105,7 +110,7 @@ namespace NuGet.CommandLine.XPlat
                     }
 
 #pragma warning disable CS0618 // Type or member is obsolete
-                    var sourceProvider = new PackageSourceProvider(XPlatUtility.GetSettingsForCurrentWorkingDirectory(), enablePackageSourcesChangedEvent: false);
+                    var sourceProvider = new PackageSourceProvider(XPlatUtility.ProcessConfigFile(configurationFile.Value()), enablePackageSourcesChangedEvent: false);
 #pragma warning restore CS0618 // Type or member is obsolete
 
                     try

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatPushTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatPushTests.cs
@@ -194,6 +194,118 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
+        [Fact]
+        public async Task PushCommand_ConfigFile_Succeeds()
+        {
+
+            using (var packageDirectory = TestDirectory.Create())
+            using (var source = TestDirectory.Create())
+            {
+                // Arrange
+                var log = new TestCommandOutputLogger(_testOutputHelper);
+                FileInfo testPackageInfo = await TestPackagesCore.GetRuntimePackageAsync(packageDirectory, "testPackageA", "1.1.0");
+                var configPath = Path.Combine(packageDirectory, Settings.DefaultSettingsFileName);
+
+                string nugetConfigContent =
+                    $@"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <configuration>
+                            <config>
+                                <add key=""defaultPushSource"" value=""{source}"" />
+                            </config>
+                        </configuration>";
+                File.WriteAllText(configPath, nugetConfigContent);
+
+                var pushArgs = new List<string>
+                {
+                    "push",
+                    testPackageInfo.FullName,
+                    "--configfile",
+                    configPath
+                };
+
+                // Act
+                var exitCode = CommandLine.XPlat.Program.MainInternal(pushArgs.ToArray(), log, TestEnvironmentVariableReader.EmptyInstance);
+
+                // Assert
+                Assert.Equal(string.Empty, log.ShowErrors());
+                Assert.Equal(0, exitCode);
+
+                Assert.Contains($"Pushing {testPackageInfo.Name}", log.ShowMessages());
+                Assert.True(File.Exists(Path.Combine(source, testPackageInfo.Name)));
+            }
+        }
+
+        [Fact]
+        public async Task PushCommand_ConfigFile_DifferentDirectory_Succeeds()
+        {
+
+            using (var configDirectory = TestDirectory.Create())
+            using (var packageDirectory = TestDirectory.Create())
+            using (var source = TestDirectory.Create())
+            {
+                // Arrange
+                var log = new TestCommandOutputLogger(_testOutputHelper);
+                FileInfo testPackageInfo = await TestPackagesCore.GetRuntimePackageAsync(packageDirectory, "testPackageA", "1.1.0");
+                var configPath = Path.Combine(configDirectory, Settings.DefaultSettingsFileName);
+
+                string nugetConfigContent =
+                    $@"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <configuration>
+                            <config>
+                                <add key=""defaultPushSource"" value=""{source}"" />
+                            </config>
+                        </configuration>";
+                File.WriteAllText(configPath, nugetConfigContent);
+
+                var pushArgs = new List<string>
+                {
+                    "push",
+                    testPackageInfo.FullName,
+                    "--configfile",
+                    configPath
+                };
+
+                // Act
+                var exitCode = CommandLine.XPlat.Program.MainInternal(pushArgs.ToArray(), log, TestEnvironmentVariableReader.EmptyInstance);
+
+                // Assert
+                Assert.Equal(string.Empty, log.ShowErrors());
+                Assert.Equal(0, exitCode);
+
+                Assert.Contains($"Pushing {testPackageInfo.Name}", log.ShowMessages());
+                Assert.True(File.Exists(Path.Combine(source, testPackageInfo.Name)));
+            }
+        }
+
+        [Fact]
+        public async Task PushCommand_NotFound_ConfigFile_Errors()
+        {
+
+            using (var packageDirectory = TestDirectory.Create())
+            using (var source = TestDirectory.Create())
+            {
+                // Arrange
+                var log = new TestCommandOutputLogger(_testOutputHelper);
+                FileInfo testPackageInfo = await TestPackagesCore.GetRuntimePackageAsync(packageDirectory, "testPackageA", "1.1.0");
+                var configPath = Path.Combine(source, "config", Settings.DefaultSettingsFileName);
+
+                var pushArgs = new List<string>
+                {
+                    "push",
+                    testPackageInfo.FullName,
+                    "--configfile",
+                    configPath
+                };
+
+                // Act
+                var exitCode = CommandLine.XPlat.Program.MainInternal(pushArgs.ToArray(), log, TestEnvironmentVariableReader.EmptyInstance);
+
+                // Assert
+                Assert.Equal(1, exitCode);
+                Assert.Contains($"File '{configPath}' does not exist", log.ShowErrors());
+            }
+        }
+
         /// <summary>
         /// This is called when the package must be deleted before being pushed. It's ok if this
         /// fails, maybe the package was never pushed.

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatPushTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatPushTests.cs
@@ -197,7 +197,6 @@ namespace NuGet.XPlat.FuncTest
         [Fact]
         public async Task PushCommand_ConfigFile_Succeeds()
         {
-
             using (var packageDirectory = TestDirectory.Create())
             using (var source = TestDirectory.Create())
             {
@@ -238,7 +237,6 @@ namespace NuGet.XPlat.FuncTest
         [Fact]
         public async Task PushCommand_ConfigFile_DifferentDirectory_Succeeds()
         {
-
             using (var configDirectory = TestDirectory.Create())
             using (var packageDirectory = TestDirectory.Create())
             using (var source = TestDirectory.Create())
@@ -274,6 +272,45 @@ namespace NuGet.XPlat.FuncTest
 
                 Assert.Contains($"Pushing {testPackageInfo.Name}", log.ShowMessages());
                 Assert.True(File.Exists(Path.Combine(source, testPackageInfo.Name)));
+            }
+        }
+
+
+        [Fact]
+        public async Task PushCommand_ConfigFile_InvalidXML_Errors()
+        {
+            using (var configDirectory = TestDirectory.Create())
+            using (var packageDirectory = TestDirectory.Create())
+            using (var source = TestDirectory.Create())
+            {
+                // Arrange
+                var log = new TestCommandOutputLogger(_testOutputHelper);
+                FileInfo testPackageInfo = await TestPackagesCore.GetRuntimePackageAsync(packageDirectory, "testPackageA", "1.1.0");
+                var configPath = Path.Combine(configDirectory, Settings.DefaultSettingsFileName);
+
+                string nugetConfigContent =
+                    $@"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <configuratio> // wrong XML
+                            <config>
+                                <add key=""defaultPushSource"" value=""{source}"" />
+                            </config>
+                        </configuration>";
+                File.WriteAllText(configPath, nugetConfigContent);
+
+                var pushArgs = new List<string>
+                {
+                    "push",
+                    testPackageInfo.FullName,
+                    "--configfile",
+                    configPath
+                };
+
+                // Act
+                var exitCode = CommandLine.XPlat.Program.MainInternal(pushArgs.ToArray(), log, TestEnvironmentVariableReader.EmptyInstance);
+
+                // Assert
+                Assert.Contains("NuGet.Config is not valid XML", log.ShowErrors());
+                Assert.Equal(1, exitCode);
             }
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/4879
Docs PR: https://github.com/dotnet/docs/pull/45050

## Description
Adds the option `--configfile` to the command dotnet nuget push. Other commands also use `XPlatUtility.ProcessConfigFile` to get the config file, if no value is passed it will default to `XPlatUtility.GetSettingsForCurrentWorkingDirectory()` which is the current implementation. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
