### PR TITLE
Improve Central Package Management error detection and fix NullReferenceException

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -769,7 +769,7 @@ namespace NuGet.Commands
 
             if (!restoreRequest.PackageSourceMapping.IsEnabled && httpSourcesCount > 1)
             {
-                // Log a warning if there are more than one configured source and package source mapping is not enabled
+                // Log a warning if there are more than one configured HTTP source and package source mapping is not enabled
                 await _logger.LogAsync(
                     RestoreLogMessage.CreateWarning(
                         NuGetLogCode.NU1507,
@@ -780,15 +780,11 @@ namespace NuGet.Commands
                             string.Join(", ", restoreRequest.DependencyProviders.RemoteProviders.Where(i => i.IsHttp).Select(i => i.Source.Name)))));
             }
 
-            List<LibraryDependency> dependenciesWithVersionOverride = restoreRequest.Project.RestoreMetadata.CentralPackageVersionOverrideDisabled ? new() : null;
-
-            List<LibraryDependency> dependenciesWithDefinedVersion = new();
-
-            List<LibraryDependency> autoReferencedAndDefinedInCentralFile = new();
-
-            List<LibraryDependency> packageReferencedDependenciesWithoutCentralVersionDefined = new();
-
-            List<CentralPackageVersion> floatingVersionDependencies = restoreRequest.Project.RestoreMetadata.CentralPackageFloatingVersionsEnabled ? null : new();
+            List<CentralPackageVersion> packageVersionItemsWithFloatingVersion = null;
+            List<LibraryDependency> implicitPackageReferenceItemsWithPackageVersion = null;
+            List<LibraryDependency> packageReferenceItemsWithNoPackageVersion = null;
+            List<LibraryDependency> packageReferenceItemsWithVersion = null;
+            List<LibraryDependency> packageReferenceItemsWithVersionOverride = null;
 
             foreach (TargetFrameworkInformation targetFrameworkInformation in _request.Project.TargetFrameworks)
             {
@@ -799,7 +795,9 @@ namespace NuGet.Commands
                         // Implicitly defined packages that the user specified a version for
                         if (targetFrameworkInformation.CentralPackageVersions.ContainsKey(libraryDependency.Name))
                         {
-                            autoReferencedAndDefinedInCentralFile.Add(libraryDependency);
+                            implicitPackageReferenceItemsWithPackageVersion ??= new();
+
+                            implicitPackageReferenceItemsWithPackageVersion.Add(libraryDependency);
                         }
                     }
                     else
@@ -807,19 +805,25 @@ namespace NuGet.Commands
                         // VersionOverride is specified but that functionality is disabled
                         if (restoreRequest.Project.RestoreMetadata.CentralPackageVersionOverrideDisabled && libraryDependency.VersionOverride != null)
                         {
-                            dependenciesWithVersionOverride.Add(libraryDependency);
+                            packageReferenceItemsWithVersionOverride ??= new();
+
+                            packageReferenceItemsWithVersionOverride.Add(libraryDependency);
                         }
 
                         // Dependencies that have a version specified
                         if (!libraryDependency.VersionCentrallyManaged && libraryDependency.LibraryRange.VersionRange != null && libraryDependency.VersionOverride == null)
                         {
-                            dependenciesWithDefinedVersion.Add(libraryDependency);
+                            packageReferenceItemsWithVersion ??= new();
+
+                            packageReferenceItemsWithVersion.Add(libraryDependency);
                         }
 
                         // Dependencies that have no version specified
                         if (libraryDependency.LibraryRange?.VersionRange == null)
                         {
-                            packageReferencedDependenciesWithoutCentralVersionDefined.Add(libraryDependency);
+                            packageReferenceItemsWithNoPackageVersion ??= new();
+
+                            packageReferenceItemsWithNoPackageVersion.Add(libraryDependency);
                         }
                     }
                 }
@@ -831,66 +835,71 @@ namespace NuGet.Commands
                         // Floating version dependencies
                         if (centralPackageVersion.Value.VersionRange.IsFloating)
                         {
-                            floatingVersionDependencies.Add(centralPackageVersion.Value);
+                            packageVersionItemsWithFloatingVersion ??= new();
+
+                            packageVersionItemsWithFloatingVersion.Add(centralPackageVersion.Value);
                         }
                     }
                 }
             }
 
-            if (dependenciesWithDefinedVersion.Count > 0)
+            if (packageReferenceItemsWithVersion != null && packageReferenceItemsWithVersion.Count > 0)
             {
+                result = false;
+
                 await _logger.LogAsync(
                     RestoreLogMessage.CreateError(
                         NuGetLogCode.NU1008,
                         string.Format(
                             CultureInfo.CurrentCulture,
                             Strings.Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed,
-                            string.Join(", ", dependenciesWithDefinedVersion.Select(d => d.Name)))));
-
-                result = false;
+                            string.Join(", ", packageReferenceItemsWithVersion.Select(d => d.Name)))));
             }
 
-            if (autoReferencedAndDefinedInCentralFile.Count > 0)
+            if (implicitPackageReferenceItemsWithPackageVersion != null && implicitPackageReferenceItemsWithPackageVersion.Count > 0)
             {
+                result = false;
+
                 await _logger.LogAsync(
                     RestoreLogMessage.CreateError(
                         NuGetLogCode.NU1009,
                         string.Format(
                             CultureInfo.CurrentCulture,
                             Strings.Error_CentralPackageManagement_ImplicitPackageReferenceWithVersionNotAllowed,
-                            string.Join(", ", autoReferencedAndDefinedInCentralFile.Select(d => d.Name)))));
-
-                result = false;
+                            string.Join(", ", implicitPackageReferenceItemsWithPackageVersion.Select(d => d.Name)))));
             }
 
-            if (packageReferencedDependenciesWithoutCentralVersionDefined.Count > 0)
+            if (packageReferenceItemsWithNoPackageVersion != null && packageReferenceItemsWithNoPackageVersion.Count > 0)
             {
+                result = false;
+
                 await _logger.LogAsync(
                     RestoreLogMessage.CreateError(
                         NuGetLogCode.NU1010,
                         string.Format(
                             CultureInfo.CurrentCulture,
                             Strings.Error_CentralPackageManagement_MissingPackageVersion,
-                            string.Join(", ", packageReferencedDependenciesWithoutCentralVersionDefined.Select(d => d.Name)))));
-
-                result = false;
+                            string.Join(", ", packageReferenceItemsWithNoPackageVersion.Select(d => d.Name)))));
             }
 
-            if (floatingVersionDependencies != null && floatingVersionDependencies.Count > 0)
+            if (packageVersionItemsWithFloatingVersion != null && packageVersionItemsWithFloatingVersion.Count > 0)
             {
+                result = false;
+
                 await _logger.LogAsync(
                     RestoreLogMessage.CreateError(
                         NuGetLogCode.NU1011,
-                        Strings.Error_CentralPackageManagement_FloatingVersionsNotAllowed));
-
-                result = false;
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.Error_CentralPackageManagement_FloatingVersionsNotAllowed,
+                            string.Join(", ", packageVersionItemsWithFloatingVersion.Select(i => i.Name)))));
             }
 
-            if (dependenciesWithVersionOverride != null)
+            if (packageReferenceItemsWithVersionOverride != null && packageReferenceItemsWithVersionOverride.Count > 0)
             {
                 result = false;
 
-                foreach (var item in dependenciesWithVersionOverride)
+                foreach (var item in packageReferenceItemsWithVersionOverride)
                 {
                     await _logger.LogAsync(
                         RestoreLogMessage.CreateError(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -775,7 +775,7 @@ namespace NuGet.Commands
                         NuGetLogCode.NU1507,
                         string.Format(
                             CultureInfo.CurrentCulture,
-                            Strings.Warning_CentralPackageVersions_MultipleSourcesWithoutPackageSourceMapping,
+                            Strings.Warning_CentralPackageManagement_MultipleSourcesWithoutPackageSourceMapping,
                             httpSourcesCount,
                             string.Join(", ", restoreRequest.DependencyProviders.RemoteProviders.Where(i => i.IsHttp).Select(i => i.Source.Name)))));
             }
@@ -844,7 +844,7 @@ namespace NuGet.Commands
                         NuGetLogCode.NU1008,
                         string.Format(
                             CultureInfo.CurrentCulture,
-                            Strings.Error_CentralPackageVersions_VersionsNotAllowed,
+                            Strings.Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed,
                             string.Join(", ", dependenciesWithDefinedVersion.Select(d => d.Name)))));
 
                 result = false;
@@ -857,7 +857,7 @@ namespace NuGet.Commands
                         NuGetLogCode.NU1009,
                         string.Format(
                             CultureInfo.CurrentCulture,
-                            Strings.Error_CentralPackageVersions_AutoreferencedReferencesNotAllowed,
+                            Strings.Error_CentralPackageManagement_ImplicitPackageReferenceWithVersionNotAllowed,
                             string.Join(", ", autoReferencedAndDefinedInCentralFile.Select(d => d.Name)))));
 
                 result = false;
@@ -870,7 +870,7 @@ namespace NuGet.Commands
                         NuGetLogCode.NU1010,
                         string.Format(
                             CultureInfo.CurrentCulture,
-                            Strings.Error_CentralPackageVersions_MissingPackageVersion,
+                            Strings.Error_CentralPackageManagement_MissingPackageVersion,
                             string.Join(", ", packageReferencedDependenciesWithoutCentralVersionDefined.Select(d => d.Name)))));
 
                 result = false;
@@ -881,7 +881,7 @@ namespace NuGet.Commands
                 await _logger.LogAsync(
                     RestoreLogMessage.CreateError(
                         NuGetLogCode.NU1011,
-                        Strings.Error_CentralPackageVersions_FloatingVersionsAreNotAllowed));
+                        Strings.Error_CentralPackageManagement_FloatingVersionsNotAllowed));
 
                 result = false;
             }
@@ -897,7 +897,7 @@ namespace NuGet.Commands
                             NuGetLogCode.NU1013,
                             string.Format(
                                 CultureInfo.CurrentCulture,
-                                Strings.Error_CentralPackageVersions_VersionOverrideDisabled,
+                                Strings.Error_CentralPackageManagement_VersionOverrideNotAllowed,
                                 item.Name)));
                 }
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -765,62 +765,144 @@ namespace NuGet.Commands
                 return true;
             }
 
-            IEnumerable<LibraryDependency> dependenciesWithVersionOverride = restoreRequest.Project.TargetFrameworks.SelectMany(tfm => tfm.Dependencies.Where(d => !d.AutoReferenced && d.VersionOverride != null));
-
-            if (restoreRequest.Project.RestoreMetadata.CentralPackageVersionOverrideDisabled)
-            {
-                // Emit a error if VersionOverride was specified for a package reference but that functionality is disabled
-                bool hasVersionOverrides = false;
-                foreach (var item in dependenciesWithVersionOverride)
-                {
-                    await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1013, string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageVersions_VersionOverrideDisabled, item.Name)));
-                    hasVersionOverrides = true;
-                }
-
-                if (hasVersionOverrides)
-                {
-                    return false;
-                }
-            }
+            bool result = true;
 
             if (!restoreRequest.PackageSourceMapping.IsEnabled && httpSourcesCount > 1)
             {
                 // Log a warning if there are more than one configured source and package source mapping is not enabled
-                await _logger.LogAsync(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1507, string.Format(CultureInfo.CurrentCulture, Strings.Warning_CentralPackageVersions_MultipleSourcesWithoutPackageSourceMapping, httpSourcesCount, string.Join(", ", restoreRequest.DependencyProviders.RemoteProviders.Where(i => i.IsHttp).Select(i => i.Source.Name)))));
+                await _logger.LogAsync(
+                    RestoreLogMessage.CreateWarning(
+                        NuGetLogCode.NU1507,
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.Warning_CentralPackageVersions_MultipleSourcesWithoutPackageSourceMapping,
+                            httpSourcesCount,
+                            string.Join(", ", restoreRequest.DependencyProviders.RemoteProviders.Where(i => i.IsHttp).Select(i => i.Source.Name)))));
             }
 
-            // The dependencies should not have versions explicitly defined if cpvm is enabled.
-            IEnumerable<LibraryDependency> dependenciesWithDefinedVersion = _request.Project.TargetFrameworks.SelectMany(tfm => tfm.Dependencies.Where(d => !d.VersionCentrallyManaged && !d.AutoReferenced && d.VersionOverride == null));
-            if (dependenciesWithDefinedVersion.Any())
-            {
-                await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1008, string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageVersions_VersionsNotAllowed, string.Join(";", dependenciesWithDefinedVersion.Select(d => d.Name)))));
-                return false;
-            }
-            IEnumerable<LibraryDependency> autoReferencedAndDefinedInCentralFile = _request.Project.TargetFrameworks.SelectMany(tfm => tfm.Dependencies.Where(d => d.AutoReferenced && tfm.CentralPackageVersions.ContainsKey(d.Name)));
-            if (autoReferencedAndDefinedInCentralFile.Any())
-            {
-                await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1009, string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageVersions_AutoreferencedReferencesNotAllowed, string.Join(";", autoReferencedAndDefinedInCentralFile.Select(d => d.Name)))));
+            List<LibraryDependency> dependenciesWithVersionOverride = restoreRequest.Project.RestoreMetadata.CentralPackageVersionOverrideDisabled ? new() : null;
 
-                return false;
-            }
-            IEnumerable<LibraryDependency> packageReferencedDependenciesWithoutCentralVersionDefined = _request.Project.TargetFrameworks.SelectMany(tfm => tfm.Dependencies.Where(d => d.LibraryRange.VersionRange == null));
-            if (packageReferencedDependenciesWithoutCentralVersionDefined.Any())
-            {
-                await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1010, string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageVersions_MissingPackageVersion, string.Join(";", packageReferencedDependenciesWithoutCentralVersionDefined.Select(d => d.Name)))));
-                return false;
-            }
+            List<LibraryDependency> dependenciesWithDefinedVersion = new();
 
-            if (!restoreRequest.Project.RestoreMetadata.CentralPackageFloatingVersionsEnabled)
+            List<LibraryDependency> autoReferencedAndDefinedInCentralFile = new();
+
+            List<LibraryDependency> packageReferencedDependenciesWithoutCentralVersionDefined = new();
+
+            List<CentralPackageVersion> floatingVersionDependencies = restoreRequest.Project.RestoreMetadata.CentralPackageFloatingVersionsEnabled ? null : new();
+
+            foreach (TargetFrameworkInformation targetFrameworkInformation in _request.Project.TargetFrameworks)
             {
-                var floatingVersionDependencies = _request.Project.TargetFrameworks.SelectMany(tfm => tfm.CentralPackageVersions.Values).Where(cpv => cpv.VersionRange.IsFloating);
-                if (floatingVersionDependencies.Any())
+                foreach (LibraryDependency libraryDependency in targetFrameworkInformation.Dependencies)
                 {
-                    await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1011, Strings.Error_CentralPackageVersions_FloatingVersionsAreNotAllowed));
-                    return false;
+                    if (libraryDependency.AutoReferenced)
+                    {
+                        // Implicitly defined packages that the user specified a version for
+                        if (targetFrameworkInformation.CentralPackageVersions.ContainsKey(libraryDependency.Name))
+                        {
+                            autoReferencedAndDefinedInCentralFile.Add(libraryDependency);
+                        }
+                    }
+                    else
+                    {
+                        // VersionOverride is specified but that functionality is disabled
+                        if (restoreRequest.Project.RestoreMetadata.CentralPackageVersionOverrideDisabled && libraryDependency.VersionOverride != null)
+                        {
+                            dependenciesWithVersionOverride.Add(libraryDependency);
+                        }
+
+                        // Dependencies that have a version specified
+                        if (!libraryDependency.VersionCentrallyManaged && libraryDependency.LibraryRange.VersionRange != null && libraryDependency.VersionOverride == null)
+                        {
+                            dependenciesWithDefinedVersion.Add(libraryDependency);
+                        }
+
+                        // Dependencies that have no version specified
+                        if (libraryDependency.LibraryRange?.VersionRange == null)
+                        {
+                            packageReferencedDependenciesWithoutCentralVersionDefined.Add(libraryDependency);
+                        }
+                    }
+                }
+
+                if (!restoreRequest.Project.RestoreMetadata.CentralPackageFloatingVersionsEnabled)
+                {
+                    foreach (KeyValuePair<string, CentralPackageVersion> centralPackageVersion in targetFrameworkInformation.CentralPackageVersions.NoAllocEnumerate())
+                    {
+                        // Floating version dependencies
+                        if (centralPackageVersion.Value.VersionRange.IsFloating)
+                        {
+                            floatingVersionDependencies.Add(centralPackageVersion.Value);
+                        }
+                    }
                 }
             }
 
-            return true;
+            if (dependenciesWithDefinedVersion.Count > 0)
+            {
+                await _logger.LogAsync(
+                    RestoreLogMessage.CreateError(
+                        NuGetLogCode.NU1008,
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.Error_CentralPackageVersions_VersionsNotAllowed,
+                            string.Join(", ", dependenciesWithDefinedVersion.Select(d => d.Name)))));
+
+                result = false;
+            }
+
+            if (autoReferencedAndDefinedInCentralFile.Count > 0)
+            {
+                await _logger.LogAsync(
+                    RestoreLogMessage.CreateError(
+                        NuGetLogCode.NU1009,
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.Error_CentralPackageVersions_AutoreferencedReferencesNotAllowed,
+                            string.Join(", ", autoReferencedAndDefinedInCentralFile.Select(d => d.Name)))));
+
+                result = false;
+            }
+
+            if (packageReferencedDependenciesWithoutCentralVersionDefined.Count > 0)
+            {
+                await _logger.LogAsync(
+                    RestoreLogMessage.CreateError(
+                        NuGetLogCode.NU1010,
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.Error_CentralPackageVersions_MissingPackageVersion,
+                            string.Join(", ", packageReferencedDependenciesWithoutCentralVersionDefined.Select(d => d.Name)))));
+
+                result = false;
+            }
+
+            if (floatingVersionDependencies != null && floatingVersionDependencies.Count > 0)
+            {
+                await _logger.LogAsync(
+                    RestoreLogMessage.CreateError(
+                        NuGetLogCode.NU1011,
+                        Strings.Error_CentralPackageVersions_FloatingVersionsAreNotAllowed));
+
+                result = false;
+            }
+
+            if (dependenciesWithVersionOverride != null)
+            {
+                result = false;
+
+                foreach (var item in dependenciesWithVersionOverride)
+                {
+                    await _logger.LogAsync(
+                        RestoreLogMessage.CreateError(
+                            NuGetLogCode.NU1013,
+                            string.Format(
+                                CultureInfo.CurrentCulture,
+                                Strings.Error_CentralPackageVersions_VersionOverrideDisabled,
+                                item.Name)));
+                }
+            }
+
+            return result;
         }
 
         private string ConcatAsString<T>(IEnumerable<T> enumerable)

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -223,7 +223,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The PackageVersion items &apos;{0}&apos; cannot specify a floating version. For more information on how to enable this functionality for projects using Central Package Management, visit https://aka.ms/nu1011.
+        ///   Looks up a localized string similar to The following PackageVersion items cannot specify a floating version: {0}. For more information on how to enable this functionality for projects using Central Package Management, visit https://aka.ms/nu1011.
         /// </summary>
         internal static string Error_CentralPackageManagement_FloatingVersionsNotAllowed {
             get {
@@ -232,7 +232,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The PackageReference items &apos;{0}&apos; are implicitly defined and cannot define a PackageVersion item.  Projects using Central Package Management require that implicit package versions be specified by the PackageReference item. For more information, visit https://aka.ms/sdkimplicitrefs.
+        ///   Looks up a localized string similar to The following PackageReference items are implicitly defined and cannot define a PackageVersion item: {0}. Projects using Central Package Management require that implicit package versions be specified by the PackageReference item. For more information, visit https://aka.ms/sdkimplicitrefs.
         /// </summary>
         internal static string Error_CentralPackageManagement_ImplicitPackageReferenceWithVersionNotAllowed {
             get {
@@ -241,7 +241,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The PackageReference items &apos;{0}&apos; do not define a corresponding PackageVersion item. Projects using Central Package Management must declare PackageReference and PackageVersion items with matching names. For more information, visit https://aka.ms/nuget/cpm/gettingstarted.
+        ///   Looks up a localized string similar to The following PackageReference items do not define a corresponding PackageVersion item: {0}. Projects using Central Package Management must declare PackageReference and PackageVersion items with matching names. For more information, visit https://aka.ms/nuget/cpm/gettingstarted.
         /// </summary>
         internal static string Error_CentralPackageManagement_MissingPackageVersion {
             get {
@@ -250,7 +250,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The PackageReference items &apos;{0}&apos; cannot define a value for Version.  Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted.
+        ///   Looks up a localized string similar to The following PackageReference items cannot define a value for Version: {0}. Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted.
         /// </summary>
         internal static string Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed {
             get {
@@ -259,7 +259,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The PackageReference items &apos;{0}&apos; cannot specify a value for VersionOverride.  Projects using Central Package Management are currently configured to disable this functionality. For more information, visit https://aka.ms/nuget/cpm/versionoverride.
+        ///   Looks up a localized string similar to The following PackageReference items cannot specify a value for VersionOverride: {0}.  Projects using Central Package Management are currently configured to disable this functionality. For more information, visit https://aka.ms/nuget/cpm/versionoverride.
         /// </summary>
         internal static string Error_CentralPackageManagement_VersionOverrideNotAllowed {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -223,47 +223,47 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The packages {0} are implicitly referenced. You do not typically need to reference them from your project or in your central package versions management file. For more information, see https://aka.ms/sdkimplicitrefs.
+        ///   Looks up a localized string similar to The PackageVersion items &apos;{0}&apos; cannot specify a floating version. For more information on how to enable this functionality for projects using Central Package Management, visit https://aka.ms/nu1011.
         /// </summary>
-        internal static string Error_CentralPackageVersions_AutoreferencedReferencesNotAllowed {
+        internal static string Error_CentralPackageManagement_FloatingVersionsNotAllowed {
             get {
-                return ResourceManager.GetString("Error_CentralPackageVersions_AutoreferencedReferencesNotAllowed", resourceCulture);
+                return ResourceManager.GetString("Error_CentralPackageManagement_FloatingVersionsNotAllowed", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Centrally defined floating package versions are not allowed..
+        ///   Looks up a localized string similar to The PackageReference items &apos;{0}&apos; are implicitly defined and cannot define a PackageVersion item.  Projects using Central Package Management require that implicit package versions be specified by the PackageReference item. For more information, visit https://aka.ms/sdkimplicitrefs.
         /// </summary>
-        internal static string Error_CentralPackageVersions_FloatingVersionsAreNotAllowed {
+        internal static string Error_CentralPackageManagement_ImplicitPackageReferenceWithVersionNotAllowed {
             get {
-                return ResourceManager.GetString("Error_CentralPackageVersions_FloatingVersionsAreNotAllowed", resourceCulture);
+                return ResourceManager.GetString("Error_CentralPackageManagement_ImplicitPackageReferenceWithVersionNotAllowed", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The PackageReference items {0} do not have corresponding PackageVersion..
+        ///   Looks up a localized string similar to The PackageReference items &apos;{0}&apos; do not define a corresponding PackageVersion item. Projects using Central Package Management must declare PackageReference and PackageVersion items with matching names. For more information, visit https://aka.ms/nuget/cpm/gettingstarted.
         /// </summary>
-        internal static string Error_CentralPackageVersions_MissingPackageVersion {
+        internal static string Error_CentralPackageManagement_MissingPackageVersion {
             get {
-                return ResourceManager.GetString("Error_CentralPackageVersions_MissingPackageVersion", resourceCulture);
+                return ResourceManager.GetString("Error_CentralPackageManagement_MissingPackageVersion", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package reference {0} specifies a VersionOverride but the ability to override a centrally defined version is currently disabled..
+        ///   Looks up a localized string similar to The PackageReference items &apos;{0}&apos; cannot define a value for Version.  Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted.
         /// </summary>
-        internal static string Error_CentralPackageVersions_VersionOverrideDisabled {
+        internal static string Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed {
             get {
-                return ResourceManager.GetString("Error_CentralPackageVersions_VersionOverrideDisabled", resourceCulture);
+                return ResourceManager.GetString("Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion items: {0}..
+        ///   Looks up a localized string similar to The PackageReference items &apos;{0}&apos; cannot specify a value for VersionOverride.  Projects using Central Package Management are currently configured to disable this functionality. For more information, visit https://aka.ms/nuget/cpm/versionoverride.
         /// </summary>
-        internal static string Error_CentralPackageVersions_VersionsNotAllowed {
+        internal static string Error_CentralPackageManagement_VersionOverrideNotAllowed {
             get {
-                return ResourceManager.GetString("Error_CentralPackageVersions_VersionsNotAllowed", resourceCulture);
+                return ResourceManager.GetString("Error_CentralPackageManagement_VersionOverrideNotAllowed", resourceCulture);
             }
         }
         
@@ -2512,9 +2512,9 @@ namespace NuGet.Commands {
         /// <summary>
         ///   Looks up a localized string similar to There are {0} package sources defined in your configuration. When using central package management, please map your package sources with package source mapping (https://aka.ms/nuget-package-source-mapping) or specify a single package source. The following sources are defined: {1}.
         /// </summary>
-        internal static string Warning_CentralPackageVersions_MultipleSourcesWithoutPackageSourceMapping {
+        internal static string Warning_CentralPackageManagement_MultipleSourcesWithoutPackageSourceMapping {
             get {
-                return ResourceManager.GetString("Warning_CentralPackageVersions_MultipleSourcesWithoutPackageSourceMapping", resourceCulture);
+                return ResourceManager.GetString("Warning_CentralPackageManagement_MultipleSourcesWithoutPackageSourceMapping", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -793,24 +793,43 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <comment>0 - package ID, 1 - expected Sha, 2 - actual sha</comment>
   </data>
   <data name="Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed" xml:space="preserve">
-    <value>The PackageReference items '{0}' cannot define a value for Version.  Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</value>
-    <comment>0 - Comma delimited list of the package IDs that specified a Version</comment>
+    <value>The following PackageReference items cannot define a value for Version: {0}. Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</value>
+    <comment>
+      0 - Comma delimited list of the package IDs that specified a Version
+      Do not localize `PackageReference`
+      Do not localize `PackageVersion`
+    </comment>
   </data>
   <data name="Error_CentralPackageManagement_ImplicitPackageReferenceWithVersionNotAllowed" xml:space="preserve">
-    <value>The PackageReference items '{0}' are implicitly defined and cannot define a PackageVersion item.  Projects using Central Package Management require that implicit package versions be specified by the PackageReference item. For more information, visit https://aka.ms/sdkimplicitrefs</value>
-    <comment>0 - Comma delimited list of the package IDs that were implicitly defined and should not have a PackageVersion item</comment>
+    <value>The following PackageReference items are implicitly defined and cannot define a PackageVersion item: {0}. Projects using Central Package Management require that implicit package versions be specified by the PackageReference item. For more information, visit https://aka.ms/sdkimplicitrefs</value>
+    <comment>
+      0 - Comma delimited list of the package IDs that were implicitly defined and should not have a PackageVersion item
+      Do not localize `PackageReference`
+      Do not localize `PackageVersion`
+  </comment>
   </data>
   <data name="Error_CentralPackageManagement_MissingPackageVersion" xml:space="preserve">
-    <value>The PackageReference items '{0}' do not define a corresponding PackageVersion item. Projects using Central Package Management must declare PackageReference and PackageVersion items with matching names. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</value>
-    <comment>0 - The comma delimited list of package names that did not have a version specified.</comment>
+    <value>The following PackageReference items do not define a corresponding PackageVersion item: {0}. Projects using Central Package Management must declare PackageReference and PackageVersion items with matching names. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</value>
+    <comment>
+      0 - The comma delimited list of package names that did not have a version specified.
+      Do not localize `PackageReference`
+      Do not localize `PackageVersion`
+    </comment>
   </data>
   <data name="Error_CentralPackageManagement_FloatingVersionsNotAllowed" xml:space="preserve">
-    <value>The PackageVersion items '{0}' cannot specify a floating version. For more information on how to enable this functionality for projects using Central Package Management, visit https://aka.ms/nu1011</value>
-    <comment>0 - The comma delimited list of package names that specified a floating version.</comment>
+    <value>The following PackageVersion items cannot specify a floating version: {0}. For more information on how to enable this functionality for projects using Central Package Management, visit https://aka.ms/nu1011</value>
+    <comment>
+      0 - The comma delimited list of package names that specified a floating version.
+      Do not localize `PackageVersion`
+  </comment>
   </data>
   <data name="Error_CentralPackageManagement_VersionOverrideNotAllowed" xml:space="preserve">
-    <value>The PackageReference items '{0}' cannot specify a value for VersionOverride.  Projects using Central Package Management are currently configured to disable this functionality. For more information, visit https://aka.ms/nuget/cpm/versionoverride</value>
-    <comment>0 - The comma delimited list of package names that specified a value for VersionOverride.</comment>
+    <value>The following PackageReference items cannot specify a value for VersionOverride: {0}.  Projects using Central Package Management are currently configured to disable this functionality. For more information, visit https://aka.ms/nuget/cpm/versionoverride</value>
+    <comment>
+      0 - The comma delimited list of package names that specified a value for VersionOverride.
+      Do not localize `PackageReference`
+      Do not localize `VersionOverride`
+    </comment>
   </data>
   <data name="Warning_CentralPackageManagement_MultipleSourcesWithoutPackageSourceMapping" xml:space="preserve">
     <value>There are {0} package sources defined in your configuration. When using central package management, please map your package sources with package source mapping (https://aka.ms/nuget-package-source-mapping) or specify a single package source. The following sources are defined: {1}</value>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -792,17 +792,27 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <value>Package content hash validation failed for {0}. Expected: {1} Actual: {2}</value>
     <comment>0 - package ID, 1 - expected Sha, 2 - actual sha</comment>
   </data>
-  <data name="Error_CentralPackageVersions_VersionsNotAllowed" xml:space="preserve">
-    <value>Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion items: {0}.</value>
+  <data name="Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed" xml:space="preserve">
+    <value>The PackageReference items '{0}' cannot define a value for Version.  Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</value>
+    <comment>0 - Comma delimited list of the package IDs that specified a Version</comment>
   </data>
-  <data name="Error_CentralPackageVersions_AutoreferencedReferencesNotAllowed" xml:space="preserve">
-    <value>The packages {0} are implicitly referenced. You do not typically need to reference them from your project or in your central package versions management file. For more information, see https://aka.ms/sdkimplicitrefs</value>
+  <data name="Error_CentralPackageManagement_ImplicitPackageReferenceWithVersionNotAllowed" xml:space="preserve">
+    <value>The PackageReference items '{0}' are implicitly defined and cannot define a PackageVersion item.  Projects using Central Package Management require that implicit package versions be specified by the PackageReference item. For more information, visit https://aka.ms/sdkimplicitrefs</value>
+    <comment>0 - Comma delimited list of the package IDs that were implicitly defined and should not have a PackageVersion item</comment>
   </data>
-  <data name="Error_CentralPackageVersions_VersionOverrideDisabled" xml:space="preserve">
-    <value>The package reference {0} specifies a VersionOverride but the ability to override a centrally defined version is currently disabled.</value>
-    <comment>0 - The name of a package reference.</comment>
+  <data name="Error_CentralPackageManagement_MissingPackageVersion" xml:space="preserve">
+    <value>The PackageReference items '{0}' do not define a corresponding PackageVersion item. Projects using Central Package Management must declare PackageReference and PackageVersion items with matching names. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</value>
+    <comment>0 - The comma delimited list of package names that did not have a version specified.</comment>
   </data>
-  <data name="Warning_CentralPackageVersions_MultipleSourcesWithoutPackageSourceMapping" xml:space="preserve">
+  <data name="Error_CentralPackageManagement_FloatingVersionsNotAllowed" xml:space="preserve">
+    <value>The PackageVersion items '{0}' cannot specify a floating version. For more information on how to enable this functionality for projects using Central Package Management, visit https://aka.ms/nu1011</value>
+    <comment>0 - The comma delimited list of package names that specified a floating version.</comment>
+  </data>
+  <data name="Error_CentralPackageManagement_VersionOverrideNotAllowed" xml:space="preserve">
+    <value>The PackageReference items '{0}' cannot specify a value for VersionOverride.  Projects using Central Package Management are currently configured to disable this functionality. For more information, visit https://aka.ms/nuget/cpm/versionoverride</value>
+    <comment>0 - The comma delimited list of package names that specified a value for VersionOverride.</comment>
+  </data>
+  <data name="Warning_CentralPackageManagement_MultipleSourcesWithoutPackageSourceMapping" xml:space="preserve">
     <value>There are {0} package sources defined in your configuration. When using central package management, please map your package sources with package source mapping (https://aka.ms/nuget-package-source-mapping) or specify a single package source. The following sources are defined: {1}</value>
     <comment>0 - The number of package sources, 1 - The URL of the package sources, comma separated.</comment>
   </data>
@@ -982,12 +992,6 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
   <data name="Log_CPVM_DowngradeError" xml:space="preserve">
     <value>Detected package downgrade: {0} from {1} to centrally defined {2}. Update the centrally managed package version to a higher version.</value>
     <comment>{0} is package id, {1} is the package version, {2} is the downgraded package version.</comment>
-  </data>
-  <data name="Error_CentralPackageVersions_MissingPackageVersion" xml:space="preserve">
-    <value>The PackageReference items {0} do not have corresponding PackageVersion.</value>
-  </data>
-  <data name="Error_CentralPackageVersions_FloatingVersionsAreNotAllowed" xml:space="preserve">
-    <value>Centrally defined floating package versions are not allowed.</value>
   </data>
   <data name="SpecValidation_OriginalTargetFrameworksMustMatchAliases" xml:space="preserve">
     <value>The original target frameworks value must match the aliases. Original target frameworks: {0}, aliases: {1}.</value>

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -410,7 +410,7 @@ namespace NuGet.ProjectModel
                                Strings.PackagesLockFile_PackageReferencesHaveChanged,
                                nuGetFramework.GetShortFolderName(),
                                lockFileDependenciesCount > 0 ? string.Join(", ", lockFileDependencies.Select(e => e.Id + ":" + e.RequestedVersion.ToNormalizedString()).OrderBy(dep => dep)) : Strings.None,
-                               newPackageDependenciesCount > 0 ? string.Join(", ", newPackageDependencies.Select(e => e.LibraryRange.Name + ":" + e.LibraryRange.VersionRange.ToNormalizedString()).OrderBy(dep => dep)) : Strings.None)
+                               newPackageDependenciesCount > 0 ? string.Join(", ", newPackageDependencies.Select(e => e.LibraryRange.Name + ":" + (e.LibraryRange.VersionRange == null ? "(null)" : e.LibraryRange.VersionRange?.ToNormalizedString())).OrderBy(dep => dep)) : Strings.None)
                            );
             }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -410,7 +410,7 @@ namespace NuGet.ProjectModel
                                Strings.PackagesLockFile_PackageReferencesHaveChanged,
                                nuGetFramework.GetShortFolderName(),
                                lockFileDependenciesCount > 0 ? string.Join(", ", lockFileDependencies.Select(e => e.Id + ":" + e.RequestedVersion.ToNormalizedString()).OrderBy(dep => dep)) : Strings.None,
-                               newPackageDependenciesCount > 0 ? string.Join(", ", newPackageDependencies.Select(e => e.LibraryRange.Name + ":" + (e.LibraryRange.VersionRange == null ? "(null)" : e.LibraryRange.VersionRange?.ToNormalizedString())).OrderBy(dep => dep)) : Strings.None)
+                               newPackageDependenciesCount > 0 ? string.Join(", ", newPackageDependencies.Select(e => e.LibraryRange.ToLockFileDependencyGroupString()).OrderBy(dep => dep)) : Strings.None)
                            );
             }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -4672,10 +4672,10 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             await result.CommitAsync(logger, CancellationToken.None);
             var packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
 
-            // Asert
+            // Assert
             result.Success.Should().BeFalse();
             result.LockFile.LogMessages.Should().HaveCount(1);
-            result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1008);
+            result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1010);
             packages.Should().HaveCount(1);
             packages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("0.0.0"))));
         }

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PackagesLockFileTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PackagesLockFileTests.cs
@@ -202,7 +202,7 @@ namespace NuGet.Commands.FuncTest
                 result.Success.Should().BeFalse();
                 logger.ErrorMessages.Count.Should().Be(1);
                 logger.ErrorMessages.Single().Should().Contain("NU1004");
-                logger.ErrorMessages.Single().Should().Contain("The package references have changed for net46. Lock file's package references: a:[1.0.0, ), project's package references: a:[1.0.0, ), b:[1.0.0, )");
+                logger.ErrorMessages.Single().Should().Contain("The package references have changed for net46. Lock file's package references: a:[1.0.0, ), project's package references: a >= 1.0.0, b >= 1.0.0");
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -1465,7 +1466,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         }
 
         [Fact]
-        public async Task RestoreCommand_CentralVersion_ErrorWhenDependenciesHaveVersion()
+        public async Task RestoreCommand_CentralPackageManagement_ErrorWhenDependenciesHaveVersion()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -1515,17 +1516,17 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 Assert.False(result.Success);
                 Assert.Equal(1, logger.ErrorMessages.Count);
                 logger.ErrorMessages.TryDequeue(out var errorMessage);
-                Assert.True(errorMessage.Contains("Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion"));
-                Assert.True(errorMessage.Contains("bar"));
-                var NU1801Messages = result.LockFile.LogMessages.Where(m => m.Code == NuGetLogCode.NU1008);
-                Assert.Equal(1, NU1801Messages.Count());
+                Assert.EndsWith(string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed, "bar"), errorMessage);
+
+                var NU1008Messages = result.LockFile.LogMessages.Where(m => m.Code == NuGetLogCode.NU1008);
+                Assert.Equal(1, NU1008Messages.Count());
             }
         }
 
         [Theory]
         [InlineData("bar")]
         [InlineData("Bar")]
-        public async Task RestoreCommand_CentralVersion_ErrorWhenCentralPackageVersionFileContainsAutoReferencedReferences(string autoreferencedpackageId)
+        public async Task RestoreCommand_CentralPackageManagement_ErrorWhenCentralPackageVersionFileContainsAutoReferencedReferences(string autoreferencedpackageId)
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -1579,15 +1580,15 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 Assert.False(result.Success);
                 Assert.Equal(1, logger.ErrorMessages.Count);
                 logger.ErrorMessages.TryDequeue(out var errorMessage);
-                Assert.True(errorMessage.Contains("You do not typically need to reference them from your project or in your central package versions management file. For more information, see https://aka.ms/sdkimplicitrefs"));
-                Assert.True(errorMessage.Contains(autoreferencedpackageId));
+                Assert.EndsWith(string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageManagement_ImplicitPackageReferenceWithVersionNotAllowed, autoreferencedpackageId), errorMessage);
+
                 var NU1009Messages = result.LockFile.LogMessages.Where(m => m.Code == NuGetLogCode.NU1009);
                 Assert.Equal(1, NU1009Messages.Count());
             }
         }
 
         [Fact]
-        public async Task RestoreCommand_CentralVersion_NoWarningWhenOnlyOneFeedAndPackageSourceMappingNotUsed()
+        public async Task RestoreCommand_CentralPackageManagement_NoWarningWhenOnlyOneFeedAndPackageSourceMappingNotUsed()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -1668,7 +1669,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task RestoreCommand_CentralVersion_WarningWhenMoreThanOneFeedAndPackageSourceMappingNotUsed(bool enablePackageSourceMapping)
+        public async Task RestoreCommand_CentralPackageManagement_WarningWhenMoreThanOneFeedAndPackageSourceMappingNotUsed(bool enablePackageSourceMapping)
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -1986,7 +1987,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task RestoreCommand_CentralVersion_ErrorWhenFloatingCentralVersions(bool enabled)
+        public async Task RestoreCommand_CentralPackageManagement_ErrorWhenFloatingCentralVersions(bool enabled)
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -2053,7 +2054,8 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                     Assert.False(result.Success);
                     Assert.Equal(1, logger.ErrorMessages.Count);
                     logger.ErrorMessages.TryDequeue(out var errorMessage);
-                    Assert.True(errorMessage.Contains("Centrally defined floating package versions are not allowed."));
+                    Assert.EndsWith(string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageManagement_FloatingVersionsNotAllowed, "foo"), errorMessage);
+
                     var messagesForNU1011 = result.LockFile.LogMessages.Where(m => m.Code == NuGetLogCode.NU1011);
                     Assert.Equal(1, messagesForNU1011.Count());
                 }
@@ -2061,7 +2063,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         }
 
         [Fact]
-        public async Task RestoreCommand_CentralVersion_ErrorWhenNotAllPRItemsHaveCorrespondingPackageVersion()
+        public async Task RestoreCommand_CentralPackageManagement_ErrorWhenNotAllPRItemsHaveCorrespondingPackageVersion()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -2111,14 +2113,15 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 Assert.False(result.Success);
                 Assert.Equal(1, logger.ErrorMessages.Count);
                 logger.ErrorMessages.TryDequeue(out var errorMessage);
-                Assert.True(errorMessage.Contains("The PackageReference items bar do not have corresponding PackageVersion."));
+                Assert.EndsWith(string.Format(CultureInfo.CurrentCulture, Strings.Error_CentralPackageManagement_MissingPackageVersion, "bar"), errorMessage);
+
                 var messagesForNU1010 = result.LockFile.LogMessages.Where(m => m.Code == NuGetLogCode.NU1010);
                 Assert.Equal(1, messagesForNU1010.Count());
             }
         }
 
         [Fact]
-        public async Task RestoreCommand_CentralVersion_Multitargeting_NoFailureSamePackageInTwoFrameworksDirectAndTransitive()
+        public async Task RestoreCommand_CentralPackageManagement_Multitargeting_NoFailureSamePackageInTwoFrameworksDirectAndTransitive()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -2199,7 +2202,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         }
 
         [Fact]
-        public async Task RestoreCommand_CentralVersion_AssetsFile_VerifyProjectsReferencesInTargets()
+        public async Task RestoreCommand_CentralPackageManagement_AssetsFile_VerifyProjectsReferencesInTargets()
         {
             // Arrange
             var framework = new NuGetFramework("net46");
@@ -2280,7 +2283,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         /// </summary>
         /// <returns></returns>
         [Fact]
-        public async Task RestoreCommand_CentralVersion_AssetsFile_PrivateAssetsFlowsToPinnedDependenciesWithTopLevelDependency()
+        public async Task RestoreCommand_CentralPackageManagement_AssetsFile_PrivateAssetsFlowsToPinnedDependenciesWithTopLevelDependency()
         {
             // Arrange
             var framework = new NuGetFramework("net46");
@@ -2397,7 +2400,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         /// </summary>
         /// <returns></returns>
         [Fact]
-        public async Task RestoreCommand_CentralVersion_AssetsFile_PrivateAssetsFlowsToPinnedDependenciesWithSingleParent()
+        public async Task RestoreCommand_CentralPackageManagement_AssetsFile_PrivateAssetsFlowsToPinnedDependenciesWithSingleParent()
         {
             // Arrange
             var framework = new NuGetFramework("net46");
@@ -2504,7 +2507,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         [Theory]
         [InlineData(LibraryIncludeFlags.All, 0)]
         [InlineData(LibraryIncludeFlags.None, 1)]
-        public async Task RestoreCommand_CentralVersion_AssetsFile_PrivateAssetsFlowsToPinnedDependenciesWithSingleParentProject(LibraryIncludeFlags privateAssets, int expectedCount)
+        public async Task RestoreCommand_CentralPackageManagement_AssetsFile_PrivateAssetsFlowsToPinnedDependenciesWithSingleParentProject(LibraryIncludeFlags privateAssets, int expectedCount)
         {
             // Arrange
             using (var testPathContext = new SimpleTestPathContext())
@@ -2596,7 +2599,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         [InlineData(LibraryIncludeFlags.All, LibraryIncludeFlags.All, LibraryIncludeFlags.All)] // When both parents have PrivateAssets="All", expect that the dependency does not flow
         [InlineData(LibraryIncludeFlags.None, LibraryIncludeFlags.None, LibraryIncludeFlags.None)] // When both parents have PrivateAssets="None", expect all assets of the dependency to flow
         [InlineData(LibraryIncludeFlags.None, LibraryIncludeFlags.Runtime | LibraryIncludeFlags.Compile, LibraryIncludeFlags.None)] // When both parents have PrivateAssets="None", expect that the dependency is completely suppressed
-        public async Task RestoreCommand_CentralVersion_AssetsFile_PrivateAssetsFlowsToPinnedDependenciesWithMultipleParents(LibraryIncludeFlags suppressParent1, LibraryIncludeFlags suppressParent2, LibraryIncludeFlags expected)
+        public async Task RestoreCommand_CentralPackageManagement_AssetsFile_PrivateAssetsFlowsToPinnedDependenciesWithMultipleParents(LibraryIncludeFlags suppressParent1, LibraryIncludeFlags suppressParent2, LibraryIncludeFlags expected)
         {
             // Arrange
             var framework = new NuGetFramework("net46");
@@ -2720,7 +2723,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public async Task RestoreCommand_CentralVersion_ErrorWhenVersionOverrideUsedButIsDisabled(bool isCentralPackageVersionOverrideDisabled, bool isVersionOverrideUsed)
+        public async Task RestoreCommand_CentralPackageManagement_ErrorWhenVersionOverrideUsedButIsDisabled(bool isCentralPackageVersionOverrideDisabled, bool isVersionOverrideUsed)
         {
             const string projectName = "TestProject";
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -1466,7 +1466,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         }
 
         [Fact]
-        public async Task RestoreCommand_CentralPackageManagement_ErrorWhenDependenciesHaveVersion()
+        public async Task ExecuteAsync_CentralPackageManagementEnabled_WhenPackageReferencesHaveVersion_LogsAnError()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -2061,7 +2061,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         }
 
         [Fact]
-        public async Task RestoreCommand_CentralVersion_ErrorWhenNotAllPRItemsHaveCorespondingPackageVersion()
+        public async Task RestoreCommand_CentralVersion_ErrorWhenNotAllPRItemsHaveCorrespondingPackageVersion()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -2070,7 +2070,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 var projectPath = Path.Combine(pathContext.SolutionRoot, projectName);
                 var outputPath = Path.Combine(projectPath, "obj");
                 // Package Bar does not have a corresponding PackageVersion
-                var packageRefDependecyBar = new LibraryDependency()
+                var packageRefDependencyBar = new LibraryDependency()
                 {
                     LibraryRange = new LibraryRange("bar", versionRange: null, typeConstraint: LibraryDependencyTarget.Package),
                 };
@@ -2078,7 +2078,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 var centralVersionFoo = new CentralPackageVersion("foo", VersionRange.Parse("1.0.0"));
 
                 var tfi = CreateTargetFrameworkInformation(
-                    [packageRefDependecyBar],
+                    [packageRefDependencyBar],
                     new List<CentralPackageVersion>() { centralVersionFoo });
 
                 var packageSpec = new PackageSpec(new List<TargetFrameworkInformation>() { tfi });
@@ -2118,7 +2118,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         }
 
         [Fact]
-        public async Task RestoreCommand_CentralVersion_Multitargeting_NoFailureSamePackageInTwoFrameworsDirectAndTransitive()
+        public async Task RestoreCommand_CentralVersion_Multitargeting_NoFailureSamePackageInTwoFrameworksDirectAndTransitive()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileUtilitiesTests.cs
@@ -1127,5 +1127,52 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
             Assert.True(actual.IsValid);
             Assert.Empty(actual.InvalidReasons);
         }
+
+        [Fact]
+        public void IsLockFileValid_WithNullVersionRange_DoesNotThrow()
+        {
+            // Arrange
+            var framework = CommonFrameworks.NetStandard20;
+
+            PackageSpec projectA = ProjectTestHelpers.GetPackageSpec(
+                projectName: "A",
+                rootPath: @"C:\",
+                framework: framework.GetShortFolderName(),
+                dependencyName: "PackageA",
+                dependencyVersion: "1.0.0")
+                    .WithTestRestoreMetadata();
+
+            ImmutableArray<LibraryDependency> deps =
+            [
+                new LibraryDependency(new LibraryRange("PackageA", LibraryDependencyTarget.Package))
+                {
+                    ReferenceType = LibraryDependencyReferenceType.Direct,
+                }
+            ];
+
+            TargetFrameworkInformation tfi = new TargetFrameworkInformation(projectA.TargetFrameworks[0])
+            {
+                Dependencies = deps
+            };
+
+            projectA.TargetFrameworks.Clear();
+
+            projectA.TargetFrameworks.Add(tfi);
+
+            // A -> B
+            var dgSpec = ProjectTestHelpers.GetDGSpecForFirstProject(projectA);
+
+            var lockFile = new PackagesLockFileBuilder()
+                .WithTarget(target => target
+                    .WithFramework(framework))
+                .Build();
+
+            var actual = PackagesLockFileUtilities.IsLockFileValid(dgSpec, lockFile);
+            Assert.False(actual.IsValid);
+            Assert.NotNull(actual.InvalidReasons);
+            Assert.Equal(1, actual.InvalidReasons.Count);
+            var invalidReason = actual.InvalidReasons.Single();
+            Assert.Contains("PackageA", invalidReason);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileUtilitiesTests.cs
@@ -1140,24 +1140,11 @@ namespace NuGet.ProjectModel.Test.ProjectLockFile
                 framework: framework.GetShortFolderName(),
                 dependencyName: "PackageA",
                 dependencyVersion: "1.0.0")
-                    .WithTestRestoreMetadata();
-
-            ImmutableArray<LibraryDependency> deps =
-            [
-                new LibraryDependency(new LibraryRange("PackageA", LibraryDependencyTarget.Package))
-                {
-                    ReferenceType = LibraryDependencyReferenceType.Direct,
-                }
-            ];
-
-            TargetFrameworkInformation tfi = new TargetFrameworkInformation(projectA.TargetFrameworks[0])
-            {
-                Dependencies = deps
-            };
-
-            projectA.TargetFrameworks.Clear();
-
-            projectA.TargetFrameworks.Add(tfi);
+                    .WithTestRestoreMetadata()
+                    .WithDependency(new LibraryDependency(new LibraryRange("PackageA", LibraryDependencyTarget.Package))
+                    {
+                        ReferenceType = LibraryDependencyReferenceType.Direct,
+                    });
 
             // A -> B
             var dgSpec = ProjectTestHelpers.GetDGSpecForFirstProject(projectA);

--- a/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
@@ -149,6 +149,14 @@ namespace NuGet.Commands.Test
             return updated;
         }
 
+        public static PackageSpec WithDependency(this PackageSpec spec, LibraryDependency libraryDependency)
+        {
+            AddDependency(spec, libraryDependency);
+
+            return spec;
+
+        }
+
         /// <summary>
         /// Creates a restore request for the first project in the <paramref name="projects"/> list. If <see cref="ProjectRestoreMetadata.Sources"/> has any values, it is used for creating the providers, otherwise <see cref="SimpleTestPathContext.PackageSource"/> from <paramref name="pathContext"/> will be used.
         /// </summary>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14164
Fixes: https://github.com/NuGet/Home/issues/13685
Fixes: https://github.com/NuGet/Home/issues/13627

## Description
The original bug https://github.com/NuGet/Home/issues/13627 reported an issue with lock files and CPM which is caused by an invalid configuration which should result in a logged error but instead hits an unhandled exception.  This is because of a bug in [PackagesLockFilesUtilities.HasDirectPackageDependencyChanged()](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs#L413) where its not expecting a null `VersionRange`.

Also, in https://github.com/NuGet/Home/issues/13685 users experience the wrong error message when CPM is misconfigured in the same way but not using lock files.  

This is because [RestoreCommand.AreCentralVersionRequirementsSatisfiedAsync()](https://github.com/NuGet/NuGet.Client/blob/13550619f90e73a1f8b4b5159c6d7f268c9756d0/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs#L746) is also not taking into account a missing version correctly.

The `AreCentralVersionRequirementsSatisfiedAsync()` method is also really bad so I decided to clean it up.  It currently loops through all target frameworks and all dependencies **four** times, I'm surprised this hasn't shown up in our performance tests before. 

I took the time to rename some tests which reference "central package versions" instead of the final name "central package management".

I also noticed that the error messages for the scenarios in `AreCentralVersionRequirementsSatisfiedAsync()` were very poorly worded so I couldn't help myself and improved them.  I will be handling the documentation in parallel and am tracking that at https://github.com/NuGet/Home/issues/14205.  The pull request that updates the docs is https://github.com/NuGet/docs.microsoft.com-nuget/pull/3414

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~~Added tests~~
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
