### PR TITLE
Don't publish RID-agnostic nuget packages when we only want RID-specific artifacts

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -2,7 +2,8 @@
 
   <ItemGroup>
     <Artifact Include="$(ArtifactsDir)nupkgs/*.nupkg"
-              PublishFlatContainer="false" />
+              PublishFlatContainer="false"
+              Condition="'$(EnableDefaultRidSpecificArtifacts)' != 'true'" />
   </ItemGroup>
 
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,9 +1,13 @@
 <Project>
-
   <ItemGroup>
     <Artifact Include="$(ArtifactsDir)nupkgs/*.nupkg"
               PublishFlatContainer="false"
               Condition="'$(EnableDefaultRidSpecificArtifacts)' != 'true'" />
+    <Artifact Include="$(ArtifactsDir)nupkgs/*.nupkg"
+              PublishFlatContainer="false"
+              Visibility="Vertical"
+              Condition="'$(EnableDefaultRidSpecificArtifacts)' == 'true' and '$(DotNetBuildOrchestrator)' == 'true'" />
   </ItemGroup>
+
 
 </Project>


### PR DESCRIPTION
This is necessary to enable us to deduplicate assets in the VMR.