### PR TITLE
Only show Error List if errors reported by NuGet

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
@@ -42,6 +42,7 @@ namespace NuGet.VisualStudio.Common
 
         private IOutputConsole _outputConsole;
         private AsyncLazyInt _verbosityLevel;
+        private bool _errorsReported;
 
         [ImportingConstructor]
         public OutputConsoleLogger(
@@ -104,8 +105,13 @@ namespace NuGet.VisualStudio.Common
                 await _outputConsole.WriteLineAsync(Resources.Finished);
                 await _outputConsole.WriteLineAsync(string.Empty);
 
-                // Give the error list focus
-                await _errorList.Value.BringToFrontIfSettingsPermitAsync();
+                if (_errorsReported)
+                {
+                    // Give the error list focus
+                    await _errorList.Value.BringToFrontIfSettingsPermitAsync();
+
+                    _errorsReported = false;
+                }
             });
         }
 
@@ -180,6 +186,7 @@ namespace NuGet.VisualStudio.Common
         {
             var errorListEntry = new ErrorListTableEntry(message);
             _errorList.Value.AddNuGetEntries(errorListEntry);
+            _errorsReported = true;
         }
 
         private void Run(Func<Task> action, [CallerMemberName] string methodName = null)

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/OutputConsoleLoggerTests.End.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/OutputConsoleLoggerTests.End.cs
@@ -35,7 +35,9 @@ namespace NuGet.VisualStudio.Common.Test
             [Fact]
             public void BringToFrontIfSettingsPermitAsync_WhenAnyCallsToReportError_IsCalled()
             {
-                _outputConsoleLogger.ReportError(new LogMessage(NuGet.Common.LogLevel.Error, "message"));
+                // ReportError will always add error entries regardless of log level.
+                LogLevel irrelevantLogLevel = LogLevel.Information;
+                _outputConsoleLogger.ReportError(new LogMessage(irrelevantLogLevel, "message"));
                 _outputConsoleLogger.End();
                 _errorList.Verify(el => el.BringToFrontIfSettingsPermitAsync());
             }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/OutputConsoleLoggerTests.End.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/OutputConsoleLoggerTests.End.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.VisualStudio.Sdk.TestFramework;
 using Moq;
+using NuGet.Common;
 using Xunit;
 
 namespace NuGet.VisualStudio.Common.Test
@@ -15,25 +16,35 @@ namespace NuGet.VisualStudio.Common.Test
                 : base(sp)
             {
                 _outputConsole.Reset();
-                _outputConsoleLogger.End();
             }
 
             [Fact]
             public void Writes_message_that_it_is_finished()
             {
+                _outputConsoleLogger.End();
                 _outputConsole.Verify(oc => oc.WriteLineAsync(Resources.Finished));
             }
 
             [Fact]
             public void Writes_empty_line()
             {
+                _outputConsoleLogger.End();
                 _outputConsole.Verify(oc => oc.WriteLineAsync(string.Empty));
             }
 
             [Fact]
-            public void Gives_error_list_focus()
+            public void BringToFrontIfSettingsPermitAsync_WhenAnyCallsToReportError_IsCalled()
             {
+                _outputConsoleLogger.ReportError(new LogMessage(NuGet.Common.LogLevel.Error, "message"));
+                _outputConsoleLogger.End();
                 _errorList.Verify(el => el.BringToFrontIfSettingsPermitAsync());
+            }
+
+            [Fact]
+            public void BringToFrontIfSettingsPermitAsync_WhenNoCallsToReportError_IsNotCalled()
+            {
+                _outputConsoleLogger.End();
+                _errorList.Verify(el => el.BringToFrontIfSettingsPermitAsync(), Times.Never);
             }
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/OutputConsoleLoggerTests.Log.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/OutputConsoleLoggerTests.Log.cs
@@ -89,6 +89,28 @@ namespace NuGet.VisualStudio.Common.Test
             {
                 VerifyThatEntryToErrorListIsNotAdded(_outputConsoleLogger.Log, logLevel, verbosityLevel);
             }
+
+            [Theory]
+            [MemberData(nameof(GetMessageVariationsWhichAreReported))]
+            public async Task BringToFrontIfSettingsPermitAsync_WhenAnyCallsToLogAreErrorLevels_IsCalled(LogLevel logLevelError, int verbosityLevel)
+            {
+                _msBuildOutputVerbosity = verbosityLevel;
+                _outputConsoleLogger.Log(new LogMessage(logLevelError, "message"));
+                await WaitForInitializationAsync();
+                _outputConsoleLogger.End();
+                _errorList.Verify(el => el.BringToFrontIfSettingsPermitAsync());
+            }
+
+            [Theory]
+            [MemberData(nameof(GetMessageVariationsWhichAreNotReported))]
+            public async Task BringToFrontIfSettingsPermitAsync_WhenNoCallsToLogAreErrorLevels_IsNotCalled(LogLevel logLevelNonError, int verbosityLevel)
+            {
+                _msBuildOutputVerbosity = verbosityLevel;
+                _outputConsoleLogger.Log(new LogMessage(logLevelNonError, "message"));
+                await WaitForInitializationAsync();
+                _outputConsoleLogger.End();
+                _errorList.Verify(el => el.BringToFrontIfSettingsPermitAsync(), Times.Never);
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/11728
Fixes: https://github.com/NuGet/Home/issues/14157
Fixes: https://github.com/NuGet/Home/issues/11276

## Description

The error list was being shown anytime the Output Console session was ended.
This change maintains that behavior only if NuGet added errors to the error list via the logger.  This is achieved by a simple flag indicating that errors were logged in the current "session" prior to calling `End` on the logger.

Having the Error List take focus unnecessarily is disruptive in normal scenarios like installing packages with PM UI. The Output pane shows useful information about the status of the install action, and always covering the output pane with the Error List makes the job harder.

No longer brings the Error List into focus in the following scenarios:
- PM UI package actions for all project types:
  - Packages.config
  - PackageReference SDK-style
  - PackageReference csproj
- "Clear NuGet Locals" command in the legacy and Unified Settings options pages

<details><summary>Before/After - Install package successfully</summary>

Before: Successful Install causes Error list to focus unnecessarily
![image](https://github.com/user-attachments/assets/4e93fac8-517a-495f-8143-b6efeba71b4f)

After: Successful Install remains on Output pane (no focus change)
![image](https://github.com/user-attachments/assets/21bd5ff8-3f9d-4107-82f4-5be399490bf2)


</details>

<details><summary>Before/After - Package install action fails</summary>

Before:  Error list appears as expected, even if the Error list is closed prior to starting the action.
(BSOA.Json 1.0.0, which fails due to missing dependencies with package source mapping)
![image](https://github.com/user-attachments/assets/987d5383-a61a-4c6c-b64f-eced473ed5a7)


After: No behavior change. Error list still appears due to NU errors that occurred during the install action.
![image](https://github.com/user-attachments/assets/8fcfffef-6723-4b94-8b5e-7b77d6a80f8d)
</details>

<details><summary>Before/After - Clear NuGet Locals command</summary>

Before : Clears NuGet Locals pops up error list for no good reason
![image](https://github.com/user-attachments/assets/550f4334-31ca-44ae-a52b-ad8ae65fd17b)

After:  Clearing NuGet Locals does not open Error List (remains on the Output pane in this case)
![image](https://github.com/user-attachments/assets/db741292-d043-4f81-9439-2a05c9abbcc8)
</details>

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. - N/A
