### PR TITLE
Handle GetFiles Exceptions during plugin discovery

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
@@ -208,7 +208,12 @@ namespace NuGet.Protocol.Plugins
                     }
                     else if (Directory.Exists(path))
                     {
-                        pluginFiles.AddRange(GetNetToolsPluginsInDirectory(path) ?? new List<PluginFile>());
+                        List<PluginFile> plugins = GetNetToolsPluginsInDirectory(path);
+
+                        if (plugins != null)
+                        {
+                            pluginFiles.AddRange(plugins);
+                        }
                     }
                 }
                 else
@@ -234,7 +239,12 @@ namespace NuGet.Protocol.Plugins
             {
                 if (PathValidator.IsValidLocalPath(path) || PathValidator.IsValidUncPath(path))
                 {
-                    pluginFiles.AddRange(GetNetToolsPluginsInDirectory(path) ?? new List<PluginFile>());
+                    List<PluginFile> plugins = GetNetToolsPluginsInDirectory(path);
+
+                    if (plugins != null)
+                    {
+                        pluginFiles.AddRange(plugins);
+                    }
                 }
             }
 
@@ -243,7 +253,7 @@ namespace NuGet.Protocol.Plugins
 
         private static List<PluginFile> GetNetToolsPluginsInDirectory(string directoryPath)
         {
-            var pluginFiles = new List<PluginFile>();
+            List<PluginFile> pluginFiles = null;
 
             if (!Directory.Exists(directoryPath))
             {
@@ -260,6 +270,7 @@ namespace NuGet.Protocol.Plugins
                     if (IsValidPluginFile(file))
                     {
                         PluginFile pluginFile = new PluginFile(file.FullName, new Lazy<PluginFileState>(() => PluginFileState.Valid), requiresDotnetHost: false);
+                        pluginFiles ??= [];
                         pluginFiles.Add(pluginFile);
                     }
                 }
@@ -268,6 +279,7 @@ namespace NuGet.Protocol.Plugins
             catch (SecurityException) { }
             catch (PathTooLongException) { }
             catch (DirectoryNotFoundException) { }
+            catch (DriveNotFoundException) { }
 
             return pluginFiles;
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -244,7 +245,12 @@ namespace NuGet.Protocol.Plugins
         {
             var pluginFiles = new List<PluginFile>();
 
-            if (Directory.Exists(directoryPath))
+            if (!Directory.Exists(directoryPath))
+            {
+                return pluginFiles;
+            }
+
+            try
             {
                 var directoryInfo = new DirectoryInfo(directoryPath);
                 var files = directoryInfo.GetFiles("nuget-plugin-*");
@@ -258,6 +264,10 @@ namespace NuGet.Protocol.Plugins
                     }
                 }
             }
+            catch (UnauthorizedAccessException) { }
+            catch (SecurityException) { }
+            catch (PathTooLongException) { }
+            catch (DirectoryNotFoundException) { }
 
             return pluginFiles;
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14192

## Description

Prevent `GetFiles` from Blocking on Inaccessible Folders

This PR ensures that `GetNetToolsPluginsInDirectory` skips folders that throw access-related exceptions, allowing the plugin search to continue without interruption. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
