### PR TITLE
Adapter for fetching metadata for a package and reuse result for various calls

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/IPackageMetadataRetrievalAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/IPackageMetadataRetrievalAdapter.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Packaging.Core;
+using NuGet.VisualStudio.Internal.Contracts;
+
+namespace NuGet.PackageManagement.UI
+{
+    internal interface IPackageMetadataRetrievalAdapter
+    {
+        public Task<PackageSearchMetadataContextInfo> GetPackageMetadataAsync(
+            PackageIdentity packageIdentity,
+            IReadOnlyCollection<PackageSourceContextInfo> packageSources,
+            bool includePrerelease,
+            CancellationToken cancellationToken);
+
+        public Task<PackageDeprecationMetadataContextInfo?> GetPackageDeprecationInfoAsync(
+            PackageIdentity packageIdentity,
+            IReadOnlyCollection<PackageSourceContextInfo> packageSources,
+            bool includePrerelease,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/IPackageMetadataRetrievalAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/IPackageMetadataRetrievalAdapter.cs
@@ -6,7 +6,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Packaging.Core;
 using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.PackageManagement.UI
@@ -14,13 +13,11 @@ namespace NuGet.PackageManagement.UI
     internal interface IPackageMetadataRetrievalAdapter
     {
         public Task<PackageSearchMetadataContextInfo> GetPackageMetadataAsync(
-            PackageIdentity packageIdentity,
             IReadOnlyCollection<PackageSourceContextInfo> packageSources,
             bool includePrerelease,
             CancellationToken cancellationToken);
 
         public Task<PackageDeprecationMetadataContextInfo?> GetPackageDeprecationInfoAsync(
-            PackageIdentity packageIdentity,
             IReadOnlyCollection<PackageSourceContextInfo> packageSources,
             bool includePrerelease,
             CancellationToken cancellationToken);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/PackageMetadataRetrievalAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/PackageMetadataRetrievalAdapter.cs
@@ -15,31 +15,31 @@ namespace NuGet.PackageManagement.UI
     internal class PackageMetadataRetrievalAdapter : IPackageMetadataRetrievalAdapter
     {
         private readonly INuGetSearchService _nugetSearchService;
+        private readonly PackageIdentity _packageIdentity;
         private ValueTask<(PackageSearchMetadataContextInfo, PackageDeprecationMetadataContextInfo?)> _packageMetadataTask;
         private readonly object _lock = new();
 
-        public PackageMetadataRetrievalAdapter(INuGetSearchService nugetSearchService)
+        public PackageMetadataRetrievalAdapter(INuGetSearchService nugetSearchService, PackageIdentity packageIdentity)
         {
-            _nugetSearchService = nugetSearchService;
+            _nugetSearchService = nugetSearchService ?? throw new ArgumentNullException(nameof(nugetSearchService));
+            _packageIdentity = packageIdentity ?? throw new ArgumentNullException(nameof(packageIdentity));
         }
 
         public async Task<PackageSearchMetadataContextInfo> GetPackageMetadataAsync(
-            PackageIdentity packageIdentity,
             IReadOnlyCollection<PackageSourceContextInfo> packageSources,
             bool includePrerelease,
             CancellationToken cancellationToken)
         {
-            var packageMetadata = await FetchMetadataAsync(packageIdentity, packageSources, includePrerelease, cancellationToken);
+            var packageMetadata = await FetchMetadataAsync(_packageIdentity, packageSources, includePrerelease, cancellationToken);
             return packageMetadata.Item1;
         }
 
         public async Task<PackageDeprecationMetadataContextInfo?> GetPackageDeprecationInfoAsync(
-            PackageIdentity packageIdentity,
             IReadOnlyCollection<PackageSourceContextInfo> packageSources,
             bool includePrerelease,
             CancellationToken cancellationToken)
         {
-            var packageMetadata = await FetchMetadataAsync(packageIdentity, packageSources, includePrerelease, cancellationToken);
+            var packageMetadata = await FetchMetadataAsync(_packageIdentity, packageSources, includePrerelease, cancellationToken);
             return packageMetadata.Item2;
         }
 
@@ -61,7 +61,7 @@ namespace NuGet.PackageManagement.UI
                     if (_packageMetadataTask == null)
                     {
                         _packageMetadataTask = _nugetSearchService.GetPackageMetadataAsync(
-                            packageIdentity,
+                            _packageIdentity,
                             packageSources,
                             includePrerelease,
                             cancellationToken);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/PackageMetadataRetrievalAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/PackageMetadataRetrievalAdapter.cs
@@ -16,13 +16,17 @@ namespace NuGet.PackageManagement.UI
     {
         private readonly INuGetSearchService _nugetSearchService;
         private readonly PackageIdentity _packageIdentity;
-        private ValueTask<(PackageSearchMetadataContextInfo, PackageDeprecationMetadataContextInfo?)> _packageMetadataTask;
+        private readonly IReadOnlyCollection<PackageSourceContextInfo> _packageSources;
+        private readonly bool _includePrerelease;
+        private Task<(PackageSearchMetadataContextInfo, PackageDeprecationMetadataContextInfo?)>? _packageMetadataTask;
         private readonly object _lock = new();
 
-        public PackageMetadataRetrievalAdapter(INuGetSearchService nugetSearchService, PackageIdentity packageIdentity)
+        public PackageMetadataRetrievalAdapter(INuGetSearchService nugetSearchService, PackageIdentity packageIdentity, IReadOnlyCollection<PackageSourceContextInfo> packageSources, bool includePrerelease)
         {
             _nugetSearchService = nugetSearchService ?? throw new ArgumentNullException(nameof(nugetSearchService));
             _packageIdentity = packageIdentity ?? throw new ArgumentNullException(nameof(packageIdentity));
+            _packageSources = packageSources ?? throw new ArgumentNullException(nameof(packageSources));
+            _includePrerelease = includePrerelease;
         }
 
         public async Task<PackageSearchMetadataContextInfo> GetPackageMetadataAsync(
@@ -30,7 +34,7 @@ namespace NuGet.PackageManagement.UI
             bool includePrerelease,
             CancellationToken cancellationToken)
         {
-            var packageMetadata = await FetchMetadataAsync(_packageIdentity, packageSources, includePrerelease, cancellationToken);
+            var packageMetadata = await FetchMetadataAsync(_packageIdentity, _packageSources, _includePrerelease, cancellationToken);
             return packageMetadata.Item1;
         }
 
@@ -39,11 +43,11 @@ namespace NuGet.PackageManagement.UI
             bool includePrerelease,
             CancellationToken cancellationToken)
         {
-            var packageMetadata = await FetchMetadataAsync(_packageIdentity, packageSources, includePrerelease, cancellationToken);
+            var packageMetadata = await FetchMetadataAsync(_packageIdentity, _packageSources, _includePrerelease, cancellationToken);
             return packageMetadata.Item2;
         }
 
-        private ValueTask<(PackageSearchMetadataContextInfo, PackageDeprecationMetadataContextInfo?)> FetchMetadataAsync(
+        private Task<(PackageSearchMetadataContextInfo, PackageDeprecationMetadataContextInfo?)> FetchMetadataAsync(
             PackageIdentity packageIdentity,
             IReadOnlyCollection<PackageSourceContextInfo> packageSources,
             bool includePrerelease,
@@ -58,14 +62,11 @@ namespace NuGet.PackageManagement.UI
             {
                 lock (_lock)
                 {
-                    if (_packageMetadataTask == null)
-                    {
-                        _packageMetadataTask = _nugetSearchService.GetPackageMetadataAsync(
-                            _packageIdentity,
-                            packageSources,
-                            includePrerelease,
-                            cancellationToken);
-                    }
+                    _packageMetadataTask ??= _nugetSearchService.GetPackageMetadataAsync(
+                        _packageIdentity,
+                        packageSources,
+                        includePrerelease,
+                        cancellationToken).AsTask();
                 }
             }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/PackageMetadataRetrievalAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/PackageMetadataRetrievalAdapter.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Packaging.Core;
+using NuGet.VisualStudio.Internal.Contracts;
+
+namespace NuGet.PackageManagement.UI
+{
+    internal class PackageMetadataRetrievalAdapter : IPackageMetadataRetrievalAdapter
+    {
+        private readonly INuGetSearchService _nugetSearchService;
+        private ValueTask<(PackageSearchMetadataContextInfo, PackageDeprecationMetadataContextInfo?)> _packageMetadataTask;
+        private readonly object _lock = new();
+
+        public PackageMetadataRetrievalAdapter(INuGetSearchService nugetSearchService)
+        {
+            _nugetSearchService = nugetSearchService;
+        }
+
+        public async Task<PackageSearchMetadataContextInfo> GetPackageMetadataAsync(
+            PackageIdentity packageIdentity,
+            IReadOnlyCollection<PackageSourceContextInfo> packageSources,
+            bool includePrerelease,
+            CancellationToken cancellationToken)
+        {
+            var packageMetadata = await FetchMetadataAsync(packageIdentity, packageSources, includePrerelease, cancellationToken);
+            return packageMetadata.Item1;
+        }
+
+        public async Task<PackageDeprecationMetadataContextInfo?> GetPackageDeprecationInfoAsync(
+            PackageIdentity packageIdentity,
+            IReadOnlyCollection<PackageSourceContextInfo> packageSources,
+            bool includePrerelease,
+            CancellationToken cancellationToken)
+        {
+            var packageMetadata = await FetchMetadataAsync(packageIdentity, packageSources, includePrerelease, cancellationToken);
+            return packageMetadata.Item2;
+        }
+
+        private ValueTask<(PackageSearchMetadataContextInfo, PackageDeprecationMetadataContextInfo?)> FetchMetadataAsync(
+            PackageIdentity packageIdentity,
+            IReadOnlyCollection<PackageSourceContextInfo> packageSources,
+            bool includePrerelease,
+            CancellationToken cancellationToken)
+        {
+            if (packageIdentity == null)
+            {
+                throw new ArgumentNullException(nameof(packageIdentity));
+            }
+
+            if (_packageMetadataTask == null)
+            {
+                lock (_lock)
+                {
+                    if (_packageMetadataTask == null)
+                    {
+                        _packageMetadataTask = _nugetSearchService.GetPackageMetadataAsync(
+                            packageIdentity,
+                            packageSources,
+                            includePrerelease,
+                            cancellationToken);
+                    }
+                }
+            }
+
+            return _packageMetadataTask;
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/PackageMetadataRetrievalAdapterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/PackageMetadataRetrievalAdapterTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using NuGet.VisualStudio.Internal.Contracts;
+using Xunit;
+
+namespace NuGet.PackageManagement.UI.Test.Models.Package
+{
+    public class PackageMetadataRetrievalAdapterTests
+    {
+        private readonly Mock<INuGetSearchService> _nugetSearchServiceMock;
+        private readonly PackageIdentity _packageIdentity;
+        private readonly PackageMetadataRetrievalAdapter _adapter;
+        private readonly IReadOnlyCollection<PackageSourceContextInfo> _packageSources;
+        private readonly bool _includePrerelease;
+
+        public PackageMetadataRetrievalAdapterTests()
+        {
+            _nugetSearchServiceMock = new Mock<INuGetSearchService>();
+            _packageIdentity = new PackageIdentity("TestPackage", new NuGetVersion("1.0.0"));
+            _packageSources = new List<PackageSourceContextInfo>();
+            _includePrerelease = false;
+            _adapter = new PackageMetadataRetrievalAdapter(_nugetSearchServiceMock.Object, _packageIdentity, _packageSources, _includePrerelease);
+        }
+
+        [Fact]
+        public async Task GetPackageMetadataAsync_WithValidMetadata_ReturnsPackageMetadata()
+        {
+            // Arrange
+            var cancellationToken = It.IsAny<CancellationToken>();
+            var expectedMetadata = new PackageSearchMetadataContextInfo();
+            _nugetSearchServiceMock
+                .Setup(s => s.GetPackageMetadataAsync(_packageIdentity, _packageSources, _includePrerelease, cancellationToken))
+                .ReturnsAsync((expectedMetadata, null));
+
+            // Act
+            var result = await _adapter.GetPackageMetadataAsync(_packageSources, _includePrerelease, cancellationToken);
+
+            // Assert
+            Assert.Equal(expectedMetadata, result);
+        }
+
+        [Fact]
+        public async Task GetPackageDeprecationInfoAsync_WithValidMetadata_ReturnsDeprecationInfo()
+        {
+            // Arrange
+            var cancellationToken = It.IsAny<CancellationToken>();
+            var expectedMetadata = new PackageSearchMetadataContextInfo();
+            var expectedDeprecationInfo = PackageDeprecationMetadataContextInfo.Create(new Protocol.PackageDeprecationMetadata());
+            _nugetSearchServiceMock
+                .Setup(s => s.GetPackageMetadataAsync(_packageIdentity, _packageSources, _includePrerelease, cancellationToken))
+                .ReturnsAsync((expectedMetadata, expectedDeprecationInfo));
+
+            // Act
+            var result = await _adapter.GetPackageDeprecationInfoAsync(_packageSources, _includePrerelease, cancellationToken);
+
+            // Assert
+            Assert.Equal(expectedDeprecationInfo, result);
+        }
+
+        [Fact]
+        public void Constructor_WhenNuGetSearchServiceIsNull_ThrowsArgumentNullException()
+        {
+            // Arrange
+            INuGetSearchService? nullService = null;
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new PackageMetadataRetrievalAdapter(nullService!, _packageIdentity, _packageSources, _includePrerelease));
+        }
+
+        [Fact]
+        public void Constructor_WhenPackageIdentityIsNull_ThrowsArgumentNullException()
+        {
+            // Arrange
+            PackageIdentity? nullIdentity = null;
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new PackageMetadataRetrievalAdapter(_nugetSearchServiceMock.Object, nullIdentity!, _packageSources, _includePrerelease));
+        }
+
+        [Fact]
+        public async Task FetchMetadataAsync_CalledMultipleTimes_OnlyRunsOperationOnce()
+        {
+            // Arrange
+            var cancellationToken = It.IsAny<CancellationToken>();
+            var expectedMetadata = new PackageSearchMetadataContextInfo();
+            var expectedDeprecationInfo = PackageDeprecationMetadataContextInfo.Create(new Protocol.PackageDeprecationMetadata());
+
+            _nugetSearchServiceMock
+                .Setup(s => s.GetPackageMetadataAsync(_packageIdentity, _packageSources, _includePrerelease, cancellationToken))
+                .ReturnsAsync((expectedMetadata, expectedDeprecationInfo));
+
+            // Act
+            var task1 = _adapter.GetPackageMetadataAsync(_packageSources, _includePrerelease, cancellationToken);
+            var task2 = _adapter.GetPackageDeprecationInfoAsync(_packageSources, _includePrerelease, cancellationToken);
+
+            await Task.WhenAll(task1, task2);
+
+            // Assert
+            _nugetSearchServiceMock.Verify(s => s.GetPackageMetadataAsync(_packageIdentity, _packageSources, _includePrerelease, cancellationToken), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->

Fixes: 

## Description
Adapter for fetching metadata for a package, handling concurrency, and using the same metadata task for various calls.

Also acts as an adapter around the Tuple that contains both the package metadata, and the deprecation info so distinct calls can be made, and a single item can be returned.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
