### PR TITLE
Don't show usage for dotnet cli commands that throw

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigCommand.cs
@@ -38,8 +38,7 @@ namespace NuGet.CommandLine.XPlat
 
         private static CliArgument<string> AllOrConfigKeyArgument = new CliArgument<string>(name: "all-or-config-key")
         {
-            Arity = ArgumentArity.ZeroOrOne,
-            HelpName = Strings.ConfigGetAllOrConfigKeyDescription,
+            Arity = ArgumentArity.ExactlyOne,
             Description = Strings.ConfigGetAllOrConfigKeyDescription
         };
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigCommand.cs
@@ -4,8 +4,6 @@
 using System;
 using System.CommandLine;
 using System.CommandLine.Help;
-using System.CommandLine.Parsing;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
 using NuGet.CommandLine.XPlat.Commands;
@@ -79,13 +77,6 @@ namespace NuGet.CommandLine.XPlat
             log.LogVerbose(e.ToString());
         }
 
-        internal static void ShowHelp(ParseResult parseResult, CliCommand cmd)
-        {
-            var tokenList = parseResult.Tokens.TakeWhile(token => token.Type == CliTokenType.Argument || token.Type == CliTokenType.Command || token.Type == CliTokenType.Directive).Select(t => t.Value).ToList();
-            tokenList.Add("-h");
-            cmd.Parse(tokenList).Invoke();
-        }
-
         internal static void Register(CommandLineApplication app)
         {
             app.Command("config", configCmd =>
@@ -145,25 +136,12 @@ namespace NuGet.CommandLine.XPlat
             // Create handler delegate handler for cmd
             cmd.SetAction((parseResult, cancellationToken) =>
             {
-                int exitCode;
-
                 var args = new ConfigPathsArgs()
                 {
                     WorkingDirectory = parseResult.GetValue(WorkingDirectory),
                 };
 
-                try
-                {
-                    ConfigPathsRunner.Run(args, getLogger);
-                    exitCode = 0;
-                }
-                catch (Exception e)
-                {
-                    LogException(e, getLogger());
-                    ShowHelp(parseResult, cmd);
-
-                    exitCode = 1;
-                }
+                int exitCode = ConfigPathsRunner.Run(args, getLogger);
                 return Task.FromResult(exitCode);
             });
         }
@@ -178,7 +156,6 @@ namespace NuGet.CommandLine.XPlat
             // Create handler delegate handler for cmd
             cmd.SetAction((parseResult, cancellationToken) =>
             {
-                int exitCode;
                 var args = new ConfigGetArgs()
                 {
                     AllOrConfigKey = parseResult.GetValue(AllOrConfigKeyArgument),
@@ -186,18 +163,7 @@ namespace NuGet.CommandLine.XPlat
                     ShowPath = parseResult.GetValue(ShowPathOption),
                 };
 
-                try
-                {
-                    ConfigGetRunner.Run(args, getLogger);
-                    exitCode = 0;
-                }
-                catch (Exception e)
-                {
-                    LogException(e, getLogger());
-                    ShowHelp(parseResult, cmd);
-
-                    exitCode = 1;
-                }
+                int exitCode = ConfigGetRunner.Run(args, getLogger);
                 return Task.FromResult(exitCode);
             });
         }
@@ -211,7 +177,6 @@ namespace NuGet.CommandLine.XPlat
             // Create handler delegate handler for cmd
             cmd.SetAction((parseResult, cancellationToken) =>
             {
-                int exitCode;
                 var args = new ConfigSetArgs()
                 {
                     ConfigKey = parseResult.GetValue(SetConfigKeyArgument),
@@ -219,18 +184,7 @@ namespace NuGet.CommandLine.XPlat
                     ConfigFile = parseResult.GetValue(ConfigFileOption),
                 };
 
-                try
-                {
-                    ConfigSetRunner.Run(args, getLogger);
-                    exitCode = 0;
-                }
-                catch (Exception e)
-                {
-                    LogException(e, getLogger());
-                    ShowHelp(parseResult, cmd);
-
-                    exitCode = 1;
-                }
+                int exitCode = ConfigSetRunner.Run(args, getLogger);
                 return Task.FromResult(exitCode);
             });
         }
@@ -243,26 +197,13 @@ namespace NuGet.CommandLine.XPlat
             // Create handler delegate handler for cmd
             cmd.SetAction((parseResult, cancellationToken) =>
             {
-                int exitCode;
-
                 var args = new ConfigUnsetArgs()
                 {
                     ConfigKey = parseResult.GetValue(UnsetConfigKeyArgument),
                     ConfigFile = parseResult.GetValue(ConfigFileOption),
                 };
 
-                try
-                {
-                    ConfigUnsetRunner.Run(args, getLogger);
-                    exitCode = 0;
-                }
-                catch (Exception e)
-                {
-                    LogException(e, getLogger());
-                    ShowHelp(parseResult, cmd);
-
-                    exitCode = 1;
-                }
+                int exitCode = ConfigUnsetRunner.Run(args, getLogger);
                 return Task.FromResult(exitCode);
             });
         }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigRunners.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigRunners.cs
@@ -14,7 +14,7 @@ namespace NuGet.CommandLine.XPlat
 {
     internal static class ConfigPathsRunner
     {
-        public static void Run(ConfigPathsArgs args, Func<ILogger> getLogger)
+        public static int Run(ConfigPathsArgs args, Func<ILogger> getLogger)
         {
             RunnerHelper.EnsureArgumentsNotNull(args, getLogger);
 
@@ -23,7 +23,16 @@ namespace NuGet.CommandLine.XPlat
                 args.WorkingDirectory = Directory.GetCurrentDirectory();
             }
 
-            var settings = RunnerHelper.GetSettingsFromDirectory(args.WorkingDirectory);
+            ISettings settings;
+            try
+            {
+                settings = RunnerHelper.GetSettingsFromDirectory(args.WorkingDirectory);
+            }
+            catch (CommandException e)
+            {
+                getLogger().LogError(e.Message);
+                return ExitCodes.InvalidArguments;
+            }
             ILogger logger = getLogger();
 
             var filePaths = settings.GetConfigFilePaths();
@@ -31,24 +40,36 @@ namespace NuGet.CommandLine.XPlat
             {
                 logger.LogMinimal(filePath);
             }
+
+            return ExitCodes.Success;
         }
     }
 
     internal static class ConfigGetRunner
     {
-        public static void Run(ConfigGetArgs args, Func<ILogger> getLogger)
+        public static int Run(ConfigGetArgs args, Func<ILogger> getLogger)
         {
             RunnerHelper.EnsureArgumentsNotNull(args, getLogger);
 
             if (args.AllOrConfigKey == null)
             {
-                throw new CommandException(string.Format(CultureInfo.CurrentCulture, Strings.ConfigCommandKeyNotFound, args.AllOrConfigKey));
+                getLogger().LogError(string.Format(CultureInfo.CurrentCulture, Strings.ConfigCommandKeyNotFound, "null"));
+                return ExitCodes.Error;
             }
 
-            var settings = RunnerHelper.GetSettingsFromDirectory(args.WorkingDirectory) as Settings;
+            Settings settings;
+            try
+            {
+                settings = RunnerHelper.GetSettingsFromDirectory(args.WorkingDirectory) as Settings;
+            }
+            catch (CommandException e)
+            {
+                getLogger().LogError(e.Message);
+                return ExitCodes.InvalidArguments;
+            }
             if (settings == null)
             {
-                return;
+                return ExitCodes.Success;
             }
             ILogger logger = getLogger();
 
@@ -57,7 +78,7 @@ namespace NuGet.CommandLine.XPlat
                 IEnumerable<string> sections = settings.GetAllSettingSections();
                 if (sections == null)
                 {
-                    return;
+                    return ExitCodes.Success;
                 }
                 RunnerHelper.LogSections(sections, settings, logger, args.ShowPath);
             }
@@ -66,39 +87,61 @@ namespace NuGet.CommandLine.XPlat
                 var configValue = RunnerHelper.GetValueForConfigKey(settings, args.AllOrConfigKey, args.ShowPath);
                 if (string.IsNullOrEmpty(configValue))
                 {
-                    throw new CommandException(string.Format(CultureInfo.CurrentCulture, Strings.ConfigCommandKeyNotFound, args.AllOrConfigKey));
+                    logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.ConfigCommandKeyNotFound, args.AllOrConfigKey));
+                    return ExitCodes.Error;
                 }
 
                 logger.LogMinimal(configValue);
             }
+
+            return ExitCodes.Success;
         }
     }
 
     internal static class ConfigSetRunner
     {
-        public static void Run(ConfigSetArgs args, Func<ILogger> getLogger)
+        public static int Run(ConfigSetArgs args, Func<ILogger> getLogger)
         {
             RunnerHelper.EnsureArgumentsNotNull(args, getLogger);
-            RunnerHelper.ValidateConfigKey(args.ConfigKey);
+            try
+            {
+                RunnerHelper.ValidateConfigKey(args.ConfigKey);
+            }
+            catch (CommandException e)
+            {
+                getLogger().LogError(e.Message);
+                return ExitCodes.InvalidArguments;
+            }
             ISettings settings = XPlatUtility.ProcessConfigFile(args.ConfigFile);
 
             bool encrypt = args.ConfigKey.Equals(ConfigurationConstants.PasswordKey, StringComparison.OrdinalIgnoreCase);
             SettingsUtility.SetConfigValue(settings, args.ConfigKey, args.ConfigValue, encrypt);
+            return ExitCodes.Success;
         }
     }
 
     internal static class ConfigUnsetRunner
     {
-        public static void Run(ConfigUnsetArgs args, Func<ILogger> getLogger)
+        public static int Run(ConfigUnsetArgs args, Func<ILogger> getLogger)
         {
             RunnerHelper.EnsureArgumentsNotNull(args, getLogger);
-            RunnerHelper.ValidateConfigKey(args.ConfigKey);
+            try
+            {
+                RunnerHelper.ValidateConfigKey(args.ConfigKey);
+            }
+            catch (CommandException e)
+            {
+                getLogger().LogError(e.Message);
+                return ExitCodes.InvalidArguments;
+            }
             ISettings settings = XPlatUtility.ProcessConfigFile(args.ConfigFile);
 
             if (!SettingsUtility.DeleteConfigValue(settings, args.ConfigKey))
             {
                 getLogger().LogMinimal(string.Format(CultureInfo.CurrentCulture, Strings.ConfigUnsetNonExistingKey, args.ConfigKey));
             }
+
+            return ExitCodes.Success;
         }
     }
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigRunners.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ConfigCommands/ConfigRunners.cs
@@ -51,12 +51,6 @@ namespace NuGet.CommandLine.XPlat
         {
             RunnerHelper.EnsureArgumentsNotNull(args, getLogger);
 
-            if (args.AllOrConfigKey == null)
-            {
-                getLogger().LogError(string.Format(CultureInfo.CurrentCulture, Strings.ConfigCommandKeyNotFound, "null"));
-                return ExitCodes.Error;
-            }
-
             Settings settings;
             try
             {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Parsing;
 using System.Globalization;
 using System.Linq;
 using System.Threading;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -117,10 +117,7 @@ namespace NuGet.CommandLine.XPlat
                 catch (Exception ex)
                 {
                     LogException(ex, log);
-                    var tokenList = parseResult.Tokens.TakeWhile(token => token.Type == CliTokenType.Argument || token.Type == CliTokenType.Command || token.Type == CliTokenType.Directive).Select(t => t.Value).ToList();
-                    tokenList.Add("-h");
-                    rootCommand.Parse(tokenList).Invoke();
-                    exitCodeValue = 1;
+                    exitCodeValue = ExitCodes.Error;
                 }
 
                 return exitCodeValue;

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/DotnetCliUtil.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/DotnetCliUtil.cs
@@ -144,7 +144,7 @@ project TFMs found: {string.Join(", ", compiledTfms.Keys.Select(k => k.ToString(
         public static void VerifyResultFailure(CommandRunnerResult result, string expectedErrorMessage)
         {
             result.ExitCode.Should().NotBe(0);
-            result.Output.Should().Contain(expectedErrorMessage);
+            result.AllOutput.Should().Contain(expectedErrorMessage);
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatConfigTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatConfigTests.cs
@@ -497,7 +497,7 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
-        public void ConfigGetCommand_WithInvalidConfigKeyArg_ThrowsCommandException()
+        public void ConfigGetCommand_WithInvalidConfigKeyArg_OutputsErrorMessage()
         {
             // Arrange & Act
             using var testInfo = new TestInfo("NuGet.Config");
@@ -515,7 +515,7 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
-        public void ConfigGetCommand_WithNullAllOrConfigKeyArg_ThrowsCommandException()
+        public void ConfigGetCommand_WithoutConfigKeyArg_OutputsErrorMessage()
         {
             // Arrange & Act
             using var testInfo = new TestInfo("NuGet.Config");
@@ -525,7 +525,7 @@ namespace NuGet.XPlat.FuncTest
                 Directory.GetCurrentDirectory(),
                 $"{XplatDll} config get",
                 testOutputHelper: _testOutputHelper);
-            var expectedError = string.Format(CultureInfo.CurrentCulture, Strings.ConfigCommandKeyNotFound, "");
+            var expectedError = "Required argument missing";
 
             // Assert
             DotnetCliUtil.VerifyResultFailure(result, expectedError);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14200

## Description

Removed code that causes usage help to be shown when an unhandled exception is thrown when running a command.

Tests were not added/modified because:

1. This code only runs when a command throws an unhandled exception.  Commands should never have unhandled exceptions.
2. This code is in the console app's Program.Main.  It would require refactoring of low level Program.Main code to make it testable just for this scenario.
3. It's not intuitive to have tests for things that shouldn't happen. Different examples of negative scenarios we don't have tests for:  Passing invalid options shows usage without creating the user-profile nuget.config. Or, when a private feed is configured and the current user doesn't have access, commands like `dotnet nuget config paths` succeeds (since that specific command doesn't need to access the nuget feeds).

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~  see description above
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
