### PR TITLE
Point GitHub Copilot to our coding conventions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,1 @@
-For both new and existing code, help enforce a maximum line length of 120 characters.
+Use the following coding guidelines: https://github.com/NuGet/NuGet.Client/blob/dev/docs/coding-guidelines.md

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -44,6 +44,8 @@ The general rule we follow is "use Visual Studio defaults".
 
 1. Avoid more than one empty line at any time. For example, do not have two blank lines between members of a type.
 
+1. Avoid lines of code longer than 120 characters.
+
 1. Avoid spurious free spaces. For example avoid `if (someVar == 0)...`, where the dots mark the spurious free spaces. Consider enabling "View White Space (Ctrl+R, Ctrl+W)" or "Edit -> Advanced -> View White Space" if using Visual Studio to aid detection.
 
 1. If a file happens to differ in style from these guidelines (e.g. private members are named `m_member` rather than `_member`), the existing style in that file takes precedence. Changes/refactorings are possible, but depending on the complexity, change frequency of the file, might need to be considered on their own merits in a separate pull request.


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

Move the instruction for line length to our coding conventions document and point GitHub Copilot to that instead.

With the change:

![image](https://github.com/user-attachments/assets/2ffea932-5a64-4c0f-9751-7ec9cccb397d)


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- ~~[ ] Added tests~~
- ~~[ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~
