### PR TITLE
Cherry Pick: Exit packages.config restore in VS early if there are no packages.config projects (#6503)

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/Audit/AuditCheckResult.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Audit/AuditCheckResult.cs
@@ -12,6 +12,11 @@ namespace NuGet.PackageManagement
 {
     public record AuditCheckResult
     {
+        internal static readonly AuditCheckResult NoopAuditResult = new AuditCheckResult(Array.Empty<ILogMessage>())
+        {
+            IsAuditEnabled = false,
+        };
+
         public IReadOnlyList<ILogMessage> Warnings { get; }
         internal bool IsAuditEnabled { get; set; } = true;
 

--- a/src/NuGet.Core/NuGet.PackageManagement/Audit/AuditChecker.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Audit/AuditChecker.cs
@@ -45,6 +45,11 @@ namespace NuGet.PackageManagement
             if (packages == null) throw new ArgumentNullException(nameof(packages));
             if (restoreAuditProperties == null) throw new ArgumentNullException(nameof(restoreAuditProperties));
 
+            if (!packages.Any())
+            {
+                return AuditCheckResult.NoopAuditResult;
+            }
+
             // Before fetching vulnerability data, check if any projects are enabled for audit
             // If there are no settings, then run the audit for all packages
             bool anyProjectsEnabledForAudit = restoreAuditProperties.Count == 0;
@@ -59,10 +64,7 @@ namespace NuGet.PackageManagement
 
             if (!anyProjectsEnabledForAudit)
             {
-                return new AuditCheckResult(Array.Empty<ILogMessage>())
-                {
-                    IsAuditEnabled = false,
-                };
+                return AuditCheckResult.NoopAuditResult;
             }
 
             Stopwatch stopwatch = Stopwatch.StartNew();

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreResult.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreResult.cs
@@ -11,6 +11,8 @@ namespace NuGet.PackageManagement
 {
     public class PackageRestoreResult
     {
+        internal static readonly PackageRestoreResult NoopRestoreResult = new(false, []);
+
         public PackageRestoreResult(bool restored, IEnumerable<PackageIdentity> restoredPackages, AuditCheckResult? auditCheckResult)
             : this(restored, restoredPackages)
         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14362

## Description
This is a cherry-pick of https://github.com/NuGet/NuGet.Client/pull/6503 into the release-6.14.x branch.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
