### PR TITLE
Pin and stabilize the `NuGetToolVersion` property in the generated NuGet props files during restore.

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -32,6 +32,21 @@ namespace NuGet.Commands
         public const string PropsExtension = ".props";
 
         /// <summary>
+        /// This value is written into generated Restore props files, but
+        /// if it changes across tooling that ships different NuGet versions
+        /// (like Visual Studio and the dotnet CLI) it can cause unintentional
+        /// problems with MSBuild incrementality. As a result, we set it to a new,
+        /// fixed value higher than the current NuGet version (6.14.x) and 
+        /// never change it again, so that starting in .NET 10 onwards this 
+        /// won't cause rebuilds.
+        /// 
+        /// We could remove the property entirely, but there are some uses of it
+        /// on public GitHub that aren't just from checked-in generated files, so
+        /// keeping it around but stable is the most compatible option.
+        /// </summary>
+        internal const string PermanentNuGetToolsVersionValue = "7.0.0";
+
+        /// <summary>
         /// The macros that we may use in MSBuild to replace path roots.
         /// </summary>
         public static readonly string[] MacroCandidates = new[]
@@ -185,7 +200,7 @@ namespace NuGet.Commands
                             GenerateProperty("NuGetPackageRoot", ReplacePathsWithMacros(repositoryRoot, environmentVariableReader)),
                             GenerateProperty("NuGetPackageFolders", string.Join(";", packageFolders)),
                             GenerateProperty("NuGetProjectStyle", projectStyle.ToString()),
-                            GenerateProperty("NuGetToolVersion", MinClientVersionUtility.GetNuGetClientVersion().ToFullString())),
+                            GenerateProperty("NuGetToolVersion", PermanentNuGetToolsVersionValue)),
                 new XElement(Namespace + "ItemGroup",
                             new XAttribute("Condition", $" {ExcludeAllCondition} "),
                             packageFolders.Select(e => GenerateItem("SourceRoot", PathUtility.EnsureTrailingSlash(e)))));


### PR DESCRIPTION
# Bug

Fixes: https://github.com/NuGet/Home/issues/14355

## Description

This prevents minor changes to this file that impact MSBuild incrementality for many other targets. When a file is Imported, MSBuild adds it to `MSBuildAllProjects`, a built-in property that accumulates all of the imported files. Some Targets use this as an input.

## PR Checklist

- [X] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
