### PR TITLE
Exit packages.config restore in VS early if there are no packages.config projects

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/Audit/AuditCheckResult.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Audit/AuditCheckResult.cs
@@ -12,6 +12,11 @@ namespace NuGet.PackageManagement
 {
     public record AuditCheckResult
     {
+        internal static readonly AuditCheckResult NoopAuditResult = new AuditCheckResult(Array.Empty<ILogMessage>())
+        {
+            IsAuditEnabled = false,
+        };
+
         public IReadOnlyList<ILogMessage> Warnings { get; }
         internal bool IsAuditEnabled { get; set; } = true;
 

--- a/src/NuGet.Core/NuGet.PackageManagement/Audit/AuditChecker.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Audit/AuditChecker.cs
@@ -45,6 +45,11 @@ namespace NuGet.PackageManagement
             if (packages == null) throw new ArgumentNullException(nameof(packages));
             if (restoreAuditProperties == null) throw new ArgumentNullException(nameof(restoreAuditProperties));
 
+            if (!packages.Any())
+            {
+                return AuditCheckResult.NoopAuditResult;
+            }
+
             // Before fetching vulnerability data, check if any projects are enabled for audit
             // If there are no settings, then run the audit for all packages
             bool anyProjectsEnabledForAudit = restoreAuditProperties.Count == 0;
@@ -59,10 +64,7 @@ namespace NuGet.PackageManagement
 
             if (!anyProjectsEnabledForAudit)
             {
-                return new AuditCheckResult(Array.Empty<ILogMessage>())
-                {
-                    IsAuditEnabled = false,
-                };
+                return AuditCheckResult.NoopAuditResult;
             }
 
             Stopwatch stopwatch = Stopwatch.StartNew();

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreResult.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreResult.cs
@@ -11,6 +11,8 @@ namespace NuGet.PackageManagement
 {
     public class PackageRestoreResult
     {
+        internal static readonly PackageRestoreResult NoopRestoreResult = new(false, []);
+
         public PackageRestoreResult(bool restored, IEnumerable<PackageIdentity> restoredPackages, AuditCheckResult? auditCheckResult)
             : this(restored, restoredPackages)
         {

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/AuditCheckerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/AuditCheckerTests.cs
@@ -927,6 +927,62 @@ namespace NuGet.PackageManagement.Test
             packagesWithReportedAdvisories[0].Should().Be(packageIdentity);
         }
 
+        [Theory]
+        [InlineData("true")]
+        [InlineData("false")]
+        public async Task CheckPackageVulnerabilitiesAsync_WithEmptyPackages_ReturnsNoopAuditResult(string enableAudit)
+        {
+            // Arrange
+            var packageSources = new List<SourceRepository>
+            {
+                new SourceRepository(new PackageSource("https://api.nuget.org/v3/index.json"), Repository.Provider.GetCoreV3())
+            };
+            var sourceCacheContext = new SourceCacheContext();
+            var logger = new TestLogger();
+            var auditChecker = new AuditChecker(packageSources, sourceCacheContext, logger);
+
+            var packages = Enumerable.Empty<PackageRestoreData>();
+            var restoreAuditProperties = new Dictionary<string, RestoreAuditProperties>
+            {
+                { "C:\\project.csproj", new RestoreAuditProperties { EnableAudit = enableAudit } }
+            };
+
+            // Act
+            var result = await auditChecker.CheckPackageVulnerabilitiesAsync(packages, restoreAuditProperties, CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().Be(AuditCheckResult.NoopAuditResult);
+
+            // Verify that we don't waste time fetching vulnerability data when there are no packages
+            logger.LogMessages.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("false")]
+        public async Task CheckPackageVulnerabilitiesAsync_WithNullPackages_ThrowsArgumentNullException(string enableAudit)
+        {
+            // Arrange
+            var packageSources = new List<SourceRepository>
+            {
+                new SourceRepository(new PackageSource("https://api.nuget.org/v3/index.json"), Repository.Provider.GetCoreV3())
+            };
+            var sourceCacheContext = new SourceCacheContext();
+            var logger = new TestLogger();
+            var auditChecker = new AuditChecker(packageSources, sourceCacheContext, logger);
+
+            IEnumerable<PackageRestoreData>? packages = null;
+            var restoreAuditProperties = new Dictionary<string, RestoreAuditProperties>
+            {
+                { "C:\\project.csproj", new RestoreAuditProperties { EnableAudit = enableAudit } }
+            };
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await auditChecker.CheckPackageVulnerabilitiesAsync(packages!, restoreAuditProperties, CancellationToken.None));
+        }
+
         [Fact]
         public async Task CheckVulnerabiltiesAsync_WithoutEnabledProjects_SkipsVulnerabilityCheckingAltogether()
         {

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/AuditCheckerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/AuditCheckerTests.cs
@@ -933,13 +933,36 @@ namespace NuGet.PackageManagement.Test
         public async Task CheckPackageVulnerabilitiesAsync_WithEmptyPackages_ReturnsNoopAuditResult(string enableAudit)
         {
             // Arrange
-            var packageSources = new List<SourceRepository>
+            string packageId = "A";
+
+            List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities = new List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>()
             {
-                new SourceRepository(new PackageSource("https://api.nuget.org/v3/index.json"), Repository.Provider.GetCoreV3())
+                new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>
+                {
+                    {
+                        packageId,
+                        new PackageVulnerabilityInfo[] {
+                            new PackageVulnerabilityInfo(new Uri("https://vulnerability1"), PackageVulnerabilitySeverity.Moderate, VersionRange.Parse("[1.0.0,2.0.0)"))
+                        }
+                    }
+                }
             };
+
+            string sourceWithVulnerabilityData = "https://contoso.com/vulnerability/v3/index.json";
+            Dictionary<string, GetVulnerabilityInfoResult> vulnerabilityResults = new()
+            {
+                { sourceWithVulnerabilityData, new GetVulnerabilityInfoResult(knownVulnerabilities, exceptions: null) }
+            };
+
+            var providers = new List<INuGetResourceProvider> { new VulnerabilityInfoResourceProvider(vulnerabilityResults) };
+            var sourceRepositories = new List<SourceRepository>
+            {
+                new SourceRepository(new PackageSource("https://contoso.com/v3/index.json"), providers)
+            };
+
             var sourceCacheContext = new SourceCacheContext();
             var logger = new TestLogger();
-            var auditChecker = new AuditChecker(packageSources, sourceCacheContext, logger);
+            var auditChecker = new AuditChecker(sourceRepositories, sourceCacheContext, logger);
 
             var packages = Enumerable.Empty<PackageRestoreData>();
             var restoreAuditProperties = new Dictionary<string, RestoreAuditProperties>
@@ -964,13 +987,36 @@ namespace NuGet.PackageManagement.Test
         public async Task CheckPackageVulnerabilitiesAsync_WithNullPackages_ThrowsArgumentNullException(string enableAudit)
         {
             // Arrange
-            var packageSources = new List<SourceRepository>
+            string packageId = "A";
+
+            List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities = new List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>()
             {
-                new SourceRepository(new PackageSource("https://api.nuget.org/v3/index.json"), Repository.Provider.GetCoreV3())
+                new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>
+                {
+                    {
+                        packageId,
+                        new PackageVulnerabilityInfo[] {
+                            new PackageVulnerabilityInfo(new Uri("https://vulnerability1"), PackageVulnerabilitySeverity.Moderate, VersionRange.Parse("[1.0.0,2.0.0)"))
+                        }
+                    }
+                }
             };
+
+            string sourceWithVulnerabilityData = "https://contoso.com/vulnerability/v3/index.json";
+            Dictionary<string, GetVulnerabilityInfoResult> vulnerabilityResults = new()
+            {
+                { sourceWithVulnerabilityData, new GetVulnerabilityInfoResult(knownVulnerabilities, exceptions: null) }
+            };
+
+            var providers = new List<INuGetResourceProvider> { new VulnerabilityInfoResourceProvider(vulnerabilityResults) };
+            var sourceRepositories = new List<SourceRepository>
+            {
+                new SourceRepository(new PackageSource("https://contoso.com/v3/index.json"), providers)
+            };
+
             var sourceCacheContext = new SourceCacheContext();
             var logger = new TestLogger();
-            var auditChecker = new AuditChecker(packageSources, sourceCacheContext, logger);
+            var auditChecker = new AuditChecker(sourceRepositories, sourceCacheContext, logger);
 
             IEnumerable<PackageRestoreData>? packages = null;
             var restoreAuditProperties = new Dictionary<string, RestoreAuditProperties>

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageRestoreManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageRestoreManagerTests.cs
@@ -440,6 +440,40 @@ namespace NuGet.Test
             nuGetPackageManager.PackageExistsInPackagesFolder((packageA.Identity)).Should().BeTrue();
         }
 
+        [Fact]
+        public async Task RestoreMissingPackagesInSolutionAsync_WhenNoPackageReferences_ReturnsNoopRestoreResult()
+        {
+            // Arrange
+            using var testSolutionManager = new TestSolutionManager();
+
+            // Create an empty solution with no packages
+            testSolutionManager.AddNewMSBuildProject(); // Add a project with no packages
+
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
+            var testSettings = Configuration.NullSettings.Instance;
+            var packageRestoreManager = new PackageRestoreManager(
+                sourceRepositoryProvider,
+                testSettings,
+                testSolutionManager);
+
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+            var logger = new TestLogger();
+            var token = CancellationToken.None;
+
+            // Act
+            var result = await packageRestoreManager.RestoreMissingPackagesInSolutionAsync(
+                testSolutionManager.SolutionDirectory,
+                testNuGetProjectContext,
+                logger,
+                token);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeSameAs(PackageRestoreResult.NoopRestoreResult);
+            result.Restored.Should().BeFalse();
+            result.RestoredPackages.Should().BeEmpty();
+        }
+
         private static DownloadResourceResult GetDownloadResult(string source, FileInfo packageFileInfo)
         {
             return new DownloadResourceResult(packageFileInfo.OpenRead(), source);

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageRestoreManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageRestoreManagerTests.cs
@@ -449,7 +449,8 @@ namespace NuGet.Test
             // Create an empty solution with no packages
             testSolutionManager.AddNewMSBuildProject(); // Add a project with no packages
 
-            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
+            using var simpleTestPathContext = new SimpleTestPathContext();
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(simpleTestPathContext.PackageSource));
             var testSettings = Configuration.NullSettings.Instance;
             var packageRestoreManager = new PackageRestoreManager(
                 sourceRepositoryProvider,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14362

## Description
The restore code path in Visual Studio that handles packages.config is run for all projects types. When there are only SDK style or Legacy Style projects in the solution and no packages.config projects, it still continues down the codepath for packages.config and causes the NuGet Audit operation to run even if it's disabled for the project. This fix checks if there are any packages from packages.config and if not, short circuits, adding robustness and resiliency for calling the associated methods for project types other than packages.config. Also included unit tests. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~

In addition to automated testing, I manually tested with the following test matrix:

| **Project Combination**                  | **NuGetAudit enabled?** | **NuGetAudit runs?** |
|------------------------------------------|--------------------------|-----------------------|
| SDK Style                                | true                     | true                  |
| SDK Style                                | false                    | false                 |
| Legacy                                   | true                     | true                  |
| Legacy                                   | false                    | false                 |
| packages.config                          | true                     | false on first install,<br>true on subsequent installs* |
| packages.config                          | false                    | false                 |
| SDK Style, Legacy                        | true                     | true                  |
| SDK Style, Legacy                        | false                    | false                 |
| SDK Style, packages.config               | true                     | true                  |
| SDK Style, packages.config               | false                    | false                 |
| Legacy, packages.config                  | true                     | true                  |
| Legacy, packages.config                  | false                    | false                 |
| SDK Style, Legacy, packages.config       | true                     | true                  |
| SDK Style, Legacy, packages.config       | false                    | false                 |

\* This behavior exists before the fix.

