### PR TITLE
Move strong name validation disable to configure.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -58,11 +58,6 @@ param (
 
 . "$PSScriptRoot\build\common.ps1"
 
-If (-Not $SkipDelaySigning)
-{
-    & "$PSScriptRoot\scripts\utils\DisableStrongNameVerification.ps1" -skipNoOpMessage
-}
-
 if (-not $Configuration) {
     $Configuration = switch ($CI.IsPresent) {
         $True   { 'Release' } # CI build is Release by default

--- a/configure.ps1
+++ b/configure.ps1
@@ -9,8 +9,11 @@ Cleans NuGet packages cache before build
 .PARAMETER Force
 Switch to force installation of required tools.
 
-.PARAMETER Test
+.PARAMETER RunTest
 Indicates the Tests need to be run. Downloads the Test cli when tests are needed to run.
+
+.PARAMETER SkipStrongName
+Don't disable strong name verification. Disabling is needed when working on NuGet's Visual Studio integration, but generally not needed for command line work.
 
 .EXAMPLE
 .\configure.ps1 -cc -v
@@ -28,7 +31,8 @@ Param (
     [switch]$Force,
     [switch]$RunTest,
     [switch]$SkipDotnetInfo,
-    [switch]$ProcDump
+    [switch]$ProcDump,
+    [switch]$SkipStrongName
 )
 
 $ErrorActionPreference = 'Stop'
@@ -42,7 +46,7 @@ $BuildErrors = @()
 if ($ProcDump -eq $true -Or $env:CI -eq "true")
 {
     Invoke-BuildStep 'Configuring Process Dump Collection' {
-    
+
         Install-ProcDump
     } -ev +BuildErrors
 }
@@ -62,6 +66,10 @@ Invoke-BuildStep 'Installing .NET SDKs for functional tests' {
 Invoke-BuildStep 'Cleaning package cache' {
     Clear-PackageCache
 } -skip:(-not $CleanCache) -ev +BuildErrors
+
+Invoke-BuildStep 'Disabling strong name verification' {
+    & "$PSScriptRoot\scripts\utils\DisableStrongNameVerification.ps1" -skipNoOpMessage
+} -skip:($SkipStrongName -Or $env:CI -eq "true") -ev +BuildErrors
 
 if ($BuildErrors) {
     $ErrorLines = $BuildErrors | %{ ">>> $($_.Exception.Message)" }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3232

## Description

Years ago we didn't do delay signing by default, but we have for years now, and I believe that our VS extension doesn't without strong name signing.  Skipping the strong name validation for our delay signed assemblies is a once-off configuration, not something that needs to be done every build, so move it to configure.ps1 instead.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ infrastructure
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ infrastructure
