### PR TITLE
Save the project file after package operation in the PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
@@ -323,6 +323,8 @@ namespace NuGet.PackageManagement.VisualStudio
                 packageVersion.OriginalString ?? packageVersion.ToShortString(),
                 metadataElements,
                 metadataValues);
+
+            _vsProject4.Project.Save();
         }
 
         public async Task RemovePackageReferenceAsync(string packageName)
@@ -332,6 +334,7 @@ namespace NuGet.PackageManagement.VisualStudio
             await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             _vsProject4.PackageReferences.Remove(packageName);
+            _vsProject4.Project.Save();
         }
 
         private bool IsCentralPackageManagementVersionsEnabled()

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
@@ -346,6 +346,9 @@ namespace NuGet.PackageManagement.VisualStudio
                         ProjectItemProperties.IncludeAssets,
                         MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(installationContext.IncludeType)));
                 }
+
+                // Save the project
+                await _unconfiguredProject.SaveAsync();
             }
 
             return true;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
@@ -403,6 +403,10 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 await configuredProject?.Services.PackageReferences.RemoveAsync(packageId);
             }
+
+            // Save the project
+            await _unconfiguredProject.SaveAsync();
+
             return true;
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
@@ -347,9 +347,10 @@ namespace NuGet.PackageManagement.VisualStudio
                         MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(installationContext.IncludeType)));
                 }
 
-                // Save the project
-                await _unconfiguredProject.SaveAsync();
             }
+
+            // Save the project
+            await _unconfiguredProject.SaveAsync();
 
             return true;
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/6013

## Description
When doing a package operation through the PM UI the project file is not being saved after updating a package reference. 
![save-project-after-install](https://github.com/user-attachments/assets/d3fcc954-d337-4d1a-8332-c7df3d138e20)

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
~- [ ] Added tests~
~- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
