### PR TITLE
[Data model] Fix Deprecation label converter due to missing deprecation metadata

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/DeprecationPackageMetadataCapability.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/DeprecationPackageMetadataCapability.cs
@@ -69,6 +69,8 @@ namespace NuGet.PackageManagement.UI.Models.Package
             }
         }
 
+        public PackageDeprecationMetadataContextInfo? DeprecationMetadata => _deprecationMetadata;
+
         public async Task PopulateDataAsync(CancellationToken cancellationToken)
         {
             _deprecationMetadata = await _packageMetadataRetrievalAdapter.GetPackageDeprecationInfoAsync(cancellationToken);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/IDeprecationCapable.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/IDeprecationCapable.cs
@@ -19,5 +19,7 @@ namespace NuGet.PackageManagement.UI.Models.Package
         public AlternatePackageMetadataContextInfo? AlternatePackage { get; }
 
         public Task PopulateDataAsync(CancellationToken cancellationToken);
+
+        public PackageDeprecationMetadataContextInfo? DeprecationMetadata { get; }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/ReferencedPackageModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/ReferencedPackageModel.cs
@@ -78,6 +78,8 @@ namespace NuGet.PackageManagement.UI.Models.Package
 
         public PackageVulnerabilitySeverity VulnerabilityMaxSeverity => _vulnerableCapability.VulnerabilityMaxSeverity;
 
+        public PackageDeprecationMetadataContextInfo? DeprecationMetadata => _deprecationCapability.DeprecationMetadata;
+
         public override async Task PopulateDataAsync(CancellationToken cancellationToken)
         {
             await _vulnerableCapability.PopulateDataAsync(cancellationToken);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/RemotePackageModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/RemotePackageModel.cs
@@ -69,6 +69,8 @@ namespace NuGet.PackageManagement.UI.Models.Package
 
         public PackageVulnerabilitySeverity VulnerabilityMaxSeverity => _vulnerableCapability.VulnerabilityMaxSeverity;
 
+        public PackageDeprecationMetadataContextInfo? DeprecationMetadata => _deprecationCapability.DeprecationMetadata;
+
         public override async Task PopulateDataAsync(CancellationToken cancellationToken)
         {
             await _vulnerableCapability.PopulateDataAsync(cancellationToken);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -368,6 +368,7 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
+        public PackageDeprecationMetadataContextInfo DeprecationMetadata => (_packageModel as IDeprecationCapable)?.DeprecationMetadata;
         public bool IsPackageDeprecated => (_packageModel as IDeprecationCapable)?.IsDeprecated ?? false;
 
         public bool IsPackageVulnerable => (_packageModel as IVulnerableCapable)?.IsVulnerable ?? false || VulnerableVersions.Count > 0;
@@ -803,6 +804,7 @@ namespace NuGet.PackageManagement.UI
             }
 
             OnPropertyChanged(nameof(IsPackageDeprecated));
+            OnPropertyChanged(nameof(DeprecationMetadata));
             OnPropertyChanged(nameof(AlternatePackage));
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -248,7 +248,7 @@
                         Grid.Row="1"
                         FormatStringSingle="{x:Static nuget:Resources.Deprecation_PackageItemMessage}"
                         FormatStringAlternative="{x:Static nuget:Resources.Deprecation_PackageItemMessageAlternative}"
-                        DataContext="{Binding AlternatePackage}" />
+                        DataContext="{Binding DeprecationMetadata}" />
         </Grid>
 
         <Grid.ToolTip>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemDeprecationLabel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemDeprecationLabel.xaml
@@ -40,11 +40,11 @@
               Style="{StaticResource HyperlinkStyleNoUriDeprecation}">
               <Hyperlink.CommandParameter>
                 <MultiBinding Converter="{StaticResource ParametersToHyperlinkTupleConverter}" Mode="OneWay">
-                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="DataContext.PackageId" Mode="OneWay" />
+                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="DataContext.AlternatePackage.PackageId" Mode="OneWay" />
                   <Binding Source="{x:Static nugettel:HyperlinkType.DeprecationAlternativePackageItem}" />
                 </MultiBinding>
               </Hyperlink.CommandParameter>
-              <Run Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DataContext.PackageId, Mode=OneWay}" />
+              <Run Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DataContext.AlternatePackage.PackageId, Mode=OneWay}" />
             </Hyperlink>
           </TextBlock>
           <TextBlock

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/DeprecationPackageMetadataCapabilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/DeprecationPackageMetadataCapabilityTests.cs
@@ -51,6 +51,7 @@ namespace NuGet.PackageManagement.UI.Test.Models.Package
 
             // Assert
             Assert.Equal(alternatePackageMetadata, capability.AlternatePackage);
+            Assert.Equal(deprecationMetadata, capability.DeprecationMetadata);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 
Vendors found a bug related to a missing label in deprecated packages. This is because the Converter used for this label uses the PackageDeprecation metadata which wasn't being exposed. 

![image](https://github.com/user-attachments/assets/e2c6160c-4da9-4b6f-91bf-c11a1f28e7c6)

Fix:
![image](https://github.com/user-attachments/assets/d4f587ce-baee-42d3-8354-2920367e2a28)
![image](https://github.com/user-attachments/assets/32887f47-d0cf-42b0-a6e0-dea38a817ad4)


## Description

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- ~[ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
