### PR TITLE
Avoid null reference exceptions when switching away from README tab.

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
@@ -43,7 +43,7 @@ namespace NuGet.PackageManagement.UI
         /// </summary>
         public bool IsBusy
         {
-            get => _isBusy || (ReadmeViewModel?.IsBusy).GetValueOrDefault(false);
+            get => _isBusy || ReadmeViewModel?.IsBusy == true;
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace NuGet.PackageManagement.UI
         /// </summary>
         public bool IsReadmeReady
         {
-            get => !_isBusy && (ReadmeViewModel?.IsReadmeReady).GetValueOrDefault(false);
+            get => !_isBusy && ReadmeViewModel?.IsReadmeReady == true;
         }
 
         public ReadmePreviewViewModel ReadmeViewModel { get => (ReadmePreviewViewModel)DataContext; }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
@@ -43,7 +43,7 @@ namespace NuGet.PackageManagement.UI
         /// </summary>
         public bool IsBusy
         {
-            get => _isBusy || ReadmeViewModel.IsBusy;
+            get => _isBusy || (ReadmeViewModel?.IsBusy).GetValueOrDefault(false);
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace NuGet.PackageManagement.UI
         /// </summary>
         public bool IsReadmeReady
         {
-            get => !_isBusy && ReadmeViewModel.IsReadmeReady;
+            get => !_isBusy && (ReadmeViewModel?.IsReadmeReady).GetValueOrDefault(false);
         }
 
         public ReadmePreviewViewModel ReadmeViewModel { get => (ReadmePreviewViewModel)DataContext; }
@@ -81,7 +81,7 @@ namespace NuGet.PackageManagement.UI
         {
             if (e.PropertyName == nameof(ReadmePreviewViewModel.ReadmeMarkdown))
             {
-                if (!string.IsNullOrWhiteSpace(ReadmeViewModel.ReadmeMarkdown))
+                if (!string.IsNullOrWhiteSpace(ReadmeViewModel?.ReadmeMarkdown))
                 {
                     CancelAndExchangeToken();
                     UpdateMarkdownAsync(ReadmeViewModel.ReadmeMarkdown, _markdownRenderingCancellationTokenSource.Token).PostOnFailure(nameof(PackageReadmeControl));
@@ -140,7 +140,7 @@ namespace NuGet.PackageManagement.UI
 
         private void PackageReadmeControl_Loaded(object sender, RoutedEventArgs e)
         {
-            if (!string.IsNullOrWhiteSpace(ReadmeViewModel.ReadmeMarkdown))
+            if (!string.IsNullOrWhiteSpace(ReadmeViewModel?.ReadmeMarkdown))
             {
                 CancelAndExchangeToken();
                 UpdateMarkdownAsync(ReadmeViewModel.ReadmeMarkdown, _markdownRenderingCancellationTokenSource.Token).PostOnFailure(nameof(PackageReadmeControl));

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageReadmeControl.xaml.cs
@@ -105,7 +105,7 @@ namespace NuGet.PackageManagement.UI
                 await TaskScheduler.Default;
                 var success = await _markdownPreview.UpdateContentAsync(markdown, ScrollHint.None, token).PostOnFailureAsync(nameof(PackageReadmeControl));
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(token);
-                if (!success)
+                if (ReadmeViewModel is not null && !success)
                 {
                     ReadmeViewModel.ErrorWithReadme = true;
                     ReadmeViewModel.ReadmeMarkdown = string.Empty;
@@ -117,8 +117,11 @@ namespace NuGet.PackageManagement.UI
         private void UpdateBusy(bool isBusy)
         {
             _isBusy = isBusy;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsReadmeReady)));
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsBusy)));
+            if (ReadmeViewModel is not null)
+            {
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsReadmeReady)));
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsBusy)));
+            }
         }
 
         private void UserControl_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14201

## Description
Avoid null reference exceptions for checking the ReadmeViewModel for the IsBusy and IsReadmeReady properties.
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ We can't test XAML
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
