### PR TITLE
Ensure naming consistency with the concrete capability classes and their interfaces

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/EmbeddedResourcesCapability.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/EmbeddedResourcesCapability.cs
@@ -11,7 +11,7 @@ using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.PackageManagement.UI.Models.Package
 {
-    internal class EmbeddedResourcesCapability : IEmbeddedResources
+    internal class EmbeddedResourcesCapability : IEmbeddedResourcesCapable
     {
         private readonly INuGetPackageFileService _nugetPackageFileService;
         private readonly PackageIdentity _packageIdentity;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/IEmbeddedResourcesCapable.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/IEmbeddedResourcesCapable.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace NuGet.PackageManagement.UI
 {
-    internal interface IEmbeddedResources
+    internal interface IEmbeddedResourcesCapable
     {
         Uri? ReadmeUri { get; }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/LocalPackageModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/LocalPackageModel.cs
@@ -21,7 +21,7 @@ namespace NuGet.PackageManagement.UI
         public LocalPackageModel(PackageIdentity identity,
             string packagePath,
             IVulnerableCapable vulnerableCapability,
-            IEmbeddedResources embeddedResources,
+            IEmbeddedResourcesCapable embeddedResources,
             string? title = null,
             string? description = null,
             string? authors = null,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/PackageModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/PackageModel.cs
@@ -14,12 +14,12 @@ using NuGet.Versioning;
 
 namespace NuGet.PackageManagement.UI
 {
-    public abstract class PackageModel : IEmbeddedResources
+    public abstract class PackageModel : IEmbeddedResourcesCapable
     {
-        private readonly IEmbeddedResources _embeddedResources;
+        private readonly IEmbeddedResourcesCapable _embeddedResources;
 
         internal PackageModel(PackageIdentity identity,
-            IEmbeddedResources embeddedResources,
+            IEmbeddedResourcesCapable embeddedResources,
             string? title = null,
             string? description = null,
             string? authors = null,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/RecommededPackageModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/RecommededPackageModel.cs
@@ -16,7 +16,7 @@ namespace NuGet.PackageManagement.UI.Models
             PackageIdentity identity,
             IVulnerableCapable vulnerableCapability,
             IDeprecationCapable deprecationCapability,
-            IEmbeddedResources embeddedResources,
+            IEmbeddedResourcesCapable embeddedResources,
             (string modelVersion, string vsixVersion) recommenderVersion,
             string? title = null,
             string? description = null,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/ReferencedPackageModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/ReferencedPackageModel.cs
@@ -25,7 +25,7 @@ namespace NuGet.PackageManagement.UI.Models
             string packagePath,
             IVulnerableCapable vulnerableCapability,
             IDeprecationCapable deprecationCapability,
-            IEmbeddedResources embeddedResources,
+            IEmbeddedResourcesCapable embeddedResources,
             string? title = null,
             string? description = null,
             string? authors = null,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/RemotePackageModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/RemotePackageModel.cs
@@ -24,7 +24,7 @@ namespace NuGet.PackageManagement.UI
             PackageIdentity identity,
             IVulnerableCapable vulnerableCapability,
             IDeprecationCapable deprecationCapability,
-            IEmbeddedResources embeddedResources,
+            IEmbeddedResourcesCapable embeddedResources,
             string? title = null,
             string? description = null,
             string? authors = null,

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/TransitivelyReferencedPackageModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/TransitivelyReferencedPackageModel.cs
@@ -21,7 +21,7 @@ namespace NuGet.PackageManagement.UI.Models
         public TransitivelyReferencedPackageModel(
             PackageIdentity identity,
             IVulnerableCapable vulnerableCapability,
-            IEmbeddedResources embeddedResources,
+            IEmbeddedResourcesCapable embeddedResources,
             IReadOnlyCollection<PackageIdentity> transitiveOrigins,
             string? title = null,
             string? description = null,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/LocalDetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/LocalDetailControlModelTests.cs
@@ -35,7 +35,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
 
             var identity = new PackageIdentity("TestPackage", new NuGetVersion("1.0.0"));
             var vulnerableCapability = new Mock<IVulnerableCapable>();
-            var embeddedResourceCapability = new Mock<IEmbeddedResources>();
+            var embeddedResourceCapability = new Mock<IEmbeddedResourcesCapable>();
             var packagePath = "C:\\TestPackage";
 
             // Act
@@ -149,7 +149,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
             var searchService = new Mock<INuGetSearchService>();
             var identity = new PackageIdentity("package", installedVersion);
             var vulnerableCapability = new Mock<IVulnerableCapable>();
-            var embeddedResourceCapability = new Mock<IEmbeddedResources>();
+            var embeddedResourceCapability = new Mock<IEmbeddedResourcesCapable>();
             var packagePath = "C:\\TestPackage";
 
             // Act
@@ -187,7 +187,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
             var searchService = new Mock<INuGetSearchService>();
             var identity = new PackageIdentity("package", installedVersion);
             var vulnerableCapability = new Mock<IVulnerableCapable>();
-            var embeddedResourceCapability = new Mock<IEmbeddedResources>();
+            var embeddedResourceCapability = new Mock<IEmbeddedResourcesCapable>();
             var packagePath = "C:\\TestPackage";
             var packageModel = new LocalPackageModel(identity, packagePath, vulnerableCapability.Object, embeddedResourceCapability.Object);
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/LocalPackageModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/LocalPackageModelTests.cs
@@ -19,12 +19,12 @@ namespace NuGet.PackageManagement.UI.Test.Models.Package
     public class LocalPackageModelTests
     {
         private Mock<IVulnerableCapable> _vulnerableCapabilityMock;
-        private Mock<IEmbeddedResources> _embeddedResourcesMock;
+        private Mock<IEmbeddedResourcesCapable> _embeddedResourcesMock;
 
         public LocalPackageModelTests()
         {
             _vulnerableCapabilityMock = new Mock<IVulnerableCapable>();
-            _embeddedResourcesMock = new Mock<IEmbeddedResources>();
+            _embeddedResourcesMock = new Mock<IEmbeddedResourcesCapable>();
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/PackageModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/PackageModelTests.cs
@@ -19,11 +19,11 @@ namespace NuGet.PackageManagement.UI.Test.Models.Package
 {
     public class PackageModelTests
     {
-        private readonly Mock<IEmbeddedResources> _embeddedResourcesMock;
+        private readonly Mock<IEmbeddedResourcesCapable> _embeddedResourcesMock;
 
         public PackageModelTests()
         {
-            _embeddedResourcesMock = new Mock<IEmbeddedResources>();
+            _embeddedResourcesMock = new Mock<IEmbeddedResourcesCapable>();
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace NuGet.PackageManagement.UI.Test.Models.Package
         {
             // Arrange
             var identity = new PackageIdentity("TestPackage", new NuGetVersion("1.0.0"));
-            IEmbeddedResources? embeddedResources = null;
+            IEmbeddedResourcesCapable? embeddedResources = null;
 
             // Act
             // Assert

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/RecommendedPackageModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/RecommendedPackageModelTests.cs
@@ -19,7 +19,7 @@ namespace NuGet.PackageManagement.UI.Test.Models.Package
             // Arrange
             var identity = new PackageIdentity("TestPackage", new NuGetVersion("1.0.0"));
             var vulnerabilityCapability = new Mock<IVulnerableCapable>();
-            var embeddedCapability = new Mock<IEmbeddedResources>();
+            var embeddedCapability = new Mock<IEmbeddedResourcesCapable>();
             var deprecatedCapability = new Mock<IDeprecationCapable>();
             (string modelVersion, string vsixVersion) recommenderVersion = ("1.0.0", "1.0.0");
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/ReferencedPackageModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/ReferencedPackageModelTests.cs
@@ -20,13 +20,13 @@ namespace NuGet.PackageManagement.UI.Test.Models.Package
     {
         private readonly Mock<IVulnerableCapable> _mockVulnerableCapability;
         private readonly Mock<IDeprecationCapable> _mockDeprecationCapable;
-        private readonly Mock<IEmbeddedResources> _mockEmbeddedResource;
+        private readonly Mock<IEmbeddedResourcesCapable> _mockEmbeddedResource;
 
         public ReferencedPackageModelTests()
         {
             _mockVulnerableCapability = new Mock<IVulnerableCapable>();
             _mockDeprecationCapable = new Mock<IDeprecationCapable>();
-            _mockEmbeddedResource = new Mock<IEmbeddedResources>();
+            _mockEmbeddedResource = new Mock<IEmbeddedResourcesCapable>();
         }
 
         [Theory]

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/RemotePackageModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/RemotePackageModelTests.cs
@@ -21,13 +21,13 @@ namespace NuGet.PackageManagement.UI.Test.Models.Package
     {
         private readonly Mock<IVulnerableCapable> _vulnerableCapabilityMock;
         private readonly Mock<IDeprecationCapable> _deprecationCapabilityMock;
-        private readonly Mock<IEmbeddedResources> _embeddedResourcesMock;
+        private readonly Mock<IEmbeddedResourcesCapable> _embeddedResourcesMock;
 
         public RemotePackageModelTests()
         {
             _vulnerableCapabilityMock = new Mock<IVulnerableCapable>();
             _deprecationCapabilityMock = new Mock<IDeprecationCapable>();
-            _embeddedResourcesMock = new Mock<IEmbeddedResources>();
+            _embeddedResourcesMock = new Mock<IEmbeddedResourcesCapable>();
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/TestPackageModel.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/TestPackageModel.cs
@@ -15,7 +15,7 @@ namespace NuGet.PackageManagement.UI.Test.Models.Package
     internal class TestPackageModel : PackageModel
     {
         public TestPackageModel(PackageIdentity identity,
-            IEmbeddedResources embeddedResources,
+            IEmbeddedResourcesCapable embeddedResources,
             string? title = null,
             string? description = null,
             string? authors = null,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/TransitivelyReferencedPackageModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/TransitivelyReferencedPackageModelTests.cs
@@ -19,7 +19,7 @@ namespace NuGet.PackageManagement.UI.Test.Models.Package
             var identity = new PackageIdentity("TestPackage", new NuGetVersion("1.0.0"));
             var mockVulnerableCapability = new Mock<IVulnerableCapable>();
             var mockDeprecationCapability = new Mock<IDeprecationCapable>();
-            var mockEmbeddedCapability = new Mock<IEmbeddedResources>();
+            var mockEmbeddedCapability = new Mock<IEmbeddedResourcesCapable>();
             var transitiveOrigins = new List<PackageIdentity>
             {
                 new PackageIdentity("OriginPackage1", new NuGetVersion("1.0.0")),

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
@@ -63,7 +63,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
             var searchService = new Mock<INuGetSearchService>();
             var identity = new PackageIdentity("package", testVersion);
             var vulnerableCapability = new Mock<IVulnerableCapable>();
-            var embeddedResourceCapability = new Mock<IEmbeddedResources>();
+            var embeddedResourceCapability = new Mock<IEmbeddedResourcesCapable>();
             var packagePath = "C:\\TestPackage";
 
             var packageModel = new LocalPackageModel(identity, packagePath, vulnerableCapability.Object, embeddedResourceCapability.Object);
@@ -328,7 +328,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
 
             var identity = new PackageIdentity("package", new NuGetVersion("1.0.0"));
             var vulnerableCapability = new Mock<IVulnerableCapable>();
-            var embeddedResourceCapability = new Mock<IEmbeddedResources>();
+            var embeddedResourceCapability = new Mock<IEmbeddedResourcesCapable>();
             var packagePath = "C:\\TestPackage";
 
             var packageModel = new LocalPackageModel(identity, packagePath, vulnerableCapability.Object, embeddedResourceCapability.Object);
@@ -382,7 +382,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
 
             var identity = new PackageIdentity("package", new NuGetVersion("1.0.0"));
             var vulnerableCapability = new Mock<IVulnerableCapable>();
-            var embeddedResourceCapability = new Mock<IEmbeddedResources>();
+            var embeddedResourceCapability = new Mock<IEmbeddedResourcesCapable>();
             var packagePath = "C:\\TestPackage";
 
             var packageModel = new LocalPackageModel(identity, packagePath, vulnerableCapability.Object, embeddedResourceCapability.Object);
@@ -434,7 +434,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 .ReturnsAsync(testVersions);
             var identity = new PackageIdentity("package", installedVersion);
             var vulnerableCapability = new Mock<IVulnerableCapable>();
-            var embeddedResourceCapability = new Mock<IEmbeddedResources>();
+            var embeddedResourceCapability = new Mock<IEmbeddedResourcesCapable>();
             var packagePath = "C:\\TestPackage";
 
             var packageModel = new LocalPackageModel(identity, packagePath, vulnerableCapability.Object, embeddedResourceCapability.Object);
@@ -476,7 +476,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 .ReturnsAsync(testVersions);
             var identity = new PackageIdentity("a", installedVersion);
             var vulnerableCapability = new Mock<IVulnerableCapable>();
-            var embeddedResourceCapability = new Mock<IEmbeddedResources>();
+            var embeddedResourceCapability = new Mock<IEmbeddedResourcesCapable>();
             var packagePath = "C:\\TestPackage";
 
             var packageModel = new LocalPackageModel(identity, packagePath, vulnerableCapability.Object, embeddedResourceCapability.Object);
@@ -701,7 +701,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
             searchService.Setup(ss => ss.GetPackageVersionsAsync(It.IsAny<PackageIdentity>(), It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IEnumerable<IProjectContextInfo>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(testVersions);
             var vulnerableCapability = new Mock<IVulnerableCapable>();
-            var embeddedResourceCapability = new Mock<IEmbeddedResources>();
+            var embeddedResourceCapability = new Mock<IEmbeddedResourcesCapable>();
             var packagePath = "C:\\TestPackage";
 
             var packageModel = new LocalPackageModel(packageIdentity, packagePath, vulnerableCapability.Object, embeddedResourceCapability.Object);
@@ -813,7 +813,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
             searchService.Setup(ss => ss.GetPackageVersionsAsync(It.IsAny<PackageIdentity>(), It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IEnumerable<IProjectContextInfo>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(testVersions);
             var vulnerableCapability = new Mock<IVulnerableCapable>();
-            var embeddedResourceCapability = new Mock<IEmbeddedResources>();
+            var embeddedResourceCapability = new Mock<IEmbeddedResourcesCapable>();
             var packagePath = "C:\\TestPackage";
 
             var packageModel = new LocalPackageModel(packageIdentity, packagePath, vulnerableCapability.Object, embeddedResourceCapability.Object);
@@ -938,7 +938,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 .ReturnsAsync(testVersions);
             var identity = new PackageIdentity("Contoso.A", new NuGetVersion(installedVersion));
             var vulnerableCapability = new Mock<IVulnerableCapable>();
-            var embeddedResourceCapability = new Mock<IEmbeddedResources>();
+            var embeddedResourceCapability = new Mock<IEmbeddedResourcesCapable>();
             var packagePath = "C:\\TestPackage";
 
             var packageModel = new LocalPackageModel(identity, packagePath, vulnerableCapability.Object, embeddedResourceCapability.Object);
@@ -1151,7 +1151,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
 
             var identity = new PackageIdentity("Contoso.A", new NuGetVersion(installedVersion));
             var vulnerableCapability = new Mock<IVulnerableCapable>();
-            var embeddedResourceCapability = new Mock<IEmbeddedResources>();
+            var embeddedResourceCapability = new Mock<IEmbeddedResourcesCapable>();
             var packagePath = "C:\\TestPackage";
 
             var packageModel = new LocalPackageModel(identity, packagePath, vulnerableCapability.Object, embeddedResourceCapability.Object);
@@ -1257,7 +1257,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
             searchService.Setup(ss => ss.GetPackageVersionsAsync(It.IsAny<PackageIdentity>(), It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IEnumerable<IProjectContextInfo>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(testVersions);
             var vulnerableCapability = new Mock<IVulnerableCapable>();
-            var embeddedResourceCapability = new Mock<IEmbeddedResources>();
+            var embeddedResourceCapability = new Mock<IEmbeddedResourcesCapable>();
             var packagePath = "C:\\TestPackage";
 
             var packageModel = new LocalPackageModel(packageIdentity, packagePath, vulnerableCapability.Object, embeddedResourceCapability.Object);
@@ -1364,7 +1364,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
 
             var identity = new PackageIdentity("Contoso.A", new NuGetVersion(installedVersion));
             var vulnerableCapability = new Mock<IVulnerableCapable>();
-            var embeddedResourceCapability = new Mock<IEmbeddedResources>();
+            var embeddedResourceCapability = new Mock<IEmbeddedResourcesCapable>();
             var packagePath = "C:\\TestPackage";
 
             var packageModel = new LocalPackageModel(identity, packagePath, vulnerableCapability.Object, embeddedResourceCapability.Object);
@@ -1520,7 +1520,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
 
             var identity = new PackageIdentity("package", installedVersion);
             var vulnerableCapability = new Mock<IVulnerableCapable>();
-            var embeddedResourceCapability = new Mock<IEmbeddedResources>();
+            var embeddedResourceCapability = new Mock<IEmbeddedResourcesCapable>();
             var packagePath = "C:\\TestPackage";
 
             var packageModel = new LocalPackageModel(identity, packagePath, vulnerableCapability.Object, embeddedResourceCapability.Object);
@@ -1576,7 +1576,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 .ReturnsAsync(testVersions);
             var identity = new PackageIdentity("package", installedVersion);
             var vulnerableCapability = new Mock<IVulnerableCapable>();
-            var embeddedResourceCapability = new Mock<IEmbeddedResources>();
+            var embeddedResourceCapability = new Mock<IEmbeddedResourcesCapable>();
             var packagePath = "C:\\TestPackage";
 
             var packageModel = new LocalPackageModel(identity, packagePath, vulnerableCapability.Object, embeddedResourceCapability.Object);
@@ -1617,7 +1617,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
                 .ReturnsAsync(testVersions);
             var identity = new PackageIdentity("a", new NuGetVersion(installedVersion));
             var vulnerableCapability = new Mock<IVulnerableCapable>();
-            var embeddedResourceCapability = new Mock<IEmbeddedResources>();
+            var embeddedResourceCapability = new Mock<IEmbeddedResourcesCapable>();
             var packagePath = "C:\\TestPackage";
 
             var packageModel = new LocalPackageModel(identity, packagePath, vulnerableCapability.Object, embeddedResourceCapability.Object);
@@ -1813,7 +1813,7 @@ namespace NuGet.PackageManagement.UI.Test.Models
 
             var identity = new PackageIdentity("package", installedVersion);
             var vulnerableCapability = new Mock<IVulnerableCapable>();
-            var embeddedResourceCapability = new Mock<IEmbeddedResources>();
+            var embeddedResourceCapability = new Mock<IEmbeddedResourcesCapable>();
             var knownOwnerCapability = new Mock<IKnownOwnersCapable>();
             var deprecationCapability = new Mock<IDeprecationCapable>();
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Xamls/InfiniteScrollListTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Xamls/InfiniteScrollListTests.cs
@@ -279,7 +279,7 @@ namespace NuGet.PackageManagement.UI.Test
             var list = new InfiniteScrollList();
             var searchService = new Mock<INuGetSearchService>();
             var packageIdentity = new PackageIdentity("TestPackage", new NuGetVersion("1.0.0"));
-            var embeddedResource = new Mock<IEmbeddedResources>();
+            var embeddedResource = new Mock<IEmbeddedResourcesCapable>();
             var vulnerableCapability = new Mock<IVulnerableCapable>();
             var deprecatedCapability = new Mock<IDeprecationCapable>();
             var packageModel = new RemotePackageModel(packageIdentity, vulnerableCapability.Object, deprecatedCapability.Object, embeddedResource.Object);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
To ensure consistent naming among the concrete capability classes and their interfaces, IEmbeddedResources and all its references was changed to IEmbeddedResourcesCapable.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests (Fixed tests)
- [ ] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~
