### PR TITLE
Add json rendering option to `nuget why` command

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/DependencyNode.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/DependencyNode.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using NuGet.Shared;
 
 namespace NuGet.CommandLine.XPlat.Commands.Why
@@ -14,8 +15,13 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
     /// </summary>
     internal class DependencyNode
     {
+        [JsonPropertyName("package")]
         public string Id { get; set; }
+
+        [JsonPropertyName("version")]
         public string Version { get; set; }
+
+        [JsonPropertyName("dependencies")]
         public HashSet<DependencyNode> Children { get; set; }
 
         public DependencyNode(string id, string version)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/IReportRenderer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/IReportRenderer.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.CommandLine.XPlat.Commands.Why
+{
+    internal interface IReportRenderer
+    {
+        void Render(WhyReportModel reportProject);
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/ReportOutputFormat.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/ReportOutputFormat.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.CommandLine.XPlat.Commands.Why
+{
+    internal enum ReportOutputFormat
+    {
+        Console,
+        Json
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommand.cs
@@ -120,7 +120,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
 
                 try
                 {
-                    IReportRenderer reportRenderer = GetOutputType(
+                    IReportRenderer reportRenderer = GetRenderer(
                         parseResult.GetValue(outputFormat),
                         parseResult.GetValue(outputVersion),
                         logger);
@@ -146,7 +146,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
             rootCommand.Subcommands.Add(whyCommand);
         }
 
-        private static IReportRenderer GetOutputType(string outputFormatOption, string outputVersionOption, ILoggerWithColor logger)
+        private static IReportRenderer GetRenderer(string outputFormatOption, string outputVersionOption, ILoggerWithColor logger)
         {
             ReportOutputFormat outputFormat = ReportOutputFormat.Console;
             if (!string.IsNullOrEmpty(outputFormatOption) &&

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommand.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Help;
 using System.CommandLine.Parsing;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
 
@@ -88,6 +90,18 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
                 Arity = ArgumentArity.OneOrMore
             };
 
+            CliOption<string> outputFormat = new CliOption<string>("--format")
+            {
+                Description = Strings.WhyCommand_FrameworksOption_Format,
+                Arity = ArgumentArity.ZeroOrOne
+            };
+
+            CliOption<string> outputVersion = new CliOption<string>("--output-version")
+            {
+                Description = Strings.WhyCommand_FrameworksOption_OutputVersion,
+                Arity = ArgumentArity.ZeroOrOne
+            };
+
             HelpOption help = new HelpOption()
             {
                 Arity = ArgumentArity.Zero
@@ -96,6 +110,8 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
             whyCommand.Arguments.Add(path);
             whyCommand.Arguments.Add(package);
             whyCommand.Options.Add(frameworks);
+            whyCommand.Options.Add(outputFormat);
+            whyCommand.Options.Add(outputVersion);
             whyCommand.Options.Add(help);
 
             whyCommand.SetAction(async (parseResult, cancellationToken) =>
@@ -104,10 +120,16 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
 
                 try
                 {
-                    var whyCommandArgs = new WhyCommandArgs(
+                    IReportRenderer reportRenderer = GetOutputType(
+                        parseResult.GetValue(outputFormat),
+                        parseResult.GetValue(outputVersion),
+                        logger);
+
+                    WhyCommandArgs whyCommandArgs = new WhyCommandArgs(
                         parseResult.GetValue(path),
                         parseResult.GetValue(package),
                         parseResult.GetValue(frameworks),
+                        reportRenderer,
                         logger,
                         cancellationToken);
 
@@ -122,6 +144,62 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
             });
 
             rootCommand.Subcommands.Add(whyCommand);
+        }
+
+        private static IReportRenderer GetOutputType(string outputFormatOption, string outputVersionOption, ILoggerWithColor logger)
+        {
+            ReportOutputFormat outputFormat = ReportOutputFormat.Console;
+            if (!string.IsNullOrEmpty(outputFormatOption) &&
+                !Enum.TryParse(outputFormatOption, ignoreCase: true, out outputFormat))
+            {
+                string currentlySupportedFormat = GetEnumValues<ReportOutputFormat>();
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.ListPkg_InvalidOutputFormat,
+                        outputFormatOption,
+                        currentlySupportedFormat));
+            }
+
+            if (outputFormat == ReportOutputFormat.Console)
+            {
+                if (!string.IsNullOrEmpty(outputVersionOption))
+                {
+                    throw new ArgumentException(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.ListPkg_OutputVersionNotApplicable));
+                }
+                return new WhyConsoleRenderer(logger);
+            }
+
+            IReportRenderer jsonReportRenderer;
+
+            var currentlySupportedReportVersions = new List<string> { "1" };
+            // If customer pass unsupported version then error out instead of defaulting to version probably unsupported by customer machine.
+            if (!string.IsNullOrEmpty(outputVersionOption) && !currentlySupportedReportVersions.Contains(outputVersionOption))
+            {
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.ListPkg_InvalidOutputVersion,
+                        outputVersionOption,
+                        string.Join(" ,", currentlySupportedReportVersions)));
+            }
+            else
+            {
+                jsonReportRenderer = new WhyJsonRenderer(logger);
+            }
+
+            return jsonReportRenderer;
+        }
+
+        private static string GetEnumValues<T>() where T : Enum
+        {
+            var enumValues = ((T[])Enum.GetValues(typeof(T)))
+               .Select(x => x.ToString());
+
+            return string.Join(", ", enumValues).ToLower(CultureInfo.CurrentCulture);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommand.cs
@@ -90,13 +90,13 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
                 Arity = ArgumentArity.OneOrMore
             };
 
-            CliOption<string> outputFormat = new CliOption<string>("--format")
+            Option<string> outputFormat = new Option<string>("--format")
             {
                 Description = Strings.WhyCommand_FrameworksOption_Format,
                 Arity = ArgumentArity.ZeroOrOne
             };
 
-            CliOption<string> outputVersion = new CliOption<string>("--output-version")
+            Option<string> outputVersion = new Option<string>("--output-version")
             {
                 Description = Strings.WhyCommand_FrameworksOption_OutputVersion,
                 Arity = ArgumentArity.ZeroOrOne

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommandArgs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommandArgs.cs
@@ -5,6 +5,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Threading;
 
 namespace NuGet.CommandLine.XPlat.Commands.Why
@@ -14,6 +16,8 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         public string Path { get; }
         public string Package { get; }
         public List<string> Frameworks { get; }
+        public IReportRenderer ReportRenderer { get; }
+        public string ArgumentText { get; }
         public ILoggerWithColor Logger { get; }
         public CancellationToken CancellationToken { get; }
 
@@ -23,20 +27,36 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         /// <param name="path">The path to the solution or project file.</param>
         /// <param name="package">The package for which we show the dependency graphs.</param>
         /// <param name="frameworks">The target framework(s) for which we show the dependency graphs.</param>
+        /// <param name="reportRenderer">The report output renderer (e.g. console, json).</param>
         /// <param name="logger"></param>
         /// <param name="cancellationToken"></param>
         public WhyCommandArgs(
             string path,
             string package,
             List<string> frameworks,
+            IReportRenderer reportRenderer,
             ILoggerWithColor logger,
             CancellationToken cancellationToken)
         {
             Path = path ?? throw new ArgumentNullException(nameof(path));
             Package = package ?? throw new ArgumentNullException(nameof(package));
             Frameworks = frameworks ?? throw new ArgumentNullException(nameof(frameworks));
+            ReportRenderer = reportRenderer ?? throw new ArgumentNullException(nameof(reportRenderer));
+            ArgumentText = GetReportParameters();
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             CancellationToken = cancellationToken;
+        }
+
+        private string GetReportParameters()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            if (Frameworks != null && Frameworks.Any())
+            {
+                sb.Append(" --framework " + string.Join(" ", Frameworks));
+            }
+
+            return sb.ToString().Trim();
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommandRunner.cs
@@ -63,24 +63,13 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
                         whyCommandArgs.Package,
                         whyCommandArgs.Frameworks);
 
-                    if (dependencyGraphPerFramework != null)
-                    {
-                        whyCommandArgs.Logger.LogMinimal(
-                            string.Format(CultureInfo.CurrentCulture,
-                                Strings.WhyCommand_Message_DependencyGraphsFoundInProject,
-                                assetsFile.PackageSpec.Name,
-                                targetPackage));
-
-                        DependencyGraphPrinter.PrintAllDependencyGraphs(dependencyGraphPerFramework, targetPackage, whyCommandArgs.Logger);
-                    }
-                    else
-                    {
-                        whyCommandArgs.Logger.LogMinimal(
-                            string.Format(CultureInfo.CurrentCulture,
-                                Strings.WhyCommand_Message_NoDependencyGraphsFoundInProject,
-                                assetsFile.PackageSpec.Name,
-                                targetPackage));
-                    }
+                    IReportRenderer reportRenderer = whyCommandArgs.ReportRenderer;
+                    WhyReportModel reportModel = new WhyReportModel(
+                        assetsFile.PackageSpec.Name,
+                        targetPackage,
+                        whyCommandArgs,
+                        dependencyGraphPerFramework);
+                    reportRenderer.Render(reportModel);
                 }
                 else
                 {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyConsoleRenderer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyConsoleRenderer.cs
@@ -5,13 +5,19 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using NuGet.Shared;
 
 namespace NuGet.CommandLine.XPlat.Commands.Why
 {
-    internal static class DependencyGraphPrinter
+    /// <summary>
+    /// Console output renderer for 'why' command
+    /// </summary>
+    internal class WhyConsoleRenderer : IReportRenderer
     {
+        private readonly ILoggerWithColor _logger;
+
         private const ConsoleColor TargetPackageColor = ConsoleColor.Cyan;
 
         // Dependency graph console output symbols
@@ -21,25 +27,42 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         private const string ChildPrefixSymbol = "│  ";
         private const string LastChildPrefixSymbol = "   ";
 
-        /// <summary>
-        /// Prints the dependency graphs for all target frameworks.
-        /// </summary>
-        /// <param name="dependencyGraphPerFramework">A dictionary mapping target frameworks to their dependency graphs.</param>
-        /// <param name="targetPackage">The package we want the dependency paths for.</param>
-        /// <param name="logger"></param>
-        public static void PrintAllDependencyGraphs(Dictionary<string, List<DependencyNode>?> dependencyGraphPerFramework, string targetPackage, ILoggerWithColor logger)
+        public WhyConsoleRenderer(ILoggerWithColor logger)
         {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public void Render(WhyReportModel reportModel)
+        {
+            if (reportModel.DependencyGraphPerFramework.Count == 0)
+            {
+                _logger.LogMinimal(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.WhyCommand_Message_NoDependencyGraphsFoundInProject,
+                        reportModel.ProjectName,
+                        reportModel.TargetPackage));
+                return;
+            }
+
+            _logger.LogMinimal(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.WhyCommand_Message_DependencyGraphsFoundInProject,
+                    reportModel.ProjectName,
+                    reportModel.TargetPackage));
+
             // print empty line
-            logger.LogMinimal("");
+            _logger.LogMinimal("");
 
             // deduplicate the dependency graphs
-            List<List<string>> deduplicatedFrameworks = GetDeduplicatedFrameworks(dependencyGraphPerFramework);
+            List<List<string>> deduplicatedFrameworks = GetDeduplicatedFrameworks(reportModel.DependencyGraphPerFramework);
 
             foreach (var frameworks in deduplicatedFrameworks)
             {
                 if (frameworks.Count > 0)
                 {
-                    PrintDependencyGraphPerFramework(frameworks, dependencyGraphPerFramework[frameworks.First()], targetPackage, logger);
+                    PrintDependencyGraphPerFramework(frameworks, reportModel.DependencyGraphPerFramework[frameworks.First()], reportModel.TargetPackage);
                 }
             }
         }
@@ -50,20 +73,19 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         /// <param name="frameworks">The list of frameworks that share this dependency graph.</param>
         /// <param name="topLevelNodes">The top-level package nodes of the dependency graph.</param>
         /// <param name="targetPackage">The package we want the dependency paths for.</param>
-        /// <param name="logger"></param>
-        private static void PrintDependencyGraphPerFramework(List<string> frameworks, List<DependencyNode>? topLevelNodes, string targetPackage, ILoggerWithColor logger)
+        private void PrintDependencyGraphPerFramework(List<string> frameworks, List<DependencyNode>? topLevelNodes, string targetPackage)
         {
             // print framework header
             foreach (var framework in frameworks)
             {
-                logger.LogMinimal($"  [{framework}]");
+                _logger.LogMinimal($"  [{framework}]");
             }
 
-            logger.LogMinimal($"   {ChildPrefixSymbol}");
+            _logger.LogMinimal($"   {ChildPrefixSymbol}");
 
             if (topLevelNodes == null || topLevelNodes.Count == 0)
             {
-                logger.LogMinimal($"   {LastChildNodeSymbol}{Strings.WhyCommand_Message_NoDependencyGraphsFoundForFramework}\n\n");
+                _logger.LogMinimal($"   {LastChildNodeSymbol}{Strings.WhyCommand_Message_NoDependencyGraphsFoundForFramework}\n\n");
                 return;
             }
 
@@ -96,12 +118,12 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
                 // print current node
                 if (current.Node.Id.Equals(targetPackage, StringComparison.OrdinalIgnoreCase))
                 {
-                    logger.LogMinimal($"{currentPrefix}", Console.ForegroundColor);
-                    logger.LogMinimal($"{current.Node.Id} (v{current.Node.Version})\n", TargetPackageColor);
+                    _logger.LogMinimal($"{currentPrefix}", Console.ForegroundColor);
+                    _logger.LogMinimal($"{current.Node.Id} (v{current.Node.Version})\n", TargetPackageColor);
                 }
                 else
                 {
-                    logger.LogMinimal($"{currentPrefix}{current.Node.Id} (v{current.Node.Version})");
+                    _logger.LogMinimal($"{currentPrefix}{current.Node.Id} (v{current.Node.Version})");
                 }
 
                 if (current.Node.Children?.Count > 0)
@@ -115,7 +137,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
                 }
             }
 
-            logger.LogMinimal("");
+            _logger.LogMinimal("");
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyJsonRenderer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyJsonRenderer.cs
@@ -57,28 +57,28 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
                     var dependencyGraph = new DependencyGraphContract
                     {
                         Framework = framework,
-                        Dependencies = ProcessDependencyNodeContracts(dependencies)
+                        Dependencies = ProcessDependencyNodes([.. dependencies])
                     };
                     dependencyGraphs.Add(dependencyGraph);
                 }
             }
+
             return dependencyGraphs;
         }
 
-        private static List<DependencyNodeContract> ProcessDependencyNodeContracts(List<DependencyNode> dependencies)
+        private static HashSet<DependencyNode> ProcessDependencyNodes(HashSet<DependencyNode> dependencies)
         {
-            List<DependencyNodeContract> dependencyNodeContracts = [];
+            HashSet<DependencyNode> dependencyNodes = [];
             foreach (var dependency in dependencies)
             {
-                var dependencyNodeContract = new DependencyNodeContract
+                var dependencyNode = new DependencyNode(dependency.Id, dependency.Version)
                 {
-                    Id = dependency.Id,
-                    Version = dependency.Version,
-                    Dependencies = ProcessDependencyNodeContracts([.. dependency.Children])
+                    Children = ProcessDependencyNodes(dependency.Children)
                 };
-                dependencyNodeContracts.Add(dependencyNodeContract);
+                dependencyNodes.Add(dependencyNode);
             }
-            return dependencyNodeContracts;
+
+            return dependencyNodes;
         }
 
         public class WhyJsonReportContract
@@ -105,19 +105,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
             public required string Framework { get; set; }
 
             [JsonPropertyName("dependencies")]
-            public required List<DependencyNodeContract> Dependencies { get; set; }
-        }
-
-        public class DependencyNodeContract
-        {
-            [JsonPropertyName("id")]
-            public required string Id { get; set; }
-
-            [JsonPropertyName("version")]
-            public required string Version { get; set; }
-
-            [JsonPropertyName("dependencies")]
-            public required List<DependencyNodeContract> Dependencies { get; set; }
+            public required HashSet<DependencyNode> Dependencies { get; set; }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyJsonRenderer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyJsonRenderer.cs
@@ -85,12 +85,16 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         {
             [JsonPropertyName("version")]
             public required int Version { get; set; }
+
             [JsonPropertyName("parameters")]
             public required string Parameters { get; set; }
+
             [JsonPropertyName("project")]
             public required string Project { get; set; }
+
             [JsonPropertyName("package")]
             public required string Package { get; set; }
+
             [JsonPropertyName("dependencyGraphs")]
             public required List<DependencyGraphContract> DependencyGraphs { get; set; }
         }
@@ -99,6 +103,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         {
             [JsonPropertyName("framework")]
             public required string Framework { get; set; }
+
             [JsonPropertyName("dependencies")]
             public required List<DependencyNodeContract> Dependencies { get; set; }
         }
@@ -107,8 +112,10 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         {
             [JsonPropertyName("id")]
             public required string Id { get; set; }
+
             [JsonPropertyName("version")]
             public required string Version { get; set; }
+
             [JsonPropertyName("dependencies")]
             public required List<DependencyNodeContract> Dependencies { get; set; }
         }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyJsonRenderer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyJsonRenderer.cs
@@ -1,0 +1,116 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NuGet.CommandLine.XPlat.Commands.Why
+{
+    /// <summary>
+    /// Json output renderer for 'why' command
+    /// </summary>
+    internal class WhyJsonRenderer : IReportRenderer
+    {
+        private const int ReportOutputVersion = 1;
+
+        private readonly ILoggerWithColor _logger;
+
+        public WhyJsonRenderer(ILoggerWithColor logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public void Render(WhyReportModel reportModel)
+        {
+            List<DependencyGraphContract> dependencyGraphs = ProcessDependencyGraphContracts(reportModel.DependencyGraphPerFramework);
+
+            WhyJsonReportContract report = new WhyJsonReportContract
+            {
+                Version = ReportOutputVersion,
+                Parameters = reportModel.WhyCommandArgs.ArgumentText,
+                Project = reportModel.ProjectName,
+                Package = reportModel.TargetPackage,
+                DependencyGraphs = dependencyGraphs,
+            };
+
+            var json = JsonSerializer.Serialize(report, new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                IncludeFields = true,
+            });
+
+            _logger.LogMinimal(json);
+        }
+
+        private static List<DependencyGraphContract> ProcessDependencyGraphContracts(Dictionary<string, List<DependencyNode>?> dependencyGraphPerFramework)
+        {
+            List<DependencyGraphContract> dependencyGraphs = [];
+            foreach (var framework in dependencyGraphPerFramework.Keys)
+            {
+                var dependencies = dependencyGraphPerFramework[framework];
+                if (dependencies != null)
+                {
+                    var dependencyGraph = new DependencyGraphContract
+                    {
+                        Framework = framework,
+                        Dependencies = ProcessDependencyNodeContracts(dependencies)
+                    };
+                    dependencyGraphs.Add(dependencyGraph);
+                }
+            }
+            return dependencyGraphs;
+        }
+
+        private static List<DependencyNodeContract> ProcessDependencyNodeContracts(List<DependencyNode> dependencies)
+        {
+            List<DependencyNodeContract> dependencyNodeContracts = [];
+            foreach (var dependency in dependencies)
+            {
+                var dependencyNodeContract = new DependencyNodeContract
+                {
+                    Id = dependency.Id,
+                    Version = dependency.Version,
+                    Dependencies = ProcessDependencyNodeContracts([.. dependency.Children])
+                };
+                dependencyNodeContracts.Add(dependencyNodeContract);
+            }
+            return dependencyNodeContracts;
+        }
+
+        public class WhyJsonReportContract
+        {
+            [JsonPropertyName("version")]
+            public required int Version { get; set; }
+            [JsonPropertyName("parameters")]
+            public required string Parameters { get; set; }
+            [JsonPropertyName("project")]
+            public required string Project { get; set; }
+            [JsonPropertyName("package")]
+            public required string Package { get; set; }
+            [JsonPropertyName("dependencyGraphs")]
+            public required List<DependencyGraphContract> DependencyGraphs { get; set; }
+        }
+
+        public class DependencyGraphContract
+        {
+            [JsonPropertyName("framework")]
+            public required string Framework { get; set; }
+            [JsonPropertyName("dependencies")]
+            public required List<DependencyNodeContract> Dependencies { get; set; }
+        }
+
+        public class DependencyNodeContract
+        {
+            [JsonPropertyName("id")]
+            public required string Id { get; set; }
+            [JsonPropertyName("version")]
+            public required string Version { get; set; }
+            [JsonPropertyName("dependencies")]
+            public required List<DependencyNodeContract> Dependencies { get; set; }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyJsonRenderer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyJsonRenderer.cs
@@ -57,28 +57,13 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
                     var dependencyGraph = new DependencyGraphContract
                     {
                         Framework = framework,
-                        Dependencies = ProcessDependencyNodes([.. dependencies])
+                        Dependencies = [.. dependencies]
                     };
                     dependencyGraphs.Add(dependencyGraph);
                 }
             }
 
             return dependencyGraphs;
-        }
-
-        private static HashSet<DependencyNode> ProcessDependencyNodes(HashSet<DependencyNode> dependencies)
-        {
-            HashSet<DependencyNode> dependencyNodes = [];
-            foreach (var dependency in dependencies)
-            {
-                var dependencyNode = new DependencyNode(dependency.Id, dependency.Version)
-                {
-                    Children = ProcessDependencyNodes(dependency.Children)
-                };
-                dependencyNodes.Add(dependencyNode);
-            }
-
-            return dependencyNodes;
         }
 
         public class WhyJsonReportContract

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyReportModel.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyReportModel.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.CommandLine.XPlat.Commands.Why
+{
+    internal class WhyReportModel
+    {
+        internal string ProjectName { get; }
+        internal string TargetPackage { get; }
+        internal WhyCommandArgs WhyCommandArgs { get; }
+        internal Dictionary<string, List<DependencyNode>?> DependencyGraphPerFramework { get; }
+
+        internal WhyReportModel(
+            string projectName,
+            string targetPackage,
+            WhyCommandArgs whyCommandArgs,
+            Dictionary<string, List<DependencyNode>?>? dependencyGraphPerFramework)
+        {
+            ProjectName = projectName ?? throw new ArgumentNullException(nameof(projectName));
+            TargetPackage = targetPackage ?? throw new ArgumentNullException(nameof(targetPackage));
+            WhyCommandArgs = whyCommandArgs ?? throw new ArgumentNullException(nameof(whyCommandArgs));
+            DependencyGraphPerFramework = dependencyGraphPerFramework ?? [];
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -2314,6 +2314,24 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Set the report output format..
+        /// </summary>
+        internal static string WhyCommand_FrameworksOption_Format {
+            get {
+                return ResourceManager.GetString("WhyCommand_FrameworksOption_Format", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The version of report output..
+        /// </summary>
+        internal static string WhyCommand_FrameworksOption_OutputVersion {
+            get {
+                return ResourceManager.GetString("WhyCommand_FrameworksOption_OutputVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Project &apos;{0}&apos; has the following dependency graph(s) for &apos;{1}&apos;:.
         /// </summary>
         internal static string WhyCommand_Message_DependencyGraphsFoundInProject {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -982,4 +982,10 @@ Non-HTTPS access will be removed in a future version. Consider migrating to 'HTT
     <value>Audit source '{0}' did not provide any vulnerability data.</value>
     <comment>{0} is the source name</comment>
   </data>
+  <data name="WhyCommand_FrameworksOption_Format" xml:space="preserve">
+    <value>Set the report output format.</value>
+  </data>
+  <data name="WhyCommand_FrameworksOption_OutputVersion" xml:space="preserve">
+    <value>The version of report output.</value>
+  </data>
 </root>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatWhyTests.cs
@@ -333,6 +333,60 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
+        public async Task WhyCommand_JsonRendererPackageNotFound_SucceedsAsync()
+        {
+            // Arrange
+            var pathContext = new SimpleTestPathContext();
+            var projectFramework = "net472";
+            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, projectFramework);
+
+            var packageX = XPlatTestUtils.CreatePackage("PackageX", "1.0.0");
+            var packageY = XPlatTestUtils.CreatePackage("PackageY", "1.0.1");
+            var packageZ = XPlatTestUtils.CreatePackage("PackageZ", "1.0.2");
+
+            packageX.Dependencies.Add(packageY);
+
+            project.AddPackageToFramework(projectFramework, packageX);
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageX,
+                packageY);
+
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var reportRenderer = new WhyJsonRenderer(logger);
+            var addPackageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, project);
+            var addPackageCommandRunner = new AddPackageReferenceCommandRunner();
+            var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageArgs, new MSBuildAPIUtility(logger));
+
+            var whyCommandArgs = new WhyCommandArgs(
+                    project.ProjectPath,
+                    packageZ.Id,
+                    [projectFramework],
+                    reportRenderer,
+                    logger,
+                    CancellationToken.None);
+
+            // Act
+            var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
+
+            // Assert
+            var output = logger.ShowMessages();
+
+            var expectedOutput = $@"{{
+  ""version"": 1,
+  ""parameters"": ""--framework {projectFramework}"",
+  ""project"": ""{project.ProjectName}"",
+  ""package"": ""{packageZ.Id}"",
+  ""dependencyGraphs"": []
+}}";
+
+            Assert.Equal(ExitCodes.Success, result);
+            Assert.Contains(expectedOutput, output);
+        }
+
+        [Fact]
         public async Task WhyCommand_JsonRendererDirectPackageFound_SucceedsAsync()
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatWhyTests.cs
@@ -46,6 +46,7 @@ namespace NuGet.XPlat.FuncTest
                 packageY);
 
             var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var reportRenderer = new WhyConsoleRenderer(logger);
             var addPackageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, project);
             var addPackageCommandRunner = new AddPackageReferenceCommandRunner();
             var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageArgs, new MSBuildAPIUtility(logger));
@@ -54,6 +55,7 @@ namespace NuGet.XPlat.FuncTest
                     project.ProjectPath,
                     packageY.Id,
                     [projectFramework],
+                    reportRenderer,
                     logger,
                     CancellationToken.None);
 
@@ -89,6 +91,7 @@ namespace NuGet.XPlat.FuncTest
                 packageZ);
 
             var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var reportRenderer = new WhyConsoleRenderer(logger);
             var addPackageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, project);
             var addPackageCommandRunner = new AddPackageReferenceCommandRunner();
             var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageArgs, new MSBuildAPIUtility(logger));
@@ -97,6 +100,7 @@ namespace NuGet.XPlat.FuncTest
                     project.ProjectPath,
                     packageZ.Id,
                     [projectFramework],
+                    reportRenderer,
                     logger,
                     CancellationToken.None);
 
@@ -115,6 +119,7 @@ namespace NuGet.XPlat.FuncTest
         {
             // Arrange
             var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var reportRenderer = new WhyConsoleRenderer(logger);
 
             var pathContext = new SimpleTestPathContext();
             var projectFramework = "net472";
@@ -131,6 +136,7 @@ namespace NuGet.XPlat.FuncTest
                     project.ProjectPath,
                     packageY.Id,
                     [projectFramework],
+                    reportRenderer,
                     logger,
                     CancellationToken.None);
 
@@ -149,11 +155,13 @@ namespace NuGet.XPlat.FuncTest
         {
             // Arrange
             var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var reportRenderer = new WhyConsoleRenderer(logger);
 
             var whyCommandArgs = new WhyCommandArgs(
                     "",
                     "PackageX",
                     [],
+                    reportRenderer,
                     logger,
                     CancellationToken.None);
 
@@ -172,6 +180,7 @@ namespace NuGet.XPlat.FuncTest
         {
             // Arrange
             var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var reportRenderer = new WhyConsoleRenderer(logger);
 
             var pathContext = new SimpleTestPathContext();
             var projectFramework = "net472";
@@ -181,6 +190,7 @@ namespace NuGet.XPlat.FuncTest
                     project.ProjectPath,
                     "",
                     [],
+                    reportRenderer,
                     logger,
                     CancellationToken.None);
 
@@ -199,6 +209,7 @@ namespace NuGet.XPlat.FuncTest
         {
             // Arrange
             var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var reportRenderer = new WhyConsoleRenderer(logger);
 
             string fakeProjectPath = "FakeProjectPath.csproj";
 
@@ -206,6 +217,7 @@ namespace NuGet.XPlat.FuncTest
                     fakeProjectPath,
                     "PackageX",
                     [],
+                    reportRenderer,
                     logger,
                     CancellationToken.None);
 
@@ -242,6 +254,7 @@ namespace NuGet.XPlat.FuncTest
                 packageY);
 
             var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var reportRenderer = new WhyConsoleRenderer(logger);
             var addPackageCommandArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, project);
             var addPackageCommandRunner = new AddPackageReferenceCommandRunner();
             var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageCommandArgs, new MSBuildAPIUtility(logger));
@@ -250,6 +263,7 @@ namespace NuGet.XPlat.FuncTest
                     project.ProjectPath,
                     packageY.Id,
                     [inputFrameworksOption, projectFramework],
+                    reportRenderer,
                     logger,
                     CancellationToken.None);
 
@@ -262,6 +276,194 @@ namespace NuGet.XPlat.FuncTest
             Assert.Equal(ExitCodes.Success, result);
             Assert.Contains($"The assets file '{project.AssetsFileOutputPath}' for project '{ProjectName}' does not contain a target for the specified input framework '{inputFrameworksOption}'.", output);
             Assert.Contains($"Project '{ProjectName}' has the following dependency graph(s) for '{packageY.Id}'", output);
+        }
+
+        [Fact]
+        public async Task WhyCommand_JsonRendererFrameworkNotFound_SucceedsAsync()
+        {
+            // Arrange
+            var pathContext = new SimpleTestPathContext();
+            var projectFramework = "net472";
+            var projectFrameworkQuery = "net6.0";
+            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, projectFramework);
+
+            var packageX = XPlatTestUtils.CreatePackage("PackageX", "1.0.0");
+            var packageY = XPlatTestUtils.CreatePackage("PackageY", "1.0.1");
+
+            packageX.Dependencies.Add(packageY);
+
+            project.AddPackageToFramework(projectFramework, packageX);
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageX,
+                packageY);
+
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var reportRenderer = new WhyJsonRenderer(logger);
+            var addPackageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, project);
+            var addPackageCommandRunner = new AddPackageReferenceCommandRunner();
+            var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageArgs, new MSBuildAPIUtility(logger));
+
+            var whyCommandArgs = new WhyCommandArgs(
+                    project.ProjectPath,
+                    packageY.Id,
+                    [projectFrameworkQuery],
+                    reportRenderer,
+                    logger,
+                    CancellationToken.None);
+
+            // Act
+            var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
+
+            // Assert
+            var output = logger.ShowMessages();
+
+            var expectedOutput = $@"{{
+  ""version"": 1,
+  ""parameters"": ""--framework {projectFrameworkQuery}"",
+  ""project"": ""{project.ProjectName}"",
+  ""package"": ""{packageY.Id}"",
+  ""dependencyGraphs"": []
+}}";
+
+            Assert.Equal(ExitCodes.Success, result);
+            Assert.Contains(expectedOutput, output);
+        }
+
+        [Fact]
+        public async Task WhyCommand_JsonRendererDirectPackageFound_SucceedsAsync()
+        {
+            // Arrange
+            var pathContext = new SimpleTestPathContext();
+            var projectFramework = "net472";
+            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, projectFramework);
+
+            var packageX = XPlatTestUtils.CreatePackage("PackageX", "1.0.0");
+            var packageY = XPlatTestUtils.CreatePackage("PackageY", "1.0.1");
+
+            packageX.Dependencies.Add(packageY);
+
+            project.AddPackageToFramework(projectFramework, packageX);
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageX,
+                packageY);
+
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var reportRenderer = new WhyJsonRenderer(logger);
+            var addPackageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, project);
+            var addPackageCommandRunner = new AddPackageReferenceCommandRunner();
+            var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageArgs, new MSBuildAPIUtility(logger));
+
+            var whyCommandArgs = new WhyCommandArgs(
+                    project.ProjectPath,
+                    packageX.Id,
+                    [projectFramework],
+                    reportRenderer,
+                    logger,
+                    CancellationToken.None);
+
+            // Act
+            var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
+
+            // Assert
+            var output = logger.ShowMessages();
+
+            var expectedOutput = $@"{{
+  ""version"": 1,
+  ""parameters"": ""--framework {projectFramework}"",
+  ""project"": ""{project.ProjectName}"",
+  ""package"": ""{packageX.Id}"",
+  ""dependencyGraphs"": [
+    {{
+      ""framework"": ""{projectFramework}"",
+      ""dependencies"": [
+        {{
+          ""id"": ""{packageX.Id}"",
+          ""version"": ""{packageX.Version}"",
+          ""dependencies"": []
+        }}
+      ]
+    }}
+  ]
+}}";
+
+            Assert.Equal(ExitCodes.Success, result);
+            Assert.Contains(expectedOutput, output);
+        }
+
+        [Fact]
+        public async Task WhyCommand_JsonRendererTransitivePackageFound_SucceedsAsync()
+        {
+            // Arrange
+            var pathContext = new SimpleTestPathContext();
+            var projectFramework = "net472";
+            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, projectFramework);
+
+            var packageX = XPlatTestUtils.CreatePackage("PackageX", "1.0.0");
+            var packageY = XPlatTestUtils.CreatePackage("PackageY", "1.0.1");
+
+            packageX.Dependencies.Add(packageY);
+
+            project.AddPackageToFramework(projectFramework, packageX);
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageX,
+                packageY);
+
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var reportRenderer = new WhyJsonRenderer(logger);
+            var addPackageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, project);
+            var addPackageCommandRunner = new AddPackageReferenceCommandRunner();
+            var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageArgs, new MSBuildAPIUtility(logger));
+
+            var whyCommandArgs = new WhyCommandArgs(
+                    project.ProjectPath,
+                    packageY.Id,
+                    [projectFramework],
+                    reportRenderer,
+                    logger,
+                    CancellationToken.None);
+
+            // Act
+            var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
+
+            // Assert
+            var output = logger.ShowMessages();
+
+            var expectedOutput = $@"{{
+  ""version"": 1,
+  ""parameters"": ""--framework {projectFramework}"",
+  ""project"": ""{project.ProjectName}"",
+  ""package"": ""{packageY.Id}"",
+  ""dependencyGraphs"": [
+    {{
+      ""framework"": ""{projectFramework}"",
+      ""dependencies"": [
+        {{
+          ""id"": ""{packageX.Id}"",
+          ""version"": ""{packageX.Version}"",
+          ""dependencies"": [
+            {{
+              ""id"": ""{packageY.Id}"",
+              ""version"": ""{packageY.Version}"",
+              ""dependencies"": []
+            }}
+          ]
+        }}
+      ]
+    }}
+  ]
+}}";
+
+            Assert.Equal(ExitCodes.Success, result);
+            Assert.Contains(expectedOutput, output);
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatWhyTests.cs
@@ -437,7 +437,7 @@ namespace NuGet.XPlat.FuncTest
       ""framework"": ""{projectFramework}"",
       ""dependencies"": [
         {{
-          ""id"": ""{packageX.Id}"",
+          ""package"": ""{packageX.Id}"",
           ""version"": ""{packageX.Version}"",
           ""dependencies"": []
         }}
@@ -501,11 +501,11 @@ namespace NuGet.XPlat.FuncTest
       ""framework"": ""{projectFramework}"",
       ""dependencies"": [
         {{
-          ""id"": ""{packageX.Id}"",
+          ""package"": ""{packageX.Id}"",
           ""version"": ""{packageX.Version}"",
           ""dependencies"": [
             {{
-              ""id"": ""{packageY.Id}"",
+              ""package"": ""{packageY.Id}"",
               ""version"": ""{packageY.Version}"",
               ""dependencies"": []
             }}
@@ -584,26 +584,26 @@ namespace NuGet.XPlat.FuncTest
       ""framework"": ""{projectFramework1}"",
       ""dependencies"": [
         {{
-          ""id"": ""{packageA.Id}"",
+          ""package"": ""{packageA.Id}"",
           ""version"": ""{packageA.Version}"",
           ""dependencies"": [
             {{
-              ""id"": ""{packageTarget.Id}"",
+              ""package"": ""{packageTarget.Id}"",
               ""version"": ""{packageTarget.Version}"",
               ""dependencies"": []
             }}
           ]
         }},
         {{
-          ""id"": ""{packageB.Id}"",
+          ""package"": ""{packageB.Id}"",
           ""version"": ""{packageB.Version}"",
           ""dependencies"": [
             {{
-              ""id"": ""{packageC.Id}"",
+              ""package"": ""{packageC.Id}"",
               ""version"": ""{packageC.Version}"",
               ""dependencies"": [
                 {{
-                  ""id"": ""{packageTarget.Id}"",
+                  ""package"": ""{packageTarget.Id}"",
                   ""version"": ""{packageTarget.Version}"",
                   ""dependencies"": []
                 }}
@@ -617,26 +617,26 @@ namespace NuGet.XPlat.FuncTest
       ""framework"": ""{projectFramework2}"",
       ""dependencies"": [
         {{
-          ""id"": ""{packageA.Id}"",
+          ""package"": ""{packageA.Id}"",
           ""version"": ""{packageA.Version}"",
           ""dependencies"": [
             {{
-              ""id"": ""{packageTarget.Id}"",
+              ""package"": ""{packageTarget.Id}"",
               ""version"": ""{packageTarget.Version}"",
               ""dependencies"": []
             }}
           ]
         }},
         {{
-          ""id"": ""{packageB.Id}"",
+          ""package"": ""{packageB.Id}"",
           ""version"": ""{packageB.Version}"",
           ""dependencies"": [
             {{
-              ""id"": ""{packageC.Id}"",
+              ""package"": ""{packageC.Id}"",
               ""version"": ""{packageC.Version}"",
               ""dependencies"": [
                 {{
-                  ""id"": ""{packageTarget.Id}"",
+                  ""package"": ""{packageTarget.Id}"",
                   ""version"": ""{packageTarget.Version}"",
                   ""dependencies"": []
                 }}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatWhyTests.cs
@@ -519,5 +519,138 @@ namespace NuGet.XPlat.FuncTest
             Assert.Equal(ExitCodes.Success, result);
             Assert.Contains(expectedOutput, output);
         }
+
+        [Fact]
+        public async Task WhyCommand_JsonRendererMultiplePackagesFound_SucceedsAsync()
+        {
+            // Arrange
+            var pathContext = new SimpleTestPathContext();
+            var projectFramework1 = "net472";
+            var projectFramework2 = "netstandard2.0";
+            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, $"{projectFramework1};{projectFramework2}");
+
+            var packageA = XPlatTestUtils.CreatePackage("PackageA", "1.0.0");
+            var packageB = XPlatTestUtils.CreatePackage("PackageB", "1.0.1");
+            var packageC = XPlatTestUtils.CreatePackage("PackageC", "1.0.2");
+            var packageTarget = XPlatTestUtils.CreatePackage("PackageTarget", "1.0.3");
+
+            packageA.Dependencies.Add(packageTarget);
+            packageB.Dependencies.Add(packageC);
+            packageC.Dependencies.Add(packageTarget);
+
+            project.AddPackageToFramework(projectFramework1, packageA);
+            project.AddPackageToFramework(projectFramework1, packageB);
+            project.AddPackageToFramework(projectFramework2, packageA);
+            project.AddPackageToFramework(projectFramework2, packageB);
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA,
+                packageB,
+                packageC,
+                packageTarget);
+
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var reportRenderer = new WhyJsonRenderer(logger);
+
+            var addPackageCommandRunner = new AddPackageReferenceCommandRunner();
+            var addPackageAArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageA.Id, packageA.Version, project);
+            await addPackageCommandRunner.ExecuteCommand(addPackageAArgs, new MSBuildAPIUtility(logger));
+            var addPackageBArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageB.Id, packageB.Version, project);
+            await addPackageCommandRunner.ExecuteCommand(addPackageBArgs, new MSBuildAPIUtility(logger));
+
+            var whyCommandArgs = new WhyCommandArgs(
+                    project.ProjectPath,
+                    packageTarget.Id,
+                    [projectFramework1, projectFramework2],
+                    reportRenderer,
+                    logger,
+                    CancellationToken.None);
+
+            // Act
+            var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
+
+            // Assert
+            var output = logger.ShowMessages();
+
+            var expectedOutput = $@"{{
+  ""version"": 1,
+  ""parameters"": ""--framework {projectFramework1} {projectFramework2}"",
+  ""project"": ""{project.ProjectName}"",
+  ""package"": ""{packageTarget.Id}"",
+  ""dependencyGraphs"": [
+    {{
+      ""framework"": ""{projectFramework1}"",
+      ""dependencies"": [
+        {{
+          ""id"": ""{packageA.Id}"",
+          ""version"": ""{packageA.Version}"",
+          ""dependencies"": [
+            {{
+              ""id"": ""{packageTarget.Id}"",
+              ""version"": ""{packageTarget.Version}"",
+              ""dependencies"": []
+            }}
+          ]
+        }},
+        {{
+          ""id"": ""{packageB.Id}"",
+          ""version"": ""{packageB.Version}"",
+          ""dependencies"": [
+            {{
+              ""id"": ""{packageC.Id}"",
+              ""version"": ""{packageC.Version}"",
+              ""dependencies"": [
+                {{
+                  ""id"": ""{packageTarget.Id}"",
+                  ""version"": ""{packageTarget.Version}"",
+                  ""dependencies"": []
+                }}
+              ]
+            }}
+          ]
+        }}
+      ]
+    }},
+    {{
+      ""framework"": ""{projectFramework2}"",
+      ""dependencies"": [
+        {{
+          ""id"": ""{packageA.Id}"",
+          ""version"": ""{packageA.Version}"",
+          ""dependencies"": [
+            {{
+              ""id"": ""{packageTarget.Id}"",
+              ""version"": ""{packageTarget.Version}"",
+              ""dependencies"": []
+            }}
+          ]
+        }},
+        {{
+          ""id"": ""{packageB.Id}"",
+          ""version"": ""{packageB.Version}"",
+          ""dependencies"": [
+            {{
+              ""id"": ""{packageC.Id}"",
+              ""version"": ""{packageC.Version}"",
+              ""dependencies"": [
+                {{
+                  ""id"": ""{packageTarget.Id}"",
+                  ""version"": ""{packageTarget.Version}"",
+                  ""dependencies"": []
+                }}
+              ]
+            }}
+          ]
+        }}
+      ]
+    }}
+  ]
+}}";
+
+            Assert.Equal(ExitCodes.Success, result);
+            Assert.Contains(expectedOutput, output);
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13927

## Description

This PR adds a new `--format` option to the `nuget why` command which supports console rendering (existing) and json rendering (new).

For the situation where the framework or package is not found we still return json, but the structure will be empty.

**Framework/package not found:**
```json
{
  "version": 1,
  "parameters": "--framework net6.0",
  "project": "Test.Project.DotnetNugetWhy",
  "package": "PackageY",
  "dependencyGraphs": []
}
```

**Package found:**
```json
{
  "version": 1,
  "parameters": "--framework net472",
  "project": "Test.Project.DotnetNugetWhy",
  "package": "PackageX",
  "dependencyGraphs": [
    {
      "framework": "net472",
      "dependencies": [
        {
          "id": "PackageX",
          "version": "1.0.0",
          "dependencies": []
        }
      ]
    }
  ]
}
```

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/dotnet/docs/issues/45888
