### PR TITLE
Account for project and package reference with the same name when adding a package reference

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -1411,6 +1411,11 @@ namespace NuGet.XPlat.FuncTest
             projectA.AddProjectToAllFrameworks(projectB);
             projectA.Save();
 
+            // Generate Package
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageX);
             var logger = new TestCommandOutputLogger(_testOutputHelper);
 
             var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA, projects: projectB);
@@ -1424,7 +1429,34 @@ namespace NuGet.XPlat.FuncTest
             // Assert
             Assert.Equal(1, result);
             Assert.Null(itemGroup);
-            logger.ErrorMessages.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task AddPkg_WithPackageReferenceMatchingExistingTransitiveProject_Succeeds()
+        {
+            using var pathContext = new SimpleTestPathContext();
+            var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
+            var packageX = XPlatTestUtils.CreatePackage(packageVersion: "2.0.0");
+            var projectB = XPlatTestUtils.CreateProject("projectB", pathContext, "net46");
+            var projectC = XPlatTestUtils.CreateProject(packageX.Id, pathContext, "net46");
+            projectA.AddProjectToAllFrameworks(projectB);
+            projectB.AddProjectToAllFrameworks(projectC);
+            projectA.Save();
+            projectB.Save();
+
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
+
+            var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA, projects: [projectB, projectC]);
+            var commandRunner = new AddPackageReferenceCommandRunner();
+
+            // Act
+            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+            var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+            var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
+
+            // Assert
+            Assert.Equal(1, result);
+            Assert.Null(itemGroup);
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -1422,7 +1422,7 @@ namespace NuGet.XPlat.FuncTest
                     PackageSaveMode.Defaultv3,
                     packageX);
 
-                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA, projects: projectB);
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
@@ -1434,9 +1434,6 @@ namespace NuGet.XPlat.FuncTest
                 Assert.Equal(1, result);
                 Assert.Null(itemGroup);
                 logger.ErrorMessages.Should().BeEmpty();
-
-                //Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, "2.0.0"));
-                //Assert.True(XPlatTestUtils.ValidateAssetsFile(projectA, packageX.Id));
             }
         }
     }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -1404,37 +1404,27 @@ namespace NuGet.XPlat.FuncTest
         [Fact]
         public async Task AddPkg_WithPackageReferenceMatchingExistingProject_Succeeds()
         {
-            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
+            var packageX = XPlatTestUtils.CreatePackage(packageVersion: "2.0.0");
+            var projectB = XPlatTestUtils.CreateProject(packageX.Id, pathContext, "net46");
+            projectA.AddProjectToAllFrameworks(projectB);
+            projectA.Save();
 
-            using (var pathContext = new SimpleTestPathContext())
-            {
-                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
-                var packageX = XPlatTestUtils.CreatePackage(packageVersion: "2.0.0");
-                var projectB = XPlatTestUtils.CreateProject(packageX.Id, pathContext, "net46");
-                projectA.AddProjectToAllFrameworks(projectB);
-                projectA.Save();
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
 
-                var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA, projects: projectB);
+            var commandRunner = new AddPackageReferenceCommandRunner();
 
-                // Generate Package
-                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    pathContext.PackageSource,
-                    PackageSaveMode.Defaultv3,
-                    packageX);
+            // Act
+            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+            var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+            var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
-                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA, projects: projectB);
-                var commandRunner = new AddPackageReferenceCommandRunner();
-
-                // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
-                var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
-
-                // Assert
-                Assert.Equal(1, result);
-                Assert.Null(itemGroup);
-                logger.ErrorMessages.Should().BeEmpty();
-            }
+            // Assert
+            Assert.Equal(1, result);
+            Assert.Null(itemGroup);
+            logger.ErrorMessages.Should().BeEmpty();
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -1400,5 +1400,44 @@ namespace NuGet.XPlat.FuncTest
             // Since user did not specify a version, the package reference will contain the resolved version
             Assert.True(XPlatTestUtils.ValidateReference(projectXmlRoot, packageX.Id, "1.0.0", stringComparison: StringComparison.Ordinal));
         }
+
+        [Fact]
+        public async Task AddPkg_WithPackageReferenceMatchingExistingProject_Succeeds()
+        {
+            // Arrange
+
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
+                var packageX = XPlatTestUtils.CreatePackage(packageVersion: "2.0.0");
+                var projectB = XPlatTestUtils.CreateProject(packageX.Id, pathContext, "net46");
+                projectA.AddProjectToAllFrameworks(projectB);
+                projectA.Save();
+
+                var logger = new TestCommandOutputLogger(_testOutputHelper);
+
+                // Generate Package
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA);
+                var commandRunner = new AddPackageReferenceCommandRunner();
+
+                // Act
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
+
+                // Assert
+                Assert.Equal(1, result);
+                Assert.Null(itemGroup);
+                logger.ErrorMessages.Should().BeEmpty();
+
+                //Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, "2.0.0"));
+                //Assert.True(XPlatTestUtils.ValidateAssetsFile(projectA, packageX.Id));
+            }
+        }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -215,12 +215,12 @@ namespace NuGet.XPlat.FuncTest
             };
         }
 
-        internal static PackageReferenceArgs GetPackageReferenceArgs(TestCommandOutputLogger logger, string packageId, string packageVersion, SimpleTestProjectContext project, string frameworks = "", string packageDirectory = "", string sources = "", bool noRestore = false, bool noVersion = false, bool prerelease = false)
+        internal static PackageReferenceArgs GetPackageReferenceArgs(TestCommandOutputLogger logger, string packageId, string packageVersion, SimpleTestProjectContext project, string frameworks = "", string packageDirectory = "", string sources = "", bool noRestore = false, bool noVersion = false, bool prerelease = false, params SimpleTestProjectContext[] projects)
         {
             var dgFilePath = string.Empty;
             if (!noRestore)
             {
-                dgFilePath = CreateDGFileForProject(project);
+                dgFilePath = CreateDGFileForProject(project, projects);
             }
             return new PackageReferenceArgs(project.ProjectPath, logger)
             {

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -346,7 +346,7 @@ namespace NuGet.XPlat.FuncTest
             }
 
             return itemGroups
-                .First(i => i.Descendants(referenceType).Any() &&
+                .FirstOrDefault(i => i.Descendants(referenceType).Any() &&
                             i.FirstAttribute == null);
         }
 
@@ -364,12 +364,16 @@ namespace NuGet.XPlat.FuncTest
                 Directory.EnumerateFiles(Path.Combine(packageDirectoryPath, package.Id.ToLower(), package.Version.ToLower())).Any();
         }
 
-        public static string CreateDGFileForProject(SimpleTestProjectContext project)
+        public static string CreateDGFileForProject(SimpleTestProjectContext project, params SimpleTestProjectContext[] projectRefs)
         {
             var dgSpec = new DependencyGraphSpec();
             var dgFilePath = Path.Combine(Directory.GetParent(project.ProjectPath).FullName, "temp.dg");
             dgSpec.AddRestore(project.ProjectName);
             dgSpec.AddProject(project.PackageSpec);
+            foreach (var projectRef in projectRefs)
+            {
+                dgSpec.AddProject(projectRef.PackageSpec);
+            }
             dgSpec.Save(dgFilePath);
             return dgFilePath;
         }

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -263,7 +263,17 @@ namespace NuGet.Test.Utility
                 _packageSpec.RestoreMetadata.OutputPath = ProjectExtensionsPath;
                 _packageSpec.RestoreMetadata.OriginalTargetFrameworks = _packageSpec.TargetFrameworks.Select(e => e.TargetAlias).ToList();
                 _packageSpec.RestoreMetadata.TargetFrameworks = Frameworks
-                    .Select(f => new ProjectRestoreMetadataFrameworkInfo(f.Framework))
+                    .Select(f => new ProjectRestoreMetadataFrameworkInfo(f.Framework)
+                    {
+                        ProjectReferences = f.ProjectReferences.Select(p => new ProjectRestoreReference()
+                        {
+                            ProjectUniqueName = p.ProjectName,
+                            ProjectPath = p.ProjectPath,
+                            ExcludeAssets = LibraryIncludeFlagUtils.GetFlags(MSBuildStringUtility.Split(p.ExcludeAssets)),
+                            IncludeAssets = LibraryIncludeFlagUtils.GetFlags(MSBuildStringUtility.Split(p.IncludeAssets)),
+                            PrivateAssets = LibraryIncludeFlagUtils.GetFlags(MSBuildStringUtility.Split(p.PrivateAssets))
+                        }).ToList(),
+                    })
                     .ToList();
                 _packageSpec.RestoreMetadata.Sources = Sources?.ToList();
                 _packageSpec.RestoreMetadata.PackagesPath = GlobalPackagesFolder;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/8543

## Description

When you attempt to add a package that shares the same id with a pre-existing project reference, the `dotnet add package` command fails with the a null ref because https://github.com/NuGet/NuGet.Client/blob/04410842ba4e3f4182c39c8a5284951105e57c32/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs#L293 returns the wrong version and then nuspecFile is empty: https://github.com/NuGet/NuGet.Client/blob/04410842ba4e3f4182c39c8a5284951105e57c32/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs#L315. 

We need to account for the fact that we're *finding* the project here and not the package. 

While restore is successful (restore just handles the deduplication), we should make a decision whether we'd want this to fail or if we should add the PackageReference.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
