### PR TITLE
Use relative path of project for test solution files

### DIFF
--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -35,7 +35,6 @@ namespace NuGet.Test.Utility
                 throw new ArgumentException(nameof(solutionRoot));
             }
 
-            SolutionRoot = solutionRoot;
             ProjectName = projectName;
             ProjectPath = Path.Combine(solutionRoot, projectName, $"{projectName}{ProjectExt}");
             ProjectExtensionsPath = Path.Combine(solutionRoot, projectName, "obj");
@@ -124,8 +123,6 @@ namespace NuGet.Test.Utility
         /// If true TargetFramework will be used instead of TargetFrameworks
         /// </summary>
         public bool SingleTargetFramework { get; set; }
-
-        public string SolutionRoot { get; set; }
 
         public bool SetMSBuildProjectExtensionsPath { get; set; } = true;
 

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -37,7 +37,7 @@ namespace NuGet.Test.Utility
 
             SolutionRoot = solutionRoot;
             ProjectName = projectName;
-            ProjectPath = Path.Combine(projectName, $"{projectName}{ProjectExt}");
+            ProjectPath = Path.Combine(solutionRoot, projectName, $"{projectName}{ProjectExt}");
             ProjectExtensionsPath = Path.Combine(solutionRoot, projectName, "obj");
             Type = type;
             if (Type == ProjectStyle.PackageReference)
@@ -337,7 +337,7 @@ namespace NuGet.Test.Utility
 
         public void Save()
         {
-            Save(Path.Combine(SolutionRoot ?? Path.GetDirectoryName(ProjectPath), ProjectPath));
+            Save(ProjectPath);
         }
 
         public void Save(string path)

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -35,8 +35,9 @@ namespace NuGet.Test.Utility
                 throw new ArgumentException(nameof(solutionRoot));
             }
 
+            SolutionRoot = solutionRoot;
             ProjectName = projectName;
-            ProjectPath = Path.Combine(solutionRoot, projectName, $"{projectName}{ProjectExt}");
+            ProjectPath = Path.Combine(projectName, $"{projectName}{ProjectExt}");
             ProjectExtensionsPath = Path.Combine(solutionRoot, projectName, "obj");
             Type = type;
             if (Type == ProjectStyle.PackageReference)
@@ -123,6 +124,8 @@ namespace NuGet.Test.Utility
         /// If true TargetFramework will be used instead of TargetFrameworks
         /// </summary>
         public bool SingleTargetFramework { get; set; }
+
+        public string SolutionRoot { get; set; }
 
         public bool SetMSBuildProjectExtensionsPath { get; set; } = true;
 
@@ -334,7 +337,7 @@ namespace NuGet.Test.Utility
 
         public void Save()
         {
-            Save(ProjectPath);
+            Save(Path.Combine(SolutionRoot ?? Path.GetDirectoryName(ProjectPath), ProjectPath));
         }
 
         public void Save(string path)

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSolutionContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSolutionContext.cs
@@ -76,7 +76,7 @@ namespace NuGet.Test.Utility
                 foreach (var project in Projects)
                 {
                     sb.AppendLine("Project(\"{" + "FAE04EC0-301F-11D3-BF4B-00C04F79EFBC" + "}"
-                        + $"\") = \"{project.ProjectName}\", " + "\"" + project.ProjectPath + "\", \"{" + project.ProjectGuid.ToString().ToUpperInvariant() + "}\"");
+                        + $"\") = \"{project.ProjectName}\", " + "\"" + GetRelativePath(project.SolutionRoot, project.ProjectPath) + "\", \"{" + project.ProjectGuid.ToString().ToUpperInvariant() + "}\"");
                     sb.AppendLine("EndProject");
                 }
 
@@ -112,7 +112,7 @@ namespace NuGet.Test.Utility
                 sb.AppendLine("<Solution>");
                 foreach (var project in Projects)
                 {
-                    sb.AppendLine($"<Project Path=\"{project.ProjectPath}\" />");
+                    sb.AppendLine($"<Project Path=\"{GetRelativePath(project.SolutionRoot, project.ProjectPath)}\" />");
                 }
                 sb.AppendLine("</Solution>");
 
@@ -164,5 +164,13 @@ namespace NuGet.Test.Utility
         }
 
         public CentralPackageVersionsManagementFile CentralPackageVersionsManagementFile { get; set; }
+
+        private static string GetRelativePath(string basePath, string targetPath)
+        {
+            var baseUri = new Uri(Path.GetFullPath(basePath) + Path.DirectorySeparatorChar);
+            var targetUri = new Uri(Path.GetFullPath(targetPath));
+            var relativeUri = baseUri.MakeRelativeUri(targetUri);
+            return Uri.UnescapeDataString(relativeUri.ToString().Replace('/', Path.DirectorySeparatorChar));
+        }
     }
 }

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSolutionContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSolutionContext.cs
@@ -30,6 +30,11 @@ namespace NuGet.Test.Utility
         public string SolutionPath { get; set; }
 
         /// <summary>
+        /// Solution root
+        /// </summary>
+        public string SolutionRoot => Path.GetDirectoryName(SolutionPath);
+
+        /// <summary>
         /// Projects
         /// </summary>
         public List<SimpleTestProjectContext> Projects { get; set; } = new List<SimpleTestProjectContext>();
@@ -76,7 +81,7 @@ namespace NuGet.Test.Utility
                 foreach (var project in Projects)
                 {
                     sb.AppendLine("Project(\"{" + "FAE04EC0-301F-11D3-BF4B-00C04F79EFBC" + "}"
-                        + $"\") = \"{project.ProjectName}\", " + "\"" + GetRelativePath(project.SolutionRoot, project.ProjectPath) + "\", \"{" + project.ProjectGuid.ToString().ToUpperInvariant() + "}\"");
+                        + $"\") = \"{project.ProjectName}\", " + "\"" + GetRelativePath(SolutionRoot, project.ProjectPath) + "\", \"{" + project.ProjectGuid.ToString().ToUpperInvariant() + "}\"");
                     sb.AppendLine("EndProject");
                 }
 
@@ -112,7 +117,7 @@ namespace NuGet.Test.Utility
                 sb.AppendLine("<Solution>");
                 foreach (var project in Projects)
                 {
-                    sb.AppendLine($"<Project Path=\"{GetRelativePath(project.SolutionRoot, project.ProjectPath)}\" />");
+                    sb.AppendLine($"<Project Path=\"{GetRelativePath(SolutionRoot, project.ProjectPath)}\" />");
                 }
                 sb.AppendLine("</Solution>");
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

 This PR makes sure the generated solution files user relative path of the project files

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
