### PR TITLE
Onboard Package Source Mapping page to Unified Settings

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceMappingPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceMappingPage.cs
@@ -1,0 +1,203 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Utilities.UnifiedSettings;
+using NuGet.Configuration;
+using NuGet.VisualStudio.Internal.Contracts;
+
+namespace NuGet.PackageManagement.VisualStudio.Options
+{
+    [Guid("ACE317DA-8399-4DA4-9828-107E02244D45")]
+    public class PackageSourceMappingPage : NuGetExternalSettingsProvider
+    {
+        internal const string MonikerPackageSourceMapping = "packageSourceMapping";
+        internal const string MonikerSourceNameEnum = "packageSourceMapping.sourceName";
+        internal const string MonikerPackageId = "packageId";
+        internal const string MonikerSourceNames = "sourceName";
+
+        public override event EventHandler<EnumSettingChoicesChangedEventArgs>? EnumSettingChoicesChanged;
+
+        private readonly IPackageSourceProvider _packageSourceProvider;
+        internal readonly PackageSourceMappingProvider _packageSourceMappingProvider;
+
+        public PackageSourceMappingPage(VSSettings vsSettings, IPackageSourceProvider packageSourceProvider, PackageSourceMappingProvider packageSourceMappingProvider)
+            : base(vsSettings)
+        {
+            _packageSourceProvider = packageSourceProvider ?? throw new ArgumentNullException(nameof(packageSourceProvider));
+            _packageSourceMappingProvider = packageSourceMappingProvider ?? throw new ArgumentNullException(nameof(packageSourceMappingProvider));
+        }
+
+        internal override void VsSettings_SettingsChanged(object sender, EventArgs e)
+        {
+            // Possible values for Package Sources need to be refreshed, so tell Unified Settings that they have changed.
+            EnumSettingChoicesChanged?.Invoke(this, new EnumSettingChoicesChangedEventArgs(MonikerSourceNameEnum));
+
+            base.VsSettings_SettingsChanged(sender, e);
+        }
+
+        public override async Task<ExternalSettingOperationResult<T>> GetValueAsync<T>(string moniker, CancellationToken cancellationToken)
+        {
+            if (moniker == MonikerPackageSourceMapping)
+            {
+                IReadOnlyList<PackageSourceMappingSourceItem> packageSourceMappingItems = await Task.Run(
+                    () => _packageSourceMappingProvider.GetPackageSourceMappingItems(),
+                    cancellationToken);
+
+                Dictionary<string, List<PackageSourceContextInfo>> packageSourceMappingDictionary = PackageSourceMappingUtility.CreatePackageSourceMappingDictionary(packageSourceMappingItems);
+                ImmutableSortedDictionary<string, List<PackageSourceContextInfo>> sortedPackageSourceMappingDictionary
+                    = packageSourceMappingDictionary.OrderBy(mapping => mapping.Key, StringComparer.OrdinalIgnoreCase).ToImmutableSortedDictionary();
+                return GetValuePackageSourceMappings<T>(sortedPackageSourceMappingDictionary);
+            }
+
+            // Shouldn't happen as these are monikers we declared in registration.json.
+            throw new InvalidOperationException();
+        }
+
+        public override async Task<ExternalSettingOperationResult> SetValueAsync<T>(string moniker, T value, CancellationToken cancellationToken)
+        {
+            var packageSourceMappingList = value as IReadOnlyList<IDictionary<string, object>>;
+            if (packageSourceMappingList is null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            try
+            {
+                // Stop listening to setting changes while saving.
+                _suppressSettingValuesChanged = true;
+                if (moniker == MonikerPackageSourceMapping)
+                {
+                    return await Task.Run(
+                        () => SavePackageSourceMappings(packageSourceMappingList, cancellationToken),
+                        cancellationToken);
+                }
+            }
+            finally
+            {
+                // Resume listening to setting changes after saving.
+                _suppressSettingValuesChanged = false;
+            }
+
+            // Shouldn't happen as these are monikers we declared in registration.json.
+            throw new InvalidOperationException();
+        }
+
+        private ExternalSettingOperationResult SavePackageSourceMappings(IReadOnlyList<IDictionary<string, object>> packageSourceMappingList, CancellationToken cancellationToken)
+        {
+            ExternalSettingOperationResult result;
+
+            try
+            {
+                List<(string, IEnumerable<string>)> packagePatternToSources = new List<(string, IEnumerable<string>)>(capacity: packageSourceMappingList.Count);
+
+                IReadOnlyList<PackageSource> existingPackageSources = _packageSourceProvider.LoadPackageSources().ToList().AsReadOnly();
+                IReadOnlyList<PackageSourceMappingSourceItem> originalPackageSourceMappings = _packageSourceMappingProvider.GetPackageSourceMappingItems();
+
+                foreach (Dictionary<string, object> packageSourceMappingDictionary in packageSourceMappingList)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    string packageIdPattern = packageSourceMappingDictionary[MonikerPackageId].ToString();
+                    var sourceObjects = (IEnumerable<object>)packageSourceMappingDictionary[MonikerSourceNames];
+                    List<string> sources = sourceObjects.Select(sourceObject => sourceObject.ToString()).ToList();
+                    packagePatternToSources.Add((packageIdPattern, sources));
+                }
+
+                var sourceNamesToPackagePatterns = new Dictionary<string, List<PackagePatternItem>>();
+
+                // Keep any existing source mappings for package sources that are not configured.
+                PackageSourceMappingUtility.PreserveInvalidPackageSourceMappings(sourceNamesToPackagePatterns, existingPackageSources, originalPackageSourceMappings);
+
+                List<PackageSourceMappingSourceItem> packageSourceMappingSourceItems =
+                    PackageSourceMappingUtility.ConvertPackageIdAndSourcesToSourceMappingSourceItems(sourceNamesToPackagePatterns, packagePatternToSources);
+
+                _packageSourceMappingProvider.SavePackageSourceMappings(packageSourceMappingSourceItems);
+
+                result = ExternalSettingOperationResult.Success.Instance;
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex) when (!(ex is OperationCanceledException && cancellationToken.IsCancellationRequested))
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                result = CreateSettingErrorResult(ex.Message, isTransient: true);
+                ActivityLog.LogError(ExceptionHelper.LogEntrySource, ex.ToString());
+            }
+
+            return result;
+        }
+
+        public override async Task<ExternalSettingOperationResult<IReadOnlyList<EnumChoice>>> GetEnumChoicesAsync(string enumSettingMoniker, CancellationToken cancellationToken)
+        {
+            if (enumSettingMoniker == MonikerSourceNameEnum)
+            {
+                List<PackageSource> packageSources = await Task.Run(() => _packageSourceProvider.LoadPackageSources().ToList());
+
+                // Source names should be unique, but in case validation was bypassed and multiple were added, de-duplicate them for the options shown for source mappings.
+                List<string> sourceNames = packageSources
+                    .Select(packageSource => packageSource.Name)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                List<EnumChoice> enumChoices = sourceNames
+                    .Select(sourceName => new EnumChoice(Moniker: sourceName, Title: sourceName))
+                    .ToList();
+
+                return ExternalSettingOperationResult.SuccessResult((IReadOnlyList<EnumChoice>)enumChoices.AsReadOnly());
+            }
+
+            return await base.GetEnumChoicesAsync(enumSettingMoniker, cancellationToken);
+        }
+
+        private static ExternalSettingOperationResult<T> GetValuePackageSourceMappings<T>(ImmutableSortedDictionary<string, List<PackageSourceContextInfo>> packageSourceMappingsDictionary)
+        {
+            ExternalSettingOperationResult<T> result;
+
+            try
+            {
+                var packageSourceMappingsList = new List<Dictionary<string, object>>(capacity: packageSourceMappingsDictionary.Count);
+
+                // Each list item is represented by a dictionary, which in this case will have a single key-value pair for ConfigPath.
+                foreach (KeyValuePair<string, List<PackageSourceContextInfo>> packageSourceMapping in packageSourceMappingsDictionary)
+                {
+                    string packageIdOrPattern = packageSourceMapping.Key;
+                    List<PackageSourceContextInfo> packageSources = packageSourceMapping.Value;
+                    IEnumerable<string> packageSourceNames = packageSources.Select(source => source.Name);
+
+                    var dict = new Dictionary<string, object>(capacity: 2)
+                    {
+                        { MonikerPackageId, packageIdOrPattern },
+                        { MonikerSourceNames, packageSourceNames },
+                    };
+
+                    packageSourceMappingsList.Add(dict);
+                }
+
+
+                T castedPackageSources = (T)(object)packageSourceMappingsList;
+                result = ExternalSettingOperationResult.SuccessResult(castedPackageSources);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                var userErrorMessage = Strings.Error_NuGetConfig_InvalidState + " " + ex.Message;
+                result = CreateSettingErrorResult<T>(userErrorMessage);
+
+                var logErrorMessage = Strings.Error_NuGetConfig_InvalidState + " " + ex.ToString();
+                ActivityLog.LogError(ExceptionHelper.LogEntrySource, logErrorMessage);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceMappingUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceMappingUtility.cs
@@ -39,9 +39,9 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             IReadOnlyList<PackageSource> existingPackageSources,
             IReadOnlyList<PackageSourceMappingSourceItem> originalPackageSourceMappings)
         {
-            List<string> configuredPackageSourceNames = existingPackageSources
+            HashSet<string> configuredPackageSourceNames = existingPackageSources
                 .Select(packageSource => packageSource.Name)
-                .ToList();
+                .ToHashSet<string>();
 
             foreach (PackageSourceMappingSourceItem originalMapping in originalPackageSourceMappings)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceMappingUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceMappingUtility.cs
@@ -1,0 +1,102 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Configuration;
+using NuGet.VisualStudio.Internal.Contracts;
+
+namespace NuGet.PackageManagement.VisualStudio.Options
+{
+    internal static class PackageSourceMappingUtility
+    {
+        internal static Dictionary<string, List<PackageSourceContextInfo>> CreatePackageSourceMappingDictionary(IReadOnlyList<PackageSourceMappingSourceItem> originalMappings)
+        {
+            var packageSourceMappingDictionary = new Dictionary<string, List<PackageSourceContextInfo>>();
+            foreach (PackageSourceMappingSourceItem sourceItem in originalMappings)
+            {
+                foreach (PackagePatternItem patternItem in sourceItem.Patterns)
+                {
+                    if (!packageSourceMappingDictionary.ContainsKey(patternItem.Pattern))
+                    {
+                        packageSourceMappingDictionary[patternItem.Pattern] = new List<PackageSourceContextInfo>();
+                    }
+                    packageSourceMappingDictionary[patternItem.Pattern].Add(new PackageSourceContextInfo(sourceItem.Key));
+                }
+            }
+
+            return packageSourceMappingDictionary;
+        }
+
+        /// <summary>
+        /// For existing package source mappings configured with package sources which don't exist, keep those invalid package source mappings in place.
+        /// Add any <paramref name="originalPackageSourceMappings"/> configured with package sources not in <paramref name="existingPackageSources"/>
+        /// back into <paramref name="sourceNamesToPackagePatterns"/>.
+        /// </summary>
+        internal static void PreserveInvalidPackageSourceMappings(
+            Dictionary<string, List<PackagePatternItem>> sourceNamesToPackagePatterns,
+            IReadOnlyList<PackageSource> existingPackageSources,
+            IReadOnlyList<PackageSourceMappingSourceItem> originalPackageSourceMappings)
+        {
+            IEnumerable<string> originalMappingSourceNames = originalPackageSourceMappings.Select(mapping => mapping.Key);
+
+            List<string> configuredPackageSourceNames = existingPackageSources
+                .Select(packageSource => packageSource.Name)
+                .ToList();
+
+            foreach (PackageSourceMappingSourceItem originalMapping in originalPackageSourceMappings)
+            {
+                string originalSourceName = originalMapping.Key;
+                if (!configuredPackageSourceNames.Contains(originalSourceName, StringComparer.OrdinalIgnoreCase))
+                {
+                    // Keep this invalid package source mapping.
+                    AddOrUpdateSourceWithPackagePatterns(sourceNamesToPackagePatterns, originalMapping.Patterns, originalSourceName);
+                }
+            }
+        }
+
+        internal static List<PackageSourceMappingSourceItem> ConvertPackageIdAndSourcesToSourceMappingSourceItems(
+            Dictionary<string, List<PackagePatternItem>> sourceNamesToPackagePatterns,
+            IReadOnlyList<(string packageIdOrPattern, IEnumerable<string> sources)> packagePatternToSources)
+        {
+            foreach ((string packageIdOrPattern, IEnumerable<string> sources) packagePatternToSource in packagePatternToSources)
+            {
+                foreach (string source in packagePatternToSource.sources)
+                {
+                    string packageIdOrPattern = packagePatternToSource.packageIdOrPattern;
+                    PackagePatternItem packagePatternItem = new(packageIdOrPattern);
+                    AddOrUpdateSourceWithPackagePatterns(sourceNamesToPackagePatterns, [packagePatternItem], source);
+                }
+            }
+
+            var packageSourceMappingsSourceItems = new List<PackageSourceMappingSourceItem>();
+            foreach (KeyValuePair<string, List<PackagePatternItem>> item in sourceNamesToPackagePatterns)
+            {
+                string source = item.Key;
+                List<PackagePatternItem> packagePatterns = item.Value;
+                packageSourceMappingsSourceItems.Add(new PackageSourceMappingSourceItem(source, packagePatterns));
+            }
+            return packageSourceMappingsSourceItems;
+        }
+
+        internal static void AddOrUpdateSourceWithPackagePatterns(
+           Dictionary<string, List<PackagePatternItem>> sourceNamesToPackagePatterns,
+           IList<PackagePatternItem> packageIdOrPatterns,
+           string source)
+        {
+            if (!sourceNamesToPackagePatterns.Keys.Contains(source, StringComparer.OrdinalIgnoreCase))
+            {
+                sourceNamesToPackagePatterns[source] = new List<PackagePatternItem>();
+            }
+
+            foreach (PackagePatternItem packagePatternItem in packageIdOrPatterns)
+            {
+                if (!sourceNamesToPackagePatterns[source].Any(id => id.Pattern == packagePatternItem.Pattern))
+                {
+                    sourceNamesToPackagePatterns[source].Add(packagePatternItem);
+                }
+            }
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceMappingUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceMappingUtility.cs
@@ -39,8 +39,6 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             IReadOnlyList<PackageSource> existingPackageSources,
             IReadOnlyList<PackageSourceMappingSourceItem> originalPackageSourceMappings)
         {
-            IEnumerable<string> originalMappingSourceNames = originalPackageSourceMappings.Select(mapping => mapping.Key);
-
             List<string> configuredPackageSourceNames = existingPackageSources
                 .Select(packageSource => packageSource.Name)
                 .ToList();
@@ -80,7 +78,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             return packageSourceMappingsSourceItems;
         }
 
-        internal static void AddOrUpdateSourceWithPackagePatterns(
+        private static void AddOrUpdateSourceWithPackagePatterns(
            Dictionary<string, List<PackagePatternItem>> sourceNamesToPackagePatterns,
            IList<PackagePatternItem> packageIdOrPatterns,
            string source)

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -59,7 +59,7 @@ namespace NuGetVSExtension
     [ProvideOptionPage(typeof(StubGeneralOptionsPage), "NuGet Package Manager", "GeneralStub", 113, 115, true, IsInUnifiedSettings = false, Sort = 0)]
     [ProvideOptionPage(typeof(ConfigurationFilesOptionsPage), "NuGet Package Manager", "Configuration Files", 113, 117, true, IsInUnifiedSettings = true, Sort = 1)]
     [ProvideOptionPage(typeof(PackageSourceOptionsPage), "NuGet Package Manager", "Package Sources", 113, 114, true, IsInUnifiedSettings = true, Sort = 2)]
-    [ProvideOptionPage(typeof(PackageSourceMappingOptionsPage), "NuGet Package Manager", "Package Source Mapping", 113, 116, true, Sort = 3)]
+    [ProvideOptionPage(typeof(PackageSourceMappingOptionsPage), "NuGet Package Manager", "Package Source Mapping", 113, 116, true, IsInUnifiedSettings = true, Sort = 3)]
     [ProvideSettingsManifest]
     [ProvideSearchProvider(typeof(NuGetSearchProvider), "NuGet Search")]
     // UI Context rule for a project that could be upgraded to PackageReference from packages.config based project.
@@ -210,6 +210,7 @@ namespace NuGetVSExtension
 
             VSSettings vsSettings = Settings.Value as VSSettings;
             PackageSourceProvider packageSourceProvider = new(Settings.Value);
+            PackageSourceMappingProvider packageSourceMappingProvider = new(Settings.Value);
 
             AddService(typeof(GeneralPage),
                 (container, ct, serviceType) => Task.FromResult<object>(new GeneralPage(vsSettings)),
@@ -219,6 +220,9 @@ namespace NuGetVSExtension
                 promote: true);
             AddService(typeof(PackageSourcesPage),
                 (container, ct, serviceType) => Task.FromResult<object>(new PackageSourcesPage(vsSettings, packageSourceProvider)),
+                promote: true);
+            AddService(typeof(PackageSourceMappingPage),
+                (container, ct, serviceType) => Task.FromResult<object>(new PackageSourceMappingPage(vsSettings, packageSourceProvider, packageSourceMappingProvider)),
                 promote: true);
 
             ClearNuGetLocalResourcesCommand clearNuGetLocalResourcesCommand = new(oleMenuCommandService: _mcs, OutputConsoleLogger);

--- a/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
@@ -367,6 +367,15 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package pattern.
+        /// </summary>
+        internal static string Text_PackageSourceMappingPattern_Header {
+            get {
+                return ResourceManager.GetString("Text_PackageSourceMappingPattern_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Name.
         /// </summary>
         internal static string Text_PackageSourceName_Header {
@@ -399,6 +408,15 @@ namespace NuGetVSExtension {
         internal static string Text_PackageSourceUrl_Header {
             get {
                 return ResourceManager.GetString("Text_PackageSourceUrl_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Contoso.Contracts or System.*.
+        /// </summary>
+        internal static string Text_Watermark_ExamplePackageIdPattern {
+            get {
+                return ResourceManager.GetString("Text_Watermark_ExamplePackageIdPattern", resourceCulture);
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.Tools/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.resx
@@ -233,4 +233,11 @@
   <data name="Text_HttpSource_Error" xml:space="preserve">
     <value>NuGet requires HTTPS sources. To use an HTTP source, you must explicitly set 'allowInsecureConnections' to true in your NuGet.Config file. Refer to [https://aka.ms/nuget-https-everywhere](https://aka.ms/nuget-https-everywhere) for more information.</value>
   </data>
+  <data name="Text_Watermark_ExamplePackageIdPattern" xml:space="preserve">
+    <value>Contoso.Contracts or System.*</value>
+    <comment>"Contoso.Contracts" and "System.*" are examples of a package ID pattern and a package prefix pattern, respectively, so these two specific examples should not be translated.</comment>
+  </data>
+  <data name="Text_PackageSourceMappingPattern_Header" xml:space="preserve">
+    <value>Package pattern</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
@@ -220,6 +220,59 @@
           "allowAdditionsAndRemovals": false
         }
       }
+    },
+    "nuGetPackageManager.packageSourceMapping.externalSettings": {
+      "type": "external",
+      "title": "@116;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+      "backingStoreDescription": "@SettingsStoredInNuGetConfiguration;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+
+      "callback": {
+        "packageId": "5fcc8577-4feb-4d04-ad72-d6c629b083cc",
+        "serviceId": "ACE317DA-8399-4DA4-9828-107E02244D45"
+      },
+
+      "realtimeNotifications": true,
+
+      // Settings within this external settings region.  Unlike "normal" settings, these have no registered default values.
+      // Their values are retrieved via IExternalSettingsProvider.GetValueAsync; when the user edits them, the new values are passed to
+      // IExternalSettingsProvider.SetValueAsync.
+      "properties": {
+        "packageSourceMapping": {
+          "type": "array",
+          "title": "Package Source Mapping",
+          "uniqueItems": true,
+
+          // Metadata about items in this array
+          "items": {
+            "type": "object",
+
+            // The properties of items in this array
+            "properties": {
+              "packageId": {
+                "type": "string",
+                "title": "@Text_PackageSourceMappingPattern_Header;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+                "example": "@Text_Watermark_ExamplePackageIdPattern;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}"
+              },
+              "sourceName": {
+                "type": "array",
+                "uniqueItems": true,
+                "title": "@Text_PackageSourceUrl_Header;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+                "items": {
+                  "type": "string",
+                  "enum": [], // These are set by PackageSourceMappingPage external settings provider.
+                  "enumItemLabels": [] // These are set by PackageSourceMappingPage external settings provider.
+                },
+                "default": []
+              }
+            }
+          },
+
+          // The actual items that appear by default; in most cases, you'd leave this array empty.
+          "default": [],
+          "allowItemEditing": true,
+          "allowAdditionsAndRemovals": true
+        }
+      }
     }
   },
   "categories": {
@@ -249,6 +302,12 @@
       "title": "@114;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
       "legacyOptionPageId": "2819C3B6-FC75-4CD5-8C77-877903DE864C",
       "order": 2
+    },
+    "nuGetPackageManager.packageSourceMapping": {
+      "title": "@116;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+      "legacyOptionPageId": "F175964E-89F5-4521-8FE2-C10C07BB968C",
+      "order": 3,
+      "helpUri": "https://learn.microsoft.com/nuget/consume-packages/package-source-mapping"
     }
   }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
@@ -240,7 +240,6 @@
         "packageSourceMapping": {
           "type": "array",
           "title": "Package Source Mapping",
-          "uniqueItems": true,
 
           // Metadata about items in this array
           "items": {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/NuGetExternalSettingsProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/NuGetExternalSettingsProviderTests.cs
@@ -20,11 +20,14 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         protected VSSettings _vsSettings;
         protected const string MonikerDoesNotExist = "TESTING!doesNotExist";
 
-        protected abstract TPage CreateInstance(VSSettings? vsSettings);
+        protected abstract TPage CreateInstance(VSSettings vsSettings);
 
         protected NuGetExternalSettingsProviderTests()
         {
             var solutionManager = new Mock<ISolutionManager>();
+            solutionManager.Setup(obj => obj.IsSolutionOpen).Returns(true);
+            solutionManager.Setup(obj => obj.SolutionDirectory).Returns(() => GetSolutionDirectory());
+
             var machineWideSettings = new Mock<IMachineWideSettings>();
             var slnConfigWatcher = new Mock<IFileWatcher>();
             var userConfigWatcher = new Mock<IFileWatcher>();
@@ -36,6 +39,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             _vsSettings = new VSSettings(solutionManager.Object, machineWideSettings.Object, watcherFactory.Object);
         }
 
+        protected virtual string GetSolutionDirectory()
+        {
+            return string.Empty;
+        }
+
         [Fact]
         public void Constructor_NullVsSettings_ThrowsArgumentNullException()
         {
@@ -43,7 +51,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             VSSettings? vsSettings = null;
 
             // Act
-            Action act = () => CreateInstance(vsSettings);
+            Action act = () => CreateInstance(vsSettings!);
 
             // Assert
             act.Should().Throw<ArgumentNullException>();

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceMappingPageTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceMappingPageTests.cs
@@ -44,6 +44,24 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             return new PackageSourceMappingPage(vsSettings, mockedPackageSourceProvider.Object, sourceMappingProvider);
         }
 
+        protected override string GetSolutionDirectory()
+        {
+            if (_pathContext is not null)
+            {
+                return _pathContext.SolutionRoot;
+            }
+
+            return base.GetSolutionDirectory();
+        }
+
+        public void Dispose()
+        {
+            if (_pathContext is not null)
+            {
+                _pathContext.Dispose();
+            }
+        }
+
         [Fact]
         public void VsSettings_SettingsChanged_RaisesEnumSettingChoicesChanged()
         {
@@ -62,15 +80,107 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             wasEnumSettingChoicesChangedRaised.Should().BeTrue();
         }
 
-        protected override string GetSolutionDirectory()
+        [Fact]
+        public async Task SetValueAsync_NewPackageSourceMapping_ReturnedByGetValueAsync()
         {
-            if (_pathContext is not null)
-            {
-                return _pathContext.SolutionRoot;
-            }
+            // Arrange
+            _pathContext = new SimpleTestPathContext();
 
-            return base.GetSolutionDirectory();
+            string addNewPackageSourceName = "unitTestingSourceName1";
+            string packageIdPattern = "Contoso.*";
+            PackageSourceMappingPage instance = CreateInstance(_vsSettings);
+
+            Dictionary<string, object> sourceMappingDictionary1 = new Dictionary<string, object>();
+            sourceMappingDictionary1[PackageSourceMappingPage.MonikerPackageId] = packageIdPattern;
+            sourceMappingDictionary1[PackageSourceMappingPage.MonikerSourceNames] = new List<string>() { addNewPackageSourceName };
+
+            IList<IDictionary<string, object>> sourceMappingDictionaryList =
+                new List<IDictionary<string, object>>(capacity: 1)
+                {
+                    sourceMappingDictionary1, // Adding a new package source mapping
+                };
+
+            // Act
+            ExternalSettingOperationResult resultSetValue = await instance.SetValueAsync(
+                PackageSourceMappingPage.MonikerPackageSourceMapping,
+                sourceMappingDictionaryList,
+                CancellationToken.None);
+
+            ExternalSettingOperationResult<IReadOnlyList<IDictionary<string, object>>> resultGetValue =
+                await instance.GetValueAsync<IReadOnlyList<IDictionary<string, object>>>(
+                    moniker: PackageSourceMappingPage.MonikerPackageSourceMapping,
+                    cancellationToken: CancellationToken.None);
+
+            // Assert
+            resultSetValue.Should().NotBeNull();
+            resultSetValue.Should().BeOfType<ExternalSettingOperationResult.Success>();
+
+            resultGetValue.Should().NotBeNull();
+            resultGetValue.Should().BeOfType<ExternalSettingOperationResult<IReadOnlyList<IDictionary<string, object>>>.Success>();
+            IReadOnlyList<IDictionary<string, object>> successResult = resultGetValue
+                .As<ExternalSettingOperationResult<IReadOnlyList<IDictionary<string, object>>>.Success>()
+                .Value;
+            successResult.Count.Should().Be(1);
+            successResult.Should().ContainEquivalentOf(sourceMappingDictionary1);
         }
+
+        [Fact]
+        public async Task SetValueAsync_EditPackageSourceMapping_ReturnedByGetValueAsync()
+        {
+            // Arrange
+            _pathContext = new SimpleTestPathContext();
+
+            string editedPackageSourceName = "unitTestingSourceName1";
+            string packageIdPattern = "Contoso.*";
+            PackageSourceMappingPage instance = CreateInstance(_vsSettings);
+
+            Dictionary<string, object> sourceMappingDictionary1 = new Dictionary<string, object>();
+            sourceMappingDictionary1[PackageSourceMappingPage.MonikerPackageId] = packageIdPattern;
+            sourceMappingDictionary1[PackageSourceMappingPage.MonikerSourceNames] = new List<string>() { editedPackageSourceName };
+
+            IList<IDictionary<string, object>> sourceMappingDictionaryList =
+                new List<IDictionary<string, object>>(capacity: 1)
+                {
+                    sourceMappingDictionary1, // Adding a new package source mapping
+                };
+
+            // Act
+            ExternalSettingOperationResult resultSetValue = await instance.SetValueAsync(
+                PackageSourceMappingPage.MonikerPackageSourceMapping,
+                sourceMappingDictionaryList,
+                CancellationToken.None);
+
+            ExternalSettingOperationResult<IReadOnlyList<IDictionary<string, object>>> resultGetValue =
+                await instance.GetValueAsync<IReadOnlyList<IDictionary<string, object>>>(
+                    moniker: PackageSourceMappingPage.MonikerPackageSourceMapping,
+                    cancellationToken: CancellationToken.None);
+
+            // Assert
+            resultSetValue.Should().NotBeNull();
+            resultSetValue.Should().BeOfType<ExternalSettingOperationResult.Success>();
+
+            resultGetValue.Should().NotBeNull();
+            resultGetValue.Should().BeOfType<ExternalSettingOperationResult<IReadOnlyList<IDictionary<string, object>>>.Success>();
+            IReadOnlyList<IDictionary<string, object>> successResult = resultGetValue
+                .As<ExternalSettingOperationResult<IReadOnlyList<IDictionary<string, object>>>.Success>()
+                .Value;
+            successResult.Count.Should().Be(1);
+        }
+
+        //// Edit Remove 1 source from existing
+        //[Fact]
+        //public async Task SetValueAsync_ggggg_zzzzAsync()
+        //{
+
+        //}
+
+        //// Remove 1 psm
+        //[Fact]
+        //public async Task SetValueAsync_ggggg_zzzzAsync()
+        //{
+
+        //}
+
 
         [Fact]
         public async Task SetValueAsync_PreviousMappingsToNonexistantSources_AddNewMapping_ExistingMappingsAreUnchangedAsync()
@@ -109,29 +219,29 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             // Configure Unified Settings input to modify an existing package source mapping.
 
             // Unchanged package source mapping.
-            Dictionary<string, object> packageSourceDictionary1 = new Dictionary<string, object>();
-            packageSourceDictionary1[PackageSourceMappingPage.MonikerPackageId] = unitTestingSourceMapping1.Patterns.Single().Pattern;
-            packageSourceDictionary1[PackageSourceMappingPage.MonikerSourceNames] = new List<string>() { unitTestingSourceMapping1.Key };
+            Dictionary<string, object> sourceMappingDictionary1 = new Dictionary<string, object>();
+            sourceMappingDictionary1[PackageSourceMappingPage.MonikerPackageId] = unitTestingSourceMapping1.Patterns.Single().Pattern;
+            sourceMappingDictionary1[PackageSourceMappingPage.MonikerSourceNames] = new List<string>() { unitTestingSourceMapping1.Key };
 
             // nonExistantSourceName is not known to Unified Settings, so it is not part of the request to SetValue.
 
             // Unchanged package source mapping.
-            Dictionary<string, object> packageSourceDictionary3 = new Dictionary<string, object>();
-            packageSourceDictionary3[PackageSourceMappingPage.MonikerPackageId] = unitTestingSourceMapping3.Patterns.Single().Pattern;
-            packageSourceDictionary3[PackageSourceMappingPage.MonikerSourceNames] = new List<string>() { unitTestingSourceMapping3.Key };
+            Dictionary<string, object> sourceMappingDictionary3 = new Dictionary<string, object>();
+            sourceMappingDictionary3[PackageSourceMappingPage.MonikerPackageId] = unitTestingSourceMapping3.Patterns.Single().Pattern;
+            sourceMappingDictionary3[PackageSourceMappingPage.MonikerSourceNames] = new List<string>() { unitTestingSourceMapping3.Key };
 
             // Add a new package source mapping for another existing source.
-            Dictionary<string, object> packageSourceDictionary4 = new Dictionary<string, object>();
-            packageSourceDictionary4[PackageSourceMappingPage.MonikerPackageId] = packageIdPattern;
-            packageSourceDictionary4[PackageSourceMappingPage.MonikerSourceNames] = new List<string>() { addNewPackageSourceName4 };
+            Dictionary<string, object> sourceMappingDictionary4 = new Dictionary<string, object>();
+            sourceMappingDictionary4[PackageSourceMappingPage.MonikerPackageId] = packageIdPattern;
+            sourceMappingDictionary4[PackageSourceMappingPage.MonikerSourceNames] = new List<string>() { addNewPackageSourceName4 };
 
             IList<IDictionary<string, object>> sourceMappingDictionaryList =
                 new List<IDictionary<string, object>>(capacity: 3)
                 {
-                    packageSourceDictionary1, // Pre-existing and unchanged.
+                    sourceMappingDictionary1, // Pre-existing and unchanged.
                     // No source mapping is sent by Unified Settings for nonExistantSourceName2.
-                    packageSourceDictionary3, // Pre-existing and unchanged.
-                    packageSourceDictionary4 // A newly added source mapping.
+                    sourceMappingDictionary3, // Pre-existing and unchanged.
+                    sourceMappingDictionary4 // A newly added source mapping.
                 };
 
             // Act
@@ -146,7 +256,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
 
             IReadOnlyList<PackageSourceMappingSourceItem> packageSourceMappingItems = instance._packageSourceMappingProvider.GetPackageSourceMappingItems();
 
-            // If the machine-wide config contains package source mappings, this count could be greater than 4.
             packageSourceMappingItems.Should().HaveCount(4);
 
             packageSourceMappingItems.Should().Contain(unitTestingSourceMapping1);
@@ -156,14 +265,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             var foundResult = packageSourceMappingItems.Should().Contain(item => item.Key.Equals(addNewPackageSourceName4), because: "The package source was added in a new source mapping.");
             PackageSourceMappingSourceItem foundNewPackageSourceMapping = foundResult.Subject;
             foundNewPackageSourceMapping.Patterns.Should().ContainSingle(packagePatternItem => packagePatternItem.Pattern == packageIdPattern, because: "One pattern was added to the new source mapping.");
-        }
-
-        public void Dispose()
-        {
-            if (_pathContext is not null)
-            {
-                _pathContext.Dispose();
-            }
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceMappingPageTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceMappingPageTests.cs
@@ -125,29 +125,29 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         }
 
         [Fact]
-        public async Task SetValueAsync_EditPackageSourceMapping_ReturnedByGetValueAsync()
+        public async Task SetValueAsync_RemovePackageSourceMapping_NotReturnedByGetValueAsync()
         {
             // Arrange
             _pathContext = new SimpleTestPathContext();
-
-            string editedPackageSourceName = "unitTestingSourceName1";
+            string unitTestingSourceName1 = "unitTestingSourceName1";
             string packageIdPattern = "Contoso.*";
+
+            _packageSources =
+            [
+                new PackageSource(source: $"https://{unitTestingSourceName1}", unitTestingSourceName1),
+            ];
+
+            var unitTestingSourceMapping1 = new PackageSourceMappingSourceItem(unitTestingSourceName1, [new PackagePatternItem(packageIdPattern)]);
+            _vsSettings.AddOrUpdate(ConfigurationConstants.PackageSourceMapping, unitTestingSourceMapping1);
+
+            var emptySourceMappingDictionaryEnumerable = Enumerable.Empty<IDictionary<string, object>>();
+
             PackageSourceMappingPage instance = CreateInstance(_vsSettings);
-
-            Dictionary<string, object> sourceMappingDictionary1 = new Dictionary<string, object>();
-            sourceMappingDictionary1[PackageSourceMappingPage.MonikerPackageId] = packageIdPattern;
-            sourceMappingDictionary1[PackageSourceMappingPage.MonikerSourceNames] = new List<string>() { editedPackageSourceName };
-
-            IList<IDictionary<string, object>> sourceMappingDictionaryList =
-                new List<IDictionary<string, object>>(capacity: 1)
-                {
-                    sourceMappingDictionary1, // Adding a new package source mapping
-                };
 
             // Act
             ExternalSettingOperationResult resultSetValue = await instance.SetValueAsync(
                 PackageSourceMappingPage.MonikerPackageSourceMapping,
-                sourceMappingDictionaryList,
+                emptySourceMappingDictionaryEnumerable,
                 CancellationToken.None);
 
             ExternalSettingOperationResult<IReadOnlyList<IDictionary<string, object>>> resultGetValue =
@@ -164,23 +164,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             IReadOnlyList<IDictionary<string, object>> successResult = resultGetValue
                 .As<ExternalSettingOperationResult<IReadOnlyList<IDictionary<string, object>>>.Success>()
                 .Value;
-            successResult.Count.Should().Be(1);
+            successResult.Count.Should().Be(0);
         }
-
-        //// Edit Remove 1 source from existing
-        //[Fact]
-        //public async Task SetValueAsync_ggggg_zzzzAsync()
-        //{
-
-        //}
-
-        //// Remove 1 psm
-        //[Fact]
-        //public async Task SetValueAsync_ggggg_zzzzAsync()
-        //{
-
-        //}
-
 
         [Fact]
         public async Task SetValueAsync_PreviousMappingsToNonexistantSources_AddNewMapping_ExistingMappingsAreUnchangedAsync()

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceMappingPageTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceMappingPageTests.cs
@@ -228,7 +228,73 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             object? sources = packagePatternToSources[PackageSourceMappingPage.MonikerSourceNames];
             sources.Should().NotBeNull();
             var listSources = ((IEnumerable<string>)sources).ToList();
+            listSources.Count.Should().Be(2);
             listSources.Should().ContainInOrder(unitTestingSourceName1, addedUnitTestingSourceName2);
+        }
+
+        [Fact]
+        public async Task SetValueAsync_EditPackageIdOrPattern_ReturnedByGetValueAsync()
+        {
+            // Arrange
+            _pathContext = new SimpleTestPathContext();
+            string unitTestingSourceName1 = "unitTestingSourceName1";
+            string packageIdPattern = "Contoso.*";
+            string editedPackageIdPattern = "Newtonsoft.Json";
+
+            _packageSources =
+            [
+                new PackageSource(source: $"https://{unitTestingSourceName1}", unitTestingSourceName1),
+            ];
+
+            var unitTestingSourceMapping1 = new PackageSourceMappingSourceItem(unitTestingSourceName1, [new PackagePatternItem(packageIdPattern)]);
+            _vsSettings.AddOrUpdate(ConfigurationConstants.PackageSourceMapping, unitTestingSourceMapping1);
+
+            Dictionary<string, object> sourceMappingDictionary1 = new Dictionary<string, object>();
+            sourceMappingDictionary1[PackageSourceMappingPage.MonikerPackageId] = editedPackageIdPattern;
+            sourceMappingDictionary1[PackageSourceMappingPage.MonikerSourceNames] = new List<string>() { unitTestingSourceName1 };
+
+            IList<IDictionary<string, object>> sourceMappingDictionaryList =
+                new List<IDictionary<string, object>>(capacity: 1)
+                {
+                    sourceMappingDictionary1, // Changing the Package ID for an existing mapping.
+                };
+
+            PackageSourceMappingPage instance = CreateInstance(_vsSettings);
+
+            // Act
+            ExternalSettingOperationResult resultSetValue = await instance.SetValueAsync(
+                PackageSourceMappingPage.MonikerPackageSourceMapping,
+                sourceMappingDictionaryList,
+                CancellationToken.None);
+
+            ExternalSettingOperationResult<IReadOnlyList<IDictionary<string, object>>> resultGetValue =
+                await instance.GetValueAsync<IReadOnlyList<IDictionary<string, object>>>(
+                    moniker: PackageSourceMappingPage.MonikerPackageSourceMapping,
+                    cancellationToken: CancellationToken.None);
+
+            // Assert
+            resultSetValue.Should().NotBeNull();
+            resultSetValue.Should().BeOfType<ExternalSettingOperationResult.Success>();
+
+            resultGetValue.Should().NotBeNull();
+            resultGetValue.Should().BeOfType<ExternalSettingOperationResult<IReadOnlyList<IDictionary<string, object>>>.Success>();
+            IReadOnlyList<IDictionary<string, object>> successResult = resultGetValue
+                .As<ExternalSettingOperationResult<IReadOnlyList<IDictionary<string, object>>>.Success>()
+                .Value;
+
+            // One package pattern, the edited Package ID/Pattern.
+            successResult.Count.Should().Be(1);
+            IDictionary<string, object> packagePatternToSources = successResult[0];
+            object? foundPackageIdPattern = packagePatternToSources[PackageSourceMappingPage.MonikerPackageId];
+            foundPackageIdPattern.Should().NotBeNull();
+            foundPackageIdPattern.ToString().Should().Be(editedPackageIdPattern);
+
+            // One mapped source, the original should be unchanged.
+            object? sources = packagePatternToSources[PackageSourceMappingPage.MonikerSourceNames];
+            sources.Should().NotBeNull();
+            var listSources = ((IEnumerable<string>)sources).ToList();
+            listSources.Count.Should().Be(1);
+            listSources.Should().Contain(unitTestingSourceName1);
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceMappingPageTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceMappingPageTests.cs
@@ -168,6 +168,70 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         }
 
         [Fact]
+        public async Task SetValueAsync_EditSourceNames_ReturnedByGetValueAsync()
+        {
+            // Arrange
+            _pathContext = new SimpleTestPathContext();
+            string unitTestingSourceName1 = "unitTestingSourceName1";
+            string addedUnitTestingSourceName2 = "addedUnitTestingSourceName2";
+            string packageIdPattern = "Contoso.*";
+
+            _packageSources =
+            [
+                new PackageSource(source: $"https://{unitTestingSourceName1}", unitTestingSourceName1),
+            ];
+
+            var unitTestingSourceMapping1 = new PackageSourceMappingSourceItem(unitTestingSourceName1, [new PackagePatternItem(packageIdPattern)]);
+            _vsSettings.AddOrUpdate(ConfigurationConstants.PackageSourceMapping, unitTestingSourceMapping1);
+
+            Dictionary<string, object> sourceMappingDictionary1 = new Dictionary<string, object>();
+            sourceMappingDictionary1[PackageSourceMappingPage.MonikerPackageId] = packageIdPattern;
+            sourceMappingDictionary1[PackageSourceMappingPage.MonikerSourceNames] = new List<string>() { unitTestingSourceName1, addedUnitTestingSourceName2 };
+
+            IList<IDictionary<string, object>> sourceMappingDictionaryList =
+                new List<IDictionary<string, object>>(capacity: 1)
+                {
+                    sourceMappingDictionary1, // Adding a new source name to existing package source mapping
+                };
+
+            PackageSourceMappingPage instance = CreateInstance(_vsSettings);
+
+            // Act
+            ExternalSettingOperationResult resultSetValue = await instance.SetValueAsync(
+                PackageSourceMappingPage.MonikerPackageSourceMapping,
+                sourceMappingDictionaryList,
+                CancellationToken.None);
+
+            ExternalSettingOperationResult<IReadOnlyList<IDictionary<string, object>>> resultGetValue =
+                await instance.GetValueAsync<IReadOnlyList<IDictionary<string, object>>>(
+                    moniker: PackageSourceMappingPage.MonikerPackageSourceMapping,
+                    cancellationToken: CancellationToken.None);
+
+            // Assert
+            resultSetValue.Should().NotBeNull();
+            resultSetValue.Should().BeOfType<ExternalSettingOperationResult.Success>();
+
+            resultGetValue.Should().NotBeNull();
+            resultGetValue.Should().BeOfType<ExternalSettingOperationResult<IReadOnlyList<IDictionary<string, object>>>.Success>();
+            IReadOnlyList<IDictionary<string, object>> successResult = resultGetValue
+                .As<ExternalSettingOperationResult<IReadOnlyList<IDictionary<string, object>>>.Success>()
+                .Value;
+
+            // One package pattern.
+            successResult.Count.Should().Be(1);
+            IDictionary<string, object> packagePatternToSources = successResult[0];
+            object? foundPackageIdPattern = packagePatternToSources[PackageSourceMappingPage.MonikerPackageId];
+            foundPackageIdPattern.Should().NotBeNull();
+            foundPackageIdPattern.ToString().Should().Be(packageIdPattern);
+
+            // Two mapped sources, the original and the added source.
+            object? sources = packagePatternToSources[PackageSourceMappingPage.MonikerSourceNames];
+            sources.Should().NotBeNull();
+            var listSources = ((IEnumerable<string>)sources).ToList();
+            listSources.Should().ContainInOrder(unitTestingSourceName1, addedUnitTestingSourceName2);
+        }
+
+        [Fact]
         public async Task SetValueAsync_PreviousMappingsToNonexistantSources_AddNewMapping_ExistingMappingsAreUnchangedAsync()
         {
             // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceMappingPageTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceMappingPageTests.cs
@@ -1,0 +1,145 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.Sdk.TestFramework;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Utilities.UnifiedSettings;
+using Moq;
+using NuGet.Configuration;
+using NuGet.PackageManagement.VisualStudio.Options;
+using NuGet.VisualStudio;
+using Xunit;
+
+namespace NuGet.PackageManagement.VisualStudio.Test.Options
+{
+    [Collection(MockedVS.Collection)]
+    public class PackageSourceMappingPageTests : NuGetExternalSettingsProviderTests<PackageSourceMappingPage>
+    {
+        private IEnumerable<PackageSource> _packageSources;
+
+        public PackageSourceMappingPageTests(GlobalServiceProvider sp)
+        {
+            sp.Reset();
+            NuGetUIThreadHelper.SetCustomJoinableTaskFactory(ThreadHelper.JoinableTaskFactory);
+            _packageSources = Enumerable.Empty<PackageSource>();
+        }
+
+        protected override PackageSourceMappingPage CreateInstance(VSSettings vsSettings)
+        {
+            Mock<IPackageSourceProvider> mockedPackageSourceProvider = new Mock<IPackageSourceProvider>();
+            mockedPackageSourceProvider.Setup(packageSourceProvider => packageSourceProvider.LoadPackageSources())
+                .Returns(_packageSources);
+
+            PackageSourceMappingProvider sourceMappingProvider = new(vsSettings);
+            return new PackageSourceMappingPage(vsSettings, mockedPackageSourceProvider.Object, sourceMappingProvider);
+        }
+
+        [Fact]
+        public void VsSettings_SettingsChanged_RaisesEnumSettingChoicesChanged()
+        {
+            // Arrange
+            bool wasEnumSettingChoicesChangedRaised = false;
+            PackageSourceMappingPage instance = CreateInstance(_vsSettings);
+            instance.EnumSettingChoicesChanged += (s, e) =>
+            {
+                wasEnumSettingChoicesChangedRaised = true;
+            };
+
+            // Act
+            instance.VsSettings_SettingsChanged(this, EventArgs.Empty);
+
+            // Assert
+            wasEnumSettingChoicesChangedRaised.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task SetValueAsync_PreviousMappingsToNonexistantSources_AddNewMapping_ExistingMappingsAreUnchangedAsync()
+        {
+            // Arrange
+            string addNewPackageSourceName4 = "unitTestingSourceName4";
+            string packageIdPattern = "Contoso.*";
+
+            var unitTestingSourceMapping1 = new PackageSourceMappingSourceItem("unitTestingSourceName1", [new PackagePatternItem(packageIdPattern)]);
+            var nonExistantSourceInSourceMapping2 = new PackageSourceMappingSourceItem("nonExistantSourceName2", [new PackagePatternItem(packageIdPattern)]);
+            var unitTestingSourceMapping3 = new PackageSourceMappingSourceItem("unitTestingSourceName3", [new PackagePatternItem(packageIdPattern)]);
+
+            _vsSettings.AddOrUpdate(ConfigurationConstants.PackageSourceMapping, unitTestingSourceMapping1);
+            _vsSettings.AddOrUpdate(ConfigurationConstants.PackageSourceMapping, nonExistantSourceInSourceMapping2);
+            _vsSettings.AddOrUpdate(ConfigurationConstants.PackageSourceMapping, unitTestingSourceMapping3);
+
+            PackageSourceMappingPage instance = CreateInstance(_vsSettings);
+
+            string sourceName1 = "unitTestingSourceName1";
+            string sourceUrl1 = "https://testsource1.com";
+
+            // nonExistantSourceName2 is not added here intentionally.
+
+            string sourceName3 = "unitTestingSourceName3";
+            string sourceUrl3 = "https://testsource3.com";
+
+            _packageSources =
+            [
+                new PackageSource(sourceUrl1, sourceName1, isEnabled: true),
+                // nonExistantSourceName is not added here intentionally.
+                new PackageSource(sourceUrl3, sourceName3, isEnabled: true)
+            ];
+
+            // Configure Unified Settings input to modify an existing package source mapping.
+
+            // Unchanged package source mapping.
+            Dictionary<string, object> packageSourceDictionary1 = new Dictionary<string, object>();
+            packageSourceDictionary1[PackageSourceMappingPage.MonikerPackageId] = unitTestingSourceMapping1.Patterns.Single().Pattern;
+            packageSourceDictionary1[PackageSourceMappingPage.MonikerSourceNames] = new List<string>() { unitTestingSourceMapping1.Key };
+
+            // nonExistantSourceName is not known to Unified Settings, so it is not part of the request to SetValue.
+
+            // Unchanged package source mapping.
+            Dictionary<string, object> packageSourceDictionary3 = new Dictionary<string, object>();
+            packageSourceDictionary3[PackageSourceMappingPage.MonikerPackageId] = unitTestingSourceMapping3.Patterns.Single().Pattern;
+            packageSourceDictionary3[PackageSourceMappingPage.MonikerSourceNames] = new List<string>() { unitTestingSourceMapping3.Key };
+
+            // Add a new package source mapping for another existing source.
+            Dictionary<string, object> packageSourceDictionary4 = new Dictionary<string, object>();
+            packageSourceDictionary4[PackageSourceMappingPage.MonikerPackageId] = packageIdPattern;
+            packageSourceDictionary4[PackageSourceMappingPage.MonikerSourceNames] = new List<string>() { addNewPackageSourceName4 };
+
+            IList<IDictionary<string, object>> sourceMappingDictionaryList =
+                new List<IDictionary<string, object>>(capacity: 3)
+                {
+                    packageSourceDictionary1, // Pre-existing and unchanged.
+                    // No source mapping is sent by Unified Settings for nonExistantSourceName2.
+                    packageSourceDictionary3, // Pre-existing and unchanged.
+                    packageSourceDictionary4 // A newly added source mapping.
+                };
+
+            // Act
+            ExternalSettingOperationResult result = await instance.SetValueAsync(
+                PackageSourceMappingPage.MonikerPackageSourceMapping,
+                sourceMappingDictionaryList,
+                CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<ExternalSettingOperationResult.Success>();
+
+            IReadOnlyList<PackageSourceMappingSourceItem> packageSourceMappingItems = instance._packageSourceMappingProvider.GetPackageSourceMappingItems();
+
+            // If the machine-wide config contains package source mappings, this count could be greater than 4.
+            packageSourceMappingItems.Should().HaveCountGreaterThanOrEqualTo(4);
+
+            packageSourceMappingItems.Should().Contain(unitTestingSourceMapping1);
+            packageSourceMappingItems.Should().Contain(nonExistantSourceInSourceMapping2);
+            packageSourceMappingItems.Should().Contain(unitTestingSourceMapping3);
+
+            var foundResult = packageSourceMappingItems.Should().Contain(item => item.Key.Equals(addNewPackageSourceName4), because: "The package source was added in a new source mapping.");
+            PackageSourceMappingSourceItem foundNewPackageSourceMapping = foundResult.Subject;
+            foundNewPackageSourceMapping.Patterns.Should().ContainSingle(packagePatternItem => packagePatternItem.Pattern == packageIdPattern, because: "One pattern was added to the new source mapping.");
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceMappingPageTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceMappingPageTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,15 +15,17 @@ using Microsoft.VisualStudio.Utilities.UnifiedSettings;
 using Moq;
 using NuGet.Configuration;
 using NuGet.PackageManagement.VisualStudio.Options;
+using NuGet.Test.Utility;
 using NuGet.VisualStudio;
 using Xunit;
 
 namespace NuGet.PackageManagement.VisualStudio.Test.Options
 {
     [Collection(MockedVS.Collection)]
-    public class PackageSourceMappingPageTests : NuGetExternalSettingsProviderTests<PackageSourceMappingPage>
+    public class PackageSourceMappingPageTests : NuGetExternalSettingsProviderTests<PackageSourceMappingPage>, IDisposable
     {
         private IEnumerable<PackageSource> _packageSources;
+        private SimpleTestPathContext? _pathContext;
 
         public PackageSourceMappingPageTests(GlobalServiceProvider sp)
         {
@@ -58,10 +62,22 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             wasEnumSettingChoicesChangedRaised.Should().BeTrue();
         }
 
+        protected override string GetSolutionDirectory()
+        {
+            if (_pathContext is not null)
+            {
+                return _pathContext.SolutionRoot;
+            }
+
+            return base.GetSolutionDirectory();
+        }
+
         [Fact]
         public async Task SetValueAsync_PreviousMappingsToNonexistantSources_AddNewMapping_ExistingMappingsAreUnchangedAsync()
         {
             // Arrange
+            _pathContext = new SimpleTestPathContext();
+
             string addNewPackageSourceName4 = "unitTestingSourceName4";
             string packageIdPattern = "Contoso.*";
 
@@ -131,7 +147,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             IReadOnlyList<PackageSourceMappingSourceItem> packageSourceMappingItems = instance._packageSourceMappingProvider.GetPackageSourceMappingItems();
 
             // If the machine-wide config contains package source mappings, this count could be greater than 4.
-            packageSourceMappingItems.Should().HaveCountGreaterThanOrEqualTo(4);
+            packageSourceMappingItems.Should().HaveCount(4);
 
             packageSourceMappingItems.Should().Contain(unitTestingSourceMapping1);
             packageSourceMappingItems.Should().Contain(nonExistantSourceInSourceMapping2);
@@ -140,6 +156,14 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             var foundResult = packageSourceMappingItems.Should().Contain(item => item.Key.Equals(addNewPackageSourceName4), because: "The package source was added in a new source mapping.");
             PackageSourceMappingSourceItem foundNewPackageSourceMapping = foundResult.Subject;
             foundNewPackageSourceMapping.Patterns.Should().ContainSingle(packagePatternItem => packagePatternItem.Pattern == packageIdPattern, because: "One pattern was added to the new source mapping.");
+        }
+
+        public void Dispose()
+        {
+            if (_pathContext is not null)
+            {
+                _pathContext.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->

Fixes: https://github.com/NuGet/Home/issues/14234
Fixes: https://github.com/nuget/home/issues/13355
Fixes: https://github.com/nuget/home/issues/13150
Fixes: https://github.com/nuget/home/issues/13115
Fixes: https://github.com/nuget/home/issues/13520
Fixes: https://github.com/NuGet/Client.Engineering/issues/2426
Fixes: https://github.com/NuGet/Client.Engineering/issues/1944

## Description

Onboards the Package Source Mapping page to Unified Settings.

- New functionality: Editing an existing Package Source Mapping is now supported.
- F1 Help link now appears as a `?` beside the page title
- Existing legacy options logic has been tucked away into a PackageSourceMappingUtility.
- The unit test `SetValueAsync_PreviousMappingsToNonexistantSources_AddNewMapping_ExistingMappingsAreUnchangedAsync` is important as it highlights the behavior of VS not deleting any misconfigured Package Source Mappings.
We may want to revisit this behavior, but I didn't want to change that as part of the onboarding. It could be something customers are relying on today.

![image](https://github.com/user-attachments/assets/d5afbdde-4551-48b2-8c5d-101676aac300)

![image](https://github.com/user-attachments/assets/7e1527de-b6dc-4f11-856f-4c400dbc4d65)
![image](https://github.com/user-attachments/assets/ec33416b-98a0-4cd5-bc9f-3f6734965009)

### Side-effects

- Remove All command is not available at this time because the behavior of USX is an immediate action, which may result in customers accidentally permanently deleting all source mappings with 1 click. Telemetry shows this command was used very little in Legacy Options compared to add/remove commands.

- "Configure" link from PM UI Details Pane no longer auto-selects the Source Mapping for the selected package. USX doesn't yet support this functionality.


### Related bugs (not being addressed)

These bugs will not be fixed, but they will have a change in behavior:

- https://github.com/nuget/home/issues/13210


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.








