### PR TITLE
Add slnf support to dotnet package list

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,6 @@
     <SystemMemoryPackageVersion Condition="'$(SystemMemoryPackageVersion)' == ''">4.6.3</SystemMemoryPackageVersion>
     <SystemSecurityCryptographyPkcsVersion Condition="'$(SystemSecurityCryptographyPkcsVersion)' == ''">9.0.6</SystemSecurityCryptographyPkcsVersion>
     <SystemSecurityCryptographyProtectedDataVersion Condition="'$(SystemSecurityCryptographyProtectedDataVersion)' == ''">9.0.6</SystemSecurityCryptographyProtectedDataVersion>
-    <MicrosoftVisualStudioSolutionPersistenceVersion Condition="'$(MicrosoftVisualStudioSolutionPersistenceVersion)' == ''">1.0.52</MicrosoftVisualStudioSolutionPersistenceVersion>
     <MicrosoftVisualStudioSdkForApex>18.0.1799-preview.1</MicrosoftVisualStudioSdkForApex>
   </PropertyGroup>
 
@@ -68,7 +67,6 @@
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem" Version="17.4.221-pre" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS" Version="17.2.0-beta1-20502-01" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.VS" Version="17.4.221-pre" />
-    <PackageVersion Include="Microsoft.VisualStudio.SolutionPersistence" Version="$(MicrosoftVisualStudioSolutionPersistenceVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.SDK" Version="17.14.40265" />
     <PackageVersion Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" Version="17.11.8" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.4.2244" />
@@ -176,7 +174,6 @@
       <_allowBuildFromSourcePackage Include="Microsoft.Extensions.CommandLineUtils.Sources" />
       <_allowBuildFromSourcePackage Include="Microsoft.Extensions.FileProviders.Abstractions" />
       <_allowBuildFromSourcePackage Include="Microsoft.Extensions.FileSystemGlobbing" />
-      <_allowBuildFromSourcePackage Include="Microsoft.VisualStudio.SolutionPersistence" />
       <_allowBuildFromSourcePackage Include="Microsoft.Web.Xdt" />
       <_allowBuildFromSourcePackage Include="Newtonsoft.Json" />
       <_allowBuildFromSourcePackage Include="System.Collections.Immutable" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -30,7 +30,6 @@
       <package pattern="Microsoft.*" />
       <package pattern="Microsoft.Build.Framework" />
       <package pattern="Microsoft.NET.StringTools" />
-      <package pattern="Microsoft.VisualStudio.SolutionPersistence" />
       <package pattern="Microsoft.VisualStudio.TemplateWizardInterface" />
       <package pattern="moq" />
       <package pattern="MSTest.TestAdapter" />

--- a/build/DotNetSdkVersions.txt
+++ b/build/DotNetSdkVersions.txt
@@ -1,4 +1,4 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
 -Channel 3.1 -Runtime dotnet
 -Channel 8.0 -Runtime dotnet
--Channel 9.0.2xx
+-Channel 9.0.3xx

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.300",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   },

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -61,11 +61,13 @@ namespace NuGet.CommandLine.XPlat
 
             //If the given file is a solution, get the list of projects
             //If not, then it's a project, which is put in a list
+            string fileExtension = Path.GetExtension(listPackageArgs.Path);
             var projectsPaths =
-                (Path.GetExtension(listPackageArgs.Path).Equals(".sln", PathUtility.GetStringComparisonBasedOnOS()) ||
-                     Path.GetExtension(listPackageArgs.Path).Equals(".slnx", PathUtility.GetStringComparisonBasedOnOS())) ?
-                           (await MSBuildAPIUtility.GetProjectsFromSolution(listPackageArgs.Path, listPackageArgs.CancellationToken)).Where(f => File.Exists(f)) :
-                           new List<string>(new string[] { listPackageArgs.Path });
+                (fileExtension.Equals(".sln", PathUtility.GetStringComparisonBasedOnOS()) ||
+                    fileExtension.Equals(".slnx", PathUtility.GetStringComparisonBasedOnOS()) ||
+                    fileExtension.Equals(".slnf", PathUtility.GetStringComparisonBasedOnOS()))
+                    ? MSBuildAPIUtility.GetProjectsFromSolution(listPackageArgs.Path).Where(File.Exists)
+                    : [listPackageArgs.Path];
 
             MSBuildAPIUtility msBuild = listPackageReportModel.MSBuildAPIUtility;
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
     <PackageReference Include="System.CommandLine" />
-    <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" />
   </ItemGroup>
 
   <!-- Microsoft.Build.Locator is needed when debugging, but should not be used in the assemblies we insert. -->


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/11789

## Description

`dotnet package list` reads solution files via an internal helper method, so this change potentially adds support for solution filters to more than just `dotnet package list`.

The biggest issue is that there is no public API to load and handle solution filters. See https://github.com/NuGet/Home/issues/11789#issuecomment-2920870654 for some more details. NuGet.exe supports slnf by using reflection to call a non-public MSBuild API. I'm using this as precedent as something testing and has been working for years. But it's a risk.

Other info:

* MSBuild's `SolutionFile` API works with slnx files, so reverted most of the PR that added Microsoft.VisualStudio.SolutionPersistance, since it's no longer needed. This makes a lot of async method into non-async methods. There's a compiler warning about private/internal methods that are async without calling await, and since we treat warnings as errors, it's not optional to deal with them. Hence why there's so much async related changes.
* XPlat.FuncTests that tests MSBuildAPIUtilityTests uses MSBuild.Locator, and therefore tests that validate slnx loading fail if MSBuild is loaded from earlier than 9.0.300, so I bumped our repo's min SDK version to that.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ [the docs on dotnet package list](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-package-list) doesn't mention solution filters or slnf, so I don't think any docs need to change.
