### PR TITLE
Allow package update to use specific version

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/IVersionChooser.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/IVersionChooser.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Versioning;
+
+namespace NuGet.CommandLine.XPlat.Commands.Package.Update
+{
+    internal interface IVersionChooser
+    {
+        Task<NuGetVersion?> GetLatestVersionAsync(
+            string packageId,
+            ILoggerWithColor logger,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/Package.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/Package.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.CommandLine.Parsing;
+using NuGet.Versioning;
+
+namespace NuGet.CommandLine.XPlat.Commands.Package.Update
+{
+    internal record Package
+    {
+        public required string Id { get; init; }
+        public required VersionRange? VersionRange { get; init; }
+
+        internal static List<Package> Parse(ArgumentResult result)
+        {
+            if (result.Tokens.Count == 0)
+            {
+                return [];
+            }
+
+            List<Package> packages = new List<Package>(result.Tokens.Count);
+
+            foreach (var token in result.Tokens)
+            {
+                string? packageId;
+                VersionRange? newVersion;
+                int separatorIndex = token.Value.IndexOf('@');
+                if (separatorIndex < 0)
+                {
+                    packageId = token.Value;
+                    newVersion = null;
+                }
+                else
+                {
+                    packageId = token.Value.Substring(0, separatorIndex);
+                    string versionString = token.Value.Substring(separatorIndex + 1);
+                    if (string.IsNullOrEmpty(versionString))
+                    {
+                        result.AddError("todo");
+                        return [];
+                    }
+                    if (!VersionRange.TryParse(versionString, out newVersion))
+                    {
+                        result.AddError("todo");
+                        return [];
+                    }
+                }
+
+                var package = new Package
+                {
+                    Id = packageId,
+                    VersionRange = newVersion
+                };
+                packages.Add(package);
+            }
+
+            return packages;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/Package.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/Package.cs
@@ -14,7 +14,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
         public required string Id { get; init; }
         public required VersionRange? VersionRange { get; init; }
 
-        internal static List<Package> Parse(ArgumentResult result)
+        internal static IReadOnlyList<Package> Parse(ArgumentResult result)
         {
             if (result.Tokens.Count == 0)
             {
@@ -39,12 +39,12 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
                     string versionString = token.Value.Substring(separatorIndex + 1);
                     if (string.IsNullOrEmpty(versionString))
                     {
-                        result.AddError("todo");
+                        result.AddError(Messages.Error_MissingVersion(token.Value));
                         return [];
                     }
                     if (!VersionRange.TryParse(versionString, out newVersion))
                     {
-                        result.AddError("todo");
+                        result.AddError(Messages.Error_InvalidVersionRange(versionString));
                         return [];
                     }
                 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateArgs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateArgs.cs
@@ -11,6 +11,6 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
     {
         public required string Project { get; init; }
 
-        public IReadOnlyList<string>? Packages { get; init; }
+        public required IReadOnlyList<Package> Packages { get; init; }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommand.cs
@@ -34,9 +34,10 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
         {
             var command = new DocumentedCommand("update", Strings.PackageUpdateCommand_Description, "https://aka.ms/dotnet/package/update");
 
-            var packagesArguments = new Argument<List<string>>("packages")
+            var packagesArguments = new Argument<List<Package>>("packages")
             {
                 Arity = ArgumentArity.ZeroOrMore,
+                CustomParser = Package.Parse
             };
             command.Arguments.Add(packagesArguments);
 
@@ -49,7 +50,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
             {
                 var logger = getLogger();
                 var project = args.GetValue(projectOption);
-                var packages = args.GetValue(packagesArguments);
+                var packages = args.GetValue(packagesArguments) ?? [];
 
                 var commandArgs = new PackageUpdateArgs
                 {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommand.cs
@@ -34,8 +34,9 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
         {
             var command = new DocumentedCommand("update", Strings.PackageUpdateCommand_Description, "https://aka.ms/dotnet/package/update");
 
-            var packagesArguments = new Argument<List<Package>>("packages")
+            var packagesArguments = new Argument<IReadOnlyList<Package>>("packages")
             {
+                Description = Strings.PackageUpdate_PackageArgumentDescription,
                 Arity = ArgumentArity.ZeroOrMore,
                 CustomParser = Package.Parse
             };

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -61,7 +61,8 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
             // Source provider will be needed to find the package version and to restore, so create it here.
             CachingSourceProvider sourceProvider = new CachingSourceProvider(new PackageSourceProvider(settings));
             using SourceCacheContext sourceCacheContext = new();
-            (PackageDependency? packageToUpdate, List<NuGetFramework>? packageTfms) = await GetPackageToUpdateAsync(args.Packages, dgSpec.Projects.Single(), sourceProvider, settings, sourceCacheContext, logger, cancellationToken);
+            var versionChooser = new VersionChooser(sourceProvider, settings, sourceCacheContext);
+            (PackageDependency? packageToUpdate, List<NuGetFramework>? packageTfms) = await GetPackageToUpdateAsync(args.Packages, dgSpec.Projects.Single(), versionChooser, settings, logger, cancellationToken);
 
             if (packageToUpdate is null)
             {
@@ -153,12 +154,11 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
             return restoreResult.Single();
         }
 
-        private static async Task<(PackageDependency?, List<NuGetFramework>?)> GetPackageToUpdateAsync(
-            IReadOnlyList<string>? packages,
+        internal static async Task<(PackageDependency?, List<NuGetFramework>?)> GetPackageToUpdateAsync(
+            IReadOnlyList<Package> packages,
             PackageSpec project,
-            CachingSourceProvider sourceProvider,
+            IVersionChooser versionChooser,
             ISettings settings,
-            SourceCacheContext sourceCacheContext,
             ILoggerWithColor logger,
             CancellationToken cancellationToken)
         {
@@ -181,7 +181,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
                 return (null, null);
             }
 
-            var packageId = packages.Single();
+            var package = packages.Single();
 
             VersionRange? existingVersion = null;
             List<NuGetFramework>? frameworks = null;
@@ -189,7 +189,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
             {
                 foreach (var dependency in tfm.Dependencies)
                 {
-                    if (string.Equals(packageId, dependency.Name, StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(package.Id, dependency.Name, StringComparison.OrdinalIgnoreCase))
                     {
                         if (frameworks is null)
                         {
@@ -201,11 +201,11 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
                         if (project.RestoreMetadata.CentralPackageFloatingVersionsEnabled)
                         {
                             if (!tfm.CentralPackageVersions.TryGetValue(
-                                packageId,
+                                package.Id,
                                 out CentralPackageVersion? centralVersion))
                             {
                                 logger.LogMinimal(
-                                    Messages.Error_CouldNotFindPackageVersionForCpmPackage(packageId),
+                                    Messages.Error_CouldNotFindPackageVersionForCpmPackage(package.Id),
                                     ConsoleColor.Red);
                                 return (null, null);
                             }
@@ -225,7 +225,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
                             if (tfmVersionRange != existingVersion)
                             {
                                 logger.LogMinimal(
-                                    Messages.Unsupported_UpdatePackageWithDifferentPerTfmVersions(packageId, project.FilePath),
+                                    Messages.Unsupported_UpdatePackageWithDifferentPerTfmVersions(package.Id, project.FilePath),
                                     ConsoleColor.Red);
                                 return (null, null);
                             }
@@ -236,31 +236,43 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
 
             if (existingVersion is null)
             {
-                logger.LogMinimal(Messages.Error_PackageNotReferenced(packageId, project.FilePath), ConsoleColor.Red);
+                logger.LogMinimal(Messages.Error_PackageNotReferenced(package.Id, project.FilePath), ConsoleColor.Red);
                 return (null, null);
             }
 
-            NuGetVersion? highestVersion = await VersionChooser.GetLatestVersionAsync(
-                packageId,
-                sourceProvider,
-                settings,
-                sourceCacheContext,
-                logger,
-                cancellationToken);
-
-            if (highestVersion is null)
+            VersionRange newVersion;
+            if (package.VersionRange is null)
             {
-                logger.LogMinimal(Messages.Error_NoVersionsAvailable(packageId), ConsoleColor.Red);
-                return (null, null);
-            }
+                NuGetVersion? highestVersion = await versionChooser.GetLatestVersionAsync(
+                    package.Id,
+                    logger,
+                    cancellationToken);
 
-            if (existingVersion.MinVersion == highestVersion)
+                if (highestVersion is null)
+                {
+                    logger.LogMinimal(Messages.Error_NoVersionsAvailable(package.Id), ConsoleColor.Red);
+                    return (null, null);
+                }
+
+                if (existingVersion.MinVersion == highestVersion)
+                {
+                    logger.LogMinimal(Messages.Warning_AlreadyHighestVersion(package.Id, highestVersion.OriginalVersion, project.FilePath), ConsoleColor.Red);
+                    return (null, null);
+                }
+
+                newVersion = new VersionRange(highestVersion);
+            }
+            else
             {
-                logger.LogMinimal(Messages.Warning_AlreadyHighestVersion(packageId, highestVersion.OriginalVersion, project.FilePath), ConsoleColor.Red);
-                return (null, null);
+                newVersion = package.VersionRange;
+                if (newVersion == existingVersion)
+                {
+                    logger.LogMinimal("todo", ConsoleColor.Red);
+                    return (null, null);
+                }
             }
 
-            PackageDependency packageToUpdate = new(packageId, new VersionRange(highestVersion));
+            PackageDependency packageToUpdate = new(package.Id, newVersion);
 
             return (packageToUpdate, frameworks);
         }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -267,7 +267,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
                 newVersion = package.VersionRange;
                 if (newVersion == existingVersion)
                 {
-                    logger.LogMinimal("todo", ConsoleColor.Red);
+                    logger.LogMinimal(Messages.Warning_AlreadyUsingSameVersion(package.Id, newVersion.OriginalString), ConsoleColor.Red);
                     return (null, null);
                 }
             }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Messages.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Messages.cs
@@ -31,5 +31,20 @@ namespace NuGet.CommandLine.XPlat
         {
             return string.Format(CultureInfo.CurrentCulture, Strings.Warning_AlreadyHighestVersion, packageId, version, projectPath);
         }
+
+        internal static string Warning_AlreadyUsingSameVersion(string packageId, string version)
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.Warning_AlreadyUsingSameVersion, packageId, version);
+        }
+
+        internal static string Error_MissingVersion(string packageId)
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.Error_MissingVersion, packageId);
+        }
+
+        internal static string Error_InvalidVersionRange(string input)
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.Error_InvalidVersionRange, input);
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -629,6 +629,24 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid version range &apos;{0}&apos;.
+        /// </summary>
+        internal static string Error_InvalidVersionRange {
+            get {
+                return ResourceManager.GetString("Error_InvalidVersionRange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Missing version from {0}.
+        /// </summary>
+        internal static string Error_MissingVersion {
+            get {
+                return ResourceManager.GetString("Error_MissingVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to MsBuild was unable to open Project &apos;{0}&apos;..
         /// </summary>
         internal static string Error_MsBuildUnableToOpenProject {
@@ -1527,6 +1545,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package reference in the form of a package identifier like &apos;Newtonsoft.Json&apos; or package identifier and version separated by &apos;@&apos; like &apos;Newtonsoft.Json@13.0.3&apos;..
+        /// </summary>
+        internal static string PackageUpdate_PackageArgumentDescription {
+            get {
+                return ResourceManager.GetString("PackageUpdate_PackageArgumentDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Preview restore with updated packages was not successful. Force mode is not yet available..
         /// </summary>
         internal static string PackageUpdate_PreviewRestoreFailed {
@@ -2346,6 +2373,15 @@ namespace NuGet.CommandLine.XPlat {
         internal static string Warning_AlreadyHighestVersion {
             get {
                 return ResourceManager.GetString("Warning_AlreadyHighestVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package {0} is already referencing version {1}.
+        /// </summary>
+        internal static string Warning_AlreadyUsingSameVersion {
+            get {
+                return ResourceManager.GetString("Warning_AlreadyUsingSameVersion", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -1024,4 +1024,20 @@ Do not translate "PackageVersion"</comment>
   <data name="Unsupported_UpgradeAllPackages" xml:space="preserve">
     <value>Unsupported: Upgrading all packages in a project is not yet supported</value>
   </data>
+  <data name="Warning_AlreadyUsingSameVersion" xml:space="preserve">
+    <value>Package {0} is already referencing version {1}</value>
+    <comment>0 - package id
+1 - version string</comment>
+  </data>
+  <data name="Error_MissingVersion" xml:space="preserve">
+    <value>Missing version from {0}</value>
+    <comment>0 - package id </comment>
+  </data>
+  <data name="Error_InvalidVersionRange" xml:space="preserve">
+    <value>Invalid version range '{0}'</value>
+    <comment>0 - string provided by customer</comment>
+  </data>
+  <data name="PackageUpdate_PackageArgumentDescription" xml:space="preserve">
+    <value>Package reference in the form of a package identifier like 'Newtonsoft.Json' or package identifier and version separated by '@' like 'Newtonsoft.Json@13.0.3'.</value>
+  </data>
 </root>

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageTests.cs
@@ -1,0 +1,116 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.CommandLine;
+using FluentAssertions;
+using NuGet.Versioning;
+using Xunit;
+
+using Pkg = NuGet.CommandLine.XPlat.Commands.Package.Update.Package;
+
+namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update
+{
+    public class PackageTests
+    {
+        private RootCommand _command;
+        private Argument<List<Pkg>> _packagesArgument;
+
+        public PackageTests()
+        {
+            _command = new RootCommand();
+
+            _packagesArgument = new Argument<List<Pkg>>("packages")
+            {
+                Arity = ArgumentArity.ZeroOrMore,
+                CustomParser = Pkg.Parse
+            };
+            _command.Arguments.Add(_packagesArgument);
+        }
+
+        [Fact]
+        public void Parse_OnePackage_ReturnsListOfOne()
+        {
+            // Arrange
+            var result = _command.Parse("packageId");
+
+            // Act
+            var packages = result.GetValue(_packagesArgument);
+
+            // Assert
+            IReadOnlyList<Pkg> expects = [new Pkg()
+            {
+                Id = "packageId",
+                VersionRange = null
+            }];
+            packages.Should().BeEquivalentTo(expects);
+        }
+
+        [Fact]
+        public void Parse_TwoPackages_ReturnsListOfTwo()
+        {
+            // Arrange
+            var result = _command.Parse("packageId1 packageId2");
+            // Act
+            var packages = result.GetValue(_packagesArgument);
+            // Assert
+            IReadOnlyList<Pkg> expects = [
+                new Pkg() { Id = "packageId1", VersionRange = null },
+                new Pkg() { Id = "packageId2", VersionRange = null }
+            ];
+            packages.Should().BeEquivalentTo(expects);
+        }
+
+        [Fact]
+        public void Parse_PackageWithVersion_ReturnsPackageWithVersion()
+        {
+            // Arrange
+            var result = _command.Parse("packageId@1.2.3");
+            // Act
+            var packages = result.GetValue(_packagesArgument);
+            // Assert
+            IReadOnlyList<Pkg> expects = [new Pkg()
+            {
+                Id = "packageId",
+                VersionRange = VersionRange.Parse("1.2.3")
+            }];
+            packages.Should().BeEquivalentTo(expects);
+        }
+
+        [Fact]
+        public void Parse_PackageWithRangeSyntax_ReturnsPackageWithVersion()
+        {
+            // Arrange
+            var result = _command.Parse("packageId@[1.2.3,2.0.0)");
+            // Act
+            var packages = result.GetValue(_packagesArgument);
+            // Assert
+            IReadOnlyList<Pkg> expects = [new Pkg()
+            {
+                Id = "packageId",
+                VersionRange = VersionRange.Parse("[1.2.3,2.0.0)")
+            }];
+            packages.Should().BeEquivalentTo(expects);
+        }
+
+        [Fact]
+        public void Parse_VersionWithNoId_ReturnsError()
+        {
+            // Arrange & Act
+            var result = _command.Parse("@1.2.3");
+
+            // Assert
+            result.Errors.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void Parse_PackageWithInvalidVersion_ReturnsError()
+        {
+            // Arrange & Act
+            var result = _command.Parse("packageId@one");
+
+            // Assert
+            result.Errors.Should().ContainSingle();
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageTests.cs
@@ -14,13 +14,13 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update
     public class PackageTests
     {
         private RootCommand _command;
-        private Argument<List<Pkg>> _packagesArgument;
+        private Argument<IReadOnlyList<Pkg>> _packagesArgument;
 
         public PackageTests()
         {
             _command = new RootCommand();
 
-            _packagesArgument = new Argument<List<Pkg>>("packages")
+            _packagesArgument = new Argument<IReadOnlyList<Pkg>>("packages")
             {
                 Arity = ArgumentArity.ZeroOrMore,
                 CustomParser = Pkg.Parse
@@ -51,8 +51,10 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update
         {
             // Arrange
             var result = _command.Parse("packageId1 packageId2");
+
             // Act
             var packages = result.GetValue(_packagesArgument);
+
             // Assert
             IReadOnlyList<Pkg> expects = [
                 new Pkg() { Id = "packageId1", VersionRange = null },
@@ -66,8 +68,10 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update
         {
             // Arrange
             var result = _command.Parse("packageId@1.2.3");
+
             // Act
             var packages = result.GetValue(_packagesArgument);
+
             // Assert
             IReadOnlyList<Pkg> expects = [new Pkg()
             {
@@ -82,8 +86,10 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update
         {
             // Arrange
             var result = _command.Parse("packageId@[1.2.3,2.0.0)");
+
             // Act
             var packages = result.GetValue(_packagesArgument);
+
             // Assert
             IReadOnlyList<Pkg> expects = [new Pkg()
             {

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunner.GetPackageToUpdateTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunner.GetPackageToUpdateTests.cs
@@ -40,7 +40,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update
                 VersionRange = new VersionRange(new NuGetVersion("1.2.3"))
             };
 
-            PackageSpec packageSpec = new TestPackageSpecFactory("c:\\src\\my.csproj", builder =>
+            PackageSpec packageSpec = new TestPackageSpecFactory(builder =>
                 {
                     builder.WithProperty("TargetFramework", "net9.0")
                            .WithItem("PackageReference", "Contoso.Utils", [new("Version", "1.0.0")]);
@@ -76,7 +76,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update
                 VersionRange = null
             };
 
-            PackageSpec packageSpec = new TestPackageSpecFactory("c:\\src\\my.csproj", builder =>
+            PackageSpec packageSpec = new TestPackageSpecFactory(builder =>
             {
                 builder.WithProperty("TargetFramework", "net9.0")
                        .WithItem("PackageReference", "Contoso.Utils", [new("Version", "1.0.0")]);
@@ -117,7 +117,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update
                 VersionRange = VersionRange.Parse("[1.2.3,2.0.0)")
             };
 
-            PackageSpec packageSpec = new TestPackageSpecFactory("c:\\src\\my.csproj", builder =>
+            PackageSpec packageSpec = new TestPackageSpecFactory(builder =>
             {
                 builder.WithProperty("TargetFramework", "net9.0")
                        .WithItem("PackageReference", "Contoso.Utils", [new("Version", "1.0.0")]);
@@ -153,7 +153,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update
                 VersionRange = null
             };
 
-            PackageSpec packageSpec = new TestPackageSpecFactory("c:\\src\\my.csproj", builder =>
+            PackageSpec packageSpec = new TestPackageSpecFactory(builder =>
             {
                 builder.WithProperty("TargetFramework", "net9.0")
                        .WithItem("PackageReference", "Contoso.Utils", [new("Version", "1.0.0")]);

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunner.GetPackageToUpdateTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunner.GetPackageToUpdateTests.cs
@@ -1,0 +1,183 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NuGet.CommandLine.XPlat;
+using NuGet.CommandLine.XPlat.Commands.Package.Update;
+using NuGet.Configuration;
+using NuGet.ProjectModel;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+using Xunit.Abstractions;
+
+using Pkg = NuGet.CommandLine.XPlat.Commands.Package.Update.Package;
+
+namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update
+{
+    public class PackageUpdateCommandRunner_GetPackageToUpdateTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public PackageUpdateCommandRunner_GetPackageToUpdateTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task RequestSinglePackage_GetsRequestedVersion()
+        {
+            // Arrange
+            Pkg package = new()
+            {
+                Id = "Contoso.Utils",
+                VersionRange = new VersionRange(new NuGetVersion("1.2.3"))
+            };
+
+            PackageSpec packageSpec = new TestPackageSpecFactory("c:\\src\\my.csproj", builder =>
+                {
+                    builder.WithProperty("TargetFramework", "net9.0")
+                           .WithItem("PackageReference", "Contoso.Utils", [new("Version", "1.0.0")]);
+                })
+                .Build();
+
+            var versionChooser = new Mock<IVersionChooser>(MockBehavior.Strict);
+            var logger = new Mock<ILoggerWithColor>();
+
+            // Act
+            var (packageToUpdate, _) = await PackageUpdateCommandRunner.GetPackageToUpdateAsync(
+                [package],
+                packageSpec,
+                versionChooser.Object,
+                NullSettings.Instance,
+                logger.Object,
+                CancellationToken.None);
+
+            // Assert
+            packageToUpdate.Should().NotBeNull();
+            packageToUpdate.Id.Should().Be("Contoso.Utils");
+            packageToUpdate.VersionRange.ToString().Should().Be("[1.2.3, )");
+            logger.Invocations.Count.Should().Be(0);
+        }
+
+        [Fact]
+        public async Task RequestPackageWithoutVersion_GetsLatestVersion()
+        {
+            // Arrange
+            Pkg package = new()
+            {
+                Id = "Contoso.Utils",
+                VersionRange = null
+            };
+
+            PackageSpec packageSpec = new TestPackageSpecFactory("c:\\src\\my.csproj", builder =>
+            {
+                builder.WithProperty("TargetFramework", "net9.0")
+                       .WithItem("PackageReference", "Contoso.Utils", [new("Version", "1.0.0")]);
+            })
+                .Build();
+
+            var versionChooser = new Mock<IVersionChooser>(MockBehavior.Strict);
+            versionChooser
+                .Setup(v => v.GetLatestVersionAsync("Contoso.Utils", It.IsAny<ILoggerWithColor>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new NuGetVersion("3.4.5"));
+
+            var sourceCacheContext = new SourceCacheContext();
+            var logger = new Mock<ILoggerWithColor>();
+
+            // Act
+            var (packageToUpdate, _) = await PackageUpdateCommandRunner.GetPackageToUpdateAsync(
+                [package],
+                packageSpec,
+                versionChooser.Object,
+                NullSettings.Instance,
+                logger.Object,
+                CancellationToken.None);
+
+            // Assert
+            packageToUpdate.Should().NotBeNull();
+            packageToUpdate.Id.Should().Be("Contoso.Utils");
+            packageToUpdate.VersionRange.ToString().Should().Be("[3.4.5, )");
+            logger.Invocations.Count.Should().Be(0);
+        }
+
+        [Fact]
+        public async Task RequestSinglePackageWithRangeSyntax_GetsRequestedVersion()
+        {
+            // Arrange
+            Pkg package = new()
+            {
+                Id = "Contoso.Utils",
+                VersionRange = VersionRange.Parse("[1.2.3,2.0.0)")
+            };
+
+            PackageSpec packageSpec = new TestPackageSpecFactory("c:\\src\\my.csproj", builder =>
+            {
+                builder.WithProperty("TargetFramework", "net9.0")
+                       .WithItem("PackageReference", "Contoso.Utils", [new("Version", "1.0.0")]);
+            })
+                .Build();
+
+            var versionChooser = new Mock<IVersionChooser>(MockBehavior.Strict);
+            var logger = new Mock<ILoggerWithColor>();
+
+            // Act
+            var (packageToUpdate, _) = await PackageUpdateCommandRunner.GetPackageToUpdateAsync(
+                [package],
+                packageSpec,
+                versionChooser.Object,
+                NullSettings.Instance,
+                logger.Object,
+                CancellationToken.None);
+
+            // Assert
+            packageToUpdate.Should().NotBeNull();
+            packageToUpdate.Id.Should().Be("Contoso.Utils");
+            packageToUpdate.VersionRange.ToString().Should().Be("[1.2.3, 2.0.0)");
+            logger.Invocations.Count.Should().Be(0);
+        }
+
+        [Fact]
+        public async Task RequestPackageNotOnSource_LogsError()
+        {
+            // Arrange
+            Pkg package = new()
+            {
+                Id = "Contoso.Utils",
+                VersionRange = null
+            };
+
+            PackageSpec packageSpec = new TestPackageSpecFactory("c:\\src\\my.csproj", builder =>
+            {
+                builder.WithProperty("TargetFramework", "net9.0")
+                       .WithItem("PackageReference", "Contoso.Utils", [new("Version", "1.0.0")]);
+            })
+                .Build();
+
+            var versionChooser = new Mock<IVersionChooser>(MockBehavior.Strict);
+            versionChooser
+                .Setup(v => v.GetLatestVersionAsync("Contoso.Utils", It.IsAny<ILoggerWithColor>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((NuGetVersion?)null);
+            var logger = new Mock<ILoggerWithColor>();
+
+            // Act
+            var (packageToUpdate, _) = await PackageUpdateCommandRunner.GetPackageToUpdateAsync(
+                [package],
+                packageSpec,
+                versionChooser.Object,
+                NullSettings.Instance,
+                logger.Object,
+                CancellationToken.None);
+
+            // Assert
+            packageToUpdate.Should().BeNull();
+            logger.Invocations.Count.Should().BeGreaterThan(0);
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/Test.Utility.csproj
+++ b/test/TestUtilities/Test.Utility/Test.Utility.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
@@ -11,6 +11,11 @@
     <SkipAnalyzers>true</SkipAnalyzers>
     <UsePublicApiAnalyzer>false</UsePublicApiAnalyzer>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(SharedDirectory)\IsExternalInit.cs" />
+    <Compile Include="$(SharedDirectory)\RequiredModifierAttributes.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Dotnet.Integration.Test" />

--- a/test/TestUtilities/Test.Utility/TestPackageSpecFactory.cs
+++ b/test/TestUtilities/Test.Utility/TestPackageSpecFactory.cs
@@ -1,0 +1,344 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Commands.Restore;
+using NuGet.Commands.Restore.Utility;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.ProjectModel;
+
+namespace Test.Utility;
+
+public class TestPackageSpecFactory
+{
+    private string _fullPath;
+    private string _directory;
+    private TestTargetFramework _outerBuild;
+    private Dictionary<string, ITargetFramework>? _targetFrameworks;
+
+    public TestPackageSpecFactory(string fullPath, Action<TargetFrameworkBuilder> builder)
+        : this(fullPath, System.IO.Path.GetDirectoryName(fullPath) ?? throw new ArgumentException(message: "Could not get directory from path", paramName: nameof(fullPath)), builder)
+    {
+    }
+
+    public TestPackageSpecFactory(string fullPath, string directory, Action<TargetFrameworkBuilder> builder)
+    {
+        _fullPath = string.IsNullOrWhiteSpace(fullPath) ? throw new ArgumentNullException(nameof(fullPath)) : fullPath;
+        _directory = string.IsNullOrWhiteSpace(directory) ? throw new ArgumentNullException(nameof(directory)) : directory;
+
+        var tfBuilder = new TargetFrameworkBuilder();
+        builder(tfBuilder);
+
+        TestTargetFramework outerBuild = tfBuilder.ToTargetFramework();
+        if (!outerBuild.Properties.TryGetValue("MSBuildProjectName", out string? msbuildProjectName))
+        {
+            msbuildProjectName = System.IO.Path.GetFileNameWithoutExtension(_fullPath);
+            outerBuild.Properties["MSBuildProjectName"] = msbuildProjectName;
+        }
+
+        string? targetFramework = outerBuild.GetProperty("TargetFramework");
+        string? targetFrameworks = outerBuild.GetProperty("TargetFrameworks");
+
+        if (string.IsNullOrWhiteSpace(targetFramework) && string.IsNullOrWhiteSpace(targetFrameworks))
+        {
+            throw new ArgumentException("TargetFramework or TargetFrameworks must be set in the outer build.");
+        }
+        else if (!string.IsNullOrWhiteSpace(targetFrameworks) && !string.IsNullOrWhiteSpace(targetFramework))
+        {
+            throw new ArgumentException("Only one of TargetFramework or TargetFrameworks can be set in the outer build.");
+        }
+
+        _outerBuild = outerBuild;
+    }
+
+    public TestPackageSpecFactory WithInnerBuild(Action<TargetFrameworkBuilder> builder)
+    {
+        if (builder is null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        var tfBuilder = new TargetFrameworkBuilder();
+        builder(tfBuilder);
+
+        ITargetFramework innerBuild = tfBuilder.ToTargetFramework(_outerBuild);
+
+        string? targetFramework = innerBuild.GetProperty("TargetFramework");
+        if (string.IsNullOrWhiteSpace(targetFramework))
+        {
+            throw new ArgumentException("TargetFramework must be set in the inner build.");
+        }
+
+        _targetFrameworks ??= new Dictionary<string, ITargetFramework>(StringComparer.OrdinalIgnoreCase);
+
+#if NETFRAMEWORK
+        if (_targetFrameworks.ContainsKey(targetFramework!))
+        {
+            throw new InvalidOperationException($"Inner build for target framework '{targetFramework}' is already set.");
+        }
+        _targetFrameworks[targetFramework!] = innerBuild;
+#else
+        if (!_targetFrameworks.TryAdd(targetFramework, innerBuild))
+        {
+            throw new InvalidOperationException($"Inner build for target framework '{targetFramework}' is already set.");
+        }
+#endif
+
+        _targetFrameworks[targetFramework!] = innerBuild;
+
+        return this;
+    }
+
+    public PackageSpec Build(ISettings? settings = null)
+    {
+        Dictionary<string, ITargetFramework> targetFrameworks;
+        if (_targetFrameworks is not null && _targetFrameworks.Count > 0)
+        {
+            targetFrameworks = _targetFrameworks;
+            var targetFrameworksProperty = _outerBuild.GetProperty("TargetFrameworks");
+            if (string.IsNullOrWhiteSpace(targetFrameworksProperty))
+            {
+                throw new InvalidOperationException("TargetFrameworks must be set in the outer build when multiple target frameworks are defined.");
+            }
+
+            HashSet<string> aliases = targetFrameworksProperty!
+                .Split([';'], StringSplitOptions.RemoveEmptyEntries)
+                .Select(alias => alias.Trim())
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            HashSet<string> missingTargetFrameworks = new HashSet<string>(
+                aliases.Where(alias => !targetFrameworks.ContainsKey(alias)),
+                StringComparer.OrdinalIgnoreCase);
+            HashSet<string> extraTargetFrameworks = new HashSet<string>(
+                targetFrameworks.Keys.Where(key => !aliases.Contains(key)),
+                StringComparer.OrdinalIgnoreCase);
+
+            if (missingTargetFrameworks.Count > 0 || extraTargetFrameworks.Count > 0)
+            {
+                string errorMessage = "The TargetFrameworks property does not match the inner builds defined in the PackageSpec.";
+                if (missingTargetFrameworks.Count > 0)
+                {
+                    errorMessage += $" Missing target frameworks: {string.Join(", ", missingTargetFrameworks)}.";
+                }
+                if (extraTargetFrameworks.Count > 0)
+                {
+                    errorMessage += $" Extra target frameworks: {string.Join(", ", extraTargetFrameworks)}.";
+                }
+                throw new InvalidOperationException(errorMessage);
+            }
+        }
+        else
+        {
+            targetFrameworks = new Dictionary<string, ITargetFramework>(StringComparer.OrdinalIgnoreCase);
+            string targetFramework = _outerBuild.GetProperty("TargetFramework") ?? throw new InvalidOperationException("TargetFramework must be set in the outer build.");
+            targetFrameworks[targetFramework] = _outerBuild;
+        }
+
+        var project = new TestProject
+        {
+            FullPath = _fullPath,
+            Directory = _directory,
+            OuterBuild = _outerBuild,
+            TargetFrameworks = targetFrameworks
+        };
+
+        var packageSpec = PackageSpecFactory.GetPackageSpec(project, settings ?? NullSettings.Instance);
+        if (packageSpec is null)
+        {
+            throw new InvalidOperationException("Failed to create PackageSpec from the provided project.");
+        }
+        return packageSpec;
+    }
+
+    public record TargetFrameworkBuilder
+    {
+        private readonly Dictionary<string, string> _properties = new(StringComparer.OrdinalIgnoreCase);
+        private Dictionary<string, List<IItem>>? _items;
+
+        public TargetFrameworkBuilder WithProperty(string name, string value)
+        {
+            if (string.IsNullOrWhiteSpace(name)) { throw new ArgumentNullException(nameof(name)); }
+            if (string.IsNullOrWhiteSpace(value)) { throw new ArgumentNullException(nameof(value)); }
+
+#if NETFRAMEWORK
+            if (_properties.ContainsKey(name))
+            {
+                throw new InvalidOperationException($"Property '{name}' is already defined.");
+            }
+            _properties[name] = value;
+#else
+            if (!_properties.TryAdd(name, value))
+            {
+                throw new InvalidOperationException($"Property '{name}' is already defined.");
+            }
+#endif
+
+            return this;
+        }
+
+        public TargetFrameworkBuilder WithItem(string itemType, string identity, KeyValuePair<string, string>[]? metadata)
+        {
+            if (string.IsNullOrWhiteSpace(itemType)) { throw new ArgumentNullException(nameof(itemType)); }
+            if (string.IsNullOrWhiteSpace(identity)) { throw new ArgumentNullException(nameof(identity)); }
+
+            TestItem item = new TestItem
+            {
+                Identity = identity,
+                Metadata = metadata?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.OrdinalIgnoreCase) ?? []
+            };
+
+            if (_items is null)
+            {
+                _items = new Dictionary<string, List<IItem>>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            if (!_items.TryGetValue(itemType, out var itemList))
+            {
+                itemList = new List<IItem>();
+                _items[itemType] = itemList;
+            }
+            itemList.Add(item);
+
+            return this;
+        }
+
+        internal TestTargetFramework ToTargetFramework(TestTargetFramework outerBuild)
+        {
+            foreach (var property in outerBuild.Properties)
+            {
+#if NETFRAMEWORK
+                if (!_properties.ContainsKey(property.Key))
+                {
+                    _properties[property.Key] = property.Value;
+                }
+#else
+                _properties.TryAdd(property.Key, property.Value);
+#endif
+            }
+
+            if (_items is not null)
+            {
+                foreach (var item in outerBuild.Items)
+                {
+                    if (!_items!.ContainsKey(item.Key))
+                    {
+                        _items[item.Key] = new List<IItem>();
+                    }
+                    _items[item.Key].AddRange(item.Value);
+                }
+            }
+            else
+            {
+                _items = outerBuild.Items;
+            }
+
+            return ToTargetFramework();
+        }
+
+        internal TestTargetFramework ToTargetFramework()
+        {
+            SimulateDotnetSdk(_properties, _items);
+
+            // Create a new TestTargetFramework with the accumulated properties and items
+            return new TestTargetFramework
+            {
+                Properties = new Dictionary<string, string>(_properties, StringComparer.OrdinalIgnoreCase),
+                Items = _items ?? new Dictionary<string, List<IItem>>(StringComparer.OrdinalIgnoreCase)
+            };
+
+            void SimulateDotnetSdk(Dictionary<string, string> properties, Dictionary<string, List<IItem>>? items)
+            {
+                if (!properties.TryGetValue("TargetFramework", out var targetFramework) || string.IsNullOrWhiteSpace(targetFramework))
+                {
+                    return;
+                }
+
+                NuGetFramework? framework = null;
+                try
+                {
+                    framework = NuGetFramework.Parse(targetFramework);
+                }
+                catch
+                {
+                }
+
+                if (!properties.TryGetValue("TargetFrameworkIdentifier", out var targetFrameworkIdentifer) && framework is not null)
+                {
+                    targetFrameworkIdentifer = framework.Framework;
+                    properties["TargetFrameworkIdentifier"] = targetFrameworkIdentifer;
+                }
+
+                if (!properties.TryGetValue("TargetFrameworkVersion", out var targetFrameworkVersion) && framework is not null)
+                {
+                    targetFrameworkVersion = $"v{framework.Version.ToString()}";
+                    properties["TargetFrameworkVersion"] = targetFrameworkVersion;
+                }
+
+                if (!properties.TryGetValue("TargetFrameworkMoniker", out var targetFrameworkMoniker))
+                {
+                    targetFrameworkMoniker = $"{targetFrameworkIdentifer},Version={targetFrameworkVersion}";
+                    properties["TargetFrameworkMoniker"] = targetFrameworkMoniker;
+                }
+
+                if (!properties.TryGetValue("TargetPlatformIdentifier", out var targetPlatformIdentifier) && framework is not null)
+                {
+                    targetPlatformIdentifier = framework.Platform;
+                }
+
+                if (!string.IsNullOrWhiteSpace(targetPlatformIdentifier))
+                {
+                    if (!properties.TryGetValue("TargetPlatformVersion", out var targetPlatformVersion))
+                    {
+                        targetPlatformVersion = framework?.PlatformVersion?.ToString();
+                        targetPlatformVersion = targetPlatformVersion is null ? "v1.0" : $"v{targetPlatformVersion}";
+                        properties["TargetPlatformVersion"] = targetPlatformVersion;
+                    }
+
+                    if (!properties.TryGetValue("TargetPlatformMoniker", out var targetPlatformMoniker))
+                    {
+                        targetPlatformMoniker = $"{targetPlatformIdentifier},Version={targetPlatformVersion}";
+                        properties["TargetPlatformMoniker"] = targetPlatformMoniker;
+                    }
+                }
+            }
+        }
+    }
+
+    private record TestProject : IProject
+    {
+        public required string FullPath { get; init; }
+        public required string Directory { get; init; }
+        public required ITargetFramework OuterBuild { get; init; }
+        public required IReadOnlyDictionary<string, ITargetFramework> TargetFrameworks { get; init; }
+    }
+
+    internal record TestTargetFramework : ITargetFramework
+    {
+        public required Dictionary<string, string> Properties { get; init; }
+        public required Dictionary<string, List<IItem>> Items { get; init; }
+
+        public string GetProperty(string propertyName) => Properties.TryGetValue(propertyName, out var value) ? value : null!;
+        public IReadOnlyList<IItem> GetItems(string itemType) => Items.TryGetValue(itemType, out var items) ? items : [];
+    }
+
+    internal record TestItem : IItem
+    {
+        public required string Identity { get; init; }
+
+        internal required IReadOnlyDictionary<string, string> Metadata { get; init; }
+
+        public string GetMetadata(string name)
+        {
+            if (Metadata.TryGetValue(name, out var value))
+            {
+                return value;
+            }
+            return null!;
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/TestPackageSpecFactory.cs
+++ b/test/TestUtilities/Test.Utility/TestPackageSpecFactory.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NuGet.Commands.Restore;
 using NuGet.Commands.Restore.Utility;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.ProjectModel;
@@ -21,6 +22,13 @@ public class TestPackageSpecFactory
     private TestTargetFramework _outerBuild;
     private Dictionary<string, ITargetFramework>? _targetFrameworks;
 
+    public static string SampleFullPath { get; } = RuntimeEnvironmentHelper.IsWindows ? "c:\\src\\my.csproj" : "/home/me/src/my.csproj";
+
+    public TestPackageSpecFactory(Action<TargetFrameworkBuilder> builder)
+        : this(SampleFullPath, builder)
+    {
+    }
+
     public TestPackageSpecFactory(string fullPath, Action<TargetFrameworkBuilder> builder)
         : this(fullPath, System.IO.Path.GetDirectoryName(fullPath) ?? throw new ArgumentException(message: "Could not get directory from path", paramName: nameof(fullPath)), builder)
     {
@@ -28,8 +36,8 @@ public class TestPackageSpecFactory
 
     public TestPackageSpecFactory(string fullPath, string directory, Action<TargetFrameworkBuilder> builder)
     {
-        _fullPath = string.IsNullOrWhiteSpace(fullPath) ? throw new ArgumentNullException(nameof(fullPath)) : fullPath;
-        _directory = string.IsNullOrWhiteSpace(directory) ? throw new ArgumentNullException(nameof(directory)) : directory;
+        _fullPath = string.IsNullOrWhiteSpace(fullPath) ? throw new ArgumentException("Must not be null or whitespace", nameof(fullPath)) : fullPath;
+        _directory = string.IsNullOrWhiteSpace(directory) ? throw new ArgumentNullException("Must not be null or whitespace", nameof(directory)) : directory;
 
         var tfBuilder = new TargetFrameworkBuilder();
         builder(tfBuilder);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14306

## Description

Allow `dotnet package update` to update to a specific version using the `packageId@version` syntax that `dotnet package add` already supports (possibly dotnet tool install as well). It also supports version ranges, in case that's what the customer wants in their project file. For example, `dotnet package update "Contoso.Utils@[1.2.3, 2.0.0)"`.

The package@version parsing is done in the CLI parser, so that when there's an error, the CLI parser can do error handling (after all, it's an input error).

Made the version chooser mockable, so that the logic to decide if the package source should be queried can be tested without needing a real package source.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/14354
