### PR TITLE
Fix file access during archive extraction zipslip

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -319,7 +319,12 @@ namespace NuGet.Packaging
                 destination = NormalizeDirectoryPath(destination);
                 ValidatePackageEntry(destination, normalizedPath, packageIdentity);
 
-                var targetFilePath = Path.Combine(destination, normalizedPath);
+                var targetFilePath = Path.GetFullPath(Path.Combine(destination, normalizedPath));
+                var fullDestDirPath = Path.GetFullPath(destination + Path.DirectorySeparatorChar);
+                if (!targetFilePath.StartsWith(fullDestDirPath, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException($"Entry is outside the target directory: {targetFilePath}");
+                }
 
                 using (var stream = entry.Open())
                 using (var sizedStream = new SizedArchiveEntryStream(stream, entry.Length))

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
@@ -28,9 +28,18 @@ namespace NuGet.Packaging
             return entry;
         }
 
-        public static IEnumerable<string> GetFiles(this ZipArchive zipArchive)
+        public static IEnumerable<string> GetFiles(this ZipArchive zipArchive, string destinationDirectory)
         {
-            return zipArchive.Entries.Select(e => UnescapePath(e.FullName));
+            string fullDestDirPath = Path.GetFullPath(destinationDirectory + Path.DirectorySeparatorChar);
+            return zipArchive.Entries.Select(e =>
+            {
+                string fullPath = Path.GetFullPath(Path.Combine(destinationDirectory, UnescapePath(e.FullName)));
+                if (!fullPath.StartsWith(fullDestDirPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException($"Entry is outside the target directory: {e.FullName}");
+                }
+                return fullPath;
+            });
         }
 
         private static string UnescapePath(string path)

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -93,15 +93,15 @@ namespace NuGet.Packaging
 
         private FileInfo GetFile(string path)
         {
-            var file = new FileInfo(Path.Combine(_root.FullName, path));
+            var fullPath = Path.GetFullPath(Path.Combine(_root.FullName, path));
 
-            if (!file.FullName.StartsWith(_root.FullName, StringComparison.OrdinalIgnoreCase))
+            if (!fullPath.StartsWith(_root.FullName + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
             {
                 // the given path does not appear under the folder root
-                throw new FileNotFoundException(path);
+                throw new FileNotFoundException($"Path is outside the root directory: {path}");
             }
 
-            return file;
+            return new FileInfo(fullPath);
         }
 
         public override IEnumerable<string> GetFiles()

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -2131,6 +2131,11 @@ namespace NuGet.Packaging.Test
 
         private static string ExtractFile(string sourcePath, string targetPath, Stream sourceStream)
         {
+            if (!targetPath.StartsWith(Path.GetFullPath(Path.GetDirectoryName(sourcePath) + Path.DirectorySeparatorChar), StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"Target path is outside the source directory: {targetPath}");
+            }
+
             using (var targetStream = File.OpenWrite(targetPath))
             {
                 sourceStream.CopyTo(targetStream);


### PR DESCRIPTION
https://github.com/NuGet/NuGet.Client/blob/37c3af85c54fec814e918761842ae9c2b550fe07/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs#L307-L307

https://github.com/NuGet/NuGet.Client/blob/37c3af85c54fec814e918761842ae9c2b550fe07/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs#L307-L307

Fix the issue need to ensure that paths derived from `entry.FullName` are properly validated to prevent directory traversal attacks. This involves:

1. Resolving the raw output path using `Path.GetFullPath` to eliminate directory traversal elements.
2. Resolving the destination directory path using `Path.GetFullPath` to ensure it is fully qualified.
3. Validating that the resolved output path starts with the resolved destination directory path. If it does not, an exception should be thrown to prevent writing files outside the intended directory.

The fix will be applied in the `CopyFiles` method of `PackageArchiveReader`. Additionally, we will update the test file `PackageArchiveReaderTests.cs` to ensure the fix is properly tested.

---

https://github.com/NuGet/NuGet.Client/blob/37c3af85c54fec814e918761842ae9c2b550fe07/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs#L31-L33

https://github.com/NuGet/NuGet.Client/blob/37c3af85c54fec814e918761842ae9c2b550fe07/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs#L96-L98

https://github.com/NuGet/NuGet.Client/blob/37c3af85c54fec814e918761842ae9c2b550fe07/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs#L101-L104

Fix the issue need to sanitize and validate paths extracted from the zip archive to prevent directory traversal attacks. Specifically:
1. Use `Path.GetFullPath` to resolve the full path of the file to handle any directory traversal elements.
2. Use `Path.GetFullPath` on the destination directory to get its fully resolved path.
3. Ensure that the resolved file path starts with the resolved destination directory path. If not, throw an exception.

The changes will be applied to the `ZipArchiveExtensions.GetFiles` method to sanitize the paths before returning them. Additionally, the `PackageFolderReader.GetFile` method will be updated to ensure paths are validated after combining.

Extracting files from a malicious zip file, or similar type of archive, is at risk of directory traversal attacks if filenames from the archive are not properly validated. Zip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (..). If these file paths are used to create a filesystem path, then a file operation may happen in an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.

[Zip Slip Refferences](https://www.meziantou.net/prevent-zip-slip-in-dotnet.htm)


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
