### PR TITLE
Fix auto referenced calculation - remove redundant work

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -283,6 +283,7 @@ namespace NuGet.PackageManagement.UI
                 {
                     VersionRange allowedVersions = VersionRange.All;
                     VersionRange versionOverride = null;
+                    bool autoReferenced = false;
 
                     // get the allowed version range and pass it to package item view model to choose the latest version based on that
                     if (_packageReferences != null)
@@ -301,6 +302,7 @@ namespace NuGet.PackageManagement.UI
                             {
                                 versionOverrides.Add(reference.VersionOverride);
                             }
+                            autoReferenced = reference.IsAutoReferenced;
                         }
 
                         allowedVersions = allowedVersionsRange.FirstOrDefault() ?? VersionRange.All;
@@ -337,6 +339,7 @@ namespace NuGet.PackageManagement.UI
                         PackageFileService = _packageFileService,
                         IncludePrerelease = _includePrerelease,
                         PackageLevel = packageLevel,
+                        AutoReferenced = autoReferenced,
                     };
 
                     if (listItem.PackageLevel == PackageLevel.TopLevel)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -949,9 +949,6 @@ namespace NuGet.PackageManagement.UI
                 _searchService.ClearFromCache(Id, Sources, IncludePrerelease);
             }
 
-            // Set auto referenced to true any reference for the given id contains the flag.
-            AutoReferenced = installedPackages.IsAutoReferenced(Id);
-
             NuGetUIThreadHelper.JoinableTaskFactory
                 .RunAsync(ReloadPackageVersionsAsync)
                 .PostOnFailure(nameof(PackageItemViewModel), nameof(ReloadPackageVersionsAsync));

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/PackageCollectionExtensions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Common/PackageCollectionExtensions.cs
@@ -41,14 +41,5 @@ namespace NuGet.PackageManagement.VisualStudio
                 .GroupById()
                 .Select(g => g.OrderBy(x => x.Version).First());
         }
-
-        /// <summary>
-        /// True if any package reference is AutoReferenced=true.
-        /// </summary>
-        public static bool IsAutoReferenced(this IEnumerable<PackageCollectionItem> packages, string id)
-        {
-            return packages.Where(e => StringComparer.OrdinalIgnoreCase.Equals(id, e.Id))
-                .Any(e => e.IsAutoReferenced());
-        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3205

## Description

I think this should address the unneeded looping over the packages. 

The bug calls out 3 scenarios for the PackageItemViewModel construction.

One in https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs#L344, which is what I'm fixing here by calculating the AutoReferenced metadata at the same spot the exactly specified version is calculated. 

https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs#L615 is called after the `PackageCollection.FromPackageReferences` which handles the metadata construction correctly. 

cc @jebriede 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ No automated tests in this space. I tested manually.
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
