### PR TITLE
Populate audit sources consistently

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -189,6 +189,7 @@ namespace NuGet.CommandLine
                 packageRestoredEvent: null,
                 packageRestoreFailedEvent: (sender, args) => { failedEvents.Enqueue(args); },
                 sourceRepositories: packageSources.Select(sourceRepositoryProvider.CreateRepository),
+                auditSources: RestoreCommand.GetAuditSources(SourceProvider),
                 maxNumberOfParallelTasks: DisableParallelProcessing ? 1 : PackageManagementConstants.DefaultMaxDegreeOfParallelism,
                 enableNuGetAudit: true,
                 restoreAuditProperties: new(),

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -352,6 +352,7 @@ namespace NuGet.CommandLine
             var repositories = packageSources
                 .Select(sourceRepositoryProvider.CreateRepository)
                 .ToList();
+            var auditSources = GetAuditSources(SourceProvider);
 
             if (!areAnyPackagesMissing)
             {
@@ -371,8 +372,6 @@ namespace NuGet.CommandLine
                     restoreSummaries);
 
                 using SourceCacheContext cacheContext = new();
-
-                var auditSources = GetAuditSources();
 
                 var auditUtility = new AuditChecker(
                     repositories,
@@ -401,6 +400,7 @@ namespace NuGet.CommandLine
                 packageRestoredEvent: (sender, args) => { Interlocked.Add(ref installCount, args.Restored ? 1 : 0); },
                 packageRestoreFailedEvent: (sender, args) => { failedEvents.Enqueue(args); },
                 sourceRepositories: repositories,
+                auditSources: auditSources,
                 maxNumberOfParallelTasks: DisableParallelProcessing
                         ? 1
                         : PackageManagementConstants.DefaultMaxDegreeOfParallelism,
@@ -472,9 +472,9 @@ namespace NuGet.CommandLine
             }
         }
 
-        private List<SourceRepository> GetAuditSources()
+        internal static List<SourceRepository> GetAuditSources(IPackageSourceProvider sourceProvider)
         {
-            IReadOnlyList<PackageSource> auditSources = SourceProvider.LoadAuditSources();
+            IReadOnlyList<PackageSource> auditSources = sourceProvider.LoadAuditSources();
 
             List<SourceRepository> auditRepositories = new List<SourceRepository>(auditSources.Count);
             for (int i = 0; i < auditSources.Count; i++)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -17,6 +17,7 @@ using NuGet.Configuration.Test;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
+using NuGet.Protocol;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Test.Utility;
@@ -2240,6 +2241,61 @@ namespace NuGet.CommandLine.Test
 
             r1.Success.Should().BeTrue();
             File.Exists(a1Nupkg).Should().BeFalse();
+        }
+
+        [SkipMono()]
+        public void InstallCommand_WithPackageWithVulnerabilities_RaisesWarnings()
+        {
+            // Arrange
+            var nugetexe = Util.GetNuGetExePath();
+            using var pathContext = new SimpleTestPathContext();
+            using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource, sourceReportsVulnerabilities: true);
+
+            mockServer.Vulnerabilities.Add(
+                "packageA",
+                new List<(Uri, PackageVulnerabilitySeverity, VersionRange)> {
+            (new Uri("https://contoso.com/advisories/12345"), PackageVulnerabilitySeverity.High, VersionRange.Parse("[1.0.0, 2.0.0)"))
+                });
+
+            pathContext.Settings.RemoveSource("source");
+            pathContext.Settings.AddSource("source", mockServer.ServiceIndexUri, allowInsecureConnectionsValue: "True");
+
+            Util.CreateTestPackage("packageA", "1.1.0", pathContext.PackageSource);
+            Util.CreateTestPackage("packageB", "2.2.0", pathContext.PackageSource);
+
+            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+            var projectA = new SimpleTestProjectContext(
+                "a",
+                ProjectStyle.PackagesConfig,
+                pathContext.SolutionRoot);
+
+            solution.Projects.Add(projectA);
+            solution.Create(pathContext.SolutionRoot);
+
+            Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+@"<packages>
+  <package id=""packageA"" version=""1.1.0"" />
+  <package id=""packageB"" version=""2.2.0"" />
+</packages>");
+
+            mockServer.Start();
+
+            var installDirectory = Path.Combine(pathContext.WorkingDirectory, "install_output");
+
+            // Act
+            var r = CommandRunner.Run(
+                nugetexe,
+                pathContext.WorkingDirectory,
+                $"install {Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "packages.config")} -OutputDirectory {installDirectory}");
+
+            mockServer.Stop();
+
+            // Assert
+            r.Success.Should().BeTrue(because: r.AllOutput);
+            var installedPackage = Path.Combine(installDirectory, "packageA.1.1.0", "packageA.1.1.0.nupkg");
+            File.Exists(installedPackage).Should().BeTrue();
+            r.AllOutput.Should().Contain("Package 'packageA' 1.1.0 has a known high severity vulnerability");
+            r.AllOutput.Should().NotContain("Package 'packageB' 2.2.0 has a known high severity vulnerability");
         }
 
         public static CommandRunnerResult RunInstall(SimpleTestPathContext pathContext, string input, int expectedExitCode = 0, params string[] additionalArgs)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -17,7 +17,6 @@ using NuGet.Configuration.Test;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
-using NuGet.Protocol;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Test.Utility;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -2244,58 +2244,9 @@ namespace NuGet.CommandLine.Test
         }
 
         [SkipMono()]
-        public void InstallCommand_WithPackageWithVulnerabilities_RaisesWarnings()
+        public void InstallCommand_WithAuditSource_AndPackageWithVulnerabilities_RaisesWarnings()
         {
-            // Arrange
-            var nugetexe = Util.GetNuGetExePath();
-            using var pathContext = new SimpleTestPathContext();
-            using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource, sourceReportsVulnerabilities: true);
-
-            mockServer.Vulnerabilities.Add(
-                "packageA",
-                new List<(Uri, PackageVulnerabilitySeverity, VersionRange)> {
-            (new Uri("https://contoso.com/advisories/12345"), PackageVulnerabilitySeverity.High, VersionRange.Parse("[1.0.0, 2.0.0)"))
-                });
-
-            pathContext.Settings.RemoveSource("source");
-            pathContext.Settings.AddSource("source", mockServer.ServiceIndexUri, allowInsecureConnectionsValue: "True");
-
-            Util.CreateTestPackage("packageA", "1.1.0", pathContext.PackageSource);
-            Util.CreateTestPackage("packageB", "2.2.0", pathContext.PackageSource);
-
-            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-            var projectA = new SimpleTestProjectContext(
-                "a",
-                ProjectStyle.PackagesConfig,
-                pathContext.SolutionRoot);
-
-            solution.Projects.Add(projectA);
-            solution.Create(pathContext.SolutionRoot);
-
-            Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
-@"<packages>
-  <package id=""packageA"" version=""1.1.0"" />
-  <package id=""packageB"" version=""2.2.0"" />
-</packages>");
-
-            mockServer.Start();
-
-            var installDirectory = Path.Combine(pathContext.WorkingDirectory, "install_output");
-
-            // Act
-            var r = CommandRunner.Run(
-                nugetexe,
-                pathContext.WorkingDirectory,
-                $"install {Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "packages.config")} -OutputDirectory {installDirectory}");
-
-            mockServer.Stop();
-
-            // Assert
-            r.Success.Should().BeTrue(because: r.AllOutput);
-            var installedPackage = Path.Combine(installDirectory, "packageA.1.1.0", "packageA.1.1.0.nupkg");
-            File.Exists(installedPackage).Should().BeTrue();
-            r.AllOutput.Should().Contain("Package 'packageA' 1.1.0 has a known high severity vulnerability");
-            r.AllOutput.Should().NotContain("Package 'packageB' 2.2.0 has a known high severity vulnerability");
+            NuGetRestoreCommandTest.Command_WithAuditSource_AndPackageWithVulnerabilities_RaisesWarnings("restore");
         }
 
         public static CommandRunnerResult RunInstall(SimpleTestPathContext pathContext, string input, int expectedExitCode = 0, params string[] additionalArgs)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -3685,6 +3685,66 @@ EndProject";
             r.AllOutput.Should().NotContain($"Package 'packageB' 2.2.0 has a known critical severity vulnerability"); // suppressed
         }
 
+        [SkipMono()]
+        public void RestoreCommand_WithAuditSource_AndPackageWithVulnerabilities_RaisesWarnings()
+        {
+            Command_WithAuditSource_AndPackageWithVulnerabilities_RaisesWarnings("restore");
+        }
+
+        internal static void Command_WithAuditSource_AndPackageWithVulnerabilities_RaisesWarnings(string command)
+        {
+            // Arrange
+            var nugetexe = Util.GetNuGetExePath();
+            using var pathContext = new SimpleTestPathContext();
+            // Very important that the mock server is using a different folder than the package source
+            using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackagesV2, sourceReportsVulnerabilities: true);
+
+            mockServer.Vulnerabilities.Add(
+                "packageA",
+                new List<(Uri, PackageVulnerabilitySeverity, VersionRange)> {
+            (new Uri("https://contoso.com/advisories/12345"), PackageVulnerabilitySeverity.High, VersionRange.Parse("[1.0.0, 2.0.0)"))
+                });
+
+            pathContext.Settings.AddAuditSource("source", mockServer.ServiceIndexUri, allowInsecureConnectionsValue: "True");
+
+            Util.CreateTestPackage("packageA", "1.1.0", pathContext.PackageSource);
+            Util.CreateTestPackage("packageB", "2.2.0", pathContext.PackageSource);
+
+            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+            var projectA = new SimpleTestProjectContext(
+                "a",
+                ProjectStyle.PackagesConfig,
+                pathContext.SolutionRoot);
+
+            solution.Projects.Add(projectA);
+            solution.Create(pathContext.SolutionRoot);
+
+            Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+@"<packages>
+  <package id=""packageA"" version=""1.1.0"" />
+  <package id=""packageB"" version=""2.2.0"" />
+</packages>");
+
+            mockServer.Start();
+
+            var installDirectory = Path.Combine(pathContext.WorkingDirectory, "install_output");
+
+            // Act
+            var r = CommandRunner.Run(
+                nugetexe,
+                pathContext.WorkingDirectory,
+                $"{command} {Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "packages.config")} -OutputDirectory {installDirectory}");
+
+            mockServer.Stop();
+
+            // Assert
+            r.Success.Should().BeTrue(because: r.AllOutput);
+            var installedPackage = Path.Combine(installDirectory, "packageA.1.1.0", "packageA.1.1.0.nupkg");
+            File.Exists(installedPackage).Should().BeTrue();
+            r.AllOutput.Should().Contain("Package 'packageA' 1.1.0 has a known high severity vulnerability");
+            r.AllOutput.Should().NotContain("Package 'packageB' 2.2.0 has a known high severity vulnerability");
+        }
+
         private static byte[] GetResource(string name)
         {
             return ResourceTestUtility.GetResourceBytes(

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -3338,6 +3338,61 @@ EndProject";
         }
 
         [SkipMono()]
+        public void InstallCommand_WithPackageWithVulnerabilities_RaisesWarnings()
+        {
+            // Arrange
+            var nugetexe = Util.GetNuGetExePath();
+            using var pathContext = new SimpleTestPathContext();
+            using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource, sourceReportsVulnerabilities: true);
+
+            mockServer.Vulnerabilities.Add(
+                "packageA",
+                new List<(Uri, PackageVulnerabilitySeverity, VersionRange)> {
+            (new Uri("https://contoso.com/advisories/12345"), PackageVulnerabilitySeverity.High, VersionRange.Parse("[1.0.0, 2.0.0)"))
+                });
+
+            pathContext.Settings.RemoveSource("source");
+            pathContext.Settings.AddSource("source", mockServer.ServiceIndexUri, allowInsecureConnectionsValue: "True");
+
+            Util.CreateTestPackage("packageA", "1.1.0", pathContext.PackageSource);
+            Util.CreateTestPackage("packageB", "2.2.0", pathContext.PackageSource);
+
+            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+            var projectA = new SimpleTestProjectContext(
+                "a",
+                ProjectStyle.PackagesConfig,
+                pathContext.SolutionRoot);
+
+            solution.Projects.Add(projectA);
+            solution.Create(pathContext.SolutionRoot);
+
+            Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+@"<packages>
+  <package id=""packageA"" version=""1.1.0"" />
+  <package id=""packageB"" version=""2.2.0"" />
+</packages>");
+
+            mockServer.Start();
+
+            var installDirectory = Path.Combine(pathContext.WorkingDirectory, "install_output");
+
+            // Act
+            var r = CommandRunner.Run(
+                nugetexe,
+                pathContext.WorkingDirectory,
+                $"install {Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "packages.config")} -OutputDirectory {installDirectory}");
+
+            mockServer.Stop();
+
+            // Assert
+            r.Success.Should().BeTrue(because: r.AllOutput);
+            var installedPackage = Path.Combine(installDirectory, "packageA.1.1.0", "packageA.1.1.0.nupkg");
+            File.Exists(installedPackage).Should().BeTrue();
+            r.AllOutput.Should().Contain("Package 'packageA' 1.1.0 has a known high severity vulnerability");
+            r.AllOutput.Should().NotContain("Package 'packageB' 2.2.0 has a known high severity vulnerability");
+        }
+
+        [SkipMono()]
         public void RestoreCommand_WithProjectWithPackagesConfig_WithNuGetAuditFalse_PackageWithVulnerabilities_DoesNotRaiseWarnings()
         {
             // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -3338,61 +3338,6 @@ EndProject";
         }
 
         [SkipMono()]
-        public void InstallCommand_WithPackageWithVulnerabilities_RaisesWarnings()
-        {
-            // Arrange
-            var nugetexe = Util.GetNuGetExePath();
-            using var pathContext = new SimpleTestPathContext();
-            using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource, sourceReportsVulnerabilities: true);
-
-            mockServer.Vulnerabilities.Add(
-                "packageA",
-                new List<(Uri, PackageVulnerabilitySeverity, VersionRange)> {
-            (new Uri("https://contoso.com/advisories/12345"), PackageVulnerabilitySeverity.High, VersionRange.Parse("[1.0.0, 2.0.0)"))
-                });
-
-            pathContext.Settings.RemoveSource("source");
-            pathContext.Settings.AddSource("source", mockServer.ServiceIndexUri, allowInsecureConnectionsValue: "True");
-
-            Util.CreateTestPackage("packageA", "1.1.0", pathContext.PackageSource);
-            Util.CreateTestPackage("packageB", "2.2.0", pathContext.PackageSource);
-
-            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-            var projectA = new SimpleTestProjectContext(
-                "a",
-                ProjectStyle.PackagesConfig,
-                pathContext.SolutionRoot);
-
-            solution.Projects.Add(projectA);
-            solution.Create(pathContext.SolutionRoot);
-
-            Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
-@"<packages>
-  <package id=""packageA"" version=""1.1.0"" />
-  <package id=""packageB"" version=""2.2.0"" />
-</packages>");
-
-            mockServer.Start();
-
-            var installDirectory = Path.Combine(pathContext.WorkingDirectory, "install_output");
-
-            // Act
-            var r = CommandRunner.Run(
-                nugetexe,
-                pathContext.WorkingDirectory,
-                $"install {Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "packages.config")} -OutputDirectory {installDirectory}");
-
-            mockServer.Stop();
-
-            // Assert
-            r.Success.Should().BeTrue(because: r.AllOutput);
-            var installedPackage = Path.Combine(installDirectory, "packageA.1.1.0", "packageA.1.1.0.nupkg");
-            File.Exists(installedPackage).Should().BeTrue();
-            r.AllOutput.Should().Contain("Package 'packageA' 1.1.0 has a known high severity vulnerability");
-            r.AllOutput.Should().NotContain("Package 'packageB' 2.2.0 has a known high severity vulnerability");
-        }
-
-        [SkipMono()]
         public void RestoreCommand_WithProjectWithPackagesConfig_WithNuGetAuditFalse_PackageWithVulnerabilities_DoesNotRaiseWarnings()
         {
             // Arrange

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -259,6 +259,13 @@ namespace NuGet.Test.Utility
             Save();
         }
 
+        public void AddAuditSource(string sourceName, string sourceUri, string allowInsecureConnectionsValue)
+        {
+            var section = GetOrAddSection(XML, "auditSources");
+            AddEntry(section, sourceName, sourceUri, "allowInsecureConnections", allowInsecureConnectionsValue);
+            Save();
+        }
+
         public void AddPackageSourceMapping(string sourceName, params string[] patterns)
         {
             XElement packageSourceMappingSection = GetOrAddSection(XML, "packageSourceMapping");


### PR DESCRIPTION

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14096

## Description

Previously `nuget install packages.config` did not print audit warnings and `nuget restore packages.config` did not print audit warnings unless all packages were already installed.

After this PR
![image](https://github.com/user-attachments/assets/60be3776-5638-43b1-957c-02d6c90e986d)


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
