### PR TITLE
Raise error when PackageReference has no version

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.DependencyGraphItem.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.DependencyGraphItem.cs
@@ -178,7 +178,7 @@ namespace NuGet.Commands
                     if (isRootProject && enablePruningWarnings && SdkAnalysisLevelMinimums.IsEnabled(
                         projectRestoreMetadata.SdkAnalysisLevel,
                         projectRestoreMetadata.UsingMicrosoftNETSdk,
-                        SdkAnalysisLevelMinimums.PruningWarnings))
+                        SdkAnalysisLevelMinimums.V10_0_100))
                     {
                         logger.Log(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1511, string.Format(CultureInfo.CurrentCulture, Strings.Error_RestorePruningProjectReference, dependency.Name), dependency.Name,
                             targetGraphName));

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -945,7 +945,7 @@ namespace NuGet.Commands
                 var diagnostic = RestoreLogMessage.CreateError(NuGetLogCode.NU1015, string.Format(CultureInfo.InvariantCulture, Strings.Error_PackageReference_NoVersion, string.Join(", ", packagesList)));
                 _logger.Log(diagnostic);
 
-            return false;
+                return false;
             }
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -168,10 +168,14 @@ namespace NuGet.Commands
             _enableNewDependencyResolver = _request.Project.RuntimeGraph.Supports.Count == 0 && ShouldUseNewResolverWithLockFile(_isLockFileEnabled, _request.Project) && !_request.Project.RestoreMetadata.UseLegacyDependencyResolver;
         }
 
-        // Use the new lock file if lock files are not enabled, or if lock files are enabled and .NET 10 SDK is used. Note that the legacy fallback is *false* in this case.
+        // Use the new resolver if lock files are not enabled, or if lock files are enabled and .NET 10 SDK is used.
         private static bool ShouldUseNewResolverWithLockFile(bool isLockFileEnabled, PackageSpec project)
         {
-            return !isLockFileEnabled || (project.RestoreMetadata.UsingMicrosoftNETSdk && SdkAnalysisLevelMinimums.IsEnabled(project.RestoreMetadata.SdkAnalysisLevel, project.RestoreMetadata.UsingMicrosoftNETSdk, SdkAnalysisLevelMinimums.NewResolverWithLockFiles));
+            return !isLockFileEnabled ||
+                (project.RestoreMetadata.UsingMicrosoftNETSdk && SdkAnalysisLevelMinimums.IsEnabled(
+                    project.RestoreMetadata.SdkAnalysisLevel,
+                    project.RestoreMetadata.UsingMicrosoftNETSdk,
+                    SdkAnalysisLevelMinimums.V10_0_100));
         }
 
         public Task<RestoreResult> ExecuteAsync()
@@ -220,15 +224,7 @@ namespace NuGet.Commands
 
                 telemetry.TelemetryEvent[NoOpResult] = false; // Getting here means we did not no-op.
 
-                if (!await AreCentralVersionRequirementsSatisfiedAsync(_request, httpSourcesCount))
-                {
-                    // the errors will be added to the assets file
-                    _success = false;
-                }
-
-                _success &= await EvaluateHttpSourceUsageAsync();
-
-                _success &= HasValidPlatformVersions();
+                _success &= BeforeGraphResolutionValidations(httpSourcesCount);
 
                 var packagesLockFilePath = PackagesLockFileUtilities.GetNuGetLockFilePath(_request.Project);
                 PackagesLockFile packagesLockFile = null;
@@ -339,6 +335,18 @@ namespace NuGet.Commands
             }
         }
 
+        private bool BeforeGraphResolutionValidations(int httpSourcesCount)
+        {
+            var success = true;
+
+            success &= AreCentralVersionRequirementsSatisfied(_request, httpSourcesCount);
+            success &= EvaluateHttpSourceUsage();
+            success &= HasValidPlatformVersions();
+            success &= PackageReferencesShouldHaveVersions();
+
+            return success;
+        }
+
         private void InitializeTelemetry(TelemetryActivity telemetry, int httpSourcesCount, bool auditEnabled)
         {
             telemetry.TelemetryEvent.AddPiiData(ProjectFilePath, _request.Project.FilePath);
@@ -433,7 +441,7 @@ namespace NuGet.Commands
             return (null, noOpCacheFileEvaluation, cacheFile);
         }
 
-        private async Task<bool> EvaluateHttpSourceUsageAsync()
+        private bool EvaluateHttpSourceUsage()
         {
             bool error = false;
 
@@ -447,11 +455,11 @@ namespace NuGet.Commands
                         var isErrorEnabled = SdkAnalysisLevelMinimums.IsEnabled(
                             _request.Project.RestoreMetadata.SdkAnalysisLevel,
                             _request.Project.RestoreMetadata.UsingMicrosoftNETSdk,
-                            SdkAnalysisLevelMinimums.HttpErrorSdkAnalysisLevelMinimumValue);
+                            SdkAnalysisLevelMinimums.V9_0_100);
 
                         if (isErrorEnabled)
                         {
-                            await _logger.LogAsync(
+                            _logger.Log(
                                 RestoreLogMessage.CreateError(
                                     NuGetLogCode.NU1302,
                                     string.Format(CultureInfo.CurrentCulture, Strings.Error_HttpSource_Single, "restore", source.Source)));
@@ -460,7 +468,7 @@ namespace NuGet.Commands
                         }
                         else
                         {
-                            await _logger.LogAsync(
+                            _logger.Log(
                                 RestoreLogMessage.CreateWarning(
                                     NuGetLogCode.NU1803,
                                     string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "restore", source.Source)));
@@ -766,7 +774,7 @@ namespace NuGet.Commands
                 SdkAnalysisLevelMinimums.IsEnabled(
                     project.RestoreMetadata.SdkAnalysisLevel,
                     project.RestoreMetadata.UsingMicrosoftNETSdk,
-                    SdkAnalysisLevelMinimums.PruningWarnings) &&
+                    SdkAnalysisLevelMinimums.V10_0_100) &&
                 HasFrameworkNewerThanNET10(project);
 
             if (!enablePruningWarnings)
@@ -884,7 +892,64 @@ namespace NuGet.Commands
             }
         }
 
-        private async Task<bool> AreCentralVersionRequirementsSatisfiedAsync(RestoreRequest restoreRequest, int httpSourcesCount)
+        private bool PackageReferencesShouldHaveVersions()
+        {
+            var project = _request?.Project;
+            if (project?.RestoreMetadata == null || project.RestoreMetadata.CentralPackageVersionsEnabled)
+            {
+                // When CPM is used, by design, the version must not be defined.
+                return true;
+            }
+
+            if (!SdkAnalysisLevelMinimums.IsEnabled(
+                project.RestoreMetadata.SdkAnalysisLevel,
+                project.RestoreMetadata.UsingMicrosoftNETSdk,
+                SdkAnalysisLevelMinimums.V10_0_100))
+            {
+                return true;
+            }
+
+            HashSet<string> packagesWithoutVersions = null;
+
+            foreach (var frameworkInfo in _request.Project.TargetFrameworks)
+            {
+                foreach (var dependency in frameworkInfo.Dependencies)
+                {
+                    if (dependency?.LibraryRange.VersionRange == VersionRange.All)
+                    {
+                        if (packagesWithoutVersions is null)
+                        {
+                            packagesWithoutVersions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                        }
+
+                        packagesWithoutVersions.Add(dependency.Name);
+                    }
+                }
+            }
+
+            // ilmerge crashes on NuGet.MSSigning.Extensions.csproj if this logging is not in a separate method.
+            // But it only crashes when ilmerging Release mode, in case you want to try to reproduce it.
+            return LogError(packagesWithoutVersions);
+
+            bool LogError(HashSet<string> packagesWithoutVersions)
+            {
+                if (packagesWithoutVersions is null)
+                {
+                    return true;
+                }
+
+                var packagesList = new List<string>(packagesWithoutVersions.Count);
+                packagesList.AddRange(packagesWithoutVersions);
+                packagesList.Sort();
+
+                var diagnostic = RestoreLogMessage.CreateError(NuGetLogCode.NU1015, string.Format(CultureInfo.InvariantCulture, Strings.Error_PackageReference_NoVersion, string.Join(", ", packagesList)));
+                _logger.Log(diagnostic);
+
+            return false;
+            }
+        }
+
+        private bool AreCentralVersionRequirementsSatisfied(RestoreRequest restoreRequest, int httpSourcesCount)
         {
             if (restoreRequest?.Project?.RestoreMetadata == null || !restoreRequest.Project.RestoreMetadata.CentralPackageVersionsEnabled)
             {
@@ -896,7 +961,7 @@ namespace NuGet.Commands
             if (!restoreRequest.PackageSourceMapping.IsEnabled && httpSourcesCount > 1)
             {
                 // Log a warning if there are more than one configured HTTP source and package source mapping is not enabled
-                await _logger.LogAsync(
+                _logger.Log(
                     RestoreLogMessage.CreateWarning(
                         NuGetLogCode.NU1507,
                         string.Format(
@@ -973,7 +1038,7 @@ namespace NuGet.Commands
             {
                 result = false;
 
-                await _logger.LogAsync(
+                _logger.Log(
                     RestoreLogMessage.CreateError(
                         NuGetLogCode.NU1008,
                         string.Format(
@@ -986,7 +1051,7 @@ namespace NuGet.Commands
             {
                 result = false;
 
-                await _logger.LogAsync(
+                _logger.Log(
                     RestoreLogMessage.CreateError(
                         NuGetLogCode.NU1009,
                         string.Format(
@@ -999,7 +1064,7 @@ namespace NuGet.Commands
             {
                 result = false;
 
-                await _logger.LogAsync(
+                _logger.Log(
                     RestoreLogMessage.CreateError(
                         NuGetLogCode.NU1010,
                         string.Format(
@@ -1012,7 +1077,7 @@ namespace NuGet.Commands
             {
                 result = false;
 
-                await _logger.LogAsync(
+                _logger.Log(
                     RestoreLogMessage.CreateError(
                         NuGetLogCode.NU1011,
                         string.Format(
@@ -1027,7 +1092,7 @@ namespace NuGet.Commands
 
                 foreach (var item in packageReferenceItemsWithVersionOverride)
                 {
-                    await _logger.LogAsync(
+                    _logger.Log(
                         RestoreLogMessage.CreateError(
                             NuGetLogCode.NU1013,
                             string.Format(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -342,7 +342,7 @@ namespace NuGet.Commands
             success &= AreCentralVersionRequirementsSatisfied(_request, httpSourcesCount);
             success &= EvaluateHttpSourceUsage();
             success &= HasValidPlatformVersions();
-            success &= PackageReferencesShouldHaveVersions();
+            success &= PackageReferencesHaveVersions();
 
             return success;
         }
@@ -892,10 +892,10 @@ namespace NuGet.Commands
             }
         }
 
-        private bool PackageReferencesShouldHaveVersions()
+        private bool PackageReferencesHaveVersions()
         {
-            var project = _request?.Project;
-            if (project?.RestoreMetadata == null || project.RestoreMetadata.CentralPackageVersionsEnabled)
+            var project = _request.Project;
+            if (project.RestoreMetadata == null || project.RestoreMetadata.CentralPackageVersionsEnabled)
             {
                 // When CPM is used, by design, the version must not be defined.
                 return true;
@@ -917,11 +917,7 @@ namespace NuGet.Commands
                 {
                     if (dependency?.LibraryRange.VersionRange == VersionRange.All)
                     {
-                        if (packagesWithoutVersions is null)
-                        {
-                            packagesWithoutVersions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                        }
-
+                        packagesWithoutVersions ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                         packagesWithoutVersions.Add(dependency.Name);
                     }
                 }
@@ -929,9 +925,9 @@ namespace NuGet.Commands
 
             // ilmerge crashes on NuGet.MSSigning.Extensions.csproj if this logging is not in a separate method.
             // But it only crashes when ilmerging Release mode, in case you want to try to reproduce it.
-            return LogError(packagesWithoutVersions);
+            return EnsureNoPackageReferencesWithoutVersions(packagesWithoutVersions);
 
-            bool LogError(HashSet<string> packagesWithoutVersions)
+            bool EnsureNoPackageReferencesWithoutVersions(HashSet<string> packagesWithoutVersions)
             {
                 if (packagesWithoutVersions is null)
                 {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -709,6 +709,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The following PackageReference item(s) do not have a version specified: {0}.
+        /// </summary>
+        internal static string Error_PackageReference_NoVersion {
+            get {
+                return ResourceManager.GetString("Error_PackageReference_NoVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Package content hash validation failed for {0}. The package is different than the last restore..
         /// </summary>
         internal static string Error_PackageValidationFailed {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -1156,5 +1156,9 @@ NuGet requires HTTPS sources. Refer to https://aka.ms/nuget-https-everywhere for
   </data>
   <data name="Invalid_Framework" xml:space="preserve">
     <value>One or more invalid frameworks were detected.</value>
+  </data>
+  <data name="Error_PackageReference_NoVersion" xml:space="preserve">
+    <value>The following PackageReference item(s) do not have a version specified: {0}</value>
+    <comment>0 - List of package names</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Utility/SdkAnalysisLevelMinimums.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/SdkAnalysisLevelMinimums.cs
@@ -13,17 +13,17 @@ namespace NuGet.Commands
         /// <summary>
         /// Minimum SDK Analysis Level required to enable HTTP Errors is 9.0.100.
         /// </summary>
-        internal static readonly NuGetVersion HttpErrorSdkAnalysisLevelMinimumValue = new("9.0.100");
+        internal static readonly NuGetVersion V9_0_100 = new("9.0.100");
 
         /// <summary>
-        /// Minimum SDK Analysis Level required for warning for packages and projects that cannot be pruned.
+        /// Minimum SDK Analysis Level required for:
+        /// <list type="bullet">
+        /// <item>warning for packages and projects that cannot be pruned</item>
+        /// <item>enabling the new restore algorithm for lock files</item>
+        /// <item>error when CPM not used and PackageReference does not have version</item>
+        /// </list>
         /// </summary>
-        internal static readonly NuGetVersion PruningWarnings = new("10.0.100");
-
-        /// <summary>
-        /// Minimum SDK Analysis Level required for enabling the new algorithm for lock files
-        /// </summary>
-        internal static readonly NuGetVersion NewResolverWithLockFiles = new("10.0.100");
+        internal static readonly NuGetVersion V10_0_100 = new("10.0.100");
 
         /// <summary>
         /// Determines whether the feature is enabled based on the SDK analysis level.
@@ -32,7 +32,7 @@ namespace NuGet.Commands
         /// <param name="usingMicrosoftNetSdk">Is it SDK project or not</param>
         /// <param name="minSdkVersion">The minimum version of the SDK required for the feature to be enabled.</param>
         /// <returns>Returns true if the feature should be enabled based on the given parameters; otherwise, false.</returns>
-        public static bool IsEnabled(NuGetVersion sdkAnalysisLevel, bool usingMicrosoftNetSdk, NuGetVersion minSdkVersion)
+        internal static bool IsEnabled(NuGetVersion sdkAnalysisLevel, bool usingMicrosoftNetSdk, NuGetVersion minSdkVersion)
         {
             if (sdkAnalysisLevel != null && sdkAnalysisLevel >= minSdkVersion ||
                 sdkAnalysisLevel == null && usingMicrosoftNetSdk == false)

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -129,6 +129,11 @@ namespace NuGet.Common
         NU1014 = 1014,
 
         /// <summary>
+        /// PackageReference without a version.
+        /// </summary>
+        NU1015 = 1015,
+
+        /// <summary>
         /// Unable to resolve package, generic message for unknown type constraints.
         /// </summary>
         NU1100 = 1100,

--- a/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+NuGet.Common.NuGetLogCode.NU1015 = 1015 -> NuGet.Common.NuGetLogCode

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SdkAnalysisLevelMinimumsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SdkAnalysisLevelMinimumsTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using FluentAssertions;
 using NuGet.Versioning;
 using Xunit;
 
@@ -12,35 +13,35 @@ namespace NuGet.Commands.Test
         public void IsEnabled_WhenSdkAnalysisLevelIsNullAndUsingMicrosoftNetSdkIsFalse_ShouldReturnTrue()
         {
             var result = SdkAnalysisLevelMinimums.IsEnabled(null, false, new NuGetVersion("9.0.100"));
-            Assert.True(result);
+            result.Should().BeTrue();
         }
 
         [Fact]
         public void IsEnabled_WhenSdkAnalysisLevelIsNullAndUsingMicrosoftNetSdkIsTrue_ShouldReturnFalse()
         {
             var result = SdkAnalysisLevelMinimums.IsEnabled(null, true, new NuGetVersion("9.0.100"));
-            Assert.False(result);
+            result.Should().BeFalse();
         }
 
         [Fact]
         public void IsEnabled_WhenSdkAnalysisLevelIsLessThanMinSdkVersion_ShouldReturnFalse()
         {
             var result = SdkAnalysisLevelMinimums.IsEnabled(new NuGetVersion("8.0.900"), true, new NuGetVersion("9.0.100"));
-            Assert.False(result);
+            result.Should().BeFalse();
         }
 
         [Fact]
         public void IsEnabled_WhenSdkAnalysisLevelIsEqualToMinSdkVersion_ShouldReturnTrue()
         {
             var result = SdkAnalysisLevelMinimums.IsEnabled(new NuGetVersion("9.0.100"), true, new NuGetVersion("9.0.100"));
-            Assert.True(result);
+            result.Should().BeTrue();
         }
 
         [Fact]
         public void IsEnabled_WhenSdkAnalysisLevelIsGreaterThanMinSdkVersion_ShouldReturnTrue()
         {
             var result = SdkAnalysisLevelMinimums.IsEnabled(new NuGetVersion("9.0.101"), true, new NuGetVersion("9.0.100"));
-            Assert.True(result);
+            result.Should().BeTrue();
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/TestLogger.cs
+++ b/test/TestUtilities/Test.Utility/TestLogger.cs
@@ -173,7 +173,7 @@ namespace NuGet.Test.Utility
         {
             LogMessages.Enqueue(message);
 
-            Log(message.Level, message.Message);
+            Log(message.Level, message.FormatWithCode());
         }
 
         public async Task LogAsync(ILogMessage message)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13796

## Description

Add validation before resolving the package graph, that PackageReference items have the version specified. Only applies for SdkAnalysisLevel 10.0.100 and above, otherwise the NU1604 "no lower bound" warning is generated as before.

I also changed the SDK Analysis Level helper, because as more features gate on different versions, each feature having its own field/property will become very long, and the existing implementation had multiple duplicate version objects. This PR changes the helper to have a field that represents the version, and references to the feature names are changed to their corresponding versions.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
