### PR TITLE
[Pack] Fix version override on nuspec when using token replacement

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
@@ -148,8 +148,8 @@ namespace NuGet.Packaging
             // Update manifest metadata version if version was provided by the CLI command
             if (propertyProvider is not null && propertyProvider.Target.GetType().Name.Equals("PackArgs"))
             {
-                var version = propertyProvider("version");
-                if (version is not null)
+                var versionProperty = propertyProvider.Target.GetType().GetProperty("Version");
+                if (versionProperty?.GetValue(propertyProvider.Target) is string version)
                 {
                     manifest.Metadata.Version = NuGetVersion.Parse(version);
                 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -342,6 +342,50 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        public void PackCommand_PackageFromNuspecWithTokenReplacement()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var workingDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                Util.CreateFile(
+                    Path.Combine(workingDirectory, "contentFiles"),
+                    "image.jpg",
+                    "");
+
+                // Arrange
+                Util.CreateFile(
+                    workingDirectory,
+                    "packageA.nuspec",
+@"<package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+  <metadata>
+    <id>$package$</id>    
+    <version>$version$$prerelease$</version>
+    <description>Package description</description>
+    <authors>Author</authors>
+  </metadata>
+</package>");
+
+                // Act
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    workingDirectory,
+                    "pack packageA.nuspec -Properties version=2.0.0;prerelease=-preview;package=test",
+                    testOutputHelper: _testOutputHelper);
+                Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
+
+                // Assert
+                var path = Path.Combine(workingDirectory, "packageA.2.0.0-preview.nupkg");
+                var package = new PackageArchiveReader(File.OpenRead(path));
+
+                var files = package.GetNonPackageDefiningFiles();
+                Assert.Equal(1, files.Count());
+            }
+        }
+
+
+        [Fact]
         public void PackCommand_PackRuntimesRefNativeNoWarnings()
         {
             var nugetexe = Util.GetNuGetExePath();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -376,7 +376,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(0 == r.ExitCode, r.Output + " " + r.Errors);
 
                 // Assert
-                var path = Path.Combine(workingDirectory, "packageA.2.0.0-preview.nupkg");
+                var path = Path.Combine(workingDirectory, "test.2.0.0-preview.nupkg");
                 var package = new PackageArchiveReader(File.OpenRead(path));
 
                 var files = package.GetNonPackageDefiningFiles();

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/PackCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/PackCommandRunnerTests.cs
@@ -81,7 +81,31 @@ namespace NuGet.Commands.Test
                     Exclude = Enumerable.Empty<string>(),
                     Logger = NullLogger.Instance,
                     Path = test.NuspecFile.FullName,
-                    Version = "3.1.2"
+                    Version = "3.1.2",
+                };
+                var runner = new PackCommandRunner(args, createProjectFactory: null);
+
+                var result = runner.RunPackageBuild();
+                Assert.True(result);
+
+                var nupkgPath = Path.Combine(test.CurrentDirectory.FullName, $"DefaultExclusions.3.1.2.nupkg");
+                File.Exists(nupkgPath).Should().BeTrue();
+            }
+        }
+
+        [Fact]
+        public void RunPackageBuild_WithVersionAndPropertiesAsArgument_NuspecVersionOverriddenByVersionArgument()
+        {
+            using (var test = DefaultExclusionsTest.Create())
+            {
+                var args = new PackArgs()
+                {
+                    CurrentDirectory = test.CurrentDirectory.FullName,
+                    Exclude = Enumerable.Empty<string>(),
+                    Logger = NullLogger.Instance,
+                    Path = test.NuspecFile.FullName,
+                    Version = "3.1.2",
+                    Properties = { { "version", "2.0.0" }, { "prerelease", "-preview" } }
                 };
                 var runner = new PackCommandRunner(args, createProjectFactory: null);
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14219

## Description
This a regression introduced by https://github.com/NuGet/NuGet.Client/pull/6092, [PackArgs stores the version specified in CLI in the `Properties` variable] (https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs#L700-L706), but customers can also add their custom Properties as an argument. 

This `Properties` are then handled by a token replacement when parsing the nuspec https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs#L125. 

The if I added was looking at the `Properties` variable from `PackArgs` instead of the `Version` property, this caused a version override with just the Version property.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- ~[ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
