### PR TITLE
remove 5 minute timeout when debugging tests in VS

### DIFF
--- a/build/test.targets
+++ b/build/test.targets
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <NoWarn>$(NoWarn);CS1701;xUnit1012;xUnit1014;xUnit2000;xUnit2009;xUnit2013</NoWarn>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.runner.visualstudio" />
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VSTestResultsDirectory>$(RepositoryRootDirectory).test\TestResults\</VSTestResultsDirectory>
-    <RunSettingsFilePath Condition="'$(RunSettingsFilePath)' == ''">$(MSBuildThisFileDirectory)xunit.runsettings</RunSettingsFilePath>
+    <RunSettingsFilePath Condition="'$(RunSettingsFilePath)' == '' AND '$(BuildingInsideVisualStudio)' != 'true'">$(MSBuildThisFileDirectory)xunit.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <!-- Workaround for test projects not automatically creating binding redirects -->


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: infrastructure

## Description

xunit.runsetings sets a number of settings, including a 5 minute timeout for individual tests. This is great for CI where we don't want to tests to run forever. But when debugging a complex test failure, 5 minutes is often not enough.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~ (infrastructure issue)
- [x] ~Added tests~ n/a
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ n/a
