### PR TITLE
General Page resets cached settings again

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/GeneralPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/GeneralPage.cs
@@ -23,15 +23,15 @@ namespace NuGet.PackageManagement.VisualStudio.Options
         private const string MonikerPackagesConfig = "packages-config";
         private const string MonikerShowPackageManagementChooser = "packageManagement.showPackageManagementChooser";
 
-        private PackageRestoreConsent? _packageRestoreConsent;
-        private BindingRedirectBehavior? _bindingRedirectBehavior;
-        private PackageManagementFormat? _packageManagementFormat;
+        internal PackageRestoreConsent? _packageRestoreConsent;
+        internal BindingRedirectBehavior? _bindingRedirectBehavior;
+        internal PackageManagementFormat? _packageManagementFormat;
 
         public GeneralPage(VSSettings vsSettings)
             : base(vsSettings)
         { }
 
-        private BindingRedirectBehavior BindingRedirectBehavior
+        internal BindingRedirectBehavior BindingRedirectBehavior
         {
             get
             {
@@ -44,7 +44,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             }
         }
 
-        private PackageRestoreConsent PackageRestoreConsent
+        internal PackageRestoreConsent PackageRestoreConsent
         {
             get
             {
@@ -57,7 +57,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             }
         }
 
-        private PackageManagementFormat PackageManagementFormat
+        internal PackageManagementFormat PackageManagementFormat
         {
             get
             {
@@ -68,6 +68,17 @@ namespace NuGet.PackageManagement.VisualStudio.Options
 
                 return _packageManagementFormat;
             }
+        }
+
+        /// <summary>
+        /// Reset any cached values for this specific page instance when the settings change.
+        /// </summary>
+        internal override void VsSettings_SettingsChanged(object sender, EventArgs e)
+        {
+            _packageRestoreConsent = null;
+            _bindingRedirectBehavior = null;
+            _packageManagementFormat = null;
+            base.VsSettings_SettingsChanged(sender, e);
         }
 
         public override Task<ExternalSettingOperationResult<T>> GetValueAsync<T>(string moniker, CancellationToken cancellationToken)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/NuGetExternalSettingsProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/NuGetExternalSettingsProvider.cs
@@ -37,7 +37,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             return Task.FromResult(ExternalSettingOperationResult.SuccessResult((IReadOnlyList<EnumChoice>)new List<EnumChoice>().AsReadOnly()));
         }
 
-        protected virtual void VsSettings_SettingsChanged(object sender, EventArgs e)
+        internal virtual void VsSettings_SettingsChanged(object sender, EventArgs e)
         {
             SettingValuesChanged?.Invoke(this, ExternalSettingsChangedEventArgs.SomeOrAll);
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/GeneralPageTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/GeneralPageTests.cs
@@ -3,7 +3,10 @@
 
 #nullable enable
 
+using System;
+using FluentAssertions;
 using NuGet.PackageManagement.VisualStudio.Options;
+using Xunit;
 
 namespace NuGet.PackageManagement.VisualStudio.Test.Options
 {
@@ -12,6 +15,31 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         protected override GeneralPage CreateInstance(VSSettings? vsSettings)
         {
             return new GeneralPage(vsSettings!);
+        }
+
+        [Fact]
+        public void VsSettings_SettingsChanged_WhenCalled_ClearsCachedSettings()
+        {
+            // Arrange
+            GeneralPage instance = CreateInstance(_vsSettings);
+
+            // Access each cached setting to ensure it's created.
+            var bindingRedirectBehavior = instance.BindingRedirectBehavior;
+            bindingRedirectBehavior.Should().NotBeNull();
+
+            var packageRestoreConsent = instance.PackageRestoreConsent;
+            packageRestoreConsent.Should().NotBeNull();
+
+            var packageManagementFormat = instance.PackageManagementFormat;
+            packageManagementFormat.Should().NotBeNull();
+
+            // Act
+            instance.VsSettings_SettingsChanged(this, EventArgs.Empty);
+
+            // Assert
+            instance._bindingRedirectBehavior.Should().BeNull();
+            instance._packageRestoreConsent.Should().BeNull();
+            instance._packageManagementFormat.Should().BeNull();
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/NuGetExternalSettingsProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/NuGetExternalSettingsProviderTests.cs
@@ -17,8 +17,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
 {
     public abstract class NuGetExternalSettingsProviderTests<TPage> where TPage : NuGetExternalSettingsProvider
     {
-        private VSSettings _vsSettings;
-        private const string MonikerDoesNotExist = "TESTING!doesNotExist";
+        protected VSSettings _vsSettings;
+        protected const string MonikerDoesNotExist = "TESTING!doesNotExist";
 
         protected abstract TPage CreateInstance(VSSettings? vsSettings);
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/14302

## Description

I recently refactored the General page and extracted an abstract class. I created a virtual method for VS Settings Changed events so that pages could override their behavior in case they have page-specific caches to invalidate. I somehow missed doing this for the general page, so this PR adds it back and adds a test around it.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
