### PR TITLE
Stop testing against netcoreapp3.1, which is long deprecated

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -34,10 +34,6 @@
     <TargetFrameworksUnitTest>$(NETCoreTargetFramework)</TargetFrameworksUnitTest>
     <TargetFrameworksUnitTest Condition="'$(IsXPlat)' != 'true' And '$(DotNetBuildSourceOnly)' != 'true'">$(NETFXTargetFramework);$(TargetFrameworksUnitTest)</TargetFrameworksUnitTest>
 
-    <!-- Target frameworks for unit tests that test libaries using signing APIs -->
-    <TargetFrameworksUnitTestForSigning>$(NETCoreTargetFramework)</TargetFrameworksUnitTestForSigning>
-    <TargetFrameworksUnitTestForSigning Condition="'$(DotNetBuildSourceOnly)' != 'true'">$(TargetFrameworksUnitTestForSigning);$(NETCoreLegacyTargetFramework)</TargetFrameworksUnitTestForSigning>
-    <TargetFrameworksUnitTestForSigning Condition="'$(IsXPlat)' != 'true' And '$(DotNetBuildSourceOnly)' != 'true'">$(NETFXTargetFramework);$(TargetFrameworksUnitTestForSigning)</TargetFrameworksUnitTestForSigning>
   </PropertyGroup>
 
   <!-- Common -->

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -13,8 +13,6 @@
     <NetStandardVersion>netstandard2.0</NetStandardVersion>
     <NETCoreTargetFramework>net9.0</NETCoreTargetFramework>
     <NETCoreTargetFramework Condition="'$(DotNetBuildSourceOnly)' == 'true'">net10.0</NETCoreTargetFramework>
-    <NETCoreLegacyTargetFramework>netcoreapp3.1</NETCoreLegacyTargetFramework>
-    <NETCoreLegacyTargetFramework Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(NETCoreTargetFramework)</NETCoreLegacyTargetFramework>
     <NETCoreLegacyTargetFrameworkForSigning>net8.0</NETCoreLegacyTargetFrameworkForSigning>
 
     <!-- Target frameworks for class libraries-->

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -175,7 +175,7 @@ stages:
         testType: Functional
         testTargetFramework: net9.0
         testProjectName: Dotnet.Integration.Test
-        timeoutInMinutes: 45
+        timeoutInMinutes: 60
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -83,23 +83,6 @@ stages:
         testType: Unit
         testTargetFramework: net9.0
 
-- ${{ if eq(parameters.RunUnitTestsOnWindows, true) }}:
-  - stage:
-    displayName: Unit Tests on Windows (.NET Core 3.1)
-    dependsOn: []
-    jobs:
-    - template: pr.job.yml
-      parameters:
-        displayName: Unit Tests on Windows (.NET Core 3.1)
-        osName: Windows
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
-        ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
-        testType: Unit
-        testTargetFramework: netcoreapp3.1
-
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
     displayName: Msbuild.Integration.Test on Windows (.NET Framework 4.7.2)
@@ -225,19 +208,6 @@ stages:
         testType: Unit
         testTargetFramework: net9.0
 
-- ${{ if eq(parameters.RunUnitTestsOnLinux, true) }}:
-  - stage:
-    displayName: Unit Tests on Linux (.NET Core 3.1)
-    dependsOn: []
-    jobs:
-    - template: pr.job.yml
-      parameters:
-        displayName: Unit Tests on Linux (.NET Core 3.1)
-        osName: Linux
-        vmImage: ubuntu-22.04
-        testType: Unit
-        testTargetFramework: netcoreapp3.1
-
 - ${{ if eq(parameters.RunFunctionalTestsOnLinux, true) }}:
   - stage:
     displayName: Functional Tests on Linux (.NET 9.0)
@@ -264,19 +234,6 @@ stages:
         vmImage: macos-latest
         testType: Unit
         testTargetFramework: net9.0
-
-- ${{ if eq(parameters.RunUnitTestsOnMacOS, true) }}:
-  - stage:
-    displayName: Unit Tests on MacOS (.NET Core 3.1)
-    dependsOn: []
-    jobs:
-    - template: pr.job.yml
-      parameters:
-        displayName: Unit Tests on MacOS (.NET Core 3.1)
-        osName: MacOS
-        vmImage: macos-latest
-        testType: Unit
-        testTargetFramework: netcoreapp3.1
 
 - ${{ if eq(parameters.RunFunctionalTestsOnMacOS, true) }}:
   - stage:

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/NuGet.Commands.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/NuGet.Commands.FuncTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Integration tests for the more involved NuGet.Commands, such as restore.</Description>
     <TestProjectType>Unit</TestProjectType>
   </PropertyGroup>

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/NuGet.Packaging.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/NuGet.Packaging.FuncTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Integration tests for the more involved NuGet.Packaging functionality, such as signing.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/NuGet.Protocol.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/NuGet.Protocol.FuncTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Integration tests for the more involved NuGet.Protocol functionality, such as plugins.</Description>
     <TestProjectType>Unit</TestProjectType>
   </PropertyGroup>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/NuGet.Commands.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/NuGet.Commands.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Unit tests for NuGet.Commands.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/NuGet.Configuration.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/NuGet.Configuration.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Unit tests for NuGet.Configuration.</Description>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/NuGet.DependencyResolver.Core.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/NuGet.DependencyResolver.Core.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Unit tests for NuGet.DependencyResolver.Core.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Unit tests for NuGet.Packaging.</Description>
     <!-- remove warnings for obsolete types and methods: SYSLIB0023: RNGCryptoServiceProvider, SYSLIB0026: X509Certificate2() blank constructor -->
     <NoWarn>$(NoWarn);SYSLIB0023;SYSLIB0026</NoWarn>

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/NuGet.ProjectModel.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/NuGet.ProjectModel.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Unit tests for NuGet.ProjectModel.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGet.Protocol.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGet.Protocol.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Unit tests for NuGet.Protocol.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Resolver.Test/NuGet.Resolver.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Resolver.Test/NuGet.Resolver.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Unit tests for NuGet.Resolver.</Description>
   </PropertyGroup>
 

--- a/test/TestExtensions/TestablePlugin/TestablePlugin.csproj
+++ b/test/TestExtensions/TestablePlugin/TestablePlugin.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <TargetLatestRuntimePatch>false</TargetLatestRuntimePatch>
     <OutputType>Exe</OutputType>
     <AssemblyName>Plugin.Testable</AssemblyName>

--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/Microsoft.Internal.NuGet.Testing.SignedPackages.csproj
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/Microsoft.Internal.NuGet.Testing.SignedPackages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>
     <IsPackable>true</IsPackable>

--- a/test/TestUtilities/Test.Utility/Test.Utility.csproj
+++ b/test/TestUtilities/Test.Utility/Test.Utility.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <NoWarn Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">$(NoWarn);CS1998</NoWarn>
     <SkipShared>true</SkipShared>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/client.engineering/issues/2549

## Description

This PR removes all the netcoreapp3.1 test legs from our repository. What this means is that for some packages, particularly ones that multitarget among netstandard2.0, net472 and net8.0, we wouldn't be testing the netstandard2.0 leg.
This isn't that big of a deal.  We do not ship the netstandard2.0 assemblies in the .NET SDK restore/ .NET CLI code, because the net8.0 version is chosen as closer.

The *only* exception is the pack assembly. The pack assembly currently ilmerges and ilmerge *does not* work for .NET 8, so we're kind of stuck with that.
We don't have to ilmerge, and we don't have to distribute the pack assemblies the way we currently do, so https://github.com/NuGet/Home/issues/13079 or https://github.com/NuGet/Home/issues/14046 will allow us to remove *all* projects that target 3 frameworks, but until that happens this is what we have.

After this change, the following projects will no longer test against netcoreapp3.1.

NuGet.Commands -> NuGet.Commands.FuncTest, NuGet.Commands.Test
NuGet.Packaging -> NuGet.Packaging.FunctTest, NuGet.Packaging.Test
NuGet.Protocol->NuGet.Protocol.FuncTest, NuGet.Protocol.Tests
NuGet.DependencyResolver.Core->NuGet.DependencyResolver.Core.Tests
NuGet.ProjectModel -> NuGet.ProjectModel.Test
NuGet.Resolver -> NuGet.Resolver.Test (.NET leg is not even used)

NuGet.Configuration.Test is a no-op, since NuGet.Configuration only targets 2 frameworks

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.

<details>
Frameworks after:

  NuGet.CommandLine.FuncTest.csproj = net472
  NuGet.MSSigning.Extensions.FuncTest.csproj = net472
  NuGet.CommandLine.Test.csproj = net472
  NuGet.Indexing.Test.csproj = net472
  NuGet.MSSigning.Extensions.Test.csproj = net472
  NuGet.PackageManagement.UI.Test.csproj = net472
  NuGet.PackageManagement.VisualStudio.Test.csproj = net472
  NuGet.SolutionRestoreManager.Test.csproj = net472
  NuGet.Tools.Test.csproj = net472
  NuGet.VisualStudio.Common.Test.csproj = net472
  NuGet.VisualStudio.Implementation.Test.csproj = net472
  NuGet.VisualStudio.Internal.Contracts.Test.csproj = net472
  NuGet.VisualStudio.Test.csproj = net472
  NuGetConsole.Host.PowerShell.Test.csproj = net472
  Dotnet.Integration.Test.csproj = net9.0
  Msbuild.Integration.Test.csproj = net472
  NuGet.Commands.FuncTest.csproj = net472;net9.0
  NuGet.Packaging.FuncTest.csproj = net472;net9.0
  NuGet.Protocol.FuncTest.csproj = net472;net9.0
  NuGet.Signing.CrossFramework.Test.csproj = net472;net9.0
  NuGet.XPlat.FuncTest.csproj = net9.0
  Microsoft.Build.NuGetSdkResolver.Test.csproj = net472;net9.0
  NuGet.Build.Tasks.Console.Test.csproj = net472;net9.0
  NuGet.Build.Tasks.Pack.Test.csproj = net472;net9.0
  NuGet.Build.Tasks.Test.csproj = net472;net9.0
  NuGet.CommandLine.Xplat.Tests.csproj = net9.0
  NuGet.Commands.Test.csproj = net472;net9.0
  NuGet.Common.Test.csproj = net472;net9.0
  NuGet.Configuration.Test.csproj = net472;net9.0
  NuGet.Credentials.Test.csproj = net472;net9.0
  NuGet.DependencyResolver.Core.Tests.csproj = net472;net9.0
  NuGet.Frameworks.Test.csproj = net472;net9.0
  NuGet.LibraryModel.Tests.csproj = net472;net9.0
  NuGet.PackageManagement.Test.csproj = net472;net9.0
  NuGet.Packaging.Test.csproj = net472;net9.0
  NuGet.ProjectModel.Test.csproj = net472;net9.0
  NuGet.Protocol.Tests.csproj = net472;net9.0
  NuGet.Resolver.Test.csproj = net472;net9.0
  NuGet.Shared.Tests.csproj = net472;net9.0
  NuGet.Versioning.Test.csproj = net472;net9.0
  API.Test.csproj = net472
  GenerateLicenseList.csproj = net8.0
  GenerateTestPackages.csproj = net472
  SampleCommandLineExtensions.csproj = net472
  TestableCredentialProvider.csproj = net472
  TestablePlugin.csproj = net472;net9.0
  Microsoft.Internal.NuGet.Testing.SignedPackages.csproj = net472;net9.0
  Test.Utility.csproj = net472;net9.0
  NuGet.CommandLine.csproj = net472
  NuGet.Console.csproj = net472
  NuGet.Indexing.csproj = net472
  NuGet.MSSigning.Extensions.csproj = net472
  NuGet.PackageManagement.PowerShellCmdlets.csproj = net472
  NuGet.PackageManagement.UI.csproj = net472
  NuGet.PackageManagement.VisualStudio.csproj = net472
  NuGet.SolutionRestoreManager.csproj = net472
  NuGet.Tools.csproj = net472
  NuGet.VisualStudio.Client.csproj = net472
  NuGet.VisualStudio.Common.csproj = net472
  NuGet.VisualStudio.Contracts.csproj = netstandard2.0
  NuGet.VisualStudio.Implementation.csproj = net472
  NuGet.VisualStudio.Internal.Contracts.csproj = net472
  NuGet.VisualStudio.Interop.csproj = net472
  NuGet.VisualStudio.csproj = net472
  Microsoft.Build.NuGetSdkResolver.csproj = net472;net9.0
  NuGet.Build.Tasks.Console.csproj = net472;net9.0
  NuGet.Build.Tasks.Pack.csproj = net472;netstandard2.0
  NuGet.Build.Tasks.csproj = net472;net9.0
  NuGet.CommandLine.XPlat.csproj = net9.0
  NuGet.Commands.csproj = net472;netstandard2.0;net8.0
  NuGet.Common.csproj = net472;netstandard2.0
  NuGet.Configuration.csproj = net472;netstandard2.0
  NuGet.Credentials.csproj = net472;netstandard2.0;net8.0
  NuGet.DependencyResolver.Core.csproj = net472;netstandard2.0;net8.0
  NuGet.Frameworks.csproj = net472;netstandard2.0
  NuGet.LibraryModel.csproj = net472;netstandard2.0
  NuGet.Localization.csproj = netstandard2.0
  NuGet.PackageManagement.csproj = net472;netstandard2.0
  NuGet.Packaging.csproj = net472;netstandard2.0;net8.0
  NuGet.ProjectModel.csproj = net472;netstandard2.0;net8.0
  NuGet.Protocol.csproj = net472;netstandard2.0;net8.0
  NuGet.Resolver.csproj = net472;netstandard2.0;net8.0
  NuGet.Versioning.csproj = net472;netstandard2.0
  NuGet.Console.TestContract.csproj = net472
  NuGet.OptProf.csproj = net472
  NuGet.PackageManagement.UI.TestContract.csproj = net472
  NuGet.Tests.Apex.Daily.csproj = net472
  NuGet.Tests.Apex.csproj = net472


</details>