### PR TITLE
Fix `nuget.exe` restore finding MSBuild from SSMS instead of Visual Studio

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildToolset.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildToolset.cs
@@ -38,16 +38,18 @@ namespace NuGet.CommandLine
             Path = GetMsBuildDirFromVsDir(sxsToolset.GetInstallationPath());
             Version = GetMsBuildVersionFromMsBuildDir(Path);
             InstallDate = ConvertFILETIMEToDateTime(sxsToolset.GetInstallDate());
+            InstallationName = sxsToolset.GetInstallationName();
         }
 
         /// <summary>
         /// This constructor is for testing purposes only
         /// </summary>
-        public MsBuildToolset(string version, string path, DateTime installDate)
+        public MsBuildToolset(string version, string path, DateTime installDate, string installationName)
         {
             Version = version;
             Path = path;
             InstallDate = installDate;
+            InstallationName = installationName;
         }
 
         public Version ParsedVersion
@@ -66,11 +68,13 @@ namespace NuGet.CommandLine
             }
         }
 
-        public bool IsValid => Path != null;
+        public bool IsValid => Path != null && (InstallationName is null || InstallationName.StartsWith("VisualStudio", StringComparison.Ordinal));
 
         public string Version { get; private set; }
 
         public string Path { get; private set; }
+
+        public string InstallationName { get; private set; }
 
         public DateTime InstallDate { get; private set; } = DateTime.MinValue;
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -54,15 +54,16 @@ namespace NuGet.CommandLine.Test
 
         // Test that GetMsBuildDirectoryInternal deals with invalid toolsets (for example ones created from SKUs that don't ship MSBuild like VS Test Agent SKU) See https://github.com/NuGet/Home/issues/5840 for more info
         [Theory]
-        [MemberData("InvalidToolsetData", MemberType = typeof(ToolsetDataSource))]
-        public void HandlesToolsetsWithInvalidPaths(List<MsBuildToolset> toolsets, string expectedPath)
+        [MemberData(nameof(ToolsetDataSource.InvalidToolsetData), MemberType = typeof(ToolsetDataSource))]
+        public void HandlesToolsetsWithInvalidPaths(List<MsBuildToolset> toolsets, string userVersion, string expectedPath)
         {
             // Arrange
             // Act
+            var orderByDescending = toolsets.OrderByDescending(t => t).ToList();
             var directory = MsBuildUtility.GetMsBuildDirectoryInternal(
-                userVersion: null,
+                userVersion: userVersion,
                 console: null,
-                installedToolsets: toolsets.OrderByDescending(t => t),
+                installedToolsets: orderByDescending,
                 getMsBuildPathInPathVar: (reader) => expectedPath).Path;
 
             // Assert
@@ -414,32 +415,44 @@ namespace NuGet.CommandLine.Test
             private static readonly MsBuildToolset Toolset15_Mon_ShortVersion = new MsBuildToolset(
                 version: "15.1",
                 path: @"c:\vs\25555.00",
-                installDate: new DateTime(2016, 9, 15));
+                installDate: new DateTime(2016, 9, 15),
+                installationName: "VisualStudio/25555.00");
             private static readonly MsBuildToolset Toolset15_Tue_ShortVersion = new MsBuildToolset(
                 version: "15.1",
                 path: @"c:\vs\25555.02",
-                installDate: new DateTime(2016, 9, 16));
+                installDate: new DateTime(2016, 9, 16),
+                installationName: "VisualStudio/25555.02");
             private static readonly MsBuildToolset Toolset15_Wed_ShortVersion = new MsBuildToolset(
                 version: "15.1",
                 path: @"c:\vs\25555.01",
-                installDate: new DateTime(2016, 9, 17));
+                installDate: new DateTime(2016, 9, 17),
+                installationName: "VisualStudio/25555.01");
 
             private static readonly MsBuildToolset Toolset15_Mon_LongVersion = new MsBuildToolset(
                 version: "15.1.137.25382",
                 path: @"c:\vs\25557.00",
-                installDate: new DateTime(2016, 9, 15));
+                installDate: new DateTime(2016, 9, 15),
+                installationName: "VisualStudio/25557.00");
             private static readonly MsBuildToolset Toolset15_Tue_LongVersion = new MsBuildToolset(
                 version: "15.1.137.25382",
                 path: @"c:\vs\25557.02",
-                installDate: new DateTime(2016, 9, 16));
+                installDate: new DateTime(2016, 9, 16),
+                installationName: "VisualStudio/25555.02");
             private static readonly MsBuildToolset Toolset15_Wed_LongVersion = new MsBuildToolset(
                 version: "15.1.137.25382",
                 path: @"c:\vs\25557.01",
-                installDate: new DateTime(2016, 9, 17));
+                installDate: new DateTime(2016, 9, 17),
+                installationName: "VisualStudio/25555.01");
             private static readonly MsBuildToolset InvalidToolsetVSTest = new MsBuildToolset(
                 version: null,
                 path: null,
-                installDate: new DateTime(2017, 9, 7));
+                installDate: new DateTime(2017, 9, 7),
+                installationName: null);
+            private static readonly MsBuildToolset InvalidToolsetVSTest_Ssms = new MsBuildToolset(
+                version: "17.14.14.31908",
+                path: @"c:\ssms\36221.01",
+                installDate: new DateTime(2025, 7, 2),
+                installationName: "SSMS/21.3.7+36221.1");
 
             // Toolset collections
 
@@ -503,10 +516,17 @@ namespace NuGet.CommandLine.Test
                 Toolset4
             };
 
-            private static List<MsBuildToolset> CombinedToolsets_MsBuild15AndVSTestToolsets = new List<MsBuildToolset> {
+            private static List<MsBuildToolset> CombinedToolsets_MsBuild15AndVSTestToolsets =
+            [
                 Toolset15_Wed_LongVersion,
                 InvalidToolsetVSTest
-            };
+            ];
+
+            private static List<MsBuildToolset> CombinedToolsets_MsBuild15AndSsmsToolsets =
+            [
+                Toolset15_Wed_LongVersion,
+                InvalidToolsetVSTest_Ssms
+            ];
 
             // Test data sets
 
@@ -573,10 +593,11 @@ namespace NuGet.CommandLine.Test
                     new object[] { LegacyToolsets_NonNumericVersion, "0" },
                 };
 
-            private static readonly List<object[]> _invalidToolsetData
-                = new List<object[]>
+            private static readonly TheoryData<List<MsBuildToolset>, string, string> _invalidToolsetData
+                = new()
                 {
-                    new object[] { CombinedToolsets_MsBuild15AndVSTestToolsets, Toolset15_Wed_LongVersion.Path}
+                    { CombinedToolsets_MsBuild15AndVSTestToolsets, null, Toolset15_Wed_LongVersion.Path },
+                    { CombinedToolsets_MsBuild15AndSsmsToolsets, "latest", Toolset15_Wed_LongVersion.Path },
                 };
 
             private static readonly List<object[]> _highestPathWithLowVersionMatchData
@@ -595,7 +616,7 @@ namespace NuGet.CommandLine.Test
             public static IEnumerable<object[]> IntegerVersionMatchData => _integerVersionMatchData;
             public static IEnumerable<object[]> NonNumericVersionMatchData => _nonNumericVersionMatchData;
             public static IEnumerable<object[]> NonNumericVersionMatchFailureData => _nonNumericVersionMatchFailureData;
-            public static IEnumerable<object[]> InvalidToolsetData => _invalidToolsetData;
+            public static TheoryData<List<MsBuildToolset>, string, string> InvalidToolsetData => _invalidToolsetData;
             public static IEnumerable<object[]> HighestPathWithLowVersionMatchData => _highestPathWithLowVersionMatchData;
 
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14349

## Description
SQL Server Management Studio (SSMS) 21 is now [managed using the Visual Studio Installer](https://techcommunity.microsoft.com/blog/sqlserver/sql-server-management-studio-ssms-21-is-now-generally-available-ga/4415230), which causes its version of MSBuild to get picked up as an SXS toolset to use by `nuget.exe`. This PR uses the Installation Name of the SXS toolset to determine whether it's a Visual Studio product or not, and thereby exclude SSMS from the considered options. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
