### PR TITLE
Show resolved versions in dotnet list package when AuditSources are used

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -207,6 +207,7 @@ namespace NuGet.CommandLine.XPlat
                     reportPackages.Add(
                         new ListReportPackage(
                             package.Name,
+                            package.OriginalRequestedVersion,
                             package.ResolvedPackageMetadata.Identity.Version.ToString(),
                             vuln));
                 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/ListPackage/ListReportPackage.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/ListPackage/ListReportPackage.cs
@@ -94,11 +94,11 @@ namespace NuGet.CommandLine.XPlat.ListPackage
                   autoReference: false)
         { }
 
-        public ListReportPackage(string packageId, string version, List<PackageVulnerabilityMetadata> vulnerabilities)
+        public ListReportPackage(string packageId, string requestedVersion, string resolvedVersion, List<PackageVulnerabilityMetadata> vulnerabilities)
             : this(
                   packageId: packageId,
-                  requestedVersion: version,
-                  resolvedVersion: null,
+                  requestedVersion: requestedVersion,
+                  resolvedVersion: resolvedVersion,
                   latestVersion: null,
                   vulnerabilities: vulnerabilities.Count == 0 ? null : vulnerabilities)
         { }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -393,6 +393,8 @@ namespace NuGet.XPlat.FuncTest
             Assert.Equal(1, result.Item2.Projects.First().TargetFrameworkPackages.Count);
             Assert.Equal(1, result.Item2.Projects.First().TargetFrameworkPackages.First().TopLevelPackages.Count);
             Assert.Equal(1, result.Item2.Projects.First().TargetFrameworkPackages.First().TopLevelPackages.First().Vulnerabilities.Count);
+            Assert.Equal("0.0.9", result.Item2.Projects.First().TargetFrameworkPackages.First().TopLevelPackages.First().RequestedVersion);
+            Assert.Equal("1.0.0", result.Item2.Projects.First().TargetFrameworkPackages.First().TopLevelPackages.First().ResolvedVersion);
             Assert.Equal(2, result.Item2.Projects[0].TargetFrameworkPackages[0].TopLevelPackages.First().Vulnerabilities.First().Severity);
             Assert.Equal("https://test/", result.Item2.Projects[0].TargetFrameworkPackages[0].TopLevelPackages.First().Vulnerabilities.First().AdvisoryUrl.ToString());
         }
@@ -500,7 +502,7 @@ namespace NuGet.XPlat.FuncTest
 
         private static SimpleTestProjectContext SetupTestProject(SimpleTestPathContext pathContext)
         {
-            var package = new SimpleTestPackageContext { Id = "task", Version = "1.0.0" };
+            var package = new SimpleTestPackageContext { Id = "task", Version = "0.0.9" };
 
             var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
             var project = SimpleTestProjectContext.CreateNETCore("ProjectA", pathContext.SolutionRoot, NuGetFramework.Parse("net8.0"));

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatListPackageJsonRendererTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatListPackageJsonRendererTests.cs
@@ -1246,7 +1246,8 @@ namespace NuGet.XPlat.FuncTest
                                     {
                                         new ListReportPackage(
                                             packageId : "A",
-                                            version : "1.0.0",
+                                            requestedVersion : "1.0.0",
+                                            resolvedVersion : "1.0.1",
                                             vulnerabilities : new List<PackageVulnerabilityMetadata>(){ new PackageVulnerabilityMetadata() }
                                             )
                                     }
@@ -1279,7 +1280,7 @@ namespace NuGet.XPlat.FuncTest
                             {{
                               'id': 'A',
                               'requestedVersion': '1.0.0',
-                              'resolvedVersion': null,
+                              'resolvedVersion': '1.0.1',
                               'vulnerabilities': [
                                 {{
                                   'severity': 'Low',
@@ -1343,7 +1344,8 @@ namespace NuGet.XPlat.FuncTest
                                     {
                                         new ListReportPackage(
                                             packageId : "A",
-                                            version : "1.0.0",
+                                            requestedVersion : "1.0.0",
+                                            resolvedVersion : "1.0.1",
                                             vulnerabilities : new List<PackageVulnerabilityMetadata>(){ new PackageVulnerabilityMetadata() }
                                             )
                                     }
@@ -1374,7 +1376,7 @@ namespace NuGet.XPlat.FuncTest
                             {{
                               'id': 'A',
                               'requestedVersion': '1.0.0',
-                              'resolvedVersion': null,
+                              'resolvedVersion': '1.0.1',
                               'latestVersion': null
                             }}
                           ]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14116

## Description
There is a bug in dotnet list package when AuditSources are used. The bug is that requested and resolved versions of a package are not logged properly. This PR makes sure we log both properly.
### Before
![image](https://github.com/user-attachments/assets/3f4de6c1-7bf9-44a9-8edf-a3c888b6ab0a)


### After
![image](https://github.com/user-attachments/assets/01b64ae7-58fc-4bc9-9620-2f3e7deebab3)

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
