### PR TITLE
When creating PrunePackageReference, set original string to allow for better hashing and write performance

### DIFF
--- a/src/NuGet.Core/NuGet.LibraryModel/PrunePackageReference.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/PrunePackageReference.cs
@@ -39,7 +39,7 @@ namespace NuGet.LibraryModel
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_PrunePackageReferenceMissingVersion, name));
             }
 
-            return new PrunePackageReference(name, new VersionRange(maxVersion: NuGetVersion.Parse(version), includeMaxVersion: true, originalString: version));
+            return new PrunePackageReference(name, VersionRange.Parse("(," + version + "]"));
         }
 
         public override string ToString()

--- a/src/NuGet.Core/NuGet.LibraryModel/PrunePackageReference.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/PrunePackageReference.cs
@@ -39,7 +39,7 @@ namespace NuGet.LibraryModel
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_PrunePackageReferenceMissingVersion, name));
             }
 
-            return new PrunePackageReference(name, new VersionRange(maxVersion: NuGetVersion.Parse(version), includeMaxVersion: true));
+            return new PrunePackageReference(name, new VersionRange(maxVersion: NuGetVersion.Parse(version), includeMaxVersion: true, originalString: version));
         }
 
         public override string ToString()

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/PrunePackageReferenceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/PrunePackageReferenceTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using FluentAssertions;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.LibraryModel.Tests
+{
+    public class PrunePackageReferenceTests
+    {
+        [Fact]
+        public void Constructor_ValidParameters_CreatesInstance()
+        {
+            // Arrange
+            string name = "TestPackage";
+            VersionRange version = VersionRange.Parse("1.0.0");
+            // Act
+            var prunePackageReference = new PrunePackageReference(name, version);
+
+            // Assert
+            prunePackageReference.Name.Should().Be(name);
+            prunePackageReference.VersionRange.Should().Be(version);
+        }
+
+        [Fact]
+        public void Create_ValidParameters_CreatesInstance()
+        {
+            // Arrange
+            string name = "TestPackage";
+            string version = "1.0.0";
+            // Act
+            var prunePackageReference = PrunePackageReference.Create(name, version);
+
+            // Assert
+            prunePackageReference.Name.Should().Be(name);
+            prunePackageReference.VersionRange.OriginalString.Should().Be("(," + version + "]");
+            prunePackageReference.VersionRange.IsMinInclusive.Should().BeFalse();
+            prunePackageReference.VersionRange.IsMaxInclusive.Should().BeTrue();
+            prunePackageReference.VersionRange.MinVersion.Should().BeNull();
+            prunePackageReference.VersionRange.MaxVersion.Should().Be(NuGetVersion.Parse("1.0.0"));
+        }
+
+        [Theory]
+        [InlineData("TestPackage", "TestPackage", "1.0.0", "1.0.0", true)]
+        [InlineData("testpackage", "TestPackage", "1.0.0", "1.0.0", true)]
+        [InlineData("TestPackage", "testpackage", "1.0.0", "1.0.0", true)]
+        [InlineData("TestPackage", "TestPackage", "2.0.0", "1.0.0", false)]
+        [InlineData("TestPackage", "TestPackage", "1.0.0", "2.0.0", false)]
+        [InlineData("TestPackage1", "TestPackage", "1.0.0", "1.0.0", false)]
+        public void Equals_ComparesPackageReferences_ReturnsExpectedResult(
+            string leftName,
+            string rightName,
+            string leftVersion,
+            string rightVersion,
+            bool expectedResult)
+        {
+            // Arrange
+            var left = new PrunePackageReference(leftName, VersionRange.Parse(leftVersion));
+            var right = new PrunePackageReference(rightName, VersionRange.Parse(rightVersion));
+
+            // Act & Assert
+            left.Equals(right).Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [InlineData("TestPackage", "TestPackage", "1.0.0", "1.0.0", true)]
+        [InlineData("testpackage", "TestPackage", "1.0.0", "1.0.0", true)]
+        [InlineData("TestPackage", "testpackage", "1.0.0", "1.0.0", true)]
+        [InlineData("TestPackage", "TestPackage", "2.0.0", "1.0.0", false)]
+        [InlineData("TestPackage", "TestPackage", "1.0.0", "2.0.0", false)]
+        [InlineData("TestPackage1", "TestPackage", "1.0.0", "1.0.0", false)]
+        public void HashCode_ComparesPackageReferences_ReturnsExpectedResult(
+            string leftName,
+            string rightName,
+            string leftVersion,
+            string rightVersion,
+            bool expectedResult)
+        {
+            // Arrange
+            var left = new PrunePackageReference(leftName, VersionRange.Parse(leftVersion));
+            var right = new PrunePackageReference(rightName, VersionRange.Parse(rightVersion));
+
+            // Act & Assert
+            left.GetHashCode().Equals(right.GetHashCode()).Should().Be(expectedResult);
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3273

## Description

The way PrunePackageReference is currently created is to avoid unneeded double parsing by setting the boundaries manually. 
What this meant is that there's no original string, which means:
https://github.com/NuGet/NuGet.Client/blob/0ccca7268b42aafa776420f04aad0612fc16fb7d/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs#L644-L657
Ends up calling VersionRange ToNormalizedString (and skips VersionRange caching), which can allocate ~100MB in some of the test cases. 

To fix that, we create the string for the range use VersionRange.Parse which sets the original string and improves caching performance as well as caches VersionRange objects (Parse caches objects)

### Numbers

The traces in the automated tests show about ~100MB. I used NuGet.CLient with pruning enable and the numbers are as follows.

Before:

```
Name                                                                	Inc %	          Inc
nuget.projectmodel!NuGet.ProjectModel.DependencyGraphSpec.GetHash()	  3.0	   67,422,552
+ nuget.projectmodel!DependencyGraphSpec.Write                      	  2.9	   65,211,072
|+ nuget.projectmodel!PackageSpecWriter.Write                       	  2.9	   65,211,072
| + nuget.projectmodel!PackageSpecWriter.SetFrameworks              	  1.9	   43,285,024
| |+ nuget.projectmodel!PackageSpecWriter.SetPackagesToPrune        	  1.4	   30,692,472
| ||+ nuget.versioning!VersionRange.ToNormalizedString              	  1.4	   30,692,472
```
After:

```
Name                                                                                                                                            	Inc %	          Inc
nuget.projectmodel!NuGet.ProjectModel.DependencyGraphSpec.GetHash()                                                                            	  1.6	   36,091,320
+ nuget.projectmodel!DependencyGraphSpec.Write                                                                                                  	  1.5	   34,318,048
|+ nuget.projectmodel!PackageSpecWriter.Write                                                                                                   	  1.5	   34,209,440
||+ nuget.projectmodel!PackageSpecWriter.SetMSBuildMetadata                                                                                     	  1.0	   23,299,784
||+ nuget.projectmodel!PackageSpecWriter.SetFrameworks                                                                                          	  0.5	   10,581,832
|||+ nuget.projectmodel!PackageSpecWriter.SetDependencies                                                                                       	  0.2	    5,040,616
|||+ nuget.projectmodel!PackageSpecWriter.SetImports                                                                                            	  0.1	    2,768,280
|||+ nuget.frameworks!NuGetFramework.GetShortFolderName                                                                                         	  0.0	    1,019,928
|||+ nuget.projectmodel!PackageSpecWriter.SetFrameworkReferences                                                                                	  0.0	      827,120
|||+ system.core.ni!?                                                                                                                           	  0.0	      581,792
|||+ nuget.projectmodel!PackageSpecWriter.SetCentralDependencies                                                                                	  0.0	      213,024
|||+ nuget.projectmodel!PackageSpecWriter.SetPackagesToPrune                                                                                    	  0.0	      131,072
||| + mscorlib.ni!System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon].System.Collections.Generic.IEnumerable>.GetEnumerator()	  0.0	      131,072
|||  + clr!JIT_New                                                                                                                              	  0.0	      131,072
|||   + clr!WKS::GCHeap::Alloc                                                                                                                  	  0.0	      131,072
|||    + clr!WKS::gc_heap::try_allocate_more_space                                                                                              	  0.0	      131,072
|||     + clr!GCToCLREventSink::FireGCAllocationTick_V3                                                                                         	  0.0	      131,072
|||      + clr!CoTemplate_qqhxpzqp                                                                                                              	  0.0	      131,072
|||       + clr!EtwCallout                                                                                                                      	  0.0	      131,072
|||        + clr!ETW::SamplingLog::SendStackTrace                                                                                               	  0.0	      131,072
|||         + Type Enumerator[System.String,NuGet.LibraryModel.PrunePackageReference]                                                           	  0.0	      131,072
```

Note that nuget.projectmodel!PackageSpecWriter.SetPackagesToPrune goes from 30,692,472 to 131,072.
This does suggest we should probably rethink the usage of normalized strings in the no-op check, but that's a consideration for another day :) 

There's a give and a take with this ofc, SetPackagesToPrune is not the only thing to look at. 

PrunePackageReference.Create allocations increase, but the increase is very minimal given that VersionRange.Parse has caching.
 
Before:
```
Name                                                  	Inc %	         Inc
||| nuget.librarymodel!PrunePackageReference.Create      	  0.1	   1,180,552
||| + clr!JIT_New                                         	  0.1	   1,180,552
||| + clr!WKS::GCHeap::Alloc                             	  0.1	   1,180,552
|||   + clr!WKS::gc_heap::try_allocate_more_space         	  0.1	   1,180,552
|||    + clr!GCToCLREventSink::FireGCAllocationTick_V3    	  0.1	   1,180,552
|||     + clr!CoTemplate_qqhxpzqp                         	  0.1	   1,180,552
|||      + clr!EtwCallout                                 	  0.1	   1,180,552
|||       + clr!ETW::SamplingLog::SendStackTrace          	  0.1	   1,180,552
|||        + Type NuGet.Versioning.VersionRange           	  0.0	     647,880
|||        + Type NuGet.LibraryModel.PrunePackageReference	  0.0	     532,672
```
After:
```
Name                                            	Inc %	         Inc
||| nuget.librarymodel!PrunePackageReference.Create	  0.1	   1,603,152
||| + mscorlib.ni!String.Concat                     	  0.0	     962,416
||| + clr!JIT_New                                   	  0.0	     531,040
||| + nuget.versioning!VersionRange.Parse           	  0.0	     109,696
```

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
