### PR TITLE
Support building on Linux when full signing is not available

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ CONFIGURATION=
 CI=0
 BUILD_NUMBER=
 RELEASE_LABEL=zlocal
+ARGUMENTS=()
 
 while true ; do
 	case "$1" in
@@ -12,6 +13,8 @@ while true ; do
 		--clear-cache) CLEAR_CACHE=1 ; shift ;;
 		-n) BUILD_NUMBER=$2 ; shift ;;
 		-l) RELEASE_LABEL=$2 ; shift ;;
+		-p:*) ARGUMENTS+=( "$1" ) ; shift ;;
+		/p:*) ARGUMENTS+=( "$1" ) ; shift ;;
 		--) shift ; break ;;
 		*) shift ; break ;;
 	esac
@@ -38,11 +41,11 @@ if [ "$CLEAR_CACHE" == "1" ]; then
 fi
 
 if [ "$BUILD_NUMBER" != "" ]; then
-	build_number_arg="/p:BuildNumber=$BUILD_NUMBER"
+	ARGUMENTS+=( "/p:BuildNumber=$BUILD_NUMBER" )
 fi
 
 if [ "$RELEASE_LABEL" != "" ]; then
-	release_label_arg="/p:ReleaseLabel=$RELEASE_LABEL"
+	ARGUMENTS+=( "/p:ReleaseLabel=$RELEASE_LABEL" )
 fi
 
 # CI build is Release by default, local builds are Debug by default
@@ -55,8 +58,8 @@ if [ "$CONFIGURATION" == "" ]; then
 fi
 
 # restore packages
-echo "dotnet msbuild build/build.proj /t:Restore /p:Configuration=$CONFIGURATION $build_number_arg $release_label_arg"
-dotnet msbuild build/build.proj /t:Restore /p:Configuration=$CONFIGURATION $build_number_arg $release_label_arg
+echo "dotnet msbuild build/build.proj /t:Restore /p:Configuration=$CONFIGURATION" ${ARGUMENTS[@]+"${ARGUMENTS[@]}"}
+dotnet msbuild build/build.proj /t:Restore /p:Configuration=$CONFIGURATION ${ARGUMENTS[@]+"${ARGUMENTS[@]}"}
 
 if [ $? -ne 0 ]; then
 	echo "Restore failed!!"
@@ -64,8 +67,8 @@ if [ $? -ne 0 ]; then
 fi
 
 # run tests
-echo "dotnet msbuild build/build.proj /t:CoreUnitTests /p:Configuration=$CONFIGURATION $build_number_arg $release_label_arg"
-dotnet msbuild build/build.proj /t:CoreUnitTests /p:Configuration=$CONFIGURATION $build_number_arg $release_label_arg
+echo "dotnet msbuild build/build.proj /t:CoreUnitTests /p:Configuration=$CONFIGURATION" ${ARGUMENTS[@]+"${ARGUMENTS[@]}"}
+dotnet msbuild build/build.proj /t:CoreUnitTests /p:Configuration=$CONFIGURATION ${ARGUMENTS[@]+"${ARGUMENTS[@]}"}
 
 if [ $? -ne 0 ]; then
 	echo "Tests failed!!"


### PR DESCRIPTION

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->

Fixes: 

## Description

Full signing requires the platform to provide the RSA+SHA1 algorithms. This is not true for some Linux distributions such as Fedora 42, or RHEL 9 (and 10). This was done to match the RSA+SHA1 deprecation:

- https://devblogs.microsoft.com/devops/ssh-rsa-deprecation/
- https://www.openssh.com/txt/release-8.2

It's easy to work around this by setting PublicSign=true and DelaySign=false, however that's not easy to do without code modifications. With this change, a user can set properties at the build command line. The following lets me build and test nuget-client on Fedora 42 without issues.

    $ ./build.sh -p:PublicSign=true -p:DelaySign=false

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
