### PR TITLE
Adding a rule for PRs labeled as breaking-change per the new .NET SDK breaking change guidance.

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -182,12 +182,15 @@ configuration:
             Added `needs-breaking-change-doc-created` label because this PR has the `breaking-change` label. 
 
 
+            When you commit this breaking change:
+
+
             1. [ ] Create and link to this issue a matching issue in the dotnet/docs repo using the [breaking change documentation template](https://aka.ms/dotnet/docs/new-breaking-change-issue), then remove this `needs-breaking-change-doc-created` label.
  
             2. [ ] Ask a committer to mail the `.NET SDK Breaking Change Notification` email list.
 
 
             You can refer to the [.NET SDK breaking change guidelines](https://github.com/dotnet/sdk/blob/main/documentation/project-docs/breaking-change-guidelines.md)
-      description: 'Add breaking change instructions to PR.'
+      description: Add breaking change instructions to PR.
 onFailure:
 onSuccess:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -182,15 +182,12 @@ configuration:
             Added `needs-breaking-change-doc-created` label because this PR has the `breaking-change` label. 
 
 
-            When you commit this breaking change:
+            When you commit this breaking change:
 
 
-            1. [ ] Create and link to this issue a matching issue in the dotnet/docs repo using the [breaking change documentation template](https://aka.ms/dotnet/docs/new-breaking-change-issue), then remove this `needs-breaking-change-doc-created` label.
+            1. [ ] Create and link to this issue a matching issue in the dotnet/docs repo using the [breaking change documentation template](https://aka.ms/dotnet/docs/new-breaking-change-issue), then remove this `needs-breaking-change-doc-created` label.
 
-      description: Add breaking change instructions to PR.
-
-
-
+            2. [ ] Ask a committer to mail the `.NET SDK Breaking Change Notification` email list.
 
 
             You can refer to the [.NET SDK breaking change guidelines](https://github.com/dotnet/sdk/blob/main/documentation/project-docs/breaking-change-guidelines.md)

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -185,13 +185,10 @@ configuration:
             When you commit this breaking change:
 
 
+            1. [ ] Create and link to this issue a matching issue in the dotnet/docs repo using the [breaking change documentation template](https://aka.ms/dotnet/docs/new-breaking-change-issue), then remove this `needs-breaking-change-doc-created` label.
 
-
-
-      description: Add breaking change instructions to PR.
-            2. [ ] Ask a committer to mail the `.NET SDK Breaking Change Notification` email list.
-
       description: Add breaking change instructions to PR.
+
 
 
 

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -185,12 +185,17 @@ configuration:
             When you commit this breaking change:
 
 
+
+
+
             1. [ ] Create and link to this issue a matching issue in the dotnet/docs repo using the [breaking change documentation template](https://aka.ms/dotnet/docs/new-breaking-change-issue), then remove this `needs-breaking-change-doc-created` label.
  
             2. [ ] Ask a committer to mail the `.NET SDK Breaking Change Notification` email list.
-
+      description: Add breaking change instructions to PR.
+
 
             You can refer to the [.NET SDK breaking change guidelines](https://github.com/dotnet/sdk/blob/main/documentation/project-docs/breaking-change-guidelines.md)
-      description: Add breaking change instructions to PR.
+      description: Add breaking change instructions to PR.
+
 onFailure:
 onSuccess:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -170,5 +170,24 @@ configuration:
         
         - [ ] Complete [localizability testing](https://github.com/NuGet/NuGet.Client/blob/dev/docs/ui-guidelines.md#localizability-testing).'
       description: 'Remind PR author to test accessibility and localizability'
+    - if:
+      - payloadType: Pull_Request
+      - labelAdded:
+          label: breaking-change
+      then:
+      - addLabel:
+          label: needs-breaking-change-doc-created
+      - addReply:
+          reply: >-
+            Added `needs-breaking-change-doc-created` label because this PR has the `breaking-change` label. 
+
+
+            1. [ ] Create and link to this issue a matching issue in the dotnet/docs repo using the [breaking change documentation template](https://aka.ms/dotnet/docs/new-breaking-change-issue), then remove this `needs-breaking-change-doc-created` label.
+ 
+            2. [ ] Ask a committer to mail the `.NET SDK Breaking Change Notification` email list.
+
+
+            You can refer to the [.NET SDK breaking change guidelines](https://github.com/dotnet/sdk/blob/main/documentation/project-docs/breaking-change-guidelines.md)
+      description: 'Add breaking change instructions to PR.'
 onFailure:
 onSuccess:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -183,16 +183,18 @@ configuration:
 
 
             When you commit this breaking change:
-
-
 
 
 
-            1. [ ] Create and link to this issue a matching issue in the dotnet/docs repo using the [breaking change documentation template](https://aka.ms/dotnet/docs/new-breaking-change-issue), then remove this `needs-breaking-change-doc-created` label.
- 
-            2. [ ] Ask a committer to mail the `.NET SDK Breaking Change Notification` email list.
+
+
       description: Add breaking change instructions to PR.
+            2. [ ] Ask a committer to mail the `.NET SDK Breaking Change Notification` email list.
 
+      description: Add breaking change instructions to PR.
+
+
+
 
             You can refer to the [.NET SDK breaking change guidelines](https://github.com/dotnet/sdk/blob/main/documentation/project-docs/breaking-change-guidelines.md)
       description: Add breaking change instructions to PR.


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

Adding a rule for PRs labeled as breaking-change per the new .NET SDK breaking change guidance which instructs authors to create an issue in the docs repo and ensure communication is sent to the .NET SDK Breaking Change Notification email list once the change is merged.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~~Added tests~~
- [ ] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~
