### PR TITLE
UIActionEngine tests no longer assert the most recent telemetry event

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -184,10 +184,10 @@ namespace NuGet.PackageManagement.UI.Test
         {
             // Arrange
             var telemetrySession = new Mock<ITelemetrySession>();
-            TelemetryEvent lastTelemetryEvent = null;
+            List<TelemetryEvent> telemetryEvents = new List<TelemetryEvent>();
             telemetrySession
                 .Setup(x => x.PostEvent(It.IsAny<TelemetryEvent>()))
-                .Callback<TelemetryEvent>(x => lastTelemetryEvent = x);
+                .Callback<TelemetryEvent>(x => telemetryEvents.Add(x));
             var telemetryService = new NuGetVSTelemetryService(telemetrySession.Object);
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
@@ -242,14 +242,22 @@ namespace NuGet.PackageManagement.UI.Test
             await uiEngine.PerformInstallOrUninstallAsync(uiService.Object, action, CancellationToken.None);
 
             // Assert
-            Assert.NotNull(lastTelemetryEvent);
-            Assert.IsType<NuGetOperationStatus>(lastTelemetryEvent[nameof(ActionEventBase.Status)]);
-            Assert.Equal(NuGetProjectActionType.Install, lastTelemetryEvent[nameof(ActionsTelemetryEvent.OperationType)]);
-            Assert.Equal(isSolutionLevel, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.IsSolutionLevel)]);
-            Assert.Equal(activeTab, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.Tab)]);
-            Assert.Equal(expectedPackageWasTransitive, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.PackageToInstallWasTransitive)]);
-            // Package Source Mapping is considered enabled if mappings already existed when the action began.
-            Assert.Equal(false, lastTelemetryEvent[VSActionsTelemetryEvent.PackageSourceMappingIsMappingEnabled]);
+            Assert.NotEmpty(telemetryEvents);
+
+            telemetryEvents.Should().NotBeEmpty();
+            IEnumerable<TelemetryEvent> actionTelemetryEvents = telemetryEvents
+                .Where(eventData => eventData.Name
+                    .Equals(ActionsTelemetryEvent.NugetActionEventName));
+
+            actionTelemetryEvents.Should().HaveCount(1);
+
+            TelemetryEvent installTelemetryEvent = actionTelemetryEvents.Single();
+            installTelemetryEvent[nameof(ActionsTelemetryEvent.OperationType)].Should().Be(NuGetProjectActionType.Install);
+            installTelemetryEvent[nameof(ActionEventBase.Status)].Should().BeOfType<NuGetOperationStatus>();
+            installTelemetryEvent[nameof(VSActionsTelemetryEvent.IsSolutionLevel)].Should().Be(isSolutionLevel);
+            installTelemetryEvent[nameof(VSActionsTelemetryEvent.Tab)].Should().Be(activeTab);
+            installTelemetryEvent[nameof(VSActionsTelemetryEvent.PackageToInstallWasTransitive)].Should().Be(expectedPackageWasTransitive);
+            installTelemetryEvent[VSActionsTelemetryEvent.PackageSourceMappingIsMappingEnabled].Should().Be(false);
         }
 
         [Fact]
@@ -332,10 +340,10 @@ namespace NuGet.PackageManagement.UI.Test
             int expectedCountCreatedTopLevelSourceMappings = 42;
             int expectedCountCreatedTransitiveSourceMappings = 24;
             var telemetrySession = new Mock<ITelemetrySession>();
-            TelemetryEvent lastTelemetryEvent = null;
+            List<TelemetryEvent> listTelemetryEvents = new List<TelemetryEvent>(capacity: 5);
             telemetrySession
                 .Setup(x => x.PostEvent(It.IsAny<TelemetryEvent>()))
-                .Callback<TelemetryEvent>(x => lastTelemetryEvent = x);
+                .Callback<TelemetryEvent>(x => listTelemetryEvents.Add(x));
 
             var operationId = Guid.NewGuid().ToString();
 
@@ -378,8 +386,9 @@ namespace NuGet.PackageManagement.UI.Test
             service.EmitTelemetryEvent(actionTelemetryData);
 
             // Assert
-            Assert.Equal(expectedCountCreatedTopLevelSourceMappings, (int)lastTelemetryEvent["CreatedTopLevelSourceMappingsCount"]);
-            Assert.Equal(expectedCountCreatedTransitiveSourceMappings, (int)lastTelemetryEvent["CreatedTransitiveSourceMappingsCount"]);
+            TelemetryEvent emittedTelemetryEvent = listTelemetryEvents.Single(telemetryEvent => telemetryEvent.Equals(actionTelemetryData));
+            Assert.Equal(expectedCountCreatedTopLevelSourceMappings, (int)emittedTelemetryEvent["CreatedTopLevelSourceMappingsCount"]);
+            Assert.Equal(expectedCountCreatedTransitiveSourceMappings, (int)emittedTelemetryEvent["CreatedTransitiveSourceMappingsCount"]);
         }
 
         [Theory]

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -7,6 +7,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Sdk.TestFramework;
@@ -432,10 +433,10 @@ namespace NuGet.PackageManagement.UI.Test
         {
             // Arrange
             var telemetrySession = new Mock<ITelemetrySession>();
-            TelemetryEvent lastTelemetryEvent = null;
+            List<TelemetryEvent> listTelemetryEvents = new List<TelemetryEvent>(capacity: 5);
             telemetrySession
                 .Setup(x => x.PostEvent(It.IsAny<TelemetryEvent>()))
-                .Callback<TelemetryEvent>(x => lastTelemetryEvent = x);
+                .Callback<TelemetryEvent>(x => listTelemetryEvents.Add(x));
             var telemetryService = new NuGetVSTelemetryService(telemetrySession.Object);
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
@@ -498,12 +499,20 @@ namespace NuGet.PackageManagement.UI.Test
             await uiEngine.PerformInstallOrUninstallAsync(uiService.Object, action, CancellationToken.None);
 
             // Assert
-            Assert.NotNull(lastTelemetryEvent);
-            Assert.IsType<NuGetOperationStatus>(lastTelemetryEvent[nameof(ActionEventBase.Status)]);
-            Assert.Equal(NuGetProjectActionType.Install, lastTelemetryEvent[nameof(ActionsTelemetryEvent.OperationType)]);
-            Assert.Equal(isSolutionLevel, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.IsSolutionLevel)]);
-            Assert.Equal(activeTab, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.Tab)]);
-            Assert.Equal(expectedPackageWasTransitive, lastTelemetryEvent[nameof(VSActionsTelemetryEvent.PackageToInstallWasTransitive)]);
+            listTelemetryEvents.Should().NotBeEmpty();
+
+            IEnumerable<TelemetryEvent> actionTelemetryEvents = listTelemetryEvents
+                .Where(telemetryEvent => telemetryEvent.Name
+                    .Equals(ActionsTelemetryEvent.NugetActionEventName));
+
+            actionTelemetryEvents.Should().HaveCount(1);
+
+            TelemetryEvent installTelemetryEvent = actionTelemetryEvents.Single();
+            installTelemetryEvent[nameof(ActionsTelemetryEvent.OperationType)].Should().Be(NuGetProjectActionType.Install);
+            installTelemetryEvent[nameof(ActionEventBase.Status)].Should().BeOfType<NuGetOperationStatus>();
+            installTelemetryEvent[nameof(VSActionsTelemetryEvent.IsSolutionLevel)].Should().Be(isSolutionLevel);
+            installTelemetryEvent[nameof(VSActionsTelemetryEvent.Tab)].Should().Be(activeTab);
+            installTelemetryEvent[nameof(VSActionsTelemetryEvent.PackageToInstallWasTransitive)].Should().Be(expectedPackageWasTransitive);
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -257,10 +257,10 @@ namespace NuGet.PackageManagement.UI.Test
         {
             // Arrange
             var telemetrySession = new Mock<ITelemetrySession>();
-            TelemetryEvent lastTelemetryEvent = null;
+            List<TelemetryEvent> telemetryEvents = new List<TelemetryEvent>();
             telemetrySession
                 .Setup(x => x.PostEvent(It.IsAny<TelemetryEvent>()))
-                .Callback<TelemetryEvent>(x => lastTelemetryEvent = x);
+                .Callback<TelemetryEvent>(x => telemetryEvents.Add(x));
 
             var operationId = Guid.NewGuid().ToString();
 
@@ -303,26 +303,26 @@ namespace NuGet.PackageManagement.UI.Test
             service.EmitTelemetryEvent(actionTelemetryData);
 
             // Assert
-            Assert.NotNull(lastTelemetryEvent);
-            Assert.NotNull(lastTelemetryEvent.ComplexData["TopLevelVulnerablePackagesMaxSeverities"] as List<int>);
-            var topLevelPkgSeverities = lastTelemetryEvent.ComplexData["TopLevelVulnerablePackagesMaxSeverities"] as List<int>;
-            Assert.Equal(lastTelemetryEvent["TopLevelVulnerablePackagesCount"], topLevelPkgSeverities.Count());
-            Assert.Collection(topLevelPkgSeverities,
-                item => Assert.Equal(1, item),
-                item => Assert.Equal(1, item),
-                item => Assert.Equal(3, item));
-            Assert.Equal(3, topLevelPkgSeverities.Count());
+            telemetryEvents.Should().NotBeEmpty();
 
-            var transitivePkgSeverities = lastTelemetryEvent.ComplexData["TransitiveVulnerablePackagesMaxSeverities"] as List<int>;
-            Assert.Equal(lastTelemetryEvent["TransitiveVulnerablePackagesCount"], transitivePkgSeverities.Count());
-            Assert.Equal(lastTelemetryEvent["TransitiveVulnerablePackagesCount"], transitivePkgSeverities.Count());
-            Assert.Collection(transitivePkgSeverities,
-                item => Assert.Equal(2, item),
-                item => Assert.Equal(3, item));
-            Assert.Equal(2, transitivePkgSeverities.Count());
+            IEnumerable<TelemetryEvent> vulnerabilityTelemetryEvents = telemetryEvents
+                .Where(telemetryEvent => telemetryEvent.ComplexData.ContainsKey("TopLevelVulnerablePackagesMaxSeverities"));
 
-            Assert.Null(lastTelemetryEvent["CreatedTopLevelSourceMappingsCount"]);
-            Assert.Null(lastTelemetryEvent["CreatedTransitiveSourceMappingsCount"]);
+            vulnerabilityTelemetryEvents.Should().HaveCount(1);
+
+            TelemetryEvent vulnerabilityTelemetryEvent = vulnerabilityTelemetryEvents.Single();
+            var topLevelPkgSeverities = vulnerabilityTelemetryEvent.ComplexData["TopLevelVulnerablePackagesMaxSeverities"] as List<int>;
+            topLevelPkgSeverities.Should().NotBeNull();
+            topLevelPkgSeverities.Should().HaveCount((int)vulnerabilityTelemetryEvent["TopLevelVulnerablePackagesCount"]);
+            topLevelPkgSeverities.Should().ContainInOrder(new[] { 1, 1, 3 });
+
+            var transitivePkgSeverities = vulnerabilityTelemetryEvent.ComplexData["TransitiveVulnerablePackagesMaxSeverities"] as List<int>;
+            transitivePkgSeverities.Should().NotBeNull();
+            transitivePkgSeverities.Should().HaveCount((int)vulnerabilityTelemetryEvent["TransitiveVulnerablePackagesCount"]);
+            transitivePkgSeverities.Should().ContainInOrder(new[] { 2, 3 });
+
+            vulnerabilityTelemetryEvent["CreatedTopLevelSourceMappingsCount"].Should().BeNull();
+            vulnerabilityTelemetryEvent["CreatedTransitiveSourceMappingsCount"].Should().BeNull();
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14402
Fixes: https://github.com/NuGet/Client.Engineering/issues/2798

## Description

Accumulate telemetry events after a UIActionEngine action, then look for the single event of the expected type.
This prevents flakiness when other telemetry events fire during a test, resulting in test failures that are unclear.

I believe https://github.com/NuGet/Client.Engineering/issues/2798 is also resolved because there are no more deterministic issues and all of the Status property checks are just for the type. In my testing, the Status is always Cancelled.

Also implements FluentAssertions for the refactored tests. Hopefully any future logs will have clearer errors.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
