### PR TITLE
Use tfm specific dependencies in UWP restore tests

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
@@ -81,13 +81,12 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestDirectory.Create())
             {
                 var configJson = JObject.Parse(@"{
-                  ""dependencies"": {
-                    ""Microsoft.AspNet.Mvc.de"": ""5.2.3""
-                  },
                   ""frameworks"": {
                     ""net46"": {
+                      ""dependencies"": {
+                        ""Microsoft.AspNet.Mvc.de"": ""5.2.3""
+                      }                    }
                     }
-                  }
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
@@ -121,14 +120,15 @@ namespace NuGet.Commands.FuncTest
 
             using var pathContext = new SimpleTestPathContext();
             var configJson = JObject.Parse(@"{
-                  ""dependencies"": {
-                    ""Microsoft.NETCore.UniversalWindowsPlatform"": {
-                        ""version"": ""5.0.0"",
-                        ""exclude"": ""build,runtime,compile,native""
-                     }
-                  },
                   ""frameworks"": {
-                    ""uap10.0"": {}
+                    ""uap10.0"": {
+                      ""dependencies"": {
+                        ""Microsoft.NETCore.UniversalWindowsPlatform"": {
+                            ""version"": ""5.0.0"",
+                            ""exclude"": ""build,runtime,compile,native""
+                         }
+                      }
+                    }
                   },
                   ""runtimes"": {
                     ""win10-arm"": {},
@@ -249,11 +249,12 @@ namespace NuGet.Commands.FuncTest
             using var pathContext = new SimpleTestPathContext();
 
             var configJson = JObject.Parse(@"{
-                  ""dependencies"": {
-                    ""Microsoft.NETCore.UniversalWindowsPlatform"": ""5.0.0""
-                  },
                   ""frameworks"": {
-                    ""uap10.0"": {}
+                    ""uap10.0"": {
+                      ""dependencies"": {
+                        ""Microsoft.NETCore.UniversalWindowsPlatform"": ""5.0.0""
+                      }
+                    }
                   },
                   ""runtimes"": {
                     ""win10-arm"": {},
@@ -304,11 +305,12 @@ namespace NuGet.Commands.FuncTest
             using var pathContext = new SimpleTestPathContext();
 
             var configJson = JObject.Parse(@"{
-                  ""dependencies"": {
-                    ""Microsoft.NETCore.UniversalWindowsPlatform"": ""5.0.0""
-                  },
                   ""frameworks"": {
-                    ""uap10.0"": {}
+                    ""uap10.0"": {
+                      ""dependencies"": {
+                        ""Microsoft.NETCore.UniversalWindowsPlatform"": ""5.0.0""
+                      }
+                    }
                   },
                   ""runtimes"": {
                     ""win10-arm"": {},

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/compiler/resources/uwpBlankAppV2.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/compiler/resources/uwpBlankAppV2.json
@@ -16903,12 +16903,12 @@
     ]
   },
   "project": {
-    "dependencies": {
-      "Microsoft.NETCore.UniversalWindowsPlatform": "[5.0.0, )"
-    },
     "frameworks": {
       "uap10.0": {
-        "targetAlias": "uap10.0"
+        "targetAlias": "uap10.0",
+        "dependencies": {
+          "Microsoft.NETCore.UniversalWindowsPlatform": "[5.0.0, )"
+        }
       }
     },
     "runtimes": {

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ProjectResolutionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ProjectResolutionTests.cs
@@ -508,16 +508,11 @@ namespace NuGet.Commands.Test
             var project1Json = @"
             {
               ""version"": ""1.0.0-*"",
-              ""description"": """",
-              ""authors"": [ ""author"" ],
-              ""tags"": [ """" ],
-              ""projectUrl"": """",
-              ""licenseUrl"": """",
-              ""dependencies"": {
-                ""project2"": ""1.0.0-*""
-              },
               ""frameworks"": {
                 ""net45"": {
+                  ""dependencies"": {
+                    ""project2"": ""1.0.0-*""
+                  }
                 }
               }
             }";
@@ -525,11 +520,6 @@ namespace NuGet.Commands.Test
             var project2Json = @"
             {
               ""version"": ""1.0.0-*"",
-              ""description"": """",
-              ""authors"": [ ""author"" ],
-              ""tags"": [ """" ],
-              ""projectUrl"": """",
-              ""licenseUrl"": """",
               ""frameworks"": {
                 ""net45"": {
                 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Related: https://github.com/NuGet/Home/issues/10212 

## Description

We're using the tfm specific deps instead of the generic ones. 
generic deps aren't supposed to be used in PR.

This is a continuation of https://github.com/NuGet/NuGet.Client/pull/6349 and https://github.com/NuGet/NuGet.Client/pull/6371

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
