### PR TITLE
Change pack success message to be compatible with msbuild terminal logger

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -134,11 +134,12 @@ namespace NuGet.Commands
         /// If for any other reason the package creation fails (like for example, a validation rule got bumped from warning to an error, this will return <see langword="null"/>.
         /// </summary>
         /// <param name="builder">The package builder to use.</param>
+        /// <param name="inputName">The name of the input to pack. For project pack, it should be the project name. For nuspec pack, it should be the nuspec filename.</param>
         /// <param name="outputPath">The package output path.</param>
         /// <param name="symbolsPackage">Whether this package is a symbols package. Symbols packages do not undergo validations.</param>
         /// <returns>A <see cref="PackageArchiveReader"/> if everything completed succesfully. Throws if a core package validation fails. Returns <see langword="null"/> if a validation rule got elevated from a warning to an error.</returns>
         /// <exception cref="PackagingException">If a core packaging validation fails.</exception>
-        private bool BuildPackage(PackageBuilder builder, string outputPath = null, bool symbolsPackage = false)
+        private bool BuildPackage(PackageBuilder builder, string inputName, string outputPath = null, bool symbolsPackage = false)
         {
             outputPath = outputPath ?? GetOutputPath(builder, _packArgs, false, builder.Version);
             Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
@@ -200,9 +201,8 @@ namespace NuGet.Commands
 
             _packArgs.Logger.Log(
                 PackagingLogMessage.CreateMessage(
-                    string.Format(CultureInfo.CurrentCulture, Strings.Log_PackageCommandSuccess, outputPath),
+                    string.Format(CultureInfo.CurrentCulture, "{0} -> {1}", inputName, outputPath),
                     LogLevel.Minimal));
-
 
             return true;
         }
@@ -657,6 +657,7 @@ namespace NuGet.Commands
         private bool BuildFromNuspec(string path)
         {
             PackageBuilder packageBuilder = CreatePackageBuilderFromNuspec(path);
+            string nuspecFileName = Path.GetFileName(path);
 
             bool successful;
 
@@ -665,7 +666,7 @@ namespace NuGet.Commands
             if (_packArgs.InstallPackageToOutputPath)
             {
                 string outputPath = GetOutputPath(packageBuilder, _packArgs);
-                successful = BuildPackage(packageBuilder, outputPath: outputPath, symbolsPackage: false);
+                successful = BuildPackage(packageBuilder, nuspecFileName, outputPath: outputPath, symbolsPackage: false);
             }
             else
             {
@@ -686,7 +687,7 @@ namespace NuGet.Commands
                     }
                 }
 
-                successful = BuildPackage(packageBuilder, symbolsPackage: false);
+                successful = BuildPackage(packageBuilder, nuspecFileName, symbolsPackage: false);
 
                 if (_packArgs.Symbols)
                 {
@@ -793,14 +794,15 @@ namespace NuGet.Commands
             // Build the main package
             if (GenerateNugetPackage)
             {
+                string projectName = Path.GetFileNameWithoutExtension(path);
                 if (_packArgs.InstallPackageToOutputPath)
                 {
                     string outputPath = GetOutputPath(mainPackageBuilder, _packArgs);
-                    successful = BuildPackage(mainPackageBuilder, outputPath: outputPath, symbolsPackage: false);
+                    successful = BuildPackage(mainPackageBuilder, projectName, outputPath: outputPath, symbolsPackage: false);
                 }
                 else
                 {
-                    successful = BuildPackage(mainPackageBuilder, symbolsPackage: false);
+                    successful = BuildPackage(mainPackageBuilder, projectName, symbolsPackage: false);
                 }
 
                 // If we're excluding symbols then do nothing else

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1403,15 +1403,6 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Successfully created package &apos;{0}&apos;..
-        /// </summary>
-        internal static string Log_PackageCommandSuccess {
-            get {
-                return ResourceManager.GetString("Log_PackageCommandSuccess", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Package content hash validation failed for {0}. Expected: {1} Actual: {2}.
         /// </summary>
         internal static string Log_PackageContentHashValidationFailed {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -262,9 +262,6 @@
   <data name="Log_PackageCommandAttemptingToBuildSymbolsPackage" xml:space="preserve">
     <value>Attempting to build symbols package for '{0}'.</value>
   </data>
-  <data name="Log_PackageCommandSuccess" xml:space="preserve">
-    <value>Successfully created package '{0}'.</value>
-  </data>
   <data name="Warning_DuplicatePropertyKey" xml:space="preserve">
     <value>'{0}' key already exists in Properties collection. Overriding value.</value>
   </data>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13998

## Description
Ever since the .NET SDK team enabled the "terminal logger" by default in .NET 8, `dotnet pack` no longer outputs the nupkg path. According to https://github.com/dotnet/msbuild/issues/9608, it looks for messages containing `->`, so that's what this PR changes it to.

Since PackCommandRunner is used for both nuget.exe and msbuild (including dotnet) pack, this will impact all pack output.

**before**: (using msbuild, rather than dotnet, because it's easier to test)
```text
Restore complete (1.3s)
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  GithubIssueTagger net8.0 succeeded (0.1s) → bin\Debug\net8.0\GithubIssueTagger.dll
  GithubIssueTagger succeeded (1.2s) → bin\Debug\net8.0\GithubIssueTagger.dll

Build succeeded in 2.9s
```

**after**:
```text
Restore complete (1.2s)
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  GithubIssueTagger net8.0 succeeded (0.1s) → bin\Debug\net8.0\GithubIssueTagger.dll
  GithubIssueTagger succeeded (1.0s) → bin\Debug\NuGet.Internal.GithubIssueTagger.2025.4.1.nupkg

Build succeeded in 2.5s
```

I don't know why the no-tfm successful build output disappeared, but this PR clearly doesn't change that, so it must be logic in msbuild's terminal logger.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
