### PR TITLE
Community PRs should auto close within 30 days

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -58,8 +58,8 @@ configuration:
       - addLabel:
           label: Status:No recent activity
       - addReply:
-          reply: This PR has been automatically marked as stale because it has no activity for **7 days**. It will be closed if no further activity occurs **within another 90 days** of this comment. If it is closed, you may reopen it anytime when you're ready again, as long as you don't delete the branch.
-    - description: '[stale community PR] [5-5] Close PRs with no activity over 90 days after warn.'
+          reply: This PR has been automatically marked as stale because it has no activity for **7 days**. It will be closed if no further activity occurs **within another 30 days** of this comment. If it is closed, you may reopen it anytime when you're ready again, as long as you don't delete the branch.
+    - description: '[stale community PR] [5-5] Close PRs with no activity over 30 days after warn.'
       frequencies:
       - hourly:
           hour: 3
@@ -71,7 +71,7 @@ configuration:
       - hasLabel:
           label: Community
       - noActivitySince:
-          days: 90
+          days: 30
       actions:
       - closeIssue
     eventResponderTasks:


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

90 is a bit excessive.

The PRs just stay open for a very long time. I feel like 30 days is a very reasonable amount of time for a PR to be open.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
