### PR TITLE
Revert "Save the project file after package operation in the PM UI (#6295)"

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
@@ -323,8 +323,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 packageVersion.OriginalString ?? packageVersion.ToShortString(),
                 metadataElements,
                 metadataValues);
-
-            _vsProject4.Project.Save();
         }
 
         public async Task RemovePackageReferenceAsync(string packageName)
@@ -334,7 +332,6 @@ namespace NuGet.PackageManagement.VisualStudio
             await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             _vsProject4.PackageReferences.Remove(packageName);
-            _vsProject4.Project.Save();
         }
 
         private bool IsCentralPackageManagementVersionsEnabled()

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
@@ -346,11 +346,7 @@ namespace NuGet.PackageManagement.VisualStudio
                         ProjectItemProperties.IncludeAssets,
                         MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(installationContext.IncludeType)));
                 }
-
             }
-
-            // Save the project
-            await _unconfiguredProject.SaveAsync();
 
             return true;
         }
@@ -404,10 +400,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 await configuredProject?.Services.PackageReferences.RemoveAsync(packageId);
             }
-
-            // Save the project
-            await _unconfiguredProject.SaveAsync();
-
             return true;
         }
 


### PR DESCRIPTION
This reverts commit 181b65dad9f440c7a31fe673abc59c258f224ada.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Related: https://github.com/NuGet/Home/issues/6013

## Description

All the [VS insertions are failing now](https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequests?_a=active&createdBy=6d3b3c1a-123d-454c-a78b-b4a426164711&assignedTo=d4920853-a725-4550-bdcc-a15ea830d4f1) due to an RPS regression. 

Upon reviewing the commit history and PerfView logs for the failing RPS tests at a high level, I guessed that commit 181b65dad9f440c7a31fe673abc59c258f224ada might be causing this regression. I reverted the commit in a private branch, [triggered an official build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=11156237&view=results), and all the CI checks passed in the [VS insertion PR](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/617388?_a=overview). 

Hence, I am creating this PR to revert the commit in the dev branch to unblock VS insertions.

cc @martinrrm 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
