### PR TITLE
VS no longer deletes Package Source attributes when Name is updated

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
@@ -12,17 +12,23 @@ namespace NuGet.PackageManagement.VisualStudio.Options
 {
     internal static class PackageSourceValidator
     {
+        /// <summary>
+        /// Finds an existing package source by its unique original package source name (identifier). If none are found, create a new package source.
+        /// </summary>
+        /// <param name="lookupName">This is the package source Name which is unique and serves as the identifier.</param>
+        /// <param name="name">The new value for the name.</param>
+        /// <exception cref="ArgumentException"></exception>
         internal static PackageSource FindExistingOrCreate(
-            string packageSourceId,
+            string lookupName,
             string source,
             string name,
             bool isEnabled,
             List<PackageSource> packageSources)
         {
-            string trimmedSourceId = packageSourceId?.Trim() ?? string.Empty;
-            if (string.IsNullOrEmpty(trimmedSourceId))
+            string trimmedLookupName = lookupName?.Trim() ?? string.Empty;
+            if (string.IsNullOrEmpty(trimmedLookupName))
             {
-                throw new ArgumentException(message: Strings.Argument_Cannot_Be_Null_Or_Empty, paramName: nameof(packageSourceId));
+                throw new ArgumentException(message: Strings.Argument_Cannot_Be_Null_Or_Empty, paramName: nameof(lookupName));
             }
 
             string trimmedSource = source?.Trim() ?? string.Empty;
@@ -37,11 +43,11 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                 throw new ArgumentException(message: Strings.Argument_Cannot_Be_Null_Or_Empty, paramName: nameof(name));
             }
 
-            PackageSource? foundById = FindById(trimmedSourceId, packageSources);
+            PackageSource? foundByName = FindByName(trimmedLookupName, packageSources);
             PackageSource packageSource;
 
             // Create and validate a new Package Source since an existing one was not found.
-            if (foundById is null)
+            if (foundByName is null)
             {
                 packageSource = new PackageSource(trimmedSource, trimmedName, isEnabled);
                 SetAllowInsecureConnectionsProperty(packageSource);
@@ -50,10 +56,10 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             else // Found an existing source to update.
             {
                 bool isHttpSourceChanged =
-                    foundById.IsHttp
+                    foundByName.IsHttp
                     && !string.Equals(
                         trimmedSource,
-                        foundById.Source,
+                        foundByName.Source,
                         StringComparison.OrdinalIgnoreCase);
 
                 // Preserve existing properties by cloning the package source.
@@ -61,17 +67,17 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                     trimmedSource,
                     trimmedName,
                     isEnabled,
-                    foundById.IsOfficial,
-                    foundById.IsPersistable)
+                    foundByName.IsOfficial,
+                    foundByName.IsPersistable)
                 {
-                    IsMachineWide = foundById.IsMachineWide,
-                    Credentials = foundById.Credentials,
-                    ClientCertificates = foundById.ClientCertificates,
-                    Description = foundById.Description,
-                    ProtocolVersion = foundById.ProtocolVersion,
-                    AllowInsecureConnections = foundById.AllowInsecureConnections,
-                    DisableTLSCertificateValidation = foundById.DisableTLSCertificateValidation,
-                    MaxHttpRequestsPerSource = foundById.MaxHttpRequestsPerSource,
+                    IsMachineWide = foundByName.IsMachineWide,
+                    Credentials = foundByName.Credentials,
+                    ClientCertificates = foundByName.ClientCertificates,
+                    Description = foundByName.Description,
+                    ProtocolVersion = foundByName.ProtocolVersion,
+                    AllowInsecureConnections = foundByName.AllowInsecureConnections,
+                    DisableTLSCertificateValidation = foundByName.DisableTLSCertificateValidation,
+                    MaxHttpRequestsPerSource = foundByName.MaxHttpRequestsPerSource,
                 };
 
                 if (isHttpSourceChanged)
@@ -175,13 +181,13 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             }
         }
 
-        private static PackageSource? FindById(string packageSourceId, List<PackageSource> packageSources)
+        private static PackageSource? FindByName(string packageSourceName, List<PackageSource> packageSources)
         {
             _ = packageSources ?? throw new ArgumentNullException(nameof(packageSources));
 
             List<PackageSource> existingPackageSource = packageSources
                 .Where(packageSource =>
-                    string.Equals(packageSource.Name, packageSourceId, StringComparison.CurrentCultureIgnoreCase))
+                    string.Equals(packageSource.Name, packageSourceName, StringComparison.CurrentCultureIgnoreCase))
                 .ToList();
 
             if (existingPackageSource.Count > 1)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
@@ -13,11 +13,18 @@ namespace NuGet.PackageManagement.VisualStudio.Options
     internal static class PackageSourceValidator
     {
         internal static PackageSource FindExistingOrCreate(
+            string packageSourceId,
             string source,
             string name,
             bool isEnabled,
             List<PackageSource> packageSources)
         {
+            string trimmedSourceId = packageSourceId?.Trim() ?? string.Empty;
+            if (string.IsNullOrEmpty(trimmedSourceId))
+            {
+                throw new ArgumentException(message: Strings.Argument_Cannot_Be_Null_Or_Empty, paramName: nameof(packageSourceId));
+            }
+
             string trimmedSource = source?.Trim() ?? string.Empty;
             if (string.IsNullOrEmpty(trimmedSource))
             {
@@ -30,68 +37,47 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                 throw new ArgumentException(message: Strings.Argument_Cannot_Be_Null_Or_Empty, paramName: nameof(name));
             }
 
-            PackageSource? foundByName = FindByName(trimmedName, packageSources);
-            PackageSource? foundBySource = FindBySource(trimmedSource, packageSources);
-
+            PackageSource? foundById = FindById(trimmedSourceId, packageSources);
             PackageSource packageSource;
 
-            // Create and validate a new Package Source since none was found by name or source.
-            if (foundByName is null && foundBySource is null)
+            // Create and validate a new Package Source since an existing one was not found.
+            if (foundById is null)
             {
                 packageSource = new PackageSource(trimmedSource, trimmedName, isEnabled);
                 SetAllowInsecureConnectionsProperty(packageSource);
                 EnsureValidSources(packageSource);
             }
-            // If both name and source match, use the existing PackageSource.
-            else if (foundByName is not null && foundBySource is not null)
+            else // Found an existing source to update.
             {
-                // Only the IsEnabled property could be changing.
-                foundByName.IsEnabled = isEnabled;
-                packageSource = foundByName;
-            }
-            // The source is changing on an existing PackageSource.
-            else if (foundByName is not null)
-            {
+                bool isHttpSourceChanged =
+                    foundById.IsHttp
+                    && !string.Equals(
+                        trimmedSource,
+                        foundById.Source,
+                        StringComparison.OrdinalIgnoreCase);
+
                 // Preserve existing properties by cloning the package source.
                 packageSource = new PackageSource(
                     trimmedSource,
-                    foundByName.Name,
-                    isEnabled,
-                    foundByName.IsOfficial,
-                    foundByName.IsPersistable)
-                {
-                    IsMachineWide = foundByName.IsMachineWide,
-                    Credentials = foundByName.Credentials,
-                    ClientCertificates = foundByName.ClientCertificates,
-                    Description = foundByName.Description,
-                    ProtocolVersion = foundByName.ProtocolVersion,
-                    AllowInsecureConnections = foundByName.AllowInsecureConnections,
-                    DisableTLSCertificateValidation = foundByName.DisableTLSCertificateValidation,
-                    MaxHttpRequestsPerSource = foundByName.MaxHttpRequestsPerSource,
-                };
-
-                SetAllowInsecureConnectionsProperty(packageSource);
-            }
-            // The name is changing on an existing PackageSource.
-            else
-            {
-                // Preserve existing properties by cloning the package source.
-                packageSource = new PackageSource(
-                    foundBySource!.Source,
                     trimmedName,
                     isEnabled,
-                    foundBySource.IsOfficial,
-                    foundBySource.IsPersistable)
+                    foundById.IsOfficial,
+                    foundById.IsPersistable)
                 {
-                    IsMachineWide = foundBySource.IsMachineWide,
-                    Credentials = foundBySource.Credentials,
-                    ClientCertificates = foundBySource.ClientCertificates,
-                    Description = foundBySource.Description,
-                    ProtocolVersion = foundBySource.ProtocolVersion,
-                    AllowInsecureConnections = foundBySource.AllowInsecureConnections,
-                    DisableTLSCertificateValidation = foundBySource.DisableTLSCertificateValidation,
-                    MaxHttpRequestsPerSource = foundBySource.MaxHttpRequestsPerSource,
+                    IsMachineWide = foundById.IsMachineWide,
+                    Credentials = foundById.Credentials,
+                    ClientCertificates = foundById.ClientCertificates,
+                    Description = foundById.Description,
+                    ProtocolVersion = foundById.ProtocolVersion,
+                    AllowInsecureConnections = foundById.AllowInsecureConnections,
+                    DisableTLSCertificateValidation = foundById.DisableTLSCertificateValidation,
+                    MaxHttpRequestsPerSource = foundById.MaxHttpRequestsPerSource,
                 };
+
+                if (isHttpSourceChanged)
+                {
+                    SetAllowInsecureConnectionsProperty(packageSource);
+                }
             }
 
             return packageSource;
@@ -189,61 +175,18 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             }
         }
 
-        private static PackageSource? FindByName(string name, List<PackageSource> packageSources)
+        private static PackageSource? FindById(string packageSourceId, List<PackageSource> packageSources)
         {
             _ = packageSources ?? throw new ArgumentNullException(nameof(packageSources));
 
-            if (name is null)
-            {
-                return null;
-            }
-
-            string trimmedName = name?.Trim() ?? string.Empty;
-
             List<PackageSource> existingPackageSource = packageSources
                 .Where(packageSource =>
-                    string.Equals(packageSource.Name, trimmedName, StringComparison.CurrentCultureIgnoreCase))
+                    string.Equals(packageSource.Name, packageSourceId, StringComparison.CurrentCultureIgnoreCase))
                 .ToList();
 
             if (existingPackageSource.Count > 1)
             {
                 throw new InvalidOperationException(message: Strings.Error_PackageSource_UniqueName);
-            }
-
-            return existingPackageSource.SingleOrDefault();
-        }
-
-        private static PackageSource? FindBySource(string source, List<PackageSource> packageSources)
-        {
-            _ = packageSources ?? throw new ArgumentNullException(nameof(packageSources));
-
-            if (source is null)
-            {
-                return null;
-            }
-
-            string trimmedSource = source?.Trim() ?? string.Empty;
-
-            List<PackageSource> existingPackageSource = packageSources
-                .Where(packageSource =>
-                {
-                    string trimmedTargetSource = packageSource.Source?.Trim() ?? string.Empty;
-                    bool areTrimmedStringsEqual =
-                        string.Equals(
-                            trimmedTargetSource,
-                            trimmedSource,
-                            StringComparison.OrdinalIgnoreCase)
-                        && string.Equals(
-                            PathValidator.GetCanonicalPath(trimmedTargetSource),
-                            PathValidator.GetCanonicalPath(trimmedSource),
-                            StringComparison.OrdinalIgnoreCase);
-                    return areTrimmedStringsEqual;
-                })
-                .ToList();
-
-            if (existingPackageSource.Count > 1)
-            {
-                throw new InvalidOperationException(message: Strings.Error_PackageSource_UniqueSource);
             }
 
             return existingPackageSource.SingleOrDefault();

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -173,29 +173,29 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             {
                 List<PackageSource> packageSources = new List<PackageSource>(capacity: packageSourceDictionaryList.Count);
                 List<PackageSource> existingPackageSources = LoadPackageSources(isMachineWide: false);
-                bool hasAnyPackageSourceIdChanged = false;
+                bool hasAnyPackageSourceNameChanged = false;
 
                 foreach (Dictionary<string, object> packageSourceDictionary in packageSourceDictionaryList)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
                     string name = packageSourceDictionary[MonikerSourceName].ToString();
-                    string packageSourceId;
+                    string lookupName;
 
                     // Package Sources that were pre-existing in the NuGet.Config when GetValueAsync was called will have a Package ID.
                     if (packageSourceDictionary.TryGetValue(MonikerPackageSourceId, out object packageSourceIdObj))
                     {
-                        packageSourceId = packageSourceIdObj.ToString();
+                        lookupName = packageSourceIdObj.ToString();
 
-                        if (!string.Equals(packageSourceId, name, StringComparison.CurrentCultureIgnoreCase))
+                        if (!string.Equals(lookupName, name, StringComparison.CurrentCultureIgnoreCase))
                         {
                             // Changing the ID needs to refresh Unified Settings since the ID is a hidden property.
-                            hasAnyPackageSourceIdChanged = true;
+                            hasAnyPackageSourceNameChanged = true;
                         }
                     }
                     else // Newly added Package Sources will not have a Package ID yet.
                     {
-                        packageSourceId = name;
+                        lookupName = name;
                     }
 
                     string source = packageSourceDictionary[MonikerSourceUrl].ToString();
@@ -203,7 +203,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
 
                     PackageSource packageSource =
                         PackageSourceValidator.FindExistingOrCreate(
-                            packageSourceId,
+                            lookupName,
                             source,
                             name,
                             isEnabled,
@@ -217,7 +217,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
 
                 _packageSourceProvider.SavePackageSources(packageSources);
 
-                hasAnyHiddenPropertyChanged = hasAnyPackageSourceIdChanged;
+                hasAnyHiddenPropertyChanged = hasAnyPackageSourceNameChanged;
 
                 result = ExternalSettingOperationResult.Success.Instance;
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -86,7 +86,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                 {
                     case MonikerPackageSources:
                         return await Task.Run(
-                            () => SavePackageSources<T>(packageSourcesList, cancellationToken, out hasAnyHiddenPropertyChanged),
+                            () => SavePackageSources(packageSourcesList, cancellationToken, out hasAnyHiddenPropertyChanged),
                             cancellationToken);
 
                     case MonikerMachineWideSources:
@@ -157,7 +157,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             return result;
         }
 
-        private ExternalSettingOperationResult SavePackageSources<T>(
+        private ExternalSettingOperationResult SavePackageSources(
             IReadOnlyList<IDictionary<string, object>> packageSourceDictionaryList,
             CancellationToken cancellationToken,
             out bool hasAnyHiddenPropertyChanged)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -86,7 +86,12 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                 {
                     case MonikerPackageSources:
                         return await Task.Run(
-                            () => SavePackageSources(packageSourcesList, cancellationToken, out hasAnyHiddenPropertyChanged),
+                            () =>
+                            {
+                                (ExternalSettingOperationResult result, bool hasAnyHiddenPropertyChanged) savePackageSourcesResult = SavePackageSources(packageSourcesList, cancellationToken);
+                                hasAnyHiddenPropertyChanged = savePackageSourcesResult.hasAnyHiddenPropertyChanged;
+                                return savePackageSourcesResult.result;
+                            },
                             cancellationToken);
 
                     case MonikerMachineWideSources:
@@ -157,12 +162,11 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             return result;
         }
 
-        private ExternalSettingOperationResult SavePackageSources(
+        private (ExternalSettingOperationResult result, bool hasAnyHiddenPropertyChanged) SavePackageSources(
             IReadOnlyList<IDictionary<string, object>> packageSourceDictionaryList,
-            CancellationToken cancellationToken,
-            out bool hasAnyHiddenPropertyChanged)
+            CancellationToken cancellationToken)
         {
-            hasAnyHiddenPropertyChanged = false;
+            bool hasAnyHiddenPropertyChanged = false;
             ExternalSettingOperationResult result;
 
             try
@@ -225,7 +229,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                 ActivityLog.LogError(ExceptionHelper.LogEntrySource, ex.ToString());
             }
 
-            return result;
+            return (result, hasAnyHiddenPropertyChanged);
         }
 
         private static ExternalSettingOperationResult<T> GetValuePackageSources<T>(List<PackageSource> packageSources)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -20,6 +20,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
     {
         internal const string MonikerPackageSources = "packageSources";
         internal const string MonikerMachineWideSources = "machineWidePackageSources";
+        internal const string MonikerPackageSourceId = "packageSourceId"; // Unique identifier for the package source
         internal const string MonikerSourceName = "sourceName";
         internal const string MonikerSourceUrl = "sourceUrl";
         internal const string MonikerIsEnabled = "isEnabled";
@@ -74,6 +75,8 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                 throw new InvalidOperationException();
             }
 
+            bool hasAnyHiddenPropertyChanged = false;
+
             try
             {
                 // Stop listening to setting changes while saving.
@@ -83,7 +86,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                 {
                     case MonikerPackageSources:
                         return await Task.Run(
-                            () => SavePackageSources<T>(packageSourcesList, cancellationToken),
+                            () => SavePackageSources<T>(packageSourcesList, cancellationToken, out hasAnyHiddenPropertyChanged),
                             cancellationToken);
 
                     case MonikerMachineWideSources:
@@ -99,6 +102,11 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             {
                 // Resume listening to setting changes after saving.
                 _suppressSettingValuesChanged = false;
+
+                if (hasAnyHiddenPropertyChanged)
+                {
+                    VsSettings_SettingsChanged(this, EventArgs.Empty);
+                }
             }
         }
 
@@ -149,25 +157,49 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             return result;
         }
 
-        private ExternalSettingOperationResult SavePackageSources<T>(IReadOnlyList<IDictionary<string, object>> packageSourceDictionaryList, CancellationToken cancellationToken)
+        private ExternalSettingOperationResult SavePackageSources<T>(
+            IReadOnlyList<IDictionary<string, object>> packageSourceDictionaryList,
+            CancellationToken cancellationToken,
+            out bool hasAnyHiddenPropertyChanged)
         {
+            hasAnyHiddenPropertyChanged = false;
             ExternalSettingOperationResult result;
 
             try
             {
                 List<PackageSource> packageSources = new List<PackageSource>(capacity: packageSourceDictionaryList.Count);
                 List<PackageSource> existingPackageSources = LoadPackageSources(isMachineWide: false);
+                bool hasAnyPackageSourceIdChanged = false;
 
                 foreach (Dictionary<string, object> packageSourceDictionary in packageSourceDictionaryList)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
                     string name = packageSourceDictionary[MonikerSourceName].ToString();
+                    string packageSourceId;
+
+                    // Package Sources that were pre-existing in the NuGet.Config when GetValueAsync was called will have a Package ID.
+                    if (packageSourceDictionary.TryGetValue(MonikerPackageSourceId, out object packageIdObj))
+                    {
+                        packageSourceId = packageIdObj.ToString();
+
+                        if (!string.Equals(packageSourceId, name, StringComparison.CurrentCultureIgnoreCase))
+                        {
+                            // Changing the ID needs to refresh Unified Settings since the ID is a hidden property.
+                            hasAnyPackageSourceIdChanged = true;
+                        }
+                    }
+                    else // Newly added Package Sources will not have a Package ID yet.
+                    {
+                        packageSourceId = name;
+                    }
+
                     string source = packageSourceDictionary[MonikerSourceUrl].ToString();
                     bool isEnabled = (bool)packageSourceDictionary[MonikerIsEnabled];
 
                     PackageSource packageSource =
                         PackageSourceValidator.FindExistingOrCreate(
+                            packageSourceId,
                             source,
                             name,
                             isEnabled,
@@ -180,6 +212,9 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                 PackageSourceValidator.ValidateUniquenessOrThrow(packageSources);
 
                 _packageSourceProvider.SavePackageSources(packageSources);
+
+                hasAnyHiddenPropertyChanged = hasAnyPackageSourceIdChanged;
+
                 result = ExternalSettingOperationResult.Success.Instance;
             }
 #pragma warning disable CA1031 // Do not catch general exception types
@@ -204,8 +239,9 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                 // Each list item is represented by a dictionary, which in this case will have a single key-value pair for ConfigPath.
                 foreach (PackageSource packageSource in packageSources)
                 {
-                    var dict = new Dictionary<string, object>(capacity: 3)
+                    var dict = new Dictionary<string, object>(capacity: 5)
                     {
+                        { MonikerPackageSourceId, packageSource.Name }, // Use the package source name as a unique identifier
                         { MonikerSourceName, packageSource.Name },
                         { MonikerSourceUrl, packageSource.SourceUri }, // Throws if Source is an invalid URI
                         { MonikerIsEnabled, packageSource.IsEnabled },

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -179,9 +179,9 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                     string packageSourceId;
 
                     // Package Sources that were pre-existing in the NuGet.Config when GetValueAsync was called will have a Package ID.
-                    if (packageSourceDictionary.TryGetValue(MonikerPackageSourceId, out object packageIdObj))
+                    if (packageSourceDictionary.TryGetValue(MonikerPackageSourceId, out object packageSourceIdObj))
                     {
-                        packageSourceId = packageIdObj.ToString();
+                        packageSourceId = packageSourceIdObj.ToString();
 
                         if (!string.Equals(packageSourceId, name, StringComparison.CurrentCultureIgnoreCase))
                         {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceValidatorTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceValidatorTests.cs
@@ -237,6 +237,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         {
             // Arrange
             string name = "TestSource3";
+            string packageSourceId = name;
             string source = "https://testsource3.com";
             bool isEnabled = true;
 
@@ -247,7 +248,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(packageSourceId, source, name, isEnabled, packageSources);
 
             // Assert
             result.Should().NotBeNull();
@@ -261,6 +262,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         {
             // Arrange
             string name = "TestSource3";
+            string packageSourceId = name;
             string source = "http://testsource3.com";
             bool isEnabled = true;
 
@@ -271,7 +273,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(packageSourceId, source, name, isEnabled, packageSources);
 
             // Assert
             result.Should().NotBeNull();
@@ -284,10 +286,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         }
 
         [Fact]
-        public void FindExistingOrCreate_FoundExistingBySource_UpdatesName()
+        public void FindExistingOrCreate_FoundExistingById_UpdatesName()
         {
             // Arrange
             string originalName = "TestSource1";
+            string packageSourceId = originalName;
             string originalSource = "http://testsource1.com";
 
             string name = "TestSource2";
@@ -309,7 +312,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(packageSourceId, source, name, isEnabled, packageSources);
 
             // Assert
             result.Should().NotBeNull();
@@ -327,16 +330,39 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         [InlineData(null)]
         [InlineData("")]
         [InlineData(" ")]
-        public void FindExistingOrCreate_NullOrEmptyName_ThrowsArgumentException(string invalidName)
+        public void FindExistingOrCreate_NullOrEmptyId_ThrowsArgumentException(string invalidId)
         {
             // Arrange
+            string name = "TestSource1";
             string source = "http://testsource1.com";
             bool isEnabled = true;
 
             List<PackageSource> packageSources = new List<PackageSource>();
 
             // Act
-            Action act = () => PackageSourceValidator.FindExistingOrCreate(source, invalidName, isEnabled, packageSources);
+            Action act = () => PackageSourceValidator.FindExistingOrCreate(invalidId, source, name, isEnabled, packageSources);
+
+            // Assert
+            ArgumentException exception = Assert.Throws<ArgumentException>(act);
+            exception.Message.Should().Contain(Strings.Argument_Cannot_Be_Null_Or_Empty);
+            exception.ParamName.Should().Be("packageSourceId");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void FindExistingOrCreate_NullOrEmptyName_ThrowsArgumentException(string invalidName)
+        {
+            // Arrange
+            string packageId = "TestSource1";
+            string source = "http://testsource1.com";
+            bool isEnabled = true;
+
+            List<PackageSource> packageSources = new List<PackageSource>();
+
+            // Act
+            Action act = () => PackageSourceValidator.FindExistingOrCreate(packageId, source, invalidName, isEnabled, packageSources);
 
             // Assert
             ArgumentException exception = Assert.Throws<ArgumentException>(act);
@@ -352,12 +378,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         {
             // Arrange
             string name = "TestSource1";
+            string packageId = name;
             bool isEnabled = true;
 
             List<PackageSource> packageSources = new List<PackageSource>();
 
             // Act
-            Action act = () => PackageSourceValidator.FindExistingOrCreate(invalidSource, name, isEnabled, packageSources);
+            Action act = () => PackageSourceValidator.FindExistingOrCreate(packageId, invalidSource, name, isEnabled, packageSources);
 
             // Assert
             ArgumentException exception = Assert.Throws<ArgumentException>(act);
@@ -366,10 +393,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         }
 
         [Fact]
-        public void FindExistingOrCreate_FoundExistingByName_UpdatesSource()
+        public void FindExistingOrCreate_FoundExistingById_UpdatesSource()
         {
             // Arrange
             string originalName = "TestSource1";
+            string packageId = originalName;
             string originalSource = "http://testsource1.com";
             bool originalAllowInsecureConnections = true;
             bool originalDisableTLSCertificateValidation = true;
@@ -391,7 +419,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(packageId, source, name, isEnabled, packageSources);
 
             // Assert
             result.Should().NotBeNull();
@@ -403,6 +431,87 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             result.DisableTLSCertificateValidation.Should().Be(originalDisableTLSCertificateValidation, because: "Only the source should have changed.");
             result.Credentials.Should().BeEquivalentTo(originalCredential, because: "Only the source should have changed.");
             result.IsEnabled.Should().Be(isEnabled, because: "Only the source should have changed.");
+        }
+
+        [Fact]
+        public void FindExistingOrCreate_UpdateHttptoHttpsSource_RemovesAllowInsecureConnectionsFromTargetOnly()
+        {
+            // Arrange
+            string sourceName1 = "unitTestingSourceName1";
+            string sourceUrl1 = "https://testsource1.com";
+            // AllowInsecureConnections is not needed but was already configured.
+            bool source1AllowInsecureConnections = true;
+
+            string sourceName2 = "unitTestingSourceName2";
+            string sourceUrl2 = "http://testsource2.com";
+
+            // AllowInsecureConnections is needed but was missing.
+            bool source2AllowInsecureConnections = false;
+
+            string sourceName3 = "unitTestingSourceName3";
+            string sourceUrl3 = "http://testsource3.com";
+            bool source3AllowInsecureConnections = true;
+
+            string targetUrl = "https://testsource3.com";
+            bool expectedAllowInsecureConnections = false;
+
+            // Configure 3 existing package sources
+            List<PackageSource> packageSources =
+            [
+                new PackageSource(sourceUrl1, sourceName1, isEnabled: true)
+                {
+                    AllowInsecureConnections = source1AllowInsecureConnections
+                },
+                new PackageSource(sourceUrl2, sourceName2, isEnabled: true)
+                {
+                    AllowInsecureConnections = source2AllowInsecureConnections
+                },
+                new PackageSource(sourceUrl3, sourceName3, isEnabled: true)
+                {
+                    AllowInsecureConnections = source3AllowInsecureConnections
+                }
+            ];
+
+            // Act
+            PackageSource result1 = PackageSourceValidator.FindExistingOrCreate(
+                packageSourceId: sourceName1,
+                sourceUrl1,
+                sourceName1,
+                isEnabled: true,
+                packageSources);
+
+            PackageSource result2 = PackageSourceValidator.FindExistingOrCreate(
+                packageSourceId: sourceName2,
+                sourceUrl2,
+                sourceName2,
+                isEnabled: true,
+                packageSources);
+
+            PackageSource result3 = PackageSourceValidator.FindExistingOrCreate(
+                packageSourceId: sourceName3,
+                targetUrl,
+                sourceName3,
+                isEnabled: true,
+                packageSources);
+
+            // Assert
+            result1.Should().NotBeNull();
+            result1.Source.Should().Be(sourceUrl1, because: "No changes were made to the package source.");
+            result1.Name.Should().Be(sourceName1, because: "No changes were made to the package source.");
+            result1.AllowInsecureConnections.Should().Be(source1AllowInsecureConnections, because: "No changes were made to the package source.");
+            result1.IsEnabled.Should().Be(true, because: "No changes were made to the package source.");
+
+            result2.Should().NotBeNull();
+            result2.Source.Should().Be(sourceUrl2, because: "No changes were made to the package source.");
+            result2.Name.Should().Be(sourceName2, because: "No changes were made to the package source.");
+            result2.AllowInsecureConnections.Should().Be(source2AllowInsecureConnections, because: "No changes were made to the package source.");
+            result2.IsEnabled.Should().Be(true, because: "No changes were made to the package source.");
+
+            result3.Should().NotBeNull();
+            result3.Source.Should().Be(targetUrl, because: "A source change was expected.");
+            result3.Name.Should().Be(sourceName3, because: "Only the source should have changed.");
+            result3.AllowInsecureConnections.Should().Be(expectedAllowInsecureConnections, because: "Changing from HTTP to HTTPS source no longer needs AllowInsecureConnections.");
+            result3.IsEnabled.Should().Be(true, because: "Only the source should have changed.");
         }
 
         [Theory]
@@ -418,6 +527,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             bool originalDisableTLSCertificateValidation = true;
 
             string name = originalName;
+            string packageId = name;
             string expectedSourceProtocol = !isOriginallyHttps ? "https://" : "http://";
             bool expectedAllowInsecureConnections = isOriginallyHttps;
             string source = $"{expectedSourceProtocol}testsource1.com";
@@ -436,7 +546,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(packageId, source, name, isEnabled, packageSources);
 
             // Assert
             result.Should().NotBeNull();
@@ -457,6 +567,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         {
             // Arrange
             string name = "TestSource1";
+            string packageId = name;
             string source = "http://testsource1.com";
             bool isEnabled = !originalIsEnabled; // Toggle the enabled state
 
@@ -475,7 +586,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(packageId, source, name, isEnabled, packageSources);
 
             // Assert
             result.Should().NotBeNull();

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceValidatorTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceValidatorTests.cs
@@ -355,14 +355,14 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         public void FindExistingOrCreate_NullOrEmptyName_ThrowsArgumentException(string invalidName)
         {
             // Arrange
-            string packageId = "TestSource1";
+            string packageSourceId = "TestSource1";
             string source = "http://testsource1.com";
             bool isEnabled = true;
 
             List<PackageSource> packageSources = new List<PackageSource>();
 
             // Act
-            Action act = () => PackageSourceValidator.FindExistingOrCreate(packageId, source, invalidName, isEnabled, packageSources);
+            Action act = () => PackageSourceValidator.FindExistingOrCreate(packageSourceId, source, invalidName, isEnabled, packageSources);
 
             // Assert
             ArgumentException exception = Assert.Throws<ArgumentException>(act);
@@ -378,13 +378,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         {
             // Arrange
             string name = "TestSource1";
-            string packageId = name;
+            string packageSourceId = name;
             bool isEnabled = true;
 
             List<PackageSource> packageSources = new List<PackageSource>();
 
             // Act
-            Action act = () => PackageSourceValidator.FindExistingOrCreate(packageId, invalidSource, name, isEnabled, packageSources);
+            Action act = () => PackageSourceValidator.FindExistingOrCreate(packageSourceId, invalidSource, name, isEnabled, packageSources);
 
             // Assert
             ArgumentException exception = Assert.Throws<ArgumentException>(act);
@@ -397,7 +397,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         {
             // Arrange
             string originalName = "TestSource1";
-            string packageId = originalName;
+            string packageSourceId = originalName;
             string originalSource = "http://testsource1.com";
             bool originalAllowInsecureConnections = true;
             bool originalDisableTLSCertificateValidation = true;
@@ -419,7 +419,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(packageId, source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(packageSourceId, source, name, isEnabled, packageSources);
 
             // Assert
             result.Should().NotBeNull();
@@ -527,7 +527,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             bool originalDisableTLSCertificateValidation = true;
 
             string name = originalName;
-            string packageId = name;
+            string packageSourceId = name;
             string expectedSourceProtocol = !isOriginallyHttps ? "https://" : "http://";
             bool expectedAllowInsecureConnections = isOriginallyHttps;
             string source = $"{expectedSourceProtocol}testsource1.com";
@@ -546,7 +546,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(packageId, source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(packageSourceId, source, name, isEnabled, packageSources);
 
             // Assert
             result.Should().NotBeNull();
@@ -567,7 +567,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         {
             // Arrange
             string name = "TestSource1";
-            string packageId = name;
+            string packageSourceId = name;
             string source = "http://testsource1.com";
             bool isEnabled = !originalIsEnabled; // Toggle the enabled state
 
@@ -586,7 +586,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(packageId, source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(packageSourceId, source, name, isEnabled, packageSources);
 
             // Assert
             result.Should().NotBeNull();

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceValidatorTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceValidatorTests.cs
@@ -237,7 +237,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         {
             // Arrange
             string name = "TestSource3";
-            string packageSourceId = name;
+            string lookupName = name;
             string source = "https://testsource3.com";
             bool isEnabled = true;
 
@@ -248,7 +248,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(packageSourceId, source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(lookupName, source, name, isEnabled, packageSources);
 
             // Assert
             result.Should().NotBeNull();
@@ -262,7 +262,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         {
             // Arrange
             string name = "TestSource3";
-            string packageSourceId = name;
+            string lookupName = name;
             string source = "http://testsource3.com";
             bool isEnabled = true;
 
@@ -273,7 +273,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(packageSourceId, source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(lookupName, source, name, isEnabled, packageSources);
 
             // Assert
             result.Should().NotBeNull();
@@ -290,7 +290,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         {
             // Arrange
             string originalName = "TestSource1";
-            string packageSourceId = originalName;
+            string lookupName = originalName;
             string originalSource = "http://testsource1.com";
 
             string name = "TestSource2";
@@ -312,7 +312,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(packageSourceId, source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(lookupName, source, name, isEnabled, packageSources);
 
             // Assert
             result.Should().NotBeNull();
@@ -345,7 +345,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             // Assert
             ArgumentException exception = Assert.Throws<ArgumentException>(act);
             exception.Message.Should().Contain(Strings.Argument_Cannot_Be_Null_Or_Empty);
-            exception.ParamName.Should().Be("packageSourceId");
+            exception.ParamName.Should().Be("lookupName");
         }
 
         [Theory]
@@ -355,14 +355,14 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         public void FindExistingOrCreate_NullOrEmptyName_ThrowsArgumentException(string invalidName)
         {
             // Arrange
-            string packageSourceId = "TestSource1";
+            string lookupName = "TestSource1";
             string source = "http://testsource1.com";
             bool isEnabled = true;
 
             List<PackageSource> packageSources = new List<PackageSource>();
 
             // Act
-            Action act = () => PackageSourceValidator.FindExistingOrCreate(packageSourceId, source, invalidName, isEnabled, packageSources);
+            Action act = () => PackageSourceValidator.FindExistingOrCreate(lookupName, source, invalidName, isEnabled, packageSources);
 
             // Assert
             ArgumentException exception = Assert.Throws<ArgumentException>(act);
@@ -378,13 +378,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         {
             // Arrange
             string name = "TestSource1";
-            string packageSourceId = name;
+            string lookupName = name;
             bool isEnabled = true;
 
             List<PackageSource> packageSources = new List<PackageSource>();
 
             // Act
-            Action act = () => PackageSourceValidator.FindExistingOrCreate(packageSourceId, invalidSource, name, isEnabled, packageSources);
+            Action act = () => PackageSourceValidator.FindExistingOrCreate(lookupName, invalidSource, name, isEnabled, packageSources);
 
             // Assert
             ArgumentException exception = Assert.Throws<ArgumentException>(act);
@@ -397,7 +397,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         {
             // Arrange
             string originalName = "TestSource1";
-            string packageSourceId = originalName;
+            string lookupName = originalName;
             string originalSource = "http://testsource1.com";
             bool originalAllowInsecureConnections = true;
             bool originalDisableTLSCertificateValidation = true;
@@ -419,7 +419,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(packageSourceId, source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(lookupName, source, name, isEnabled, packageSources);
 
             // Assert
             result.Should().NotBeNull();
@@ -474,21 +474,21 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
 
             // Act
             PackageSource result1 = PackageSourceValidator.FindExistingOrCreate(
-                packageSourceId: sourceName1,
+                lookupName: sourceName1,
                 sourceUrl1,
                 sourceName1,
                 isEnabled: true,
                 packageSources);
 
             PackageSource result2 = PackageSourceValidator.FindExistingOrCreate(
-                packageSourceId: sourceName2,
+                lookupName: sourceName2,
                 sourceUrl2,
                 sourceName2,
                 isEnabled: true,
                 packageSources);
 
             PackageSource result3 = PackageSourceValidator.FindExistingOrCreate(
-                packageSourceId: sourceName3,
+                lookupName: sourceName3,
                 targetUrl,
                 sourceName3,
                 isEnabled: true,
@@ -527,7 +527,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             bool originalDisableTLSCertificateValidation = true;
 
             string name = originalName;
-            string packageSourceId = name;
+            string lookupName = name;
             string expectedSourceProtocol = !isOriginallyHttps ? "https://" : "http://";
             bool expectedAllowInsecureConnections = isOriginallyHttps;
             string source = $"{expectedSourceProtocol}testsource1.com";
@@ -546,7 +546,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(packageSourceId, source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(lookupName, source, name, isEnabled, packageSources);
 
             // Assert
             result.Should().NotBeNull();
@@ -567,7 +567,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         {
             // Arrange
             string name = "TestSource1";
-            string packageSourceId = name;
+            string lookupName = name;
             string source = "http://testsource1.com";
             bool isEnabled = !originalIsEnabled; // Toggle the enabled state
 
@@ -586,7 +586,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(packageSourceId, source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(lookupName, source, name, isEnabled, packageSources);
 
             // Assert
             result.Should().NotBeNull();

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourcesPageTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourcesPageTests.cs
@@ -85,6 +85,57 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         }
 
         [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task SetValueAsync_WhenPackageNameChanging_RaisesSettingValuesChangedAsync(bool isPackageNameChanging)
+        {
+            // Arrange
+            string originalSourceName = "unitTestingSourceName";
+            string originalSourceUrl = "https://unitTestingSource";
+            string newSourceName = isPackageNameChanging ? "unitTestingSourceNameEdited" : originalSourceName;
+            // Change the source if the name is not changing so that something gets updated.
+            string newSourceUrl = isPackageNameChanging ? originalSourceUrl : "https://unitTestingSourceEdited";
+
+            bool wasVsSettingsSettingsChangedCalled = false;
+
+            _packageSources =
+            [
+                new PackageSource(originalSourceUrl, originalSourceName)
+            ];
+
+            PackageSourcesPage instance = CreateInstance(_vsSettings);
+            instance.SettingValuesChanged += (sender, e) =>
+            {
+                wasVsSettingsSettingsChangedCalled = true;
+            };
+
+            Dictionary<string, object> packageSourceDictionary = new Dictionary<string, object>();
+
+            // The ID from Unified Settings has not been updated to match the new name.
+            packageSourceDictionary[PackageSourcesPage.MonikerPackageSourceId] = originalSourceName;
+            packageSourceDictionary[PackageSourcesPage.MonikerSourceName] = newSourceName;
+            packageSourceDictionary[PackageSourcesPage.MonikerSourceUrl] = newSourceUrl;
+            packageSourceDictionary[PackageSourcesPage.MonikerIsEnabled] = true;
+
+            IList<IDictionary<string, object>> packageSourceDictionaryList =
+                new List<IDictionary<string, object>>(capacity: 1)
+                {
+                    packageSourceDictionary
+                };
+
+            // Act
+            ExternalSettingOperationResult result = await instance.SetValueAsync(
+                PackageSourcesPage.MonikerPackageSources,
+                packageSourceDictionaryList,
+                CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<ExternalSettingOperationResult.Success>();
+            wasVsSettingsSettingsChangedCalled.Should().Be(isPackageNameChanging);
+        }
+
+        [Theory]
         [InlineData(@"http://")]
         [InlineData(@"https://")]
         [InlineData(@"https:// ")]
@@ -97,9 +148,9 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             PackageSourcesPage instance = CreateInstance(_vsSettings);
             Dictionary<string, object> packageSourceDictionary = new Dictionary<string, object>();
 
-            packageSourceDictionary["sourceName"] = "unitTestingSourceName";
-            packageSourceDictionary["sourceUrl"] = invalidSource;
-            packageSourceDictionary["isEnabled"] = true;
+            packageSourceDictionary[PackageSourcesPage.MonikerSourceName] = "unitTestingSourceName";
+            packageSourceDictionary[PackageSourcesPage.MonikerSourceUrl] = invalidSource;
+            packageSourceDictionary[PackageSourcesPage.MonikerIsEnabled] = true;
 
             IList<IDictionary<string, object>> packageSourceDictionaryList =
                 new List<IDictionary<string, object>>(capacity: 1)
@@ -141,9 +192,9 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             PackageSourcesPage instance = CreateInstance(_vsSettings);
             Dictionary<string, object> packageSourceDictionary = new Dictionary<string, object>();
 
-            packageSourceDictionary["sourceName"] = "unitTestingSourceName";
-            packageSourceDictionary["sourceUrl"] = invalidSource;
-            packageSourceDictionary["isEnabled"] = true;
+            packageSourceDictionary[PackageSourcesPage.MonikerSourceName] = "unitTestingSourceName";
+            packageSourceDictionary[PackageSourcesPage.MonikerSourceUrl] = invalidSource;
+            packageSourceDictionary[PackageSourcesPage.MonikerIsEnabled] = true;
 
             IList<IDictionary<string, object>> packageSourceDictionaryList =
                 new List<IDictionary<string, object>>(capacity: 1)
@@ -207,19 +258,19 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
 
             // Configure Unified Settings input to Toggle 2 of the 3 IsEnabled states.
             Dictionary<string, object> packageSourceDictionary1 = new Dictionary<string, object>();
-            packageSourceDictionary1["sourceName"] = sourceName1;
-            packageSourceDictionary1["sourceUrl"] = sourceUrl1;
-            packageSourceDictionary1["isEnabled"] = !isSource1Enabled; // Toggle the enabled state for the first source.
+            packageSourceDictionary1[PackageSourcesPage.MonikerSourceName] = sourceName1;
+            packageSourceDictionary1[PackageSourcesPage.MonikerSourceUrl] = sourceUrl1;
+            packageSourceDictionary1[PackageSourcesPage.MonikerIsEnabled] = !isSource1Enabled; // Toggle the enabled state for the first source.
 
             Dictionary<string, object> packageSourceDictionary2 = new Dictionary<string, object>();
-            packageSourceDictionary2["sourceName"] = sourceName2;
-            packageSourceDictionary2["sourceUrl"] = sourceUrl2;
-            packageSourceDictionary2["isEnabled"] = isSource2Enabled;
+            packageSourceDictionary2[PackageSourcesPage.MonikerSourceName] = sourceName2;
+            packageSourceDictionary2[PackageSourcesPage.MonikerSourceUrl] = sourceUrl2;
+            packageSourceDictionary2[PackageSourcesPage.MonikerIsEnabled] = isSource2Enabled;
 
             Dictionary<string, object> packageSourceDictionary3 = new Dictionary<string, object>();
-            packageSourceDictionary3["sourceName"] = sourceName3;
-            packageSourceDictionary3["sourceUrl"] = sourceUrl3;
-            packageSourceDictionary3["isEnabled"] = !isSource3Enabled; // Toggle the enabled state for the third source.
+            packageSourceDictionary3[PackageSourcesPage.MonikerSourceName] = sourceName3;
+            packageSourceDictionary3[PackageSourcesPage.MonikerSourceUrl] = sourceUrl3;
+            packageSourceDictionary3[PackageSourcesPage.MonikerIsEnabled] = !isSource3Enabled; // Toggle the enabled state for the third source.
 
             IList<IDictionary<string, object>> packageSourceDictionaryList =
                 new List<IDictionary<string, object>>(capacity: 3)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14370

## Description

When using Legacy VS settings, updating the Name on a package source would truncate attributes that a customer had set in their NuGet.Config.
This was due to considering an updated package source name as a brand new package source.

By storing a unique identifier with each package source item, this loss of data can be prevented.
Now, the modified package source can be loaded by using the ID, so we know when we're updating a source name versus when adding a brand new source.

| Action | Legacy VS Options Behavior | Unified Settings Behavior |
|------|---|--|
| Edit Name | ❌ Deleted package source attributes (such as `disableTLSCertificateValidation="True"`) | ✅ Preserves existing attributes  |
| Edit Source | ✅ Preserves existing attributes | ✅ Preserves existing attributes  |
| Edit Name & Source | ❌ Deleted package source attributes (such as `disableTLSCertificateValidation="True"`) | ✅ Preserves existing attributes  |


- This PR removes name/source lookup logic (reduces by 21 `src/` lines) and instead looks at a unique ID (the original package source `Name`).

- When reviewing strategies for storing a unique ID for Array settings with the Unified Settings team, we discovered that properties can be passed along even if they aren't part of the registration.json and not shown to the user.

- When a Name changes, we need to signal a refresh to Unified Settings so that it can repopulate the hidden ID properties. 
  - Added test `SetValueAsync_WhenPackageNameChanging_RaisesSettingValuesChangedAsync` to ensure SettingValuesChanged event is only invoked when a Name has changed.

- Added test `FindExistingOrCreate_UpdateHttptoHttpsSource_RemovesAllowInsecureConnectionsFromTargetOnly` to ensure `allowInsecureConnections` is only updated for the item being changed, and only if the Source was edited.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
