### PR TITLE
Test:  make signing test support class public

### DIFF
--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/X509AuthorityInformationAccessExtension.cs
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/X509AuthorityInformationAccessExtension.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #nullable enable
+#pragma warning disable CS1591
 
 using System;
 using System.Formats.Asn1;
@@ -9,9 +10,9 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.Internal.NuGet.Testing.SignedPackages
 {
-    internal sealed class X509AuthorityInformationAccessExtension : X509Extension
+    public sealed class X509AuthorityInformationAccessExtension : X509Extension
     {
-        internal X509AuthorityInformationAccessExtension(Uri? ocspResponderUrl, Uri? caIssuersUrl)
+        public X509AuthorityInformationAccessExtension(Uri? ocspResponderUrl, Uri? caIssuersUrl)
             : base(TestOids.AuthorityInfoAccess.Value!, Encode(ocspResponderUrl, caIssuersUrl), critical: false)
         {
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  N/A

## Description

This change makes a signing test support class public so it can be used by NuGetGallery tests.

## PR Checklist

- [X] Meaningful title, helpful description and a linked NuGet/Home issue
- ~~[ ] Added tests~~ N/A
- ~~[ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~ N/A
