### PR TITLE
Reenable new resolver with lock files for legacy csproj

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -168,14 +168,14 @@ namespace NuGet.Commands
             _enableNewDependencyResolver = _request.Project.RuntimeGraph.Supports.Count == 0 && ShouldUseNewResolverWithLockFile(_isLockFileEnabled, _request.Project) && !_request.Project.RestoreMetadata.UseLegacyDependencyResolver;
         }
 
-        // Use the new resolver if lock files are not enabled, or if lock files are enabled and .NET 10 SDK is used.
+        // Use the new resolver if lock files are not enabled, or if lock files are enabled and legacy projects or .NET 10 SDK is used.
         private static bool ShouldUseNewResolverWithLockFile(bool isLockFileEnabled, PackageSpec project)
         {
             return !isLockFileEnabled ||
-                (project.RestoreMetadata.UsingMicrosoftNETSdk && SdkAnalysisLevelMinimums.IsEnabled(
+                SdkAnalysisLevelMinimums.IsEnabled(
                     project.RestoreMetadata.SdkAnalysisLevel,
                     project.RestoreMetadata.UsingMicrosoftNETSdk,
-                    SdkAnalysisLevelMinimums.V10_0_100));
+                    SdkAnalysisLevelMinimums.V10_0_100);
         }
 
         public Task<RestoreResult> ExecuteAsync()

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -4051,8 +4051,8 @@ namespace NuGet.Commands.FuncTest
         }
 
         [Theory]
-        [InlineData(false, null, false)]
-        [InlineData(false, "10.0.100", false)]
+        [InlineData(false, null, true)]
+        [InlineData(false, "10.0.100", true)]
         [InlineData(true, "10.0.100", true)]
         [InlineData(true, "9.0.100", false)]
         public async Task Restore_WithLockFilesAndSdkAnalysisLevel_UsesCorrectResolver(bool useSDK, string SDKAnalysisLevel, bool useNewResolver)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13800

## Description

Earlier on we enabled the new resolver with lock files for SDK based projects, but now we're doing it for all of them.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
