### PR TITLE
Promote NU3043 warning to error in NuGet.exe sign command

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SignCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SignCommand.cs
@@ -78,7 +78,7 @@ namespace NuGet.CommandLine
         {
             ValidatePackagePath();
             WarnIfNoTimestamper(Console);
-            ValidateCertificateInputs(Console);
+            ValidateCertificateInputs();
             ValidateOutputDirectory();
 
             var signingSpec = SigningSpecifications.V1;
@@ -164,7 +164,7 @@ namespace NuGet.CommandLine
             }
         }
 
-        private void ValidateCertificateInputs(ILogger logger)
+        private void ValidateCertificateInputs()
         {
             if (string.IsNullOrEmpty(CertificatePath) &&
                 string.IsNullOrEmpty(CertificateFingerprint) &&
@@ -189,13 +189,12 @@ namespace NuGet.CommandLine
             }
             else if (CertificateFingerprint != null)
             {
-                if (!CertificateUtility.TryDeduceHashAlgorithm(CertificateFingerprint, out HashAlgorithmName hashAlgorithmName))
+                if (!CertificateUtility.TryDeduceHashAlgorithm(CertificateFingerprint, out HashAlgorithmName hashAlgorithmName) ||
+                    hashAlgorithmName == HashAlgorithmName.SHA1)
                 {
-                    throw new ArgumentException(NuGetCommand.SignCommandInvalidCertificateFingerprint);
-                }
-                else if (hashAlgorithmName == HashAlgorithmName.SHA1)
-                {
-                    logger.Log(LogMessage.CreateWarning(NuGetLogCode.NU3043, NuGetCommand.SignCommandInvalidCertificateFingerprint));
+                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
+                        NuGetCommand.SignCommandInvalidCertificateFingerprint,
+                        NuGetLogCode.NU3043));
                 }
             }
         }

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -1609,7 +1609,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid value for &apos;CertificateFingerprint&apos; option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal)..
+        ///   Looks up a localized string similar to {0}: Invalid value for &apos;CertificateFingerprint&apos; option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal)..
         /// </summary>
         internal static string SignCommandInvalidCertificateFingerprint {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -938,6 +938,7 @@ nuget client-certs List</value>
     <value>Allows HTTP connections for adding or updating packages. Note: This method is not secure. For secure options, see https://aka.ms/nuget-https-everywhere for more information.</value>
   </data>
   <data name="SignCommandInvalidCertificateFingerprint" xml:space="preserve">
-    <value>Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</value>
+    <value>{0}: Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</value>
+    <comment>{0} - error code</comment>
   </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -722,9 +722,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
         }
 
         [CIOnlyFact]
-        public async Task SignCommand_SignPackageWithInsecureCertificateFingerprint_RaisesWarningAsync()
+        public async Task SignCommand_SignPackageWithInsecureCertificateFingerprint_RaisesExceptionAsync()
         {
-            await ExecuteSignPackageTestWithCertificateFingerprintAsync(HashAlgorithmName.SHA1, expectInsecureFingerprintWarning: true);
+            var result = await ExecuteSignPackageTestWithCertificateFingerprintAsync(HashAlgorithmName.SHA1);
+
+            Assert.False(result.Success, result.AllOutput);
+            Assert.True(result.Errors.Contains(_insecureCertificateFingerprintCode), result.AllOutput);
         }
 
         [CIOnlyTheory]
@@ -733,12 +736,13 @@ namespace NuGet.CommandLine.FuncTest.Commands
         [InlineData(HashAlgorithmName.SHA512)]
         public async Task SignCommand_SignPackageWithSecureCertificateFingerprint_SucceedsAsync(HashAlgorithmName hashAlgorithmName)
         {
-            await ExecuteSignPackageTestWithCertificateFingerprintAsync(hashAlgorithmName, expectInsecureFingerprintWarning: false);
+            var result = await ExecuteSignPackageTestWithCertificateFingerprintAsync(hashAlgorithmName);
+
+            Assert.True(result.Success, result.AllOutput);
+            Assert.False(result.AllOutput.Contains(_insecureCertificateFingerprintCode), result.AllOutput);
         }
 
-        private async Task ExecuteSignPackageTestWithCertificateFingerprintAsync(
-            HashAlgorithmName hashAlgorithmName,
-            bool expectInsecureFingerprintWarning)
+        private async Task<CommandRunnerResult> ExecuteSignPackageTestWithCertificateFingerprintAsync(HashAlgorithmName hashAlgorithmName)
         {
             // Arrange
             var testServer = await _testFixture.GetSigningTestServerAsync();
@@ -755,7 +759,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 using var certificate = _testFixture.UntrustedSelfIssuedCertificateInCertificateStore;
 
-                string certFingerprint = expectInsecureFingerprintWarning ? certificate.Thumbprint :
+                string certFingerprint = hashAlgorithmName == HashAlgorithmName.SHA1 ? certificate.Thumbprint :
                     SignatureTestUtility.GetFingerprint(certificate, hashAlgorithmName);
 
                 var result = CommandRunner.Run(
@@ -764,16 +768,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     $"sign {packageFile.FullName} -CertificateFingerprint {certFingerprint} -Timestamper {timestampService.Url}",
                 testOutputHelper: _testOutputHelper);
 
-                // Assert
-                Assert.True(result.Success, result.AllOutput);
-                if (expectInsecureFingerprintWarning)
-                {
-                    Assert.True(result.AllOutput.Contains(_insecureCertificateFingerprintCode), result.AllOutput);
-                }
-                else
-                {
-                    Assert.False(result.AllOutput.Contains(_insecureCertificateFingerprintCode), result.AllOutput);
-                }
+                return result;
             }
         }
     }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -64,11 +64,13 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     zipStream.CopyTo(fileStream);
                 }
 
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(_trustedTestCert.Source.Cert, HashAlgorithmName.SHA256);
+
                 // Act
                 var result = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation}",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation}",
                     testOutputHelper: _testOutputHelper);
 
                 // Assert
@@ -96,11 +98,13 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     zipStream.CopyTo(fileStream);
                 }
 
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(invalidEkuCert.Source.Cert, HashAlgorithmName.SHA256);
+
                 // Act
                 var result = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {invalidEkuCert.Source.Cert.Thumbprint} -CertificateStoreName {invalidEkuCert.StoreName} -CertificateStoreLocation {invalidEkuCert.StoreLocation}",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash} -CertificateStoreName {invalidEkuCert.StoreName} -CertificateStoreLocation {invalidEkuCert.StoreLocation}",
                     testOutputHelper: _testOutputHelper);
 
                 // Assert
@@ -128,11 +132,13 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     zipStream.CopyTo(fileStream);
                 }
 
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(expiredCert.Source.Cert, HashAlgorithmName.SHA256);
+
                 // Act
                 var result = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {expiredCert.Source.Cert.Thumbprint} -CertificateStoreName {expiredCert.StoreName} -CertificateStoreLocation {expiredCert.StoreLocation}",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash} -CertificateStoreName {expiredCert.StoreName} -CertificateStoreLocation {expiredCert.StoreLocation}",
                     testOutputHelper: _testOutputHelper);
 
                 // Assert
@@ -161,11 +167,13 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     zipStream.CopyTo(fileStream);
                 }
 
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(cert.Source.Cert, HashAlgorithmName.SHA256);
+
                 // Act
                 var result = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {cert.Source.Cert.Thumbprint} -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation}",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash} -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation}",
                     testOutputHelper: _testOutputHelper);
 
                 // Assert
@@ -194,11 +202,13 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     zipStream.CopyTo(fileStream);
                 }
 
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(_trustedTestCert.Source.Cert, HashAlgorithmName.SHA256);
+
                 // Act
                 var result = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint}  -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation} -Timestamper {timestampService.Url.OriginalString}",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash}  -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation} -Timestamper {timestampService.Url.OriginalString}",
                     testOutputHelper: _testOutputHelper);
 
                 // Assert
@@ -226,11 +236,13 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     zipStream.CopyTo(fileStream);
                 }
 
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(cert.Source.Cert, HashAlgorithmName.SHA256);
+
                 // Act
                 var result = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {cert.Source.Cert.Thumbprint}  -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation}",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash}  -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation}",
                     testOutputHelper: _testOutputHelper);
 
                 // Assert
@@ -258,11 +270,13 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     zipStream.CopyTo(fileStream);
                 }
 
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(cert.Source.Cert, HashAlgorithmName.SHA256);
+
                 // Act
                 var result = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {cert.Source.Cert.Thumbprint}  -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation}",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash}  -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation}",
                     testOutputHelper: _testOutputHelper);
 
                 // Assert
@@ -290,11 +304,13 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     zipStream.CopyTo(fileStream);
                 }
 
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(cert.Source.Cert, HashAlgorithmName.SHA256);
+
                 // Act
                 var result = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {cert.Source.Cert.Thumbprint} -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation}",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash} -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation}",
                     testOutputHelper: _testOutputHelper);
 
                 // Assert
@@ -326,11 +342,13 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     zipStream.CopyTo(fileStream);
                 }
 
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(_trustedTestCert.Source.Cert, HashAlgorithmName.SHA256);
+
                 // Act
                 var result = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint}  -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation} -OutputDirectory {outputDir}",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash}  -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation} -OutputDirectory {outputDir}",
                     testOutputHelper: _testOutputHelper);
 
                 // Assert
@@ -358,17 +376,19 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     zipStream.CopyTo(fileStream);
                 }
 
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(_trustedTestCert.Source.Cert, HashAlgorithmName.SHA256);
+
                 var firstResult = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint}  -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation}",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash}  -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation}",
                     testOutputHelper: _testOutputHelper);
 
                 // Act
                 var secondResult = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint}  -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation}",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash}  -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation}",
                     testOutputHelper: _testOutputHelper);
 
                 // Assert
@@ -397,17 +417,19 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     zipStream.CopyTo(fileStream);
                 }
 
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(_trustedTestCert.Source.Cert, HashAlgorithmName.SHA256);
+
                 // Act
                 var firstResult = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation}",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation}",
                     testOutputHelper: _testOutputHelper);
 
                 var secondResult = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation} -Overwrite",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation} -Overwrite",
                     testOutputHelper: _testOutputHelper);
 
                 // Assert
@@ -436,11 +458,13 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     zipStream.CopyTo(fileStream);
                 }
 
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(_trustedTestCert.Source.Cert, HashAlgorithmName.SHA256);
+
                 // Act
                 var firstResult = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation} -Overwrite",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation} -Overwrite",
                     testOutputHelper: _testOutputHelper);
 
                 // Assert
@@ -676,10 +700,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 using (var certificate = _testFixture.UntrustedSelfIssuedCertificateInCertificateStore)
                 {
+                    string certSha256Hash = SignatureTestUtility.GetFingerprint(certificate, HashAlgorithmName.SHA256);
+
                     var result = CommandRunner.Run(
                         _nugetExePath,
                         directory,
-                        $"sign {packageFile.FullName} -CertificateFingerprint {certificate.Thumbprint}",
+                        $"sign {packageFile.FullName} -CertificateFingerprint {certSha256Hash}",
                     testOutputHelper: _testOutputHelper);
 
                     Assert.True(result.Success);
@@ -705,10 +731,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 using (var certificate = _testFixture.UntrustedSelfIssuedCertificateInCertificateStore)
                 {
+                    string certSha256Hash = SignatureTestUtility.GetFingerprint(certificate, HashAlgorithmName.SHA256);
+
                     var result = CommandRunner.Run(
                         _nugetExePath,
                         directory,
-                        $"sign {packageFile.FullName} -CertificateFingerprint {certificate.Thumbprint} -Timestamper {timestampService.Url}",
+                        $"sign {packageFile.FullName} -CertificateFingerprint {certSha256Hash} -Timestamper {timestampService.Url}",
                     testOutputHelper: _testOutputHelper);
 
                     Assert.False(result.Success);

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/VerifyCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/VerifyCommandTests.cs
@@ -59,10 +59,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     zipStream.CopyTo(fileStream);
                 }
 
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(_trustedTestCert.Source.Cert, HashAlgorithmName.SHA256);
+
                 var signResult = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation}",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation}",
                     testOutputHelper: _testOutputHelper);
 
                 signResult.Success.Should().BeTrue();
@@ -99,10 +101,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     zipStream.CopyTo(fileStream);
                 }
 
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(_trustedTestCert.Source.Cert, HashAlgorithmName.SHA256);
+
                 var signResult = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -Timestamper {timestampService.Url.OriginalString} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation}",
+                    $"sign {packagePath} -Timestamper {timestampService.Url.OriginalString} -CertificateFingerprint {certSha256Hash} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation}",
                     testOutputHelper: _testOutputHelper);
 
                 signResult.Success.Should().BeTrue();
@@ -137,16 +141,18 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     zipStream.CopyTo(fileStream);
                 }
 
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(_trustedTestCert.Source.Cert, HashAlgorithmName.SHA256);
+
                 var firstResult = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation}",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation}",
                     testOutputHelper: _testOutputHelper);
 
                 var secondResult = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation} -Overwrite",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation} -Overwrite",
                     testOutputHelper: _testOutputHelper);
 
                 firstResult.Success.Should().BeTrue();
@@ -184,10 +190,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     zipStream.CopyTo(fileStream);
                 }
 
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(cert.Source.Cert, HashAlgorithmName.SHA256);
+
                 var signResult = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {cert.Source.Cert.Thumbprint} -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation}",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash} -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation}",
                     testOutputHelper: _testOutputHelper);
 
                 signResult.Success.Should().BeTrue();
@@ -224,21 +232,21 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     zipStream.CopyTo(fileStream);
                 }
 
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(cert.Source.Cert, HashAlgorithmName.SHA256);
+
                 var signResult = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {cert.Source.Cert.Thumbprint} -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation}",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash} -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation}",
                     testOutputHelper: _testOutputHelper);
 
                 signResult.Success.Should().BeTrue();
-
-                var certificateFingerprintString = SignatureTestUtility.GetFingerprint(cert.Source.Cert, HashAlgorithmName.SHA256);
 
                 // Act
                 var verifyResult = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"verify {packagePath} -Signatures -CertificateFingerprint {certificateFingerprintString};abc;def",
+                    $"verify {packagePath} -Signatures -CertificateFingerprint {certSha256Hash};abc;def",
                     testOutputHelper: _testOutputHelper);
 
                 // Assert
@@ -266,10 +274,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     zipStream.CopyTo(fileStream);
                 }
 
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(cert.Source.Cert, HashAlgorithmName.SHA256);
+
                 var signResult = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {cert.Source.Cert.Thumbprint} -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation}",
+                    $"sign {packagePath} -CertificateFingerprint {certSha256Hash} -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation}",
                     testOutputHelper: _testOutputHelper);
 
                 signResult.Success.Should().BeTrue();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSignCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSignCommandTest.cs
@@ -16,7 +16,8 @@ namespace NuGet.CommandLine.Test
         private const string InvalidArgException = "Invalid value provided for '{0}'. For a list of accepted values, please visit https://docs.nuget.org/docs/reference/command-line-reference";
         private const string NoPackageException = "No package was provided. For a list of accepted ways to provide a package, please visit https://docs.nuget.org/docs/reference/command-line-reference";
         private const string MultipleCertificateException = "Multiple options were used to specify a certificate. For a list of accepted ways to provide a certificate, please visit https://docs.nuget.org/docs/reference/command-line-reference";
-        private const string Sha1Hash = "89967D1DD995010B6C66AE24FF8E66885E6E03A8";
+        private const string InvalidCertificateFingerprintException = "Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).";
+        private const string Sha256Hash = "A591A6D40BF420404A011733CFB7B190D62C65BF0BCDA32B56C92B409B0F9DCA";
 
         [Fact]
         public void SignCommandArgParsing_NoPackagePath()
@@ -81,7 +82,7 @@ namespace NuGet.CommandLine.Test
             // Arrange
             var packagePath = @"\\path\package.nupkg";
             var timestamper = "https://timestamper.test";
-            var certificateFingerprint = Sha1Hash;
+            var certificateFingerprint = Sha256Hash;
             var parsable = Enum.TryParse(storeName, ignoreCase: true, result: out StoreName parsedStoreName);
             var mockConsole = new Mock<IConsole>();
             var signCommand = new SignCommand
@@ -106,7 +107,7 @@ namespace NuGet.CommandLine.Test
             // Arrange
             var packagePath = @"\\path\package.nupkg";
             var timestamper = "https://timestamper.test";
-            var certificateFingerprint = Sha1Hash;
+            var certificateFingerprint = Sha256Hash;
             var storeName = "random_store";
             var mockConsole = new Mock<IConsole>();
             var signCommand = new SignCommand
@@ -134,7 +135,7 @@ namespace NuGet.CommandLine.Test
             // Arrange
             var packagePath = @"\\path\package.nupkg";
             var timestamper = "https://timestamper.test";
-            var certificateFingerprint = Sha1Hash;
+            var certificateFingerprint = Sha256Hash;
             var parsable = Enum.TryParse(storeLocation, ignoreCase: true, result: out StoreLocation parsedStoreLocation);
             var mockConsole = new Mock<IConsole>();
             var signCommand = new SignCommand
@@ -160,7 +161,7 @@ namespace NuGet.CommandLine.Test
             // Arrange
             var packagePath = @"\\path\package.nupkg";
             var timestamper = "https://timestamper.test";
-            var certificateFingerprint = Sha1Hash;
+            var certificateFingerprint = Sha256Hash;
             var storeLocation = "random_location";
             var mockConsole = new Mock<IConsole>();
             var signCommand = new SignCommand
@@ -298,7 +299,7 @@ namespace NuGet.CommandLine.Test
             // Arrange
             var packagePath = @"\\path\package.nupkg";
             var timestamper = "https://timestamper.test";
-            var certificateFingerprint = Sha1Hash;
+            var certificateFingerprint = Sha256Hash;
             var hashAlgorithm = "sha256";
             Enum.TryParse(hashAlgorithm, ignoreCase: true, result: out HashAlgorithmName parsedHashAlgorithm);
             var timestampHashAlgorithm = "sha512";
@@ -459,22 +460,9 @@ namespace NuGet.CommandLine.Test
             Util.TestCommandInvalidArguments(cmd);
         }
 
-        [Fact]
-        public void SignCommandArgParsing_LogsAWarningForInsecureCertificateFingerprint()
-        {
-            //Arrange
-            var logMessages = new StringBuilder();
-            var signCommand = ArrangeSignCommand(Sha1Hash, logMessages);
-
-            // Act
-            _ = signCommand.GetSignArgs();
-
-            //Assert
-            Assert.Equal(expected: NuGetCommand.SignCommandInvalidCertificateFingerprint, actual: logMessages.ToString().Trim());
-        }
-
         [Theory]
-        [InlineData("89967D1DD995010B6C66AE24FF8E66885E6E03")] // 39 characters long not SHA-1
+        [InlineData("89967D1DD995010B6C66AE24FF8E66885E6E03A8")] // 40 characters long SHA-1
+        [InlineData("89967D1DD995010B6C66AE24FF8E66885E6E03")] // 38 characters long not SHA-1
         [InlineData("invalid-certificate-fingerprint")]
         public void SignCommandArgParsing_ThrowsAnExceptionWarningForInsecureCertificateFingerprint(string certificateFingerprint)
         {
@@ -482,7 +470,7 @@ namespace NuGet.CommandLine.Test
 
             // Act & Assert
             var ex = Assert.Throws<ArgumentException>(() => signCommand.GetSignArgs());
-            Assert.True(ex.Message.Contains(NuGetCommand.SignCommandInvalidCertificateFingerprint));
+            Assert.True(ex.Message.Contains(InvalidCertificateFingerprintException));
         }
 
         private static SignCommand ArrangeSignCommand(string certificateFingerprint, StringBuilder logMessages = null)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13962

## Description

Updated NuGet.exe sign command to accept fingerprints from the SHA-2 family (SHA256, SHA384, or SHA512) instead of SHA-1. If a SHA-1 fingerprint or invalid value is passed, the commands raise an [NU3043](https://learn.microsoft.com/nuget/reference/errors-and-warnings/nu3043) error indicating that SHA-1 is insecure. 

dotnet.exe changes have been merged already in https://github.com/NuGet/Home/issues/13814.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. - https://github.com/NuGet/Home/issues/13963
