### PR TITLE
Use tfm specific dependencies in tests

### DIFF
--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
@@ -58,32 +58,29 @@ namespace NuGet.Commands
                 {
                     frameworks.Add(new TargetFrameworkInformation
                     {
-                        FrameworkName = tf
+                        FrameworkName = tf,
+                        Dependencies = [new LibraryDependency()
+                            {
+                                LibraryRange = new LibraryRange(
+                                    libraryIdentity.Name,
+                                    new VersionRange(
+                                        minVersion: libraryIdentity.Version,
+                                        includeMinVersion: true,
+                                        maxVersion: libraryIdentity.Version,
+                                        includeMaxVersion: true),
+                                    LibraryDependencyTarget.Package),
+                                SuppressParent = LibraryIncludeFlags.All,
+                                AutoReferenced = true,
+                                IncludeType = LibraryIncludeFlags.None,
+                            }
+                        ]
                     });
-
                     originalTargetFrameworks.Add(tf.ToString());
                 }
 
                 // The package spec details what packages to restore
                 var packageSpec = new PackageSpec(frameworks)
                 {
-                    Dependencies = new List<LibraryDependency>
-                    {
-                        new LibraryDependency()
-                        {
-                            LibraryRange = new LibraryRange(
-                                libraryIdentity.Name,
-                                new VersionRange(
-                                    minVersion: libraryIdentity.Version,
-                                    includeMinVersion: true,
-                                    maxVersion: libraryIdentity.Version,
-                                    includeMaxVersion: true),
-                                LibraryDependencyTarget.Package),
-                            SuppressParent = LibraryIncludeFlags.All,
-                            AutoReferenced = true,
-                            IncludeType = LibraryIncludeFlags.None,
-                        }
-                    },
                     RestoreMetadata = new ProjectRestoreMetadata
                     {
                         ProjectPath = projectFullPath,

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -350,9 +350,6 @@ namespace NuGet.ProjectModel
 
             if (packageSpec != null)
             {
-                // Add dependencies section
-                dependencies.AddRange(packageSpec.Dependencies);
-
                 // Add framework specific dependencies
                 var targetFrameworkInfo = packageSpec.GetTargetFramework(targetFramework);
 

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -350,6 +350,9 @@ namespace NuGet.ProjectModel
 
             if (packageSpec != null)
             {
+                // Add dependencies section
+                dependencies.AddRange(packageSpec.Dependencies);
+
                 // Add framework specific dependencies
                 var targetFrameworkInfo = packageSpec.GetTargetFramework(targetFramework);
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -156,16 +156,14 @@ namespace NuGet.Commands.FuncTest
                 Directory.CreateDirectory(Path.Combine(projectDir, "TestProject"));
                 var projectSpecPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var projectSpec = JsonPackageSpecReader.GetPackageSpec(BasicConfigWithNet46.ToString(), "TestProject", projectSpecPath).WithTestRestoreMetadata();
-                projectSpec.Dependencies = new List<LibraryDependency>
+
+                ProjectTestHelpers.AddDependency(projectSpec, new LibraryDependency()
                 {
-                    new LibraryDependency()
-                    {
-                        LibraryRange = new LibraryRange(
+                    LibraryRange = new LibraryRange(
                             "REFERENCEDPROJECT",
                             VersionRange.Parse("*"),
                             LibraryDependencyTarget.Project)
-                    }
-                };
+                });
 
                 Directory.CreateDirectory(Path.Combine(projectDir, "ReferencedProject"));
                 var referenceSpecPath = Path.Combine(projectDir, "ReferencedProject", "project.json");
@@ -5289,35 +5287,22 @@ namespace NuGet.Commands.FuncTest
                 }
             };
 
-            for (int i = 0; i < spec.TargetFrameworks.Count; i++)
-            {
-                List<LibraryDependency> dependencies = new List<LibraryDependency>();
-                dependencies.AddRange(spec.TargetFrameworks[i].Dependencies);
-                dependencies.Add(target);
-
-                spec.TargetFrameworks[i] = new TargetFrameworkInformation(spec.TargetFrameworks[i])
-                {
-                    Dependencies = dependencies.ToImmutableArray()
-                };
-            }
+            ProjectTestHelpers.AddDependency(spec, target);
         }
 
         private static JObject BasicConfig
         {
             get
             {
-
-
-                var frameworks = new JObject
-                {
-                    ["netcore50"] = new JObject()
-                };
-
                 var json = new JObject
                 {
-                    ["dependencies"] = new JObject(),
-
-                    ["frameworks"] = frameworks
+                    ["frameworks"] = new JObject
+                    {
+                        ["netcore50"] = new JObject()
+                        {
+                            ["dependencies"] = new JObject()
+                        }
+                    }
                 };
 
                 json.Add("runtimes", JObject.Parse("{ \"uap10-x86\": { }, \"uap10-x86-aot\": { } }"));
@@ -5330,18 +5315,16 @@ namespace NuGet.Commands.FuncTest
         {
             get
             {
-
-
-                var frameworks = new JObject
-                {
-                    ["net46"] = new JObject()
-                };
-
                 var json = new JObject
                 {
-                    ["dependencies"] = new JObject(),
 
-                    ["frameworks"] = frameworks
+                    ["frameworks"] = new JObject
+                    {
+                        ["net46"] = new JObject()
+                        {
+                            ["dependencies"] = new JObject(),
+                        }
+                    }
                 };
 
                 json.Add("runtimes", JObject.Parse("{ \"uap10-x86\": { }, \"uap10-x86-aot\": { } }"));

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -503,13 +504,13 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""Newtonsoft.Json"": ""7.0.1""
-                    },
                     ""frameworks"": {
                         ""dotnet"": {
                             ""imports"": ""portable-net452+win81"",
-                            ""warn"": false
+                            ""warn"": false,
+                            ""dependencies"": {
+                                ""Newtonsoft.Json"": ""7.0.1""
+                            }
                         }
                     }
                 }");
@@ -559,13 +560,13 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""Newtonsoft.Json"": ""7.0.1""
-                    },
                     ""frameworks"": {
                         ""netstandard1.2"": {
                             ""imports"": [""dotnet5.3"",""portable-net452+win81""],
-                            ""warn"": false
+                            ""warn"": false,
+                            ""dependencies"": {
+                                ""Newtonsoft.Json"": ""7.0.1""
+                            }
                         }
                     }
                 }");
@@ -675,13 +676,13 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""Newtonsoft.Json"": ""7.0.1""
-                    },
                     ""frameworks"": {
                         ""dotnet"": {
                             ""imports"": ""portable-net452+win81"",
-                            ""warn"": false
+                            ""warn"": false,
+                            ""dependencies"": {
+                                ""Newtonsoft.Json"": ""7.0.1""
+                            }
                         }
                     }
                 }");
@@ -775,13 +776,13 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""WindowsAzure.Storage"": ""4.4.1-preview""
-                    },
                     ""frameworks"": {
                         ""dotnet"": {
                             ""imports"": ""portable-net452+win81"",
-                            ""warn"": false
+                            ""warn"": false,
+                            ""dependencies"": {
+                                ""WindowsAzure.Storage"": ""4.4.1-preview""
+                            }
                         }
                     }
                 }");
@@ -1139,17 +1140,11 @@ namespace NuGet.Commands.FuncTest
 
             var project1Json = @"
             {
-              ""version"": ""1.0.0"",
-              ""description"": """",
-              ""authors"": [ ""author"" ],
-              ""tags"": [ """" ],
-              ""projectUrl"": """",
-              ""licenseUrl"": """",
-              ""dependencies"": {
-                ""packageA"": ""1.0.0""
-              },
               ""frameworks"": {
                 ""net45"": {
+                    ""dependencies"": {
+                        ""packageA"": ""1.0.0""
+                    }
                 }
               }
             }";
@@ -1893,11 +1888,12 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""Newtonsoft.Json"": ""7.0.1""
-                    },
                      ""frameworks"": {
-                        ""net45"": { }
+                        ""net45"": {
+                            ""dependencies"": {
+                                ""Newtonsoft.Json"": ""7.0.1""
+                            }
+                        }
                     }
                 }");
 
@@ -1987,11 +1983,12 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""Newtonsoft.Json"": ""7.0.1-*""
-                    },
                      ""frameworks"": {
-                        ""net45"": { }
+                        ""net45"": {
+                            ""dependencies"": {
+                                ""Newtonsoft.Json"": ""7.0.1-*""
+                            }
+                        }
                     }
                 }");
 
@@ -2028,11 +2025,12 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""Newtonsoft.Json"": ""7.0.1-*""
-                    },
                      ""frameworks"": {
-                        ""net45"": { }
+                        ""net45"": {
+                            ""dependencies"": {
+                                ""Newtonsoft.Json"": ""7.0.1-*""
+                            }
+                        }
                     }
                 }");
 
@@ -2338,11 +2336,12 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""XXX"": ""7.0.91""
-                    },
                      ""frameworks"": {
-                        ""net45"": { }
+                        ""net45"": {
+                            ""dependencies"": {
+                                ""XXX"": ""7.0.91""
+                            }
+                        }
                     }
                 }");
 
@@ -2388,11 +2387,12 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""XXX"": ""7.0.91""
-                    },
                      ""frameworks"": {
-                        ""net45"": { }
+                        ""net45"": {
+                            ""dependencies"": {
+                                ""XXX"": ""7.0.91""
+                            }
+                        }
                     }
                 }");
 
@@ -2438,11 +2438,12 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""XXX"": ""7.0.91""
-                    },
                      ""frameworks"": {
-                        ""net45"": { }
+                        ""net45"": {
+                            ""dependencies"": {
+                                ""XXX"": ""7.0.91""
+                            }
+                        }
                     }
                 }");
 
@@ -5288,12 +5289,17 @@ namespace NuGet.Commands.FuncTest
                 }
             };
 
-            if (spec.Dependencies == null)
+            for (int i = 0; i < spec.TargetFrameworks.Count; i++)
             {
-                spec.Dependencies = new List<LibraryDependency>();
-            }
+                List<LibraryDependency> dependencies = new List<LibraryDependency>();
+                dependencies.AddRange(spec.TargetFrameworks[i].Dependencies);
+                dependencies.Add(target);
 
-            spec.Dependencies.Add(target);
+                spec.TargetFrameworks[i] = new TargetFrameworkInformation(spec.TargetFrameworks[i])
+                {
+                    Dependencies = dependencies.ToImmutableArray()
+                };
+            }
         }
 
         private static JObject BasicConfig

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFilesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFilesTests.cs
@@ -60,15 +60,7 @@ namespace NuGet.Commands.Test
 
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
-
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                JObject configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -130,14 +122,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -199,14 +184,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -274,14 +252,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -370,14 +341,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -469,14 +433,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -565,14 +522,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -658,14 +608,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -734,15 +677,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
-
+                JObject configJson = GetConfigWithFrameworkAndDependency(framework);
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
 
@@ -805,14 +740,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -875,14 +803,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -945,14 +866,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -1022,14 +936,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -1097,14 +1004,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -1175,14 +1075,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -1254,14 +1147,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -1334,14 +1220,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -1415,14 +1294,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -1498,14 +1370,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -1581,14 +1446,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -1658,14 +1516,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -1730,14 +1581,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                JObject configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -1785,14 +1629,7 @@ namespace NuGet.Commands.Test
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));
 
-                var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
-                    ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
-                    }
-                }".Replace("_FRAMEWORK_", framework));
+                var configJson = GetConfigWithFrameworkAndDependency(framework);
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath).WithTestRestoreMetadata();
@@ -1998,14 +1835,7 @@ namespace NuGet.Commands.Test
 
                 if (configJson == null)
                 {
-                    configJson = JObject.Parse(@"{
-                      ""dependencies"": {
-                        ""packageA"": ""1.0.0""
-                      },
-                      ""frameworks"": {
-                        ""_FRAMEWORK_"": {}
-                      }
-                    }".Replace("_FRAMEWORK_", framework));
+                    configJson = GetConfigWithFrameworkAndDependency(framework);
                 }
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
@@ -2023,6 +1853,19 @@ namespace NuGet.Commands.Test
 
                 return result;
             }
+        }
+
+        private static JObject GetConfigWithFrameworkAndDependency(string framework)
+        {
+            return JObject.Parse(@"{
+                    ""frameworks"": {
+                    ""_FRAMEWORK_"": {
+                        ""dependencies"": {
+                          ""packageA"": ""1.0.0""
+                        }
+                      }
+                    }
+                }".Replace("_FRAMEWORK_", framework));
         }
 
         private static FileInfo CreateRuntimesPackage(string repositoryDir)

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/DependencyTypeConstraintTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/DependencyTypeConstraintTests.cs
@@ -190,11 +190,11 @@ namespace NuGet.Commands.Test
 
             var project1Json = @"
             {
-              ""dependencies"": {
-                ""packageA"": ""1.0.0""
-              },
               ""frameworks"": {
                 ""net45"": {
+                  ""dependencies"": {
+                    ""packageA"": ""1.0.0""
+                  }
                 }
               }
             }";
@@ -301,32 +301,19 @@ namespace NuGet.Commands.Test
 
             var project1Json = @"
             {
-              ""version"": ""1.0.0"",
-              ""description"": """",
-              ""authors"": [ ""author"" ],
-              ""tags"": [ """" ],
-              ""projectUrl"": """",
-              ""licenseUrl"": """",
-              ""dependencies"": {
-                ""packageA"": {
-                    ""version"": ""1.0.0"",
-                    ""target"": ""package""
-                }
-              },
               ""frameworks"": {
                 ""net45"": {
-                }
+                  ""dependencies"": {
+                    ""packageA"": {
+                        ""version"": ""1.0.0"",
+                        ""target"": ""package""
+                    }
+                  }                }
               }
             }";
 
             var packageAProjectJson = @"
             {
-              ""version"": ""1.0.0"",
-              ""description"": """",
-              ""authors"": [ ""author"" ],
-              ""tags"": [ """" ],
-              ""projectUrl"": """",
-              ""licenseUrl"": """",
               ""frameworks"": {
                 ""net45"": {
                 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/IncludeTypeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/IncludeTypeTests.cs
@@ -33,26 +33,25 @@ namespace NuGet.Commands.Test
             using (var pathContext = new SimpleTestPathContext())
             {
                 var configJson2 = @"{
-                ""dependencies"": {
-                    ""packageX"": {
-                        ""version"": ""1.0.0"",
-                        ""suppressParent"": ""runtime,compile""
-                    },
-                    ""packageY"": {
-                        ""version"": ""1.0.0"",
-                        ""exclude"": ""runtime,compile"",
-                        ""suppressParent"": ""runtime,compile""
-                    }
-                },
                 ""frameworks"": {
-                ""net46"": {}
+                ""net46"": {
+                    ""dependencies"": {
+                        ""packageX"": {
+                            ""version"": ""1.0.0"",
+                            ""suppressParent"": ""runtime,compile""
+                        },
+                        ""packageY"": {
+                            ""version"": ""1.0.0"",
+                            ""exclude"": ""runtime,compile"",
+                            ""suppressParent"": ""runtime,compile""
+                        }
+                    }
+                }
                 },
                 ""runtimes"": { ""any"": { } }
             }";
 
                 var configJson1 = @"{
-                ""dependencies"": {
-                },
                 ""frameworks"": {
                 ""net46"": {}
                 },
@@ -90,17 +89,18 @@ namespace NuGet.Commands.Test
             using (var pathContext = new SimpleTestPathContext())
             {
                 var configJson2 = @"{
-                ""dependencies"": {
-                    ""packageX"": {
-                        ""version"": ""1.0.0""
-                    },
-                    ""packageY"": {
-                        ""version"": ""1.0.0"",
-                        ""exclude"": ""runtime,compile""
-                    }
-                },
                 ""frameworks"": {
-                ""net46"": {}
+                ""net46"": {
+                    ""dependencies"": {
+                        ""packageX"": {
+                            ""version"": ""1.0.0""
+                        },
+                        ""packageY"": {
+                            ""version"": ""1.0.0"",
+                            ""exclude"": ""runtime,compile""
+                        }
+                    }
+                }
                 },
                 ""runtimes"": { ""any"": { } }
             }";
@@ -146,20 +146,19 @@ namespace NuGet.Commands.Test
             using (var pathContext = new SimpleTestPathContext())
             {
                 var configJson2 = @"{
-                ""dependencies"": {
-                    ""packageX"": {
-                        ""version"": ""1.0.0""
-                    }
-                },
                 ""frameworks"": {
-                ""net46"": {}
+                ""net46"": {
+                    ""dependencies"": {
+                        ""packageX"": {
+                            ""version"": ""1.0.0""
+                        }
+                    }
+                }
                 },
                 ""runtimes"": { ""any"": { } }
             }";
 
                 var configJson1 = @"{
-                ""dependencies"": {
-                },
                 ""frameworks"": {
                 ""net46"": {}
                 },
@@ -215,14 +214,15 @@ namespace NuGet.Commands.Test
             using (var pathContext = new SimpleTestPathContext())
             {
                 var configJson2 = @"{
-                ""dependencies"": {
-                    ""packageX"": {
-                        ""version"": ""1.0.0"",
-                        ""suppressParent"": ""none""
-                    }
-                },
                 ""frameworks"": {
-                ""net46"": {}
+                ""net46"": {
+                    ""dependencies"": {
+                        ""packageX"": {
+                            ""version"": ""1.0.0"",
+                            ""suppressParent"": ""none""
+                        }
+                    }
+                }
                 },
                 ""runtimes"": { ""any"": { } }
             }";
@@ -285,14 +285,15 @@ namespace NuGet.Commands.Test
             using (var pathContext = new SimpleTestPathContext())
             {
                 var configJson2 = @"{
-                ""dependencies"": {
-                    ""packageX"": {
-                        ""version"": ""1.0.0"",
-                        ""suppressParent"": ""none""
-                    }
-                },
                 ""frameworks"": {
-                ""net46"": {}
+                ""net46"": {
+                    ""dependencies"": {
+                        ""packageX"": {
+                            ""version"": ""1.0.0"",
+                            ""suppressParent"": ""none""
+                        }
+                    }
+                }
                 },
                 ""runtimes"": { ""any"": { } }
             }";
@@ -354,34 +355,34 @@ namespace NuGet.Commands.Test
             using (var pathContext = new SimpleTestPathContext())
             {
                 var configJson3 = @"{
-                    ""dependencies"": {
-                        ""packageX"": {
-                            ""version"": ""1.0.0"",
-                            ""suppressParent"": ""compile,runtime""
-                        }
-                    },
                     ""frameworks"": {
-                    ""net46"": {}
+                    ""net46"": {
+                        ""dependencies"": {
+                            ""packageX"": {
+                                ""version"": ""1.0.0"",
+                                ""suppressParent"": ""compile,runtime""
+                            }
+                        }
+                    }
                     },
                 ""runtimes"": { ""any"": { } }
                 }";
 
                 var configJson2 = @"{
-                    ""dependencies"": {
-                        ""packageX"": {
-                            ""version"": ""1.0.0"",
-                            ""suppressParent"": ""native,runtime""
-                        }
-                    },
                     ""frameworks"": {
-                    ""net46"": {}
+                    ""net46"": {
+                        ""dependencies"": {
+                            ""packageX"": {
+                                ""version"": ""1.0.0"",
+                                ""suppressParent"": ""native,runtime""
+                            }
+                        }
+                    }
                     },
                   ""runtimes"": { ""any"": { } }
                 }";
 
                 var configJson1 = @"{
-                    ""dependencies"": {
-                    },
                     ""frameworks"": {
                     ""net46"": {}
                     },
@@ -424,17 +425,18 @@ namespace NuGet.Commands.Test
             {
 
                 var projectJson = @"{
-                        ""dependencies"": {
-                            ""packageA"": {
-                                ""version"": ""1.0.0""
-                            },
-                            ""packageB"": {
-                                ""version"": ""1.0.0"",
-                                ""exclude"": ""all""
-                            }
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                            ""dependencies"": {
+                                    ""packageA"": {
+                                        ""version"": ""1.0.0""
+                                    },
+                                    ""packageB"": {
+                                        ""version"": ""1.0.0"",
+                                        ""exclude"": ""all""
+                                    }
+                                }
+                            }
                         },
                         ""runtimes"": { ""any"": { } }
                     }";
@@ -471,11 +473,12 @@ namespace NuGet.Commands.Test
             using (var workingDir = TestDirectory.Create())
             {
                 var projectJson = @"{
-                        ""dependencies"": {
-                            ""packageX"": ""1.0.0""
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageX"": ""1.0.0""
+                                }
+                            }
                         },
                         ""runtimes"": { ""any"": { } }
                  }";
@@ -545,12 +548,13 @@ namespace NuGet.Commands.Test
             using (var workingDir = TestDirectory.Create())
             {
                 var projectJson = @"{
-                        ""dependencies"": {
-                            ""packageA"": ""1.0.0"",
-                            ""packageB"": ""2.0.0""
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageA"": ""1.0.0"",
+                                    ""packageB"": ""2.0.0""
+                                }
+                            }
                         },
                         ""runtimes"": { ""any"": { } }
                  }";
@@ -639,24 +643,26 @@ namespace NuGet.Commands.Test
             using (var pathContext = new SimpleTestPathContext())
             {
                 var configJson2 = @"{
-                    ""dependencies"": {
-                        ""packageX"": ""1.0.0""
-                    },
                     ""frameworks"": {
-                    ""net46"": {}
+                    ""net46"": {
+                        ""dependencies"": {
+                            ""packageX"": ""1.0.0""
+                        }
+                    }
                     },
                     ""runtimes"": { ""any"": { } }
                 }";
 
                 var configJson1 = @"{
-                    ""dependencies"": {
-                        ""packageX"": {
-                            ""version"": ""1.0.0"",
-                            ""exclude"": ""build""
-                        }
-                    },
                     ""frameworks"": {
-                    ""net46"": {}
+                    ""net46"": {
+                        ""dependencies"": {
+                            ""packageX"": {
+                                ""version"": ""1.0.0"",
+                                ""exclude"": ""build""
+                            }
+                        }
+                    }
                     },
                     ""runtimes"": { ""any"": { } }
                 }";
@@ -690,23 +696,25 @@ namespace NuGet.Commands.Test
             using (var pathContext = new SimpleTestPathContext())
             {
                 var configJson2 = @"{
-                    ""dependencies"": {
-                        ""packageX"": {
-                            ""version"": ""1.0.0""
-                        }
-                    },
                     ""frameworks"": {
-                    ""net46"": {}
+                    ""net46"": {
+                        ""dependencies"": {
+                            ""packageX"": {
+                                ""version"": ""1.0.0""
+                            }
+                        }
+                    }
                     },
                     ""runtimes"": { ""any"": { } }
                 }";
 
                 var configJson1 = @"{
-                    ""dependencies"": {
-                        ""packageX"": ""1.0.0""
-                    },
                     ""frameworks"": {
-                    ""net46"": {}
+                    ""net46"": {
+                        ""dependencies"": {
+                            ""packageX"": ""1.0.0""
+                        }
+                    }
                     },
                     ""runtimes"": { ""any"": { } }
                 }";
@@ -740,13 +748,14 @@ namespace NuGet.Commands.Test
             using (var pathContext = new SimpleTestPathContext())
             {
                 var configJson2 = @"{
-                    ""dependencies"": {
-                        ""packageX"": {
-                            ""version"": ""1.0.0""
-                        }
-                    },
                     ""frameworks"": {
-                    ""net46"": {}
+                    ""net46"": {
+                        ""dependencies"": {
+                            ""packageX"": {
+                                ""version"": ""1.0.0""
+                            }
+                        }
+                    }
                     },
                     ""runtimes"": { ""any"": { } }
                 }";
@@ -789,13 +798,14 @@ namespace NuGet.Commands.Test
             using (var pathContext = new SimpleTestPathContext())
             {
                 var configJson2 = @"{
-                    ""dependencies"": {
-                        ""packageX"": {
-                            ""version"": ""1.0.0""
-                        }
-                    },
                     ""frameworks"": {
-                    ""net46"": {}
+                    ""net46"": {
+                        ""dependencies"": {
+                            ""packageX"": {
+                                ""version"": ""1.0.0""
+                            }
+                        }
+                    }
                     },
                     ""runtimes"": { ""any"": { } }
                 }";
@@ -890,24 +900,26 @@ namespace NuGet.Commands.Test
             using (var pathContext = new SimpleTestPathContext())
             {
                 var configJson2 = @"{
-                    ""dependencies"": {
-                        ""packageX"": {
-                            ""version"": ""1.0.0"",
-                            ""suppressParent"": ""all""
-                        }
-                    },
                     ""frameworks"": {
-                    ""net46"": {}
+                    ""net46"": {
+                        ""dependencies"": {
+                            ""packageX"": {
+                                ""version"": ""1.0.0"",
+                                ""suppressParent"": ""all""
+                            }
+                        }
+                        }
                     },
                     ""runtimes"": { ""any"": { } }
                 }";
 
                 var configJson1 = @"{
-                    ""dependencies"": {
-                        ""packageZ"": ""1.0.0""
-                    },
                     ""frameworks"": {
-                    ""net46"": {}
+                    ""net46"": {
+                        ""dependencies"": {
+                          ""packageZ"": ""1.0.0""
+                        }
+                      }
                     },
                     ""runtimes"": { ""any"": { } }
                 }";
@@ -992,20 +1004,19 @@ namespace NuGet.Commands.Test
             using (var pathContext = new SimpleTestPathContext())
             {
                 var configJson2 = @"{
-                    ""dependencies"": {
-                        ""packageX"": {
-                            ""version"": ""1.0.0"",
-                        }
-                    },
                     ""frameworks"": {
-                    ""net46"": {}
+                    ""net46"": {
+                        ""dependencies"": {
+                            ""packageX"": {
+                                ""version"": ""1.0.0"",
+                            }
+                        }
+                    }
                     },
                     ""runtimes"": { ""any"": { } }
                 }";
 
                 var configJson1 = @"{
-                    ""dependencies"": {
-                    },
                     ""frameworks"": {
                     ""net46"": {}
                     },
@@ -1037,14 +1048,15 @@ namespace NuGet.Commands.Test
             using (var pathContext = new SimpleTestPathContext())
             {
                 var configJson1 = @"{
-                    ""dependencies"": {
-                        ""packageX"": {
-                            ""version"": ""1.0.0"",
-                            ""type"": ""build""
-                        }
-                    },
                     ""frameworks"": {
-                    ""net46"": {}
+                    ""net46"": {
+                        ""dependencies"": {
+                            ""packageX"": {
+                                ""version"": ""1.0.0"",
+                                ""type"": ""build""
+                            }
+                        }
+                    }
                     },
                     ""runtimes"": { ""any"": { } }
                 }";
@@ -1098,16 +1110,17 @@ namespace NuGet.Commands.Test
             using (var workingDir = TestDirectory.Create())
             {
                 var projectJson = @"{
-                        ""dependencies"": {
-                            ""packageX"": {
-                                ""version"": ""1.0.0"",
-                                ""include"": ""compile""
+                        ""frameworks"": {
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageX"": {
+                                        ""version"": ""1.0.0"",
+                                        ""include"": ""compile""
+                                    }
+                                }
                             }
                         },
-                        ""frameworks"": {
-                            ""net46"": {}
-                        },
-                        ""runtimes"": { ""any"": { } }
+                    ""runtimes"": { ""any"": { } }
                  }";
 
                 await CreateXYZAsync(Path.Combine(workingDir, "source"));
@@ -1143,15 +1156,16 @@ namespace NuGet.Commands.Test
             using (var workingDir = TestDirectory.Create())
             {
                 var projectJson = @"{
-                        ""dependencies"": {
-                            ""packageX"": {
-                                ""version"": ""1.0.0""
-                            },
-                            ""packageY"": ""1.0.0"",
-                            ""packageZ"": ""1.0.0""
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageX"": {
+                                        ""version"": ""1.0.0""
+                                    },
+                                    ""packageY"": ""1.0.0"",
+                                    ""packageZ"": ""1.0.0""
+                                }
+                            }
                         },
                          ""runtimes"": { ""any"": { } }
                  }";
@@ -1271,16 +1285,17 @@ namespace NuGet.Commands.Test
             using (var workingDir = TestDirectory.Create())
             {
                 var projectJson = @"{
-                        ""dependencies"": {
-                            ""packageX"": {
-                                ""version"": ""1.0.0""
+                        ""frameworks"": {
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageX"": {
+                                        ""version"": ""1.0.0""
+                                    }
+                                }
                             }
                         },
-                        ""frameworks"": {
-                            ""net46"": {}
-                        },
                     ""runtimes"": { ""any"": { } }
-                 }";
+                    }";
 
                 await CreateXYZAsync(Path.Combine(workingDir, "source"), string.Empty, "build");
 
@@ -1313,13 +1328,14 @@ namespace NuGet.Commands.Test
             using (var workingDir = TestDirectory.Create())
             {
                 var projectJson = @"{
-                        ""dependencies"": {
-                            ""packageX"": {
-                                ""version"": ""1.0.0""
-                            }
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageX"": {
+                                        ""version"": ""1.0.0""
+                                    }
+                                }
+                            }
                         },
                     ""runtimes"": { ""any"": { } }
                  }";
@@ -1357,13 +1373,14 @@ namespace NuGet.Commands.Test
             using (var workingDir = TestDirectory.Create())
             {
                 var projectJson = @"{
-                        ""dependencies"": {
-                            ""packageX"": {
-                                ""version"": ""1.0.0""
-                            }
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageX"": {
+                                        ""version"": ""1.0.0""
+                                    }
+                                }
+                            }
                         },
                     ""runtimes"": { ""any"": { } }
                  }";
@@ -1398,16 +1415,17 @@ namespace NuGet.Commands.Test
             using (var workingDir = TestDirectory.Create())
             {
                 var projectJson = @"{
-                        ""dependencies"": {
-                            ""packageA"": {
-                                ""version"": ""1.0.0""
-                            },
-                            ""packageB"": {
-                                ""version"": ""1.0.0""
-                            }
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageA"": {
+                                        ""version"": ""1.0.0""
+                                    },
+                                    ""packageB"": {
+                                        ""version"": ""1.0.0""
+                                    }
+                                }
+                            }
                         },
                     ""runtimes"": { ""any"": { } }
                     }";
@@ -1444,13 +1462,14 @@ namespace NuGet.Commands.Test
             using (var workingDir = TestDirectory.Create())
             {
                 var projectJson = @"{
-                        ""dependencies"": {
-                            ""packageA"": {
-                                ""version"": ""1.0.0""
-                            }
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageA"": {
+                                        ""version"": ""1.0.0""
+                                    }
+                                }
+                            }
                         },
                     ""runtimes"": { ""any"": { } }
                     }";
@@ -1484,107 +1503,115 @@ namespace NuGet.Commands.Test
 
         [Theory]
         [InlineData(@"{
-                        ""dependencies"": {
-                            ""packageA"": {
-                                ""version"": ""1.0.0"",
-                                ""suppressParent"": ""all""
-                            },
-                            ""packageB"": {
-                                ""version"": ""1.0.0"",
-                                ""suppressParent"": ""all"",
-                                ""exclude"": ""contentFiles""
-                            }
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageA"": {
+                                        ""version"": ""1.0.0"",
+                                        ""suppressParent"": ""all""
+                                    },
+                                    ""packageB"": {
+                                        ""version"": ""1.0.0"",
+                                        ""suppressParent"": ""all"",
+                                        ""exclude"": ""contentFiles""
+                                    }
+                                }       
+                            }
                         },
                         ""runtimes"": { ""any"": { } }
                     }")]
         [InlineData(@"{
-                        ""dependencies"": {
-                            ""packageA"": {
-                                ""version"": ""1.0.0""
-                            },
-                            ""packageB"": {
-                                ""version"": ""1.0.0"",
-                                ""exclude"": ""contentFiles""
-                            }
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageA"": {
+                                        ""version"": ""1.0.0""
+                                    },
+                                    ""packageB"": {
+                                        ""version"": ""1.0.0"",
+                                        ""exclude"": ""contentFiles""
+                                    }
+                                }
+                            }
                         },
                         ""runtimes"": { ""any"": { } }
                     }")]
         [InlineData(@"{
-                        ""dependencies"": {
-                            ""packageA"": {
-                                ""version"": ""1.0.0""
-                            },
-                            ""packageB"": {
-                                ""version"": ""1.0.0"",
-                                ""include"": ""build,compile,runtime,native""
-                            }
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageA"": {
+                                        ""version"": ""1.0.0""
+                                    },
+                                    ""packageB"": {
+                                        ""version"": ""1.0.0"",
+                                        ""include"": ""build,compile,runtime,native""
+                                    }
+                                }
+                            }
                         },
                         ""runtimes"": { ""any"": { } }
                     }")]
         [InlineData(@"{
-                        ""dependencies"": {
-                            ""packageA"": {
-                                ""version"": ""1.0.0"",
-                                ""include"": ""build,compile,runtime,native,contentfiles""
-                            }
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageA"": {
+                                        ""version"": ""1.0.0"",
+                                        ""include"": ""build,compile,runtime,native,contentfiles""
+                                    }
+                                }
+                        }
                         },
                         ""runtimes"": { ""any"": { } }
                     }")]
         [InlineData(@"{
-                        ""dependencies"": {
-                            ""packageA"": {
-                                ""version"": ""1.0.0"",
-                                ""include"": ""all"",
-                                ""exclude"": ""none""
-                            }
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageA"": {
+                                        ""version"": ""1.0.0"",
+                                        ""include"": ""all"",
+                                        ""exclude"": ""none""
+                                    }
+                                }
+                            }
                         },
                         ""runtimes"": { ""any"": { } }
                     }")]
         [InlineData(@"{
-                        ""dependencies"": {
-                            ""packageA"": {
-                                ""version"": ""1.0.0"",
-                                ""exclude"": ""none""
-                            }
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageA"": {
+                                        ""version"": ""1.0.0"",
+                                        ""exclude"": ""none""
+                                    }
+                                }
+                            }
                         },
                         ""runtimes"": { ""any"": { } }
                     }")]
         [InlineData(@"{
-                        ""dependencies"": {
-                            ""packageA"": {
-                                ""version"": ""1.0.0"",
-                                ""include"": ""all""
-                            }
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageA"": {
+                                        ""version"": ""1.0.0"",
+                                        ""include"": ""all""
+                                    }
+                                }
+                            }
                         },
                         ""runtimes"": { ""any"": { } }
                     }")]
         [InlineData(@"{
-                        ""dependencies"": {
-                            ""packageA"": ""1.0.0""
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageA"": ""1.0.0""
+                                }  
+                            }
                         },
                         ""runtimes"": { ""any"": { } }
                     }")]
@@ -1640,15 +1667,16 @@ namespace NuGet.Commands.Test
             using (var workingDir = TestDirectory.Create())
             {
                 var projectJson = @"{
-                        ""dependencies"": {
-                            ""packageX"": {
-                                ""version"": ""1.0.0""
-                            },
-                            ""packageY"": ""1.0.0"",
-                            ""packageZ"": ""1.0.0""
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageX"": {
+                                        ""version"": ""1.0.0""
+                                    },
+                                    ""packageY"": ""1.0.0"",
+                                    ""packageZ"": ""1.0.0""
+                                }
+                            }
                         },
                          ""runtimes"": { ""any"": { } }
                  }";
@@ -1682,17 +1710,18 @@ namespace NuGet.Commands.Test
             using (var workingDir = TestDirectory.Create())
             {
                 var projectJson = @"{
-                        ""dependencies"": {
-                            ""packageX"": {
-                                ""version"": ""1.0.0""
-                            },
-                            ""packageY"": ""1.0.0"",
-                            ""packageZ"": ""1.0.0"",
-                            ""packageA"": ""1.0.0"",
-                            ""packageB"": ""1.0.0""
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageX"": {
+                                        ""version"": ""1.0.0""
+                                    },
+                                    ""packageY"": ""1.0.0"",
+                                    ""packageZ"": ""1.0.0"",
+                                    ""packageA"": ""1.0.0"",
+                                    ""packageB"": ""1.0.0""
+                                }
+                            }
                         },
                          ""runtimes"": { ""any"": { } }
                  }";
@@ -1730,15 +1759,16 @@ namespace NuGet.Commands.Test
             using (var workingDir = TestDirectory.Create())
             {
                 var projectJson = @"{
-                        ""dependencies"": {
-                            ""packageX"": {
-                                ""version"": ""1.0.0""
-                            },
-                            ""packageY"": ""1.0.0"",
-                            ""packageZ"": ""1.0.0""
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageX"": {
+                                        ""version"": ""1.0.0""
+                                    },
+                                    ""packageY"": ""1.0.0"",
+                                    ""packageZ"": ""1.0.0""
+                                }
+                            }
                         },
                          ""runtimes"": { ""any"": { } }
                  }";

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/PackagesWithResourcesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/PackagesWithResourcesTests.cs
@@ -61,11 +61,12 @@ namespace NuGet.Commands.Test
                 sources.Add(new PackageSource(repository));
 
                 var configJson = JObject.Parse(@"{
-                    ""dependencies"": {
-                    ""packageA"": ""1.0.0""
-                    },
                     ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
+                    ""_FRAMEWORK_"": {
+                        ""dependencies"": {
+                          ""packageA"": ""1.0.0""
+                        }
+                    }
                     }
                 }".Replace("_FRAMEWORK_", framework));
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -1262,16 +1262,11 @@ namespace NuGet.Commands.Test.RestoreCommandTests
             var project1Json = @"
             {
               ""version"": ""1.0.0-*"",
-              ""description"": """",
-              ""authors"": [ ""author"" ],
-              ""tags"": [ """" ],
-              ""projectUrl"": """",
-              ""licenseUrl"": """",
-              ""dependencies"": {
-                ""project1"": { ""version"": ""1.0.0"", ""target"": ""package"" }
-              },
               ""frameworks"": {
                 ""net45"": {
+                  ""dependencies"": {
+                    ""project1"": { ""version"": ""1.0.0"", ""target"": ""package"" }
+                  }
                 }
               }
             }";

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
@@ -126,12 +126,13 @@ namespace NuGet.Commands.Test
                     ""runtimes"": {
                         ""unix"": {}
                     },
-                    ""dependencies"": {
-                        ""packageA"": ""1.0.0"",
-                        ""packageB"": ""1.0.0""
-                    },
                     ""frameworks"": {
-                        ""_FRAMEWORK_"": {}
+                        ""_FRAMEWORK_"": {
+                            ""dependencies"": {
+                                ""packageA"": ""1.0.0"",
+                                ""packageB"": ""1.0.0""
+                            }
+                        }
                     }
                 }".Replace("_FRAMEWORK_", framework));
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegrationTestUtility.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegrationTestUtility.cs
@@ -37,11 +37,12 @@ namespace NuGet.PackageManagement.Test
         }
 
         public const string ProjectJsonWithPackage = @"{
-  ""dependencies"": {
-    ""EntityFramework"": ""5.0.0""
-  },
   ""frameworks"": {
-    ""net46"": { }
+    ""net46"": {
+      ""dependencies"": {
+        ""EntityFramework"": ""5.0.0""
+      }
+    }
   }
 }";
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
@@ -202,10 +202,12 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
 
             var json = new JObject
             {
-                ["dependencies"] = dependenciesJObject,
                 ["frameworks"] = new JObject
                 {
                     ["net46"] = new JObject()
+                    {
+                        ["dependencies"] = dependenciesJObject
+                    }
                 }
             };
 
@@ -230,8 +232,13 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
 
             Assert.Contains(telemetryEvents.Where(p => p.Name == ActionTelemetryStepEvent.NugetActionStepsEventName), p => (string)p["SubStepName"] == TelemetryConstants.PreviewBuildIntegratedStepName);
 
-            Assert.True((string)telemetryEvents
-                .Last(p => p.Name == "ProjectRestoreInformation")["ErrorCodes"] == NuGetLogCode.NU1102.ToString());
+            Assert.Equal((bool)telemetryEvents
+                .Last(p => p.Name == "ProjectRestoreInformation")["RestoreSuccess"], !errorCodeExistsInJson);
+            if (errorCodeExistsInJson)
+            {
+                Assert.Contains((string)telemetryEvents
+                    .Last(p => p.Name == "ProjectRestoreInformation")["ErrorCodes"], NuGetLogCode.NU1102.ToString());
+            }
 
             var projectFilePaths = telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").SelectMany(x => x.GetPiiData()).Where(x => x.Key == "ProjectFilePath");
             Assert.Equal(2, projectFilePaths.Count());

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
@@ -231,14 +231,8 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             Assert.Equal(1, telemetryEvents.Count(p => p.Name == ActionTelemetryStepEvent.NugetActionStepsEventName));
 
             Assert.Contains(telemetryEvents.Where(p => p.Name == ActionTelemetryStepEvent.NugetActionStepsEventName), p => (string)p["SubStepName"] == TelemetryConstants.PreviewBuildIntegratedStepName);
-
-            Assert.Equal((bool)telemetryEvents
-                .Last(p => p.Name == "ProjectRestoreInformation")["RestoreSuccess"], !errorCodeExistsInJson);
-            if (errorCodeExistsInJson)
-            {
-                Assert.Contains((string)telemetryEvents
-                    .Last(p => p.Name == "ProjectRestoreInformation")["ErrorCodes"], NuGetLogCode.NU1102.ToString());
-            }
+            Assert.Contains((string)telemetryEvents
+                .Last(p => p.Name == "ProjectRestoreInformation")["ErrorCodes"], NuGetLogCode.NU1102.ToString());
 
             var projectFilePaths = telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").SelectMany(x => x.GetPiiData()).Where(x => x.Key == "ProjectFilePath");
             Assert.Equal(2, projectFilePaths.Count());

--- a/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
@@ -324,5 +324,16 @@ namespace NuGet.Commands.Test
             }
             return packageSpec;
         }
+
+        public static void AddDependency(PackageSpec spec, LibraryDependency libraryDependency)
+        {
+            for (int i = 0; i < spec.TargetFrameworks.Count; i++)
+            {
+                spec.TargetFrameworks[i] = new TargetFrameworkInformation(spec.TargetFrameworks[i])
+                {
+                    Dependencies = [.. spec.TargetFrameworks[i].Dependencies, libraryDependency]
+                };
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Related: https://github.com/NuGet/Home/issues/10212 

## Description

We're using the tfm specific deps instead of the generic ones. 
generic deps aren't supposed to be used in PR.

This is a continuation of https://github.com/NuGet/NuGet.Client/pull/6349. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
