### PR TITLE
Fix OptProf

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,6 +29,7 @@
     <SystemSecurityCryptographyPkcsVersion Condition="'$(SystemSecurityCryptographyPkcsVersion)' == ''">9.0.6</SystemSecurityCryptographyPkcsVersion>
     <SystemSecurityCryptographyProtectedDataVersion Condition="'$(SystemSecurityCryptographyProtectedDataVersion)' == ''">9.0.6</SystemSecurityCryptographyProtectedDataVersion>
     <MicrosoftVisualStudioSolutionPersistenceVersion Condition="'$(MicrosoftVisualStudioSolutionPersistenceVersion)' == ''">1.0.52</MicrosoftVisualStudioSolutionPersistenceVersion>
+    <MicrosoftVisualStudioSdkForApex>18.0.1799-preview.1</MicrosoftVisualStudioSdkForApex>
   </PropertyGroup>
 
   <ItemGroup>
@@ -59,7 +60,7 @@
     <PackageVersion Include="Microsoft.PowerShell.3.ReferenceAssemblies" Version="1.0.0" />
     <!-- Microsoft.TeamFoundationServer.ExtendedClient has vulnerable dependencies Microsoft.IdentityModel.JsonWebTokens and System.IdentityModel.Tokens.Jwt . When it's upgraded, try removing the pinned packages -->
     <PackageVersion Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="16.153.0" />
-    <PackageVersion Include="Microsoft.Test.Apex.VisualStudio" Version="17.14.35906.295" />
+    <PackageVersion Include="Microsoft.Test.Apex.VisualStudio" Version="18.0.0-preview-1-10723-180" />
     <PackageVersion Include="Microsoft.TestPlatform.Portable" Version="17.1.0" />
     <PackageVersion Include="Microsoft.VisualStudio.LanguageServices" Version="4.3.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Markdown.Platform" Version="17.14.76-preview" />

--- a/test/NuGet.Tests.Apex/NuGet.OptProf/NuGet.OptProf.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.OptProf/NuGet.OptProf.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Test.Apex.VisualStudio" ExcludeAssets="Compile" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.VisualStudio.Sdk" />
+    <PackageReference Include="Microsoft.VisualStudio.Sdk" VersionOverride="$(MicrosoftVisualStudioSdkForApex)" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGet.Tests.Apex.Daily.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGet.Tests.Apex.Daily.csproj
@@ -19,7 +19,7 @@
  
   <ItemGroup>
     <PackageReference Include="Microsoft.Test.Apex.VisualStudio" ExcludeAssets="Compile" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.VisualStudio.Sdk" />
+    <PackageReference Include="Microsoft.VisualStudio.Sdk" VersionOverride="$(MicrosoftVisualStudioSdkForApex)" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
   </ItemGroup>

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
@@ -26,7 +26,7 @@
  
   <ItemGroup>
     <PackageReference Include="Microsoft.Test.Apex.VisualStudio" ExcludeAssets="Compile" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.VisualStudio.Sdk" />
+    <PackageReference Include="Microsoft.VisualStudio.Sdk" VersionOverride="$(MicrosoftVisualStudioSdkForApex)" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
   </ItemGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3262

## Description
This fixes our OptProf pipeline: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=11829358&view=results

It's not ideal to have the projects referencing the apex test package to use a different version of the VS SDK as the rest of the repo, but it's a quick fix to get OptProf working, and we can progress cleaning up our package versions at a more relaxed rate by doing this.

Unfortunately the VS tests are still failing, but one step at a time.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
