### PR TITLE
Preserve user entered NuGetAuditMode

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -73,7 +73,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Report all severity vulnerabilities (low severity and higher). Allowed values are: low, moderate, high, critical -->
     <NuGetAuditLevel Condition=" '$(NuGetAuditLevel)' == '' ">low</NuGetAuditLevel>
     <!-- Report known vulnerabilities on direct and transitive dependencies for .NET 10 and higher, direct only otherwise -->
-    <NuGetAuditMode Condition=" '$(NuGetExeSkipSdkAnalysisLevelCheck)' != 'true'
+    <NuGetAuditMode Condition=" '$(NuGetAuditMode)' == ''
+                    AND '$(NuGetExeSkipSdkAnalysisLevelCheck)' != 'true'
                     AND '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
                     AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '10.0'))">all</NuGetAuditMode>
     <NuGetAuditMode Condition=" '$(NuGetAuditMode)' == '' ">direct</NuGetAuditMode>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -3086,6 +3086,39 @@ EndGlobal";
             assetsFile.Targets[0].Libraries.Should().Contain(e => e.Name.Equals("Y"));
         }
 
+        [Theory]
+        [InlineData(null, "net10.0", "all")]
+        [InlineData("direct", "net10.0", "direct")]
+        [InlineData("all", "net10.0", "all")]
+        public void DotnetRestore_WritesExpectedAuditModeInAssetsFile(string userAuditMode, string targetFrameworkVersion, string expectedAuditMode)
+        {
+            using var pathContext = _dotnetFixture.CreateSimpleTestPathContext();
+            var projectName = "AuditProject";
+            var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
+            var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+            _dotnetFixture.CreateDotnetNewProject(pathContext.SolutionRoot, projectName, "classlib", testOutputHelper: _testOutputHelper);
+
+            using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
+            {
+                var xml = XDocument.Load(stream);
+                ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", targetFrameworkVersion);
+
+                if (!string.IsNullOrEmpty(userAuditMode))
+                {
+                    ProjectFileUtils.AddProperty(xml, "NuGetAuditMode", userAuditMode);
+                }
+
+                ProjectFileUtils.WriteXmlToFile(xml, stream);
+            }
+
+            _dotnetFixture.RunDotnetExpectSuccess(workingDirectory, $"restore {projectFile}", testOutputHelper: _testOutputHelper);
+
+            var assetsFilePath = Path.Combine(workingDirectory, "obj", "project.assets.json");
+            LockFile assetsFile = new LockFileFormat().Read(assetsFilePath);
+            assetsFile.PackageSpec.RestoreMetadata.RestoreAuditProperties.AuditMode.Should().Be(expectedAuditMode);
+        }
+
         private void AssertRelatedProperty(IList<LockFileItem> items, string path, string related)
         {
             var item = items.Single(i => i.Path.Equals(path));

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -3092,6 +3092,7 @@ EndGlobal";
         [InlineData("all", "all")]
         public void DotnetRestore_WritesExpectedAuditModeInAssetsFile(string userAuditMode, string expectedAuditMode)
         {
+            // Arrange
             using var pathContext = _dotnetFixture.CreateSimpleTestPathContext();
             var projectName = "AuditProject";
             var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
@@ -3102,7 +3103,6 @@ EndGlobal";
             using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
             {
                 var xml = XDocument.Load(stream);
-                ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", Constants.DefaultTargetFramework.GetShortFolderName());
 
                 if (!string.IsNullOrEmpty(userAuditMode))
                 {
@@ -3112,10 +3112,13 @@ EndGlobal";
                 ProjectFileUtils.WriteXmlToFile(xml, stream);
             }
 
+            // Act
             _dotnetFixture.RunDotnetExpectSuccess(workingDirectory, $"restore {projectFile}", testOutputHelper: _testOutputHelper);
 
             var assetsFilePath = Path.Combine(workingDirectory, "obj", "project.assets.json");
             LockFile assetsFile = new LockFileFormat().Read(assetsFilePath);
+
+            // Assert
             assetsFile.PackageSpec.RestoreMetadata.RestoreAuditProperties.AuditMode.Should().Be(expectedAuditMode);
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -3087,30 +3087,22 @@ EndGlobal";
         }
 
         [Theory]
-        [InlineData(null, "default", "all")]
-        [InlineData(null, "net9.0", "direct")]
-        [InlineData("direct", "default", "direct")]
-        [InlineData("all", "default", "all")]
-        [InlineData("direct", "net9.0", "direct")]
-        [InlineData("all", "net9.0", "all")]
-        public void DotnetRestore_WritesExpectedAuditModeInAssetsFile(string userAuditMode, string targetFrameworkVersion, string expectedAuditMode)
+        [InlineData(null, "all")]
+        [InlineData("direct", "direct")]
+        [InlineData("all", "all")]
+        public void DotnetRestore_WritesExpectedAuditModeInAssetsFile(string userAuditMode, string expectedAuditMode)
         {
-            if (targetFrameworkVersion == "default")
-            {
-                targetFrameworkVersion = Constants.DefaultTargetFramework.GetShortFolderName();
-            }
-
             using var pathContext = _dotnetFixture.CreateSimpleTestPathContext();
             var projectName = "AuditProject";
             var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
             var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
 
-            _dotnetFixture.CreateDotnetNewProject(pathContext.SolutionRoot, projectName, $"classlib -f {targetFrameworkVersion}", testOutputHelper: _testOutputHelper);
+            _dotnetFixture.CreateDotnetNewProject(pathContext.SolutionRoot, projectName, $"classlib", testOutputHelper: _testOutputHelper);
 
             using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
             {
                 var xml = XDocument.Load(stream);
-                ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", targetFrameworkVersion);
+                ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", Constants.DefaultTargetFramework.GetShortFolderName());
 
                 if (!string.IsNullOrEmpty(userAuditMode))
                 {

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -3087,17 +3087,25 @@ EndGlobal";
         }
 
         [Theory]
-        [InlineData(null, "net10.0", "all")]
-        [InlineData("direct", "net10.0", "direct")]
-        [InlineData("all", "net10.0", "all")]
+        [InlineData(null, "default", "all")]
+        [InlineData(null, "net9.0", "direct")]
+        [InlineData("direct", "default", "direct")]
+        [InlineData("all", "default", "all")]
+        [InlineData("direct", "net9.0", "direct")]
+        [InlineData("all", "net9.0", "all")]
         public void DotnetRestore_WritesExpectedAuditModeInAssetsFile(string userAuditMode, string targetFrameworkVersion, string expectedAuditMode)
         {
+            if (targetFrameworkVersion == "default")
+            {
+                targetFrameworkVersion = Constants.DefaultTargetFramework.GetShortFolderName();
+            }
+
             using var pathContext = _dotnetFixture.CreateSimpleTestPathContext();
             var projectName = "AuditProject";
             var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
             var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
 
-            _dotnetFixture.CreateDotnetNewProject(pathContext.SolutionRoot, projectName, "classlib", testOutputHelper: _testOutputHelper);
+            _dotnetFixture.CreateDotnetNewProject(pathContext.SolutionRoot, projectName, $"classlib -f {targetFrameworkVersion}", testOutputHelper: _testOutputHelper);
 
             using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14252

## Description

This PR makes sure we check the user entered `NuGetAuditMode` is empty before we assign it a default value. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
