### PR TITLE
Stop testing against netcoreapp3.1, which is long deprecated (#6498)

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -34,10 +34,6 @@
     <TargetFrameworksUnitTest>$(NETCoreTargetFramework)</TargetFrameworksUnitTest>
     <TargetFrameworksUnitTest Condition="'$(IsXPlat)' != 'true' And '$(DotNetBuildSourceOnly)' != 'true'">$(NETFXTargetFramework);$(TargetFrameworksUnitTest)</TargetFrameworksUnitTest>
 
-    <!-- Target frameworks for unit tests that test libaries using signing APIs -->
-    <TargetFrameworksUnitTestForSigning>$(NETCoreTargetFramework)</TargetFrameworksUnitTestForSigning>
-    <TargetFrameworksUnitTestForSigning Condition="'$(DotNetBuildSourceOnly)' != 'true'">$(TargetFrameworksUnitTestForSigning);$(NETCoreLegacyTargetFramework)</TargetFrameworksUnitTestForSigning>
-    <TargetFrameworksUnitTestForSigning Condition="'$(IsXPlat)' != 'true' And '$(DotNetBuildSourceOnly)' != 'true'">$(NETFXTargetFramework);$(TargetFrameworksUnitTestForSigning)</TargetFrameworksUnitTestForSigning>
   </PropertyGroup>
 
   <!-- Common -->

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -83,6 +83,7 @@ stages:
         testType: Unit
         testTargetFramework: net8.0
 
+<<<<<<< HEAD
 - ${{ if eq(parameters.RunUnitTestsOnWindows, true) }}:
   - stage:
     displayName: Unit Tests on Windows (.NET Core 3.1)
@@ -100,6 +101,8 @@ stages:
         testType: Unit
         testTargetFramework: netcoreapp3.1
 
+=======
+>>>>>>> b0972c13f (Stop testing against netcoreapp3.1, which is long deprecated (#6498))
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
     displayName: Functional Tests on Windows (.NET Framework 4.7.2)
@@ -151,8 +154,65 @@ stages:
         ${{ else }}:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Functional
-        testTargetFramework: netcoreapp3.1
+        testTargetFramework: net472
+        testProjectName: NuGet.CommandLine.Test
+        testVerbosity: normal
+        timeoutInMinutes: 45
+
+- ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
+  - stage:
+    displayName: NuGet.Packaging.FuncTest on Windows (.NET Framework 4.7.2)
+    dependsOn: []
+    jobs:
+    - template: pr.job.yml
+      parameters:
+        displayName: NuGet.Packaging.FuncTest on Windows (.NET Framework 4.7.2)
+        osName: Windows
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          agentPool: NetCore-Public
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+        ${{ else }}:
+          agentPool: VSEngSS-MicroBuild2022-1ES
+        testType: Functional
+        testTargetFramework: net472
+        testProjectName: NuGet.Packaging.FuncTest
+
+- ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
+  - stage:
+    displayName: Dotnet.Integration.Test on Windows (.NET 9.0)
+    dependsOn: []
+    jobs:
+    - template: pr.job.yml
+      parameters:
+        displayName: Dotnet.Integration.Test on Windows (.NET 9.0)
+        osName: Windows
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          agentPool: NetCore-Public
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+        ${{ else }}:
+          agentPool: VSEngSS-MicroBuild2022-1ES
+        testType: Functional
+        testTargetFramework: net9.0
+        testProjectName: Dotnet.Integration.Test
         timeoutInMinutes: 60
+
+- ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
+  - stage:
+    displayName: NuGet.Packaging.FuncTest on Windows (.NET 9.0)
+    dependsOn: []
+    jobs:
+    - template: pr.job.yml
+      parameters:
+        displayName: NuGet.Packaging.FuncTest on Windows (.NET 9.0)
+        osName: Windows
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          agentPool: NetCore-Public
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+        ${{ else }}:
+          agentPool: VSEngSS-MicroBuild2022-1ES
+        testType: Functional
+        testTargetFramework: net9.0
+        testProjectName: NuGet.Packaging.FuncTest
 
 - ${{ if eq(parameters.RunUnitTestsOnLinux, true) }}:
   - stage:
@@ -166,19 +226,6 @@ stages:
         vmImage: ubuntu-latest
         testType: Unit
         testTargetFramework: net8.0
-
-- ${{ if eq(parameters.RunUnitTestsOnLinux, true) }}:
-  - stage:
-    displayName: Unit Tests on Linux (.NET Core 3.1)
-    dependsOn: []
-    jobs:
-    - template: pr.job.yml
-      parameters:
-        displayName: Unit Tests on Linux (.NET Core 3.1)
-        osName: Linux
-        vmImage: ubuntu-22.04
-        testType: Unit
-        testTargetFramework: netcoreapp3.1
 
 - ${{ if eq(parameters.RunFunctionalTestsOnLinux, true) }}:
   - stage:
@@ -219,19 +266,6 @@ stages:
         vmImage: macos-latest
         testType: Unit
         testTargetFramework: net8.0
-
-- ${{ if eq(parameters.RunUnitTestsOnMacOS, true) }}:
-  - stage:
-    displayName: Unit Tests on MacOS (.NET Core 3.1)
-    dependsOn: []
-    jobs:
-    - template: pr.job.yml
-      parameters:
-        displayName: Unit Tests on MacOS (.NET Core 3.1)
-        osName: MacOS
-        vmImage: macos-latest
-        testType: Unit
-        testTargetFramework: netcoreapp3.1
 
 - ${{ if eq(parameters.RunFunctionalTestsOnMacOS, true) }}:
   - stage:

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -83,26 +83,6 @@ stages:
         testType: Unit
         testTargetFramework: net8.0
 
-<<<<<<< HEAD
-- ${{ if eq(parameters.RunUnitTestsOnWindows, true) }}:
-  - stage:
-    displayName: Unit Tests on Windows (.NET Core 3.1)
-    dependsOn: []
-    jobs:
-    - template: pr.job.yml
-      parameters:
-        displayName: Unit Tests on Windows (.NET Core 3.1)
-        osName: Windows
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
-        ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
-        testType: Unit
-        testTargetFramework: netcoreapp3.1
-
-=======
->>>>>>> b0972c13f (Stop testing against netcoreapp3.1, which is long deprecated (#6498))
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
     displayName: Functional Tests on Windows (.NET Framework 4.7.2)
@@ -139,81 +119,6 @@ stages:
         testTargetFramework: net8.0
         timeoutInMinutes: 60
 
-- ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
-  - stage:
-    displayName: Functional Tests on Windows (.NET Core 3.1)
-    dependsOn: []
-    jobs:
-    - template: pr.job.yml
-      parameters:
-        displayName: Functional Tests on Windows (.NET Core 3.1)
-        osName: Windows
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022Preview.Amd64.Open
-        ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
-        testType: Functional
-        testTargetFramework: net472
-        testProjectName: NuGet.CommandLine.Test
-        testVerbosity: normal
-        timeoutInMinutes: 45
-
-- ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
-  - stage:
-    displayName: NuGet.Packaging.FuncTest on Windows (.NET Framework 4.7.2)
-    dependsOn: []
-    jobs:
-    - template: pr.job.yml
-      parameters:
-        displayName: NuGet.Packaging.FuncTest on Windows (.NET Framework 4.7.2)
-        osName: Windows
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
-        ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
-        testType: Functional
-        testTargetFramework: net472
-        testProjectName: NuGet.Packaging.FuncTest
-
-- ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
-  - stage:
-    displayName: Dotnet.Integration.Test on Windows (.NET 9.0)
-    dependsOn: []
-    jobs:
-    - template: pr.job.yml
-      parameters:
-        displayName: Dotnet.Integration.Test on Windows (.NET 9.0)
-        osName: Windows
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
-        ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
-        testType: Functional
-        testTargetFramework: net9.0
-        testProjectName: Dotnet.Integration.Test
-        timeoutInMinutes: 60
-
-- ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
-  - stage:
-    displayName: NuGet.Packaging.FuncTest on Windows (.NET 9.0)
-    dependsOn: []
-    jobs:
-    - template: pr.job.yml
-      parameters:
-        displayName: NuGet.Packaging.FuncTest on Windows (.NET 9.0)
-        osName: Windows
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
-        ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
-        testType: Functional
-        testTargetFramework: net9.0
-        testProjectName: NuGet.Packaging.FuncTest
-
 - ${{ if eq(parameters.RunUnitTestsOnLinux, true) }}:
   - stage:
     displayName: Unit Tests on Linux (.NET 8.0)
@@ -241,18 +146,6 @@ stages:
         testTargetFramework: net8.0
         timeoutInMinutes: 60
 
-- ${{ if eq(parameters.RunFunctionalTestsOnLinux, true) }}:
-  - stage:
-    displayName: Functional Tests on Linux (.NET Core 3.1)
-    dependsOn: []
-    jobs:
-    - template: pr.job.yml
-      parameters:
-        displayName: Functional Tests on Linux (.NET Core 3.1)
-        osName: Linux
-        vmImage: ubuntu-22.04
-        testType: Functional
-        testTargetFramework: netcoreapp3.1
 
 - ${{ if eq(parameters.RunUnitTestsOnMacOS, true) }}:
   - stage:
@@ -280,19 +173,6 @@ stages:
         testType: Functional
         testTargetFramework: net8.0
         timeoutInMinutes: 60
-
-- ${{ if eq(parameters.RunFunctionalTestsOnMacOS, true) }}:
-  - stage:
-    displayName: Functional Tests on MacOS (.NET Core 3.1)
-    dependsOn: []
-    jobs:
-    - template: pr.job.yml
-      parameters:
-        displayName: Functional Tests on MacOS (.NET Core 3.1)
-        osName: MacOS
-        vmImage: macos-latest
-        testType: Functional
-        testTargetFramework: netcoreapp3.1
 
 - ${{ if or(eq(parameters.RunSourceBuild, true), eq(parameters.RunStaticAnalysis, true)) }}:
   - stage:

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/NuGet.Commands.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/NuGet.Commands.FuncTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Integration tests for the more involved NuGet.Commands, such as restore.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/NuGet.Packaging.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/NuGet.Packaging.FuncTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Integration tests for the more involved NuGet.Packaging functionality, such as signing.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/NuGet.Protocol.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/NuGet.Protocol.FuncTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Integration tests for the more involved NuGet.Protocol functionality, such as plugins.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/NuGet.Commands.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/NuGet.Commands.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Unit tests for NuGet.Commands.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/NuGet.Configuration.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/NuGet.Configuration.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Unit tests for NuGet.Configuration.</Description>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/NuGet.DependencyResolver.Core.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/NuGet.DependencyResolver.Core.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Unit tests for NuGet.DependencyResolver.Core.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Unit tests for NuGet.Packaging.</Description>
     <!-- remove warnings for obsolete types and methods: SYSLIB0023: RNGCryptoServiceProvider, SYSLIB0026: X509Certificate2() blank constructor -->
     <NoWarn>$(NoWarn);SYSLIB0023;SYSLIB0026</NoWarn>

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/NuGet.ProjectModel.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/NuGet.ProjectModel.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Unit tests for NuGet.ProjectModel.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGet.Protocol.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGet.Protocol.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Unit tests for NuGet.Protocol.</Description>
   </PropertyGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.Resolver.Test/NuGet.Resolver.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Resolver.Test/NuGet.Resolver.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <Description>Unit tests for NuGet.Resolver.</Description>
   </PropertyGroup>
 

--- a/test/TestExtensions/TestablePlugin/TestablePlugin.csproj
+++ b/test/TestExtensions/TestablePlugin/TestablePlugin.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <TargetLatestRuntimePatch>false</TargetLatestRuntimePatch>
     <OutputType>Exe</OutputType>
     <AssemblyName>Plugin.Testable</AssemblyName>

--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/Microsoft.Internal.NuGet.Testing.SignedPackages.csproj
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/Microsoft.Internal.NuGet.Testing.SignedPackages.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
+    <PackProject>true</PackProject>
+    <Shipping>true</Shipping>
+    <IsPackable>true</IsPackable>
+    <SkipShared>true</SkipShared>
+    <TestProject>false</TestProject>
+    <Description>Intended for internal NuGet testing only, for signed package validation.</Description>
+    <SkipAnalyzers>true</SkipAnalyzers>
+    <UsePublicApiAnalyzer>false</UsePublicApiAnalyzer>
+    <SignWithNuGetKey>true</SignWithNuGetKey>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="compiler\resources\*" />
+    <None Remove="compiler\resources\*" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
+    <Reference Include="System.Security" />
+    <PackageReference Include="System.Formats.Asn1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' != '.NETFramework' ">
+    <PackageReference Include="System.Security.Cryptography.Pkcs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\NuGet.Core\NuGet.Packaging\NuGet.Packaging.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/TestUtilities/Test.Utility/Test.Utility.csproj
+++ b/test/TestUtilities/Test.Utility/Test.Utility.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksUnitTestForSigning)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksUnitTest)</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <NoWarn Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">$(NoWarn);CS1998</NoWarn>
     <PackProject>true</PackProject>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

https://github.com/NuGet/NuGet.Client/pull/6498, https://github.com/NuGet/Client.Engineering/issues/2549


## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
