### PR TITLE
PrunePackageReference improvements - restore applies PrivateAssets=all and IncludeAssets=none to all prunable direct references

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -1007,6 +1007,7 @@ namespace NuGet.Build.Tasks.Pack
             }
 
             return ImmutableCollectionsMarshal.AsImmutableArray(updatedDependencies);
+
         }
 
         private static LibraryDependency GetUpdatedPackageDependency(

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -1007,7 +1007,6 @@ namespace NuGet.Build.Tasks.Pack
             }
 
             return ImmutableCollectionsMarshal.AsImmutableArray(updatedDependencies);
-
         }
 
         private static LibraryDependency GetUpdatedPackageDependency(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/IncludeFlagUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/IncludeFlagUtils.cs
@@ -49,19 +49,43 @@ namespace NuGet.Commands
 
             // Override the flags for direct dependencies. This lets the
             // user take control when needed.
-            //foreach (var dependency in directDependencies)
-            //{
-            //    if (result.ContainsKey(dependency.Name))
-            //    {
-            //        result[dependency.Name] = dependency.IncludeType;
-            //    }
-            //    else
-            //    {
-            //        result.Add(dependency.Name, dependency.IncludeType);
-            //    }
-            //}
+            foreach (var dependency in directDependencies)
+            {
+                if (result.ContainsKey(dependency.Name))
+                {
+                    if (IsDependencyPruned(dependency, specFramework?.PackagesToPrune))
+                    {
+                        result[dependency.Name] = LibraryIncludeFlags.None;
+                    }
+                    else
+                    {
+                        result[dependency.Name] = dependency.IncludeType;
+                    }
+                }
+                else
+                {
+                    if (IsDependencyPruned(dependency, specFramework?.PackagesToPrune))
+                    {
+                        result[dependency.Name] = LibraryIncludeFlags.None;
+                    }
+                    else
+                    {
+                        result.Add(dependency.Name, dependency.IncludeType);
+                    }
+                }
+            }
 
             return result;
+
+            static bool IsDependencyPruned(LibraryDependency dependency, IReadOnlyDictionary<string, PrunePackageReference> packagesToPrune)
+            {
+                if (packagesToPrune?.TryGetValue(dependency.Name, out PrunePackageReference packageToPrune) == true
+                    && dependency.LibraryRange.VersionRange.Satisfies(packageToPrune.VersionRange.MaxVersion))
+                {
+                    return true;
+                }
+                return false;
+            }
         }
 
         private static void FlattenDependencyTypesUnified(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/IncludeFlagUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/IncludeFlagUtils.cs
@@ -51,27 +51,17 @@ namespace NuGet.Commands
             // user take control when needed.
             foreach (var dependency in directDependencies)
             {
+                LibraryIncludeFlags includeType = IsDependencyPruned(dependency, specFramework?.PackagesToPrune) ?
+                    LibraryIncludeFlags.None :
+                    dependency.IncludeType;
+
                 if (result.ContainsKey(dependency.Name))
                 {
-                    if (IsDependencyPruned(dependency, specFramework?.PackagesToPrune))
-                    {
-                        result[dependency.Name] = LibraryIncludeFlags.None;
-                    }
-                    else
-                    {
-                        result[dependency.Name] = dependency.IncludeType;
-                    }
+                    result[dependency.Name] = includeType;
                 }
                 else
                 {
-                    if (IsDependencyPruned(dependency, specFramework?.PackagesToPrune))
-                    {
-                        result[dependency.Name] = LibraryIncludeFlags.None;
-                    }
-                    else
-                    {
-                        result.Add(dependency.Name, dependency.IncludeType);
-                    }
+                    result.Add(dependency.Name, includeType);
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/IncludeFlagUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/IncludeFlagUtils.cs
@@ -49,17 +49,17 @@ namespace NuGet.Commands
 
             // Override the flags for direct dependencies. This lets the
             // user take control when needed.
-            foreach (var dependency in directDependencies)
-            {
-                if (result.ContainsKey(dependency.Name))
-                {
-                    result[dependency.Name] = dependency.IncludeType;
-                }
-                else
-                {
-                    result.Add(dependency.Name, dependency.IncludeType);
-                }
-            }
+            //foreach (var dependency in directDependencies)
+            //{
+            //    if (result.ContainsKey(dependency.Name))
+            //    {
+            //        result[dependency.Name] = dependency.IncludeType;
+            //    }
+            //    else
+            //    {
+            //        result.Add(dependency.Name, dependency.IncludeType);
+            //    }
+            //}
 
             return result;
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -385,7 +385,6 @@ namespace NuGet.ProjectModel
 
                 for (var i = 0; i < dependencies.Count; i++)
                 {
-                    bool isPruned = IsDependencyPruned(dependencies[i], targetFrameworkInfo.PackagesToPrune);
                     // Do not push the dependency changes here upwards, as the original package
                     // spec should not be modified.
 
@@ -393,6 +392,7 @@ namespace NuGet.ProjectModel
                     // This will require that projects referenced by an msbuild project
                     // must be external projects.
                     var dependency = dependencies[i];
+                    bool isPruned = IsDependencyPruned(dependency, targetFrameworkInfo.PackagesToPrune);
                     var libraryRange = new LibraryRange(dependency.LibraryRange) { TypeConstraint = dependency.LibraryRange.TypeConstraint & ~LibraryDependencyTarget.Project };
                     dependencies[i] = new LibraryDependency(dependency)
                     {

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -385,6 +385,7 @@ namespace NuGet.ProjectModel
 
                 for (var i = 0; i < dependencies.Count; i++)
                 {
+                    bool isPruned = IsDependencyPruned(dependencies[i], targetFrameworkInfo.PackagesToPrune);
                     // Do not push the dependency changes here upwards, as the original package
                     // spec should not be modified.
 
@@ -393,11 +394,26 @@ namespace NuGet.ProjectModel
                     // must be external projects.
                     var dependency = dependencies[i];
                     var libraryRange = new LibraryRange(dependency.LibraryRange) { TypeConstraint = dependency.LibraryRange.TypeConstraint & ~LibraryDependencyTarget.Project };
-                    dependencies[i] = new LibraryDependency(dependency) { LibraryRange = libraryRange };
+                    dependencies[i] = new LibraryDependency(dependency)
+                    {
+                        LibraryRange = libraryRange,
+                        SuppressParent = isPruned ? LibraryIncludeFlags.All : dependency.SuppressParent,
+                        IncludeType = isPruned ? LibraryIncludeFlags.None : dependency.IncludeType,
+                    };
                 }
             }
 
             return dependencies;
+
+            static bool IsDependencyPruned(LibraryDependency dependency, IReadOnlyDictionary<string, PrunePackageReference> packagesToPrune)
+            {
+                if (packagesToPrune?.TryGetValue(dependency.Name, out PrunePackageReference packageToPrune) == true
+                    && dependency.LibraryRange.VersionRange.Satisfies(packageToPrune.VersionRange.MaxVersion))
+                {
+                    return true;
+                }
+                return false;
+            }
         }
 
         private bool IsProject(LibraryDependency dependency)

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -4081,6 +4081,62 @@ namespace NuGet.Commands.FuncTest
             command._enableNewDependencyResolver.Should().Be(useNewResolver);
         }
 
+        [Fact]
+        public async Task RestoreCommand_WithCustomIncludeAssets_WhenDirectPackageAppearsInTransitiveGraph_DirectIncludeAssetsTakePrecedence()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                new SimpleTestPackageContext("packageA", "1.0.0")
+                {
+                    Dependencies = [new SimpleTestPackageContext("packageB", "1.0.0")],
+                },
+                new SimpleTestPackageContext("packageB", "1.0.0"));
+
+            var leafProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                        ""packageB"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                            ""include"": ""Runtime, Compile"",
+                        },
+                }
+            }
+          }
+        }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, leafProject);
+
+            // Act & Assert
+            var result = await RunRestoreAsync(pathContext, projectSpec);
+            result.Success.Should().BeTrue();
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
+            result.LockFile.Targets[0].Libraries[0].CompileTimeAssemblies.Should().BeEquivalentTo([new LockFileItem("lib/net45/a.dll")]);
+            result.LockFile.Targets[0].Libraries[0].RuntimeAssemblies.Should().BeEquivalentTo([new LockFileItem("lib/net45/a.dll")]);
+            result.LockFile.Targets[0].Libraries[0].ContentFiles.Should().HaveCount(2);
+            result.LockFile.Targets[0].Libraries[0].RuntimeTargets.Should().ContainSingle(e => e.Path == "runtimes/any/native/a.dll");
+            result.LockFile.Targets[0].Libraries[0].Build.Should().BeEquivalentTo([new LockFileItem("build/net45/packageA.targets")]);
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("packageB");
+            result.LockFile.Targets[0].Libraries[1].CompileTimeAssemblies.Should().BeEquivalentTo([new LockFileItem("lib/net45/a.dll")]);
+            result.LockFile.Targets[0].Libraries[1].RuntimeAssemblies.Should().BeEquivalentTo([new LockFileItem("lib/net45/a.dll")]);
+            result.LockFile.Targets[0].Libraries[1].ContentFiles.Should().ContainSingle(e => e.Path == "contentFiles/any/any/_._");
+            result.LockFile.Targets[0].Libraries[1].RuntimeTargets.Should().ContainSingle(e => e.Path == "runtimes/any/native/_._");
+            result.LockFile.Targets[0].Libraries[1].Build.Should().BeEquivalentTo([new LockFileItem("build/net45/_._")]);
+        }
+
         private static void CreateFakeProjectFile(PackageSpec project2spec)
         {
             Directory.CreateDirectory(Path.GetDirectoryName(project2spec.RestoreMetadata.ProjectUniqueName));

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
@@ -189,6 +189,19 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[1].Dependencies.Should().HaveCount(0);
             result.LockFile.Targets[0].Libraries[2].Name.Should().Be("C");
             result.LockFile.Targets[0].Libraries[2].Dependencies.Should().HaveCount(0);
+            result.LockFile.Targets[0].Libraries[2].CompileTimeAssemblies.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[2].CompileTimeAssemblies[0].Path.Should().EndWith("_._");
+            result.LockFile.Targets[0].Libraries[2].RuntimeAssemblies.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[2].RuntimeAssemblies[0].Path.Should().EndWith("_._");
+            result.LockFile.Targets[0].Libraries[2].FrameworkAssemblies.Should().BeEmpty();
+            result.LockFile.Targets[0].Libraries[2].FrameworkReferences.Should().BeEmpty();
+            result.LockFile.Targets[0].Libraries[2].NativeLibraries.Should().BeEmpty();
+            result.LockFile.Targets[0].Libraries[2].ResourceAssemblies.Should().BeEmpty();
+            result.LockFile.Targets[0].Libraries[2].RuntimeTargets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[2].RuntimeTargets[0].Path.Should().EndWith("_._");
+            result.LockFile.Targets[0].Libraries[2].ContentFiles.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[2].ContentFiles[0].Path.Should().EndWith("_._");
+
             if (shouldWarn)
             {
                 result.LockFile.LogMessages.Should().HaveCount(1);
@@ -2319,6 +2332,55 @@ namespace NuGet.Commands.FuncTest
             result.Success.Should().BeFalse(because: testLogger.ShowMessages());
             result.LockFile.LogMessages.Should().HaveCount(1);
             result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1004);
+        }
+
+        [Fact]
+        public async Task RestoreCommand_PrunableDependenciesFromDirectPackageReference_DoNotFlowTransitively()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                new SimpleTestPackageContext("packageA", "1.0.0"),
+                new SimpleTestPackageContext("packageB", "1.0.0"));
+
+            var leafProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                        ""packageB"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""packageB"" : ""(,1.0.0]"" 
+                }
+            }
+          }
+        }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, "net472");
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, leafProject);
+            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+
+            // Act & Assert
+            var restoreResult = await RunRestoreAsync(pathContext, projectSpec, projectSpec2);
+            restoreResult.Success.Should().BeTrue();
+            restoreResult.LockFile.Targets.Should().HaveCount(1);
+            restoreResult.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+            restoreResult.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
+            restoreResult.LockFile.Targets[0].Libraries[0].Dependencies.Should().BeEmpty();
+            restoreResult.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
+            restoreResult.LockFile.Targets[0].Libraries[1].Dependencies.Should().HaveCount(1);
         }
 
         // Add a test where a new package is introduced, but a different package gets pruned, bringing the counter to be the same.


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14196

## Description

Builds on top of https://github.com/NuGet/NuGet.Client/pull/6540. 

Design in https://github.com/NuGet/Home/pull/14325. 
This PR ensures that pruning privatizes direct packages .

This is the final of the pruning for directs work. Note that we have a P7 urgency and we're trying 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. - https://github.com/NuGet/Home/issues/14410
- [x] Breaking change doc: https://github.com/dotnet/docs/issues/47292
