### PR TITLE
Use VersionRange.All in PM UI scenarios when a CPM project is configured incorrectly. 

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/GetPackageReferenceUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/GetPackageReferenceUtility.cs
@@ -52,7 +52,7 @@ namespace NuGet.PackageManagement.VisualStudio.Utility
             }
             else
             {
-                ProjectInstalledPackage newInstalledPackage = new ProjectInstalledPackage(projectLibrary.LibraryRange.VersionRange, new PackageIdentity(projectLibrary.Name, resolvedVersion));
+                ProjectInstalledPackage newInstalledPackage = new ProjectInstalledPackage(projectLibrary.LibraryRange.VersionRange ?? VersionRange.All, new PackageIdentity(projectLibrary.Name, resolvedVersion));
                 installedPackages.Add(projectLibrary.Name, newInstalledPackage);
             }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -4621,57 +4621,90 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async Task GetInstalledVersion_WithMissingCPMVersion_ReturnsEmptyVersion()
+        public async Task GetInstalledVersion_WithMissingCPMVersion_ReturnsPackageInstalledWithEmptyVersion()
         {
-            using (var testDirectory = TestDirectory.Create())
+            using var testDirectory = TestDirectory.Create();
+            // Setup
+            var projectName = "project1";
+            var projectFullPath = Path.Combine(testDirectory.Path, projectName + ".csproj");
+
+            // Project
+            var projectCache = new ProjectSystemCache();
+            IVsProjectAdapter projectAdapter = (new Mock<IVsProjectAdapter>()).Object;
+            var project = CreateCpsPackageReferenceProject(projectName, projectFullPath, projectCache);
+
+            var projectNames = GetTestProjectNames(projectFullPath, projectName);
+            var packageSpec = GetCPMPackageSpec(projectName, projectFullPath);
+
+            packageSpec.TargetFrameworks[0] = new TargetFrameworkInformation(packageSpec.TargetFrameworks[0])
             {
-                // Setup
-                var projectName = "project1";
-                var projectFullPath = Path.Combine(testDirectory.Path, projectName + ".csproj");
+                Dependencies = [new LibraryDependency(packageSpec.TargetFrameworks[0].Dependencies[0]) {
+                        LibraryRange = new LibraryRange(packageSpec.TargetFrameworks[0].Dependencies[0].LibraryRange){
+                            VersionRange = null
+                        }
+                    }]
+            };
 
-                // Project
-                var projectCache = new ProjectSystemCache();
-                IVsProjectAdapter projectAdapter = (new Mock<IVsProjectAdapter>()).Object;
-                var project = CreateCpsPackageReferenceProject(projectName, projectFullPath, projectCache);
+            // Restore info
+            var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
+            projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
+            projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
 
-                var projectNames = GetTestProjectNames(projectFullPath, projectName);
-                var packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.0.0, )");
+            // Package directories
+            var sources = new List<PackageSource>();
+            var packagesDir = new DirectoryInfo(Path.Combine(testDirectory, "globalPackages"));
+            var packageSource = new DirectoryInfo(Path.Combine(testDirectory, "packageSource"));
+            packagesDir.Create();
+            packageSource.Create();
+            sources.Add(new PackageSource(packageSource.FullName));
 
-                // packageSpec.TargetFrameworks[0].Dependencies[0].LibraryRange.VersionRange = null;
+            var logger = new TestLogger();
+            var request = new TestRestoreRequest(packageSpec, sources, packagesDir.FullName, logger)
+            {
+                LockFilePath = Path.Combine(testDirectory, "project.assets.json")
+            };
 
-                // Restore info
-                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
-                projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
-                projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
+            await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, "packageA", "3.0.0");
 
-                // Package directories
-                var sources = new List<PackageSource>();
-                var packagesDir = new DirectoryInfo(Path.Combine(testDirectory, "globalPackages"));
-                var packageSource = new DirectoryInfo(Path.Combine(testDirectory, "packageSource"));
-                packagesDir.Create();
-                packageSource.Create();
-                sources.Add(new PackageSource(packageSource.FullName));
+            // Act
+            var command = new RestoreCommand(request);
+            var result = await command.ExecuteAsync();
+            await result.CommitAsync(logger, CancellationToken.None);
+            var packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
 
-                var logger = new TestLogger();
-                var request = new TestRestoreRequest(packageSpec, sources, packagesDir.FullName, logger)
-                {
-                    LockFilePath = Path.Combine(testDirectory, "project.assets.json")
-                };
+            // Asert
+            result.Success.Should().BeFalse();
+            result.LockFile.LogMessages.Should().HaveCount(1);
+            result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1008);
+            packages.Should().HaveCount(1);
+            packages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("0.0.0"))));
+        }
 
-                await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, "packageA", "3.0.0");
-
-                // Act
-                var command = new RestoreCommand(request);
-                var result = await command.ExecuteAsync();
-                await result.CommitAsync(logger, CancellationToken.None);
-                var packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
-
-                // Asert
-                Assert.True(result.Success);
-                packages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("3.0.0"))));
-            }
-
-
+        internal static PackageSpec GetCPMPackageSpec(string projectName, string packageSpecFullPath)
+        {
+            string referenceSpec = $@"
+                {{
+                    ""restore"":
+                    {{
+                      ""centralPackageVersionsManagementEnabled"": true,
+                    }},
+                    ""frameworks"":
+                    {{
+                        ""net5.0"":
+                        {{
+                            ""dependencies"":
+                            {{
+                                ""packageA"":
+                                {{
+                                    ""target"": ""Package"",
+                                     ""version"": ""(, )""
+                                }},
+                            }}
+                        }}
+                    }}
+                }}";
+            return JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, packageSpecFullPath).WithTestRestoreMetadata();
+        }
 
         private static PackageSpec GetPackageSpecNoPackages(string projectName, string testDirectory)
         {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -201,7 +201,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             {
                 // Setup
                 var projectName = "project1";
-                var projectFullPath = Path.Combine(testDirectory.Path, projectName + ".csproj");
+                var packageSpec = ProjectTestHelpers.GetPackageSpec(projectName, testDirectory);
+                var projectFullPath = packageSpec.FilePath;
 
                 // Project
                 var projectCache = new ProjectSystemCache();
@@ -209,7 +210,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var project = CreateCpsPackageReferenceProject(projectName, projectFullPath, projectCache);
 
                 var projectNames = GetTestProjectNames(projectFullPath, projectName);
-                var packageSpec = GetPackageSpecNoPackages(projectName, projectFullPath);
 
                 // Restore info
                 var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
@@ -295,7 +295,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             {
                 // Setup
                 var projectName = "project1";
-                var projectFullPath = Path.Combine(testDirectory.Path, projectName + ".csproj");
+                var packageSpec = ProjectTestHelpers.GetPackageSpec(projectName, testDirectory);
+                var projectFullPath = packageSpec.FilePath;
 
                 // Project
                 var projectCache = new ProjectSystemCache();
@@ -303,7 +304,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var project = CreateCpsPackageReferenceProject(projectName, projectFullPath, projectCache);
 
                 var projectNames = GetTestProjectNames(projectFullPath, projectName);
-                var packageSpec = GetPackageSpecNoPackages(projectName, projectFullPath);
 
                 // Restore info
                 var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
@@ -4704,21 +4704,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     }}
                 }}";
             return JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, packageSpecFullPath).WithTestRestoreMetadata();
-        }
-
-        private static PackageSpec GetPackageSpecNoPackages(string projectName, string testDirectory)
-        {
-            const string referenceSpec = @"
-                {
-                    ""frameworks"": {
-                        ""net5.0"": {
-                            ""dependencies"": {
-                                }
-                            }
-                        }
-                    }
-                }";
-            return JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, testDirectory).WithTestRestoreMetadata();
         }
 
         private static PackageSpec GetPackageSpecMultipleVersions(string projectName, string testDirectory)

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -4620,6 +4620,59 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             progressReporter.VerifyAll();
         }
 
+        [Fact]
+        public async Task GetInstalledVersion_WithMissingCPMVersion_ReturnsEmptyVersion()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Setup
+                var projectName = "project1";
+                var projectFullPath = Path.Combine(testDirectory.Path, projectName + ".csproj");
+
+                // Project
+                var projectCache = new ProjectSystemCache();
+                IVsProjectAdapter projectAdapter = (new Mock<IVsProjectAdapter>()).Object;
+                var project = CreateCpsPackageReferenceProject(projectName, projectFullPath, projectCache);
+
+                var projectNames = GetTestProjectNames(projectFullPath, projectName);
+                var packageSpec = GetPackageSpec(projectName, projectFullPath, "[2.0.0, )");
+
+                // packageSpec.TargetFrameworks[0].Dependencies[0].LibraryRange.VersionRange = null;
+
+                // Restore info
+                var projectRestoreInfo = ProjectTestHelpers.GetDGSpecForAllProjects(packageSpec);
+                projectCache.AddProjectRestoreInfo(projectNames, projectRestoreInfo, new List<IAssetsLogMessage>());
+                projectCache.AddProject(projectNames, projectAdapter, project).Should().BeTrue();
+
+                // Package directories
+                var sources = new List<PackageSource>();
+                var packagesDir = new DirectoryInfo(Path.Combine(testDirectory, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(testDirectory, "packageSource"));
+                packagesDir.Create();
+                packageSource.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(packageSpec, sources, packagesDir.FullName, logger)
+                {
+                    LockFilePath = Path.Combine(testDirectory, "project.assets.json")
+                };
+
+                await SimpleTestPackageUtility.CreateFullPackageAsync(packageSource.FullName, "packageA", "3.0.0");
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+                var packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
+
+                // Asert
+                Assert.True(result.Success);
+                packages.Should().Contain(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("3.0.0"))));
+            }
+
+
+
         private static PackageSpec GetPackageSpecNoPackages(string projectName, string testDirectory)
         {
             const string referenceSpec = @"

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectFactories.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectFactories.cs
@@ -155,29 +155,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             return JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, packageSpecFullPath).WithTestRestoreMetadata();
         }
 
-        internal static PackageSpec GetPackageSpec2(string projectName, string packageSpecFullPath)
-        {
-            //       "centralPackageVersionsManagementEnabled": true,
-
-            string referenceSpec = $@"
-                {{
-                    ""frameworks"":
-                    {{
-                        ""net5.0"":
-                        {{
-                            ""dependencies"":
-                            {{
-                                ""packageA"":
-                                {{
-                                    ""target"": ""Package""
-                                }},
-                            }}
-                        }}
-                    }}
-                }}";
-            return JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, packageSpecFullPath).WithTestRestoreMetadata();
-        }
-
         internal static async Task CreatePackagesAsync(SimpleTestPathContext rootDir, string packageAVersion = "2.15.3", string packageBVersion = "1.0.0")
         {
             await SimpleTestPackageUtility.CreateFullPackageAsync(rootDir.PackageSource, "PackageB", packageBVersion);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectFactories.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectFactories.cs
@@ -155,6 +155,29 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             return JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, packageSpecFullPath).WithTestRestoreMetadata();
         }
 
+        internal static PackageSpec GetPackageSpec2(string projectName, string packageSpecFullPath)
+        {
+            //       "centralPackageVersionsManagementEnabled": true,
+
+            string referenceSpec = $@"
+                {{
+                    ""frameworks"":
+                    {{
+                        ""net5.0"":
+                        {{
+                            ""dependencies"":
+                            {{
+                                ""packageA"":
+                                {{
+                                    ""target"": ""Package""
+                                }},
+                            }}
+                        }}
+                    }}
+                }}";
+            return JsonPackageSpecReader.GetPackageSpec(referenceSpec, projectName, packageSpecFullPath).WithTestRestoreMetadata();
+        }
+
         internal static async Task CreatePackagesAsync(SimpleTestPathContext rootDir, string packageAVersion = "2.15.3", string packageBVersion = "1.0.0")
         {
             await SimpleTestPackageUtility.CreateFullPackageAsync(rootDir.PackageSource, "PackageB", packageBVersion);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13933

## Description

In CPM, when a package does not have a version, it is set to null, to allow restore to figure out that a package version is missing. 

In the PM UI model, we'd throw when we see the VersionRange is null.

In order to show that the package is declared as installed, but there's no version, we can pass VersionRange.All. 

I considered an alternative of not adding the package in the "installed" packages, but restore would've failed anyways, so the only consequence from that would be that the PM UI does not show the package at all which is incorrect.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
