### PR TITLE
Change the for each pattern being used in EmitIfNeeded_MultipleThreads_EmitsOnceAsync

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/TelemetryOnceEmitterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/TelemetryOnceEmitterTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading.Tasks;
 using Moq;
 using NuGet.Common;
@@ -53,29 +54,16 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async Task EmitIfNeeded_MultipleThreads_EmitsOnceAsync()
+        public void EmitIfNeeded_MultipleThreads_EmitsOnce()
         {
             // Arrange
             TelemetryOnceEmitter logger = new("TestEvent");
-            Task[] tasks = new[]
-            {
-                new Task(() => logger.EmitIfNeeded()),
-                new Task(() => logger.EmitIfNeeded()),
-                new Task(() => logger.EmitIfNeeded()),
-                new Task(() => logger.EmitIfNeeded()),
-                new Task(() => logger.EmitIfNeeded())
-            };
 
             // Act
-            Parallel.ForEach(tasks, t =>
+            Parallel.ForEach(Enumerable.Range(1, 5), t =>
             {
-                if (t.Status == TaskStatus.Created)
-                {
-                    _output.WriteLine($"{t.Id} {t.Status}");
-                    t.Start();
-                }
+                logger.EmitIfNeeded();
             });
-            await Task.WhenAll(tasks);
 
             // Assert
             Assert.Equal(1, _telemetryEvents.Count);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

This test has been flaky, and has a pattern that can be simplified. 
Not 100% sure this fixes it, but my tests suggested it might. Either way, I think it's worth a shot.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
