### PR TITLE
Ensure stable order of entries in Content_Types.xml

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -426,7 +426,7 @@ namespace NuGet.Packaging
                 WriteManifest(package, DetermineMinimumSchemaVersion(Files, DependencyGroups), psmdcpPath);
 
                 // Write the files to the package
-                HashSet<string> filesWithoutExtensions = new HashSet<string>();
+                SortedSet<string> filesWithoutExtensions = new();
                 var extensions = WriteFiles(package, filesWithoutExtensions);
 
                 extensions.Add("nuspec");
@@ -1045,9 +1045,9 @@ namespace NuGet.Packaging
             }
         }
 
-        private HashSet<string> WriteFiles(ZipArchive package, HashSet<string> filesWithoutExtensions)
+        private SortedSet<string> WriteFiles(ZipArchive package, SortedSet<string> filesWithoutExtensions)
         {
-            var extensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var extensions = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
             var warningMessage = new StringBuilder();
 
             // Add files that might not come from expanding files on disk
@@ -1295,7 +1295,7 @@ namespace NuGet.Packaging
             }
         }
 
-        private void WriteOpcContentTypes(ZipArchive package, HashSet<string> extensions, HashSet<string> filesWithoutExtensions)
+        private void WriteOpcContentTypes(ZipArchive package, SortedSet<string> extensions, SortedSet<string> filesWithoutExtensions)
         {
             // OPC backwards compatibility
             ZipArchiveEntry relsEntry = CreateEntry(package, "[Content_Types].xml", CompressionLevel.Optimal);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

Fixes: https://github.com/NuGet/Home/issues/14357

## Description

The order of package entries can change from run to run of the package building tooling. That results in different package binaries even when the same sources are re-compiled. Ensuring a stable order makes it easier to create reproducible builds.

Contributes to: https://github.com/dotnet/source-build/issues/4963

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
