### PR TITLE
Add deprecated option integration tests

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -557,7 +557,7 @@ namespace NuGet.CommandLine.Test
         /// </summary>
         public static JObject CreateSinglePackageRegistrationBlob(MockServer server, string id, string version)
         {
-            return FeedUtilities.CreatePackageRegistrationBlob(server.Uri, id, new KeyValuePair<string, bool>[] { new KeyValuePair<string, bool>(version, true) });
+            return FeedUtilities.CreatePackageRegistrationBlob(server.Uri, id, new KeyValuePair<string, bool>[] { new KeyValuePair<string, bool>(version, true) }, new HashSet<PackageIdentity>());
         }
 
         public static string CreateProjFileContent(

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -12,6 +12,7 @@ using System.Xml.Linq;
 using FluentAssertions;
 using Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess;
 using NuGet.Configuration;
+using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Test.Utility;
 using NuGet.XPlat.FuncTest;
@@ -865,6 +866,54 @@ namespace Dotnet.Integration.Test
             packageA100.Dependencies.Add(packageB100);
 
             await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packageA100);
+
+            using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource);
+            var packageSource = new PackageSource(mockServer.ServiceIndexUri, "source");
+            pathContext.Settings.RemoveSource(packageSource.Name);
+            pathContext.Settings.AddSource(packageSource.Name, packageSource.Source, allowInsecureConnectionsValue: "true");
+            mockServer.Start();
+
+            mockServer.DeprecatedPackages.Add(packageB100.Identity);
+
+            _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, $"add package A --version 1.0.0", testOutputHelper: _testOutputHelper);
+
+            // Act
+            var result = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, $"list package --deprecated {additionalOptions}", testOutputHelper: _testOutputHelper);
+
+            // Assert
+            string[] lines = result.AllOutput.Split([Environment.NewLine], StringSplitOptions.RemoveEmptyEntries);
+            lines.Should().NotContain(DirectHeading);
+
+            if (shouldReportTransitivePackages)
+            {
+                lines.Should().Contain(TransitiveHeading);
+                var index = Array.IndexOf(lines, TransitiveHeading) + 1;
+                lines[index].Should().StartWith("   > B                     1.0.0      CriticalBugs");
+                lines[index + 1].Should().NotStartWith("   >");
+            }
+            else
+            {
+                lines.Should().NotContain(TransitiveHeading);
+            }
+        }
+
+        [PlatformTheory(Platform.Windows)]
+        [InlineData(" --include-transitive", true)]
+        [InlineData(" --include-transitive --framework net10.0", false)]
+        [InlineData(" --include-transitive --framework net472", true)]
+        [InlineData("", false)]
+        public async Task DeprecatedOption_WithMultiTargetedProjectsAndDeprecatedPackages_Succeeds(string additionalOptions, bool shouldReportTransitivePackages)
+        {
+            // Arrange
+            using var pathContext = _fixture.CreateSimpleTestPathContext();
+            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, "net472;net10.0");
+
+            var packageA100 = new SimpleTestPackageContext("A", "1.0.0");
+            var packageB100 = new SimpleTestPackageContext("B", "1.0.0");
+            packageA100.PerFrameworkDependencies.Add(FrameworkConstants.CommonFrameworks.Net472, [packageB100]);
+            packageA100.PerFrameworkDependencies.Add(FrameworkConstants.CommonFrameworks.Net10_0, []);
+
+            await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packageA100, packageB100);
 
             using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource);
             var packageSource = new PackageSource(mockServer.ServiceIndexUri, "source");

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -27,6 +27,9 @@ namespace Dotnet.Integration.Test
     {
         private static readonly string ProjectName = "test_project_listpkg";
 
+        private static readonly string TransitiveHeading = "   Transitive Package      Resolved   Reason(s)      Alternative";
+        private static readonly string DirectHeading = "   Top-level Package      Requested   Resolved   Reason(s)      Alternative";
+
         private readonly DotnetIntegrationTestFixture _fixture;
         private readonly ITestOutputHelper _testOutputHelper;
 
@@ -814,6 +817,83 @@ namespace Dotnet.Integration.Test
                 Environment.NewLine + string.Join(Environment.NewLine, httpSources.Select(s => s.Name)));
 
             result.AllOutput.Should().Contain(expectedError);
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task DeprecatedOption_WithDirectPackageReferenceDeprecated_Succeeds()
+        {
+            // Arrange
+            using var pathContext = _fixture.CreateSimpleTestPathContext();
+            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, "net472");
+
+            var packageA100 = new SimpleTestPackageContext("A", "1.0.0");
+            await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packageA100);
+
+            using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource);
+            var packageSource = new PackageSource(mockServer.ServiceIndexUri, "source");
+            pathContext.Settings.RemoveSource(packageSource.Name);
+            pathContext.Settings.AddSource(packageSource.Name, packageSource.Source, allowInsecureConnectionsValue: "true");
+            mockServer.Start();
+
+            mockServer.DeprecatedPackages.Add(packageA100.Identity);
+
+            _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, $"add package A --version 1.0.0", testOutputHelper: _testOutputHelper);
+
+            // Act
+            var result = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, $"list package --deprecated", testOutputHelper: _testOutputHelper);
+
+            // Assert
+            string[] lines = result.AllOutput.Split([Environment.NewLine], StringSplitOptions.RemoveEmptyEntries);
+            lines.Should().Contain(DirectHeading);
+            var index = Array.IndexOf(lines, DirectHeading) + 1;
+            lines[index].Should().StartWith("   > A                    1.0.0       1.0.0      CriticalBugs");
+            lines[index + 1].Should().NotStartWith("   >");
+            lines.Should().NotContain(TransitiveHeading);
+        }
+
+        [PlatformTheory(Platform.Windows)]
+        [InlineData(" --include-transitive", true)]
+        [InlineData("", false)]
+        public async Task DeprecatedOption_WithTransitivePackageReferenceDeprecated_Succeeds(string additionalOptions, bool shouldReportTransitivePackages)
+        {
+            // Arrange
+            using var pathContext = _fixture.CreateSimpleTestPathContext();
+            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, "net472");
+
+            var packageA100 = new SimpleTestPackageContext("A", "1.0.0");
+            var packageB100 = new SimpleTestPackageContext("B", "1.0.0");
+            packageA100.Dependencies.Add(packageB100);
+
+            await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packageA100);
+
+            using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource);
+            var packageSource = new PackageSource(mockServer.ServiceIndexUri, "source");
+            pathContext.Settings.RemoveSource(packageSource.Name);
+            pathContext.Settings.AddSource(packageSource.Name, packageSource.Source, allowInsecureConnectionsValue: "true");
+            mockServer.Start();
+
+            mockServer.DeprecatedPackages.Add(packageB100.Identity);
+
+            _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, $"add package A --version 1.0.0", testOutputHelper: _testOutputHelper);
+
+            // Act
+            var result = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, $"list package --deprecated {additionalOptions}", testOutputHelper: _testOutputHelper);
+
+            // Assert
+            string[] lines = result.AllOutput.Split([Environment.NewLine], StringSplitOptions.RemoveEmptyEntries);
+            lines.Should().NotContain(DirectHeading);
+
+            if (shouldReportTransitivePackages)
+            {
+                lines.Should().Contain(TransitiveHeading);
+                var index = Array.IndexOf(lines, TransitiveHeading) + 1;
+                lines[index].Should().StartWith("   > B                     1.0.0      CriticalBugs");
+                lines[index + 1].Should().NotStartWith("   >");
+            }
+            else
+            {
+                lines.Should().NotContain(TransitiveHeading);
+            }
         }
 
         private static string CollapseSpaces(string input)

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -848,7 +848,10 @@ namespace Dotnet.Integration.Test
             lines.Should().Contain(DirectHeading);
             var index = Array.IndexOf(lines, DirectHeading) + 1;
             lines[index].Should().StartWith("   > A                    1.0.0       1.0.0      CriticalBugs");
-            lines[index + 1].Should().NotStartWith("   >");
+            if (lines.Length > index + 1)
+            {
+                lines[index + 1].Should().NotStartWith("   >");
+            }
             lines.Should().NotContain(TransitiveHeading);
         }
 
@@ -889,7 +892,10 @@ namespace Dotnet.Integration.Test
                 lines.Should().Contain(TransitiveHeading);
                 var index = Array.IndexOf(lines, TransitiveHeading) + 1;
                 lines[index].Should().StartWith("   > B                     1.0.0      CriticalBugs");
-                lines[index + 1].Should().NotStartWith("   >");
+                if (lines.Length > index + 1)
+                {
+                    lines[index + 1].Should().NotStartWith("   >");
+                }
             }
             else
             {
@@ -937,7 +943,10 @@ namespace Dotnet.Integration.Test
                 lines.Should().Contain(TransitiveHeading);
                 var index = Array.IndexOf(lines, TransitiveHeading) + 1;
                 lines[index].Should().StartWith("   > B                     1.0.0      CriticalBugs");
-                lines[index + 1].Should().NotStartWith("   >");
+                if (lines.Length > index + 1)
+                {
+                    lines[index + 1].Should().NotStartWith("   >");
+                }
             }
             else
             {

--- a/test/TestUtilities/Test.Utility/FileSystemBackedV3MockServer.cs
+++ b/test/TestUtilities/Test.Utility/FileSystemBackedV3MockServer.cs
@@ -33,6 +33,8 @@ namespace Test.Utility
 
         public Dictionary<string, List<(Uri, PackageVulnerabilitySeverity, VersionRange)>> Vulnerabilities = new();
 
+        public ISet<PackageIdentity> DeprecatedPackages { get; } = new HashSet<PackageIdentity>();
+
         public string ServiceIndexUri => _builder.GetV3Source();
 
         private void InitializeServer()
@@ -139,7 +141,7 @@ namespace Test.Utility
                         {
                             response.ContentType = "text/javascript";
                             var packageToListedMapping = packages.Select(e => new KeyValuePair<PackageIdentity, bool>(e.Identity, !UnlistedPackages.Contains(e.Identity))).ToArray();
-                            MockResponse mockResponse = _builder.BuildRegistrationIndexResponse(Uri, packageToListedMapping);
+                            MockResponse mockResponse = _builder.BuildRegistrationIndexResponse(Uri, packageToListedMapping, DeprecatedPackages);
                             SetResponseContent(response, mockResponse.Content);
                         });
                     }

--- a/test/TestUtilities/Test.Utility/MockResponses/FeedUtilities.cs
+++ b/test/TestUtilities/Test.Utility/MockResponses/FeedUtilities.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Newtonsoft.Json.Linq;
+using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Versioning;
 
@@ -95,7 +96,7 @@ namespace Test.Utility
         /// <summary>
         /// Create a registration blob for a package
         /// </summary>
-        public static JObject CreatePackageRegistrationBlob(string serverUri, string id, IEnumerable<KeyValuePair<string, bool>> versionToListedMap)
+        public static JObject CreatePackageRegistrationBlob(string serverUri, string id, IEnumerable<KeyValuePair<string, bool>> versionToListedMap, ISet<PackageIdentity> deprecatedPackages)
         {
             var indexUrl = string.Format(CultureInfo.InvariantCulture,
                                     "{0}reg/{1}/index.json", serverUri, id);
@@ -132,13 +133,18 @@ namespace Test.Utility
             page.Add(new JProperty("items", items));
             foreach (var versionToListed in versionToListedMap)
             {
-                var item = GetPackageRegistrationItem(serverUri, id, version: versionToListed.Key, listed: versionToListed.Value, indexUrl);
+                var item = GetPackageRegistrationItem(serverUri,
+                    id,
+                    version: versionToListed.Key,
+                    listed: versionToListed.Value,
+                    isDeprecated: deprecatedPackages.Contains(new PackageIdentity(id, new NuGetVersion(versionToListed.Key))),
+                    indexUrl);
                 items.Add(item);
             }
             return regBlob;
         }
 
-        private static JObject GetPackageRegistrationItem(string serverUri, string id, string version, bool listed, string indexUrl)
+        private static JObject GetPackageRegistrationItem(string serverUri, string id, string version, bool listed, bool isDeprecated, string indexUrl)
         {
             var item = new JObject();
 
@@ -157,6 +163,10 @@ namespace Test.Utility
             catalogEntry.Add(new JProperty("@id",
                 string.Format(CultureInfo.InvariantCulture, "{0}catalog/{1}/{2}.json", serverUri, id, version)));
 
+            if (isDeprecated)
+            {
+                catalogEntry.Add(GetDeprecatedEntry());
+            }
             catalogEntry.Add(new JProperty("@type", "PackageDetails"));
             catalogEntry.Add(new JProperty("authors", "test"));
             catalogEntry.Add(new JProperty("description", "test"));
@@ -175,6 +185,19 @@ namespace Test.Utility
             catalogEntry.Add(new JProperty("tags", new JArray()));
 
             return item;
+
+            static JProperty GetDeprecatedEntry()
+            {
+                return new JProperty("deprecation",
+                                    new JObject
+                                    {
+                        new JProperty("reasons", new JArray
+                        {
+                            "CriticalBugs"
+                        }),
+                        new JProperty("message", "This package is unstable and broken!")
+                                    });
+            }
         }
 
         public static void AddVulnerabilitiesResource(JObject index, string serverUri)

--- a/test/TestUtilities/Test.Utility/MockResponses/FeedUtilities.cs
+++ b/test/TestUtilities/Test.Utility/MockResponses/FeedUtilities.cs
@@ -188,15 +188,16 @@ namespace Test.Utility
 
             static JProperty GetDeprecatedEntry()
             {
-                return new JProperty("deprecation",
-                                    new JObject
-                                    {
-                        new JProperty("reasons", new JArray
+                return new JProperty(
+                        "deprecation",
+                        new JObject
                         {
-                            "CriticalBugs"
-                        }),
-                        new JProperty("message", "This package is unstable and broken!")
-                                    });
+                            new JProperty("reasons", new JArray
+                            {
+                                "CriticalBugs"
+                            }),
+                            new JProperty("message", "This package is unstable and broken!")
+                        });
             }
         }
 

--- a/test/TestUtilities/Test.Utility/MockResponses/MockResponseBuilder.cs
+++ b/test/TestUtilities/Test.Utility/MockResponses/MockResponseBuilder.cs
@@ -180,17 +180,18 @@ namespace Test.Utility
                 packageIdentities.Select(e =>
                     new KeyValuePair<PackageIdentity, bool>(
                         e,
-                        true)).ToArray());
+                        true)).ToArray(),
+                new HashSet<PackageIdentity>());
         }
 
-        public MockResponse BuildRegistrationIndexResponse(string serverUri, KeyValuePair<PackageIdentity, bool>[] packageIdentityToListed)
+        public MockResponse BuildRegistrationIndexResponse(string serverUri, KeyValuePair<PackageIdentity, bool>[] packageIdentityToListed, ISet<PackageIdentity> deprecatedPackages)
         {
             var id = packageIdentityToListed[0].Key.Id.ToLowerInvariant();
             var versions = packageIdentityToListed.Select(
                 e => new KeyValuePair<string, bool>(
                     e.Key.Version.ToNormalizedString().ToLowerInvariant(),
                     e.Value));
-            var registrationIndex = FeedUtilities.CreatePackageRegistrationBlob(serverUri, id, versions);
+            var registrationIndex = FeedUtilities.CreatePackageRegistrationBlob(serverUri, id, versions, deprecatedPackages);
 
             return new MockResponse
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

- Add an option in our mock server to advertise deprecated packages
- Add `--deprecated` option integration tests covering the various scenarios, direct, transitive and multi-targeting. 

This is part of our ongoing work to enhance the dotnet.exe test suite

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
