### PR TITLE
Fix UIActionEngine test flakiness

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -22,6 +22,7 @@ using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
+using NuGet.VisualStudio.Telemetry;
 using Task = System.Threading.Tasks.Task;
 using TelemetryPiiProperty = Microsoft.VisualStudio.Telemetry.TelemetryPiiProperty;
 
@@ -37,6 +38,7 @@ namespace NuGet.PackageManagement.UI
         private readonly ISourceRepositoryProvider _sourceProvider;
         private readonly NuGetPackageManager _packageManager;
         private readonly INuGetLockService _lockService;
+        private readonly INuGetTelemetryProvider _telemetryProvider;
 
         /// <summary>
         /// Create a UIActionEngine to perform installs/uninstalls
@@ -44,11 +46,13 @@ namespace NuGet.PackageManagement.UI
         public UIActionEngine(
             ISourceRepositoryProvider sourceProvider,
             NuGetPackageManager packageManager,
-            INuGetLockService lockService)
+            INuGetLockService lockService,
+            INuGetTelemetryProvider telemetryProvider)
         {
             _sourceProvider = sourceProvider ?? throw new ArgumentNullException(nameof(sourceProvider));
             _packageManager = packageManager ?? throw new ArgumentNullException(nameof(packageManager));
             _lockService = lockService ?? throw new ArgumentNullException(nameof(lockService));
+            _telemetryProvider = telemetryProvider ?? throw new ArgumentNullException(nameof(telemetryProvider));
         }
 
         /// <summary>
@@ -130,7 +134,7 @@ namespace NuGet.PackageManagement.UI
                     NuGetOperationStatus.Cancelled,
                     packagesCount);
 
-                TelemetryActivity.EmitTelemetryEvent(upgradeTelemetryEvent);
+                _telemetryProvider.EmitEvent(upgradeTelemetryEvent);
 
                 return;
             }
@@ -584,7 +588,7 @@ namespace NuGet.PackageManagement.UI
                     }
                     actionTelemetryEvent["InstalledPackageEnumerationTimeInMilliseconds"] = packageEnumerationTime.ElapsedMilliseconds;
 
-                    TelemetryActivity.EmitTelemetryEvent(actionTelemetryEvent);
+                    _telemetryProvider.EmitEvent(actionTelemetryEvent);
                 }
             }, cancellationToken);
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -129,6 +129,7 @@ namespace NuGet.PackageManagement.UI
                 deleteOnRestartManager,
                 lockService,
                 restoreProgressReporter,
+                nuGetTelemetryProvider,
                 cancellationToken);
 
             nuGetUi.UIContext.Projects = projects;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUIContext.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUIContext.cs
@@ -154,6 +154,7 @@ namespace NuGet.PackageManagement.UI
             IDeleteOnRestartManager deleteOnRestartManager,
             INuGetLockService lockService,
             IRestoreProgressReporter restoreProgressReporter,
+            INuGetTelemetryProvider telemetryProvider,
             CancellationToken cancellationToken)
         {
             Assumes.NotNull(serviceBroker);
@@ -198,7 +199,8 @@ namespace NuGet.PackageManagement.UI
             var actionEngine = new UIActionEngine(
                 sourceRepositoryProvider,
                 packageManager,
-                lockService);
+                lockService,
+                telemetryProvider);
 
             return new NuGetUIContext(
                 serviceBroker,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/UserInterfaceService/NuGetUIContextTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/UserInterfaceService/NuGetUIContextTests.cs
@@ -18,6 +18,7 @@ using NuGet.Test.Utility;
 using NuGet.Versioning;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
+using NuGet.VisualStudio.Telemetry;
 using Xunit;
 
 namespace NuGet.PackageManagement.UI.Test.UserInterfaceService
@@ -155,9 +156,10 @@ namespace NuGet.PackageManagement.UI.Test.UserInterfaceService
             _testDirectory.Dispose();
         }
 
-        private NuGetUIContext CreateNuGetUIContext(ISettings settings = null)
+        private NuGetUIContext CreateNuGetUIContext(ISettings settings = null, INuGetTelemetryProvider nuGetTelemetryProvider = null)
         {
             settings = settings ?? Mock.Of<ISettings>();
+            nuGetTelemetryProvider = nuGetTelemetryProvider ?? Mock.Of<INuGetTelemetryProvider>();
             var sourceRepositoryProvider = Mock.Of<ISourceRepositoryProvider>();
             var packageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
@@ -173,7 +175,8 @@ namespace NuGet.PackageManagement.UI.Test.UserInterfaceService
                 new UIActionEngine(
                     sourceRepositoryProvider,
                     packageManager,
-                    Mock.Of<INuGetLockService>()),
+                    Mock.Of<INuGetLockService>(),
+                    Mock.Of<INuGetTelemetryProvider>()),
                 Mock.Of<IPackageRestoreManager>(),
                 Mock.Of<IOptionsPageActivator>(),
                 Mock.Of<IUserSettingsManager>(),


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14402
Fixes: https://github.com/NuGet/Client.Engineering/issues/2798

## Description

Follow up to a discussion with @donnie-msft and his PR https://github.com/NuGet/NuGet.Client/pull/6535. 

The root cause is that we're calling the telemetry service static. This PR moves away from that in a similar fashion like https://github.com/NuGet/NuGet.Client/pull/6419 and https://github.com/NuGet/NuGet.Client/pull/6417

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
