### PR TITLE
Update dotnet list package to read solutions outside of CWD

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -88,7 +88,12 @@ namespace NuGet.CommandLine.XPlat
         {
             ISolutionSerializer serializer = SolutionSerializers.GetSerializerByMoniker(solutionPath);
             SolutionModel solution = await serializer.OpenAsync(solutionPath, cancellationToken);
-            return solution.SolutionProjects.Select(p => p.FilePath);
+            return solution.SolutionProjects.Select(p =>
+            {
+                return Path.IsPathRooted(p.FilePath)
+                ? p.FilePath
+                : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(solutionPath), p.FilePath));
+            });
         }
 
         /// <summary>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -365,10 +365,56 @@ namespace NuGet.XPlat.FuncTest
 
             using var pathContext = new SimpleTestPathContext();
             var project = SetupTestProject(pathContext);
-            SetupAssetsAndProps(project);
+            SetupAssetsAndProps(Path.GetDirectoryName(project.ProjectPath));
 
             var listPackageArgs = new ListPackageArgs(
                 path: project.ProjectPath,
+                packageSources: new List<PackageSource> { new PackageSource(pathContext.PackageSource) },
+                frameworks: new List<string>(),
+                ReportType.Vulnerable,
+                mockRenderer.Object,
+                includeTransitive: true,
+                prerelease: false,
+                highestPatch: false,
+                highestMinor: false,
+                new List<PackageSource> { auditSource },
+                mockLogger.Object,
+                CancellationToken.None
+            );
+
+            var listPackageCommandRunner = new ListPackageCommandRunner();
+
+
+            // Act
+            var result = await listPackageCommandRunner.GetReportDataAsync(listPackageArgs);
+
+            // Assert
+            Assert.Equal(1, result.Item2.Projects.Count);
+            Assert.Equal(1, result.Item2.Projects.First().TargetFrameworkPackages.Count);
+            Assert.Equal(1, result.Item2.Projects.First().TargetFrameworkPackages.First().TopLevelPackages.Count);
+            Assert.Equal(1, result.Item2.Projects.First().TargetFrameworkPackages.First().TopLevelPackages.First().Vulnerabilities.Count);
+            Assert.Equal("0.0.9", result.Item2.Projects.First().TargetFrameworkPackages.First().TopLevelPackages.First().RequestedVersion);
+            Assert.Equal("1.0.0", result.Item2.Projects.First().TargetFrameworkPackages.First().TopLevelPackages.First().ResolvedVersion);
+            Assert.Equal(2, result.Item2.Projects[0].TargetFrameworkPackages[0].TopLevelPackages.First().Vulnerabilities.First().Severity);
+            Assert.Equal("https://test/", result.Item2.Projects[0].TargetFrameworkPackages[0].TopLevelPackages.First().Vulnerabilities.First().AdvisoryUrl.ToString());
+        }
+
+        [Fact]
+        public async Task GetReportDataAsync_WhenSolutionFileOutsideCWD_ShouldList()
+        {
+            // Arrange
+            using var mockServer = SetupMockServer();
+            var auditSource = new PackageSource(mockServer.Uri + "v3/index.json") { AllowInsecureConnections = true };
+
+            var mockRenderer = new Mock<IReportRenderer>();
+            var mockLogger = new Mock<ILogger>();
+
+            using var pathContext = new SimpleTestPathContext();
+            var solution = SetupTestSolution(pathContext);
+            SetupAssetsAndProps(Path.Combine(solution.Projects[0].SolutionRoot, solution.Projects[0].ProjectName).ToString());
+
+            var listPackageArgs = new ListPackageArgs(
+                path: solution.SolutionPath,
                 packageSources: new List<PackageSource> { new PackageSource(pathContext.PackageSource) },
                 frameworks: new List<string>(),
                 ReportType.Vulnerable,
@@ -418,7 +464,7 @@ namespace NuGet.XPlat.FuncTest
 
             using var pathContext = new SimpleTestPathContext();
             var project = SetupTestProject(pathContext);
-            SetupAssetsAndProps(project);
+            SetupAssetsAndProps(Path.GetDirectoryName(project.ProjectPath));
 
             var mockRenderer = new Mock<IReportRenderer>();
             var mockLogger = new Mock<ILogger>();
@@ -500,6 +546,23 @@ namespace NuGet.XPlat.FuncTest
             Assert.True(13 == fields.Length, "Number of fields are changed in ListPackageArgs.cs. Please make sure this change is accounted for GetReportParameters method in that file.");
         }
 
+        private static SimpleTestSolutionContext SetupTestSolution(SimpleTestPathContext pathContext)
+        {
+            var package = new SimpleTestPackageContext { Id = "task", Version = "0.0.9" };
+
+            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+            var project = SimpleTestProjectContext.CreateNETCore("ProjectA", pathContext.SolutionRoot, NuGetFramework.Parse("net8.0"));
+            project.Type = ProjectStyle.PackageReference;
+            project.SingleTargetFramework = true;
+            project.AddPackageToAllFrameworks(package);
+            project.ProjectPath = Path.GetRelativePath(pathContext.SolutionRoot, project.ProjectPath);
+
+            solution.Projects.Add(project);
+            solution.Create(pathContext.SolutionRoot);
+
+            return solution;
+        }
+
         private static SimpleTestProjectContext SetupTestProject(SimpleTestPathContext pathContext)
         {
             var package = new SimpleTestPackageContext { Id = "task", Version = "0.0.9" };
@@ -516,9 +579,9 @@ namespace NuGet.XPlat.FuncTest
             return project;
         }
 
-        private void SetupAssetsAndProps(SimpleTestProjectContext project)
+        private void SetupAssetsAndProps(string projectFolder)
         {
-            string objFolder = Path.Combine(Path.GetDirectoryName(project.ProjectPath), "obj");
+            string objFolder = Path.Combine(projectFolder, "obj");
             Directory.CreateDirectory(objFolder);
 
             string assetsPath = Path.Combine(objFolder, "project.assets.json");

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -365,7 +365,7 @@ namespace NuGet.XPlat.FuncTest
 
             using var pathContext = new SimpleTestPathContext();
             var project = SetupTestProject(pathContext);
-            SetupAssetsAndProps(Path.GetDirectoryName(project.ProjectPath));
+            SetupAssetsAndProps(project);
 
             var listPackageArgs = new ListPackageArgs(
                 path: project.ProjectPath,
@@ -411,7 +411,7 @@ namespace NuGet.XPlat.FuncTest
 
             using var pathContext = new SimpleTestPathContext();
             var solution = SetupTestSolution(pathContext);
-            SetupAssetsAndProps(Path.Combine(Path.GetDirectoryName(solution.SolutionPath), solution.Projects[0].ProjectName).ToString());
+            SetupAssetsAndProps(solution.Projects[0]);
 
             var listPackageArgs = new ListPackageArgs(
                 path: solution.SolutionPath,
@@ -464,7 +464,7 @@ namespace NuGet.XPlat.FuncTest
 
             using var pathContext = new SimpleTestPathContext();
             var project = SetupTestProject(pathContext);
-            SetupAssetsAndProps(Path.GetDirectoryName(project.ProjectPath));
+            SetupAssetsAndProps(project);
 
             var mockRenderer = new Mock<IReportRenderer>();
             var mockLogger = new Mock<ILogger>();
@@ -578,13 +578,12 @@ namespace NuGet.XPlat.FuncTest
             return project;
         }
 
-        private void SetupAssetsAndProps(string projectFolder)
+        private void SetupAssetsAndProps(SimpleTestProjectContext project)
         {
-            string objFolder = Path.Combine(projectFolder, "obj");
-            Directory.CreateDirectory(objFolder);
+            Directory.CreateDirectory(project.ProjectExtensionsPath);
 
-            string assetsPath = Path.Combine(objFolder, "project.assets.json");
-            string propsPath = Path.Combine(objFolder, "ProjectA.csproj.nuget.g.props");
+            string assetsPath = Path.Combine(project.ProjectExtensionsPath, "project.assets.json");
+            string propsPath = Path.Combine(project.ProjectExtensionsPath, "ProjectA.csproj.nuget.g.props");
 
             string assetsContent = ResourceTestUtility.GetResource(
                 "NuGet.XPlat.FuncTest.compiler.resources.Test.OnePackage.project.assets.json",

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -430,7 +430,6 @@ namespace NuGet.XPlat.FuncTest
 
             var listPackageCommandRunner = new ListPackageCommandRunner();
 
-
             // Act
             var result = await listPackageCommandRunner.GetReportDataAsync(listPackageArgs);
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -400,7 +400,7 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
-        public async Task GetReportDataAsync_WhenSolutionFileOutsideCWD_ShouldList()
+        public async Task GetReportDataAsync_WithSolutionFilePassed_ShouldList()
         {
             // Arrange
             using var mockServer = SetupMockServer();

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -411,7 +411,7 @@ namespace NuGet.XPlat.FuncTest
 
             using var pathContext = new SimpleTestPathContext();
             var solution = SetupTestSolution(pathContext);
-            SetupAssetsAndProps(Path.Combine(solution.Projects[0].SolutionRoot, solution.Projects[0].ProjectName).ToString());
+            SetupAssetsAndProps(Path.Combine(Path.GetDirectoryName(solution.SolutionPath), solution.Projects[0].ProjectName).ToString());
 
             var listPackageArgs = new ListPackageArgs(
                 path: solution.SolutionPath,
@@ -555,7 +555,6 @@ namespace NuGet.XPlat.FuncTest
             project.Type = ProjectStyle.PackageReference;
             project.SingleTargetFramework = true;
             project.AddPackageToAllFrameworks(package);
-            project.ProjectPath = Path.GetRelativePath(pathContext.SolutionRoot, project.ProjectPath);
 
             solution.Projects.Add(project);
             solution.Create(pathContext.SolutionRoot);

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -35,7 +35,6 @@ namespace NuGet.Test.Utility
                 throw new ArgumentException(nameof(solutionRoot));
             }
 
-            SolutionRoot = solutionRoot;
             ProjectName = projectName;
             ProjectPath = Path.Combine(solutionRoot, projectName, $"{projectName}{ProjectExt}");
             ProjectExtensionsPath = Path.Combine(solutionRoot, projectName, "obj");
@@ -126,8 +125,6 @@ namespace NuGet.Test.Utility
         public bool SingleTargetFramework { get; set; }
 
         public bool SetMSBuildProjectExtensionsPath { get; set; } = true;
-
-        public string SolutionRoot { get; set; }
 
         /// <summary>
         /// project.lock.json or project.assets.json
@@ -337,14 +334,7 @@ namespace NuGet.Test.Utility
 
         public void Save()
         {
-            string path = ProjectPath;
-
-            if (!Path.IsPathRooted(ProjectPath))
-            {
-                path = Path.Combine(SolutionRoot ?? Path.GetDirectoryName(ProjectPath), ProjectPath);
-            }
-
-            Save(path);
+            Save(ProjectPath);
         }
 
         public void Save(string path)

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -35,6 +35,7 @@ namespace NuGet.Test.Utility
                 throw new ArgumentException(nameof(solutionRoot));
             }
 
+            SolutionRoot = solutionRoot;
             ProjectName = projectName;
             ProjectPath = Path.Combine(solutionRoot, projectName, $"{projectName}{ProjectExt}");
             ProjectExtensionsPath = Path.Combine(solutionRoot, projectName, "obj");
@@ -125,6 +126,8 @@ namespace NuGet.Test.Utility
         public bool SingleTargetFramework { get; set; }
 
         public bool SetMSBuildProjectExtensionsPath { get; set; } = true;
+
+        public string SolutionRoot { get; set; }
 
         /// <summary>
         /// project.lock.json or project.assets.json
@@ -334,7 +337,14 @@ namespace NuGet.Test.Utility
 
         public void Save()
         {
-            Save(ProjectPath);
+            string path = ProjectPath;
+
+            if (!Path.IsPathRooted(ProjectPath))
+            {
+                path = Path.Combine(SolutionRoot ?? Path.GetDirectoryName(ProjectPath), ProjectPath);
+            }
+
+            Save(path);
         }
 
         public void Save(string path)

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSolutionContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSolutionContext.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using NuGet.Common;
 
 namespace NuGet.Test.Utility
 {
@@ -76,7 +77,7 @@ namespace NuGet.Test.Utility
                 foreach (var project in Projects)
                 {
                     sb.AppendLine("Project(\"{" + "FAE04EC0-301F-11D3-BF4B-00C04F79EFBC" + "}"
-                        + $"\") = \"{project.ProjectName}\", " + "\"" + project.ProjectPath + "\", \"{" + project.ProjectGuid.ToString().ToUpperInvariant() + "}\"");
+                        + $"\") = \"{project.ProjectName}\", " + "\"" + PathUtility.GetRelativePath(SolutionPath, project.ProjectPath) + "\", \"{" + project.ProjectGuid.ToString().ToUpperInvariant() + "}\"");
                     sb.AppendLine("EndProject");
                 }
 
@@ -112,7 +113,7 @@ namespace NuGet.Test.Utility
                 sb.AppendLine("<Solution>");
                 foreach (var project in Projects)
                 {
-                    sb.AppendLine($"<Project Path=\"{project.ProjectPath}\" />");
+                    sb.AppendLine($"<Project Path=\"{PathUtility.GetRelativePath(SolutionPath, project.ProjectPath)}\" />");
                 }
                 sb.AppendLine("</Solution>");
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/dotnet/sdk/issues/48062
Fixes: https://github.com/NuGet/Home/issues/14177

## Description
Regression introduced here: https://github.com/NuGet/NuGet.Client/pull/6219#discussion_r2042888958

https://github.com/NuGet/NuGet.Client/blob/04a1f669ae8c6eba60720decdb58c2a7d2fe4776/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs#L91 is returning a relative path to projects in a solution, and the list package command runner is not able to understand the relative paths.

This PR updates the method to read solutions outside of CWD by getting the absolute path of a project

### Before
![image](https://github.com/user-attachments/assets/0d28d0e4-a677-4bd3-ae65-0135ea646646)

### After
![image](https://github.com/user-attachments/assets/ca7554a5-08cc-4e97-8e97-76a8fb009c45)

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
