### PR TITLE
Remove options page VisibilityContext to show General stub page

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "sdk": {
     "version": "8.0.100",
     "rollForward": "latestMajor",
-    "allowPrerelease": true
+    "allowPrerelease": false
   },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.0"

--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "sdk": {
     "version": "8.0.100",
     "rollForward": "latestMajor",
-    "allowPrerelease": false
+    "allowPrerelease": true
   },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.0"

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -55,9 +55,7 @@ namespace NuGetVSExtension
         Window = "{34E76E81-EE4A-11D0-AE2E-00A0C90FFFC3}", // this is the guid of the Output tool window, which is present in both VS and VWD
         Orientation = ToolWindowOrientation.Right)]
     [ProvideOptionPage(typeof(GeneralOptionPage), "NuGet Package Manager", "General", 113, 115, true, IsInUnifiedSettings = true)]
-    [ProvideOptionPage(typeof(StubGeneralOptionsPage), "NuGet Package Manager", "GeneralStub", 113, 115, true, IsInUnifiedSettings = false, Sort = 0,
-        // Only show the stub legacy settings General page by using a visibility context indicating when the unified settings feature is enabled.
-        VisibilityCmdUIContexts = "13b56f17-0b98-4a51-a9a0-9767d84796da")]
+    [ProvideOptionPage(typeof(StubGeneralOptionsPage), "NuGet Package Manager", "GeneralStub", 113, 115, true, IsInUnifiedSettings = false, Sort = 0)]
     [ProvideOptionPage(typeof(ConfigurationFilesOptionsPage), "NuGet Package Manager", "Configuration Files", 113, 117, true, IsInUnifiedSettings = true, Sort = 1)]
     [ProvideOptionPage(typeof(PackageSourceOptionsPage), "NuGet Package Manager", "Package Sources", 113, 114, true, Sort = 2)]
     [ProvideOptionPage(typeof(PackageSourceMappingOptionsPage), "NuGet Package Manager", "Package Source Mapping", 113, 116, true, Sort = 3)]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14281

## Description

The visibility context `13b56f17-0b98-4a51-a9a0-9767d84796da` was removed by the Unified Settings team. They forgot we depended on it, but since I'm already onboarding other pages, this is no longer needed and can be removed.

We expect this change to show the General stub page in the legacy settings until I remove all of the legacy settings.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
