### PR TITLE
Create Restore Bar logger in Package Manager UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/RestoreBarLogger.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/RestoreBarLogger.cs
@@ -14,6 +14,12 @@ namespace NuGet.PackageManagement.UI.Utility
     {
         private readonly INuGetProjectContext _nuGetProjectContext;
 
+        /// <summary>
+        /// Creates a <see cref="LoggerBase"/> with verbosity level <see cref="Common.LogLevel.Warning"/>
+        /// so that only critical log messages are shown in the <see cref="PackageRestoreBar"/>.
+        /// </summary>
+        /// <param name="nuGetProjectContext"></param>
+        /// <exception cref="ArgumentNullException"></exception>
         public RestoreBarLogger(INuGetProjectContext nuGetProjectContext)
             : base(verbosityLevel: LogLevel.Warning)
         {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/RestoreBarLogger.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/RestoreBarLogger.cs
@@ -18,8 +18,7 @@ namespace NuGet.PackageManagement.UI.Utility
         /// Creates a <see cref="LoggerBase"/> with verbosity level <see cref="Common.LogLevel.Warning"/>
         /// so that only critical log messages are shown in the <see cref="PackageRestoreBar"/>.
         /// </summary>
-        /// <param name="nuGetProjectContext"></param>
-        /// <exception cref="ArgumentNullException"></exception>
+        /// <param name="nuGetProjectContext">Underlying <see cref="ILogger"/> implementation to invoke.</param>
         public RestoreBarLogger(INuGetProjectContext nuGetProjectContext)
             : base(verbosityLevel: LogLevel.Warning)
         {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/RestoreBarLogger.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/RestoreBarLogger.cs
@@ -32,7 +32,8 @@ namespace NuGet.PackageManagement.UI.Utility
 
         public override Task LogAsync(ILogMessage message)
         {
-            throw new NotImplementedException();
+            Log(message);
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/RestoreBarLogger.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/RestoreBarLogger.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.ProjectManagement;
+
+namespace NuGet.PackageManagement.UI.Utility
+{
+    internal class RestoreBarLogger : LoggerBase
+    {
+        private readonly INuGetProjectContext _nuGetProjectContext;
+
+        public RestoreBarLogger(INuGetProjectContext nuGetProjectContext)
+            : base(verbosityLevel: LogLevel.Warning)
+        {
+            _nuGetProjectContext = nuGetProjectContext ?? throw new ArgumentNullException(nameof(nuGetProjectContext));
+        }
+
+        public override void Log(ILogMessage message)
+        {
+            _nuGetProjectContext.Log(message);
+        }
+
+        public override Task LogAsync(ILogMessage message)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
@@ -17,6 +17,7 @@ using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
 using NuGet.Common;
+using NuGet.PackageManagement.UI.Utility;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
 using NuGet.ProjectManagement;
@@ -269,7 +270,7 @@ namespace NuGet.PackageManagement.UI
                 string solutionDirectory = await _solutionManager.GetSolutionDirectoryAsync(token);
                 await _packageRestoreManager.RestoreMissingPackagesInSolutionAsync(solutionDirectory,
                     this,
-                    new LoggerAdapter(this),
+                    new RestoreBarLogger(this),
                     token);
 
                 if (_restoreException == null)

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Utility/RestoreBarLoggerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Utility/RestoreBarLoggerTests.cs
@@ -46,7 +46,7 @@ namespace NuGet.PackageManagement.UI.Test.Utility
         }
 
         [Fact]
-        public void Log_InvokesNuGetProjectContextLog_Once()
+        public void Log_InvokesNuGetProjectContextLog_Always()
         {
             // Arrange
             var mockNuGetProjectContext = new Mock<INuGetProjectContext>();
@@ -58,6 +58,107 @@ namespace NuGet.PackageManagement.UI.Test.Utility
 
             // Assert
             mockNuGetProjectContext.Verify(nuGetProjectContext => nuGetProjectContext.Log(It.IsAny<ILogMessage>()), Times.Once());
+        }
+
+        [Fact]
+        public void LogError_InvokesNuGetProjectContextLog_Always()
+        {
+            // Arrange
+            var mockNuGetProjectContext = new Mock<INuGetProjectContext>();
+            var message = Mock.Of<ILogMessage>();
+
+            // Act
+            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
+            restoreBarLogger.LogError(data: "Message should be logged");
+
+            // Assert
+            mockNuGetProjectContext.Verify(nuGetProjectContext => nuGetProjectContext.Log(It.IsAny<ILogMessage>()), Times.Once());
+        }
+
+        [Fact]
+        public void LogWarning_InvokesNuGetProjectContextLog_Always()
+        {
+            // Arrange
+            var mockNuGetProjectContext = new Mock<INuGetProjectContext>();
+            var message = Mock.Of<ILogMessage>();
+
+            // Act
+            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
+            restoreBarLogger.LogWarning(data: "Message should be logged");
+
+            // Assert
+            mockNuGetProjectContext.Verify(nuGetProjectContext => nuGetProjectContext.Log(It.IsAny<ILogMessage>()), Times.Once());
+        }
+
+        [Fact]
+        public void LogInformation_InvokesNuGetProjectContextLog_Never()
+        {
+            // Arrange
+            var mockNuGetProjectContext = new Mock<INuGetProjectContext>();
+
+            // Act
+            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
+            restoreBarLogger.LogInformation(data: "Message which should be ignored");
+
+            // Assert
+            mockNuGetProjectContext.Verify(nuGetProjectContext => nuGetProjectContext.Log(It.IsAny<ILogMessage>()), Times.Never());
+        }
+
+        [Fact]
+        public void LogInformationSummary_InvokesNuGetProjectContextLog_Never()
+        {
+            // Arrange
+            var mockNuGetProjectContext = new Mock<INuGetProjectContext>();
+
+            // Act
+            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
+            restoreBarLogger.LogInformationSummary(data: "Message which should be ignored");
+
+            // Assert
+            mockNuGetProjectContext.Verify(nuGetProjectContext => nuGetProjectContext.Log(It.IsAny<ILogMessage>()), Times.Never());
+        }
+
+        [Fact]
+        public void LogDebug_InvokesNuGetProjectContextLog_Never()
+        {
+            // Arrange
+            var mockNuGetProjectContext = new Mock<INuGetProjectContext>();
+
+            // Act
+            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
+            restoreBarLogger.LogDebug(data: "Message which should be ignored");
+
+            // Assert
+            mockNuGetProjectContext.Verify(nuGetProjectContext => nuGetProjectContext.Log(It.IsAny<ILogMessage>()), Times.Never());
+        }
+
+
+        [Fact]
+        public void LogMinimal_InvokesNuGetProjectContextLog_Never()
+        {
+            // Arrange
+            var mockNuGetProjectContext = new Mock<INuGetProjectContext>();
+
+            // Act
+            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
+            restoreBarLogger.LogMinimal(data: "Message which should be ignored");
+
+            // Assert
+            mockNuGetProjectContext.Verify(nuGetProjectContext => nuGetProjectContext.Log(It.IsAny<ILogMessage>()), Times.Never());
+        }
+
+        [Fact]
+        public void LogVerbose_InvokesNuGetProjectContextLog_Never()
+        {
+            // Arrange
+            var mockNuGetProjectContext = new Mock<INuGetProjectContext>();
+
+            // Act
+            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
+            restoreBarLogger.LogVerbose(data: "Message which should be ignored");
+
+            // Assert
+            mockNuGetProjectContext.Verify(nuGetProjectContext => nuGetProjectContext.Log(It.IsAny<ILogMessage>()), Times.Never());
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Utility/RestoreBarLoggerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Utility/RestoreBarLoggerTests.cs
@@ -31,18 +31,18 @@ namespace NuGet.PackageManagement.UI.Test.Utility
         }
 
         [Fact]
-        public async Task LogAsync_ShouldThrowNotImplementedException_ThrowsAsync()
+        public async Task LogAsync_InvokesNuGetProjectContextLog_Always()
         {
             // Arrange
-            var nuGetProjectContext = Mock.Of<INuGetProjectContext>();
+            var mockNuGetProjectContext = new Mock<INuGetProjectContext>();
             var message = Mock.Of<ILogMessage>();
-            var restoreBarLogger = new RestoreBarLogger(nuGetProjectContext);
+            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
 
             // Act
-            var act = async () => await restoreBarLogger.LogAsync(message);
+            await restoreBarLogger.LogAsync(message);
 
             // Assert
-            await act.Should().ThrowAsync<NotImplementedException>();
+            mockNuGetProjectContext.Verify(nuGetProjectContext => nuGetProjectContext.Log(It.IsAny<ILogMessage>()), Times.Once());
         }
 
         [Fact]
@@ -51,9 +51,9 @@ namespace NuGet.PackageManagement.UI.Test.Utility
             // Arrange
             var mockNuGetProjectContext = new Mock<INuGetProjectContext>();
             var message = Mock.Of<ILogMessage>();
+            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
 
             // Act
-            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
             restoreBarLogger.Log(message);
 
             // Assert
@@ -66,9 +66,9 @@ namespace NuGet.PackageManagement.UI.Test.Utility
             // Arrange
             var mockNuGetProjectContext = new Mock<INuGetProjectContext>();
             var message = Mock.Of<ILogMessage>();
+            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
 
             // Act
-            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
             restoreBarLogger.LogError(data: "Message should be logged");
 
             // Assert
@@ -81,9 +81,9 @@ namespace NuGet.PackageManagement.UI.Test.Utility
             // Arrange
             var mockNuGetProjectContext = new Mock<INuGetProjectContext>();
             var message = Mock.Of<ILogMessage>();
+            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
 
             // Act
-            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
             restoreBarLogger.LogWarning(data: "Message should be logged");
 
             // Assert
@@ -95,9 +95,9 @@ namespace NuGet.PackageManagement.UI.Test.Utility
         {
             // Arrange
             var mockNuGetProjectContext = new Mock<INuGetProjectContext>();
+            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
 
             // Act
-            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
             restoreBarLogger.LogInformation(data: "Message which should be ignored");
 
             // Assert
@@ -109,9 +109,9 @@ namespace NuGet.PackageManagement.UI.Test.Utility
         {
             // Arrange
             var mockNuGetProjectContext = new Mock<INuGetProjectContext>();
+            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
 
             // Act
-            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
             restoreBarLogger.LogInformationSummary(data: "Message which should be ignored");
 
             // Assert
@@ -123,9 +123,9 @@ namespace NuGet.PackageManagement.UI.Test.Utility
         {
             // Arrange
             var mockNuGetProjectContext = new Mock<INuGetProjectContext>();
+            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
 
             // Act
-            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
             restoreBarLogger.LogDebug(data: "Message which should be ignored");
 
             // Assert
@@ -138,9 +138,9 @@ namespace NuGet.PackageManagement.UI.Test.Utility
         {
             // Arrange
             var mockNuGetProjectContext = new Mock<INuGetProjectContext>();
+            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
 
             // Act
-            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
             restoreBarLogger.LogMinimal(data: "Message which should be ignored");
 
             // Assert
@@ -152,9 +152,9 @@ namespace NuGet.PackageManagement.UI.Test.Utility
         {
             // Arrange
             var mockNuGetProjectContext = new Mock<INuGetProjectContext>();
+            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
 
             // Act
-            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
             restoreBarLogger.LogVerbose(data: "Message which should be ignored");
 
             // Assert

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Utility/RestoreBarLoggerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Utility/RestoreBarLoggerTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NuGet.Common;
+using NuGet.PackageManagement.UI.Utility;
+using NuGet.ProjectManagement;
+using Xunit;
+
+namespace NuGet.PackageManagement.UI.Test.Utility
+{
+    public class RestoreBarLoggerTests
+    {
+        [Fact]
+        public void Constructor_NullParameterNuGetProjectContext_Throws()
+        {
+            // Arrange
+            INuGetProjectContext? nuGetProjectContext = null;
+
+            // Act
+            Action act = () => new RestoreBarLogger(nuGetProjectContext!);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>()
+                .WithParameterName("nuGetProjectContext");
+        }
+
+        [Fact]
+        public async Task LogAsync_ShouldThrowNotImplementedException_ThrowsAsync()
+        {
+            // Arrange
+            var nuGetProjectContext = Mock.Of<INuGetProjectContext>();
+            var message = Mock.Of<ILogMessage>();
+            var restoreBarLogger = new RestoreBarLogger(nuGetProjectContext);
+
+            // Act
+            var act = async () => await restoreBarLogger.LogAsync(message);
+
+            // Assert
+            await act.Should().ThrowAsync<NotImplementedException>();
+        }
+
+        [Fact]
+        public void Log_InvokesNuGetProjectContextLog_Once()
+        {
+            // Arrange
+            var mockNuGetProjectContext = new Mock<INuGetProjectContext>();
+            var message = Mock.Of<ILogMessage>();
+
+            // Act
+            var restoreBarLogger = new RestoreBarLogger(mockNuGetProjectContext.Object);
+            restoreBarLogger.Log(message);
+
+            // Assert
+            mockNuGetProjectContext.Verify(nuGetProjectContext => nuGetProjectContext.Log(It.IsAny<ILogMessage>()), Times.Once());
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13407

## Description

Informational messages are no longer logged to the RestoreBar (InfoBar / Gold Bar / Yellow bar) in NuGet's Package Manager UI.

- Create a new logger that specifically models the RestoreBar's logger where only `Warning` level or higher are displayed.
  - Maintains the adapter approach for `INuGetProjectContext`.
- Output Pane continues to show `Info` level, informational logging.
  - For example, `CACHE https://api.nuget.org/v3/vulnerabilities/index.json` is shown in Output Pane but no longer in the Restore Bar.

![image](https://github.com/user-attachments/assets/ec3fae3a-22ef-4748-ac7a-58503a59835b)


### Side effects

- Reduces screen flicker which occurred from briefly showing and hiding the Restore Bar for HTTP status (GET / OK / CACHE).

### Future considerations

- Suggest that the next step be to look into simplifying the logging overall. 
- Possibly `LoggerBase` and `LoggerAdapter` can be merged as there's a lot of overlap.
- `INuGetProjectContext` representing a project and a logger isn't a great abstraction. The separation of concerns could be improved.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
