### PR TITLE
Use the model and capabilities to hydrate metadata and make better use of model

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/DeprecationPackageMetadataCapability.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/DeprecationPackageMetadataCapability.cs
@@ -15,21 +15,22 @@ namespace NuGet.PackageManagement.UI
     internal class DeprecationPackageMetadataCapability : IDeprecationCapable
     {
         private readonly IPackageMetadataRetrievalAdapter _packageMetadataRetrievalAdapter;
+        private PackageDeprecationMetadataContextInfo? _deprecationMetadata;
 
         public DeprecationPackageMetadataCapability(IPackageMetadataRetrievalAdapter packageMetadataRetrievalAdapter)
         {
             _packageMetadataRetrievalAdapter = packageMetadataRetrievalAdapter ?? throw new ArgumentNullException(nameof(packageMetadataRetrievalAdapter));
         }
 
-        public PackageDeprecationMetadataContextInfo? DeprecationMetadata { get; private set; }
+        public AlternatePackageMetadataContextInfo? AlternatePackage => _deprecationMetadata?.AlternatePackage;
 
-        public bool IsDeprecated => DeprecationMetadata != null;
+        public bool IsDeprecated => _deprecationMetadata != null;
 
         public PackageDeprecationReasonEnum PackageDeprecationReasons
         {
             get
             {
-                if (DeprecationMetadata?.Reasons == null || !DeprecationMetadata.Reasons.Any())
+                if (_deprecationMetadata?.Reasons == null || !_deprecationMetadata.Reasons.Any())
                 {
                     return PackageDeprecationReasonEnum.Unknown;
                 }
@@ -37,7 +38,7 @@ namespace NuGet.PackageManagement.UI
                 bool hasCriticalBugs = false;
                 bool hasLegacy = false;
 
-                foreach (var reason in DeprecationMetadata.Reasons)
+                foreach (var reason in _deprecationMetadata.Reasons)
                 {
                     if (string.Equals(reason, PackageDeprecationReason.CriticalBugs, StringComparison.OrdinalIgnoreCase))
                     {
@@ -70,7 +71,7 @@ namespace NuGet.PackageManagement.UI
 
         public async Task PopulateDataAsync(CancellationToken cancellationToken)
         {
-            DeprecationMetadata = await _packageMetadataRetrievalAdapter.GetPackageDeprecationInfoAsync(cancellationToken);
+            _deprecationMetadata = await _packageMetadataRetrievalAdapter.GetPackageDeprecationInfoAsync(cancellationToken);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/IDeprecationCapable.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/IDeprecationCapable.cs
@@ -6,6 +6,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Protocol.Model;
+using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -14,6 +15,8 @@ namespace NuGet.PackageManagement.UI
         public bool IsDeprecated { get; }
 
         public PackageDeprecationReasonEnum PackageDeprecationReasons { get; }
+
+        public AlternatePackageMetadataContextInfo? AlternatePackage { get; }
 
         public Task PopulateDataAsync(CancellationToken cancellationToken);
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/LocalPackageModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/LocalPackageModel.cs
@@ -49,7 +49,7 @@ namespace NuGet.PackageManagement.UI
 
         public PackageVulnerabilitySeverity VulnerabilityMaxSeverity => _vulnerableCapability.VulnerabilityMaxSeverity;
 
-        public async Task PopulateDataAsync(CancellationToken cancellationToken)
+        public override async Task PopulateDataAsync(CancellationToken cancellationToken)
         {
             await _vulnerableCapability.PopulateDataAsync(cancellationToken);
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/NoDeprecationCapability.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/NoDeprecationCapability.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Protocol.Model;
+using NuGet.VisualStudio.Internal.Contracts;
+
+namespace NuGet.PackageManagement.UI
+{
+    internal class NoDeprecationCapability : IDeprecationCapable
+    {
+        public bool IsDeprecated => false;
+
+        public PackageDeprecationReasonEnum PackageDeprecationReasons => PackageDeprecationReasonEnum.Unknown;
+
+        public AlternatePackageMetadataContextInfo? AlternatePackage => null;
+
+        public Task PopulateDataAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/PackageModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/PackageModel.cs
@@ -89,6 +89,8 @@ namespace NuGet.PackageManagement.UI
 
         public Uri? ReadmeUri => _embeddedResources.ReadmeUri;
 
+        public abstract Task PopulateDataAsync(CancellationToken cancellationToken);
+
         public ValueTask<Stream?> GetIconAsync(CancellationToken cancellationToken) => _embeddedResources.GetIconAsync(cancellationToken);
 
         public ValueTask<Stream?> GetLicenseAsync(CancellationToken cancellationToken) => _embeddedResources.GetLicenseAsync(cancellationToken);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/PackageModelFactory.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/PackageModelFactory.cs
@@ -38,19 +38,18 @@ namespace NuGet.PackageManagement.UI
             }
 
             EmbeddedResourcesCapability embeddedResources = new EmbeddedResourcesCapability(_packageFileService, metadata.Identity!, metadata.ReadmeUrl);
-            PackageMetadataRetrievalAdapter packageMetadataRetrievalAdapter = new PackageMetadataRetrievalAdapter(_searchService, metadata.Identity!, _packageSources, _includePrerelease);
-            IDeprecationCapable deprecationCapable = new DeprecationPackageMetadataCapability(packageMetadataRetrievalAdapter);
 
             if (metadata.PackagePath != null)
             {
                 if (metadata.TransitiveOrigins != null)
                 {
                     IVulnerableCapable vulnerableDatabaseCapability = new VulnerableDatabaseCapability(_packageVulnerabilityService, metadata.Identity);
+                    IDeprecationCapable noDeprecationCapable = new NoDeprecationCapability();
                     return new TransitivelyReferencedPackageModel(
                         metadata.Identity!,
                         metadata.PackagePath,
                         vulnerableDatabaseCapability,
-                        deprecationCapable,
+                        noDeprecationCapable,
                         embeddedResources,
                         metadata.TransitiveOrigins,
                         metadata.Title,
@@ -69,6 +68,8 @@ namespace NuGet.PackageManagement.UI
                         metadata.IconUrl);
                 }
 
+                PackageMetadataRetrievalAdapter packageMetadataRetrievalAdapter = new PackageMetadataRetrievalAdapter(_searchService, metadata.Identity!, _packageSources, _includePrerelease);
+                IDeprecationCapable deprecationCapable = new DeprecationPackageMetadataCapability(packageMetadataRetrievalAdapter);
                 IVulnerableCapable vulnerableCapability = new VulnerablePackageMetadataCapability(packageMetadataRetrievalAdapter);
 
                 if (!itemFilter.Equals(ContractItemFilter.Installed))
@@ -117,6 +118,8 @@ namespace NuGet.PackageManagement.UI
             }
             else
             {
+                PackageMetadataRetrievalAdapter packageMetadataRetrievalAdapter = new PackageMetadataRetrievalAdapter(_searchService, metadata.Identity!, _packageSources, _includePrerelease);
+                IDeprecationCapable deprecationCapable = new DeprecationPackageMetadataCapability(packageMetadataRetrievalAdapter);
                 VulnerablePackageMetadataCapability vulnerableCapability = new VulnerablePackageMetadataCapability(packageMetadataRetrievalAdapter);
 
                 if (metadata.IsRecommended)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/ReferencedPackageModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/ReferencedPackageModel.cs
@@ -70,13 +70,15 @@ namespace NuGet.PackageManagement.UI.Models
 
         public PackageDeprecationReasonEnum PackageDeprecationReasons => _deprecationCapability.PackageDeprecationReasons;
 
+        public AlternatePackageMetadataContextInfo? AlternatePackage => _deprecationCapability.AlternatePackage;
+
         public IReadOnlyList<PackageVulnerabilityMetadataContextInfo>? Vulnerabilities => _vulnerableCapability.Vulnerabilities;
 
         public bool IsVulnerable => _vulnerableCapability.IsVulnerable;
 
         public PackageVulnerabilitySeverity VulnerabilityMaxSeverity => _vulnerableCapability.VulnerabilityMaxSeverity;
 
-        public async Task PopulateDataAsync(CancellationToken cancellationToken)
+        public override async Task PopulateDataAsync(CancellationToken cancellationToken)
         {
             await _vulnerableCapability.PopulateDataAsync(cancellationToken);
             await _deprecationCapability.PopulateDataAsync(cancellationToken);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/RemotePackageModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/RemotePackageModel.cs
@@ -61,13 +61,15 @@ namespace NuGet.PackageManagement.UI
 
         public PackageDeprecationReasonEnum PackageDeprecationReasons => _deprecationCapability.PackageDeprecationReasons;
 
+        public AlternatePackageMetadataContextInfo? AlternatePackage => _deprecationCapability.AlternatePackage;
+
         public IReadOnlyList<PackageVulnerabilityMetadataContextInfo>? Vulnerabilities => _vulnerableCapability.Vulnerabilities;
 
         public bool IsVulnerable => _vulnerableCapability.IsVulnerable;
 
         public PackageVulnerabilitySeverity VulnerabilityMaxSeverity => _vulnerableCapability.VulnerabilityMaxSeverity;
 
-        public async Task PopulateDataAsync(CancellationToken cancellationToken)
+        public override async Task PopulateDataAsync(CancellationToken cancellationToken)
         {
             await _vulnerableCapability.PopulateDataAsync(cancellationToken);
             await _deprecationCapability.PopulateDataAsync(cancellationToken);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/VulnerableCapabilityBase.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/VulnerableCapabilityBase.cs
@@ -40,7 +40,7 @@ namespace NuGet.PackageManagement.UI
             {
                 if (!IsVulnerable || Vulnerabilities is null)
                 {
-                    throw new InvalidOperationException("Vulnerabilities is empty");
+                    return PackageVulnerabilitySeverity.Unknown;
                 }
 
                 // Vulnerabilities are ordered on set so the first element is always the highest severity

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -135,7 +135,6 @@ namespace NuGet.PackageManagement.UI
             };
 
             _packageFileService = packageFileService ?? await GetPackageFileServiceAsync(CancellationToken.None);
-            _packageModelFactory = new PackageModelFactory(_searchService, _packageFileService, _packageVulnerabilityService, _includePrerelease, _packageSources);
             _serviceBroker.AvailabilityChanged += OnAvailabilityChanged;
         }
 
@@ -317,6 +316,7 @@ namespace NuGet.PackageManagement.UI
                         knownOwnerViewModels = LoadKnownOwnerViewModels(metadataContextInfo);
                     }
 
+                    _packageModelFactory ??= new PackageModelFactory(_searchService, _packageFileService, _packageVulnerabilityService, _includePrerelease, _packageSources);
                     PackageModel packageModel = _packageModelFactory.Create(metadataContextInfo, _itemFilter);
 
                     var listItem = new PackageItemViewModel(_searchService, packageModel, _packageVulnerabilityService)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -276,7 +275,7 @@ namespace NuGet.PackageManagement.UI
                 {
                     if (packageLevel == PackageLevel.Transitive)
                     {
-                        UpdateTransitiveInfo(existingListItem, metadataContextInfo);
+                        existingListItem.UpdateTransitiveInfo(metadataContextInfo);
                     }
 
                     existingListItem.UpdateInstalledPackagesVulnerabilities(metadataContextInfo.Identity);
@@ -337,8 +336,8 @@ namespace NuGet.PackageManagement.UI
                     }
                     else
                     {
-                        UpdateTransitiveInfo(listItem, metadataContextInfo);
-                        listItem.UpdateTransitivePackageStatus(metadataContextInfo.Identity.Version);
+                        listItem.UpdateTransitiveInfo(metadataContextInfo);
+                        listItem.UpdateTransitivePackageStatus();
                     }
 
                     listItemViewModels[packageId] = listItem;
@@ -346,13 +345,6 @@ namespace NuGet.PackageManagement.UI
             }
 
             return listItemViewModels.Values.ToArray();
-        }
-
-        private static void UpdateTransitiveInfo(PackageItemViewModel listItem, PackageSearchMetadataContextInfo metadataContextInfo)
-        {
-            listItem.TransitiveInstalledVersions.Add(metadataContextInfo.Identity.Version);
-            listItem.TransitiveOrigins.AddRange(metadataContextInfo.TransitiveOrigins);
-            listItem.TransitiveToolTipMessage = string.Format(CultureInfo.CurrentCulture, Resources.PackageVersionWithTransitiveOrigins, string.Join(", ", listItem.TransitiveInstalledVersions), string.Join(", ", listItem.TransitiveOrigins));
         }
 
         private static ImmutableList<KnownOwnerViewModel> LoadKnownOwnerViewModels(PackageSearchMetadataContextInfo metadataContextInfo)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -38,8 +38,9 @@ namespace NuGet.PackageManagement.UI
 
         private readonly CancellationTokenSource _cancellationTokenSource;
         private readonly IPackageVulnerabilityService _vulnerabilityService;
-
         private readonly PackageModel _packageModel;
+        private List<NuGetVersion> _transitiveInstalledVersions;
+        private List<PackageIdentity> _transitiveOrigins;
 
         public PackageItemViewModel(INuGetSearchService searchService, PackageModel packageModel, IPackageVulnerabilityService vulnerabilityService = default)
         {
@@ -47,6 +48,8 @@ namespace NuGet.PackageManagement.UI
             _searchService = searchService;
             _vulnerabilityService = vulnerabilityService;
             _packageModel = packageModel;
+            _transitiveInstalledVersions = [];
+            _transitiveOrigins = [];
         }
 
         // same URIs can reuse the bitmapImage that we've already used.
@@ -74,7 +77,7 @@ namespace NuGet.PackageManagement.UI
 
         public ImmutableList<KnownOwnerViewModel> KnownOwnerViewModels { get; internal set; }
 
-        public string Owner => string.Join(",", _packageModel.OwnersList);
+        public string Owner => string.Join(",", _packageModel.OwnersList ?? []);
 
         public string Author => _packageModel.Authors;
 
@@ -110,32 +113,14 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        public string ByAuthor
-        {
-            get
-            {
-                return !string.IsNullOrWhiteSpace(_packageModel.Authors) ? string.Format(CultureInfo.CurrentCulture, Resx.Text_ByAuthor, _packageModel.Authors) : null;
-            }
-        }
+        public string ByAuthor => !string.IsNullOrWhiteSpace(_packageModel.Authors) ? string.Format(CultureInfo.CurrentCulture, Resx.Text_ByAuthor, _packageModel.Authors) : null;
 
         /// <summary>
         /// Fallback to <see cref="ByAuthor"/> only when <see cref="ByOwner"> is null.
         /// </summary>
-        public string ByOwnerOrAuthor
-        {
-            get
-            {
-                return ByOwner ?? ByAuthor;
-            }
-        }
+        public string ByOwnerOrAuthor => ByOwner ?? ByAuthor;
 
-        public string VulnerableVersionsString
-        {
-            get
-            {
-                return string.Join(", ", VulnerableVersions.Keys);
-            }
-        }
+        public string VulnerableVersionsString => string.Join(", ", VulnerableVersions.Keys);
 
         private readonly Dictionary<NuGetVersion, int> _vulnerableVersions = [];
         public Dictionary<NuGetVersion, int> VulnerableVersions => _vulnerableVersions;
@@ -229,34 +214,6 @@ namespace NuGet.PackageManagement.UI
             {
                 _autoReferenced = value;
                 OnPropertyChanged(nameof(AutoReferenced));
-            }
-        }
-
-        private List<NuGetVersion> _transitiveInstalledVersions;
-        public List<NuGetVersion> TransitiveInstalledVersions
-        {
-            get
-            {
-                if (_transitiveInstalledVersions == null)
-                {
-                    _transitiveInstalledVersions = new();
-                }
-
-                return _transitiveInstalledVersions;
-            }
-        }
-
-        private List<PackageIdentity> _transitiveOrigins;
-        public List<PackageIdentity> TransitiveOrigins
-        {
-            get
-            {
-                if (_transitiveOrigins == null)
-                {
-                    _transitiveOrigins = new();
-                }
-
-                return _transitiveOrigins;
             }
         }
 
@@ -411,35 +368,21 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private bool _isPackageDeprecated;
-        public bool IsPackageDeprecated
-        {
-            get { return _isPackageDeprecated; }
-            set
-            {
-                if (_isPackageDeprecated != value)
-                {
-                    _isPackageDeprecated = value;
-                    OnPropertyChanged(nameof(IsPackageDeprecated));
-                    OnPropertyChanged(nameof(IsPackageWithWarnings));
-                }
-            }
-        }
+        public bool IsPackageDeprecated => (_packageModel as IDeprecationCapable)?.IsDeprecated ?? false;
 
         public bool IsPackageVulnerable => (_packageModel as IVulnerableCapable)?.IsVulnerable ?? false;
 
-        private int _vulnerabilityMaxSeverity = -1;
         public int VulnerabilityMaxSeverity
         {
-            get { return _vulnerabilityMaxSeverity; }
-            set
+            get
             {
-                if (_vulnerabilityMaxSeverity != value)
+                if (VulnerableVersions.Count > 0)
                 {
-                    _vulnerabilityMaxSeverity = value;
-                    OnPropertyChanged(nameof(VulnerabilityMaxSeverity));
-                    OnPropertyChanged(nameof(IsPackageVulnerable));
-                    OnPropertyChanged(nameof(IsPackageWithWarnings));
+                    return VulnerableVersions.Values.Max();
+                }
+                else
+                {
+                    return -1;
                 }
             }
         }
@@ -578,21 +521,22 @@ namespace NuGet.PackageManagement.UI
 #pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
         }
 
-        private PackageDeprecationMetadataContextInfo _deprecationMetadata;
-        public PackageDeprecationMetadataContextInfo DeprecationMetadata
-        {
-            get => _deprecationMetadata;
-            set
-            {
-                if (_deprecationMetadata != value)
-                {
-                    _deprecationMetadata = value;
-                    OnPropertyChanged(nameof(DeprecationMetadata));
-                }
-            }
-        }
+        public AlternatePackageMetadataContextInfo AlternatePackage => (_packageModel as IDeprecationCapable)?.AlternatePackage;
 
         public IEnumerable<PackageVulnerabilityMetadataContextInfo> Vulnerabilities => (_packageModel as IVulnerableCapable)?.Vulnerabilities ?? [];
+
+        public void UpdateTransitiveInfo(PackageSearchMetadataContextInfo metadataContextInfo)
+        {
+            if (metadataContextInfo.TransitiveOrigins == null)
+            {
+                return;
+            }
+
+            _transitiveInstalledVersions.Add(metadataContextInfo.Identity.Version);
+            _transitiveOrigins.AddRange(metadataContextInfo.TransitiveOrigins);
+            TransitiveToolTipMessage = string.Format(CultureInfo.CurrentCulture, Resources.PackageVersionWithTransitiveOrigins, string.Join(", ", _transitiveInstalledVersions), string.Join(", ", _transitiveOrigins));
+            OnPropertyChanged(nameof(TransitiveToolTipMessage));
+        }
 
         private (BitmapSource, IconBitmapStatus) GetInitialIconBitmapAndStatus()
         {
@@ -740,7 +684,7 @@ namespace NuGet.PackageManagement.UI
             BitmapImageCache.Set(cacheKey, iconBitmapImage, policy);
         }
 
-        private async System.Threading.Tasks.Task ReloadPackageVersionsAsync()
+        private async Task ReloadPackageVersionsAsync()
         {
             CancellationToken cancellationToken = _cancellationTokenSource.Token;
             try
@@ -783,18 +727,20 @@ namespace NuGet.PackageManagement.UI
             CancellationToken cancellationToken = _cancellationTokenSource.Token;
             try
             {
-                var identity = new PackageIdentity(Id, Version);
-
-                (PackageSearchMetadataContextInfo packageMetadata, PackageDeprecationMetadataContextInfo deprecationMetadata) =
-                    await _searchService.GetPackageMetadataAsync(identity, Sources, IncludePrerelease, cancellationToken);
-
+                await _packageModel.PopulateDataAsync(cancellationToken);
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
                 cancellationToken.ThrowIfCancellationRequested();
 
-                DeprecationMetadata = deprecationMetadata;
-                IsPackageDeprecated = deprecationMetadata != null;
+                OnPropertyChanged(nameof(IsPackageDeprecated));
+                OnPropertyChanged(nameof(AlternatePackage));
+                OnPropertyChanged(nameof(VulnerabilityMaxSeverity));
+                OnPropertyChanged(nameof(IsPackageVulnerable));
+                OnPropertyChanged(nameof(IsPackageWithWarnings));
 
-                SetVulnerabilityMaxSeverity(identity.Version, packageMetadata?.Vulnerabilities?.FirstOrDefault()?.Severity ?? -1);
+                if (_packageModel is IVulnerableCapable vulnPackage)
+                {
+                    SetVulnerabilityMaxSeverity(Version, (int)vulnPackage.VulnerabilityMaxSeverity);
+                }
             }
             catch (OperationCanceledException)
             {
@@ -850,10 +796,10 @@ namespace NuGet.PackageManagement.UI
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfoList =
-                        await _vulnerabilityService.GetVulnerabilityInfoAsync(packageIdentity, cancellationToken);
+            IVulnerableCapable vulnerabilityDatabaseCapability = new VulnerableDatabaseCapability(_vulnerabilityService, packageIdentity);
+            await vulnerabilityDatabaseCapability.PopulateDataAsync(cancellationToken);
 
-            SetVulnerabilityMaxSeverity(packageIdentity.Version, vulnerabilityInfoList?.FirstOrDefault()?.Severity ?? -1);
+            SetVulnerabilityMaxSeverity(packageIdentity.Version, (int)vulnerabilityDatabaseCapability.VulnerabilityMaxSeverity);
         }
 
         private void SetVulnerabilityMaxSeverity(NuGetVersion version, int maxSeverity)
@@ -864,9 +810,8 @@ namespace NuGet.PackageManagement.UI
                 {
                     OnPropertyChanged(nameof(VulnerableVersions));
                     OnPropertyChanged(nameof(VulnerableVersionsString));
+                    OnPropertyChanged(nameof(VulnerabilityMaxSeverity));
                 }
-
-                VulnerabilityMaxSeverity = Math.Max(VulnerabilityMaxSeverity, maxSeverity);
 
                 OnPropertyChanged(nameof(Status));
             }
@@ -883,36 +828,50 @@ namespace NuGet.PackageManagement.UI
 
         public void UpdatePackageStatus(IEnumerable<PackageCollectionItem> installedPackages, bool clearCache = false)
         {
-            // Get the maximum version installed in any target project/solution
-            InstalledVersion = installedPackages
-                .GetPackageVersions(Id)
-                .MaxOrDefault();
-
-            if (clearCache && InstalledVersion != null)
+            if (PackageLevel == PackageLevel.TopLevel)
             {
-                _searchService.ClearFromCache(Id, Sources, IncludePrerelease);
+                // Get the maximum version installed in any target project/solution
+                InstalledVersion = installedPackages
+                    .GetPackageVersions(Id)
+                    .MaxOrDefault();
+
+                if (clearCache && InstalledVersion != null)
+                {
+                    _searchService.ClearFromCache(Id, Sources, IncludePrerelease);
+                }
+
+                // Set auto referenced to true any reference for the given id contains the flag.
+                AutoReferenced = installedPackages.IsAutoReferenced(Id);
+
+                NuGetUIThreadHelper.JoinableTaskFactory
+                    .RunAsync(ReloadPackageVersionsAsync)
+                    .PostOnFailure(nameof(PackageItemViewModel), nameof(ReloadPackageVersionsAsync));
+
+                NuGetUIThreadHelper.JoinableTaskFactory
+                    .RunAsync(ReloadTopLevelPackageMetadataAsync)
+                    .PostOnFailure(nameof(PackageItemViewModel), nameof(ReloadTopLevelPackageMetadataAsync));
             }
+            else
+            {
+                InstalledVersion = Version;
 
-            // Set auto referenced to true any reference for the given id contains the flag.
-            AutoReferenced = installedPackages.IsAutoReferenced(Id);
+                // Transitive packages cannot be updated and can only be installed as top-level packages with their currently installed version.
+                LatestVersion = InstalledVersion;
 
-            NuGetUIThreadHelper.JoinableTaskFactory
-                .RunAsync(ReloadPackageVersionsAsync)
-                .PostOnFailure(nameof(PackageItemViewModel), nameof(ReloadPackageVersionsAsync));
-
-            NuGetUIThreadHelper.JoinableTaskFactory
-                .RunAsync(ReloadTopLevelPackageMetadataAsync)
-                .PostOnFailure(nameof(PackageItemViewModel), nameof(ReloadTopLevelPackageMetadataAsync));
+                NuGetUIThreadHelper.JoinableTaskFactory
+                    .RunAsync(ReloadTransitivePackageMetadataAsync)
+                    .PostOnFailure(nameof(PackageItemViewModel), nameof(ReloadTransitivePackageMetadataAsync));
+            }
 
             OnPropertyChanged(nameof(Status));
         }
 
-        public void UpdateTransitivePackageStatus(NuGetVersion installedVersion)
+        public void UpdateTransitivePackageStatus()
         {
-            InstalledVersion = installedVersion ?? throw new ArgumentNullException(nameof(installedVersion));
+            InstalledVersion = Version;
 
             // Transitive packages cannot be updated and can only be installed as top-level packages with their currently installed version.
-            LatestVersion = installedVersion;
+            LatestVersion = InstalledVersion;
 
             NuGetUIThreadHelper.JoinableTaskFactory
                 .RunAsync(ReloadTransitivePackageMetadataAsync)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -616,7 +616,7 @@ namespace NuGet.PackageManagement.UI
                 }
                 else
                 {
-                    package.UpdateTransitivePackageStatus(package.InstalledVersion);
+                    package.UpdateTransitivePackageStatus();
                 }
             }
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -256,17 +256,17 @@
             <TextBlock
               Style="{StaticResource TooltipStyle}">
               <Run
-                Text="{Binding Id}"
+                Text="{Binding Id, Mode=OneTime}"
                 FontWeight="Bold" /> <Run Text="{Binding ByOwnerOrAuthor, Mode=OneTime}"/>
             </TextBlock>
             <TextBlock Style="{StaticResource PackageDescriptionToolTipStyle}">
-              <Run Text="{Binding Summary}" />
+              <Run Text="{Binding Summary, Mode=OneTime}" />
             </TextBlock>
             <TextBlock Style="{StaticResource TransitiveInfoToolTipStyle}">
               <Run
                 Text="{x:Static nuget:Resources.ToolTip_TransitiveDependency}"
                 FontWeight="Bold" />
-              <Run Text="{Binding TransitiveToolTipMessage}" />
+              <Run Text="{Binding TransitiveToolTipMessage, Mode=OneTime}" />
               <Run>
                 <Run.Style>
                   <Style TargetType="Run">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -248,7 +248,7 @@
                         Grid.Row="1"
                         FormatStringSingle="{x:Static nuget:Resources.Deprecation_PackageItemMessage}"
                         FormatStringAlternative="{x:Static nuget:Resources.Deprecation_PackageItemMessageAlternative}"
-                        DataContext="{Binding DeprecationMetadata}" />
+                        DataContext="{Binding AlternatePackage}" />
         </Grid>
 
         <Grid.ToolTip>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemDeprecationLabel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemDeprecationLabel.xaml
@@ -40,11 +40,11 @@
               Style="{StaticResource HyperlinkStyleNoUriDeprecation}">
               <Hyperlink.CommandParameter>
                 <MultiBinding Converter="{StaticResource ParametersToHyperlinkTupleConverter}" Mode="OneWay">
-                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="DataContext.AlternatePackage.PackageId" Mode="OneWay" />
+                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="DataContext.PackageId" Mode="OneWay" />
                   <Binding Source="{x:Static nugettel:HyperlinkType.DeprecationAlternativePackageItem}" />
                 </MultiBinding>
               </Hyperlink.CommandParameter>
-              <Run Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DataContext.AlternatePackage.PackageId, Mode=OneWay}" />
+              <Run Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DataContext.PackageId, Mode=OneWay}" />
             </Hyperlink>
           </TextBlock>
           <TextBlock

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1175,7 +1175,7 @@ namespace NuGet.PackageManagement.UI
             var operationId = _packageList.OperationId;
             var selectedIndex = _packageList.SelectedIndex;
             var recommendedCount = _packageList.PackageItems.Count(item => item.Recommended == true);
-            var hasDeprecationAlternative = selectedPackage.DeprecationMetadata?.AlternatePackage != null;
+            var hasDeprecationAlternative = selectedPackage.AlternatePackage != null;
 
             if (_topPanel.Filter == ItemFilter.All
                 && operationId.HasValue

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/DeprecationPackageMetadataCapabilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/DeprecationPackageMetadataCapabilityTests.cs
@@ -4,11 +4,11 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using NuGet.Protocol.Model;
+using NuGet.Versioning;
 using NuGet.VisualStudio.Internal.Contracts;
 using Xunit;
 
@@ -38,7 +38,8 @@ namespace NuGet.PackageManagement.UI.Test
         public async Task PopulateDataAsync_WithValidData_PopulatesDeprecationMetadata()
         {
             // Arrange
-            var deprecationMetadata = new PackageDeprecationMetadataContextInfo("Test message", new List<string> { "Legacy" }, null);
+            var alternatePackageMetadata = new AlternatePackageMetadataContextInfo("Test.Package", It.IsAny<VersionRange>());
+            var deprecationMetadata = new PackageDeprecationMetadataContextInfo("Test message", ["Legacy"], alternatePackageMetadata);
             _packageMetadataRetrievalAdapterMock.Setup(pm => pm.GetPackageDeprecationInfoAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(deprecationMetadata);
 
@@ -48,14 +49,14 @@ namespace NuGet.PackageManagement.UI.Test
             await capability.PopulateDataAsync(CancellationToken.None);
 
             // Assert
-            Assert.Equal(deprecationMetadata, capability.DeprecationMetadata);
+            Assert.Equal(alternatePackageMetadata, capability.AlternatePackage);
         }
 
         [Fact]
         public async Task IsDeprecated_WithDeprecationMetadata_IsTrue()
         {
             // Arrange
-            var deprecationMetadata = new PackageDeprecationMetadataContextInfo("Test message", new List<string> { "Legacy" }, null);
+            var deprecationMetadata = new PackageDeprecationMetadataContextInfo("Test message", ["Legacy"], null);
             _packageMetadataRetrievalAdapterMock.Setup(pm => pm.GetPackageDeprecationInfoAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(deprecationMetadata);
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/NoDeprecationCapabilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/NoDeprecationCapabilityTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Protocol.Model;
+using Xunit;
+
+namespace NuGet.PackageManagement.UI.Test.Models.Package
+{
+    public class NoDeprecationCapabilityTests
+    {
+        [Fact]
+        public void IsDeprecated_UnderAnyCondition_ReturnsFalse()
+        {
+            // Arrange
+            var capability = new NoDeprecationCapability();
+
+            // Act
+            var result = capability.IsDeprecated;
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void PackageDeprecationReasons_UnderAnyCondition_ReturnsUnknown()
+        {
+            // Arrange
+            var capability = new NoDeprecationCapability();
+
+            // Act
+            var result = capability.PackageDeprecationReasons;
+
+            // Assert
+            Assert.Equal(PackageDeprecationReasonEnum.Unknown, result);
+        }
+
+        [Fact]
+        public void AlternatePackage_UnderAnyCondition_ReturnsNull()
+        {
+            // Arrange
+            var capability = new NoDeprecationCapability();
+
+            // Act
+            var result = capability.AlternatePackage;
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task PopulateDataAsync_UnderAnyCondition_ReturnsCompleteTask()
+        {
+            // Arrange
+            var capability = new NoDeprecationCapability();
+            var cancellationToken = CancellationToken.None;
+
+            // Act
+            var task = capability.PopulateDataAsync(cancellationToken);
+            await task;
+
+            // Assert
+            Assert.True(task.IsCompleted);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/TestPackageModel.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/TestPackageModel.cs
@@ -5,6 +5,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 
@@ -28,6 +30,11 @@ namespace NuGet.PackageManagement.UI.Test.Models.Package
             bool requireLicenseAcceptance = false)
             : base(identity, embeddedResources, title, description, authors, projectUrl, tags, ownersList, packageDependencyGroups, summary, publishedDate, licenseMetadata, licenseUrl, requireLicenseAcceptance)
         {
+        }
+
+        public override Task PopulateDataAsync(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/VulnerableCapabilityBaseTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/VulnerableCapabilityBaseTests.cs
@@ -50,23 +50,23 @@ namespace NuGet.PackageManagement.UI.Test.Models.Package
         }
 
         [Fact]
-        public void VulnerabilityMaxSeverity_EmptyVulnerabilitiesList_ThrowsException()
+        public void VulnerabilityMaxSeverity_EmptyVulnerabilitiesList_ReturnsUnknown()
         {
             // Arrange
             var vulnerableCapability = new TestVulnerableCapability([]);
 
             // Act & Assert
-            Assert.Throws<InvalidOperationException>(() => vulnerableCapability.VulnerabilityMaxSeverity);
+            Assert.Equal(PackageVulnerabilitySeverity.Unknown, vulnerableCapability.VulnerabilityMaxSeverity);
         }
 
         [Fact]
-        public void VulnerabilityMaxSeverity_NullVulnerabilitiesList_ThrowsException()
+        public void VulnerabilityMaxSeverity_NullVulnerabilitiesList_ReturnsUnknown()
         {
             // Arrange
             var vulnerableCapability = new TestVulnerableCapability(null);
 
             // Act & Assert
-            Assert.Throws<InvalidOperationException>(() => vulnerableCapability.VulnerabilityMaxSeverity);
+            Assert.Equal(PackageVulnerabilitySeverity.Unknown, vulnerableCapability.VulnerabilityMaxSeverity);
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageManagerListItemsTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageManagerListItemsTest.cs
@@ -9,6 +9,7 @@ using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Sdk.TestFramework;
 using Microsoft.VisualStudio.Threading;
 using Moq;
+using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -28,6 +29,7 @@ namespace NuGet.PackageManagement.UI.Test
             var uiContext = new Mock<INuGetUIContext>();
             var searchService = Mock.Of<INuGetSearchService>();
             var packageFileService = Mock.Of<INuGetPackageFileService>();
+            var packageVulnerabilityService = Mock.Of<IPackageVulnerabilityService>();
 
             uiContext.Setup(x => x.SolutionManagerService)
                 .Returns(solutionManager);
@@ -57,7 +59,8 @@ namespace NuGet.PackageManagement.UI.Test
                 searchService,
                 packageFileService,
                 "EntityFramework",
-                includePrerelease: false);
+                includePrerelease: false,
+                vulnerabilityService: packageVulnerabilityService);
 
             var packageSearchMetadata = new PackageSearchMetadataBuilder.ClonedPackageSearchMetadata()
             {
@@ -90,6 +93,7 @@ namespace NuGet.PackageManagement.UI.Test
             var uiContext = new Mock<INuGetUIContext>();
             var searchService = Mock.Of<INuGetSearchService>();
             var packageFileService = Mock.Of<INuGetPackageFileService>();
+            var packageVulnerabilityService = Mock.Of<IPackageVulnerabilityService>();
 
             uiContext.Setup(x => x.SolutionManagerService)
                 .Returns(solutionManager);
@@ -125,7 +129,8 @@ namespace NuGet.PackageManagement.UI.Test
                 searchService,
                 packageFileService,
                 "EntityFramework",
-                includePrerelease: false);
+                includePrerelease: false,
+                vulnerabilityService: packageVulnerabilityService);
 
             var packageSearchMetadata = new PackageSearchMetadataBuilder.ClonedPackageSearchMetadata()
             {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageItemViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageItemViewModelTests.cs
@@ -307,7 +307,7 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
         [Fact]
         public void UpdateTransitivePackageStatus_WhenGivenInstalledVersion_SetsLatestVersionEqualToInstalledVersion()
         {
-            _testInstance.UpdateTransitivePackageStatus(new NuGetVersion("1.0.0"));
+            _testInstance.UpdateTransitivePackageStatus();
             Assert.Equal(_testInstance.LatestVersion, _testInstance.InstalledVersion);
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
Makes use of the package model and its capabilities to hydrate the vulnerabilities and deprecation data from metadata.
It also makes better use of the model in the ViewModel, filling in properties that were not plumbed through yet.
In addition, some fixes were made to get the code to run successfully, namely fixing the tooltip binding mode for the Package ID. The Tooltip in XAML seems to default to wanting to write to the source property so we set it to OneTime binding mode so it does not attempt to write to the readonly property.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~
