### PR TITLE
Update packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,9 +18,9 @@
     <MicrosoftBuildVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'netstandard2.0'">16.8.0</MicrosoftBuildVersion>
     <!-- The last package version of MSBuild that works with net5.0 is 16.11.0.  Our assemblies are still compiled against MSBuild assembly version 15.1.0.0 which will work with all versions -->
     <MicrosoftBuildVersion Condition="'$(TargetFramework)' == 'netcoreapp5.0'">16.11.0</MicrosoftBuildVersion>
-    <MicrosoftBuildVersion Condition="'$(DotNetBuildSourceOnly)' == 'true'">17.13.9</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion Condition="'$(DotNetBuildSourceOnly)' == 'true'">17.12.6</MicrosoftBuildVersion>
     <!-- Read docs/updating-packages.md before updating MSBuild's version -->
-    <MicrosoftBuildVersion Condition="'$(MicrosoftBuildVersion)' == ''">17.13.9</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion Condition="'$(MicrosoftBuildVersion)' == ''">17.11.4</MicrosoftBuildVersion>
   </PropertyGroup>
 
     <!-- Overridden by source build to ensure the same version is used across products, do not remove these properties -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,9 +18,9 @@
     <MicrosoftBuildVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'netstandard2.0'">16.8.0</MicrosoftBuildVersion>
     <!-- The last package version of MSBuild that works with net5.0 is 16.11.0.  Our assemblies are still compiled against MSBuild assembly version 15.1.0.0 which will work with all versions -->
     <MicrosoftBuildVersion Condition="'$(TargetFramework)' == 'netcoreapp5.0'">16.11.0</MicrosoftBuildVersion>
-    <MicrosoftBuildVersion Condition="'$(DotNetBuildSourceOnly)' == 'true'">17.12.6</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion Condition="'$(DotNetBuildSourceOnly)' == 'true'">17.13.9</MicrosoftBuildVersion>
     <!-- Read docs/updating-packages.md before updating MSBuild's version -->
-    <MicrosoftBuildVersion Condition="'$(MicrosoftBuildVersion)' == ''">17.11.4</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion Condition="'$(MicrosoftBuildVersion)' == ''">17.13.9</MicrosoftBuildVersion>
   </PropertyGroup>
 
     <!-- Overridden by source build to ensure the same version is used across products, do not remove these properties -->
@@ -76,13 +76,13 @@
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.VS" Version="17.4.221-pre" />
     <PackageVersion Include="Microsoft.VisualStudio.SolutionPersistence" Version="$(MicrosoftVisualStudioSolutionPersistenceVersion)" />
     <!-- Microsoft.VisualStudio.SDK has vulnerable dependencies System.Text.json and Microsoft.IO.Redist. When it's upgraded, try removing the pinned packages -->
-    <PackageVersion Include="Microsoft.VisualStudio.SDK" Version="17.11.39714" />
+    <PackageVersion Include="Microsoft.VisualStudio.SDK" Version="17.13.39276" />
     <PackageVersion Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" Version="17.11.8" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.4.2244" />
     <PackageVersion Include="Microsoft.VisualStudio.TemplateWizardInterface" Version="17.10.40170" />
-    <PackageVersion Include="Microsoft.VisualStudio.VCProjectEngine" Version="17.11.39721" />
+    <PackageVersion Include="Microsoft.VisualStudio.VCProjectEngine" Version="17.13.39273" />
     <PackageVersion Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="17.0.7-preview-0001-g5492e466a9" />
-    <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.12.2069" />
+    <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.13.2126" />
     <PackageVersion Include="Microsoft.Web.Xdt" Version="$(MicrosoftWebXdtPackageVersion)" />
     <PackageVersion Include="Moq" Version="4.18.1" />
     <PackageVersion Include="MSTest.TestAdapter" Version="$(MSTestPackageVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,6 +42,7 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="ILMerge" Version="3.0.41" />
     <PackageVersion Include="Lucene.Net" Version="3.0.3" />
+    <PackageVersion Include="MessagePack" Version="2.5.192" />
     <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageVersion Include="Microsoft.Build.Artifacts" Version="4.2.0" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
@@ -136,11 +137,11 @@
               '$(MSBuildProjectFile)' == 'NuGet.VisualStudio.Contracts.csproj' OR
               '$(MSBuildProjectFile)' == 'NuGet.VisualStudio.Interop.csproj' OR
               '$(MSBuildProjectFile)' == 'NuGet.SolutionRestoreManager.Interop.csproj'">
-    <PackageVersion Include="Microsoft.ServiceHub.Framework" Version="4.5.31" />
+    <PackageVersion Include="Microsoft.ServiceHub.Framework" Version="4.8.3" />
     <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost" Version="17.10.191" />
     <PackageVersion Update="Microsoft.VisualStudio.SDK" Version="" />
     <!-- Microsoft.VisualStudio.Shell.15.0 has vulnerable dependencies System.Text.Json and Microsoft.IO.Redist. When it's upgraded, try removing the pinned packages -->
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.10.40173" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.13.40008" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
@@ -7,15 +7,13 @@ Azure.Core.dll
 Ben.Demystifier.dll
 Markdig.Signed.dll
 Microsoft.DataAI.NuGetRecommender.Contracts.dll
-Microsoft.IO.Redist.dll
-Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll
 Microsoft.IdentityModel.Clients.ActiveDirectory.dll
+Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll
 Microsoft.IdentityModel.JsonWebTokens.dll
 Microsoft.IdentityModel.Logging.dll
 Microsoft.IdentityModel.Tokens.dll
 Microsoft.Internal.VisualStudio.Shell.Framework.dll
 Microsoft.Internal.VisualStudio.Shell.Framework.resources.dll
-Microsoft.NET.StringTools.dll
 Microsoft.TeamFoundation.Build.Client.dll
 Microsoft.TeamFoundation.Build.Client.resources.dll
 Microsoft.TeamFoundation.Build.Common.dll
@@ -56,16 +54,16 @@ Microsoft.TeamFoundation.TestManagement.Client.resources.dll
 Microsoft.TeamFoundation.TestManagement.Common.dll
 Microsoft.TeamFoundation.TestManagement.WebApi.dll
 Microsoft.TeamFoundation.VersionControl.Client.dll
+Microsoft.TeamFoundation.VersionControl.Common.dll
 Microsoft.TeamFoundation.VersionControl.Common.Integration.dll
 Microsoft.TeamFoundation.VersionControl.Common.Integration.resources.dll
-Microsoft.TeamFoundation.VersionControl.Common.dll
 Microsoft.TeamFoundation.VersionControl.Common.resources.dll
 Microsoft.TeamFoundation.Wiki.WebApi.dll
 Microsoft.TeamFoundation.Work.WebApi.dll
 Microsoft.TeamFoundation.WorkItemTracking.Client.DataStoreLoader.dll
+Microsoft.TeamFoundation.WorkItemTracking.Client.dll
 Microsoft.TeamFoundation.WorkItemTracking.Client.QueryLanguage.dll
 Microsoft.TeamFoundation.WorkItemTracking.Client.QueryLanguage.resources.dll
-Microsoft.TeamFoundation.WorkItemTracking.Client.dll
 Microsoft.TeamFoundation.WorkItemTracking.Client.resources.dll
 Microsoft.TeamFoundation.WorkItemTracking.Common.dll
 Microsoft.TeamFoundation.WorkItemTracking.Common.resources.dll
@@ -75,29 +73,28 @@ Microsoft.TeamFoundation.WorkItemTracking.Proxy.resources.dll
 Microsoft.TeamFoundation.WorkItemTracking.WebApi.dll
 Microsoft.VisualStudio.Debugger.UI.Interfaces.dll
 Microsoft.VisualStudio.Extensibility.Editor.Contracts.dll
+Microsoft.VisualStudio.ExtensionEngineContract.dll
 Microsoft.VisualStudio.HotReload.Components.dll
 Microsoft.VisualStudio.Linux.ConnectionManager.Store.dll
 Microsoft.VisualStudio.Markdown.Core.dll
 Microsoft.VisualStudio.Markdown.Platform.dll
 Microsoft.VisualStudio.Markdown.Platform.resources.dll
-Microsoft.VisualStudio.ProjectSystem.Managed.VS.dll
-Microsoft.VisualStudio.ProjectSystem.Managed.VS.resources.dll
 Microsoft.VisualStudio.ProjectSystem.Managed.dll
 Microsoft.VisualStudio.ProjectSystem.Managed.resources.dll
+Microsoft.VisualStudio.ProjectSystem.Managed.VS.dll
+Microsoft.VisualStudio.ProjectSystem.Managed.VS.resources.dll
 Microsoft.VisualStudio.ProjectSystem.Query.dll
 Microsoft.VisualStudio.ProjectSystem.Query.resources.dll
 Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.dll
 Microsoft.VisualStudio.Services.TestResults.WebApi.dll
-System.Configuration.ConfigurationManager.dll
+Microsoft.VisualStudio.Setup.Common.dll
+Microsoft.VisualStudio.SolutionPersistence.dll
 System.Drawing.Common.dll
 System.IdentityModel.Tokens.Jwt.dll
 System.Management.Automation.dll
 System.Memory.Data.dll
 System.Net.Http.Formatting.dll
-System.Reflection.MetadataLoadContext.dll
-System.Resources.Extensions.dll
 System.Text.Encodings.Web.dll
-System.Text.Json.dll
 System.Web.Http.dll
 
 # Ignore third party assemblies because we sign them in a specific location on disk and manually add them to the list
@@ -105,6 +102,7 @@ Lucene.Net.dll
 
 # Assembly XML Documentation isn't needed in the VSIX
 Microsoft.Build.NuGetSdkResolver.xml
+Microsoft.VisualStudio.ExtensionEngineContract.xml
 NuGet.Build.Tasks.xml
 NuGet.Commands.xml
 NuGet.Common.xml

--- a/src/NuGet.Clients/NuGet.VisualStudio.Contracts/NuGet.VisualStudio.Contracts.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Contracts/NuGet.VisualStudio.Contracts.csproj
@@ -27,5 +27,8 @@
     <PackageReference Include="Newtonsoft.Json" PrivateAssets="all" ExcludeAssets="all" />
     <!-- System.Text.Json is a dependency of Microsoft.ServiceHub.Framework. Remove the PackageReference once it no longer depends on a vulnerable version -->
     <PackageReference Include="System.Text.Json" />
+
+    <!-- MessagePack is a dependency of StreamJsonRpc. Remove the PackageReference once it no longer depends on a vulnerable version -->
+    <PackageReference Include="MessagePack" />
   </ItemGroup>
 </Project>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/NuGet.VisualStudio.Implementation.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/NuGet.VisualStudio.Implementation.csproj
@@ -29,8 +29,8 @@
     <ProjectReference Include="..\NuGet.VisualStudio.Common\NuGet.VisualStudio.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" IncludeAssets="None" PrivateAssets="all"/>
-    <PackageReference Include="Microsoft.Build.Framework" IncludeAssets="None" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.Build" IncludeAssets="None" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" IncludeAssets="None" PrivateAssets="all" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" IncludeAssets="None" PrivateAssets="all"/>
     <PackageReference Include="Microsoft.Build.Utilities.Core" IncludeAssets="None" PrivateAssets="all"/>
     <PackageReference Include="Microsoft.CodeAnalysis" IncludeAssets="None" PrivateAssets="all" />

--- a/src/NuGet.Clients/NuGet.VisualStudio.Interop/NuGet.VisualStudio.Interop.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Interop/NuGet.VisualStudio.Interop.csproj
@@ -18,15 +18,6 @@
     <PackageReference Include="Newtonsoft.Json" ExcludeAssets="all" />
   </ItemGroup>
 
-  <ItemGroup Label="transitive package pinning">
-    <!--
-      These packages are dependencies of Microsoft.VisualStudio.Shell.15.0
-      When it is upgraded to a newer version, try deleting the below PackageReferences
-      -->
-    <PackageReference Include="Microsoft.IO.Redist" />
-    <PackageReference Include="System.Text.Json" />
-  </ItemGroup>
-
   <ItemGroup>
     <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -22,8 +22,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.NET.StringTools" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="Runtime" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.TestPlatform.Portable" IncludeAssets="None" />
   </ItemGroup>
 

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/NuGet.SolutionRestoreManager.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/NuGet.SolutionRestoreManager.Test.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" />
-    <PackageReference Include="Microsoft.Build.Framework" />
-    <PackageReference Include="Microsoft.NET.StringTools" />
+    <PackageReference Include="Microsoft.Build.Framework" NoWarn="NU1605" />
   </ItemGroup>
 </Project>

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/NuGet.VisualStudio.Common.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/NuGet.VisualStudio.Common.Test.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" />
-    <PackageReference Include="Microsoft.Build.Framework" />
-    <PackageReference Include="Microsoft.NET.StringTools" />
+    <PackageReference Include="Microsoft.Build.Framework" NoWarn="NU1605" />
   </ItemGroup>
 </Project>

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" />
-    <PackageReference Include="Microsoft.Build.Framework" />
-    <PackageReference Include="Microsoft.NET.StringTools" />
+    <PackageReference Include="Microsoft.Build.Framework" NoWarn="NU1605" />
   </ItemGroup>
 </Project>

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/Microsoft.Build.NuGetSdkResolver.Test.csproj
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Test/Microsoft.Build.NuGetSdkResolver.Test.csproj
@@ -4,7 +4,7 @@
     <Description>Unit tests for Microsoft.Build.NuGetSdkResolver.</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" />
+    <PackageReference Include="Microsoft.Build.Framework" NoWarn="NU1605" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\NuGet.Core\Microsoft.Build.NuGetSdkResolver\Microsoft.Build.NuGetSdkResolver.csproj" />

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/NuGet.Build.Tasks.Console.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/NuGet.Build.Tasks.Console.Test.csproj
@@ -8,7 +8,7 @@
     <ProjectReference Include="..\..\TestUtilities\Test.Utility\Test.Utility.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="All" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="All" />
   </ItemGroup>

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/NuGet.Build.Tasks.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/NuGet.Build.Tasks.Test.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="All" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3211

## Description
This updates packages to ensure that we're not using a version of MessagePack with known vulnerabilities.  This gets us onto versoin 2.5.295 which is what Visual Studio currently has an assembly binding redirect to:

![image](https://github.com/user-attachments/assets/3a452f78-137c-452d-9193-4abea402a732)

![image](https://github.com/user-attachments/assets/25172a54-a5b6-4dad-8fab-6e451ecf7f3a)

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
