### PR TITLE
Update ngen Priorities for VS

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -148,19 +148,19 @@
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
       <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
-      <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\..\NuGet.Core\NuGet.ProjectModel\NuGet.ProjectModel.csproj">
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
       <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
-      <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
+      <NgenPriority>1</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\..\NuGet.Core\NuGet.Protocol\NuGet.Protocol.csproj">
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
       <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
-      <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\..\NuGet.Core\NuGet.Resolver\NuGet.Resolver.csproj" />
     <ProjectReference Include="..\..\NuGet.Core\NuGet.Versioning\NuGet.Versioning.csproj">
@@ -184,7 +184,7 @@
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
       <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
-      <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
+      <NgenPriority>1</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\..\NuGet.Core\NuGet.Credentials\NuGet.Credentials.csproj">
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
@@ -197,7 +197,7 @@
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
       <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
-      <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\NuGet.VisualStudio.Contracts\NuGet.VisualStudio.Contracts.csproj" />
     <ProjectReference Include="..\NuGet.VisualStudio.Implementation\NuGet.VisualStudio.Implementation.csproj">
@@ -226,7 +226,7 @@
       <Ngen>True</Ngen>
       <NgenApplication>$(NgenApplicationDefault)</NgenApplication>
       <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
-      <NgenPriority>$(NgenPriorityDefault)</NgenPriority>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\NuGet.VisualStudio.Internal.Contracts\NuGet.VisualStudio.Internal.Contracts.csproj">
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>


### PR DESCRIPTION
# Bug
Updating the ngen priorities of a few assemblies based on JIT time data for VS. We are experimenting with a mechanism to asynchronously generate important NGEN images immediately after VS setup in 17.14, and to do this are adjusting NGEN priorities of assemblies, so that the most important ones, based on JIT time, usage and user observable scenarios, are generated first. These changes are as a result of that analysis. If you have any questions on this, feel free to reach out to me or the VS Perf and Rel team.

## Description

NuGet.Commands.dll and NuGet.ProjectModel.dll are going from priority 3 to priority 1, and the following are going from priority 3 to priority 2:
NuGet.PackageManagement.VisualStudio.dll
NuGet.Packaging.dll
NuGet.Protocol.dll
NuGet.SolutionRestoreManager.dll

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
