### PR TITLE
Reduce activity log output from VsSolutionRestoreService.NominateProjectAsync

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -251,9 +251,6 @@ namespace NuGet.SolutionRestoreManager
 
             try
             {
-                _logger.LogInformation(
-                    $"The nominate API is called for '{projectUniqueName}'.");
-
                 ProjectNames projectNames = await GetProjectNamesAsync(projectUniqueName, token);
 
                 DependencyGraphSpec dgSpec;


### PR DESCRIPTION
This method adds quite a bit of output to the activity log with very little utility.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14153

## Description
Removes a single logging call that was adding quite a bit of information to the VS activity log
![image](https://github.com/user-attachments/assets/9fda2a79-a62a-42ba-b25c-a48d2cee51c4)

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
