### PR TITLE
Fix whitespace formatting errors in 6.10 branch

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -868,7 +868,7 @@ namespace NuGet.DependencyResolver
                 // Some node were marked ambiguous, thus we need another run to check if nodes previously not marked ambiguous should be marked ambiguous this time.
                 if (!nodeMarkedAmbiguous)
                     break;
-            };
+            }
         }
 
         private static void RejectCentralTransitiveBecauseOfRejectedParents<TItem>(this GraphNode<TItem> root, Tracker<TItem> tracker, List<GraphNode<TItem>> centralTransitiveNodes)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -9815,7 +9815,7 @@ namespace NuGet.CommandLine.Test
                     result.Files.Clear();
                     source.Add(result);
                     return result;
-                };
+                }
 
                 var projectA = SimpleTestProjectContext.CreateNETCore(
                    "projectA",
@@ -10066,7 +10066,7 @@ namespace NuGet.CommandLine.Test
                     result.Files.Clear();
                     source.Add(result);
                     return result;
-                };
+                }
 
                 var projectA = SimpleTestProjectContext.CreateNETCore(
                    "projectA",

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/ListPackageCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/ListPackageCommandRunnerTests.cs
@@ -244,7 +244,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                 if (includeTopLevelPositives)
                 {
                     topLevelPackages.Add(ListPackageTestHelper.CreateInstalledPackageReference(isDeprecated: true));
-                };
+                }
                 if (includeTransitivePositives)
                 {
                     transitivePackages.Add(ListPackageTestHelper.CreateInstalledPackageReference(isDeprecated: true));
@@ -318,7 +318,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                 if (includeTopLevelPositives)
                 {
                     topLevelPackages.Add(ListPackageTestHelper.CreateInstalledPackageReference(vulnerabilityCount: 1));
-                };
+                }
                 if (includeTransitivePositives)
                 {
                     transitivePackages.Add(ListPackageTestHelper.CreateInstalledPackageReference(vulnerabilityCount: 1));


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->

## Description

Fix whitespace formatting errors in 6.10 branch. [Link to official build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=11552941&view=logs&j=05c93c9e-1e6d-54c9-bea4-701773852b98&t=ace55480-569f-557a-9ed3-d2ed255eda7f&l=20). It seems the implementation of the `dotnet format whitespace --verify-no-changes NuGet.sln` command may have changed, causing these issues. 

> ==============================================================================
Generating script.
Script contents: shell
dotnet format whitespace --verify-no-changes NuGet.sln
========================== Starting Command Output ===========================
"C:\Windows\system32\cmd.exe" /D /E:ON /V:OFF /S /C "CALL "D:\a\_work\_temp\31b3439d-7e4a-4629-9c27-22da3e84655a.cmd""
Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.
D:\a\_work\1\s\src\NuGet.Core\NuGet.DependencyResolver.Core\GraphModel\GraphOperations.cs(871,14): error WHITESPACE: Fix whitespace formatting. Insert '\r\n\s\s\s\s\s\s\s\s\s\s\s\s'. 
[D:\a\_work\1\s\src\NuGet.Core\NuGet.DependencyResolver.Core\NuGet.DependencyResolver.Core.csproj]
D:\a\_work\1\s\test\NuGet.Clients.Tests\NuGet.CommandLine.Test\RestoreNETCoreTest.cs(9818,18): error WHITESPACE: Fix whitespace formatting. Insert '\r\n\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s'. [D:\a\_work\1\s\test\NuGet.Clients.Tests\NuGet.CommandLine.Test\NuGet.CommandLine.Test.csproj]
D:\a\_work\1\s\test\NuGet.Clients.Tests\NuGet.CommandLine.Test\RestoreNETCoreTest.cs(10069,18): error WHITESPACE: Fix whitespace formatting. Insert '\r\n\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s'. [D:\a\_work\1\s\test\NuGet.Clients.Tests\NuGet.CommandLine.Test\NuGet.CommandLine.Test.csproj]
D:\a\_work\1\s\test\NuGet.Core.Tests\NuGet.CommandLine.Xplat.Tests\ListPackageCommandRunnerTests.cs(247,18): error WHITESPACE: Fix whitespace formatting. Insert '\r\n\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s'. [D:\a\_work\1\s\test\NuGet.Core.Tests\NuGet.CommandLine.Xplat.Tests\NuGet.CommandLine.Xplat.Tests.csproj]
D:\a\_work\1\s\test\NuGet.Core.Tests\NuGet.CommandLine.Xplat.Tests\ListPackageCommandRunnerTests.cs(321,18): error WHITESPACE: Fix whitespace formatting. Insert '\r\n\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s'. [D:\a\_work\1\s\test\NuGet.Core.Tests\NuGet.CommandLine.Xplat.Tests\NuGet.CommandLine.Xplat.Tests.csproj]
##[error]Cmd.exe exited with code '2'.
Finishing: Check whitespace formatting

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- ~[ ] Added tests~
- ~[ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
