### PR TITLE
Ask PR authors to address servicing branches for CI changes

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -170,22 +170,22 @@ configuration:
         
         - [ ] Complete [localizability testing](https://github.com/NuGet/NuGet.Client/blob/dev/docs/ui-guidelines.md#localizability-testing).'
       description: 'Remind PR author to test accessibility and localizability'
-  - if:
-    - payloadType: Pull_Request
-    - isAction:
-        action: Opened
-    - filesMatchPattern:
-        pattern: '.*\.yml$'
-        matchAny: true
-    then:
-    - addReply:
-        reply: 'Since this PR is changing CI as it modifies YML files, please verify that you''ve addressed how this change should apply to release branches. Either: 
-        
-        - [ ] Link to equivalent PRs for each currently [supported branch](https://github.com/NuGet/Client.Engineering/blob/main/docs/HotSeat/NuGet.Client-Branches.md#supported-branches). 
-        
-        **or**
-        
-        - [ ] Explain in the PR description why this change doesn''t apply to release branches.'
+    - if:
+      - payloadType: Pull_Request
+      - isAction:
+          action: Opened
+      - filesMatchPattern:
+          pattern: '.*\.yml$'
+          matchAny: true
+      then:
+      - addReply:
+          reply: 'Since this PR is changing CI as it modifies YML files, please verify that you''ve addressed how this change should apply to release branches. Either: 
+          
+          - [ ] Link to equivalent PRs for each currently [supported branch](https://github.com/NuGet/Client.Engineering/blob/main/docs/HotSeat/NuGet.Client-Branches.md#supported-branches). 
+          
+          **or**
+          
+          - [ ] Explain in the PR description why this change doesn''t apply to release branches.'
       description: 'Remind PR author to address release branches when making CI changes.'
     - if:
       - payloadType: Pull_Request

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -181,7 +181,7 @@ configuration:
       - addReply:
           reply: 'Since this PR is changing CI as it modifies YML files, please verify that you''ve addressed how this change should apply to release branches. Either: 
           
-          - [ ] Link to equivalent PRs for each currently [supported branch](https://github.com/NuGet/Client.Engineering/blob/main/docs/HotSeat/NuGet.Client-Branches.md#supported-branches). 
+          - [ ] Link to equivalent PRs or Issues for each currently [supported branch](https://github.com/NuGet/Client.Engineering/blob/main/docs/HotSeat/NuGet.Client-Branches.md#supported-branches). 
           
           **or**
           

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -170,6 +170,23 @@ configuration:
         
         - [ ] Complete [localizability testing](https://github.com/NuGet/NuGet.Client/blob/dev/docs/ui-guidelines.md#localizability-testing).'
       description: 'Remind PR author to test accessibility and localizability'
+  - if:
+    - payloadType: Pull_Request
+    - isAction:
+        action: Opened
+    - filesMatchPattern:
+        pattern: '.*\.yml$'
+        matchAny: true
+    then:
+    - addReply:
+        reply: 'Since this PR is changing CI as it modifies YML files, please verify that you''ve addressed how this change should apply to release branches. Either: 
+        
+        - [ ] Link to equivalent PRs for each currently [supported branch](https://github.com/NuGet/Client.Engineering/blob/main/docs/HotSeat/NuGet.Client-Branches.md#supported-branches). 
+        
+        **or**
+        
+        - [ ] Explain in the PR description why this change doesn''t apply to release branches.'
+      description: 'Remind PR author to address release branches when making CI changes.'
     - if:
       - payloadType: Pull_Request
       - labelAdded:


### PR DESCRIPTION
In an effort to help PR authors remember to address all of our servicing branches for CI changes, introduce a bot rule to comment asking for either the description to explain how servicing branches are affected, or link to Issues/PRs that will address servicing branches.

![image](https://github.com/user-attachments/assets/321e1052-74ec-427f-9ba9-109ed18fa996)
