### PR TITLE
Set build number to arcade build revision for VMR builds

### DIFF
--- a/eng/dotnet-build/dotnet-build.proj
+++ b/eng/dotnet-build/dotnet-build.proj
@@ -29,6 +29,9 @@
     <ItemGroup>
       <_InnerBuildProperties Include="DotNetBuildPhase=InnerRepo" />
       <_InnerBuildProperties Include="DotNetBuildInnerRepo=true" />
+      <!-- NuGet uses a pre-release string that is dependent on the build revision. This is normally set via their
+           YAML. Set based on the parsed version information. -->
+      <_InnerBuildProperties Condition="'$(VersionSuffixBuildOfTheDay)' != ''" Include="BuildNumber=$(VersionSuffixBuildOfTheDay)" />
     </ItemGroup>
 
     <!-- Pass _ImportOrUseTooling = false to avoid attempting to restore unneeded packages in Tools.proj.


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/dotnet/source-build/issues/4936

## Description

In VMR builds, the official build id's revision wasn't getting propagated to NuGet, so we were always getting builds with 32767 as the package revision.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
