### PR TITLE
Raise pruning warnings for .NET 10 only

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.DependencyGraphItem.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.DependencyGraphItem.cs
@@ -84,6 +84,7 @@ namespace NuGet.Commands
             public async Task<GraphItem<RemoteResolveResult>> GetGraphItemAsync(
                 ProjectRestoreMetadata projectRestoreMetadata,
                 IReadOnlyDictionary<string, PrunePackageReference>? packagesToPrune,
+                bool enablePruningWarnings,
                 bool isRootProject,
                 ILogger logger)
             {
@@ -105,7 +106,7 @@ namespace NuGet.Commands
                     LibraryDependency dependency = item.Data.Dependencies[i];
 
                     // Skip any packages that should be pruned or will be replaced with a runtime dependency
-                    if (ShouldPrunePackage(projectRestoreMetadata, packagesToPrune, dependency, item.Key, isRootProject, logger)
+                    if (ShouldPrunePackage(projectRestoreMetadata, packagesToPrune, enablePruningWarnings, dependency, item.Key, isRootProject, logger)
                         || RuntimeDependencies?.Contains(dependency) == true)
                     {
                         continue;
@@ -119,7 +120,7 @@ namespace NuGet.Commands
                     // Add any runtime dependencies unless they should be pruned
                     foreach (LibraryDependency runtimeDependency in RuntimeDependencies)
                     {
-                        if (ShouldPrunePackage(projectRestoreMetadata, packagesToPrune, runtimeDependency, item.Key, isRootProject, logger) == true)
+                        if (ShouldPrunePackage(projectRestoreMetadata, packagesToPrune, enablePruningWarnings, runtimeDependency, item.Key, isRootProject, logger) == true)
                         {
                             continue;
                         }
@@ -155,6 +156,7 @@ namespace NuGet.Commands
             private static bool ShouldPrunePackage(
                 ProjectRestoreMetadata projectRestoreMetadata,
                 IReadOnlyDictionary<string, PrunePackageReference>? packagesToPrune,
+                bool enablePruningWarnings,
                 LibraryDependency dependency,
                 LibraryIdentity parentLibrary,
                 bool isRootProject,
@@ -171,7 +173,7 @@ namespace NuGet.Commands
 
                 if (!isPackage)
                 {
-                    if (isRootProject && SdkAnalysisLevelMinimums.IsEnabled(
+                    if (isRootProject && enablePruningWarnings && SdkAnalysisLevelMinimums.IsEnabled(
                         projectRestoreMetadata.SdkAnalysisLevel,
                         projectRestoreMetadata.UsingMicrosoftNETSdk,
                         SdkAnalysisLevelMinimums.PruningWarnings))
@@ -184,7 +186,7 @@ namespace NuGet.Commands
 
                 if (isRootProject)
                 {
-                    if (SdkAnalysisLevelMinimums.IsEnabled(
+                    if (enablePruningWarnings && SdkAnalysisLevelMinimums.IsEnabled(
                         projectRestoreMetadata.SdkAnalysisLevel,
                         projectRestoreMetadata.UsingMicrosoftNETSdk,
                         SdkAnalysisLevelMinimums.PruningWarnings))

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -904,7 +904,7 @@ namespace NuGet.Commands
         private async Task<Dictionary<LibraryDependencyIndex, ResolvedDependencyGraphItem>> ResolveDependencyGraphItemsAsync(
             bool isCentralPackageTransitivePinningEnabled,
             FrameworkRuntimePair pair,
-            TargetFrameworkInformation? projectTargetFramework,
+            TargetFrameworkInformation projectTargetFramework,
             RuntimeGraph? runtimeGraph,
             Dictionary<LibraryDependencyIndex,
             VersionRange>? pinnedPackageVersions,
@@ -969,7 +969,7 @@ namespace NuGet.Commands
                 // Determine if what is being processed is the root project itself which has different rules vs a transitive dependency
                 bool isRootProject = currentDependencyGraphItem.LibraryDependencyIndex == LibraryDependencyIndex.Project;
 
-                GraphItem<RemoteResolveResult> currentGraphItem = await currentDependencyGraphItem.GetGraphItemAsync(_request.Project.RestoreMetadata, projectTargetFramework?.PackagesToPrune, isRootProject, _logger);
+                GraphItem<RemoteResolveResult> currentGraphItem = await currentDependencyGraphItem.GetGraphItemAsync(_request.Project.RestoreMetadata, projectTargetFramework.PackagesToPrune, IsNewerThanNET10(projectTargetFramework.FrameworkName), isRootProject, _logger);
 
                 LibraryDependencyTarget typeConstraint = currentDependencyGraphItem.LibraryDependency.LibraryRange.TypeConstraint;
                 if (evictions.TryGetValue(currentDependencyGraphItem.LibraryRangeIndex, out (LibraryRangeIndex[], LibraryDependencyIndex, LibraryDependencyTarget) eviction))
@@ -1407,6 +1407,15 @@ namespace NuGet.Commands
             }
 
             return resolvedDependencyGraphItems;
+        }
+
+        private static bool IsNewerThanNET10(NuGetFramework frameworkName)
+        {
+            if (frameworkName.Framework == FrameworkConstants.FrameworkIdentifiers.NetCoreApp)
+            {
+                return frameworkName.Version.Major >= 10;
+            }
+            return false;
         }
 
         /// <summary>

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -4353,7 +4353,67 @@ namespace NuGet.Commands.FuncTest
         // P -> C 1.0.0
         // Prune C 1.0.0
         [Fact]
-        public async Task RestoreCommand_WithPrunePackageReferences_DoesNotPruneDirectDependencies_AndVerifiesEquivalency()
+        public async Task RestoreCommand_WithPrunePackageReferences_DoesNotPruneDirectDependenciesAndWarns()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("A", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("B", "1.0.0")]
+            };
+            var packageC = new SimpleTestPackageContext("C", "1.0.0");
+
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA,
+                packageC);
+
+            var rootProject = @"
+        {
+          ""frameworks"": {
+            ""net10.0"": {
+                ""dependencies"": {
+                        ""A"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                        ""C"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""C"" : ""(,1.0.0]"" 
+                }
+            }
+          }
+        }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+
+            // Act & Assert
+            var result = await RunRestoreAsync(pathContext, projectSpec);
+
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("A");
+            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("B");
+            result.LockFile.Targets[0].Libraries[1].Dependencies.Should().HaveCount(0);
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("C");
+            result.LockFile.Targets[0].Libraries[2].Dependencies.Should().HaveCount(0);
+            result.LockFile.LogMessages.Should().HaveCount(1);
+            result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1510);
+            ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
+            installedPackages.Should().HaveCount(3);
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithPrunePackageReferencesAndOlderFramework_DoesNotPruneDirectDependenciesAndDoesNotWarn()
         {
             using var pathContext = new SimpleTestPathContext();
 
@@ -4392,7 +4452,6 @@ namespace NuGet.Commands.FuncTest
           }
         }";
 
-
             // Setup project
             var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
 
@@ -4407,8 +4466,7 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[1].Dependencies.Should().HaveCount(0);
             result.LockFile.Targets[0].Libraries[2].Name.Should().Be("C");
             result.LockFile.Targets[0].Libraries[2].Dependencies.Should().HaveCount(0);
-            result.LockFile.LogMessages.Should().HaveCount(1);
-            result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1510);
+            result.LockFile.LogMessages.Should().BeEmpty();
             ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
             installedPackages.Should().HaveCount(3);
         }

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -4412,65 +4412,6 @@ namespace NuGet.Commands.FuncTest
             installedPackages.Should().HaveCount(3);
         }
 
-        [Fact]
-        public async Task RestoreCommand_WithPrunePackageReferencesAndOlderFramework_DoesNotPruneDirectDependenciesAndDoesNotWarn()
-        {
-            using var pathContext = new SimpleTestPathContext();
-
-            // Setup packages
-            var packageA = new SimpleTestPackageContext("A", "1.0.0")
-            {
-                Dependencies = [new SimpleTestPackageContext("B", "1.0.0")]
-            };
-            var packageC = new SimpleTestPackageContext("C", "1.0.0");
-
-
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                pathContext.PackageSource,
-                PackageSaveMode.Defaultv3,
-                packageA,
-                packageC);
-
-            var rootProject = @"
-        {
-          ""frameworks"": {
-            ""net472"": {
-                ""dependencies"": {
-                        ""A"": {
-                            ""version"": ""[1.0.0,)"",
-                            ""target"": ""Package"",
-                        },
-                        ""C"": {
-                            ""version"": ""[1.0.0,)"",
-                            ""target"": ""Package"",
-                        },
-                },
-                ""packagesToPrune"": {
-                    ""C"" : ""(,1.0.0]"" 
-                }
-            }
-          }
-        }";
-
-            // Setup project
-            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
-
-            // Act & Assert
-            var result = await RunRestoreAsync(pathContext, projectSpec);
-
-            result.LockFile.Targets.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
-            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("A");
-            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("B");
-            result.LockFile.Targets[0].Libraries[1].Dependencies.Should().HaveCount(0);
-            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("C");
-            result.LockFile.Targets[0].Libraries[2].Dependencies.Should().HaveCount(0);
-            result.LockFile.LogMessages.Should().BeEmpty();
-            ISet<LibraryIdentity> installedPackages = result.GetAllInstalled();
-            installedPackages.Should().HaveCount(3);
-        }
-
         // P -> P2 -> B 1.0.0 -> C 1.0.0
         // P -> A 1.0.0
         // Prune B 1.0.0
@@ -4721,10 +4662,12 @@ namespace NuGet.Commands.FuncTest
         // P1 -> P2 (project)
         // Prune B 1.0.0
         [Theory]
-        [InlineData("10.0.100", true, true)]
-        [InlineData("9.0.100", true, false)]
-        [InlineData("", false, true)]
-        public async Task RestoreCommand_WithDirectProjectReferenceSpecifiedForPruning_SkipsPruning(string sdkAnalysisLevel, bool usingMicrosoftNETSdk, bool shouldWarn)
+        [InlineData("net10.0", "10.0.100", true, true)]
+        [InlineData("net10.0", "9.0.100", true, false)]
+        [InlineData("net10.0", "", false, true)]
+        [InlineData("net472", "", false, false)]
+        [InlineData("net472", "10.0.100", false, false)]
+        public async Task RestoreCommand_WithDirectProjectReferenceSpecifiedForPruning_SkipsPruning(string framework, string sdkAnalysisLevel, bool usingMicrosoftNETSdk, bool shouldWarn)
         {
             using var pathContext = new SimpleTestPathContext();
 
@@ -4742,7 +4685,7 @@ namespace NuGet.Commands.FuncTest
             var rootProject = @"
         {
           ""frameworks"": {
-            ""net472"": {
+            ""FRAMEWORK"": {
                 ""dependencies"": {
                         ""packageA"": {
                             ""version"": ""[1.0.0,)"",
@@ -4755,13 +4698,13 @@ namespace NuGet.Commands.FuncTest
                 }
             }
           }
-        }";
+        }".Replace("FRAMEWORK", framework);
 
             // Setup project
             var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
             projectSpec.RestoreMetadata.SdkAnalysisLevel = !string.IsNullOrEmpty(sdkAnalysisLevel) ? NuGetVersion.Parse(sdkAnalysisLevel) : null;
             projectSpec.RestoreMetadata.UsingMicrosoftNETSdk = usingMicrosoftNETSdk;
-            var projectSpec2 = ProjectTestHelpers.GetPackageSpec("Project2", framework: "net472");
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpec("Project2", framework: framework);
 
             projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -4704,7 +4704,7 @@ namespace NuGet.Commands.FuncTest
             var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
             projectSpec.RestoreMetadata.SdkAnalysisLevel = !string.IsNullOrEmpty(sdkAnalysisLevel) ? NuGetVersion.Parse(sdkAnalysisLevel) : null;
             projectSpec.RestoreMetadata.UsingMicrosoftNETSdk = usingMicrosoftNETSdk;
-            var projectSpec2 = ProjectTestHelpers.GetPackageSpec("Project2", framework: framework);
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpec("Project2", framework);
 
             projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14126

## Description

We agreed to raise the pruning warnings for .NET 10 only to minimize the disruption.

Note that this PR is not closing the issue as we're still considering means to reenable these warnings. 
That being said, no point in waiting for that to happen since we want this change regardless of that effort.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/14254
