### PR TITLE
Add content hash to verify output

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.Commands {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -2389,6 +2389,15 @@ namespace NuGet.Commands {
         internal static string UnsupportedProject {
             get {
                 return ResourceManager.GetString("UnsupportedProject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Content hash: {0}.
+        /// </summary>
+        internal static string VerifyCommand_ContentHash {
+            get {
+                return ResourceManager.GetString("VerifyCommand_ContentHash", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1161,4 +1161,7 @@ NuGet requires HTTPS sources. Refer to https://aka.ms/nuget-https-everywhere for
     <value>The following PackageReference item(s) do not have a version specified: {0}</value>
     <comment>0 - List of package names</comment>
   </data>
+  <data name="VerifyCommand_ContentHash" xml:space="preserve">
+    <value>Content hash: {0}</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/VerifyCommand/VerifyCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/VerifyCommand/VerifyCommandRunner.cs
@@ -119,6 +119,10 @@ namespace NuGet.Commands
                 logger.LogMinimal(Environment.NewLine + string.Format(CultureInfo.CurrentCulture,
                     Strings.VerifyCommand_VerifyingPackage,
                     packageIdentity.ToString()));
+                string contentHash = packageReader.GetContentHash(CancellationToken.None);
+                logger.LogMinimal(string.Format(CultureInfo.CurrentCulture,
+                    Strings.VerifyCommand_ContentHash,
+                    contentHash));
                 logger.LogInformation($"{packagePath}{Environment.NewLine}");
 
                 var logMessages = verificationResult.Results.SelectMany(p => p.Issues).ToList();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14384

## Description

Adds package content hash to `dotnet nuget verify` output.

```diff
 Verifying NuGet.Versioning.7.0.0-zlocal.32767
+Content hash: JMOJrSJCEvQXUbJyz8D7mQ7yHrXChIZr5xalqrEhFfhEAZzUewn28TRF6jzb/tg1SCNaW7O+QRYh8PAcBKlUWw==

 error: NU3004: The package is not signed.

 Package signature validation failed.
```

This will help customers understand restore failures when using lock files, if a package content hash is different on different package sources, or packages that ship in the .NET SDK being different to the same version on nuget.org, etc.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/14411
