### PR TITLE
Fixing parameters for adapter to use instance variables instead

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/DeprecationPackageMetadataCapability.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/DeprecationPackageMetadataCapability.cs
@@ -12,7 +12,7 @@ using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.PackageManagement.UI
 {
-    public class DeprecationPackageMetadataCapability : IDeprecationCapable
+    internal class DeprecationPackageMetadataCapability : IDeprecationCapable
     {
         private readonly IPackageMetadataRetrievalAdapter _packageMetadataRetrievalAdapter;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/IPackageMetadataRetrievalAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/IPackageMetadataRetrievalAdapter.cs
@@ -3,7 +3,6 @@
 
 #nullable enable
 
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.VisualStudio.Internal.Contracts;
@@ -13,13 +12,9 @@ namespace NuGet.PackageManagement.UI
     internal interface IPackageMetadataRetrievalAdapter
     {
         public Task<PackageSearchMetadataContextInfo> GetPackageMetadataAsync(
-            IReadOnlyCollection<PackageSourceContextInfo> packageSources,
-            bool includePrerelease,
             CancellationToken cancellationToken);
 
         public Task<PackageDeprecationMetadataContextInfo?> GetPackageDeprecationInfoAsync(
-            IReadOnlyCollection<PackageSourceContextInfo> packageSources,
-            bool includePrerelease,
             CancellationToken cancellationToken);
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/PackageMetadataRetrievalAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/PackageMetadataRetrievalAdapter.cs
@@ -30,42 +30,30 @@ namespace NuGet.PackageManagement.UI
         }
 
         public async Task<PackageSearchMetadataContextInfo> GetPackageMetadataAsync(
-            IReadOnlyCollection<PackageSourceContextInfo> packageSources,
-            bool includePrerelease,
             CancellationToken cancellationToken)
         {
-            var packageMetadata = await FetchMetadataAsync(_packageIdentity, _packageSources, _includePrerelease, cancellationToken);
+            var packageMetadata = await FetchMetadataAsync(cancellationToken);
             return packageMetadata.Item1;
         }
 
         public async Task<PackageDeprecationMetadataContextInfo?> GetPackageDeprecationInfoAsync(
-            IReadOnlyCollection<PackageSourceContextInfo> packageSources,
-            bool includePrerelease,
             CancellationToken cancellationToken)
         {
-            var packageMetadata = await FetchMetadataAsync(_packageIdentity, _packageSources, _includePrerelease, cancellationToken);
+            var packageMetadata = await FetchMetadataAsync(cancellationToken);
             return packageMetadata.Item2;
         }
 
         private Task<(PackageSearchMetadataContextInfo, PackageDeprecationMetadataContextInfo?)> FetchMetadataAsync(
-            PackageIdentity packageIdentity,
-            IReadOnlyCollection<PackageSourceContextInfo> packageSources,
-            bool includePrerelease,
             CancellationToken cancellationToken)
         {
-            if (packageIdentity == null)
-            {
-                throw new ArgumentNullException(nameof(packageIdentity));
-            }
-
             if (_packageMetadataTask == null)
             {
                 lock (_lock)
                 {
                     _packageMetadataTask ??= _nugetSearchService.GetPackageMetadataAsync(
                         _packageIdentity,
-                        packageSources,
-                        includePrerelease,
+                        _packageSources,
+                        _includePrerelease,
                         cancellationToken).AsTask();
                 }
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/VulnerablePackageMetadataCapability.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/VulnerablePackageMetadataCapability.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace NuGet.PackageManagement.UI
 {
-    public class VulnerablePackageMetadataCapability : VulnerableCapabilityBase
+    internal class VulnerablePackageMetadataCapability : VulnerableCapabilityBase
     {
         private readonly IPackageMetadataRetrievalAdapter _packageMetadataRetrievalAdapter;
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/PackageMetadataRetrievalAdapterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/PackageMetadataRetrievalAdapterTests.cs
@@ -43,7 +43,7 @@ namespace NuGet.PackageManagement.UI.Test.Models.Package
                 .ReturnsAsync((expectedMetadata, null));
 
             // Act
-            var result = await _adapter.GetPackageMetadataAsync(_packageSources, _includePrerelease, cancellationToken);
+            var result = await _adapter.GetPackageMetadataAsync(cancellationToken);
 
             // Assert
             Assert.Equal(expectedMetadata, result);
@@ -61,7 +61,7 @@ namespace NuGet.PackageManagement.UI.Test.Models.Package
                 .ReturnsAsync((expectedMetadata, expectedDeprecationInfo));
 
             // Act
-            var result = await _adapter.GetPackageDeprecationInfoAsync(_packageSources, _includePrerelease, cancellationToken);
+            var result = await _adapter.GetPackageDeprecationInfoAsync(cancellationToken);
 
             // Assert
             Assert.Equal(expectedDeprecationInfo, result);
@@ -100,8 +100,8 @@ namespace NuGet.PackageManagement.UI.Test.Models.Package
                 .ReturnsAsync((expectedMetadata, expectedDeprecationInfo));
 
             // Act
-            var task1 = _adapter.GetPackageMetadataAsync(_packageSources, _includePrerelease, cancellationToken);
-            var task2 = _adapter.GetPackageDeprecationInfoAsync(_packageSources, _includePrerelease, cancellationToken);
+            var task1 = _adapter.GetPackageMetadataAsync(cancellationToken);
+            var task2 = _adapter.GetPackageDeprecationInfoAsync(cancellationToken);
 
             await Task.WhenAll(task1, task2);
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
Fixing the arguments needed for the methods on the adapter so that it uses the instance variables. Also fixed the scope of the capability classes to be internal.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~
