### PR TITLE
Onboard Package Sources page to Unified Settings

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/NuGetExternalSettingsProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/NuGetExternalSettingsProvider.cs
@@ -40,12 +40,34 @@ namespace NuGet.PackageManagement.VisualStudio.Options
 
         internal virtual void VsSettings_SettingsChanged(object sender, EventArgs e)
         {
-            if (_suppressSettingValuesChanged)
+            if (_suppressSettingValuesChanged && !IsSuppressionDisabledByEnvironment())
             {
                 return; // Suppress the event invocation
             }
 
             SettingValuesChanged?.Invoke(this, ExternalSettingsChangedEventArgs.SomeOrAll);
+        }
+
+        /// <summary>
+        /// For DEBUG purposes only. Expected to be removed by the next release.
+        /// </summary>
+        private static bool IsSuppressionDisabledByEnvironment()
+        {
+            try
+            {
+                const string envVarName = "NUGET_DISABLE_SUPPRESS_SETTING_VALUES_CHANGED";
+                return string.Equals(
+                    Common.EnvironmentVariableWrapper.Instance.GetEnvironmentVariable(envVarName),
+                    "true",
+                    StringComparison.OrdinalIgnoreCase);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                // Ignore errors since this is not a production feature.
+                return false;
+            }
         }
 
         public virtual Task<string> GetMessageTextAsync(string messageId, CancellationToken cancellationToken)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/NuGetExternalSettingsProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/NuGetExternalSettingsProvider.cs
@@ -92,12 +92,12 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             return failure;
         }
 
-        public static ExternalSettingOperationResult CreateSettingErrorResult(string errorMessage)
+        public static ExternalSettingOperationResult CreateSettingErrorResult(string errorMessage, bool isTransient)
         {
             var failure = new ExternalSettingOperationResult.Failure(
                 errorMessage,
                 scope: ExternalSettingsErrorScope.SingleSettingOnly,
-                isTransient: true);
+                isTransient);
 
             return failure;
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/NuGetExternalSettingsProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/NuGetExternalSettingsProvider.cs
@@ -15,6 +15,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
     public abstract class NuGetExternalSettingsProvider : IExternalSettingsProvider
     {
         protected readonly VSSettings _vsSettings;
+        protected bool _suppressSettingValuesChanged;
 
         protected NuGetExternalSettingsProvider(VSSettings vsSettings)
         {
@@ -39,6 +40,11 @@ namespace NuGet.PackageManagement.VisualStudio.Options
 
         internal virtual void VsSettings_SettingsChanged(object sender, EventArgs e)
         {
+            if (_suppressSettingValuesChanged)
+            {
+                return; // Suppress the event invocation
+            }
+
             SettingValuesChanged?.Invoke(this, ExternalSettingsChangedEventArgs.SomeOrAll);
         }
 
@@ -57,6 +63,16 @@ namespace NuGet.PackageManagement.VisualStudio.Options
         public static ExternalSettingOperationResult<T> CreateSettingErrorResult<T>(string errorMessage)
         {
             var failure = new ExternalSettingOperationResult<T>.Failure(
+                errorMessage,
+                scope: ExternalSettingsErrorScope.SingleSettingOnly,
+                isTransient: true);
+
+            return failure;
+        }
+
+        public static ExternalSettingOperationResult CreateSettingErrorResult(string errorMessage)
+        {
+            var failure = new ExternalSettingOperationResult.Failure(
                 errorMessage,
                 scope: ExternalSettingsErrorScope.SingleSettingOnly,
                 isTransient: true);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
@@ -19,7 +19,16 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             List<PackageSource> packageSources)
         {
             string trimmedSource = source?.Trim() ?? string.Empty;
+            if (string.IsNullOrEmpty(trimmedSource))
+            {
+                throw new ArgumentException(message: Strings.Argument_Cannot_Be_Null_Or_Empty, paramName: nameof(source));
+            }
+
             string trimmedName = name?.Trim() ?? string.Empty;
+            if (string.IsNullOrEmpty(trimmedName))
+            {
+                throw new ArgumentException(message: Strings.Argument_Cannot_Be_Null_Or_Empty, paramName: nameof(name));
+            }
 
             PackageSource? foundByName = FindByName(trimmedName, packageSources);
             PackageSource? foundBySource = FindBySource(trimmedSource, packageSources);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
@@ -89,7 +89,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
         /// <summary>
         /// Validates the Uri of a remote or local package source.
         /// The regex used here will eventually be supported in the Unified Settings registration.json file
-        /// for the package sources page.
+        /// for the package sources page. See https://github.com/NuGet/Home/issues/14358.
         /// </summary>
         /// <param name="packageSource"></param>
         /// <exception cref="ArgumentNullException"></exception>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
@@ -1,0 +1,234 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Configuration;
+
+namespace NuGet.PackageManagement.VisualStudio.Options
+{
+    internal static class PackageSourceValidator
+    {
+        internal static PackageSource FindExistingOrCreate(
+            string source,
+            string name,
+            bool isEnabled,
+            List<PackageSource> packageSources)
+        {
+            string trimmedSource = source?.Trim() ?? string.Empty;
+            string trimmedName = name?.Trim() ?? string.Empty;
+
+            PackageSource? foundByName = FindByName(trimmedName, packageSources);
+            PackageSource? foundBySource = FindBySource(trimmedSource, packageSources);
+
+            PackageSource packageSource;
+
+            // Create and validate a new Package Source since none was found by name or source.
+            if (foundByName is null && foundBySource is null)
+            {
+                packageSource = new PackageSource(trimmedSource, trimmedName, isEnabled);
+                SetAllowInsecureConnectionsProperty(packageSource);
+                EnsureValidSources(packageSource);
+            }
+            // If both name and source match, use the existing PackageSource.
+            else if (foundByName is not null && foundBySource is not null)
+            {
+                // Only the IsEnabled property could be changing.
+                foundByName.IsEnabled = isEnabled;
+                packageSource = foundByName;
+            }
+            // The source is changing on an existing PackageSource.
+            else if (foundByName is not null)
+            {
+                // Preserve existing properties by cloning the package source.
+                packageSource = new PackageSource(
+                    trimmedSource,
+                    foundByName.Name,
+                    isEnabled,
+                    foundByName.IsOfficial,
+                    foundByName.IsPersistable)
+                {
+                    IsMachineWide = foundByName.IsMachineWide,
+                    Credentials = foundByName.Credentials,
+                    ClientCertificates = foundByName.ClientCertificates,
+                    Description = foundByName.Description,
+                    ProtocolVersion = foundByName.ProtocolVersion,
+                    AllowInsecureConnections = foundByName.AllowInsecureConnections,
+                    DisableTLSCertificateValidation = foundByName.DisableTLSCertificateValidation,
+                    MaxHttpRequestsPerSource = foundByName.MaxHttpRequestsPerSource,
+                };
+            }
+            // The name is changing on an existing PackageSource.
+            else
+            {
+                // Preserve existing properties by cloning the package source.
+                packageSource = new PackageSource(
+                    foundBySource!.Source,
+                    trimmedName,
+                    isEnabled,
+                    foundBySource.IsOfficial,
+                    foundBySource.IsPersistable)
+                {
+                    IsMachineWide = foundBySource.IsMachineWide,
+                    Credentials = foundBySource.Credentials,
+                    ClientCertificates = foundBySource.ClientCertificates,
+                    Description = foundBySource.Description,
+                    ProtocolVersion = foundBySource.ProtocolVersion,
+                    AllowInsecureConnections = foundBySource.AllowInsecureConnections,
+                    DisableTLSCertificateValidation = foundBySource.DisableTLSCertificateValidation,
+                    MaxHttpRequestsPerSource = foundBySource.MaxHttpRequestsPerSource,
+                };
+            }
+
+            return packageSource;
+        }
+
+        /// <summary>
+        /// Validates the Uri of a remote or local package source.
+        /// The regex used here will eventually be supported in the Unified Settings registration.json file
+        /// for the package sources page.
+        /// </summary>
+        /// <param name="packageSource"></param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        internal static void EnsureValidSources(PackageSource packageSource)
+        {
+            _ = packageSource ?? throw new ArgumentNullException(nameof(packageSource));
+            string source = packageSource.Source;
+
+            if (!Common.PathValidator.IsValidLocalPath(source) &&
+                !Common.PathValidator.IsValidUncPath(source) &&
+                !Common.PathValidator.IsValidUrl(source))
+            {
+                throw new ArgumentOutOfRangeException(
+                    paramName: nameof(PackageSource.Source),
+                    actualValue: source,
+                    Strings.Error_PackageSource_InvalidSource);
+            }
+        }
+
+        internal static void ValidateUniquenessOrThrow(List<PackageSource> packageSources)
+        {
+            _ = packageSources ?? throw new ArgumentNullException(nameof(packageSources));
+
+            EnsureUniqueNames(packageSources);
+            EnsureUniqueSources(packageSources);
+        }
+
+        private static void EnsureUniqueNames(List<PackageSource> packageSources)
+        {
+            var seen = new HashSet<string>(
+                capacity: packageSources.Count,
+                comparer: StringComparer.CurrentCultureIgnoreCase);
+
+            foreach (PackageSource packageSource in packageSources)
+            {
+                if (!seen.Add(packageSource.Name.Trim()))
+                {
+                    throw new ArgumentException(message: Strings.Error_PackageSource_UniqueName);
+                }
+            }
+        }
+
+        private static void EnsureUniqueSources(List<PackageSource> packageSources)
+        {
+            var seen = new HashSet<string>(
+                capacity: packageSources.Count,
+                comparer: StringComparer.OrdinalIgnoreCase);
+
+            foreach (PackageSource packageSource in packageSources)
+            {
+                string trimmedSource = packageSource.Source?.Trim() ?? string.Empty;
+
+                bool isDuplicate;
+                if (packageSource.IsLocal)
+                {
+                    string canonicalPath = PathValidator.GetCanonicalPath(trimmedSource);
+                    isDuplicate = !seen.Add(canonicalPath);
+                }
+                else
+                {
+                    isDuplicate = !seen.Add(trimmedSource);
+                }
+
+                if (isDuplicate)
+                {
+                    throw new ArgumentException(message: Strings.Error_PackageSource_UniqueSource);
+                }
+            }
+        }
+
+        private static void SetAllowInsecureConnectionsProperty(PackageSource packageSource)
+        {
+            _ = packageSource ?? throw new ArgumentNullException(nameof(packageSource));
+
+            if (packageSource.IsHttp && !packageSource.IsHttps)
+            {
+                packageSource.AllowInsecureConnections = true;
+            }
+        }
+
+        private static PackageSource? FindByName(string name, List<PackageSource> packageSources)
+        {
+            _ = packageSources ?? throw new ArgumentNullException(nameof(packageSources));
+
+            if (name is null)
+            {
+                return null;
+            }
+
+            string trimmedName = name?.Trim() ?? string.Empty;
+
+            List<PackageSource> existingPackageSource = packageSources
+                .Where(packageSource =>
+                    string.Equals(packageSource.Name, trimmedName, StringComparison.CurrentCultureIgnoreCase))
+                .ToList();
+
+            if (existingPackageSource.Count > 1)
+            {
+                throw new InvalidOperationException(message: Strings.Error_PackageSource_UniqueName);
+            }
+
+            return existingPackageSource.SingleOrDefault();
+        }
+
+        private static PackageSource? FindBySource(string source, List<PackageSource> packageSources)
+        {
+            _ = packageSources ?? throw new ArgumentNullException(nameof(packageSources));
+
+            if (source is null)
+            {
+                return null;
+            }
+
+            string trimmedSource = source?.Trim() ?? string.Empty;
+
+            List<PackageSource> existingPackageSource = packageSources
+                .Where(packageSource =>
+                {
+                    string trimmedTargetSource = packageSource.Source?.Trim() ?? string.Empty;
+                    bool areTrimmedStringsEqual =
+                        string.Equals(
+                            trimmedTargetSource,
+                            trimmedSource,
+                            StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(
+                            PathValidator.GetCanonicalPath(trimmedTargetSource),
+                            PathValidator.GetCanonicalPath(trimmedSource),
+                            StringComparison.OrdinalIgnoreCase);
+                    return areTrimmedStringsEqual;
+                })
+                .ToList();
+
+            if (existingPackageSource.Count > 1)
+            {
+                throw new InvalidOperationException(message: Strings.Error_PackageSource_UniqueSource);
+            }
+
+            return existingPackageSource.SingleOrDefault();
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -133,9 +133,6 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                             _packageSourceProvider.DisablePackageSource(originalPackageSourceName);
                         }
                     }
-
-                    // Only one value can be set at a time from Unified Settings, so we're done once a change is made.
-                    break;
                 }
 
                 result = ExternalSettingOperationResult.Success.Instance;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -140,12 +140,8 @@ namespace NuGet.PackageManagement.VisualStudio.Options
 
                 result = ExternalSettingOperationResult.Success.Instance;
             }
-            catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
-            {
-                throw ex;
-            }
 #pragma warning disable CA1031 // Do not catch general exception types
-            catch (Exception ex)
+            catch (Exception ex) when (!(ex is OperationCanceledException && cancellationToken.IsCancellationRequested))
 #pragma warning restore CA1031 // Do not catch general exception types
             {
                 result = CreateSettingErrorResult(ex.Message + " ('" + MonikerMachineWideSources + "')");
@@ -187,12 +183,8 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                 _packageSourceProvider.SavePackageSources(packageSources);
                 result = ExternalSettingOperationResult.Success.Instance;
             }
-            catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
-            {
-                throw ex;
-            }
 #pragma warning disable CA1031 // Do not catch general exception types
-            catch (Exception ex)
+            catch (Exception ex) when (!(ex is OperationCanceledException && cancellationToken.IsCancellationRequested))
 #pragma warning restore CA1031 // Do not catch general exception types
             {
                 result = CreateSettingErrorResult(ex.Message);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -141,7 +141,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             catch (Exception ex) when (!(ex is OperationCanceledException && cancellationToken.IsCancellationRequested))
 #pragma warning restore CA1031 // Do not catch general exception types
             {
-                result = CreateSettingErrorResult(ex.Message + " ('" + MonikerMachineWideSources + "')");
+                result = CreateSettingErrorResult(ex.Message + " ('" + MonikerMachineWideSources + "')", isTransient: true);
             }
 
             return result;
@@ -184,7 +184,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             catch (Exception ex) when (!(ex is OperationCanceledException && cancellationToken.IsCancellationRequested))
 #pragma warning restore CA1031 // Do not catch general exception types
             {
-                result = CreateSettingErrorResult(ex.Message);
+                result = CreateSettingErrorResult(ex.Message, isTransient: true);
                 ActivityLog.LogError(ExceptionHelper.LogEntrySource, ex.ToString());
             }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -66,7 +66,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
 
         public override async Task<ExternalSettingOperationResult> SetValueAsync<T>(string moniker, T value, CancellationToken cancellationToken)
         {
-            var packageSourcesList = value as IList<IDictionary<string, object>>;
+            var packageSourcesList = value as IReadOnlyList<IDictionary<string, object>>;
             if (packageSourcesList is null)
             {
                 throw new InvalidOperationException();
@@ -101,7 +101,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
         }
 
         private ExternalSettingOperationResult SetIsEnabledOnMachineWidePackageSources(
-            IList<IDictionary<string, object>> packageSourcesList,
+            IReadOnlyList<IDictionary<string, object>> packageSourcesList,
             CancellationToken cancellationToken)
         {
             ExternalSettingOperationResult result;
@@ -147,7 +147,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             return result;
         }
 
-        private ExternalSettingOperationResult SavePackageSources<T>(IList<IDictionary<string, object>> packageSourceDictionaryList, CancellationToken cancellationToken)
+        private ExternalSettingOperationResult SavePackageSources<T>(IReadOnlyList<IDictionary<string, object>> packageSourceDictionaryList, CancellationToken cancellationToken)
         {
             ExternalSettingOperationResult result;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -1,0 +1,243 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Utilities.UnifiedSettings;
+using NuGet.Configuration;
+
+namespace NuGet.PackageManagement.VisualStudio.Options
+{
+    [Guid("15C605EC-4FD7-446B-BA4A-75ECF0C0B2D0")]
+    public class PackageSourcesPage : NuGetExternalSettingsProvider
+    {
+        internal const string MonikerPackageSources = "packageSources";
+        internal const string MonikerMachineWideSources = "machineWidePackageSources";
+        internal const string MonikerSourceName = "sourceName";
+        internal const string MonikerSourceUrl = "sourceUrl";
+        internal const string MonikerIsEnabled = "isEnabled";
+        private IPackageSourceProvider _packageSourceProvider;
+
+        public PackageSourcesPage(VSSettings vsSettings, IPackageSourceProvider packageSourceProvider)
+            : base(vsSettings)
+        {
+            _packageSourceProvider = packageSourceProvider ?? throw new ArgumentNullException(nameof(packageSourceProvider));
+        }
+
+        private List<PackageSource> LoadPackageSources(bool isMachineWide)
+        {
+            IEnumerable<PackageSource> all = _packageSourceProvider.LoadPackageSources();
+            List<PackageSource> filteredPackageSources = all
+                .Where(packageSource => packageSource.IsMachineWide == isMachineWide).ToList();
+            return filteredPackageSources;
+        }
+
+        public override async Task<ExternalSettingOperationResult<T>> GetValueAsync<T>(string moniker, CancellationToken cancellationToken)
+        {
+            switch (moniker)
+            {
+                case MonikerPackageSources:
+                    var packageSources = await Task.Run(
+                        () => LoadPackageSources(isMachineWide: false),
+                        cancellationToken);
+
+                    return GetValuePackageSources<T>(packageSources);
+
+                case MonikerMachineWideSources:
+                    var machineWidePackageSources = await Task.Run(
+                        () => LoadPackageSources(isMachineWide: true),
+                        cancellationToken);
+
+                    return GetValuePackageSources<T>(machineWidePackageSources);
+
+                default: break;
+            }
+
+            // Shouldn't happen as these are monikers we declared in registration.json.
+            throw new InvalidOperationException();
+        }
+
+        public override async Task<ExternalSettingOperationResult> SetValueAsync<T>(string moniker, T value, CancellationToken cancellationToken)
+        {
+            var packageSourcesList = value as IList<IDictionary<string, object>>;
+            if (packageSourcesList is null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            try
+            {
+                // Stop listening to setting changes while saving.
+                _suppressSettingValuesChanged = true;
+
+                switch (moniker)
+                {
+                    case MonikerPackageSources:
+                        return await Task.Run(
+                            () => SavePackageSources<T>(packageSourcesList, cancellationToken),
+                            cancellationToken);
+
+                    case MonikerMachineWideSources:
+                        return await Task.Run(
+                            () => SetIsEnabledOnMachineWidePackageSources(packageSourcesList, cancellationToken),
+                            cancellationToken);
+
+                    default:
+                        throw new InvalidOperationException();
+                }
+            }
+            finally
+            {
+                // Resume listening to setting changes after saving.
+                _suppressSettingValuesChanged = false;
+            }
+        }
+
+        private ExternalSettingOperationResult SetIsEnabledOnMachineWidePackageSources(
+            IList<IDictionary<string, object>> packageSourcesList,
+            CancellationToken cancellationToken)
+        {
+            ExternalSettingOperationResult result;
+
+            try
+            {
+                var machineWidePackageSources = LoadPackageSources(isMachineWide: true);
+
+                foreach (PackageSource originalMachineWideSource in machineWidePackageSources)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    string originalPackageSourceName = originalMachineWideSource.Name;
+                    IDictionary<string, object> targetPackageSource = packageSourcesList
+                        .Single(packageSourceDictionary =>
+                            packageSourceDictionary[MonikerSourceName].ToString() == originalPackageSourceName);
+
+                    bool originalIsEnabled = originalMachineWideSource.IsEnabled;
+                    bool targetIsEnabled = (bool)targetPackageSource[MonikerIsEnabled];
+
+                    if (originalIsEnabled != targetIsEnabled)
+                    {
+                        if (targetIsEnabled)
+                        {
+                            _packageSourceProvider.EnablePackageSource(originalPackageSourceName);
+                        }
+                        else
+                        {
+                            _packageSourceProvider.DisablePackageSource(originalPackageSourceName);
+                        }
+                    }
+
+                    // Only one value can be set at a time from Unified Settings, so we're done once a change is made.
+                    break;
+                }
+
+                result = ExternalSettingOperationResult.Success.Instance;
+            }
+            catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
+            {
+                throw ex;
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                result = CreateSettingErrorResult(ex.Message + " ('" + MonikerMachineWideSources + "')");
+            }
+
+            return result;
+        }
+
+        private ExternalSettingOperationResult SavePackageSources<T>(IList<IDictionary<string, object>> packageSourceDictionaryList, CancellationToken cancellationToken)
+        {
+            ExternalSettingOperationResult result;
+
+            try
+            {
+                List<PackageSource> packageSources = new List<PackageSource>(capacity: packageSourceDictionaryList.Count);
+                List<PackageSource> existingPackageSources = LoadPackageSources(isMachineWide: false);
+
+                foreach (Dictionary<string, object> packageSourceDictionary in packageSourceDictionaryList)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    string name = packageSourceDictionary[MonikerSourceName].ToString();
+                    string source = packageSourceDictionary[MonikerSourceUrl].ToString();
+                    bool isEnabled = (bool)packageSourceDictionary[MonikerIsEnabled];
+
+                    PackageSource packageSource =
+                        PackageSourceValidator.FindExistingOrCreate(
+                            source,
+                            name,
+                            isEnabled,
+                            existingPackageSources);
+
+                    packageSources.Add(packageSource);
+                }
+
+                // Throw any validation errors before saving.
+                PackageSourceValidator.ValidateUniquenessOrThrow(packageSources);
+
+                _packageSourceProvider.SavePackageSources(packageSources);
+                result = ExternalSettingOperationResult.Success.Instance;
+            }
+            catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
+            {
+                throw ex;
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                result = CreateSettingErrorResult(ex.Message);
+                ActivityLog.LogError(ExceptionHelper.LogEntrySource, ex.ToString());
+            }
+
+            return result;
+        }
+
+        private static ExternalSettingOperationResult<T> GetValuePackageSources<T>(List<PackageSource> packageSources)
+        {
+            ExternalSettingOperationResult<T> result;
+
+            try
+            {
+                var packageSourcesList = new List<Dictionary<string, object>>(capacity: packageSources.Count);
+
+                // Each list item is represented by a dictionary, which in this case will have a single key-value pair for ConfigPath.
+                foreach (PackageSource packageSource in packageSources)
+                {
+                    var dict = new Dictionary<string, object>(capacity: 3)
+                    {
+                        { MonikerSourceName, packageSource.Name },
+                        { MonikerSourceUrl, packageSource.SourceUri }, // Throws if Source is an invalid URI
+                        { MonikerIsEnabled, packageSource.IsEnabled },
+                    };
+
+                    packageSourcesList.Add(dict);
+                }
+
+                T castedPackageSources = (T)(object)packageSourcesList;
+                result = ExternalSettingOperationResult.SuccessResult(castedPackageSources);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                var userErrorMessage = Strings.Error_NuGetConfig_InvalidState + " " + ex.Message;
+                result = CreateSettingErrorResult<T>(userErrorMessage);
+
+                var logErrorMessage = Strings.Error_NuGetConfig_InvalidState + " " + ex.ToString();
+                ActivityLog.LogError(ExceptionHelper.LogEntrySource, logErrorMessage);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.PackageManagement.VisualStudio {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Strings {
@@ -246,6 +246,42 @@ namespace NuGet.PackageManagement.VisualStudio {
         public static string Error_MultipleFrameworks {
             get {
                 return ResourceManager.GetString("Error_MultipleFrameworks", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to One or more NuGet.Config files contain an error..
+        /// </summary>
+        public static string Error_NuGetConfig_InvalidState {
+            get {
+                return ResourceManager.GetString("Error_NuGetConfig_InvalidState", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The source specified is invalid..
+        /// </summary>
+        public static string Error_PackageSource_InvalidSource {
+            get {
+                return ResourceManager.GetString("Error_PackageSource_InvalidSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The name specified has already been added to the list of available package sources..
+        /// </summary>
+        public static string Error_PackageSource_UniqueName {
+            get {
+                return ResourceManager.GetString("Error_PackageSource_UniqueName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The source specified has already been added to the list of available package sources..
+        /// </summary>
+        public static string Error_PackageSource_UniqueSource {
+            get {
+                return ResourceManager.GetString("Error_PackageSource_UniqueSource", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.resx
@@ -292,4 +292,16 @@
   <data name="VSOptions_Button_Open" xml:space="preserve">
     <value>_Open</value>
   </data>
+  <data name="Error_PackageSource_InvalidSource" xml:space="preserve">
+    <value>The source specified is invalid.</value>
+  </data>
+  <data name="Error_PackageSource_UniqueName" xml:space="preserve">
+    <value>The name specified has already been added to the list of available package sources.</value>
+  </data>
+  <data name="Error_PackageSource_UniqueSource" xml:space="preserve">
+    <value>The source specified has already been added to the list of available package sources.</value>
+  </data>
+  <data name="Error_NuGetConfig_InvalidState" xml:space="preserve">
+    <value>One or more NuGet.Config files contain an error.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGetVSExtension {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -102,6 +102,33 @@ namespace NuGetVSExtension {
         internal static string DTE_ProjectUnsupported {
             get {
                 return ResourceManager.GetString("DTE_ProjectUnsupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A name must be provided..
+        /// </summary>
+        internal static string Error_PackageSourceName_Missing {
+            get {
+                return ResourceManager.GetString("Error_PackageSourceName_Missing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A source must be provided..
+        /// </summary>
+        internal static string Error_PackageSourceUri_Missing {
+            get {
+                return ResourceManager.GetString("Error_PackageSourceUri_Missing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A hostname must be provided after &apos;://&apos;..
+        /// </summary>
+        internal static string Error_PackageSourceUriHostname_Missing {
+            get {
+                return ResourceManager.GetString("Error_PackageSourceUriHostname_Missing", resourceCulture);
             }
         }
         
@@ -309,6 +336,60 @@ namespace NuGetVSExtension {
         internal static string Text_FilePath_Header {
             get {
                 return ResourceManager.GetString("Text_FilePath_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You are attempting to add an HTTP source, which is insecure..
+        /// </summary>
+        internal static string Text_HttpSource_Warning {
+            get {
+                return ResourceManager.GetString("Text_HttpSource_Warning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enabled.
+        /// </summary>
+        internal static string Text_PackageSourceEnabled_Header {
+            get {
+                return ResourceManager.GetString("Text_PackageSourceEnabled_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name.
+        /// </summary>
+        internal static string Text_PackageSourceName_Header {
+            get {
+                return ResourceManager.GetString("Text_PackageSourceName_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Machine-wide package sources.
+        /// </summary>
+        internal static string Text_PackageSources_MachineWide {
+            get {
+                return ResourceManager.GetString("Text_PackageSources_MachineWide", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package sources.
+        /// </summary>
+        internal static string Text_PackageSources_NotMachineWide {
+            get {
+                return ResourceManager.GetString("Text_PackageSources_NotMachineWide", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Source.
+        /// </summary>
+        internal static string Text_PackageSourceUrl_Header {
+            get {
+                return ResourceManager.GetString("Text_PackageSourceUrl_Header", resourceCulture);
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.Tools/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.resx
@@ -203,4 +203,31 @@
   <data name="Text_FilePath_Header" xml:space="preserve">
     <value>File Path</value>
   </data>
+  <data name="Text_PackageSourceName_Header" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="Text_PackageSourceUrl_Header" xml:space="preserve">
+    <value>Source</value>
+  </data>
+  <data name="Text_PackageSourceEnabled_Header" xml:space="preserve">
+    <value>Enabled</value>
+  </data>
+  <data name="Text_HttpSource_Warning" xml:space="preserve">
+    <value>You are attempting to add an HTTP source, which is insecure.</value>
+  </data>
+  <data name="Text_PackageSources_MachineWide" xml:space="preserve">
+    <value>Machine-wide package sources</value>
+  </data>
+  <data name="Text_PackageSources_NotMachineWide" xml:space="preserve">
+    <value>Package sources</value>
+  </data>
+  <data name="Error_PackageSourceName_Missing" xml:space="preserve">
+    <value>A name must be provided.</value>
+  </data>
+  <data name="Error_PackageSourceUri_Missing" xml:space="preserve">
+    <value>A source must be provided.</value>
+  </data>
+  <data name="Error_PackageSourceUriHostname_Missing" xml:space="preserve">
+    <value>A hostname must be provided after '://'.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
@@ -120,6 +120,103 @@
           ]
         }
       }
+    },
+    "nuGetPackageManager.packageSources.externalSettings": {
+      "type": "external",
+      "title": "@114;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+      "backingStoreDescription": "@SettingsStoredInNuGetConfiguration;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+
+      "callback": {
+        "packageId": "5fcc8577-4feb-4d04-ad72-d6c629b083cc",
+        "serviceId": "15C605EC-4FD7-446B-BA4A-75ECF0C0B2D0"
+      },
+
+      "realtimeNotifications": true,
+
+      // Settings within this external settings region.  Unlike "normal" settings, these have no registered default values.
+      // Their values are retrieved via IExternalSettingsProvider.GetValueAsync; when the user edits them, the new values are passed to
+      // IExternalSettingsProvider.SetValueAsync.
+      "properties": {
+        "packageSources": {
+          "type": "array",
+          "title": "@Text_PackageSources_NotMachineWide;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+
+          // Metadata about items in this array
+          "items": {
+            "type": "object",
+
+            // The properties of items in this array
+            "properties": {
+              "isEnabled": {
+                "type": "boolean",
+                "title": "@Text_PackageSourceEnabled_Header;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+                "default": true
+              },
+              "sourceName": {
+                "type": "string",
+                "title": "@Text_PackageSourceName_Header;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+                "default": "Package source"
+              },
+              "sourceUrl": {
+                "type": "string",
+                "format": "path",
+                "pathKind": "folderOrUri",
+                "title": "@Text_PackageSourceUrl_Header;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+                "default": "https://packagesource",
+                "messages": [
+                  {
+                    "text": "@Text_HttpSource_Warning;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+                    "visibleWhen": "${config:sourceUrl} ~= '(?i)^http\\\\:'",
+                    "severity": "warning"
+                  }
+                ]
+              }
+            }
+          },
+
+          // The actual items that appear by default; in most cases, you'd leave this array empty.
+          "default": [],
+          "allowItemEditing": true,
+          "allowAdditionsAndRemovals": true,
+          "messages": []
+        },
+        "machineWidePackageSources": {
+          "type": "array",
+          "title": "@Text_PackageSources_MachineWide;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+          "uniqueItems": true,
+          // Don't show Machine-wide Package Sources section when empty.
+          "visibleWhen": "${config:machineWidePackageSources} != '[]'",
+
+          // Metadata about items in this array
+          "items": {
+            "type": "object",
+
+            // The properties of items in this array
+            "properties": {
+              "isEnabled": {
+                "type": "boolean",
+                "title": "@Text_PackageSourceEnabled_Header;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}"
+              },
+              "sourceName": {
+                "type": "string",
+                "title": "@Text_PackageSourceName_Header;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}"
+              },
+              "sourceUrl": {
+                "type": "string",
+                "format": "path",
+                "pathKind": "folderOrUri",
+                "title": "@Text_PackageSourceUrl_Header;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}"
+              }
+            }
+          },
+
+          // The actual items that appear by default; in most cases, you'd leave this array empty.
+          "default": [],
+          "allowItemEditing": false,
+          "allowAdditionsAndRemovals": false,
+          "messages": []
+        }
+      }
     }
   },
   "categories": {
@@ -144,6 +241,11 @@
       "title": "@117;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
       "legacyOptionPageId": "C17B308A-00BB-446E-9212-2D14E1005985",
       "order": 1
+    },
+    "nuGetPackageManager.packageSources": {
+      "title": "@114;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+      "legacyOptionPageId": "2819C3B6-FC75-4CD5-8C77-877903DE864C",
+      "order": 2
     }
   }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
@@ -177,8 +177,7 @@
           // The actual items that appear by default; in most cases, you'd leave this array empty.
           "default": [],
           "allowItemEditing": true,
-          "allowAdditionsAndRemovals": true,
-          "messages": []
+          "allowAdditionsAndRemovals": true
         },
         "machineWidePackageSources": {
           "type": "array",
@@ -213,8 +212,7 @@
           // The actual items that appear by default; in most cases, you'd leave this array empty.
           "default": [],
           "allowItemEditing": false,
-          "allowAdditionsAndRemovals": false,
-          "messages": []
+          "allowAdditionsAndRemovals": false
         }
       }
     }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceValidatorTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceValidatorTests.cs
@@ -323,6 +323,48 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             result.IsEnabled.Should().Be(isEnabled, because: "Only the name should have changed.");
         }
 
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void FindExistingOrCreate_NullOrEmptyName_ThrowsArgumentException(string invalidName)
+        {
+            // Arrange
+            string source = "http://testsource1.com";
+            bool isEnabled = true;
+
+            List<PackageSource> packageSources = new List<PackageSource>();
+
+            // Act
+            Action act = () => PackageSourceValidator.FindExistingOrCreate(source, invalidName, isEnabled, packageSources);
+
+            // Assert
+            ArgumentException exception = Assert.Throws<ArgumentException>(act);
+            exception.Message.Should().Contain(Strings.Argument_Cannot_Be_Null_Or_Empty);
+            exception.ParamName.Should().Be("name");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void FindExistingOrCreate_NullOrEmptySource_ThrowsArgumentException(string invalidSource)
+        {
+            // Arrange
+            string name = "TestSource1";
+            bool isEnabled = true;
+
+            List<PackageSource> packageSources = new List<PackageSource>();
+
+            // Act
+            Action act = () => PackageSourceValidator.FindExistingOrCreate(invalidSource, name, isEnabled, packageSources);
+
+            // Assert
+            ArgumentException exception = Assert.Throws<ArgumentException>(act);
+            exception.Message.Should().Contain(Strings.Argument_Cannot_Be_Null_Or_Empty);
+            exception.ParamName.Should().Be("source");
+        }
+
         [Fact]
         public void FindExistingOrCreate_FoundExistingByName_UpdatesSource()
         {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceValidatorTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceValidatorTests.cs
@@ -1,0 +1,416 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using NuGet.Configuration;
+using NuGet.PackageManagement.VisualStudio.Options;
+using Xunit;
+
+namespace NuGet.PackageManagement.VisualStudio.Test.Options
+{
+    public class PackageSourceValidatorTests
+    {
+        [Theory]
+        [InlineData("TestSource", "TestSource")]
+        [InlineData(" TestSource ", " TestSource ")]
+        [InlineData("TestSource ", "TestSource ")]
+        [InlineData(" TestSource", "TestSource")]
+        [InlineData("TestSource", " TestSource")]
+        [InlineData("TestSource ", "TestSource")]
+        [InlineData("TestSource", "TestSource ")]
+        public void ValidateUniquenessOrThrow_DuplicateSourceNames_ThrowsArgumentException(string name1, string name2)
+        {
+            // Arrange
+            var packageSources = new List<PackageSource>
+            {
+                new PackageSource(source: "https://testsource1.com", name1),
+                new PackageSource(source: "https://testsource2.com", name2)
+            };
+
+            // Act
+            Action act = () => PackageSourceValidator.ValidateUniquenessOrThrow(packageSources);
+
+            // Assert
+            ArgumentException exception = Assert.Throws<ArgumentException>(act);
+            exception.Message.Should().Be(Strings.Error_PackageSource_UniqueName);
+        }
+
+        [Fact]
+        public void ValidateUniquenessOrThrow_ExactDuplicate_RemoteSources_ThrowsArgumentException()
+        {
+            // Arrange
+            string duplicateSource = "https://testsource.com";
+
+            var packageSources = new List<PackageSource>
+            {
+                new PackageSource(duplicateSource, name: "TestSource1"),
+                new PackageSource(duplicateSource, name: "TestSource2")
+            };
+
+            // Act
+            Action act = () => PackageSourceValidator.ValidateUniquenessOrThrow(packageSources);
+
+            // Assert
+            ArgumentException exception = Assert.Throws<ArgumentException>(act);
+            exception.Message.Should().Be(Strings.Error_PackageSource_UniqueSource);
+        }
+
+        [Fact]
+        public void ValidateUniquenessOrThrow_DuplicateWhenIgnoringTrailingSlash_RemoteSources_Succeeds()
+        {
+            // Arrange
+            string source1 = "https://testsource.com";
+            string source2 = $"{source1}/";
+
+            var packageSources = new List<PackageSource>
+            {
+                new PackageSource(source1, name: "TestSource1"),
+                new PackageSource(source2, name: "TestSource2")
+            };
+
+            // Act
+            PackageSourceValidator.ValidateUniquenessOrThrow(packageSources);
+
+            // Assert
+            // No exception should be thrown, indicating success.
+        }
+
+        [Theory]
+        [InlineData(@" custom://testsource.com/", @"custom://testsource.com/")]
+        [InlineData(@"custom://testsource.com/", @" custom://testsource.com/")]
+        [InlineData(@"custom://testsource.com/ ", @"custom://testsource.com/")]
+        [InlineData(@"custom://testsource.com/", @" custom://testsource.com/ ")]
+        [InlineData(@" https://testsource.com", @"https://testsource.com")]
+        [InlineData(@"https://testsource.com", @" https://testsource.com")]
+        [InlineData(@"https://testsource.com ", @"https://testsource.com")]
+        [InlineData(@"https://testsource.com", @"https://testsource.com ")]
+        [InlineData(@" https://api.nuget.org/v3/index.json", @"https://api.nuget.org/v3/index.json")]
+        [InlineData(@"https://api.nuget.org/v3/index.json", @" https://api.nuget.org/v3/index.json")]
+        [InlineData(@"https://api.nuget.org/v3/index.json ", @"https://api.nuget.org/v3/index.json")]
+        [InlineData(@"https://api.nuget.org/v3/index.json", @"https://api.nuget.org/v3/index.json ")]
+        public void ValidateUniquenessOrThrow_DuplicateWhenIgnoringWhitespace_RemoteSources_ThrowsArgumentException(string source1, string source2)
+        {
+            // Arrange
+            var packageSources = new List<PackageSource>
+            {
+                new PackageSource(source1, name: "TestSource1"),
+                new PackageSource(source2, name: "TestSource2")
+            };
+
+            // Act
+            Action act = () => PackageSourceValidator.ValidateUniquenessOrThrow(packageSources);
+
+            // Assert
+            ArgumentException exception = Assert.Throws<ArgumentException>(act);
+            exception.Message.Should().Be(Strings.Error_PackageSource_UniqueSource);
+        }
+
+        [Theory]
+        [InlineData(@"\\server\share", @"\\server\share\")]
+        [InlineData(@"C:\path", @"C:\path\")]
+        [InlineData(@"C:\path\to", @"C:\path\to\")]
+        public void ValidateUniquenessOrThrow_DuplicateWhenIgnoringTrailingSlash_PathSources_ThrowsArgumentException(string source1, string source2)
+        {
+            // Arrange
+            var packageSources = new List<PackageSource>
+            {
+                new PackageSource(source: source1, name: "TestSource1"),
+                new PackageSource(source: source2, name: "TestSource2")
+            };
+
+            // Act
+            Action act = () => PackageSourceValidator.ValidateUniquenessOrThrow(packageSources);
+
+            // Assert
+            ArgumentException exception = Assert.Throws<ArgumentException>(act);
+            exception.Message.Should().Be(Strings.Error_PackageSource_UniqueSource);
+        }
+
+        [Theory]
+        [InlineData(@"http://")]
+        [InlineData(@"https://")]
+        [InlineData(@"https:// ")]
+        public void EnsureValidSources_MissingProtocol_RemoteSource_ThrowsArgumentOutOfRangeException(string invalidSource)
+        {
+            // Arrange
+            var packageSource = new PackageSource(source: invalidSource, name: "TestSource1");
+
+            // Act
+            Action act = () => PackageSourceValidator.EnsureValidSources(packageSource);
+
+            // Assert
+            ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(act);
+            exception.ParamName.Should().Be(nameof(PackageSource.Source));
+            exception.Message.Should().StartWith(Strings.Error_PackageSource_InvalidSource);
+        }
+
+        [Theory]
+        [InlineData(@" https://")]
+        [InlineData(@"ftp://")]
+        [InlineData(@"http:/")]
+        public void EnsureValidSources_InvalidSource_RemoteSource_ThrowsArgumentOutOfRangeException(string invalidSource)
+        {
+            // Arrange
+            var packageSource = new PackageSource(source: invalidSource, name: "TestInvalidSource");
+
+            // Act
+            Action act = () => PackageSourceValidator.EnsureValidSources(packageSource);
+
+            // Assert
+            ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(act);
+            exception.ParamName.Should().Be(nameof(PackageSource.Source));
+            exception.Message.Should().StartWith(Strings.Error_PackageSource_InvalidSource);
+        }
+
+        [Theory]
+        [InlineData(@"custom://testsource.com/")]
+        [InlineData(@"https://testsource.com/")]
+        [InlineData(@"https://api.nuget.org/v3/index.json")]
+        [InlineData(@"https://1")]
+        [InlineData(@"https://testsource.com")]
+        [InlineData(@"ftp://1")]
+        [InlineData(@"ftp://testsource.com")]
+        public void ValidateUniquenessOrThrow_ValidRemoteSources_Successful(string validSource)
+        {
+            // Arrange
+            var packageSources = new List<PackageSource>
+            {
+                new PackageSource(validSource, name: "TestSource1"),
+            };
+
+            // Act
+            PackageSourceValidator.ValidateUniquenessOrThrow(packageSources);
+
+            // Assert
+            // No exception should be thrown, indicating success.
+        }
+
+        [Theory]
+        [InlineData(@"C")]
+        [InlineData(@"http")] // Missing :// causes this to be treated as a file path.
+        [InlineData(@"http:")]
+        [InlineData(@"ftp")] // Missing :// causes this to be treated as a file path.
+        [InlineData(@"C:")]
+        [InlineData(@"C:\invalid\*\'\chars")]
+        [InlineData(@"\\server\invalid\*\")]
+        [InlineData(@"..\packages")]
+        [InlineData(@"./configs/source.config")]
+        [InlineData(@"../local-packages/")]
+        public void EnsureValidSources_InvalidUncPath_ThrowsArgumentOutOfRangeException(string invalidSource)
+        {
+            // Arrange
+            var packageSource = new PackageSource(source: invalidSource, name: "TestInvalidSource");
+
+            // Act
+            Action act = () => PackageSourceValidator.EnsureValidSources(packageSource);
+
+            // Assert
+            ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(act);
+            exception.ParamName.Should().Be(nameof(PackageSource.Source));
+            exception.Message.Should().StartWith(Strings.Error_PackageSource_InvalidSource);
+        }
+
+        [Theory]
+        [InlineData(@"C:\")]
+        [InlineData(@"C:\path")]
+        [InlineData(@"C:\path\")]
+        [InlineData(@"C:\path\to")]
+        [InlineData(@"C:\path\to\")]
+        public void EnsureValidSources_ValidUncPath_Successful(string validSource)
+        {
+            // Arrange
+            var packageSource = new PackageSource(source: validSource, name: "TestValidSource");
+
+            // Act
+            PackageSourceValidator.EnsureValidSources(packageSource);
+
+            // Assert
+            // No exception should be thrown, indicating success.
+        }
+
+        [Fact]
+        public void FindExistingOrCreate_NewSource_CreatesNewSource()
+        {
+            // Arrange
+            string name = "TestSource3";
+            string source = "https://testsource3.com";
+            bool isEnabled = true;
+
+            var packageSources = new List<PackageSource>
+            {
+                new PackageSource(source: "https://testsource1.com", name: "TestSource1", isEnabled: true),
+                new PackageSource(source: "https://testsource2.com", name: "TestSource2", isEnabled: true)
+            };
+
+            // Act
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(source, name, isEnabled, packageSources);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Name.Should().Be(name);
+            result.Source.Should().Be(source);
+            result.IsEnabled.Should().Be(isEnabled);
+        }
+
+        [Fact]
+        public void FindExistingOrCreate_NewHttpSource_CreatesNewSource_WithAllowInsecureConnectionsSetToTrue()
+        {
+            // Arrange
+            string name = "TestSource3";
+            string source = "http://testsource3.com";
+            bool isEnabled = true;
+
+            var packageSources = new List<PackageSource>
+            {
+                new PackageSource(source: "https://testsource1.com", name: "TestSource1", isEnabled: true),
+                new PackageSource(source: "https://testsource2.com", name: "TestSource2", isEnabled: true)
+            };
+
+            // Act
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(source, name, isEnabled, packageSources);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Name.Should().Be(name);
+            result.Source.Should().Be(source);
+            result.IsEnabled.Should().Be(isEnabled);
+            result.AllowInsecureConnections
+                .Should()
+                .BeTrue(because: "New HTTP sources should allow insecure connections by default.");
+        }
+
+        [Fact]
+        public void FindExistingOrCreate_FoundExistingBySource_UpdatesName()
+        {
+            // Arrange
+            string originalName = "TestSource1";
+            string originalSource = "http://testsource1.com";
+
+            string name = "TestSource2";
+            string source = originalSource;
+            bool isEnabled = true;
+
+            bool originalAllowInsecureConnections = true;
+            bool originalDisableTLSCertificateValidation = true;
+            PackageSourceCredential originalCredential = GetTestPackageSourceCredential(name);
+
+            var packageSources = new List<PackageSource>
+            {
+                new PackageSource(source: originalSource, name: originalName, isEnabled)
+                {
+                    AllowInsecureConnections = originalAllowInsecureConnections,
+                    DisableTLSCertificateValidation = originalDisableTLSCertificateValidation,
+                    Credentials = originalCredential
+                }
+            };
+
+            // Act
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(source, name, isEnabled, packageSources);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Name.Should().Be(name, because: "A rename was expected.");
+
+            // Verify unchanged properties.
+            result.Source.Should().Be(source, because: "Only the name should have changed.");
+            result.AllowInsecureConnections.Should().Be(originalAllowInsecureConnections, because: "Only the name should have changed.");
+            result.DisableTLSCertificateValidation.Should().Be(originalDisableTLSCertificateValidation, because: "Only the name should have changed.");
+            result.Credentials.Should().BeEquivalentTo(originalCredential, because: "Only the name should have changed.");
+            result.IsEnabled.Should().Be(isEnabled, because: "Only the name should have changed.");
+        }
+
+        [Fact]
+        public void FindExistingOrCreate_FoundExistingByName_UpdatesSource()
+        {
+            // Arrange
+            string originalName = "TestSource1";
+            string originalSource = "http://testsource1.com";
+
+            string name = originalName;
+            string source = "https://testsource2.com";
+            bool isEnabled = true;
+
+            bool originalAllowInsecureConnections = true;
+            bool originalDisableTLSCertificateValidation = true;
+            PackageSourceCredential originalCredential = GetTestPackageSourceCredential(name);
+
+            var packageSources = new List<PackageSource>
+            {
+                new PackageSource(source: originalSource, name: originalName, isEnabled)
+                {
+                    AllowInsecureConnections = originalAllowInsecureConnections,
+                    DisableTLSCertificateValidation = originalDisableTLSCertificateValidation,
+                    Credentials = originalCredential
+                }
+            };
+
+            // Act
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(source, name, isEnabled, packageSources);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Source.Should().Be(source, because: "A source change was expected.");
+
+            // Verify unchanged properties.
+            result.Name.Should().Be(originalName, because: "Only the source should have changed.");
+            result.AllowInsecureConnections.Should().Be(originalAllowInsecureConnections, because: "Only the source should have changed.");
+            result.DisableTLSCertificateValidation.Should().Be(originalDisableTLSCertificateValidation, because: "Only the source should have changed.");
+            result.Credentials.Should().BeEquivalentTo(originalCredential, because: "Only the source should have changed.");
+            result.IsEnabled.Should().Be(isEnabled, because: "Only the source should have changed.");
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void FindExistingOrCreate_FoundExistingByNameAndSource_UpdatesIsEnabled(bool originalIsEnabled)
+        {
+            // Arrange
+            string name = "TestSource1";
+            string source = "http://testsource1.com";
+            bool isEnabled = !originalIsEnabled; // Toggle the enabled state
+
+            bool originalAllowInsecureConnections = true;
+            bool originalDisableTLSCertificateValidation = true;
+            PackageSourceCredential originalCredential = GetTestPackageSourceCredential(name);
+
+            var packageSources = new List<PackageSource>
+            {
+                new PackageSource(source, name, originalIsEnabled)
+                {
+                    AllowInsecureConnections = originalAllowInsecureConnections,
+                    DisableTLSCertificateValidation = originalDisableTLSCertificateValidation,
+                    Credentials = originalCredential
+                }
+            };
+
+            // Act
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(source, name, isEnabled, packageSources);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsEnabled.Should().Be(isEnabled, because: "The IsEnabled state should have been toggled.");
+
+            // Verify unchanged properties.
+            result.Name.Should().Be(name, because: "Only IsEnabled should have changed.");
+            result.Source.Should().Be(source, because: "Only IsEnabled should have changed.");
+            result.AllowInsecureConnections.Should().Be(originalAllowInsecureConnections, because: "Only IsEnabled should have changed.");
+            result.DisableTLSCertificateValidation.Should().Be(originalDisableTLSCertificateValidation, because: "Only IsEnabled should have changed.");
+            result.Credentials.Should().BeEquivalentTo(originalCredential, because: "Only IsEnabled should have changed.");
+            result.IsEnabled.Should().Be(isEnabled, because: "Only IsEnabled should have changed.");
+        }
+
+        private static PackageSourceCredential GetTestPackageSourceCredential(string packageSourceName)
+        {
+            return new(
+                source: packageSourceName,
+                username: "user",
+                passwordText: "pass",
+                isPasswordClearText: true,
+                validAuthenticationTypesText: "basic");
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourcesPageTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourcesPageTests.cs
@@ -1,0 +1,153 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.Sdk.TestFramework;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Utilities.UnifiedSettings;
+using NuGet.Configuration;
+using NuGet.PackageManagement.VisualStudio.Options;
+using NuGet.VisualStudio;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.PackageManagement.VisualStudio.Test.Options
+{
+    [Collection(MockedVS.Collection)]
+    public class PackageSourcesPageTests : NuGetExternalSettingsProviderTests<PackageSourcesPage>
+    {
+        private IEnumerable<PackageSource>? _packageSources;
+
+        public PackageSourcesPageTests(GlobalServiceProvider sp)
+        {
+            sp.Reset();
+            NuGetUIThreadHelper.SetCustomJoinableTaskFactory(ThreadHelper.JoinableTaskFactory);
+            _packageSources = Enumerable.Empty<PackageSource>();
+        }
+
+        protected override PackageSourcesPage CreateInstance(VSSettings? vsSettings)
+        {
+            TestPackageSourceProvider packageSourceProvider = new(_packageSources);
+
+            return new PackageSourcesPage(vsSettings!, packageSourceProvider);
+        }
+
+        [Fact]
+        public async Task GetValueAsync_WhenNuGetConfigHasInvalidSource_ReturnsFailureResultTaskAsync()
+        {
+            // Arrange
+            string invalidSource = "http://";
+            _packageSources =
+            [
+                new PackageSource(invalidSource, "unitTestingSourceName")
+            ];
+
+            PackageSourcesPage instance = CreateInstance(_vsSettings);
+
+            // Act
+            var result = await instance.GetValueAsync<List<Dictionary<string, object>>>(
+                PackageSourcesPage.MonikerPackageSources,
+                CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<ExternalSettingOperationResult<List<Dictionary<string, object>>>.Failure>();
+
+            var failure = result as ExternalSettingOperationResult<List<Dictionary<string, object>>>.Failure;
+            failure.Should().NotBeNull();
+            failure.IsTransient.Should().BeTrue();
+            failure.Scope.Should().Be(ExternalSettingsErrorScope.SingleSettingOnly);
+            failure.ErrorMessage.Should().StartWith(Strings.Error_NuGetConfig_InvalidState);
+        }
+
+        [Theory]
+        [InlineData(@"http://")]
+        [InlineData(@"https://")]
+        [InlineData(@"https:// ")]
+        [InlineData(@" https://")]
+        [InlineData(@"ftp://")]
+        [InlineData(@"http:/")]
+        public async Task SetValueAsync_WithInvalidRemoteSource_ReturnsFailureResultTaskAsync(string invalidSource)
+        {
+            // Arrange
+            PackageSourcesPage instance = CreateInstance(_vsSettings);
+            Dictionary<string, object> packageSourceDictionary = new Dictionary<string, object>();
+
+            packageSourceDictionary["sourceName"] = "unitTestingSourceName";
+            packageSourceDictionary["sourceUrl"] = invalidSource;
+            packageSourceDictionary["isEnabled"] = true;
+
+            IList<IDictionary<string, object>> packageSourceDictionaryList =
+                new List<IDictionary<string, object>>(capacity: 1)
+                {
+                    packageSourceDictionary
+                };
+
+            // Act
+            ExternalSettingOperationResult result = await instance.SetValueAsync(
+                PackageSourcesPage.MonikerPackageSources,
+                packageSourceDictionaryList,
+                CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<ExternalSettingOperationResult.Failure>();
+
+            var failure = result as ExternalSettingOperationResult.Failure;
+            failure.Should().NotBeNull();
+            failure.IsTransient.Should().BeTrue();
+            failure.Scope.Should().Be(ExternalSettingsErrorScope.SingleSettingOnly);
+            failure.ErrorMessage.Should().StartWith(Strings.Error_PackageSource_InvalidSource);
+        }
+
+        [Theory]
+        [InlineData(@"C")]
+        [InlineData(@"http")] // Missing :// causes this to be treated as a file path.
+        [InlineData(@"http:")]
+        [InlineData(@"ftp")] // Missing :// causes this to be treated as a file path.
+        [InlineData(@"C:")]
+        [InlineData(@"C:\invalid\*\'\chars")]
+        [InlineData(@"\\server\invalid\*\")]
+        [InlineData(@"..\packages")]
+        [InlineData(@"./configs/source.config")]
+        [InlineData(@"../local-packages/")]
+        public async Task SetValueAsync_WithInvalidUncPath_ReturnsFailureResultTaskAsync(string invalidSource)
+        {
+            // Arrange
+            PackageSourcesPage instance = CreateInstance(_vsSettings);
+            Dictionary<string, object> packageSourceDictionary = new Dictionary<string, object>();
+
+            packageSourceDictionary["sourceName"] = "unitTestingSourceName";
+            packageSourceDictionary["sourceUrl"] = invalidSource;
+            packageSourceDictionary["isEnabled"] = true;
+
+            IList<IDictionary<string, object>> packageSourceDictionaryList =
+                new List<IDictionary<string, object>>(capacity: 1)
+                {
+                    packageSourceDictionary
+                };
+
+            // Act
+            ExternalSettingOperationResult result = await instance.SetValueAsync(
+                PackageSourcesPage.MonikerPackageSources,
+                packageSourceDictionaryList,
+                CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<ExternalSettingOperationResult.Failure>();
+
+            var failure = result as ExternalSettingOperationResult.Failure;
+            failure.Should().NotBeNull();
+            failure.IsTransient.Should().BeTrue();
+            failure.Scope.Should().Be(ExternalSettingsErrorScope.SingleSettingOnly);
+            failure.ErrorMessage.Should().StartWith(Strings.Error_PackageSource_InvalidSource);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourcesPageTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourcesPageTests.cs
@@ -11,10 +11,10 @@ using FluentAssertions;
 using Microsoft.VisualStudio.Sdk.TestFramework;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Utilities.UnifiedSettings;
+using Moq;
 using NuGet.Configuration;
 using NuGet.PackageManagement.VisualStudio.Options;
 using NuGet.VisualStudio;
-using Test.Utility;
 using Xunit;
 
 namespace NuGet.PackageManagement.VisualStudio.Test.Options
@@ -22,7 +22,9 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
     [Collection(MockedVS.Collection)]
     public class PackageSourcesPageTests : NuGetExternalSettingsProviderTests<PackageSourcesPage>
     {
-        private IEnumerable<PackageSource>? _packageSources;
+        private IEnumerable<PackageSource> _packageSources;
+        private int _countEnablePackageSourceCalled = 0;
+        private int _countDisablePackageSourceCalled = 0;
 
         public PackageSourcesPageTests(GlobalServiceProvider sp)
         {
@@ -33,9 +35,25 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
 
         protected override PackageSourcesPage CreateInstance(VSSettings? vsSettings)
         {
-            TestPackageSourceProvider packageSourceProvider = new(_packageSources);
+            Mock<IPackageSourceProvider> mockedPackageSourceProvider = new Mock<IPackageSourceProvider>();
+            mockedPackageSourceProvider.Setup(packageSourceProvider => packageSourceProvider.LoadPackageSources())
+                .Returns(_packageSources);
 
-            return new PackageSourcesPage(vsSettings!, packageSourceProvider);
+            mockedPackageSourceProvider.Setup(packageSourceProvider =>
+                packageSourceProvider.EnablePackageSource(It.IsAny<string>()))
+                .Callback<string>(name =>
+                {
+                    _countEnablePackageSourceCalled++;
+                });
+
+            mockedPackageSourceProvider.Setup(packageSourceProvider =>
+                packageSourceProvider.DisablePackageSource(It.IsAny<string>()))
+                .Callback<string>(name =>
+                {
+                    _countDisablePackageSourceCalled++;
+                });
+
+            return new PackageSourcesPage(vsSettings!, mockedPackageSourceProvider.Object);
         }
 
         [Fact]
@@ -148,6 +166,82 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             failure.IsTransient.Should().BeTrue();
             failure.Scope.Should().Be(ExternalSettingsErrorScope.SingleSettingOnly);
             failure.ErrorMessage.Should().StartWith(Strings.Error_PackageSource_InvalidSource);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task SetValueAsync_MonikerMachineWideSources_UpdatesIsEnabledAsync(bool isEnabled)
+        {
+            // Arrange
+            string sourceName1 = "unitTestingSourceName1";
+            string sourceUrl1 = "https://testsource1.com";
+            bool isSource1Enabled = isEnabled;
+
+            string sourceName2 = "unitTestingSourceName2";
+            string sourceUrl2 = "https://testsource2.com";
+            bool isSource2Enabled = true;
+
+            string sourceName3 = "unitTestingSourceName3";
+            string sourceUrl3 = "https://testsource3.com";
+            bool isSource3Enabled = isEnabled;
+
+            // Configure 3 existing package sources
+            _packageSources =
+            [
+                new PackageSource(sourceUrl1, sourceName1, isSource1Enabled)
+                {
+                    IsMachineWide=true
+                },
+                new PackageSource(sourceUrl2, sourceName2, isSource2Enabled)
+                {
+                    IsMachineWide=true
+                },
+                new PackageSource(sourceUrl3, sourceName3, isSource3Enabled)
+                {
+                    IsMachineWide=true
+                }
+            ];
+
+            PackageSourcesPage instance = CreateInstance(_vsSettings);
+
+            // Configure Unified Settings input to Toggle 2 of the 3 IsEnabled states.
+            Dictionary<string, object> packageSourceDictionary1 = new Dictionary<string, object>();
+            packageSourceDictionary1["sourceName"] = sourceName1;
+            packageSourceDictionary1["sourceUrl"] = sourceUrl1;
+            packageSourceDictionary1["isEnabled"] = !isSource1Enabled; // Toggle the enabled state for the first source.
+
+            Dictionary<string, object> packageSourceDictionary2 = new Dictionary<string, object>();
+            packageSourceDictionary2["sourceName"] = sourceName2;
+            packageSourceDictionary2["sourceUrl"] = sourceUrl2;
+            packageSourceDictionary2["isEnabled"] = isSource2Enabled;
+
+            Dictionary<string, object> packageSourceDictionary3 = new Dictionary<string, object>();
+            packageSourceDictionary3["sourceName"] = sourceName3;
+            packageSourceDictionary3["sourceUrl"] = sourceUrl3;
+            packageSourceDictionary3["isEnabled"] = !isSource3Enabled; // Toggle the enabled state for the third source.
+
+            IList<IDictionary<string, object>> packageSourceDictionaryList =
+                new List<IDictionary<string, object>>(capacity: 3)
+                {
+                    packageSourceDictionary1,
+                    packageSourceDictionary2,
+                    packageSourceDictionary3
+                };
+
+            // Act
+            ExternalSettingOperationResult result = await instance.SetValueAsync(
+                PackageSourcesPage.MonikerMachineWideSources,
+                packageSourceDictionaryList,
+                CancellationToken.None);
+
+            // Assert
+            int expectedEnableCount = isEnabled ? 0 : 2;
+            int expectedDisableCount = isEnabled ? 2 : 0;
+            _countEnablePackageSourceCalled.Should().Be(expectedEnableCount);
+            _countDisablePackageSourceCalled.Should().Be(expectedDisableCount);
+            result.Should().NotBeNull();
+            result.Should().BeOfType<ExternalSettingOperationResult.Success>();
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourcesPageTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourcesPageTests.cs
@@ -191,15 +191,15 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             [
                 new PackageSource(sourceUrl1, sourceName1, isSource1Enabled)
                 {
-                    IsMachineWide=true
+                    IsMachineWide = true
                 },
                 new PackageSource(sourceUrl2, sourceName2, isSource2Enabled)
                 {
-                    IsMachineWide=true
+                    IsMachineWide = true
                 },
                 new PackageSource(sourceUrl3, sourceName3, isSource3Enabled)
                 {
-                    IsMachineWide=true
+                    IsMachineWide = true
                 }
             ];
 

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/PathValidatorTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/PathValidatorTest.cs
@@ -48,13 +48,14 @@ namespace NuGet.Common
         }
 
         [Theory]
-        [InlineData(@"C:", "windows")]
-        //[InlineData(@"\\server\invalid\*\","windows")] TODO: Enabled once this issue is fixed: https://github.com/NuGet/Home/issues/7588
-        [InlineData(@"https://test", "windows")]
-        [InlineData(@"..\packages", "windows")]
-        public void PathValidatorTest_InvalidUncSharePath(string path, string os)
+        [InlineData(@"C")]
+        [InlineData(@"C:")]
+        [InlineData(@"\\server\invalid\*\")]
+        [InlineData(@"https://test")]
+        [InlineData(@"..\packages")]
+        public void PathValidatorTest_InvalidUncSharePath(string path)
         {
-            if ((os == "windows" && RuntimeEnvironmentHelper.IsWindows) || (os == "unix-base" && !RuntimeEnvironmentHelper.IsWindows))
+            if (RuntimeEnvironmentHelper.IsWindows)
             {
                 Assert.False(PathValidator.IsValidUncPath(path));
             }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/PathValidatorTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/PathValidatorTest.cs
@@ -50,7 +50,10 @@ namespace NuGet.Common
         [Theory]
         [InlineData(@"C")]
         [InlineData(@"C:")]
+        // .NET 9.0 and later support wildcards in UNC paths, so this test is only valid for earlier versions.
+#if !NET9_0_OR_GREATER
         [InlineData(@"\\server\invalid\*\")]
+#endif
         [InlineData(@"https://test")]
         [InlineData(@"..\packages")]
         public void PathValidatorTest_InvalidUncSharePath(string path)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14233
Fixes: https://github.com/NuGet/Home/issues/13057
Fixes: https://github.com/NuGet/Home/issues/13434
Fixes: https://github.com/NuGet/Home/issues/14374
Fixes: https://github.com/NuGet/Home/issues/13278
Fixes: https://github.com/NuGet/Home/issues/7560
Fixes: https://github.com/NuGet/Home/issues/7822

## Description

Registers the Package Sources options page with Unified Settings (USX) as a table of Name, Source, and IsEnabled which can be added or edited using the buttons below the table or the IsEnabled column checkbox, directly. 

A second table will appear when Machine Wide Package Sources are available. This table only supports changing the IsEnabled column checkbox for existing sources.

![image](https://github.com/user-attachments/assets/9addd896-018d-4551-bb56-ae5477c44651)


Most of the Legacy VS Options ("Legacy") behavior is maintained or enhanced.
There were no unit tests around behavior there which I've now added. 
  - Extracts legacy VS Options WinForms logic for managing package sources into a static class, `PackageSourceValidator`:
    - looking up or creation of a package source
    - uniqueness checking
    - source (path/HTTPS) validation

### Enhancements
- No longer overwrites PackageSource properties (eg, `disableTLSCertificateValidation`,  `packageSourceCredentials`, etc are preserved) when changing **either name or source**. However, if **both name and source** are edited in the same transaction, the package source is removed/added so it does lose those properties.
  - Legacy always overwrote properties when changing name or source
  - **Future** iteration can handle the "both edited" case once USX supports an Identifier for data items, or similar means of identifying the user-modified item.

- Add/Edit now happens in a dialog so we no longer have to use the legacy Update button and logic.
![image](https://github.com/user-attachments/assets/5eef2450-3af5-49a3-8a89-27040240db10)

### Known Bugs

- [Blocked until next iteration] Any PackageSource validation error will require restarting VS to continue using the Package Sources settings page 
  - Unified Settings API bug fix is promised for June 2025 so I expect to iterate with a fix this Sprint.
  - ![image](https://github.com/user-attachments/assets/2870b4b7-f25f-4d16-9d00-7e4824c8c69c)

### Other Scenarios

- Insecure Connections warning icons are shown in the list.
![image](https://github.com/user-attachments/assets/d8168e84-5dbf-4913-b17c-7c2f0bd1b3ad)

- Reminder that in Legacy, `allowInsecureConnections` was set to `true` once the user continues adding an HTTP source despite the warning. This behavior has been brought into USX as well.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/14039
