### PR TITLE
TelemetryOnceEmitter no longer depends on statics, making it more testable and fixing the flaky tests

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/TelemetryOnceEmitter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/TelemetryOnceEmitter.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Threading;
 using NuGet.Common;
@@ -13,8 +15,9 @@ namespace NuGet.PackageManagement.VisualStudio
     internal class TelemetryOnceEmitter
     {
         private int _emittedFlag = 0;
+        private INuGetTelemetryService? _nuGetTelemetryService;
 
-        internal TelemetryOnceEmitter(string eventName)
+        internal TelemetryOnceEmitter(string eventName, INuGetTelemetryService? nuGetTelemetryService)
         {
             if (string.IsNullOrEmpty(eventName))
             {
@@ -22,6 +25,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             EventName = eventName;
+            _nuGetTelemetryService = nuGetTelemetryService;
         }
 
         internal string EventName { get; }
@@ -33,7 +37,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             if (Interlocked.CompareExchange(ref _emittedFlag, 1, 0) == 0)
             {
-                TelemetryActivity.EmitTelemetryEvent(new TelemetryEvent(EventName));
+                _nuGetTelemetryService?.EmitTelemetryEvent(new TelemetryEvent(EventName));
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/TelemetryOnceEmitterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/TelemetryOnceEmitterTests.cs
@@ -9,24 +9,22 @@ using Moq;
 using NuGet.Common;
 using NuGet.VisualStudio;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace NuGet.PackageManagement.VisualStudio.Test
 {
     public class TelemetryOnceEmitterTests
     {
-        private readonly ITestOutputHelper _output;
         private readonly ConcurrentQueue<TelemetryEvent> _telemetryEvents;
+        private readonly NuGetVSTelemetryService _telemetryService;
 
-        public TelemetryOnceEmitterTests(ITestOutputHelper output)
+        public TelemetryOnceEmitterTests()
         {
-            _output = output;
             var telemetrySession = new Mock<ITelemetrySession>();
             _telemetryEvents = new ConcurrentQueue<TelemetryEvent>();
             telemetrySession
                 .Setup(x => x.PostEvent(It.IsAny<TelemetryEvent>()))
                 .Callback<TelemetryEvent>(x => _telemetryEvents.Enqueue(x));
-            TelemetryActivity.NuGetTelemetryService = new NuGetVSTelemetryService(telemetrySession.Object);
+            _telemetryService = new NuGetVSTelemetryService(telemetrySession.Object);
         }
 
         [Theory]
@@ -34,14 +32,14 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         [InlineData("")]
         public void TelemetryOnceEmitter_NullOrEmptyEventName_Throws(string eventName)
         {
-            Assert.Throws<ArgumentException>(() => new TelemetryOnceEmitter(eventName));
+            Assert.Throws<ArgumentException>(() => new TelemetryOnceEmitter(eventName, _telemetryService));
         }
 
         [Fact]
         public void EmitIfNeeded_TwoCalls_EmitsTelemetryOnce()
         {
             // Arrange
-            TelemetryOnceEmitter logger = new("TestEvent");
+            TelemetryOnceEmitter logger = new("TestEvent", _telemetryService);
 
             // Act and Assert I 
             logger.EmitIfNeeded();
@@ -57,7 +55,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         public void EmitIfNeeded_MultipleThreads_EmitsOnce()
         {
             // Arrange
-            TelemetryOnceEmitter logger = new("TestEvent");
+            TelemetryOnceEmitter logger = new("TestEvent", _telemetryService);
 
             // Act
             Parallel.ForEach(Enumerable.Range(1, 5), t =>
@@ -74,7 +72,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         public void Reset_WithAlreadyEmitted_Restarts()
         {
             // Arrange
-            TelemetryOnceEmitter logger = new("TestEvent");
+            TelemetryOnceEmitter logger = new("TestEvent", _telemetryService);
             logger.EmitIfNeeded();
 
             // Act


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13920

## Description

The TelemetryOnceEmitter tests are among the most flaky tests we have. 
Originally i thought the issue was with the task queuing, but I missed the fact that we're depend on the static instance of the telemetry service and that is super prone to failures.

TelemetryOnceEmitter is only occasionally used for counter factual logging, and in the past instances it's been scenarios where the service is already setup, so no harm in doing this refactoring.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
