### PR TITLE
Configure SBOM for Build pipeline

### DIFF
--- a/eng/common/generate-sbom-prep.ps1
+++ b/eng/common/generate-sbom-prep.ps1
@@ -2,15 +2,12 @@ Param(
     [Parameter(Mandatory=$true)][string] $ManifestDirPath    # Manifest directory where sbom will be placed
 )
 
-Write-Host "Creating dir $ManifestDirPath"
 # create directory for sbom manifest to be placed
 if (!(Test-Path -path $ManifestDirPath))
 {
+  Write-Host "Creating dir $ManifestDirPath"
   New-Item -ItemType Directory -path $ManifestDirPath
   Write-Host "Successfully created directory $ManifestDirPath"
-}
-else{
-  Write-PipelineTelemetryError -category 'Build'  "Unable to create sbom folder."
 }
 
 Write-Host "Updating artifact name"

--- a/eng/common/templates/steps/generate-sbom.yml
+++ b/eng/common/templates/steps/generate-sbom.yml
@@ -5,9 +5,9 @@
 
 parameters:
   PackageVersion: 7.0.0
-  BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
+  BuildDropPath: '$(Build.SourcesDirectory)\artifacts'
   PackageName: '.NET'
-  ManifestDirPath: $(Build.ArtifactStagingDirectory)/sbom
+  ManifestDirPath: '$(Build.SourcesDirectory)\artifacts'
   sbomContinueOnError: true
 
 steps:

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -68,13 +68,15 @@ extends:
         enabled: true
         scanOutputDirectoryOnly: true
       sbom:
-        enabled: false
+        enabled: true
       credscan:
         enabled: false
     pool:
       name: AzurePipelines-EO
       image: 1ESPT-Windows2022
       os: windows
+    featureFlags:
+      enablePrepareFilesForSbom: true
     customBuildTags:
     - ES365AIMigrationTooling
     stages:

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -73,13 +73,15 @@ extends:
         enabled: true
         scanOutputDirectoryOnly: true
       sbom:
-        enabled: false
+        enabled: true
       credscan:
         enabled: false
     pool:
       name: AzurePipelines-EO
       image: 1ESPT-Windows2022
       os: windows
+    featureFlags:
+      enablePrepareFilesForSbom: true
     customBuildTags:
     - ES365AIMigrationTooling
     stages:

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -263,7 +263,7 @@ steps:
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.Core\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:ManifestDirPath=$(Build.ArtifactStagingDirectory)/sbom /binarylogger:$(Build.StagingDirectory)\\binlog\\16.GenerateVSManifestForVSIX.binlog"
+    msbuildArguments: "/property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\16.GenerateVSManifestForVSIX.binlog"
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1
@@ -271,7 +271,7 @@ steps:
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:IsVsixBuild=false /property:ManifestDirPath=$(Build.ArtifactStagingDirectory)/sbom /binarylogger:$(Build.StagingDirectory)\\binlog\\17.GenerateVSManifestForToolsVSIX.binlog"
+    msbuildArguments: "/property:IsVsixBuild=false /property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\17.GenerateVSManifestForToolsVSIX.binlog"
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
 - task: NuGetCommand@2

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -127,18 +127,21 @@ stages:
         condition: "succeeded()"
         targetPath: '$(Build.Repository.LocalPath)\artifacts\buildinfo.json'
         artifactName: 'BuildInfo'
+        sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish NuGet.CommandLine.Test as artifact'
         condition: "and(succeeded(),ne(variables['RunMonoTestsOnMac'], 'false'))"
         targetPath: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472"
         artifactName: "NuGet.CommandLine.Test"
+        sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish nupkgs'
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)"
         artifactName: "nupkgs - $(RtmLabel)"
+        sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish BootstrapperInfo.json as a build artifact'
@@ -147,6 +150,7 @@ stages:
         artifactName: MicroBuildOutputs
         # need to make daily Apex test pipeline build its own bootstrapper, and remove this from official pipeline
         codeSignValidationEnabled: false
+        sbomEnabled: false
 
       - output: artifactsDrop
         displayName: 'Publish the .runsettings files to artifact services'
@@ -174,18 +178,21 @@ stages:
         displayName: 'Publish NuGet.exe and VSIX as artifact'
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
         artifactName: "$(VsixPublishDir)"
+        sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish localizationArtifacts artifact'
         condition: "or(eq(variables['OverridePublishLocalizationArtifact'], 'true'), and(succeededOrFailed(), eq(variables['IsOfficialBuild'], 'true')))"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\localizationArtifacts\\"
         artifactName: "localizationArtifacts"
+        sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish symbols as pipeline artifacts'
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
         artifactName: "symbols - $(RtmLabel)"
+        sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: artifactsDrop
         displayName: 'Upload VSTS Drop'
@@ -202,17 +209,20 @@ stages:
         condition: "succeeded()"
         artifactName: LocValidationLogs
         targetPath: "$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs"
+        sbomEnabled: true
 
       - output: pipelineArtifact
         displayName: 'Publish binlogs'
         condition: "or(failed(), eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['System.debug'], 'true'))"
         artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
-        targetPath: $(Build.StagingDirectory)\binlog
+        targetPath: '$(Build.StagingDirectory)\binlog'
+        sbomEnabled: false
 
       - output: pipelineArtifact
         displayName: Publish SBOM manifest
         artifactName: $(ARTIFACT_NAME)
-        targetPath: '$(Build.ArtifactStagingDirectory)/sbom'
+        targetPath: '$(Build.SourcesDirectory)/artifacts'
+        sbomEnabled: false
 
     steps:
     - template: /eng/pipelines/templates/Build_and_UnitTest.yml@self
@@ -254,23 +264,27 @@ stages:
         condition: "succeeded()"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)"
         artifactName: "nupkgs - $(RtmLabel)"
+        sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish NuGet.exe and VSIX as artifact'
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
         artifactName: "$(VsixPublishDir)"
+        sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish symbols as pipeline artifacts'
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
         artifactName: "symbols - $(RtmLabel)"
+        sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish binlogs'
         condition: "or(failed(), eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['System.debug'], 'true'))"
         artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
         targetPath: $(Build.StagingDirectory)\binlog
+        sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
     steps:
     - template: /eng/pipelines/templates/Build_and_UnitTest.yml@self
       parameters:
@@ -315,6 +329,7 @@ stages:
         condition: "or(failed(), eq(variables['System.debug'], 'true'))"
         targetPath: "artifacts/sb/log/source-inner-build.binlog"
         artifactName: "Source-build log"
+        sbomEnabled: false
     steps:
     - template: /eng/pipelines/templates/Source_Build.yml@self
 
@@ -346,12 +361,14 @@ stages:
         condition: "or(failed(), canceled())"
         targetPath: "$(Build.Repository.LocalPath)/build/TestResults"
         artifactName: "$(Agent.JobName)"
+        sbomEnabled: false
 
       - output: pipelineArtifact
         displayName: 'Publish binlogs'
         condition: "or(failed(), eq(variables['System.debug'], 'true'))"
         artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
         targetPath: $(Build.StagingDirectory)\binlog
+        sbomEnabled: false
     steps:
     - template: /eng/pipelines/templates/Functional_Tests_On_Windows.yml@self
 
@@ -384,12 +401,14 @@ stages:
         condition: "or(failed(), canceled())"
         targetPath: "$(Build.Repository.LocalPath)/build/TestResults"
         artifactName: "$(Agent.JobName)"
+        sbomEnabled: false
 
       - output: pipelineArtifact
         displayName: 'Publish binlogs'
         condition: "or(failed(), eq(variables['System.debug'], 'true'))"
         artifactName: binlog - $(TestRunDisplayName) On Linux - Attempt $(System.JobAttempt)
         targetPath: $(Build.StagingDirectory)/binlog
+        sbomEnabled: false
     steps:
     - template: /eng/pipelines/templates/Tests_On_Linux.yml@self
 
@@ -421,12 +440,14 @@ stages:
         condition: "or(failed(), canceled())"
         targetPath: "$(Build.Repository.LocalPath)/build/TestResults"
         artifactName: "$(Agent.JobName)"
+        sbomEnabled: false
 
       - output: pipelineArtifact
         displayName: 'Publish binlogs'
         condition: "or(failed(), eq(variables['System.debug'], 'true'))"
         artifactName: binlog - $(TestRunDisplayName) On Mac - Attempt $(System.JobAttempt)
         targetPath: $(Build.StagingDirectory)/binlog
+        sbomEnabled: false
     steps:
     - template: /eng/pipelines/templates/Tests_On_Mac.yml@self
 
@@ -448,12 +469,14 @@ stages:
         condition: "or(failed(), canceled())"
         targetPath: "$(Build.Repository.LocalPath)/build/TestResults"
         artifactName: "$(Agent.JobName)"
+        sbomEnabled: false
 
       - output: pipelineArtifact
         displayName: 'Publish binlogs'
         condition: "or(failed(), eq(variables['System.debug'], 'true'))"
         artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
         targetPath: $(Build.StagingDirectory)\binlog
+        sbomEnabled: false
     steps:
     - template: /eng/pipelines/templates/CrossFramework_Tests_On_Windows.yml@self
 
@@ -483,11 +506,13 @@ stages:
         condition: "or(failed(), canceled())"
         targetPath: "$(Build.Repository.LocalPath)/build/TestResults"
         artifactName: "$(Agent.JobName)"
+        sbomEnabled: false
 
       - output: pipelineArtifact
         displayName: 'Publish binlogs'
         condition: "or(failed(), eq(variables['System.debug'], 'true'))"
         artifactName: binlog - $(TestRunDisplayName) On Mac - Attempt $(System.JobAttempt)
         targetPath: $(Build.StagingDirectory)/binlog
+        sbomEnabled: false
     steps:
     - template: /eng/pipelines/templates/Tests_On_Mac.yml@self

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -190,14 +190,14 @@ steps:
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.Core\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:ManifestDirPath=$(Build.StagingDirectory)/sbom /binarylogger:$(Build.StagingDirectory)\\binlog\\10.GenerateVSManifestForVSIX.binlog"
+    msbuildArguments: "/property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\10.GenerateVSManifestForVSIX.binlog"
 
 - task: MSBuild@1
   displayName: "Generate VSMAN file for Build Tools VSIX"
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:IsVsixBuild=false /property:ManifestDirPath=$(Build.StagingDirectory)/sbom /binarylogger:$(Build.StagingDirectory)\\binlog\\11.GenerateVSManifestForToolsVSIX.binlog"
+    msbuildArguments: "/property:IsVsixBuild=false /property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\11.GenerateVSManifestForToolsVSIX.binlog"
 
 - task: MSBuild@1
   displayName: "Create EndToEnd Test Package"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

In order to migrate to 1ES PT Release templates, our build must create artifacts with an SBOM to be compliant.

1. Enable SBOM for official builds and explicitly set the `sbomBuildDropPath`.
1. Stop using a special directory (`/sbom`) as the release templates do not support looking for these in subdirectories of the artifacts. 
This prevents errors like this: 
"Could not find a part of the path 'D:\a\_work\1\nupkgs - RTM\_manifest\spdx_2.2\manifest.spdx.json'."
1. Disabled SBOM on tasks that generate artifacts that we do not release.
1. PR Builds have SBOM generation enabled to validate any issues generating SBOMs prior to starting official builds. (Feedback from @zivkan )

### Servicing branches

My plan is to make the same change on all servicing branches after merged to `dev`. 

### Validation

Tested in our new release pipeline. Eg, see `6.14.0.85-2` as a recent example of the VS Insertion successfully finding these SBOM artifacts.

Tested our existing release pipeline to ensure it still completes with changes from this PR.  It created this PR (which I abandoned): https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/621001.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Client.Engineering/issues/3206
