### PR TITLE
Remove unused BouncyCastle reference in NuGet.config

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -39,7 +39,6 @@
       <package pattern="netstandard.library" />
       <package pattern="newtonsoft.json" />
       <package pattern="nuget.*" />
-      <package pattern="portable.bouncycastle" />
       <package pattern="runtime.*" />
       <package pattern="sharpziplib" />
       <package pattern="streamjsonrpc" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

## Description

This change removes an unused BouncyCastle reference.  I missed it in https://github.com/NuGet/NuGet.Client/pull/5937

## PR Checklist

- [X] Meaningful title, helpful description and a linked NuGet/Home issue
- ~[ ] Added tests~ N/A
- ~[ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
