### PR TITLE
Report path for invalid nupkg metadata

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
@@ -56,22 +56,20 @@ namespace NuGet.Packaging
             }
             catch (System.Text.Json.JsonException ex)
             {
-                LogMessage(log, path, ex);
-                throw;
+                throw LogAndWrap(log, path, ex);
             }
             catch (Exception ex)
             {
-                LogMessage(log, path, ex);
-                throw;
+                throw LogAndWrap(log, path, ex);
             }
 
-            static void LogMessage(ILogger log, string path, Exception ex)
+            static InvalidDataException LogAndWrap(ILogger log, string path, Exception ex)
             {
                 string message = (string.Format(CultureInfo.CurrentCulture,
                     Strings.Error_LoadingHashFile,
                     path, ex.Message));
                 log.LogWarning(message);
-                throw new InvalidDataException(message, ex);
+                return new InvalidDataException(message, ex);
             }
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NupkgMetadata/NupkgMetadataFileFormat.cs
@@ -57,7 +57,7 @@ namespace NuGet.Packaging
             catch (System.Text.Json.JsonException ex)
             {
                 LogMessage(log, path, ex);
-                throw new InvalidDataException(ex.Message, ex);
+                throw;
             }
             catch (Exception ex)
             {
@@ -67,9 +67,11 @@ namespace NuGet.Packaging
 
             static void LogMessage(ILogger log, string path, Exception ex)
             {
-                log.LogWarning(string.Format(CultureInfo.CurrentCulture,
+                string message = (string.Format(CultureInfo.CurrentCulture,
                     Strings.Error_LoadingHashFile,
                     path, ex.Message));
+                log.LogWarning(message);
+                throw new InvalidDataException(message, ex);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NupkgMetadataFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NupkgMetadataFileFormatTests.cs
@@ -84,12 +84,14 @@ namespace NuGet.Packaging.Test
         {
             // Arrange
             var logger = new TestLogger();
+            string path = "my path";
 
             // Act
-            Assert.Throws<InvalidDataException>(() => Read(contents, logger, "from memory"));
+            Assert.Throws<InvalidDataException>(() => Read(contents, logger, path));
 
             // Assert
             Assert.Equal(1, logger.Messages.Count);
+            Assert.Contains(logger.Messages, item => item.Contains(path));
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13763

## Description

This PR makes sure we report the path where parsing the nupkg metadata failed instead of just re throwing the exception.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
