### PR TITLE
Stop setting CurrentDirectory in TestFileSystemUtility

### DIFF
--- a/src/NuGet.Core/NuGet.Common/GlobalSuppressions.cs
+++ b/src/NuGet.Core/NuGet.Common/GlobalSuppressions.cs
@@ -40,3 +40,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Build", "CA1012:Abstract type LoggerBase should not have constructors", Justification = "<Pending>", Scope = "type", Target = "~T:NuGet.Common.LoggerBase")]
 [assembly: SuppressMessage("Build", "CA1815:SearchPathResult should override Equals.", Justification = "<Pending>", Scope = "type", Target = "~T:NuGet.Common.PathResolver.SearchPathResult")]
 [assembly: SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "<Pending>", Scope = "member", Target = "~M:NuGet.Common.Migrations.MigrationRunner.Run(System.String,NuGet.Common.IEnvironmentVariableReader)")]
+[assembly: SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "<Pending>", Scope = "member", Target = "~M:NuGet.Common.PathUtility.CheckIfFileSystemIsCaseInsensitive~System.Boolean")]

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
@@ -450,16 +450,26 @@ namespace NuGet.Common
             }
             else
             {
-                var listOfPathsToCheck = new string[]
+                var listOfPathsToCheck = new Func<string>[]
                 {
-                    NuGetEnvironment.GetFolderPath(NuGetFolderPath.NuGetHome),
-                    NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp),
-                    Directory.GetCurrentDirectory()
+                    () => NuGetEnvironment.GetFolderPath(NuGetFolderPath.NuGetHome),
+                    () => NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp),
+                    () => Directory.GetCurrentDirectory()
                 };
 
                 var isCaseInsensitive = true;
-                foreach (var path in listOfPathsToCheck)
+                foreach (var pathFunc in listOfPathsToCheck)
                 {
+                    string path;
+                    try
+                    {
+                        path = pathFunc();
+                    }
+                    catch (Exception)
+                    {
+                        continue;
+                    }
+
                     string? firstParentDirectory = GetFirstParentDirectoryThatExists(path);
                     if (firstParentDirectory is not null)
                     {

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatPushTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatPushTests.cs
@@ -30,7 +30,6 @@ namespace NuGet.XPlat.FuncTest
         {
             // Arrange
             using (var packageDir = TestDirectory.Create())
-            using (TestFileSystemUtility.SetCurrentDirectory(packageDir))
             {
                 var packageId = "XPlatPushTests.PushToServerSucceeds";
                 var packageVersion = "1.0.0";
@@ -72,7 +71,6 @@ namespace NuGet.XPlat.FuncTest
         {
             // Arrange
             using (var packageDir = TestDirectory.Create())
-            using (TestFileSystemUtility.SetCurrentDirectory(packageDir))
             {
                 var packageId = "XPlatPushTests.PushToServerSucceeds";
                 var packageVersion = "1.0.0";
@@ -121,7 +119,6 @@ namespace NuGet.XPlat.FuncTest
         {
             // Arrange
             using (var packageDir = TestDirectory.Create())
-            using (TestFileSystemUtility.SetCurrentDirectory(packageDir))
             {
                 var packageId = "XPlatPushTests.PushToServerSucceeds";
                 var packageVersion = "1.0.0";

--- a/test/TestUtilities/Test.Utility/TestFileSystemUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestFileSystemUtility.cs
@@ -195,27 +195,6 @@ namespace NuGet.Test.Utility
             }
         }
 
-        private class ResetDirectory : IDisposable
-        {
-            public string OldPath { get; set; }
-
-            void IDisposable.Dispose()
-            {
-                Directory.SetCurrentDirectory(OldPath);
-            }
-        }
-
-        public static IDisposable SetCurrentDirectory(string path)
-        {
-            var oldPath = Directory.GetCurrentDirectory();
-            Directory.SetCurrentDirectory(path);
-
-            return new ResetDirectory()
-            {
-                OldPath = oldPath
-            };
-        }
-
         public static DirectoryInfo GetDirectoryOfPathAbove(string relativePath)
         {
             var currentDirInfo = new DirectoryInfo(Directory.GetCurrentDirectory());


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

This should fix the flaky tests that are failing to set the current directory when its been deleted.  Setting the current directory is process wide which is bad and then setting it to temporary folders and restoring it is worse.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
