### PR TITLE
Enable xUnit2024, fix violations

### DIFF
--- a/build/test.targets
+++ b/build/test.targets
@@ -5,6 +5,7 @@
 
   <PropertyGroup>
     <NoWarn>$(NoWarn);CS1701;xUnit1012;xUnit1014;xUnit2000;xUnit2009;xUnit2013</NoWarn>
+    <WarningsAsErrors>$(WarningsAsErrors);xUnit2024</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSourcesCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSourcesCommandTest.cs
@@ -1205,7 +1205,7 @@ namespace NuGet.CommandLine.Test
 
                 // test to ensure detailed format is the default
                 Assert.True(result.Output.StartsWith("Registered Sources:"));
-                Assert.True(result.ExitCode == 0);
+                Assert.Equal(0, result.ExitCode);
                 Assert.Contains("encyclopaedia [Enabled]", result.Output);
                 Assert.Contains("encyclopædia [Enabled]", result.Output);
                 Assert.DoesNotContain("Encyclopaedia", result.Output);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -1003,7 +1003,7 @@ namespace NuGet.CommandLine.Test
                 var output = r.Output + " " + r.Errors;
 
                 // Assert
-                Assert.True(r.ExitCode == 1);
+                Assert.Equal(1, r.ExitCode);
                 Assert.Contains("no run-time assembly compatible", output);
             }
         }
@@ -1047,7 +1047,7 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext, testOutputHelper: _testOutputHelper);
 
                 // Assert
-                Assert.True(r.ExitCode == 0);
+                Assert.Equal(0, r.ExitCode);
                 Assert.DoesNotContain("no run-time assembly compatible", r.Errors);
             }
         }
@@ -1093,7 +1093,7 @@ namespace NuGet.CommandLine.Test
                 var output = r.Output + " " + r.Errors;
 
                 // Assert
-                Assert.True(r.ExitCode == 1);
+                Assert.Equal(1, r.ExitCode);
                 Assert.Contains("no run-time assembly compatible", output);
             }
         }
@@ -2913,7 +2913,7 @@ namespace NuGet.CommandLine.Test
                 Assert.Equal(1, msbuildTargetsItems.Count);
                 Assert.Equal(1, msbuildPropsItems.Count);
 
-                Assert.True(r.ExitCode == 0);
+                Assert.Equal(0, r.ExitCode);
             }
         }
 
@@ -2966,7 +2966,7 @@ namespace NuGet.CommandLine.Test
 
                 // Act
                 r = Util.RestoreSolution(pathContext, testOutputHelper: _testOutputHelper);
-                Assert.True(r.ExitCode == 0);
+                Assert.Equal(0, r.ExitCode);
                 Assert.True(File.Exists(projectA.TargetsOutput), r.Output);
             }
         }
@@ -7199,8 +7199,8 @@ namespace NuGet.CommandLine.Test
                 Assert.Equal(1, lockFile.Targets.First().Libraries.Count);
                 Assert.Equal("FrameworkRef", string.Join(",", lockFile.Targets.First().Libraries.First().FrameworkReferences));
                 Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX.Identity.Id, packageX.Version)), $"{packageX.ToString()} is not installed");
-                Assert.True(1 == lockFile.PackageSpec.TargetFrameworks.Single().FrameworkReferences.Count(dep => FrameworkDependencyFlagsUtils.GetFlagString(dep.PrivateAssets) == "all"));
-                Assert.True(1 == lockFile.PackageSpec.TargetFrameworks.Single().FrameworkReferences.Count(dep => FrameworkDependencyFlagsUtils.GetFlagString(dep.PrivateAssets) == "none"));
+                Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks.Single().FrameworkReferences.Count(dep => FrameworkDependencyFlagsUtils.GetFlagString(dep.PrivateAssets) == "all"));
+                Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks.Single().FrameworkReferences.Count(dep => FrameworkDependencyFlagsUtils.GetFlagString(dep.PrivateAssets) == "none"));
 
                 // Assert 2
                 Assert.True(File.Exists(projectB.AssetsFileOutputPath), r.AllOutput);
@@ -8705,7 +8705,7 @@ namespace NuGet.CommandLine.Test
                 //The orders are not equal.  Then resave the lock file and project.
                 //The null RID must be the first one otherwise this fails
                 Assert.False(originalTargets.SequenceEqual(reorderedTargets));
-                Assert.True(packagesLockFile.Targets[0].RuntimeIdentifier == null);
+                Assert.Null(packagesLockFile.Targets[0].RuntimeIdentifier);
                 PackagesLockFileFormat.Write(projectA.NuGetLockFileOutputPath, packagesLockFile);
                 projectA.Properties.Add("RestoreLockedMode", "true");
                 projectA.Save();

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -285,7 +285,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                 // Asert
                 var exists = packages.Where(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("4.0.0"))));
-                Assert.True(exists.Count() == 1);
+                Assert.Equal(1, exists.Count());
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -1200,7 +1200,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                 // Asert
                 var exists = packages.Where(a => a.PackageIdentity.Equals(new PackageIdentity("packageA", new NuGetVersion("4.0.0"))));
-                Assert.True(exists.Count() == 1);
+                Assert.Equal(1, exists.Count());
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/PackageVulnerabilityServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/PackageVulnerabilityServiceTests.cs
@@ -64,7 +64,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             List<PackageVulnerabilityMetadataContextInfo> vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
 
             // Assert
-            Assert.True(vulnerabilities.Count == 1);
+            Assert.Equal(1, vulnerabilities.Count);
         }
 
         [Fact]
@@ -106,13 +106,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             // Act & Assert
             List<PackageVulnerabilityMetadataContextInfo> vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
-            Assert.True(vulnerabilities.Count == 1);
+            Assert.Equal(1, vulnerabilities.Count);
             Assert.Equal(1, getVulnerabilityCallCount);
             vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
-            Assert.True(vulnerabilities.Count == 1);
+            Assert.Equal(1, vulnerabilities.Count);
             Assert.Equal(1, getVulnerabilityCallCount);
             vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
-            Assert.True(vulnerabilities.Count == 1);
+            Assert.Equal(1, vulnerabilities.Count);
             Assert.Equal(1, getVulnerabilityCallCount);
         }
 
@@ -155,17 +155,17 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             // Act & Assert
             List<PackageVulnerabilityMetadataContextInfo> vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
-            Assert.True(vulnerabilities.Count == 1);
+            Assert.Equal(1, vulnerabilities.Count);
             Assert.Equal(1, getVulnerabilityCallCount);
             // Reset the vulnerability data
             packageVulnerabilityService.ResetVulnerabilityData();
             vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
-            Assert.True(vulnerabilities.Count == 1);
+            Assert.Equal(1, vulnerabilities.Count);
             Assert.Equal(2, getVulnerabilityCallCount);
             // Reset the vulnerability data again
             packageVulnerabilityService.ResetVulnerabilityData();
             vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
-            Assert.True(vulnerabilities.Count == 1);
+            Assert.Equal(1, vulnerabilities.Count);
             Assert.Equal(3, getVulnerabilityCallCount);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Utility/GetPackageReferenceUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Utility/GetPackageReferenceUtilityTests.cs
@@ -76,7 +76,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             // Act and Assert 3: Both are null
             int result3 = GetPackageReferenceUtility.PackageReferenceMergeComparer.Compare(null, null);
-            Assert.True(result3 == 0);
+            Assert.Equal(0, result3);
 
             var prWithNullIdentity = new PackageReference(null, null);
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -1899,11 +1899,11 @@ namespace Dotnet.Integration.Test
 
                     if (expectedIncludeString == null)
                     {
-                        Assert.True(contentFiles.Count() == 0);
+                        Assert.Equal(0, contentFiles.Count());
                     }
                     else
                     {
-                        Assert.True(contentFiles.Count() == 1);
+                        Assert.Equal(1, contentFiles.Count());
                         var contentFile = contentFiles[0];
                         Assert.Equal(expectedIncludeString, contentFile.Include);
                         Assert.Equal("Content", contentFile.BuildAction);
@@ -1991,12 +1991,12 @@ namespace Dotnet.Integration.Test
 
                     if (expectedIncludeString == null)
                     {
-                        Assert.True(contentFiles.Count() == 0);
+                        Assert.Equal(0, contentFiles.Count());
                     }
                     else
                     {
                         var expectedStrings = expectedIncludeString.Split(';');
-                        Assert.True(contentFiles.Count() == 2);
+                        Assert.Equal(2, contentFiles.Count());
                         var contentFileSet = contentFiles.Select(p => p.Include);
                         var files = nupkgReader.GetFiles("contentFiles");
                         foreach (var expected in expectedStrings)
@@ -2637,7 +2637,7 @@ namespace ClassLibrary
                     var nuspecReader = nupkgReader.NuspecReader;
                     // Validate the assets.
                     var srcItems = nupkgReader.GetFiles("src").ToArray();
-                    Assert.True(srcItems.Length == 4);
+                    Assert.Equal(4, srcItems.Length);
                     Assert.Contains("src/ClassLibrary1/ClassLibrary1.csproj", srcItems);
                     Assert.Contains("src/ClassLibrary1/Class1.cs", srcItems);
                     Assert.Contains("src/ClassLibrary1/Extensions/ExtensionMethods.cs", srcItems);
@@ -3258,7 +3258,7 @@ namespace ClassLibrary
                     var nuspecReader = nupkgReader.NuspecReader;
                     var contentFiles = nuspecReader.GetContentFiles().ToArray();
 
-                    Assert.True(contentFiles.Count() == 1);
+                    Assert.Equal(1, contentFiles.Count());
                     var contentFile = contentFiles[0];
                     Assert.Equal(expectedBuildAction, contentFile.BuildAction);
                 }
@@ -4735,7 +4735,7 @@ namespace ClassLibrary
                     Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard20, libItems[0].TargetFramework);
                     Assert.Equal(new[] { "lib/netstandard2.0/ClassLibrary1.dll" }, libItems[0].Items);
                     Assert.Equal(new[] { "lib/netstandard2.0/ClassLibrary1.dll", "lib/netstandard2.0/ClassLibrary1.pdb" }, libSymItems[0].Items);
-                    Assert.True(symbolReader.GetEntry(symbolReader.NuspecReader.GetLicenseMetadata().License) != null);
+                    Assert.NotNull(symbolReader.GetEntry(symbolReader.NuspecReader.GetLicenseMetadata().License));
                 }
             }
         }

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskPackageSourceMappingTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskPackageSourceMappingTests.cs
@@ -128,7 +128,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true", ignoreExitCode: true, testOutputHelper: _testOutputHelper);
 
                 // Assert
-                Assert.True(result.ExitCode == 0);
+                Assert.Equal(0, result.ExitCode);
                 var contosoRestorePath = Path.Combine(projectAPackages, packageOpenSourceContosoMvc.ToString(), packageOpenSourceContosoMvc.ToString() + ".nupkg");
                 using (var nupkgReader = new PackageArchiveReader(contosoRestorePath))
                 {
@@ -228,7 +228,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true", ignoreExitCode: true, testOutputHelper: _testOutputHelper);
 
                 // Assert
-                Assert.True(result.ExitCode == 1);
+                Assert.Equal(1, result.ExitCode);
                 var packageContosoBuffersPath = Path.Combine(projectAPackages, packageContosoBuffersOpenSource.ToString(), packageContosoBuffersOpenSource.ToString() + ".nupkg");
                 Assert.True(File.Exists(packageContosoBuffersPath));
                 // Assert Contoso.MVC.ASP is not restored.
@@ -338,7 +338,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true", ignoreExitCode: true, testOutputHelper: _testOutputHelper);
 
                 // Assert
-                Assert.True(result.ExitCode == 0);
+                Assert.Equal(0, result.ExitCode);
                 var contosoRestorePath = Path.Combine(projectAPackages, packageOpenSourceContosoMvc.ToString(), packageOpenSourceContosoMvc.ToString() + ".nupkg");
                 using (var nupkgReader = new PackageArchiveReader(contosoRestorePath))
                 {
@@ -438,7 +438,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true", ignoreExitCode: true, testOutputHelper: _testOutputHelper);
 
                 // Assert
-                Assert.True(result.ExitCode == 1);
+                Assert.Equal(1, result.ExitCode);
                 var packageContosoBuffersPath = Path.Combine(projectAPackages, packageContosoBuffersOpenSource.ToString(), packageContosoBuffersOpenSource.ToString() + ".nupkg");
                 Assert.True(File.Exists(packageContosoBuffersPath));
                 // Assert Contoso.MVC.ASP is not restored.
@@ -550,7 +550,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore -v:d {pathContext.SolutionRoot} /p:RestorePackagesConfig=true", ignoreExitCode: true, testOutputHelper: _testOutputHelper);
 
                 // Assert
-                Assert.True(result.ExitCode == 0);
+                Assert.Equal(0, result.ExitCode);
                 var contosoRestorePath = Path.Combine(projectAPackages, packageOpenSourceContosoMvc.ToString(), packageOpenSourceContosoMvc.ToString() + ".nupkg");
                 using (var nupkgReader = new PackageArchiveReader(contosoRestorePath))
                 {
@@ -559,7 +559,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                     Assert.Contains("lib/net461/realA.dll", allFiles);
                 }
 
-                Assert.True(result.ExitCode == 0);
+                Assert.Equal(0, result.ExitCode);
                 Assert.Contains("Package source mapping matches found for package ID 'Contoso.MVC.ASP' are: 'SharedRepository'", result.Output);
             }
         }
@@ -740,7 +740,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 var result = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore {pathContext.SolutionRoot} /p:RestorePackagesConfig=true", ignoreExitCode: true, testOutputHelper: _testOutputHelper);
 
                 // Assert
-                Assert.True(result.ExitCode == 0);
+                Assert.Equal(0, result.ExitCode);
                 var contosoRestorePath = Path.Combine(projectAPackages, packageContosoMvcReal1.ToString(), packageContosoMvcReal1.ToString() + ".nupkg");
                 using (var nupkgReader = new PackageArchiveReader(contosoRestorePath))
                 {
@@ -877,7 +877,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             var r = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore -v:d {pathContext.SolutionRoot}", ignoreExitCode: true, testOutputHelper: _testOutputHelper);
 
             // Assert
-            Assert.True(r.ExitCode == 0);
+            Assert.Equal(0, r.ExitCode);
             Assert.Contains($"Package source mapping matches found for package ID 'Contoso.MVC.ASP' are: 'PrivateRepository'", r.Output);
             Assert.Contains($"Package source mapping matches found for package ID 'Contoso.Opensource.A' are: 'PublicRepository'", r.Output);
             var localResolver = new VersionFolderPathResolver(pathContext.UserPackagesFolder);
@@ -963,7 +963,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             var r = _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:restore -v:d {pathContext.SolutionRoot}", ignoreExitCode: true, testOutputHelper: _testOutputHelper);
 
             // Assert
-            Assert.True(r.ExitCode == 1);
+            Assert.Equal(1, r.ExitCode);
             Assert.Contains($"Package source mapping match not found for package ID 'Contoso.MVC.ASP'.", r.Output);
             Assert.Contains($"Package source mapping matches found for package ID 'Contoso.Opensource.A' are: 'PublicRepository'", r.Output);
         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFilesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFilesTests.cs
@@ -1539,7 +1539,7 @@ namespace NuGet.Commands.Test
                 Assert.Equal(0, result.CompatibilityCheckResults.Sum(checkResult => checkResult.Issues.Count));
                 Assert.Equal(0, logger.Errors);
                 Assert.Equal(0, logger.Warnings);
-                Assert.True(contentFile.Properties["buildAction"] == "None");
+                Assert.Equal("None", contentFile.Properties["buildAction"]);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/ConfigurationDefaultsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/ConfigurationDefaultsTests.cs
@@ -176,7 +176,7 @@ namespace NuGet.Configuration
                 File.WriteAllText(nugetConfigFilePath, configurationDefaultsContent);
 
                 ConfigurationDefaults configDefaults = new ConfigurationDefaults(nugetConfigFileFolder, nugetConfigFile);
-                Assert.True(configDefaults.DefaultPackageSources.ToList().Count == 0);
+                Assert.Equal(0, configDefaults.DefaultPackageSources.ToList().Count);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderTests.cs
@@ -105,7 +105,7 @@ namespace NuGet.Credentials.Test
                 var token = CancellationToken.None;
                 var credentialResponse = await provider.GetAsync(_uri, proxy, credType, message, isRetry, isInteractive, token);
 
-                Assert.True(credentialResponse.Status == CredentialStatus.Success);
+                Assert.Equal(credentialResponse.Status, CredentialStatus.Success);
                 Assert.NotNull(credentialResponse.Credentials);
                 Assert.Equal(_username, credentialResponse.Credentials.GetCredential(_uri, authType: null).UserName);
                 Assert.Equal(_password, credentialResponse.Credentials.GetCredential(_uri, authType: null).Password);
@@ -140,11 +140,11 @@ namespace NuGet.Credentials.Test
                 var token = CancellationToken.None;
                 var credentialResponse = await provider.GetAsync(_uri, proxy, credType, message, isRetry, isInteractive, token);
 
-                Assert.True(credentialResponse.Status == CredentialStatus.ProviderNotApplicable);
+                Assert.Equal(credentialResponse.Status, CredentialStatus.ProviderNotApplicable);
                 Assert.Null(credentialResponse.Credentials);
 
                 var credentialResponse2 = await provider.GetAsync(_uri, proxy, credType, message, isRetry, isInteractive, token);
-                Assert.True(credentialResponse2.Status == CredentialStatus.ProviderNotApplicable);
+                Assert.Equal(credentialResponse2.Status, CredentialStatus.ProviderNotApplicable);
                 Assert.Null(credentialResponse2.Credentials);
             }
         }
@@ -177,7 +177,7 @@ namespace NuGet.Credentials.Test
                 var token = CancellationToken.None;
                 var credentialResponse = await provider.GetAsync(_uri, proxy, credType, message, isRetry, isInteractive, token);
 
-                Assert.True(credentialResponse.Status == CredentialStatus.Success);
+                Assert.Equal(credentialResponse.Status, CredentialStatus.Success);
                 Assert.NotNull(credentialResponse.Credentials);
                 Assert.Equal(_username, credentialResponse.Credentials.GetCredential(_uri, authType: null).UserName);
                 Assert.Equal(_password, credentialResponse.Credentials.GetCredential(_uri, authType: null).Password);
@@ -219,7 +219,7 @@ namespace NuGet.Credentials.Test
                 var token = CancellationToken.None;
                 var credentialResponse = await provider.GetAsync(_uri, proxy, credType, message, isRetry, isInteractive, token);
 
-                Assert.True(credentialResponse.Status == CredentialStatus.Success);
+                Assert.Equal(credentialResponse.Status, CredentialStatus.Success);
                 Assert.NotNull(credentialResponse.Credentials);
                 Assert.Equal(_username, credentialResponse.Credentials.GetCredential(_uri, authType: null).UserName);
                 Assert.Equal(_password, credentialResponse.Credentials.GetCredential(_uri, authType: null).Password);
@@ -254,7 +254,7 @@ namespace NuGet.Credentials.Test
                 var token = CancellationToken.None;
                 var credentialResponse = await provider.GetAsync(_uri, proxy, credType, message, isRetry, isInteractive, token);
 
-                Assert.True(credentialResponse.Status == CredentialStatus.ProviderNotApplicable);
+                Assert.Equal(credentialResponse.Status, CredentialStatus.ProviderNotApplicable);
                 Assert.Null(credentialResponse.Credentials);
             }
 
@@ -284,7 +284,7 @@ namespace NuGet.Credentials.Test
                 var token = CancellationToken.None;
                 var credentialResponse = await provider.GetAsync(_uri, proxy, credType, message, isRetry, isInteractive, token);
 
-                Assert.True(credentialResponse.Status == CredentialStatus.ProviderNotApplicable);
+                Assert.Equal(credentialResponse.Status, CredentialStatus.ProviderNotApplicable);
                 Assert.Null(credentialResponse.Credentials);
             }
         }
@@ -322,7 +322,7 @@ namespace NuGet.Credentials.Test
                 var token = CancellationToken.None;
                 var credentialResponse = await provider.GetAsync(_uri, proxy, credType, message, isRetry, isInteractive, token);
 
-                Assert.True(credentialResponse.Status == CredentialStatus.Success);
+                Assert.Equal(credentialResponse.Status, CredentialStatus.Success);
                 Assert.NotNull(credentialResponse.Credentials);
                 Assert.Equal(_username, credentialResponse.Credentials.GetCredential(_uri, authType: null).UserName);
                 Assert.Equal(_password, credentialResponse.Credentials.GetCredential(_uri, authType: null).Password);
@@ -390,7 +390,7 @@ namespace NuGet.Credentials.Test
                 var token = CancellationToken.None;
                 var credentialResponse = await provider.GetAsync(_uri, proxy, credType, message, isRetry, isInteractive, token);
 
-                Assert.True(credentialResponse.Status == CredentialStatus.UserCanceled);
+                Assert.Equal(credentialResponse.Status, CredentialStatus.UserCanceled);
                 Assert.Null(credentialResponse.Credentials);
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
@@ -1570,7 +1570,7 @@ namespace NuGet.DependencyResolver.Tests
                 {
                     // No D node expected in the graph
                     // all downgrades shoudl have been removed
-                    Assert.True(n.Key.Name != "D");
+                    Assert.NotEqual("D", n.Key.Name);
 
                     if ((n.Key.Name == "C" && n.Key.VersionRange.OriginalString == "1.0.0") ||
                         (n.Key.Name == "H" && n.Key.VersionRange.OriginalString == "1.0.0"))
@@ -1666,7 +1666,7 @@ namespace NuGet.DependencyResolver.Tests
                 {
                     // No D node expected in the graph
                     // all downgrades should have been removed
-                    Assert.True(n.Key.Name != "D");
+                    Assert.NotEqual("D", n.Key.Name);
 
                     if ((n.Key.Name == "C" && n.Key.VersionRange.OriginalString == "1.0.0") ||
                         (n.Key.Name == "H" && n.Key.VersionRange.OriginalString == "1.0.0"))
@@ -1759,7 +1759,7 @@ namespace NuGet.DependencyResolver.Tests
                 {
                     // No D node expected in the graph
                     // all downgrades should have been removed
-                    Assert.True(n.Key.Name != "D");
+                    Assert.NotEqual("D", n.Key.Name);
 
                     if ((n.Key.Name == "C" && n.Key.VersionRange.OriginalString == "1.0.0"))
                     {

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedRestoreUtilityTests.cs
@@ -66,7 +66,7 @@ namespace NuGet.Test
 
                     // Assert
                     Assert.True(File.Exists(Path.Combine(packageSpec.RestoreMetadata.OutputPath, LockFileFormat.AssetsFileName)));
-                    Assert.True(testLogger.Errors == 0);
+                    Assert.Equal(0, testLogger.Errors);
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/BatchedEventTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/BatchedEventTests.cs
@@ -98,8 +98,8 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
                     Assert.Equal(1, packagesInPackagesConfig.Count);
 
                     // Check batch events data
-                    Assert.True(batchStartIds.Count == 1);
-                    Assert.True(batchEndIds.Count == 1);
+                    Assert.Equal(1, batchStartIds.Count);
+                    Assert.Equal(1, batchEndIds.Count);
                     Assert.Equal(batchStartIds[0], batchEndIds[0]);
                     Assert.Equal("testA", projectName);
                 }
@@ -165,8 +165,8 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
                     Assert.Equal(1, packagesInPackagesConfig.Count);
 
                     // Check batch events data
-                    Assert.True(batchStartIds.Count == 1);
-                    Assert.True(batchEndIds.Count == 1);
+                    Assert.Equal(1, batchStartIds.Count);
+                    Assert.Equal(1, batchEndIds.Count);
                     Assert.Equal(batchStartIds[0], batchEndIds[0]);
 
                     // Update
@@ -184,8 +184,8 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
                     Assert.Equal(1, packagesInPackagesConfig.Count);
 
                     // Check batch events data
-                    Assert.True(batchStartIds.Count == 2);
-                    Assert.True(batchEndIds.Count == 2);
+                    Assert.Equal(2, batchStartIds.Count);
+                    Assert.Equal(2, batchEndIds.Count);
                     Assert.Equal(batchStartIds[1], batchEndIds[1]);
                     Assert.NotEqual(batchStartIds[0], batchStartIds[1]);
                 }
@@ -249,8 +249,8 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
                     // Assert
 
                     // Check batch events data
-                    Assert.True(batchStartIds.Count == 2);
-                    Assert.True(batchEndIds.Count == 2);
+                    Assert.Equal(2, batchStartIds.Count);
+                    Assert.Equal(2, batchEndIds.Count);
                     Assert.Equal(batchStartIds[0], batchEndIds[0]);
                     Assert.Equal(batchStartIds[1], batchEndIds[1]);
                     Assert.NotEqual(batchStartIds[0], batchStartIds[1]);
@@ -325,8 +325,8 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
 
                     //Assert
                     // Check batch events data
-                    Assert.True(batchStartIds.Count == 1);
-                    Assert.True(batchEndIds.Count == 1);
+                    Assert.Equal(1, batchStartIds.Count);
+                    Assert.Equal(1, batchEndIds.Count);
                     Assert.Equal(batchStartIds[0], batchEndIds[0]);
                     Assert.Equal("testA", projectName);
                 }
@@ -402,12 +402,12 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
                     Assert.Equal(1, packagesInPackagesConfigB.Count);
 
                     // Check batch events data
-                    Assert.True(batchStartIds.Count == 2);
-                    Assert.True(batchEndIds.Count == 2);
+                    Assert.Equal(2, batchStartIds.Count);
+                    Assert.Equal(2, batchEndIds.Count);
                     Assert.Equal(batchStartIds[0], batchEndIds[0]);
                     Assert.Equal(batchStartIds[1], batchEndIds[1]);
                     Assert.NotEqual(batchStartIds[0], batchStartIds[1]);
-                    Assert.True(projectNames.Count == 2);
+                    Assert.Equal(2, projectNames.Count);
                     Assert.Equal("testA", projectNames[0]);
                     Assert.Equal("testB", projectNames[1]);
                 }
@@ -467,8 +467,8 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
                     Assert.Equal(0, packagesInPackagesConfig.Count);
 
                     // Check batch events data
-                    Assert.True(batchStartIds.Count == 1);
-                    Assert.True(batchEndIds.Count == 1);
+                    Assert.Equal(1, batchStartIds.Count);
+                    Assert.Equal(1, batchEndIds.Count);
                     Assert.Equal(batchStartIds[0], batchEndIds[0]);
                 }
             }
@@ -536,8 +536,8 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
                     Assert.NotNull(exception);
 
                     // Check batch events data
-                    Assert.True(batchStartIds.Count == 1);
-                    Assert.True(batchEndIds.Count == 1);
+                    Assert.Equal(1, batchStartIds.Count);
+                    Assert.Equal(1, batchEndIds.Count);
                     Assert.Equal(batchStartIds[0], batchEndIds[0]);
                 }
             }
@@ -607,8 +607,8 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
                     Assert.NotNull(exception);
 
                     // Check batch events data
-                    Assert.True(batchStartIds.Count == 0);
-                    Assert.True(batchEndIds.Count == 0);
+                    Assert.Equal(0, batchStartIds.Count);
+                    Assert.Equal(0, batchEndIds.Count);
 
                 }
             }
@@ -677,8 +677,8 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
                     Assert.NotNull(exception);
 
                     // Check batch events data
-                    Assert.True(batchStartIds.Count == 1);
-                    Assert.True(batchEndIds.Count == 1);
+                    Assert.Equal(1, batchStartIds.Count);
+                    Assert.Equal(1, batchEndIds.Count);
                     Assert.Equal(batchStartIds[0], batchEndIds[0]);
                 }
             }
@@ -734,8 +734,8 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
 
                 // Assert
                 // Check batch events data
-                Assert.True(batchStartIds.Count == 0);
-                Assert.True(batchEndIds.Count == 0);
+                Assert.Equal(0, batchStartIds.Count);
+                Assert.Equal(0, batchEndIds.Count);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/Core/comparers/PackageIdentityComparerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/Core/comparers/PackageIdentityComparerTests.cs
@@ -61,11 +61,11 @@ namespace NuGet.Protocol.Tests
         public void PackageIdentityComparer_Compare()
         {
             // Test Compare is Reflexive
-            Assert.True(comp.Compare(A100, A100) == 0);
+            Assert.Equal(0, comp.Compare(A100, A100));
 
             // Test compare is symmetric
-            Assert.True(comp.Compare(A100, A100DUP) == 0);
-            Assert.True(comp.Compare(A100DUP, A100) == 0);
+            Assert.Equal(0, comp.Compare(A100, A100DUP));
+            Assert.Equal(0, comp.Compare(A100DUP, A100));
             Assert.True(comp.Compare(A100, A200) < 0);
             Assert.True(comp.Compare(A200, A100) > 0);
             Assert.True(comp.Compare(B100, B200) < 0);
@@ -82,11 +82,11 @@ namespace NuGet.Protocol.Tests
 
             //Run all tests again to check for consistency
             // Test Compare is Reflexive
-            Assert.True(comp.Compare(A100, A100) == 0);
+            Assert.Equal(0, comp.Compare(A100, A100));
 
             // Test compare is symmetric
-            Assert.True(comp.Compare(A100, A100DUP) == 0);
-            Assert.True(comp.Compare(A100DUP, A100) == 0);
+            Assert.Equal(0, comp.Compare(A100, A100DUP));
+            Assert.Equal(0, comp.Compare(A100DUP, A100));
             Assert.True(comp.Compare(A100, A200) < 0);
             Assert.True(comp.Compare(A200, A100) > 0);
             Assert.True(comp.Compare(B100, B200) < 0);

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/IncludeFlagTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/IncludeFlagTests.cs
@@ -143,7 +143,7 @@ namespace NuGet.ProjectModel.Test
             var dependency = spec.TargetFrameworks[0].Dependencies.Single();
 
             // Assert
-            Assert.True(dependency.SuppressParent == LibraryIncludeFlags.All);
+            Assert.Equal(dependency.SuppressParent, LibraryIncludeFlags.All);
         }
 
         [Fact]
@@ -168,7 +168,7 @@ namespace NuGet.ProjectModel.Test
             var dependency = spec.TargetFrameworks[0].Dependencies.Single();
 
             // Assert
-            Assert.True(dependency.SuppressParent == LibraryIncludeFlagUtils.DefaultSuppressParent);
+            Assert.Equal(dependency.SuppressParent, LibraryIncludeFlagUtils.DefaultSuppressParent);
         }
 
         [Fact]
@@ -195,7 +195,7 @@ namespace NuGet.ProjectModel.Test
             var dependency = spec.TargetFrameworks[0].Dependencies.Single();
 
             // Assert
-            Assert.True(dependency.IncludeType == LibraryIncludeFlags.None);
+            Assert.Equal(dependency.IncludeType, LibraryIncludeFlags.None);
         }
 
         [Fact]
@@ -221,7 +221,7 @@ namespace NuGet.ProjectModel.Test
             var dependency = spec.TargetFrameworks[0].Dependencies.Single();
 
             // Assert
-            Assert.True(dependency.IncludeType == LibraryIncludeFlags.All);
+            Assert.Equal(dependency.IncludeType, LibraryIncludeFlags.All);
         }
 
         [Fact]
@@ -247,7 +247,7 @@ namespace NuGet.ProjectModel.Test
             var dependency = spec.TargetFrameworks[0].Dependencies.Single();
 
             // Assert
-            Assert.True(dependency.IncludeType == LibraryIncludeFlags.None);
+            Assert.Equal(dependency.IncludeType, LibraryIncludeFlags.None);
         }
 
         [Fact]
@@ -299,8 +299,8 @@ namespace NuGet.ProjectModel.Test
             var dependency = spec.TargetFrameworks[0].Dependencies.Single();
 
             // Assert
-            Assert.True(dependency.IncludeType
-                == LibraryIncludeFlagUtils.GetFlags(new string[] { "contentFiles" }));
+            Assert.Equal(dependency.IncludeType
+, LibraryIncludeFlagUtils.GetFlags(new string[] { "contentFiles" }));
         }
 
         [Fact]
@@ -327,7 +327,7 @@ namespace NuGet.ProjectModel.Test
             var dependency = spec.TargetFrameworks[0].Dependencies.Single();
 
             // Assert
-            Assert.True(dependency.IncludeType == LibraryIncludeFlags.None);
+            Assert.Equal(dependency.IncludeType, LibraryIncludeFlags.None);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalPackageListResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalPackageListResourceTests.cs
@@ -138,21 +138,21 @@ namespace NuGet.Protocol.Tests
         private void AssertAll(PackageSearchResourceMock mock)
         {
             Assert.Equal(mock._searchTerm, mock._actualSearchTerm);
-            Assert.True(0 == mock._actualSkip);
+            Assert.Equal(0, mock._actualSkip);
             Assert.True(int.MaxValue == mock._actualTake);
-            Assert.True(mock._searchFilter.OrderBy == SearchOrderBy.Id);
+            Assert.Equal(SearchOrderBy.Id, mock._searchFilter.OrderBy);
             if (mock._allVersions)
             {
-                Assert.True(mock._searchFilter.Filter == null);
+                Assert.Null(mock._searchFilter.Filter);
             }
             if (!mock._allVersions && mock._prerelease)
             {
-                Assert.True(mock._searchFilter.Filter == SearchFilterType.IsAbsoluteLatestVersion);
+                Assert.Equal(SearchFilterType.IsAbsoluteLatestVersion, mock._searchFilter.Filter);
             }
 
             if (!mock._allVersions && !mock._prerelease)
             {
-                Assert.True(mock._searchFilter.Filter == SearchFilterType.IsLatestVersion);
+                Assert.Equal(SearchFilterType.IsLatestVersion, mock._searchFilter.Filter);
             }
 
             Assert.True(mock._searchFilter.IncludeDelisted == mock._includeDelisted);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ServiceIndexResourceV3ProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ServiceIndexResourceV3ProviderTests.cs
@@ -189,7 +189,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
 
             var endpoints = resource.GetServiceEntryUris(new NuGetVersion(4, 0, 0), "Citrus");
 
-            Assert.True(endpoints.Count == 1);
+            Assert.Equal(1, endpoints.Count);
 
             var endpointSet = new HashSet<string>(endpoints.Select(u => u.AbsoluteUri));
             Assert.Contains("http://tempuri.org/orange", endpointSet);
@@ -219,7 +219,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
 
             var endpoints = resource.GetServiceEntryUris(new NuGetVersion(4, 0, 0), "Fruit");
 
-            Assert.True(endpoints.Count == 3);
+            Assert.Equal(3, endpoints.Count);
 
             var endpointSet = new HashSet<string>(endpoints.Select(u => u.AbsoluteUri));
             Assert.Contains("http://tempuri.org/banana", endpointSet);
@@ -251,7 +251,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
 
             var endpoints = resource.GetServiceEntryUris(new NuGetVersion(4, 0, 0), "Chocolate", "Vegetable");
 
-            Assert.True(endpoints.Count == 1);
+            Assert.Equal(1, endpoints.Count);
 
             var endpointSet = new HashSet<string>(endpoints.Select(u => u.AbsoluteUri));
             Assert.Contains("http://tempuri.org/chocolate", endpointSet);
@@ -281,7 +281,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
 
             var endpoints = resource.GetServiceEntryUris(new NuGetVersion(4, 0, 0), "A", "B");
 
-            Assert.True(endpoints.Count == 1);
+            Assert.Equal(1, endpoints.Count);
 
             var endpointSet = new HashSet<string>(endpoints.Select(u => u.AbsoluteUri));
             Assert.Contains("http://tempuri.org/A/4.0.0", endpointSet);
@@ -311,7 +311,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
 
             var endpoints = resource.GetServiceEntryUris(NuGetVersion.Parse("0.0.0-beta"), "A");
 
-            Assert.True(endpoints.Count == 0);
+            Assert.Equal(0, endpoints.Count);
         }
 
         [Fact]
@@ -338,7 +338,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
 
             var endpoints = resource.GetServiceEntryUris(new NuGetVersion(4, 1, 0), "A", "B");
 
-            Assert.True(endpoints.Count == 1);
+            Assert.Equal(1, endpoints.Count);
 
             var endpointSet = new HashSet<string>(endpoints.Select(u => u.AbsoluteUri));
             Assert.Contains("http://tempuri.org/A/4.0.0", endpointSet);
@@ -368,7 +368,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
 
             var endpoints = resource.GetServiceEntryUris(new NuGetVersion(4, 1, 0), "A", "B");
 
-            Assert.True(endpoints.Count == 1);
+            Assert.Equal(1, endpoints.Count);
 
             var endpointSet = new HashSet<string>(endpoints.Select(u => u.AbsoluteUri));
             Assert.Contains("http://tempuri.org/B", endpointSet);
@@ -398,7 +398,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
 
             var endpoints = resource.GetServiceEntryUris(new NuGetVersion(5, 0, 0), "A", "B");
 
-            Assert.True(endpoints.Count == 2);
+            Assert.Equal(2, endpoints.Count);
 
             var endpointSet = new HashSet<string>(endpoints.Select(u => u.AbsoluteUri));
             Assert.Contains("http://tempuri.org/A/5.0.0/1", endpointSet);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

The `Assert.True(r.ExitCode == 1);`  is a bad one, we're better off using equals as the xUnit2024 is suggesting. 
This PR fixes all of the violations and enables this warning as an error.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
