### PR TITLE
Provide required `backingStoreDescription` property to Unified Settings

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
@@ -79,7 +79,7 @@
     "nuGetPackageManager.configurationFiles.externalSettings": {
       "type": "external",
       "title": "@117;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
-      "description": "@Text_ConfigurationFiles_Priority;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+      "backingStoreDescription": "@Text_ConfigurationFiles_Priority;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
 
       "callback": {
         "packageId": "5fcc8577-4feb-4d04-ad72-d6c629b083cc",


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14270

## Description

When backingStoreDescription is null but is required, which is causing a runtime caching lookup of a MessagePack deserialization to fail. 
- Fixes an RPS regression due caused by an increase in fault telemetry
- No effective UI change since it's just a specific property required by external settings pages. Either `description` or `backingStoreDescription` work, it's just that the latter is required.

Validated by using telemetry monitor to ensure no fault was logged when loading VS after this change.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~ See description
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
