### PR TITLE
Add telemetry for which error codes are suppressed at restore time

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/RestoreCollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/RestoreCollectorLogger.cs
@@ -16,6 +16,8 @@ namespace NuGet.Commands
     {
         private readonly ILogger _innerLogger;
         private readonly ConcurrentQueue<IRestoreLogMessage> _errors;
+        private readonly ConcurrentQueue<IRestoreLogMessage> _suppressedWarnings;
+
         private readonly bool _hideWarningsAndErrors;
         private IEnumerable<RestoreTargetGraph> _restoreTargetGraphs;
         private PackageSpec _projectSpec;
@@ -24,6 +26,8 @@ namespace NuGet.Commands
         public string ProjectPath => _projectSpec?.RestoreMetadata?.ProjectPath;
 
         public IEnumerable<IRestoreLogMessage> Errors => _errors.ToArray();
+        internal IEnumerable<IRestoreLogMessage> SuppressedWarnings => _suppressedWarnings.ToArray();
+
 
         public WarningPropertiesCollection ProjectWarningPropertiesCollection { get; set; }
 
@@ -90,6 +94,7 @@ namespace NuGet.Commands
         {
             _innerLogger = innerLogger;
             _errors = new ConcurrentQueue<IRestoreLogMessage>();
+            _suppressedWarnings = new ConcurrentQueue<IRestoreLogMessage>();
             _hideWarningsAndErrors = hideWarningsAndErrors;
         }
 
@@ -221,23 +226,29 @@ namespace NuGet.Commands
         /// <returns>bool indicating if the message should be suppressed.</returns>
         private bool IsWarningSuppressed(IRestoreLogMessage message)
         {
+            var isWarningSupressed = false;
             if (message.Level == LogLevel.Warning)
             {
                 // If the ProjectWarningPropertiesCollection is present then test if the warning is suppressed in
                 // project wide no warn or package specific no warn
                 if (ProjectWarningPropertiesCollection?.ApplyNoWarnProperties(message) == true)
                 {
-                    return true;
+                    isWarningSupressed = true;
                 }
                 else
                 {
                     // Use transitive warning properties only if the project does not suppress the warning
                     // In transitive warning properties look at only the package specific ones as all properties are per package reference.
-                    return TransitiveWarningPropertiesCollection?.ApplyNoWarnProperties(message) == true;
+                    isWarningSupressed = TransitiveWarningPropertiesCollection?.ApplyNoWarnProperties(message) == true;
                 }
             }
 
-            return false;
+            if (isWarningSupressed)
+            {
+                _suppressedWarnings.Enqueue(message);
+            }
+
+            return isWarningSupressed;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/RestoreCollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/RestoreCollectorLogger.cs
@@ -226,29 +226,29 @@ namespace NuGet.Commands
         /// <returns>bool indicating if the message should be suppressed.</returns>
         private bool IsWarningSuppressed(IRestoreLogMessage message)
         {
-            var isWarningSupressed = false;
+            var isWarningSuppressed = false;
             if (message.Level == LogLevel.Warning)
             {
                 // If the ProjectWarningPropertiesCollection is present then test if the warning is suppressed in
                 // project wide no warn or package specific no warn
                 if (ProjectWarningPropertiesCollection?.ApplyNoWarnProperties(message) == true)
                 {
-                    isWarningSupressed = true;
+                    isWarningSuppressed = true;
                 }
                 else
                 {
                     // Use transitive warning properties only if the project does not suppress the warning
                     // In transitive warning properties look at only the package specific ones as all properties are per package reference.
-                    isWarningSupressed = TransitiveWarningPropertiesCollection?.ApplyNoWarnProperties(message) == true;
+                    isWarningSuppressed = TransitiveWarningPropertiesCollection?.ApplyNoWarnProperties(message) == true;
                 }
             }
 
-            if (isWarningSupressed)
+            if (isWarningSuppressed)
             {
                 _suppressedWarnings.Enqueue(message);
             }
 
-            return isWarningSupressed;
+            return isWarningSuppressed;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -42,6 +42,11 @@ namespace NuGet.Commands
 
         public Guid ParentId { get; }
 
+        /// <summary>
+        /// ex: [NU1901]Package.A
+        /// </summary>
+        private const string SuppressedWarningFormat = "[{0}]{1}";
+
         private const string ProjectRestoreInformation = nameof(ProjectRestoreInformation);
 
         // status names for ProjectRestoreInformation
@@ -616,7 +621,15 @@ namespace NuGet.Commands
 
                 var errorCodes = ConcatAsString(new HashSet<NuGetLogCode>(logs.Where(l => l.Level == LogLevel.Error).Select(l => l.Code)));
                 var warningCodes = ConcatAsString(new HashSet<NuGetLogCode>(logs.Where(l => l.Level == LogLevel.Warning).Select(l => l.Code)));
-                var suppressedWarningCodes = ConcatAsString(new HashSet<NuGetLogCode>(_logger.SuppressedWarnings.Select(l => l.Code)));
+                var suppressedWarningCodes = ConcatAsString(new HashSet<string>(_logger.SuppressedWarnings.Select(l =>
+                {
+                    if (string.IsNullOrEmpty(l.LibraryId))
+                    {
+                        return l.Code.ToString();
+                    }
+                    return string.Format(CultureInfo.InvariantCulture, SuppressedWarningFormat, l.Code, l.LibraryId);
+                }
+                )));
 
                 if (!string.IsNullOrEmpty(errorCodes))
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -42,11 +42,6 @@ namespace NuGet.Commands
 
         public Guid ParentId { get; }
 
-        /// <summary>
-        /// ex: [NU1901]Package.A
-        /// </summary>
-        private const string SuppressedWarningFormat = "[{0}]{1}";
-
         private const string ProjectRestoreInformation = nameof(ProjectRestoreInformation);
 
         // status names for ProjectRestoreInformation
@@ -621,15 +616,7 @@ namespace NuGet.Commands
 
                 var errorCodes = ConcatAsString(new HashSet<NuGetLogCode>(logs.Where(l => l.Level == LogLevel.Error).Select(l => l.Code)));
                 var warningCodes = ConcatAsString(new HashSet<NuGetLogCode>(logs.Where(l => l.Level == LogLevel.Warning).Select(l => l.Code)));
-                var suppressedWarningCodes = ConcatAsString(new HashSet<string>(_logger.SuppressedWarnings.Select(l =>
-                {
-                    if (string.IsNullOrEmpty(l.LibraryId))
-                    {
-                        return l.Code.ToString();
-                    }
-                    return string.Format(CultureInfo.InvariantCulture, SuppressedWarningFormat, l.Code, l.LibraryId);
-                }
-                )));
+                var suppressedWarningCodes = ConcatAsString(new HashSet<NuGetLogCode>(_logger.SuppressedWarnings.Select(l => l.Code)));
 
                 if (!string.IsNullOrEmpty(errorCodes))
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -47,6 +47,7 @@ namespace NuGet.Commands
         // status names for ProjectRestoreInformation
         private const string ErrorCodes = nameof(ErrorCodes);
         private const string WarningCodes = nameof(WarningCodes);
+        private const string SuppressedWarningCodes = nameof(SuppressedWarningCodes);
         private const string RestoreSuccess = nameof(RestoreSuccess);
         private const string ProjectFilePath = nameof(ProjectFilePath);
         private const string IsCentralVersionManagementEnabled = nameof(IsCentralVersionManagementEnabled);
@@ -615,6 +616,7 @@ namespace NuGet.Commands
 
                 var errorCodes = ConcatAsString(new HashSet<NuGetLogCode>(logs.Where(l => l.Level == LogLevel.Error).Select(l => l.Code)));
                 var warningCodes = ConcatAsString(new HashSet<NuGetLogCode>(logs.Where(l => l.Level == LogLevel.Warning).Select(l => l.Code)));
+                var suppressedWarningCodes = ConcatAsString(new HashSet<NuGetLogCode>(_logger.SuppressedWarnings.Select(l => l.Code)));
 
                 if (!string.IsNullOrEmpty(errorCodes))
                 {
@@ -624,6 +626,11 @@ namespace NuGet.Commands
                 if (!string.IsNullOrEmpty(warningCodes))
                 {
                     telemetry.TelemetryEvent[WarningCodes] = warningCodes;
+                }
+
+                if (!string.IsNullOrEmpty(suppressedWarningCodes))
+                {
+                    telemetry.TelemetryEvent[SuppressedWarningCodes] = suppressedWarningCodes;
                 }
 
                 telemetry.TelemetryEvent[NewPackagesInstalledCount] = graphs.Where(g => !g.InConflict).SelectMany(g => g.Install).Distinct().Count();

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/CollectorLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/CollectorLoggerTests.cs
@@ -1081,7 +1081,7 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
-        public void CollectorLogger_PackageSpecificNoWarnSet_SupressedWarningsTracked()
+        public void CollectorLogger_PackageSpecificNoWarnSet_SuppressedWarningsTracked()
         {
             // Arrange
             var libraryId = "test_library";

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/CollectorLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/CollectorLoggerTests.cs
@@ -1056,6 +1056,92 @@ namespace NuGet.Commands.Test
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
         }
 
+        [Fact]
+        public void CollectorLogger_NoSuppressedWarnings_SuppressedWarningsEmpty()
+        {
+            // Arrange
+            var noWarnSet = new HashSet<NuGetLogCode> { };
+            var warnAsErrorSet = new HashSet<NuGetLogCode> { };
+            var warningsNotAsErrors = new HashSet<NuGetLogCode>();
+            var allWarningsAsErrors = false;
+            var innerLogger = new Mock<ILogger>();
+            var collector = new RestoreCollectorLogger(innerLogger.Object)
+            {
+                ProjectWarningPropertiesCollection = new WarningPropertiesCollection(
+                    new WarningProperties(warnAsErrorSet, noWarnSet, allWarningsAsErrors, warningsNotAsErrors),
+                    null,
+                    null)
+            };
+
+            // Act
+            collector.Log(new RestoreLogMessage(LogLevel.Warning, NuGetLogCode.NU1500, "Warning") { ShouldDisplay = true });
+
+            // Assert
+            Assert.Equal(0, collector.SuppressedWarnings.Count());
+        }
+
+        [Fact]
+        public void CollectorLogger_PackageSpecificNoWarnSet_SupressedWarningsTracked()
+        {
+            // Arrange
+            var libraryId = "test_library";
+            var frameworkString = "net45";
+            var targetFramework = NuGetFramework.Parse(frameworkString);
+            var noWarnSet = new HashSet<NuGetLogCode> { };
+            var warnAsErrorSet = new HashSet<NuGetLogCode> { };
+            var warningsNotAsErrors = new HashSet<NuGetLogCode>();
+            var allWarningsAsErrors = false;
+            var packageSpecificWarningProperties = new PackageSpecificWarningProperties();
+            packageSpecificWarningProperties.Add(NuGetLogCode.NU1500, libraryId, targetFramework);
+            packageSpecificWarningProperties.Add(NuGetLogCode.NU1601, libraryId, targetFramework);
+            packageSpecificWarningProperties.Add(NuGetLogCode.NU1605, libraryId, targetFramework);
+
+            var innerLogger = new Mock<ILogger>();
+            var collector = new RestoreCollectorLogger(innerLogger.Object)
+            {
+                ProjectWarningPropertiesCollection = new WarningPropertiesCollection(
+                    new WarningProperties(warnAsErrorSet, noWarnSet, allWarningsAsErrors, warningsNotAsErrors),
+                    packageSpecificWarningProperties,
+                    null)
+            };
+
+            // Act
+            collector.Log(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId, frameworkString));
+            collector.Log(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1601, "Warning", libraryId, frameworkString));
+            collector.Log(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1605, "Warning", libraryId, frameworkString));
+
+            // Assert
+            Assert.Equal(3, collector.SuppressedWarnings.Count());
+            Assert.Contains(NuGetLogCode.NU1500, collector.SuppressedWarnings.Select(x => x.Code));
+            Assert.Contains(NuGetLogCode.NU1601, collector.SuppressedWarnings.Select(x => x.Code));
+            Assert.Contains(NuGetLogCode.NU1605, collector.SuppressedWarnings.Select(x => x.Code));
+        }
+
+        [Fact]
+        public void CollectorLogger_ProjectWideNoWarnSet_SuppressedWarningsTracked()
+        {
+            // Arrange
+            var noWarnSet = new HashSet<NuGetLogCode> { NuGetLogCode.NU1500 };
+            var warnAsErrorSet = new HashSet<NuGetLogCode> { };
+            var warningsNotAsErrors = new HashSet<NuGetLogCode>();
+            var allWarningsAsErrors = false;
+            var innerLogger = new Mock<ILogger>();
+            var collector = new RestoreCollectorLogger(innerLogger.Object)
+            {
+                ProjectWarningPropertiesCollection = new WarningPropertiesCollection(
+                    new WarningProperties(warnAsErrorSet, noWarnSet, allWarningsAsErrors, warningsNotAsErrors),
+                    null,
+                    null)
+            };
+
+            // Act
+            collector.Log(new RestoreLogMessage(LogLevel.Warning, NuGetLogCode.NU1500, "Warning") { ShouldDisplay = true });
+
+            // Assert
+            Assert.Equal(1, collector.SuppressedWarnings.Count());
+            Assert.Contains(NuGetLogCode.NU1500, collector.SuppressedWarnings.Select(x => x.Code));
+        }
+
         private void VerifyInnerLoggerCalls(Mock<ILogger> innerLogger, LogLevel messageLevel, string message, Times times, NuGetLogCode code = NuGetLogCode.Undefined, string filePath = null, string projectPath = null)
         {
             innerLogger.Verify(x => x.Log(It.Is<RestoreLogMessage>(l =>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -2963,7 +2963,8 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
             // Assert
             var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
-            Assert.Equal("NU1603", projectInformationEvent["SuppressedWarningCodes"]);
+            Assert.Contains("NU1603", projectInformationEvent["SuppressedWarningCodes"].ToString());
+            Assert.Contains("a", projectInformationEvent["SuppressedWarningCodes"].ToString());
             Assert.Null(projectInformationEvent["WarningCodes"]);
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -2963,8 +2963,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
             // Assert
             var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
-            Assert.Contains("NU1603", projectInformationEvent["SuppressedWarningCodes"].ToString());
-            Assert.Contains("a", projectInformationEvent["SuppressedWarningCodes"].ToString());
+            Assert.Equal("NU1603", projectInformationEvent["SuppressedWarningCodes"]);
             Assert.Null(projectInformationEvent["WarningCodes"]);
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2384

## Description
Modified RestoreCollectorLogger to keep track of which warnings were suppressed. This is then added to telemetry. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
