### PR TITLE
Fix CanListPackagesForProjectsInSolutions, don't use a private server, use outdated scenario with local feed

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -322,10 +322,6 @@ namespace NuGet.XPlat.FuncTest
             solution.Projects.Add(projectB);
             solution.Create(pathContext.SolutionRoot);
 
-            using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource, isPrivateFeed: true);
-            mockServer.Start();
-            pathContext.Settings.AddSource(sourceName: "private-source", sourceUri: mockServer.ServiceIndexUri, allowInsecureConnectionsValue: bool.TrueString);
-
             // List package command requires restore to be run before it can list packages.
             await RestoreProjectsAsync(pathContext, projectA, projectB, _testOutputHelper);
 
@@ -337,9 +333,9 @@ namespace NuGet.XPlat.FuncTest
             ListPackageCommandRunner listPackageCommandRunner = new();
             var packageRefArgs = new ListPackageArgs(
                                         path: solution.SolutionPath,
-                                        packageSources: [new(mockServer.ServiceIndexUri)],
+                                        packageSources: [new PackageSource(pathContext.PackageSource)],
                                         frameworks: ["net6.0"],
-                                        reportType: ReportType.Vulnerable,
+                                        reportType: ReportType.Outdated,
                                         renderer: new ListPackageConsoleRenderer(consoleOut, consoleError),
                                         includeTransitive: false,
                                         prerelease: false,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14266
Fixes: https://github.com/NuGet/Client.Engineering/issues/3241

## Description

This test is flaky is the root cause of many many of the test host crashes, might be the root cause of https://github.com/NuGet/Client.Engineering/issues/3241 too, 

It doesn't need to use a private source which is where the flakiness happens.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
