### PR TITLE
Fail build if vsmanproj if SBOM file doesn't exist

### DIFF
--- a/setup/Directory.Build.targets
+++ b/setup/Directory.Build.targets
@@ -15,8 +15,8 @@
   -->
   <Target Name="_ensureSbomExists" BeforeTargets="Build" Condition=" '$(SkipSbomExistsCheck)' != 'true' AND '$(MSBuildProjectExtension)' == '.vsmanproj' ">
     <Error Condition="!Exists($(SBOMFileLocation)) AND '$(SBOMFileLocation)' != ''"
-      Message="SBOM file '$(SBOMFileLocation)' does not exist" />
+      Text="SBOM file '$(SBOMFileLocation)' does not exist" />
     <Error Condition="'$(SBOMFileLocation)' == ''"
-      Message="Property 'SBOMFileLocation' is not defined" />
+      Text="Property 'SBOMFileLocation' is not defined" />
   </Target>
 </Project>

--- a/setup/Directory.Build.targets
+++ b/setup/Directory.Build.targets
@@ -8,4 +8,15 @@
     <TargetFileName>$(TargetName)$(TargetExt)</TargetFileName>
     <TargetPath>$(TargetDir)$(TargetFileName)</TargetPath>
   </PropertyGroup>
+
+  <!--
+    VS requires the generated vsman files to contain the path to an SBOM file, but this isn't validated until VS insertion.
+    So, check here that the file exists and fail our build, so we get early notice of build errors.
+  -->
+  <Target Name="_ensureSbomExists" BeforeTargets="Build" Condition=" '$(SkipSbomExistsCheck)' != 'true' AND '$(MSBuildProjectExtension)' == '.vsmanproj' ">
+    <Error Condition="!Exists($(SBOMFileLocation)) AND '$(SBOMFileLocation)' != ''"
+      Message="SBOM file '$(SBOMFileLocation)' does not exist" />
+    <Error Condition="'$(SBOMFileLocation)' == ''"
+      Message="Property 'SBOMFileLocation' is not defined" />
+  </Target>
 </Project>

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
@@ -9,6 +9,7 @@
     <TargetName>$(MSBuildProjectName)</TargetName>
     <OutputPath>$(VsixPublishDestination)</OutputPath>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <SBOMFileLocation>$(ManifestDirPath)\_manifest\spdx_2.2\manifest.spdx.json</SBOMFileLocation>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
@@ -25,11 +26,11 @@
 
   <ItemGroup Condition=" '$(IsVsixBuild)' != 'true' ">
     <MergeManifest Include="$(VsixPublishDestination)$(MSBuildProjectName).json"
-                   SBOMFileLocation="$(ManifestDirPath)\_manifest\spdx_2.2\manifest.spdx.json" />
+                   SBOMFileLocation="$(SBOMFileLocation)" />
   </ItemGroup>
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
-  
+
   <Target Name="ValidateManifest"
           Condition="'$(IsVsixBuild)' == 'true'" />
 </Project>

--- a/setup/Microsoft.VisualStudio.NuGet.Core/Microsoft.VisualStudio.NuGet.Core.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.Core/Microsoft.VisualStudio.NuGet.Core.vsmanproj
@@ -9,12 +9,13 @@
     <TargetName>$(MSBuildProjectName)</TargetName>
     <OutputPath>$(VsixPublishDestination)</OutputPath>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <SBOMFileLocation>$(ManifestDirPath)\_manifest\spdx_2.2\manifest.spdx.json</SBOMFileLocation>
   </PropertyGroup>
 
   <ItemGroup>
     <MergeManifest Include="$(VsixPublishDestination)Microsoft.VisualStudio.NuGet.Core.json"
-                   SBOMFileLocation="$(ManifestDirPath)\_manifest\spdx_2.2\manifest.spdx.json" />
+                   SBOMFileLocation="$(SBOMFileLocation)" />
   </ItemGroup>
-  
+
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 </Project>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: infrastructure

## Description

As title says, fail build if SBOM file doesn't exist when vsmanproj projects are built. VS requires the SBOM to exist, so failing our build gives us earlier notifications than VS insertion, or VSEng telling us our insertion is non-compliant.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
