### PR TITLE
Use newer versions of MSBuild's packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,10 +17,10 @@
     <!-- The last package version of MSBuild that works with netcoreapp3.1 or netstandard2.0 is 16.8.0.  Our assemblies are still compiled against MSBuild assembly version 15.1.0.0 which will work with all versions -->
     <MicrosoftBuildVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'netstandard2.0'">16.8.0</MicrosoftBuildVersion>
     <!-- The last package version of MSBuild that works with net5.0 is 16.11.0.  Our assemblies are still compiled against MSBuild assembly version 15.1.0.0 which will work with all versions -->
-    <MicrosoftBuildVersion Condition="'$(TargetFramework)' == 'netcoreapp5.0'">16.11.0</MicrosoftBuildVersion>
-    <MicrosoftBuildVersion Condition="'$(DotNetBuildSourceOnly)' == 'true'">17.12.6</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion Condition="'$(TargetFramework)' == 'netcoreapp5.0'">16.11.6</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion Condition="'$(DotNetBuildSourceOnly)' == 'true'">17.12.36</MicrosoftBuildVersion>
     <!-- Read docs/updating-packages.md before updating MSBuild's version -->
-    <MicrosoftBuildVersion Condition="'$(MicrosoftBuildVersion)' == ''">17.11.4</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion Condition="'$(MicrosoftBuildVersion)' == ''">17.11.31</MicrosoftBuildVersion>
   </PropertyGroup>
 
     <!-- Overridden by source build to ensure the same version is used across products, do not remove these properties -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,10 +14,6 @@
 
   <!-- MSBuild has vulnerable dependencies Microsoft.IO.Redist and System.Security.Cryptography.Xml. When it's upgraded, try removing pinned packages-->
   <PropertyGroup>
-    <!-- The last package version of MSBuild that works with netcoreapp3.1 or netstandard2.0 is 16.8.0.  Our assemblies are still compiled against MSBuild assembly version 15.1.0.0 which will work with all versions -->
-    <MicrosoftBuildVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'netstandard2.0'">16.8.0</MicrosoftBuildVersion>
-    <!-- The last package version of MSBuild that works with net5.0 is 16.11.0.  Our assemblies are still compiled against MSBuild assembly version 15.1.0.0 which will work with all versions -->
-    <MicrosoftBuildVersion Condition="'$(TargetFramework)' == 'netcoreapp5.0'">16.11.6</MicrosoftBuildVersion>
     <MicrosoftBuildVersion Condition="'$(DotNetBuildSourceOnly)' == 'true'">17.12.36</MicrosoftBuildVersion>
     <!-- Read docs/updating-packages.md before updating MSBuild's version -->
     <MicrosoftBuildVersion Condition="'$(MicrosoftBuildVersion)' == ''">17.11.31</MicrosoftBuildVersion>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -135,9 +135,9 @@
         $(PathToBuiltNuGetPack) ^
         @(BuildArtifacts, ' ')</IlmergeCommand>
       <IlmergeCommand Condition=" '$(TargetFramework)' != '$(NETFXTargetFramework)' ">$(IlmergeCommand) ^
-        /lib:$(PkgMicrosoft_Build_Utilities_Core)\lib\netstandard2.0 ^
-        /lib:$(PkgMicrosoft_Build_Tasks_Core)\lib\netstandard2.0 ^
-        /lib:$(PkgMicrosoft_Build_Framework)\lib\netstandard2.0
+        /lib:$(PkgMicrosoft_Build_Utilities_Core)\ref\netstandard2.0 ^
+        /lib:$(PkgMicrosoft_Build_Tasks_Core)\ref\netstandard2.0 ^
+        /lib:$(PkgMicrosoft_Build_Framework)\ref\netstandard2.0
       </IlmergeCommand>
 
     </PropertyGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -45,9 +45,6 @@
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" GeneratePathProperty="true" />
-    <NuGetAuditSuppress
-      Include="https://github.com/advisories/GHSA-h4j7-5rxr-p4wc"
-      Justification="The package is used at compile time only. At runtime, the version shipped in VS or the .NET SDK is used." />
   </ItemGroup>
 
   <ItemGroup Label="transitive package pinning">

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -45,6 +45,9 @@
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" GeneratePathProperty="true" />
+    <NuGetAuditSuppress
+      Include="https://github.com/advisories/GHSA-h4j7-5rxr-p4wc"
+      Justification="The package is used at compile time only. At runtime, the version shipped in VS or the .NET SDK is used." />
   </ItemGroup>
 
   <ItemGroup Label="transitive package pinning">


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14342

## Description

Update MSBuild package versions to ones that don't have known vulnerabilities.

None of our tests running on netcoreapp3.1 or net5.0 need msbuild packages, so they were removed.

NuGet.Build.Tasks.Pack needed a change to its ILMerge config to use the package's ref assemblies, because the later versions of MSBuild don't ship `lib/netsandard2.0/*` assemblies. Note, we never merged MSBuild into NuGet.Build.Tasks.Pack.dll, but ILMerge still wants to be able to find the assemblies for "compile time" validation.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
