### PR TITLE
Fix PackageArchiveReader arbitrary file access during archive extraction zipslip

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -319,7 +319,13 @@ namespace NuGet.Packaging
                 destination = NormalizeDirectoryPath(destination);
                 ValidatePackageEntry(destination, normalizedPath, packageIdentity);
 
-                var targetFilePath = Path.Combine(destination, normalizedPath);
+                var targetFilePath = Path.GetFullPath(Path.Combine(destination, normalizedPath));
+                var fullDestDirPath = Path.GetFullPath(destination + Path.DirectorySeparatorChar);
+
+                if (!targetFilePath.StartsWith(fullDestDirPath, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException($"Entry is outside the target directory: {targetFilePath}");
+                }
 
                 using (var stream = entry.Open())
                 using (var sizedStream = new SizedArchiveEntryStream(stream, entry.Length))


### PR DESCRIPTION
https://github.com/NuGet/NuGet.Client/blob/f8e8b00a404664727d49f236e5efef0e9005afa2/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs#L307-L307
https://github.com/NuGet/NuGet.Client/blob/f8e8b00a404664727d49f236e5efef0e9005afa2/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs#L322-L322


Fix the issue the code should validate the constructed file paths to ensure they do not allow directory traversal. This involves:
1. Using `Path.GetFullPath` to resolve the full path of the target file.
2. Using `Path.GetFullPath` on the destination directory to resolve its full path.
3. Ensuring the resolved target file path starts with the resolved destination directory path.
4. Throwing an exception if the validation fails.

These steps should be implemented in the `CopyFiles` method, specifically before the `targetFilePath` is used for file operations.



## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
