### PR TITLE
Ignore null or empty plugins

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
@@ -183,15 +183,10 @@ namespace NuGet.Protocol.Plugins
         internal List<PluginFile> GetPluginsInNuGetPluginPaths()
         {
             var pluginFiles = new List<PluginFile>();
-            string[] paths = _nuGetPluginPaths?.Split(Path.PathSeparator) ?? Array.Empty<string>();
+            string[] paths = _nuGetPluginPaths?.Split([Path.PathSeparator], StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
 
             foreach (var path in paths)
             {
-                if (string.IsNullOrEmpty(path))
-                {
-                    continue;
-                }
-
                 if (PathValidator.IsValidLocalPath(path) || PathValidator.IsValidUncPath(path))
                 {
                     if (File.Exists(path))

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
@@ -187,6 +187,11 @@ namespace NuGet.Protocol.Plugins
 
             foreach (var path in paths)
             {
+                if (string.IsNullOrEmpty(path))
+                {
+                    continue;
+                }
+
                 if (PathValidator.IsValidLocalPath(path) || PathValidator.IsValidUncPath(path))
                 {
                     if (File.Exists(path))
@@ -213,7 +218,7 @@ namespace NuGet.Protocol.Plugins
                         pluginFiles.AddRange(GetNetToolsPluginsInDirectory(path) ?? new List<PluginFile>());
                     }
                 }
-                else if (!string.IsNullOrEmpty(path))
+                else
                 {
                     pluginFiles.Add(new PluginFile(path, new Lazy<PluginFileState>(() => PluginFileState.InvalidFilePath)));
                 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
@@ -213,7 +213,7 @@ namespace NuGet.Protocol.Plugins
                         pluginFiles.AddRange(GetNetToolsPluginsInDirectory(path) ?? new List<PluginFile>());
                     }
                 }
-                else
+                else if (!string.IsNullOrEmpty(path))
                 {
                     pluginFiles.Add(new PluginFile(path, new Lazy<PluginFileState>(() => PluginFileState.InvalidFilePath)));
                 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
@@ -226,7 +226,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 Directory.CreateDirectory(pluginPath);
                 var myPlugin = Path.Combine(pluginPath, fileName);
                 Mock<IEnvironmentVariableReader> environmentalVariableReader = new Mock<IEnvironmentVariableReader>();
-                environmentalVariableReader.Setup(env => env.GetEnvironmentVariable("NUGET_PLUGIN_PATHS")).Returns(pluginPath);
+                environmentalVariableReader.Setup(env => env.GetEnvironmentVariable(EnvironmentVariableConstants.PluginPaths)).Returns($"{Path.PathSeparator}{pluginPath}{Path.PathSeparator}");
                 environmentalVariableReader.Setup(env => env.GetEnvironmentVariable("PATHS")).Returns("");
                 File.WriteAllText(myPlugin, string.Empty);
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14144

## Description

We previously logged all invalid plugin files, including null/empty ones. Null/empty plugin paths could be passed of an environment variable that has a trailing semicolon (Path Seperator)

For example: `C:\something\tools\CredentialProvider.Microsoft\CredentialProvider.Microsoft.exe;` 
This PR ignores the null after the semicolon

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
