### PR TITLE
`ErrorListTableDataSource` checks for NuGet entries instead of each caller

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -44,7 +44,6 @@ namespace NuGet.SolutionRestoreManager
 
         private bool _cancelled;
         private bool _hasHeaderBeenShown;
-        private bool _showErrorList;
 
         // The value of the "MSBuild project build output verbosity" setting
         // of VS. From 0 (quiet) to 4 (Diagnostic).
@@ -122,11 +121,8 @@ namespace NuGet.SolutionRestoreManager
         {
             await _jtc.JoinTillEmptyAsync();
 
-            if (_showErrorList)
-            {
-                // Give the error list focus
-                await _errorList.Value.BringToFrontIfSettingsPermitAsync();
-            }
+            // Give the error list focus
+            await _errorList.Value.BringToFrontIfSettingsPermitAsync();
         }
 
         public override void LogInformationSummary(string data)
@@ -239,9 +235,6 @@ namespace NuGet.SolutionRestoreManager
 
                 // Add the entry to the list
                 _errorList.Value.AddNuGetEntries(errorListEntry);
-
-                // Display the error list after restore completes
-                _showErrorList = true;
             }
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ErrorListTableDataSource.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ErrorListTableDataSource.cs
@@ -171,14 +171,14 @@ namespace NuGet.VisualStudio.Common
         /// </summary>
         public async Task BringToFrontIfSettingsPermitAsync()
         {
-            EnsureInitialized();
-
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
             if (_entries.Count == 0)
             {
                 return;
             }
+
+            EnsureInitialized();
+
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             bool showErrorListOnBuildEnd = true;
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ErrorListTableDataSource.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ErrorListTableDataSource.cs
@@ -183,16 +183,19 @@ namespace NuGet.VisualStudio.Common
                 return;
             }
 
+            bool showErrorListOnBuildEnd = true;
+
             // Check the setting without caching since the user can change it at any time.
             IVsShell vsShell = await _asyncServiceProvider.GetServiceAsync<IVsShell, IVsShell>(throwOnFailure: false);
-            int getPropertyReturnCode = vsShell.GetProperty((int)__VSSPROPID.VSSPROPID_ShowTasklistOnBuildEnd, out object propertyShowTaskListOnBuildEnd);
-            bool showErrorListOnBuildEnd = false;
-
-            if (getPropertyReturnCode == VSConstants.S_OK)
+            if (vsShell is not null)
             {
-                if (bool.TryParse(propertyShowTaskListOnBuildEnd?.ToString(), out bool result))
+                int getPropertyReturnCode = vsShell.GetProperty((int)__VSSPROPID.VSSPROPID_ShowTasklistOnBuildEnd, out object propertyShowTaskListOnBuildEnd);
+                if (getPropertyReturnCode == VSConstants.S_OK)
                 {
-                    showErrorListOnBuildEnd = result;
+                    if (bool.TryParse(propertyShowTaskListOnBuildEnd?.ToString(), out bool result))
+                    {
+                        showErrorListOnBuildEnd = result;
+                    }
                 }
             }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ErrorListTableDataSource.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ErrorListTableDataSource.cs
@@ -29,6 +29,7 @@ namespace NuGet.VisualStudio.Common
         private readonly IAsyncServiceProvider _asyncServiceProvider = AsyncServiceProvider.GlobalProvider;
         private IReadOnlyList<TableSubscription> _subscriptions = new List<TableSubscription>();
         private readonly List<ErrorListTableEntry> _entries = new List<ErrorListTableEntry>();
+        private bool _errorsReported;
 
         public string SourceTypeIdentifier => StandardTableDataSources.ErrorTableDataSource;
 
@@ -114,6 +115,7 @@ namespace NuGet.VisualStudio.Common
                 {
                     // Clear all entries
                     _entries.Clear();
+                    _errorsReported = false;
                 }
 
                 var subscriptions = _subscriptions;
@@ -147,6 +149,7 @@ namespace NuGet.VisualStudio.Common
                 {
                     // Update the full set of entries
                     _entries.AddRange(entries);
+                    _errorsReported = true;
                 }
 
                 // Add new entries to each sink
@@ -175,9 +178,15 @@ namespace NuGet.VisualStudio.Common
 
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
+            if (!_errorsReported)
+            {
+                return;
+            }
+
+            // Check the setting without caching since the user can change it at any time.
             IVsShell vsShell = await _asyncServiceProvider.GetServiceAsync<IVsShell, IVsShell>(throwOnFailure: false);
             int getPropertyReturnCode = vsShell.GetProperty((int)__VSSPROPID.VSSPROPID_ShowTasklistOnBuildEnd, out object propertyShowTaskListOnBuildEnd);
-            bool showErrorListOnBuildEnd = true;
+            bool showErrorListOnBuildEnd = false;
 
             if (getPropertyReturnCode == VSConstants.S_OK)
             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ErrorListTableDataSource.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ErrorListTableDataSource.cs
@@ -29,7 +29,6 @@ namespace NuGet.VisualStudio.Common
         private readonly IAsyncServiceProvider _asyncServiceProvider = AsyncServiceProvider.GlobalProvider;
         private IReadOnlyList<TableSubscription> _subscriptions = new List<TableSubscription>();
         private readonly List<ErrorListTableEntry> _entries = new List<ErrorListTableEntry>();
-        private bool _errorsReported;
 
         public string SourceTypeIdentifier => StandardTableDataSources.ErrorTableDataSource;
 
@@ -115,7 +114,6 @@ namespace NuGet.VisualStudio.Common
                 {
                     // Clear all entries
                     _entries.Clear();
-                    _errorsReported = false;
                 }
 
                 var subscriptions = _subscriptions;
@@ -149,7 +147,6 @@ namespace NuGet.VisualStudio.Common
                 {
                     // Update the full set of entries
                     _entries.AddRange(entries);
-                    _errorsReported = true;
                 }
 
                 // Add new entries to each sink
@@ -178,7 +175,7 @@ namespace NuGet.VisualStudio.Common
 
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            if (!_errorsReported)
+            if (_entries.Count == 0)
             {
                 return;
             }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/INuGetErrorList.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/INuGetErrorList.cs
@@ -13,7 +13,7 @@ namespace NuGet.VisualStudio.Common
         /// <param name="entries"> NuGet entries to add to the error list. </param>
         void AddNuGetEntries(params ErrorListTableEntry[] entries);
 
-        /// <summary> Bring to front if settings permit. </summary>
+        /// <summary> Bring to front if settings permit only when NuGet entries were added to the error list. </summary>
         Task BringToFrontIfSettingsPermitAsync();
 
         /// <summary> Clear NuGet entries. </summary>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/OutputConsoleLogger.cs
@@ -42,7 +42,6 @@ namespace NuGet.VisualStudio.Common
 
         private IOutputConsole _outputConsole;
         private AsyncLazyInt _verbosityLevel;
-        private bool _errorsReported;
 
         [ImportingConstructor]
         public OutputConsoleLogger(
@@ -105,13 +104,7 @@ namespace NuGet.VisualStudio.Common
                 await _outputConsole.WriteLineAsync(Resources.Finished);
                 await _outputConsole.WriteLineAsync(string.Empty);
 
-                if (_errorsReported)
-                {
-                    // Give the error list focus
-                    await _errorList.Value.BringToFrontIfSettingsPermitAsync();
-
-                    _errorsReported = false;
-                }
+                await _errorList.Value.BringToFrontIfSettingsPermitAsync();
             });
         }
 
@@ -186,7 +179,6 @@ namespace NuGet.VisualStudio.Common
         {
             var errorListEntry = new ErrorListTableEntry(message);
             _errorList.Value.AddNuGetEntries(errorListEntry);
-            _errorsReported = true;
         }
 
         private void Run(Func<Task> action, [CallerMemberName] string methodName = null)

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/OutputConsoleLoggerTests.End.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/OutputConsoleLoggerTests.End.cs
@@ -43,10 +43,10 @@ namespace NuGet.VisualStudio.Common.Test
             }
 
             [Fact]
-            public void BringToFrontIfSettingsPermitAsync_WhenNoCallsToReportError_IsNotCalled()
+            public void BringToFrontIfSettingsPermitAsync_WhenNoCallsToReportError_IsCalledOnce()
             {
                 _outputConsoleLogger.End();
-                _errorList.Verify(el => el.BringToFrontIfSettingsPermitAsync(), Times.Never);
+                _errorList.Verify(el => el.BringToFrontIfSettingsPermitAsync(), Times.Once);
             }
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/OutputConsoleLoggerTests.Log.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/OutputConsoleLoggerTests.Log.cs
@@ -103,13 +103,13 @@ namespace NuGet.VisualStudio.Common.Test
 
             [Theory]
             [MemberData(nameof(GetMessageVariationsWhichAreNotReported))]
-            public async Task BringToFrontIfSettingsPermitAsync_WhenNoCallsToLogAreErrorLevels_IsNotCalled(LogLevel logLevelNonError, int verbosityLevel)
+            public async Task BringToFrontIfSettingsPermitAsync_WhenNoCallsToLogAreErrorLevels_IsCalled(LogLevel logLevelNonError, int verbosityLevel)
             {
                 _msBuildOutputVerbosity = verbosityLevel;
                 _outputConsoleLogger.Log(new LogMessage(logLevelNonError, "message"));
                 await WaitForInitializationAsync();
                 _outputConsoleLogger.End();
-                _errorList.Verify(el => el.BringToFrontIfSettingsPermitAsync(), Times.Never);
+                _errorList.Verify(el => el.BringToFrontIfSettingsPermitAsync(), Times.Once);
             }
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14163

## Description

_Follow-up to https://github.com/NuGet/NuGet.Client/pull/6297#discussion_r1978156134_

Shift the responsibility of showing the Error List when NuGet errors are present into the `ErrorListTableDataSource`.

`BringToFrontIfSettingsPermitAsync` can be invoked by callers without worrying whether the errors were already added.

Optimization: for scenarios where NuGet never needed to load the error list, now VS Error List won't be loaded. Output logging will not cause the error list to be loaded just to show it unnecessarily! (ie, either no NuGet errors present, or user-setting disabled)

If `IVsShell` cannot be loaded, a NRE could have been thrown due to no null-check on the instance. Added a null-check and I've kept the default of `showErrorListOnBuildEnd = true`. This happened to me when running Tests as the shell isn't available. I would assume it's not possible to be null when VS is running.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. N/A
