### PR TITLE
Run integration test against .NET 10

### DIFF
--- a/build/DotNetSdkTestVersions.txt
+++ b/build/DotNetSdkTestVersions.txt
@@ -1,3 +1,4 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Channel 9.0.3xx -Quality daily
+-Channel 10.0.1xx -Quality daily
+-Channel 9.0 -Runtime dotnet
 -Channel 8.0 -Runtime dotnet

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Constants.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Constants.cs
@@ -8,9 +8,9 @@ namespace Dotnet.Integration.Test
 {
     internal static class Constants
     {
-#if NET8_0 || NET9_0
+#if NET9_0
         // Specifies a target framework for projects used during testing.  This should match the framework that the SDK being tested has.
-        internal const string ProjectTargetFramework = "net9.0";
+        internal const string ProjectTargetFramework = "net10.0";
         internal static readonly NuGetFramework DefaultTargetFramework = NuGetFramework.Parse(ProjectTargetFramework);
 #else
 #error Update the logic for which target framework to use for tests projects!!!

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -85,7 +85,7 @@ namespace Dotnet.Integration.Test
                     testOutputHelper: _testOutputHelper);
 
                 CommandRunnerResult listResult = _fixture.RunDotnetExpectFailure(Directory.GetParent(projectA.ProjectPath).FullName,
-                    $"list {projectA.ProjectPath} package",
+                    $"list {projectA.ProjectPath} package --no-restore",
                     testOutputHelper: _testOutputHelper);
 
                 Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, "No assets file was found".Replace(" ", "")));
@@ -748,7 +748,7 @@ namespace Dotnet.Integration.Test
             pathContext.Settings.AddSource("http-source", mockServer.ServiceIndexUri, allowInsecureConnections);
 
             // Act
-            CommandRunnerResult listResult = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, $"list package --outdated", testOutputHelper: _testOutputHelper);
+            CommandRunnerResult listResult = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, $"list package --outdated --no-restore", testOutputHelper: _testOutputHelper);
             mockServer.Stop();
 
             // Assert

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
@@ -505,7 +505,7 @@ namespace Dotnet.Integration.Test
                     CommandRunnerResult result = _dotnetFixture.RunDotnetExpectFailure(
                         pathContext.PackageSource,
                         $"nuget sign {packageFilePath} " +
-                        $"--certificate-fingerprint {SignatureTestUtility.GetFingerprint(storeCertificate.Certificate, HashAlgorithmName.SHA256)}} " +
+                        $"--certificate-fingerprint {SignatureTestUtility.GetFingerprint(storeCertificate.Certificate, HashAlgorithmName.SHA256)} " +
                         $"--timestamper {timestampService.Url}",
                     testOutputHelper: _testOutputHelper);
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
@@ -81,7 +81,7 @@ namespace Dotnet.Integration.Test
                 CommandRunnerResult result = _dotnetFixture.RunDotnetExpectSuccess(
                     pathContext.PackageSource,
                     $"nuget sign .{Path.DirectorySeparatorChar}{packageFileName} " +
-                    $"--certificate-fingerprint {storeCertificate.Certificate.Thumbprint} " +
+                    $"--certificate-fingerprint {storeCertificate.Certificate.GetCertHashString(System.Security.Cryptography.HashAlgorithmName.SHA256)} " +
                     $"--certificate-store-name {storeCertificate.StoreName} " +
                     $"--certificate-store-location {storeCertificate.StoreLocation}",
                     testOutputHelper: _testOutputHelper);
@@ -471,7 +471,7 @@ namespace Dotnet.Integration.Test
                 CommandRunnerResult result = _dotnetFixture.RunDotnetExpectSuccess(
                     pathContext.PackageSource,
                     $"nuget sign {packageFilePath} " +
-                    $"--certificate-fingerprint {storeCertificate.Certificate.Thumbprint}",
+                    $"--certificate-fingerprint {storeCertificate.Certificate.GetCertHashString(System.Security.Cryptography.HashAlgorithmName.SHA256)}",
                     testOutputHelper: _testOutputHelper);
 
                 // Assert
@@ -505,7 +505,7 @@ namespace Dotnet.Integration.Test
                     CommandRunnerResult result = _dotnetFixture.RunDotnetExpectFailure(
                         pathContext.PackageSource,
                         $"nuget sign {packageFilePath} " +
-                        $"--certificate-fingerprint {storeCertificate.Certificate.Thumbprint} " +
+                        $"--certificate-fingerprint {storeCertificate.Certificate.GetCertHashString(System.Security.Cryptography.HashAlgorithmName.SHA256)}} " +
                         $"--timestamper {timestampService.Url}",
                     testOutputHelper: _testOutputHelper);
 
@@ -517,23 +517,6 @@ namespace Dotnet.Integration.Test
                     byte[] resultingFile = File.ReadAllBytes(packageFilePath);
                     Assert.Equal(resultingFile, originalFile);
                 }
-            }
-        }
-
-        [PlatformFact(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Client.Engineering/issues/2781
-        public async Task DotnetSign_SignPackageWithInsecureCertificateFingerprint_RaisesWarningAsync()
-        {
-            var result = await ExecuteSignPackageTestWithCertificateFingerprintAsync(HashAlgorithmName.SHA1);
-
-            if (typeof(int).Assembly.GetName().Version.Major >= 10)
-            {
-                Assert.False(result.Success, result.AllOutput);
-                Assert.True(result.Errors.Contains(_insecureCertificateFingerprintCode), result.Errors);
-            }
-            else
-            {
-                Assert.True(result.Success, result.AllOutput);
-                Assert.True(result.AllOutput.Contains(_insecureCertificateFingerprintCode), result.AllOutput);
             }
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Runtime.Intrinsics.Arm;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.Intrinsics.Arm;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
@@ -585,7 +586,7 @@ namespace Dotnet.Integration.Test
         private static string GetDefaultArgs(string packageFilePath, IX509StoreCertificate storeCertificate)
         {
             return $"nuget sign {packageFilePath} " +
-                $"--certificate-fingerprint {storeCertificate.Certificate.Thumbprint} " +
+                $"--certificate-fingerprint {storeCertificate.Certificate.GetCertHashString(System.Security.Cryptography.HashAlgorithmName.SHA256)} " +
                 $"--certificate-store-name {storeCertificate.StoreName} " +
                 $"--certificate-store-location {storeCertificate.StoreLocation}";
         }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
@@ -512,7 +512,6 @@ namespace Dotnet.Integration.Test
                     // Assert
                     result.AllOutput.Should().Contain(_timestampUnsupportedDigestAlgorithmCode);
                     Assert.Contains("The timestamp signature has an unsupported digest algorithm (SHA1). The following algorithms are supported: SHA256, SHA384, SHA512.", result.AllOutput);
-                    Assert.True(result.AllOutput.Contains(_insecureCertificateFingerprintCode), result.AllOutput);
 
                     byte[] resultingFile = File.ReadAllBytes(packageFilePath);
                     Assert.Equal(resultingFile, originalFile);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
@@ -81,7 +81,7 @@ namespace Dotnet.Integration.Test
                 CommandRunnerResult result = _dotnetFixture.RunDotnetExpectSuccess(
                     pathContext.PackageSource,
                     $"nuget sign .{Path.DirectorySeparatorChar}{packageFileName} " +
-                    $"--certificate-fingerprint {storeCertificate.Certificate.GetCertHashString(System.Security.Cryptography.HashAlgorithmName.SHA256)} " +
+                    $"--certificate-fingerprint {SignatureTestUtility.GetFingerprint(storeCertificate.Certificate, HashAlgorithmName.SHA256)} " +
                     $"--certificate-store-name {storeCertificate.StoreName} " +
                     $"--certificate-store-location {storeCertificate.StoreLocation}",
                     testOutputHelper: _testOutputHelper);
@@ -471,7 +471,7 @@ namespace Dotnet.Integration.Test
                 CommandRunnerResult result = _dotnetFixture.RunDotnetExpectSuccess(
                     pathContext.PackageSource,
                     $"nuget sign {packageFilePath} " +
-                    $"--certificate-fingerprint {storeCertificate.Certificate.GetCertHashString(System.Security.Cryptography.HashAlgorithmName.SHA256)}",
+                    $"--certificate-fingerprint {SignatureTestUtility.GetFingerprint(storeCertificate.Certificate, HashAlgorithmName.SHA256)}",
                     testOutputHelper: _testOutputHelper);
 
                 // Assert
@@ -505,7 +505,7 @@ namespace Dotnet.Integration.Test
                     CommandRunnerResult result = _dotnetFixture.RunDotnetExpectFailure(
                         pathContext.PackageSource,
                         $"nuget sign {packageFilePath} " +
-                        $"--certificate-fingerprint {storeCertificate.Certificate.GetCertHashString(System.Security.Cryptography.HashAlgorithmName.SHA256)}} " +
+                        $"--certificate-fingerprint {SignatureTestUtility.GetFingerprint(storeCertificate.Certificate, HashAlgorithmName.SHA256)}} " +
                         $"--timestamper {timestampService.Url}",
                     testOutputHelper: _testOutputHelper);
 
@@ -568,7 +568,7 @@ namespace Dotnet.Integration.Test
         private static string GetDefaultArgs(string packageFilePath, IX509StoreCertificate storeCertificate)
         {
             return $"nuget sign {packageFilePath} " +
-                $"--certificate-fingerprint {storeCertificate.Certificate.GetCertHashString(System.Security.Cryptography.HashAlgorithmName.SHA256)} " +
+                $"--certificate-fingerprint {SignatureTestUtility.GetFingerprint(storeCertificate.Certificate, HashAlgorithmName.SHA256)} " +
                 $"--certificate-store-name {storeCertificate.StoreName} " +
                 $"--certificate-store-location {storeCertificate.StoreLocation}";
         }

--- a/test/NuGet.Core.FuncTests/NuGet.Signing.CrossFramework.Test/CrossVerifyTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Signing.CrossFramework.Test/CrossVerifyTestFixture.cs
@@ -16,8 +16,8 @@ namespace NuGet.Signing.CrossFramework.Test
         private const string DotnetExe = "dotnet.exe";
         //In net472 code path, the SDK version and TFM could not be detected automatically, so we manually specified according to the sdk version we're testing against.
         //https://github.com/NuGet/Home/issues/12187
-        private const string SdkVersion = "9";
-        private const string SdkTfm = "net9.0";
+        private const string SdkVersion = "10";
+        private const string SdkTfm = "net10.0";
         internal string _dotnetExePath;
 #else
         private const string NuGetExe = "NuGet.exe";

--- a/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
@@ -16,8 +16,8 @@ namespace NuGet.Test.Utility
 {
     public static class TestDotnetCLiUtility
     {
-#if NET8_0 // This override allows us to test the next version of the CLI without making all the projects target that version.
-        private static NuGetFramework FrameworkOverride = new NuGetFramework("net9.0");
+#if NET9_0 // This override allows us to test the next version of the CLI without making all the projects target that version.
+        private static NuGetFramework FrameworkOverride = new NuGetFramework("net10.0");
 #elif !IS_DESKTOP
         private static NuGetFramework FrameworkOverride = null;
 #endif


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

We need to run our tests against .NET 10. 
As part of that, I needed to update a few tests:
- Added `--no-restore` option in the dotnet list package tests that effectively tested restore not being run.
- Used the SHA256 fingerprint when running dotnet sign tests because sha1 values are now blocked in .NET 10. 
Ideally we would've had tests against .NET 10 as well earlier so that these tests would've been updated, but unfortunately we didn't have the infrastructure for that.
- Removed DotnetSign_SignPackageWithInsecureCertificateFingerprint_RaisesWarningAsync, as now the warning is raised regardless. There's other tests that satisfy this scenario

cc @kartheekp-ms in case you have some time to take a look at the test  changes.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
