### PR TITLE
Run the update status of installed and transitive packages in background

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -336,12 +336,14 @@ namespace NuGet.PackageManagement.UI
 
                     if (listItem.PackageLevel == PackageLevel.TopLevel)
                     {
-                        listItem.UpdatePackageStatus(_installedPackages);
+                        Task.Run(() => listItem.UpdatePackageStatus(_installedPackages))
+                            .PostOnFailure(nameof(PackageItemLoader), nameof(GetCurrent));
                     }
                     else
                     {
                         listItem.UpdateTransitiveInfo(metadataContextInfo);
-                        listItem.UpdateTransitivePackageStatus();
+                        Task.Run(listItem.UpdateTransitivePackageStatus)
+                            .PostOnFailure(nameof(PackageItemLoader), nameof(GetCurrent));
                     }
 
                     listItemViewModels[packageId] = listItem;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -336,13 +336,13 @@ namespace NuGet.PackageManagement.UI
 
                     if (listItem.PackageLevel == PackageLevel.TopLevel)
                     {
-                        Task.Run(() => listItem.UpdatePackageStatus(_installedPackages))
+                        listItem.UpdatePackageStatusAsync(_installedPackages)
                             .PostOnFailure(nameof(PackageItemLoader), nameof(GetCurrent));
                     }
                     else
                     {
                         listItem.UpdateTransitiveInfo(metadataContextInfo);
-                        Task.Run(listItem.UpdateTransitivePackageStatus)
+                        listItem.UpdateTransitivePackageStatusAsync()
                             .PostOnFailure(nameof(PackageItemLoader), nameof(GetCurrent));
                     }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -830,7 +830,7 @@ namespace NuGet.PackageManagement.UI
                 .PostOnFailure(nameof(PackageItemViewModel), nameof(UpdatePackageMaxVulnerabilityAsync));
         }
 
-        public void UpdatePackageStatus(IEnumerable<PackageCollectionItem> installedPackages, bool clearCache = false)
+        public async Task UpdatePackageStatusAsync(IEnumerable<PackageCollectionItem> installedPackages, bool clearCache = false)
         {
             // Get the maximum version installed in any target project/solution
             InstalledVersion = installedPackages
@@ -842,27 +842,20 @@ namespace NuGet.PackageManagement.UI
                 _searchService.ClearFromCache(Id, Sources, IncludePrerelease);
             }
 
-            NuGetUIThreadHelper.JoinableTaskFactory
-                .RunAsync(ReloadPackageVersionsAsync)
-                .PostOnFailure(nameof(PackageItemViewModel), nameof(ReloadPackageVersionsAsync));
-
-            NuGetUIThreadHelper.JoinableTaskFactory
-                .RunAsync(ReloadPackageMetadataAsync)
-                .PostOnFailure(nameof(PackageItemViewModel), nameof(ReloadPackageMetadataAsync));
+            await ReloadPackageVersionsAsync();
+            await ReloadPackageMetadataAsync();
 
             OnPropertyChanged(nameof(Status));
         }
 
-        public void UpdateTransitivePackageStatus()
+        public async Task UpdateTransitivePackageStatusAsync()
         {
             InstalledVersion = Version;
 
             // Transitive packages cannot be updated and can only be installed as top-level packages with their currently installed version.
             LatestVersion = InstalledVersion;
 
-            NuGetUIThreadHelper.JoinableTaskFactory
-                .RunAsync(ReloadPackageMetadataAsync)
-                .PostOnFailure(nameof(PackageItemViewModel), nameof(ReloadPackageMetadataAsync));
+            await ReloadPackageMetadataAsync();
 
             OnPropertyChanged(nameof(Status));
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -604,7 +604,7 @@ namespace NuGet.PackageManagement.UI
             _loadingStatusBar.ItemsLoaded = 0;
         }
 
-        public void UpdatePackageStatus(PackageCollectionItem[] installedPackages, bool clearCache = false)
+        public async Task UpdatePackageStatusAsync(PackageCollectionItem[] installedPackages, bool clearCache = false)
         {
             // in this case, we only need to update PackageStatus of
             // existing items in the package list
@@ -612,11 +612,11 @@ namespace NuGet.PackageManagement.UI
             {
                 if (package.PackageLevel == PackageLevel.TopLevel)
                 {
-                    package.UpdatePackageStatus(installedPackages, clearCache);
+                    await package.UpdatePackageStatusAsync(installedPackages, clearCache);
                 }
                 else
                 {
-                    package.UpdateTransitivePackageStatus();
+                    await package.UpdateTransitivePackageStatusAsync();
                 }
             }
         }
@@ -751,9 +751,7 @@ namespace NuGet.PackageManagement.UI
                 var last = _scrollViewer.ViewportHeight + first;
                 if (_scrollViewer.ViewportHeight > 0 && last >= packagesCount)
                 {
-                    NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() =>
-                        LoadItemsAsync(selectedPackageItem: null, token: CancellationToken.None)
-                    ).PostOnFailure(nameof(InfiniteScrollList));
+                    _ = LoadItemsAsync(selectedPackageItem: null, token: CancellationToken.None);
                 }
             }
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1321,7 +1321,7 @@ namespace NuGet.PackageManagement.UI
                     Model.Context.ServiceBroker,
                     Model.Context.Projects,
                     CancellationToken.None);
-                _packageList.UpdatePackageStatus(installedPackages.ToArray(), clearCache);
+                await _packageList.UpdatePackageStatusAsync(installedPackages.ToArray(), clearCache);
 
                 await RefreshInstalledAndUpdatesTabsAsync();
             }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageItemViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageItemViewModelTests.cs
@@ -305,9 +305,9 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
         }
 
         [Fact]
-        public void UpdateTransitivePackageStatus_WhenGivenInstalledVersion_SetsLatestVersionEqualToInstalledVersion()
+        public async Task UpdateTransitivePackageStatus_WhenGivenInstalledVersion_SetsLatestVersionEqualToInstalledVersionAsync()
         {
-            _testInstance.UpdateTransitivePackageStatus();
+            await _testInstance.UpdateTransitivePackageStatusAsync();
             Assert.Equal(_testInstance.LatestVersion, _testInstance.InstalledVersion);
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14256

## Description
This change will yield the packages list to the caller before it finishes running the expensive operations to populate extra metadata for the Installed packages. Previously, the expensive operations were being synchronously ran and blocking the caller thread until finished, causing the packages list to not be returned for display until the versions and metadata was also fetched, along with some other computations that happened beforehand.

Taking the duration measurement (in milliseconds) for the PMUIRefresh when VS.NuGet.RefreshSource is PackageManagerLoaded for the after and before cases, using OrchardCore as the same solution, and loading the Solution PM UI produced these results:

Run | Before Duration | After Duration
-- | -- | --
Run 1 | 65332.9408 | 11206.2541
Run 2 | 16534.3167 | 13645.67
Run 3 | 17677.6345 | 15105.5598
Run 4 | 19484.0274 | 13327.0325
Run 5 | 17657.166 | 10660.1747

The average runtime for the Before durations is 27337.22 ms and for the After durations is 12788.94 ms. The percentage increase in performance from the After duration compared to Before is **53.22%**. Removing the outliers from the Before and After (the highest and lowest), the increase in performance from the After duration compared to Before is **30.35%**.

These metrics are subject to variation depending on the user's network and other computer factors. However, the slower the network connection, the greater the improvement is expected to be.

The behavior change is that the packages list will load faster on the Installed tab and the Versions, Metadata (including vulnerability information and deprecations) will be computed in the background and updated as soon as available. This will drastically reduce the time until a user can interact with the packages list in the PM UI.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~~Added tests~~
- [ ] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~
