### PR TITLE
Stop warning for transitive PRs

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.DependencyGraphItem.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.DependencyGraphItem.cs
@@ -171,7 +171,7 @@ namespace NuGet.Commands
 
                 if (!isPackage)
                 {
-                    if (SdkAnalysisLevelMinimums.IsEnabled(
+                    if (isRootProject && SdkAnalysisLevelMinimums.IsEnabled(
                         projectRestoreMetadata.SdkAnalysisLevel,
                         projectRestoreMetadata.UsingMicrosoftNETSdk,
                         SdkAnalysisLevelMinimums.PruningWarnings))

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -4786,7 +4786,7 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project3");
             result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
             result.LockFile.Targets[0].Libraries[2].Dependencies.Should().BeEmpty();
-            result.LockFile.LogMessages.Should().HaveCount(0);
+            result.LockFile.LogMessages.Should().BeEmpty();
             ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
             installedPackages.Should().HaveCount(1);
         }
@@ -5202,8 +5202,7 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
             result.LockFile.Targets[0].Libraries[2].Dependencies.Should().BeEmpty();
 
-            result.LockFile.LogMessages.Should().HaveCount(1);
-            result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1511);
+            result.LockFile.LogMessages.Should().BeEmpty();
 
             ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
             installedPackages.Should().HaveCount(1);

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -4729,11 +4729,8 @@ namespace NuGet.Commands.FuncTest
         // P1 -> A 1.0.0 -> B 1.0.0
         // P1 -> P2 (project) -> P3 (project)
         // Prune B 1.0.0
-        [Theory]
-        [InlineData("10.0.100", true, true)]
-        [InlineData("9.0.100", true, false)]
-        [InlineData("", false, true)]
-        public async Task RestoreCommand_WithTransitiveProjectReferenceSpecifiedForPruning_SkipsPruning_AndVerifiesEquivalency(string sdkAnalysisLevel, bool usingMicrosoftNETSdk, bool shouldWarn)
+        [Fact]
+        public async Task RestoreCommand_WithTransitiveProjectReferenceSpecifiedForPruning_SkipsPruningAndDoesNotWarn_AndVerifiesEquivalency()
         {
             using var pathContext = new SimpleTestPathContext();
 
@@ -4768,8 +4765,8 @@ namespace NuGet.Commands.FuncTest
 
             // Setup project
             var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
-            projectSpec.RestoreMetadata.SdkAnalysisLevel = !string.IsNullOrEmpty(sdkAnalysisLevel) ? NuGetVersion.Parse(sdkAnalysisLevel) : null;
-            projectSpec.RestoreMetadata.UsingMicrosoftNETSdk = usingMicrosoftNETSdk;
+            projectSpec.RestoreMetadata.SdkAnalysisLevel = NuGetVersion.Parse("10.0.100");
+            projectSpec.RestoreMetadata.UsingMicrosoftNETSdk = true;
             var projectSpec2 = ProjectTestHelpers.GetPackageSpec("Project2", framework: "net472");
             var projectSpec3 = ProjectTestHelpers.GetPackageSpec("Project3", framework: "net472");
 
@@ -4789,11 +4786,7 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project3");
             result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
             result.LockFile.Targets[0].Libraries[2].Dependencies.Should().BeEmpty();
-            if (shouldWarn)
-            {
-                result.LockFile.LogMessages.Should().HaveCount(1);
-                result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1511);
-            }
+            result.LockFile.LogMessages.Should().HaveCount(0);
             ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
             installedPackages.Should().HaveCount(1);
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14103

## Description

ProjectReference cannot be pruned. 
There might be an attempt to prune one, but usually that's an authoring error (except in the .NET runtime where they build the libraries). 

Pruning warnings for transitive project refs are not helpful since they aren't actionable for that particular project. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
