### PR TITLE
Re-enable System.Commandline dependent tests

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
@@ -16,20 +16,4 @@
     <ProjectReference Include="..\..\..\src\NuGet.Core\NuGet.Build.Tasks.Console\NuGet.Build.Tasks.Console.csproj" />
     <ProjectReference Include="..\..\..\src\NuGet.Core\Microsoft.Build.NuGetSdkResolver\Microsoft.Build.NuGetSdkResolver.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <!-- tests disabled temporarily to enable System.CommandLine update flow -->
-    <Compile Remove="DotnetAddPackageTests.cs" />
-    <Compile Remove="DotnetPackageSearchTests.cs" />
-    <Compile Remove="DotnetRestoreTests.cs" />
-    <Compile Remove="DotnetSignTests.cs" />
-    <Compile Remove="DotnetSourcesTests.cs" />
-    <Compile Remove="DotnetTrustTests.cs" />
-    <Compile Remove="DotnetVerifyTests.cs" />
-    <Compile Remove="DotnetWhyTests.cs" />
-    <Compile Remove="DotnetListPackageTests.cs" />
-    <Compile Remove="DotnetRestoreTLSCertificateValidationTests.cs" />
-    <Compile Remove="DotnetToolTests.cs" />
-    <Compile Remove="PackCommandTests.cs" />
-  </ItemGroup>
 </Project>

--- a/test/NuGet.Core.FuncTests/NuGet.Signing.CrossFramework.Test/NuGet.Signing.CrossFramework.Test.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Signing.CrossFramework.Test/NuGet.Signing.CrossFramework.Test.csproj
@@ -14,11 +14,5 @@
     <ProjectReference Include="..\..\NuGet.Core.Tests\NuGet.Configuration.Test\NuGet.Configuration.Test.csproj" />
     <ProjectReference Include="..\..\TestUtilities\Test.Utility\Test.Utility.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <!-- tests disabled temporarily to enable System.CommandLine update flow -->
-    <Compile Remove="CrossFrameworkVerificationTest.cs" />
-  </ItemGroup>
-
 </Project>
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

Re enable tests disabled in https://github.com/NuGet/NuGet.Client/pull/6236

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
