### PR TITLE
Update Why Command help output to allow assets file

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommand.cs
@@ -41,7 +41,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         {
             var whyCommand = new DocumentedCommand("why", Strings.WhyCommand_Description, "https://aka.ms/dotnet/nuget/why");
 
-            Argument<string> path = new Argument<string>("PROJECT|SOLUTION")
+            Argument<string> path = new Argument<string>("PROJECT|SOLUTION|ASSETSFILE")
             {
                 Description = Strings.WhyCommand_PathArgument_Description,
                 // We really want this to be zero or one, however, because this is the first argument, it doesn't work.

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -2458,7 +2458,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A path to a project, solution file, assets file, or directory..
+        ///   Looks up a localized string similar to A path to a project, solution file, project assets file, or directory..
         /// </summary>
         internal static string WhyCommand_PathArgument_Description {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -2458,7 +2458,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A path to a project, solution file, assets file or directory..
+        ///   Looks up a localized string similar to A path to a project, solution file, assets file, or directory..
         /// </summary>
         internal static string WhyCommand_PathArgument_Description {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -2458,7 +2458,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A path to a project, solution file, or directory..
+        ///   Looks up a localized string similar to A path to a project, solution file, assets file or directory..
         /// </summary>
         internal static string WhyCommand_PathArgument_Description {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -921,7 +921,7 @@ NuGet requires HTTPS sources. To use HTTP sources, you must explicitly set 'allo
     <value>Shows the dependency graph for a particular package for a given project or solution.</value>
   </data>
   <data name="WhyCommand_PathArgument_Description" xml:space="preserve">
-    <value>A path to a project, solution file, assets file, or directory.</value>
+    <value>A path to a project, solution file, project assets file, or directory.</value>
   </data>
   <data name="WhyCommand_PackageArgument_Description" xml:space="preserve">
     <value>The package name to lookup in the dependency graph.</value>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -921,7 +921,7 @@ NuGet requires HTTPS sources. To use HTTP sources, you must explicitly set 'allo
     <value>Shows the dependency graph for a particular package for a given project or solution.</value>
   </data>
   <data name="WhyCommand_PathArgument_Description" xml:space="preserve">
-    <value>A path to a project, solution file, assets file or directory.</value>
+    <value>A path to a project, solution file, assets file, or directory.</value>
   </data>
   <data name="WhyCommand_PackageArgument_Description" xml:space="preserve">
     <value>The package name to lookup in the dependency graph.</value>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -921,7 +921,7 @@ NuGet requires HTTPS sources. To use HTTP sources, you must explicitly set 'allo
     <value>Shows the dependency graph for a particular package for a given project or solution.</value>
   </data>
   <data name="WhyCommand_PathArgument_Description" xml:space="preserve">
-    <value>A path to a project, solution file, or directory.</value>
+    <value>A path to a project, solution file, assets file or directory.</value>
   </data>
   <data name="WhyCommand_PackageArgument_Description" xml:space="preserve">
     <value>The package name to lookup in the dependency graph.</value>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

update the help output for `dotnet nuget why` to indicate assets file is supported as per https://github.com/NuGet/NuGet.Client/pull/5922

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
